### PR TITLE
performance improvement when querying node info w/ dhcp

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -18,6 +18,7 @@ Version <stableRelease> released on <releaseDate>
 Enhancements
  * Configuration item to notify of guest sponsorships by email: guests_self_registration.sponsorship_cc
  * Developers guide was migrated from Docbook into the asciidoc format
+ * Important database performance improvement in VoIP and fingerprint checks
 
 Bug Fixes
  * FreeRADIUS watchdog updated for 3.5.0 changes (#1514)

--- a/UPGRADE
+++ b/UPGRADE
@@ -5,6 +5,12 @@ http://www.packetfence.org/
 Notes on upgrading from an older release
 ----------------------------------------
 
+o Upgrading from a version prior to <stableRelease>:
+
+    - Deprecation advance notice: pf::node's node_view_with_fingerprint
+    node_view_with_fingerprint will be deprecated somewhere in 2013. Please
+    migrate your custom code to the faster node_attributes_with_fingerprint.
+
 o Upgrading from a version prior to 3.5.0:
 
     - Database schema update

--- a/addons/recovery.pl
+++ b/addons/recovery.pl
@@ -269,7 +269,7 @@ sub recoverSwitch {
                 @currentPhones
                     = $switch->getPhonesDPAtIfIndex($currentIfIndex);
                 foreach my $mac (@currentMacs) {
-                    my $node_info = node_view_with_fingerprint($mac);
+                    my $node_info = node_attributes_with_fingerprint($mac);
                     my $isPhone   = (
                         ( grep( {/^$mac$/i} @currentPhones ) != 0 )
                             || ( defined($node_info)

--- a/lib/pf/SNMP.pm
+++ b/lib/pf/SNMP.pm
@@ -1474,7 +1474,7 @@ sub isPhoneAtIfIndex {
         return 0;
     }
     $logger->trace("determining DHCP fingerprint info for $mac");
-    my $node_info = node_view_with_fingerprint($mac);
+    my $node_info = node_attributes_with_fingerprint($mac);
 
     if (defined($node_info->{'voip'}) && $node_info->{'voip'} eq $VOIP) {
         $logger->debug("This is a VoIP phone according to node.voip");

--- a/t/dao/node.t
+++ b/t/dao/node.t
@@ -48,8 +48,8 @@ my @simple_methods = qw(
     }
 }
 
-# node_view_with_fingerprint returns 0 on failure, test against that
-ok(node_view_with_fingerprint('f0:4d:a2:cb:d9:c5'), "node_view_with_fingerprint SQL query pass");
+# node_attributes_with_fingerprint returns 0 on failure, test against that
+ok(node_attributes_with_fingerprint('f0:4d:a2:cb:d9:c5'), "node_attributes_with_fingerprint SQL query pass");
 
 # node_view returns 0 on failure, test against that
 ok(node_view('f0:4d:a2:cb:d9:c5'), "node_view SQL query pass");
@@ -64,7 +64,7 @@ Olivier Bilodeau <obilodeau@inverse.ca>
         
 =head1 COPYRIGHT
         
-Copyright (C) 2010-2011 Inverse inc.
+Copyright (C) 2010-2012 Inverse inc.
 
 =head1 LICENSE
     


### PR DESCRIPTION
Field tested. Ready for review.

commit log:

```
Introduced a new call node_attributes_with_fingerprint that carries less
information than node_view_with_fingerprint but that is a lot less intensive
on CPU. All core code callers didn't require the extended informations
anyway.

node_view_with_fingerprint is explicitly deprecated. To the point where
warnings will be logged when it's used.
```
