### PR TITLE
Feature/remove default switch

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -19,6 +19,7 @@ New Hardware
  * Support for Cisco Catalyst 2960G in 802.1X / MAC-Authentication
 
 Enhancements
+ * Removed 127.0.0.1 switch from the config and added in the code
 
 Bug Fixes
  * Adding radius.log into the logrotate script (#1526)

--- a/UPGRADE
+++ b/UPGRADE
@@ -29,6 +29,8 @@ Upgrading from a version prior to 3.5.0
 
 ----
 
+    - Switch 127.0.0.1 must be removed from the switches.conf
+
     - Database schema update
     New accounting violations and other violation related stuff needed some modifications
     to the current database schema. Make sur you run the following to update

--- a/bin/pfcmd
+++ b/bin/pfcmd
@@ -964,6 +964,7 @@ sub switchconfig {
         #sort the switches (http://www.sysarch.com/Perl/sort_paper.html)
         my %switches_conf_tmp = %switches_conf;
         delete $switches_conf_tmp{'default'};
+        delete $switches_conf_tmp{'127.0.0.1'};
         my @sections_tmp = keys(%switches_conf_tmp);
         my @sections
             = map substr( $_, 4 ) => sort

--- a/bin/pfcmd
+++ b/bin/pfcmd
@@ -992,7 +992,7 @@ sub switchconfig {
         }
     } elsif ( $mode eq 'delete' ) {
         my $section = $cmd{'command'}[2];
-        if ( $section =~ /^(default|all|127.0.0.1)$/ ) {
+        if ( $section =~ /^(default|all)$/ ) {
             print "This switch can't be deleted (Error at line ".__LINE__." in pfcmd)\n";
             exit;
         } else {

--- a/conf/switches.conf
+++ b/conf/switches.conf
@@ -82,14 +82,6 @@ radiusSecret=
 # Format: <category_name1>=<controller_role1>;<category_name2>=<controller_role2>;...
 roles=
 
-[127.0.0.1]
-type = PacketFence
-mode = production
-uplink = dynamic
-# SNMP Traps v1 are used for internal messages
-SNMPVersionTrap=1
-SNMPCommunityTrap=public
-
 [192.168.0.1]
 type = Cisco::Catalyst_2900XL
 mode = production

--- a/lib/pf/SwitchFactory.pm
+++ b/lib/pf/SwitchFactory.pm
@@ -358,6 +358,11 @@ sub readConfig {
             $SwitchConfig{$section}{$key} =~ s/\s+$//;
         }
     }
+    #Prevent the presence of 127.0.0.1 in switches.conf
+    if (defined($SwitchConfig{'127.0.0.1'})) {
+        delete $SwitchConfig{'127.0.0.1'};
+    }
+
     #Instanciate 127.0.0.1 switch
     $SwitchConfig{'127.0.0.1'} = {type => 'PacketFence', mode => 'production', uplink => 'dynamic', SNMPVersionTrap => '1', SNMPCommunityTrap => 'public'};
 

--- a/lib/pf/SwitchFactory.pm
+++ b/lib/pf/SwitchFactory.pm
@@ -358,6 +358,10 @@ sub readConfig {
             $SwitchConfig{$section}{$key} =~ s/\s+$//;
         }
     }
+    #Instanciate 127.0.0.1 switch
+    $SwitchConfig{'127.0.0.1'} = {type => 'PacketFence', mode => 'production', uplink => 'dynamic', SNMPVersionTrap => '1', SNMPCommunityTrap => 'public'};
+
+
     %{ $this->{_config} } = %SwitchConfig;
 
     return 1;

--- a/lib/pf/configfile.pm
+++ b/lib/pf/configfile.pm
@@ -29,6 +29,15 @@ use Log::Log4perl;
 use File::Copy;
 
 use constant CONFIGFILE => 'configfile';
+use constant DEFAULT_SWITCH => '
+[127.0.0.1]
+type=PacketFence
+mode=production
+uplink=dynamic
+# SNMP Traps v1 are used for internal messages
+SNMPVersionTrap=1
+SNMPCommunityTrap=public
+';
 
 BEGIN {
     use Exporter ();
@@ -157,9 +166,13 @@ sub configfile_add {
     my $lastMod = ( stat($filename) )[9];
 
     open my $configfile_fh, '<', $filename;
-    my @content = <$configfile_fh>;
+    my $content ='';
+    while (<$configfile_fh>) {
+        $content .= $_;
+    }
+    $content .= DEFAULT_SWITCH;
     close $configfile_fh;
-    db_query_execute(CONFIGFILE, $configfile_statements, 'configfile_add_sql', $filename, join('', @content), $lastMod)
+    db_query_execute(CONFIGFILE, $configfile_statements, 'configfile_add_sql', $filename, $content, $lastMod)
         || return (0);
     return (1);
 }
@@ -169,10 +182,14 @@ sub configfile_update {
     my $lastMod = ( stat($filename) )[9];
 
     open my $configfile_fh, '<', $filename;
-    my @content = <$configfile_fh>;
+    my $content ='';
+    while (<$configfile_fh>) {
+        $content .= $_;
+    }
+    $content .= DEFAULT_SWITCH;
     close $configfile_fh;
-    db_query_execute(CONFIGFILE, $configfile_statements, 'configfile_update_sql', 
-        join('', @content), $lastMod, $filename)
+    db_query_execute(CONFIGFILE, $configfile_statements, 'configfile_update_sql',
+        $content, $lastMod, $filename)
         || return (0);
     return (1);
 }

--- a/lib/pf/configfile.pm
+++ b/lib/pf/configfile.pm
@@ -29,15 +29,6 @@ use Log::Log4perl;
 use File::Copy;
 
 use constant CONFIGFILE => 'configfile';
-use constant DEFAULT_SWITCH => '
-[127.0.0.1]
-type=PacketFence
-mode=production
-uplink=dynamic
-# SNMP Traps v1 are used for internal messages
-SNMPVersionTrap=1
-SNMPCommunityTrap=public
-';
 
 BEGIN {
     use Exporter ();
@@ -166,13 +157,9 @@ sub configfile_add {
     my $lastMod = ( stat($filename) )[9];
 
     open my $configfile_fh, '<', $filename;
-    my $content ='';
-    while (<$configfile_fh>) {
-        $content .= $_;
-    }
-    $content .= DEFAULT_SWITCH;
+    my @content = <$configfile_fh>;
     close $configfile_fh;
-    db_query_execute(CONFIGFILE, $configfile_statements, 'configfile_add_sql', $filename, $content, $lastMod)
+    db_query_execute(CONFIGFILE, $configfile_statements, 'configfile_add_sql', $filename, join('', @content), $lastMod)
         || return (0);
     return (1);
 }
@@ -182,14 +169,10 @@ sub configfile_update {
     my $lastMod = ( stat($filename) )[9];
 
     open my $configfile_fh, '<', $filename;
-    my $content ='';
-    while (<$configfile_fh>) {
-        $content .= $_;
-    }
-    $content .= DEFAULT_SWITCH;
+    my @content = <$configfile_fh>;
     close $configfile_fh;
     db_query_execute(CONFIGFILE, $configfile_statements, 'configfile_update_sql',
-        $content, $lastMod, $filename)
+        join('', @content), $lastMod, $filename)
         || return (0);
     return (1);
 }

--- a/lib/pf/pfcmd/checkup.pm
+++ b/lib/pf/pfcmd/checkup.pm
@@ -854,6 +854,9 @@ sub switches {
     foreach my $section ( keys %switches_conf ) {
         # skip default switch parameters
         next if ( $section =~ /^default$/i ); 
+        if ( $section eq '127.0.0.1' ) {
+            add_problem( $WARN, "switches.conf | Switch 127.0.0.1 is defined but it had to be removed" );
+        }
         
         # validate that switches are not duplicated (we check for type and mode specifically) fixes #766
         if ( ref($switches_conf{$section}{'type'}) eq 'ARRAY' || ref($switches_conf{$section}{'mode'}) eq 'ARRAY' ) {

--- a/t/SwitchFactory.t
+++ b/t/SwitchFactory.t
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use diagnostics;
 
-use Test::More tests => 41;
+use Test::More tests => 35;
 use lib '/usr/local/pf/lib';
 
 BEGIN { use_ok('pf::SwitchFactory') }
@@ -12,15 +12,6 @@ BEGIN { use_ok('pf::SwitchFactory') }
 my $switchFactory = pf::SwitchFactory->getInstance( -configFile => './data/switches.conf' );
 
 my $switch;
-$switch = $switchFactory->instantiate('127.0.0.1');
-isa_ok( $switch, 'pf::SNMP::PacketFence' );
-is( $switch->{_ip}, '127.0.0.1', 'IP Address of 127.0.0.1' );
-is_deeply( $switch->{_uplink}, [qw(dynamic)], 'Uplink of 127.0.0.1' );
-is( $switch->{_SNMPVersion}, '2c', 'SNMP version of 127.0.0.1' );
-is( $switch->{_SNMPCommunityTrap},
-    'public', 'SNMP trap community of 127.0.0.1' );
-is( $switch->{_SNMPVersionTrap}, '2c', 'SNMP trap version of 127.0.0.1' );
-
 $switch = $switchFactory->instantiate('192.168.0.1');
 isa_ok( $switch, 'pf::SNMP::Cisco::Catalyst_2900XL' );
 is( $switch->{_ip}, '192.168.0.1', 'IP Address of 192.168.0.1' );


### PR DESCRIPTION
Remove the switch 127.0.0.1 in the switches.conf and instantiate it on the code
## 

NEWS entry:
- Removed static configuration of 127.0.0.1 switch in switches.conf to avoid borked configuration by people who deleted this one switch needed for communication between PacketFence and pfsetvlan.

UPGRADE entry:
- We removed the static configuration of 127.0.0.1 switch in switches.conf as described in the NEWS document. You can safely remove this one switch from your current configuration. Failure to do so won't affect the proper functioning of the solution but we encourage you to proceed.
