### PR TITLE
Support for Aironet in Wireless Directory Services (WDS) mode

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -17,7 +17,8 @@ Version <stable-version> released on <releaseDate>
 
 New Hardware
  * H3C S5120 series supports MAC-Authentication and 802.1X with or without VoIP
- * Added Role support for all Cisco Wireless (WLC) models
+ * Role support for all Cisco Wireless (WLC) models
+ * Cisco Aironet in Wireless Directory Services (WDS) mode
 
 New Features
  * debian packages (#1066, #1067)

--- a/README.network-devices
+++ b/README.network-devices
@@ -40,6 +40,7 @@ Packetfence supports the following access points:
 - Cisco 1130AG
 - Cisco 1240AG
 - Cisco 1250
+- Cisco Aironet in WDS mode
 - Dlink DWL Access Points
 - HP ProCurve
 - Xirrus WiFi Arrays
@@ -87,6 +88,8 @@ Aruba                        |    xx    |    --    |    XX    |
 Avaya WC                     |    --    |    XX    |    --    |
 -----------------------------|----------|----------|----------|
 Cisco Aironet                |    XX    |    --    |    --    |
+-----------------------------|----------|----------|----------|
+Cisco Aironet (WDS)          |    --    |    --    |    XX    |
 -----------------------------|----------|----------|----------|
 Cisco WiSM                   |    --    |    xx    |    XX    |
 -----------------------------|----------|----------|----------|

--- a/docs/PacketFence_Network_Devices_Configuration_Guide.asciidoc
+++ b/docs/PacketFence_Network_Devices_Configuration_Guide.asciidoc
@@ -80,8 +80,7 @@ PacketFence supports the following devices:
 |Cisco            |Aironet 1130 AG             |Cisco::Aironet_1130
 |                 |Aironet 1240 AG             |Cisco::Aironet_1242
 |                 |Aironet 1250                |Cisco::Aironet_1250
-|                 |2100 Wireless Controller    |Cisco::WLC_2106
-|                 |4400 Wireless Controller    |Cisco::WLC_4400
+|                 |Aironet (WDS)               |Cisco::Aironet_WDS
 |                 |Catalyst 2900XL Series      |Cisco::Catalyst_2900XL
 |                 |Catalyst 2950               |Cisco::Catalyst_2950
 |                 |Catalyst 2960               |Cisco::Catalyst_2960
@@ -94,6 +93,11 @@ PacketFence supports the following devices:
 |                 |Catalyst 6500               |Cisco::Catalyst_6500
 |                 |Router ISR 1800 Series      |Cisco::ISR_1800
 |                 |Wireless Services Module    |Cisco::WiSM
+|                 |Wireless Services Module 2  |Cisco::WiSM2
+|                 |2100 Wireless Controller    |Cisco::WLC_2106
+|                 |4400 Wireless Controller    |Cisco::WLC_4400
+|                 |5500 Wireless Controller    |Cisco::WLC_5500
+|                 |Wireless Controller (WLC)   |Cisco::WLC
 |D-Link           |DES 3526                    |Dlink::DES_3526
 |                 |DES 3550                    |Dlink::DES_3550
 |                 |DGS 3100                    |Dlink::DGS_3100

--- a/docs/PacketFence_Network_Devices_Configuration_Guide.asciidoc
+++ b/docs/PacketFence_Network_Devices_Configuration_Guide.asciidoc
@@ -2220,6 +2220,12 @@ aaa authentication login mac_methods group rad_mac
 ----
 
 
+Aironet (WDS)
+^^^^^^^^^^^^^
+
+  To be contributed...
+
+
 Wireless LAN Controller (WLC) 2106 and 4400
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/lib/pf/SNMP.pm
+++ b/lib/pf/SNMP.pm
@@ -2671,6 +2671,9 @@ sub radiusDisconnect {
         $logger->info("controllerIp is set, we will use controller $self->{_controllerIp} to perform deauth");
         $send_disconnect_to = $self->{'_controllerIp'};
     }
+    # allowing client code to override where we connect with NAS-IP-Address
+    $send_disconnect_to = $add_attributes_ref->{'NAS-IP-Address'} 
+        if (defined($add_attributes_ref->{'NAS-IP-Address'}));
 
     my $response;
     try {

--- a/lib/pf/SNMP/Cisco/Aironet.pm
+++ b/lib/pf/SNMP/Cisco/Aironet.pm
@@ -55,6 +55,7 @@ use Net::SNMP;
 use base ('pf::SNMP::Cisco');
 
 use pf::config;
+use pf::util qw(format_mac_as_cisco);
 
 =head1 SUBROUTINES
 
@@ -83,17 +84,10 @@ sub deauthenticateMac {
     my ( $this, $mac ) = @_;
     my $logger = Log::Log4perl::get_logger( ref($this) );
 
-    #format MAC
-    if ( length($mac) == 17 ) {
-        $mac =~ s/://g;
-        $mac
-            = substr( $mac, 0, 4 ) . "."
-            . substr( $mac, 4, 4 ) . "."
-            . substr( $mac, 8, 4 );
-    } else {
-        $logger->error(
-            "ERROR: MAC format is incorrect ($mac). Should be xx:xx:xx:xx:xx:xx"
-        );
+    $mac = format_mac_as_cisco($mac);
+    if ( !defined($mac) ) {
+        $logger->error("ERROR: MAC format is incorrect. Aborting deauth...");
+        # TODO return 1, really?
         return 1;
     }
 

--- a/lib/pf/SNMP/Cisco/Aironet.pm
+++ b/lib/pf/SNMP/Cisco/Aironet.pm
@@ -205,6 +205,7 @@ sub isVoIPEnabled {
 Overriding default extractSsid because on Aironet AP SSID is in the Cisco-AVPair VSA.
 
 =cut
+# Same as in pf::SNMP::Cisco::Aironet_WDS. Please keep both in sync. Once Moose push in a role.
 sub extractSsid {
     my ($this, $radius_request) = @_;
     my $logger = Log::Log4perl::get_logger(ref($this));

--- a/lib/pf/SNMP/Cisco/Aironet_WDS.pm
+++ b/lib/pf/SNMP/Cisco/Aironet_WDS.pm
@@ -90,18 +90,18 @@ sub getCurrentApFromMac {
     my $session;
     try {
         $session = Net::Appliance::Session->new(
-            Host => $this->{_ip},
+            Host => $self->{_ip},
             Timeout => 5,
-            Transport => $this->{_cliTransport},
+            Transport => $self->{_cliTransport},
         );
         $session->connect(
-            Name     => $this->{_cliUser},
-            Password => $this->{_cliPwd}
+            Name     => $self->{_cliUser},
+            Password => $self->{_cliPwd}
         );
     }
     catch {
         chomp($_);
-        $logger->warn("Unable to connect to ".$this->{'_ip'}." using ".$this->{_cliTransport}.". Failed with $_");
+        $logger->warn("Unable to connect to ".$self->{'_ip'}." using ".$self->{_cliTransport}.". Failed with $_");
         $session = undef;
     }
     return if (!defined($session));
@@ -116,7 +116,7 @@ sub getCurrentApFromMac {
     try { @output = $session->cmd(String => $command, Timeout => '5'); }
     catch {
         chomp($_);
-        $logger->warn("Error with command $command on ".$this->{'_ip'}.". Failed with $_");
+        $logger->warn("Error with command $command on ".$self->{'_ip'}.". Failed with $_");
         $session->close();
     }
     return if (!@output);
@@ -150,7 +150,7 @@ sub getCurrentApFromMac {
     }
 
     # otherwise report an error
-    $logger->warn("Error with command $command on ".$this->{'_ip'}.". Failed with ".join(@output));
+    $logger->warn("Error with command $command on ".$self->{'_ip'}.". Failed with ".join(@output));
     $session->close();
     return;
 }
@@ -162,8 +162,8 @@ Overriding default extractSsid because on Aironet AP SSID is in the Cisco-AVPair
 =cut
 # Same as in pf::SNMP::Cisco::Aironet. Please keep both in sync. Once Moose push in a role.
 sub extractSsid {
-    my ($this, $radius_request) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my ($self, $radius_request) = @_;
+    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
 
     if (defined($radius_request->{'Cisco-AVPair'})) {
 
@@ -175,7 +175,7 @@ sub extractSsid {
     }
 
     $logger->warn(
-        "Unable to extract SSID for module " . ref($this) . ". SSID-based VLAN assignments won't work. "
+        "Unable to extract SSID for module " . ref($self) . ". SSID-based VLAN assignments won't work. "
         . "Make sure you enable Vendor Specific Attributes (VSA) on the AP if you want them to work."
     );
     return;

--- a/lib/pf/SNMP/Cisco/Aironet_WDS.pm
+++ b/lib/pf/SNMP/Cisco/Aironet_WDS.pm
@@ -111,7 +111,7 @@ sub getCurrentApFromMac {
 
     # running the command
     my $command = "show wlccp wds mn detail mac-address $mac_for_cmd";
-    $logger->trace("sending CLI command '$command'");
+    $logger->debug("sending CLI command '$command'");
     my @output;
     try { @output = $session->cmd(String => $command, Timeout => '5'); }
     catch {

--- a/lib/pf/SNMP/Cisco/Aironet_WDS.pm
+++ b/lib/pf/SNMP/Cisco/Aironet_WDS.pm
@@ -117,7 +117,7 @@ sub getCurrentApFromMac {
     try {
         $session = Net::Appliance::Session->new(
             Host => $self->{_ip},
-            Timeout => 5,
+            Timeout => 25, # apparently these things are very slow
             Transport => $self->{_cliTransport},
         );
         $session->connect(
@@ -139,7 +139,7 @@ sub getCurrentApFromMac {
     my $command = "show wlccp wds mn detail mac-address $mac_for_cmd";
     $logger->debug("sending CLI command '$command'");
     my @output;
-    try { @output = $session->cmd(String => $command, Timeout => '5'); }
+    try { @output = $session->cmd(String => $command, Timeout => '15'); } # apparently these things are very slow
     catch {
         chomp($_);
         $logger->warn("Error with command $command on ".$self->{'_ip'}.". Failed with $_");

--- a/lib/pf/SNMP/Cisco/Aironet_WDS.pm
+++ b/lib/pf/SNMP/Cisco/Aironet_WDS.pm
@@ -103,7 +103,7 @@ sub getCurrentApFromMac {
         chomp($_);
         $logger->warn("Unable to connect to ".$self->{'_ip'}." using ".$self->{_cliTransport}.". Failed with $_");
         $session = undef;
-    }
+    };
     return if (!defined($session));
 
     # preparing parameters
@@ -118,7 +118,7 @@ sub getCurrentApFromMac {
         chomp($_);
         $logger->warn("Error with command $command on ".$self->{'_ip'}.". Failed with $_");
         $session->close();
-    }
+    };
     return if (!@output);
 
     # interpreting the result

--- a/lib/pf/SNMP/Cisco/Aironet_WDS.pm
+++ b/lib/pf/SNMP/Cisco/Aironet_WDS.pm
@@ -162,6 +162,7 @@ sub getCurrentApFromMac {
     foreach my $line (@output) {
         if ($line =~ /^Cur-AP: [0-9a-f]{4}\.[0-9a-f]{4}\.[0-9a-f]{4}, ([0-9.]*)/) {
             $cur_ap_ip = $1;
+            last;
         }
     }
 

--- a/lib/pf/SNMP/Cisco/Aironet_WDS.pm
+++ b/lib/pf/SNMP/Cisco/Aironet_WDS.pm
@@ -52,6 +52,32 @@ sub deauthenticateMac {
     return $self->radiusDisconnect( $mac, { 'Calling-Station-Id' => $mac, } );
 }
 
+=item extractSsid
+
+Overriding default extractSsid because on Aironet AP SSID is in the Cisco-AVPair VSA.
+
+=cut
+# Same as in pf::SNMP::Cisco::Aironet. Please keep both in sync. Once Moose push in a role.
+sub extractSsid {
+    my ($this, $radius_request) = @_;
+    my $logger = Log::Log4perl::get_logger(ref($this));
+
+    if (defined($radius_request->{'Cisco-AVPair'})) {
+
+        if ($radius_request->{'Cisco-AVPair'} =~ /^ssid=(.*)$/) { # ex: Cisco-AVPair = "ssid=PacketFence-Secure"
+            return $1;
+        } else {
+            $logger->info("Unable to extract SSID of Cisco-AVPair: ".$radius_request->{'Cisco-AVPair'});
+        }
+    }
+
+    $logger->warn(
+        "Unable to extract SSID for module " . ref($this) . ". SSID-based VLAN assignments won't work. "
+        . "Make sure you enable Vendor Specific Attributes (VSA) on the AP if you want them to work."
+    );
+    return;
+}
+
 =head1 AUTHOR
 
 Olivier Bilodeau <obilodeau@inverse.ca>

--- a/lib/pf/SNMP/Cisco/Aironet_WDS.pm
+++ b/lib/pf/SNMP/Cisco/Aironet_WDS.pm
@@ -1,0 +1,86 @@
+package pf::SNMP::Cisco::Aironet_WDS;
+=head1 NAME
+
+pf::SNMP::Cisco::Aironet_WDS - Object oriented module to parse SNMP traps 
+and manage Cisco Aironet configured in Wireless Domain Services (WDS) mode.
+
+=head1 STATUS
+
+This module is implements little changes on top of L<pf::SNMP::Cisco::WLC>. 
+You should also consult its documentation if you experience issues.
+
+Tested on an Aironet WDS on IOS 12.3.8JEC3
+
+=cut
+use strict;
+use warnings;
+
+use Log::Log4perl;
+use Net::SNMP;
+
+use base ('pf::SNMP::Cisco::WLC');
+
+use pf::util qw(format_mac_as_cisco);
+
+=item deauthenticateMac
+    
+De-authenticate a MAC address from wireless network (including 802.1x).
+    
+Diverges from L<pf::SNMP::Cisco::WLC> in the following aspects:
+
+=over
+
+=item No Service-Type
+
+=item Called-Station-Id in the Cisco format (aabb.ccdd.eeff)
+
+=back
+
+=cut
+# The Service-Type entry was causing the WDS enabled Aironet to crash (IOS 12.3.8JEC3)
+sub deauthenticateMac {
+    my ( $self, $mac, $is_dot1x ) = @_;
+    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+
+    if ( !$self->isProductionMode() ) {
+        $logger->info("not in production mode... we won't perform deauthentication");
+        return 1;
+    }
+
+    $logger->debug("deauthenticate $mac using RADIUS Disconnect-Request deauth method");
+    $mac = format_mac_as_cisco($mac);
+    return $self->radiusDisconnect( $mac, { 'Calling-Station-Id' => $mac, } );
+}
+
+=head1 AUTHOR
+
+Olivier Bilodeau <obilodeau@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2012 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;
+
+# vim: set shiftwidth=4:
+# vim: set expandtab:
+# vim: set backspace=indent,eol,start:

--- a/lib/pf/SNMP/Cisco/WLC_2100.pm
+++ b/lib/pf/SNMP/Cisco/WLC_2100.pm
@@ -44,6 +44,7 @@ use Net::SNMP;
 use base ('pf::SNMP::Cisco::WLC');
 
 use pf::config;
+use pf::util qw(format_mac_as_cisco);
 
 =head1 SUBROUTINES
 
@@ -78,17 +79,10 @@ sub _deauthenticateMacSnmp {
     my ( $this, $mac ) = @_;
     my $logger = Log::Log4perl::get_logger( ref($this) );
 
-    #format MAC
-    if ( length($mac) == 17 ) {
-        $mac =~ s/://g;
-        $mac
-            = substr( $mac, 0, 4 ) . "."
-            . substr( $mac, 4, 4 ) . "."
-            . substr( $mac, 8, 4 );
-    } else {
-        $logger->error(
-            "ERROR: MAC format is incorrect ($mac). Should be xx:xx:xx:xx:xx:xx"
-        );
+    $mac = format_mac_as_cisco($mac);
+    if ( !defined($mac) ) {
+        $logger->error("ERROR: MAC format is incorrect. Aborting deauth...");
+        # TODO return 1, really?
         return 1;
     }
 

--- a/lib/pf/util.pm
+++ b/lib/pf/util.pm
@@ -33,7 +33,7 @@ BEGIN {
     @ISA = qw(Exporter);
     @EXPORT = qw(
         valid_date valid_ip reverse_ip clean_ip 
-        clean_mac valid_mac mac2nb macoui2nb whitelisted_mac trappable_mac format_mac_for_acct
+        clean_mac valid_mac mac2nb macoui2nb whitelisted_mac trappable_mac format_mac_for_acct format_mac_as_cisco
         trappable_ip reggable_ip
         inrange_ip ip2gateway ip2interface ip2device isinternal pfmailer 
         isenabled isdisabled isempty
@@ -166,7 +166,7 @@ sub clean_mac {
 
 =item format_mac_for_acct
 
-Put the mac address in the accounting format, accepting xx:xx:xx:xx:xx
+Put the mac address in the accounting format, accepting xx:xx:xx:xx:xx:xx
 
 Returning format XXXXXXXXXXXX
 
@@ -181,6 +181,25 @@ sub format_mac_for_acct {
     return ($mac);
 }
 
+=item format_mac_as_cisco
+
+Put the mac address in the cisco format, accepting xx:xx:xx:xx:xx:xx
+
+Returning format aabb.ccdd.eeff
+
+=cut
+sub format_mac_as_cisco {
+    my ($mac) = @_;
+
+    if (defined($mac) && 
+        $mac =~ /^([0-9a-f]{2}):([0-9a-f]{2}):([0-9a-f]{2}):([0-9a-f]{2}):([0-9a-f]{2}):([0-9a-f]{2})$/
+        ) {
+            return "$1$2.$3$4.$5$6";
+    }
+
+    # couldn't process, return undef
+    return;
+}
 
 =item valid_mac 
 

--- a/t/util.t
+++ b/t/util.t
@@ -5,7 +5,7 @@ use warnings;
 use diagnostics;
 
 use lib '/usr/local/pf/lib';
-use Test::More tests => 16;
+use Test::More tests => 18;
 use Test::NoWarnings;
 
 BEGIN { use_ok('pf::util') }
@@ -39,6 +39,9 @@ is_deeply(
     ["day", "days", 3],
     "able to translate new format with capital date modifiers"
 );
+
+is( format_mac_as_cisco('f0:4d:a2:cb:d9:c5'), 'f04d.a2cb.d9c5', 'format_mac_as_cisco legit conversion');
+is( format_mac_as_cisco(), undef, 'format_mac_as_cisco return undef on failure');
 
 # TODO add more tests, we should test:
 #  - all methods ;)


### PR DESCRIPTION
ready for review

working in a lab

doc TODO
- network device guide documentation:
  - the fact that the radius dynauth server runs on a non-standard port by default (not 3799)
  - MAC in format aaaa.bbbb.cccc
- module POD bugs and limitations:
  - no Service-Type otherwise the WDS crashes (confirmed on IOS 12.3.8JEC3)

We should maybe do this also while we are at it: [#1452: Aironet should perform deauth with RFC3576 Packet of Disconnect (PoD)](http://packetfence.org/bugs/view.php?id=1452)
