### PR TITLE
refactoring related to #1516: illegal characters in webservices user / pass not properly escaped

### DIFF
--- a/lib/pf/util/freeradius.pm
+++ b/lib/pf/util/freeradius.pm
@@ -1,0 +1,100 @@
+package pf::util::freeradius;
+
+=head1 NAME
+
+pf::util::freeradius - FreeRADIUS rlm_perl related utilities
+
+=cut
+
+=head1 DESCRIPTION
+
+Small thread-safe utilities for our FreeRADIUS rlm_perl modules.
+
+=cut
+use strict;
+use warnings;
+
+BEGIN {
+    use Exporter ();
+    our ( @ISA, @EXPORT, @EXPORT_OK );
+    @ISA = qw(Exporter);
+    @EXPORT = qw();
+    @EXPORT_OK = qw(clean_mac sanitize_parameter);
+}
+
+=head1 SUBROUTINES
+
+=over
+
+=item clean_mac 
+
+Clean a MAC address accepting xx-xx-xx-xx-xx-xx, xx:xx:xx:xx:xx:xx, xxxx-xxxx-xxxx and xxxx.xxxx.xxxx.
+
+Returns a string with MAC in format: xx:xx:xx:xx:xx:xx
+
+=cut
+sub clean_mac {
+    my ($mac) = @_;
+    return (0) if ( !$mac );
+    # trim garbage
+    $mac =~ s/[\s\-\.:]//g;
+    # lowercase
+    $mac = lc($mac);
+    # inject :
+    $mac =~ s/([a-f0-9]{2})(?!$)/$1:/g if ( $mac =~ /^[a-f0-9]{12}$/i );
+    return ($mac);
+}
+
+=item sanitize_parameter
+
+URL encode illegal characters from WS_USER/WS_PASS used in SOAP calls.
+
+Ref: http://tools.ietf.org/html/rfc1738#section-3.1
+
+=cut
+sub sanitize_parameter {
+    my ($parameter) = @_;
+
+    my %ascii_hex_value = (
+        ':' => '%3A',
+        '@' => '%40',
+        '/' => '%2F',
+    );
+
+    while (my ($find, $replace) = each %ascii_hex_value) {
+        eval { $parameter =~ s{$find}{$replace}g; };
+    }
+
+    return $parameter;
+}
+
+=back
+
+=head1 AUTHOR
+
+Olivier Bilodeau <obilodeau@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2012 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;

--- a/raddb/packetfence-soh.pm
+++ b/raddb/packetfence-soh.pm
@@ -12,7 +12,7 @@ This module forwards SoH authorization requests to Packetfence.
 
 use strict;
 use warnings;
-use diagnostics;
+
 use Sys::Syslog;
 use Try::Tiny;
 
@@ -144,11 +144,9 @@ Abhijit Menon-Sen <amenonsen@inverse.ca>
 
 Derek Wuelfrath <dwuelfrath@inverse.ca>
 
-Based on packetfence.pm (from PacketFence's 802.1x addon).
-
 =head1 COPYRIGHT
 
-Copyright (C) 2011-2012 Inverse inc. <support@inverse.ca>
+Copyright (C) 2011-2012 Inverse inc.
 
 =head1 LICENSE
 

--- a/raddb/packetfence-soh.pm
+++ b/raddb/packetfence-soh.pm
@@ -16,6 +16,10 @@ use warnings;
 use Sys::Syslog;
 use Try::Tiny;
 
+use lib '/usr/local/pf/lib/';
+
+use pf::util::freeradius qw(sanitize_parameter);
+
 # Configuration parameters
 use constant {
     # FreeRADIUS to PacketFence communications (SOAP Server settings)
@@ -109,29 +113,6 @@ sub authorize {
     return $code;
 }
 
-=item * sanitize_parameter
-
-URL encode illegal characters from WS_USER/WS_PASS used in SOAP calls.
-
-Ref: http://tools.ietf.org/html/rfc1738#section-3.1
-
-=cut
-sub sanitize_parameter {
-    my ($parameter) = @_;
-
-    my %ascii_hex_value = (
-        ':' => '%3A',
-        '@' => '%40',
-        '/' => '%2F',
-    );
-
-    while (my ($find, $replace) = each %ascii_hex_value) {
-        eval { $parameter =~ s{$find}{$replace}g; };
-    }
-
-    return $parameter;
-}
-
 =back
 
 =head1 SEE ALSO
@@ -139,6 +120,8 @@ sub sanitize_parameter {
 L<http://wiki.freeradius.org/Rlm_perl>
 
 =head1 AUTHOR
+
+Olivier Bilodeau <obilodeau@inverse.ca>
 
 Abhijit Menon-Sen <amenonsen@inverse.ca>
 

--- a/raddb/packetfence.pm
+++ b/raddb/packetfence.pm
@@ -13,6 +13,10 @@ packetfence.pm contains the functions necessary to integrate PacketFence and Fre
 use strict;
 use warnings;
 
+use lib '/usr/local/pf/lib/';
+
+use pf::util::freeradius qw(clean_mac sanitize_parameter);
+
 # Configuration parameters
 use constant {
     # FreeRADIUS to PacketFence communications (SOAP Server settings)
@@ -246,50 +250,6 @@ sub is_eap_mac_authentication {
         }
     }
     return 0;
-}
-
-=item * clean_mac 
-
-Clean a MAC address accepting xx-xx-xx-xx-xx-xx, xx:xx:xx:xx:xx:xx, xxxx-xxxx-xxxx and xxxx.xxxx.xxxx.
-
-Returns a string with MAC in format: xx:xx:xx:xx:xx:xx
-
-Note: This sub was copied from pf::util.
-
-=cut
-sub clean_mac {
-    my ($mac) = @_;
-    return (0) if ( !$mac );
-    # trim garbage
-    $mac =~ s/[\s\-\.:]//g;
-    # lowercase
-    $mac = lc($mac);
-    # inject :
-    $mac =~ s/([a-f0-9]{2})(?!$)/$1:/g if ( $mac =~ /^[a-f0-9]{12}$/i );
-    return ($mac);
-}
-
-=item * sanitize_parameter
-
-URL encode illegal characters from WS_USER/WS_PASS used in SOAP calls.
-
-Ref: http://tools.ietf.org/html/rfc1738#section-3.1
-
-=cut
-sub sanitize_parameter {
-    my ($parameter) = @_;
-
-    my %ascii_hex_value = (
-        ':' => '%3A',
-        '@' => '%40',
-        '/' => '%2F',
-    );
-
-    while (my ($find, $replace) = each %ascii_hex_value) {
-        eval { $parameter =~ s{$find}{$replace}g; };
-    }
-
-    return $parameter;
 }
 
 #

--- a/raddb/packetfence.pm
+++ b/raddb/packetfence.pm
@@ -387,7 +387,7 @@ Copyright (C) 2002  The FreeRADIUS server project
 
 Copyright (C) 2002  Boian Jordanov <bjordanov@orbitel.bg>
 
-Copyright (C) 2006-2010, 2012 Inverse inc. <support@inverse.ca>
+Copyright (C) 2006-2010, 2012 Inverse inc.
 
 =head1 LICENSE
 


### PR DESCRIPTION
As discussed in pull request #46 the code duplication in the fix for [issue # 1516](http://packetfence.org/bugs/view.php?id=1516) is bad.

Here's a refactoring of the duplicated code into a shared lib.

Targeted to devel because I only tested with a single RADIUS request in the lab and not if there were unintended high-load / multi-threaded consequences.

NEWS entry:

```
Enhancements:
 * Minor refactoring
```
