### PR TITLE
bulk import now supports default node properties in pf.conf

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -25,6 +25,7 @@ New Hardware
 New Features
  * debian packages (#1066, #1067)
  * Support for up to 100 custom VLANs (Defaults to 5 see relevant FAQ entry to enable more)
+ * Node bulk importation now allow you to define default values for pid, category and voip in pf.conf
 
 Enhancements
  * minor refactoring and cleanup

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -956,3 +956,22 @@ type=text
 description=<<EOT
 The merchant's unique Transaction Key (Provided by Authorize.net)
 EOT
+
+[node_import.pid]
+type=text
+description=<<EOT
+Default pid value to assign to imported nodes.
+EOT
+
+[node_import.category]
+type=text
+description=<<EOT
+Default category to assign to imported nodes.
+EOT
+
+[node_import.voip]
+type=toggle
+options=yes|no
+description=<<EOT
+By default is an imported node a Voice over IP device or not?
+EOT

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -743,3 +743,20 @@ authorizenet_login =
 #
 # The merchant's unique Transaction Key (Provided by Authorize.net)
 authorizenet_trankey =
+
+[node_import]
+#
+# node_import.pid
+#
+# Default pid value to assign to imported nodes.
+pid=1
+#
+# node_import.category
+#
+# Default category to assign to imported nodes.
+category=default
+#
+# node_import.voip
+#
+# By default is an imported node a Voice over IP device or not?
+voip=no

--- a/html/admin/node/import.php
+++ b/html/admin/node/import.php
@@ -68,7 +68,10 @@
        <td align="right"><input type="submit" value="Import nodes"></td>
     </tr>
     <tr>
-       <td>Importing automatically registers the nodes with pid 1.</td>
+       <td>
+         Importing automatically registers the nodes with pid 1<br/>
+         unless your configured otherwise in <tt>pf.conf</tt>.
+       </td>
     </tr>
   </table>
 </form>

--- a/lib/pf/import.pm
+++ b/lib/pf/import.pm
@@ -28,6 +28,7 @@ use warnings;
 
 use Log::Log4perl;
 use Text::CSV;
+use POSIX;
 
 BEGIN {
     use Exporter ();
@@ -72,11 +73,14 @@ sub nodes {
         $logger->logdie("Nodes import expects first column of first row to be a MAC address. Not processing file.");
     }
 
-    # TODO extract these in parameters under [import] in pf.conf
     # pre-compute info hash
     my %info = (
         notes => POSIX::strftime("Imported on %Y-%m-%d %H:%M:%S", localtime(time))
     );
+
+    # Assign default values from parameters under [node_import] in pf.conf
+    # fancy hash slicing assigns pid to pid, etc.
+    @info{qw/pid category voip/} = @{$Config{'node_import'}}{qw/pid category voip/};
 
     do {
         # setup

--- a/lib/pf/pfcmd/help.pm
+++ b/lib/pf/pfcmd/help.pm
@@ -612,7 +612,9 @@ sub help_import {
     print STDERR << "EOT";
 Usage: pfcmd import <format> <filename>
 
-Bulk import into the database. File input must be a of CSV format.
+Bulk import into the database. File input must be a of CSV format. Default
+pid, category and voip status assigned to the imported nodes can be modified
+in pf.conf.
 
 Supported format:
 - nodes
@@ -620,7 +622,8 @@ Supported format:
 Nodes import format:
 <MAC>
 
-Node import automatically registers MACs with pid = 1
+Node import automatically registers MACs with pid = 1 unless you configured
+otherwise in pf.conf.
 
 example:
   pfcmd import nodes /tmp/new-nodes.csv


### PR DESCRIPTION
So in `pf.conf` with:

```
[node_import]
category=staff
```

It will import and register the nodes with a staff category.

pid, category and voip (yes/no) is supported.

Someone please ACK.
