### PR TITLE
pid (username) of the form 'domain\\user' are now allowed

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -40,6 +40,7 @@ Bug Fixes
  * 'uninitialized value' warnings in checkup phase (pfcmd checkup)
  * got rid of the unused (unuseful) logs/pfdhcplistener_<int> log files. See logs/packetfence.log instead.
  * pfdhcplistener doesn't hang anymore
+ * pid (username) of the form 'domain\\user' are now allowed (#1253)
 
 --------------------------------------------------------------------------------
 Version 3.3.2 released on 2012-04-23

--- a/lib/pf/pfcmd.pm
+++ b/lib/pf/pfcmd.pm
@@ -31,7 +31,7 @@ Readonly our $ERROR_CONFIG_NO_HELP => 11;
 my $pid_re = qr{(?: 
     ( [a-zA-Z0-9\-\_\.\@\/\:\+\!,]+ )                               # unquoted allowed
     |                                                               # OR
-    \" ( [&=?\(\)\/,0-9a-zA-Z_\*\.\-\:\;\@\ \+\!\^\[\]\|\#]+ ) \"   # quoted allowed
+    \" ( [&=?\(\)\/,0-9a-zA-Z_\*\.\-\:\;\@\ \+\!\^\[\]\|\#\\]+ ) \" # quoted allowed
 )}xo;
 
 sub parseCommandLine {

--- a/lib/pf/pfcmd/pfcmd.pm
+++ b/lib/pf/pfcmd/pfcmd.pm
@@ -58,7 +58,7 @@ $grammar = q {
 
    manage_options : 'register' macaddr pid edit_options(?)
 
-   person_options : 'add' value person_edit_options(?)  | 'edit' value person_edit_options | 'delete' value
+   person_options : 'add' pid person_edit_options(?)  | 'edit' pid person_edit_options | 'delete' value
 
    node_options : 'add' macaddr node_edit_options | 'edit' macaddr node_edit_options 
 
@@ -90,7 +90,8 @@ $grammar = q {
    date : /[^,=]+/
 
    # backticks only tolerated because pfcmd manage register is always called within single quotes
-   pid: '"' /[&=?()\/,0-9a-zA-Z_\*\.\-\:\;\@\ \+\!\^\[\]\|\#]*/ '"' {$item[2]} | /[&=?()\/,0-9a-zA-Z_\*\.\-\:\;\@\ \+\!\^\[\]\|\#]*/
+   # another pid regex is also defined in pf::pfcmd. Make sure to maintain both.
+   pid: '"' /[&=?()\/,0-9a-zA-Z_\*\.\-\:\;\@\ \+\!\^\[\]\|\#\\\\]*/ '"' {$item[2]} | /[&=?()\/,0-9a-zA-Z_\*\.\-\:\;\@\ \+\!\^\[\]\|\#]*/
 
    edit_options : <leftop: assignment ',' assignment>
 
@@ -137,8 +138,8 @@ $grammar = q {
    violationconfig_assignment : violationconfig_view_field '=' value
                 {push @{$main::cmd{$item[0]}}, [$item{violationconfig_view_field},$item{value}] }
 
-   node_assignment : node_view_field '=' value
-                {push @{$main::cmd{$item[0]}}, [$item{node_view_field},$item{value}] }
+   node_assignment : node_view_field '=' value {push @{$main::cmd{$item[0]}}, [$item{node_view_field},$item{value}] }
+                     | 'pid' '=' pid {push @{$main::cmd{$item[0]}}, ['pid',$item{pid}] }
 
    nodecategory_assignment : nodecategory_view_field '=' value
                 {push @{$main::cmd{$item[0]}}, [$item{nodecategory_view_field},$item{value}] }


### PR DESCRIPTION
http://packetfence.org/bugs/view.php?id=1253

Tested in 'in the field' and worked. Pull request opened mostly so reviewers get a hold of our complex grammar setup.
