### PR TITLE
getting rid of domain from our gettext po resources (#1433)

### DIFF
--- a/addons/packages/packetfence.spec
+++ b/addons/packages/packetfence.spec
@@ -223,8 +223,8 @@ mv pfcmd_pregrammar.pm lib/pf/pfcmd/
 
 # generate translations
 for TRANSLATION in de en es fr he_IL it nl pt_BR; do 
-    /usr/bin/msgfmt conf/locale/$TRANSLATION/LC_MESSAGES/packetfence.po
-    mv packetfence.mo conf/locale/$TRANSLATION/LC_MESSAGES/
+    /usr/bin/msgfmt conf/locale/$TRANSLATION/LC_MESSAGES/packetfence.po \
+      --output-file conf/locale/$TRANSLATION/LC_MESSAGES/packetfence.mo
 done
 
 # RHEL6 only: generating PDF guides

--- a/conf/locale/de/LC_MESSAGES/packetfence.po
+++ b/conf/locale/de/LC_MESSAGES/packetfence.po
@@ -4,8 +4,6 @@
 # Translators:
 # Tino Matysiak <tmatysiak@meetyoo.de>, 2011.
 #
-domain "packetfence"
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PacketFence\n"

--- a/conf/locale/en/LC_MESSAGES/packetfence.po
+++ b/conf/locale/en/LC_MESSAGES/packetfence.po
@@ -5,8 +5,6 @@
 # Olivier Bilodeau <obilodeau@inverse.ca>, 2009-2012.
 # Derek Wuelfrath <dwuelfrath@inverse.ca>, 2012.
 #
-domain "packetfence"
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PacketFence\n"

--- a/conf/locale/es/LC_MESSAGES/packetfence.po
+++ b/conf/locale/es/LC_MESSAGES/packetfence.po
@@ -6,8 +6,6 @@
 # Juan Camilo Valencia <juan.valencia@seguratec.com.co>, 2011-2012.
 # Dominique Couot <dcouot@hotmail.com>, 2012.
 #
-domain "packetfence"
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PacketFence\n"

--- a/conf/locale/fr/LC_MESSAGES/packetfence.po
+++ b/conf/locale/fr/LC_MESSAGES/packetfence.po
@@ -7,8 +7,6 @@
 # Dominique Couot <dcouot@hotmail.com>, 2012.
 # Inverse inc.  <info@inverse.ca>, 2012.
 #
-domain "packetfence"
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PacketFence\n"

--- a/conf/locale/he_IL/LC_MESSAGES/packetfence.po
+++ b/conf/locale/he_IL/LC_MESSAGES/packetfence.po
@@ -4,8 +4,6 @@
 # Translators:
 # Ereli <ereli@securegion.com>, 2011.
 #
-domain "packetfence"
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PacketFence\n"

--- a/conf/locale/it/LC_MESSAGES/packetfence.po
+++ b/conf/locale/it/LC_MESSAGES/packetfence.po
@@ -4,8 +4,6 @@
 # Translators:
 # Mario Varelli <mvarelli@biologia.unipi.it>, 2009.
 #
-domain "packetfence"
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PacketFence\n"

--- a/conf/locale/nl/LC_MESSAGES/packetfence.po
+++ b/conf/locale/nl/LC_MESSAGES/packetfence.po
@@ -3,8 +3,6 @@
 # 
 # Translators:
 #
-domain "packetfence"
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PacketFence\n"

--- a/conf/locale/pt_BR/LC_MESSAGES/packetfence.po
+++ b/conf/locale/pt_BR/LC_MESSAGES/packetfence.po
@@ -5,8 +5,6 @@
 # Brivaldo Junior <condector@gmail.com>, 2011.
 # Diego de Souza Lopes <djkakaroto@gmail.com>, 2011, 2012.
 #
-domain "packetfence"
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PacketFence\n"


### PR DESCRIPTION
fix for [#1433: get rid of our domain in packetfence's gettext (PO) files](http://packetfence.org/bugs/view.php?id=1433)

simplifies greatly transifex sync

debian package not updated since it's not even creating translations right now. Will fix that in a separate branch.

```
NEWS

Bug fixes:
 * No more domain in our gettext po resources files (#1433)

```
