### PR TITLE
person pid parsing regression #1523

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -21,6 +21,7 @@ Bug Fixes
  * cosmetic fix in `pfcmd service ... status` regarding pfdhcplistener (#1515)
  * Guests are not able to confirm registration in some cases - take 2 (#1302)
  * Sponsored guests regressions (#1505)
+ * Command parsing issue with `pfcmd person` (#1523)
 
 --------------------------------------------------------------------------------
 Version 3.5.0 released on 2012-08-01

--- a/UPGRADE
+++ b/UPGRADE
@@ -5,6 +5,18 @@ http://www.packetfence.org/
 Notes on upgrading from an older release
 ----------------------------------------
 
+Upgrading from a version prior to <stableRelease>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.Parser updates
+Changes were made to the command parser. If you are using a packaged
+distribution you have nothing to do. If you installed from source, you
+will need to regenerate the precompiled grammar. Follow the instructions
+in:
+
+    perldoc /usr/local/pf/lib/pfcmd/pfcmd.pm
+
+
 o Upgrading from a version prior to 3.5.0:
 
     - Database schema update

--- a/lib/pf/pfcmd/pfcmd.pm
+++ b/lib/pf/pfcmd/pfcmd.pm
@@ -89,9 +89,8 @@ $grammar = q {
 
    date : /[^,=]+/
 
-   # backticks only tolerated because pfcmd manage register is always called within single quotes
    # another pid regex is also defined in pf::pfcmd. Make sure to maintain both.
-   pid: '"' /[&=?()\/,0-9a-zA-Z_\*\.\-\:\;\@\ \+\!\^\[\]\|\#\\\\]*/ '"' {$item[2]} | /[&=?()\/,0-9a-zA-Z_\*\.\-\:\;\@\ \+\!\^\[\]\|\#]*/
+   pid: '"' /[&=?()\/,0-9a-zA-Z_\*\.\-\:\;\@\ \+\!\^\[\]\|\#\\\\]+/ '"' {$item[2]} | /[a-zA-Z0-9\-\_\.\@\/\:\+\!,]+/
 
    edit_options : <leftop: assignment ',' assignment>
 

--- a/t/pfcmd.t
+++ b/t/pfcmd.t
@@ -14,7 +14,7 @@ use diagnostics;
 
 use lib '/usr/local/pf/lib';
 
-use Test::More tests => 89;
+use Test::More tests => 91;
 use Test::NoWarnings;
 
 use English '-no_match_vars';
@@ -207,6 +207,35 @@ is_deeply(\%cmd,
     { 'command' => [ 'person', 'view', 'user name' ], 'person_options' => [ 'view', 'user name' ] },
     'pfcmd person view pid with space'
 );
+
+# regression tests for #1523
+# Watch out! Grammar parser is tested differently than normal regex parser.
+# TODO we should probably refactor it to make it easier to test.
+%cmd = pf::pfcmd::parseCommandLine('person add peter@initech.com firstname="",lastname="",email="",telephone="",company="",address="",notes="",sponsor=""');
+is( $cmd{'grammar'}, 1, 'pfcmd person add pid spaces without quotes regression (issue 1523) - grammar passed' );
+
+# avoiding use only once warning for %main::cmd
+# we can safely remove it once we use it at least twice
+{
+    no warnings 'once';
+    is_deeply(\%main::cmd,
+        {
+            'command' => [ 'person', ],
+            'person_assignment' => [
+                [ 'firstname', '' ],
+                [ 'lastname', '' ],
+                [ 'email', '' ],
+                [ 'telephone', '' ],
+                [ 'company', '' ],
+                [ 'address', '' ],
+                [ 'notes', '' ],
+                [ 'sponsor', '' ]
+            ],
+            'person_options' => [ 'add', 'peter@initech.com', [ 1, 2, 3, 4, 5, 6, 7, 8 ] ],
+        },
+        'pfcmd person add pid spaces without quotes regression (issue 1523) - proper option parse'
+    );
+}
 
 %cmd = pf::pfcmd::parseCommandLine('reload fingerprints');
 is_deeply(\%cmd,


### PR DESCRIPTION
The pid parser allowed spaces even in the unquoted format which means that
it greadily expanded to grab the next token (pid firstname=...) instead of
just sticking to it's pid.

Regression introduced in `manage register` in 3.0 and further exposed to
person commands in 3.4.0.

Regression test included.

http://packetfence.org/bugs/view.php?id=1523
