### PR TITLE
pfdhcplistener process management improvements

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -15,6 +15,9 @@ For a list of compatibility related changes see the UPGRADE file.
 --------------------------------------------------------------------------------
 Version <stableRelease> released on <releaseDate>
 
+Enhancements
+ * Improved pfdhcplistener process surveillance (#1490)
+
 Bug Fixes
  * FreeRADIUS watchdog updated for 3.5.0 changes (#1514)
  * debian packages improvements regarding FreeRADIUS configuration

--- a/NEWS
+++ b/NEWS
@@ -21,6 +21,7 @@ Bug Fixes
  * cosmetic fix in `pfcmd service ... status` regarding pfdhcplistener (#1515)
  * Guests are not able to confirm registration in some cases - take 2 (#1302)
  * Sponsored guests regressions (#1505)
+ * pfdhcplistener process name identifies listened to interface (#1478)
 
 --------------------------------------------------------------------------------
 Version 3.5.0 released on 2012-08-01

--- a/sbin/pfdhcplistener
+++ b/sbin/pfdhcplistener
@@ -144,6 +144,10 @@ sub dhcp_detector {
     my $mask;
     my $opt = 1;
     my $err;
+
+    # updating process name so we know what interface we are listening on
+    # WARNING: the format is expected by watchdog in pf::services. Don't change lightly.
+    $PROGRAM_NAME = basename($PROGRAM_NAME) . ": listening on $interface";
     $pcap = Net::Pcap::pcap_open_live( $interface, 576, 1, 0, \$err );
 
     if (!defined($pcap)) {


### PR DESCRIPTION
Fixes
#1478: pfdhcplistener process name identifies listened to interface

http://packetfence.org/bugs/view.php?id=1478
#1490:

```
    Improved pfdhcplistener process surveillance (#1490)
    - listing exactly the interfaces that should run pfdhcplisteners (previous implementation had a bug)
    - using pgrep and looking exactly for `pfdhcplistener: listening on $interface`. This means unrelated hung proces
    - improved logging to help log analysis after problems
```

http://packetfence.org/bugs/view.php?id=1490
