### PR TITLE
Improved LLDP support

### DIFF
--- a/UPGRADE
+++ b/UPGRADE
@@ -6,6 +6,16 @@ http://www.packetfence.org/
 Notes on upgrading from an older release.
 
 
+Upgrading from a version prior to <stableRelease>
+-------------------------------------------------
+
+.LLDP Support
+
+LLDP discovery of VoIP phones has been improved and streamlined. Let us know
+if you experience any regressions or if you have switches that support LLDP
+that you would like to see supported.
+
+
 Upgrading from a version prior to 3.5.1
 ---------------------------------------
 

--- a/lib/pf/SNMP.pm
+++ b/lib/pf/SNMP.pm
@@ -151,6 +151,28 @@ sub supportsSaveConfig {
     return $FALSE;
 }
 
+=item supportsCdp
+
+Does the network device supports Cisco Discovery Protocol (CDP)
+
+=cut
+sub supportsCdp {
+    my ( $this ) = @_;
+    my $logger = Log::Log4perl::get_logger( ref($this) );
+    return $FALSE;
+}
+
+=item supportsLldp
+
+Does the network device supports Link-Layer Discovery Protocol (LLDP)
+
+=cut
+sub supportsLldp {
+    my ( $this ) = @_;
+    my $logger = Log::Log4perl::get_logger( ref($this) );
+    return $FALSE;
+}
+
 =item supportsRadiusDynamicVlanAssignment
 
 =cut
@@ -1420,15 +1442,38 @@ sub isStaticPortSecurityEnabled {
     return ( 0 == 1 );
 }
 
+=item getPhonesDPAtIfIndex
+
+Obtain phones from discovery protocol at ifIndex.
+
+Polls from all supported sources and will filter out duplicates.
+
+=cut
+# TODO one day, with Moose roles, the CDP / LLDP role will require the proper
+# implementations of getPhonesCDPAtIfIndex / getPhonesLLDPAtIfIndex
 sub getPhonesDPAtIfIndex {
     my ( $this, $ifIndex ) = @_;
     my $logger = Log::Log4perl::get_logger( ref($this) );
-    my @phones;
+
     if ( !$this->isVoIPEnabled() ) {
-        $logger->debug( "VoIP not enabled on switch " . $this->{_ip} );
-        return @phones;
+        $logger->debug( "VoIP not enabled on network device $this->{_ip}: no phones returned" );
+        return;
     }
-    return @phones;
+
+    my @phones = ();
+    # CDP
+    if ($this->supportsCdp()) {
+        push @phones, $this->getPhonesCDPAtIfIndex($ifIndex);
+    }
+
+    # LLDP
+    if ($this->supportsLldp()) {
+        push @phones, $this->getPhonesLLDPAtIfIndex($ifIndex);
+    }
+
+    # filtering duplicates w/ hashmap (key collisions handles it)
+    my %phones = map { $_ => $TRUE } @phones;
+    return keys %phones;
 }
 
 =item hasPhoneAtIfIndex

--- a/lib/pf/SNMP.pm
+++ b/lib/pf/SNMP.pm
@@ -1473,6 +1473,13 @@ sub getPhonesDPAtIfIndex {
 
     # filtering duplicates w/ hashmap (key collisions handles it)
     my %phones = map { $_ => $TRUE } @phones;
+
+    # Log
+    if (%phones) {
+        $logger->info("We found an IP phone through discovery protocols for ifIndex $ifIndex");
+    } else {
+        $logger->info("Could not find any IP phones through discovery protocols for ifIndex $ifIndex");   
+    }
     return keys %phones;
 }
 

--- a/lib/pf/SNMP/Cisco.pm
+++ b/lib/pf/SNMP/Cisco.pm
@@ -29,6 +29,7 @@ use pf::util::radius qw(perform_coa);
 # CAPABILITIES
 # special features 
 sub supportsSaveConfig { return $TRUE; }
+sub supportsCdp { return $TRUE; }
 
 =head1 SUBROUTINES
 
@@ -1327,19 +1328,6 @@ sub getHubs {
 
     }
     return $hubPorts;
-}
-
-sub getPhonesDPAtIfIndex {
-    my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
-    my @phones;
-    if ( !$this->isVoIPEnabled() ) {
-        $logger->debug( "VoIP not enabled on switch "
-                . $this->{_ip}
-                . ". getPhonesDPAtIfIndex will return empty list." );
-        return @phones;
-    }
-    return $this->getPhonesCDPAtIfIndex($ifIndex);
 }
 
 sub getPhonesCDPAtIfIndex {

--- a/lib/pf/SNMP/Cisco/Aironet.pm
+++ b/lib/pf/SNMP/Cisco/Aironet.pm
@@ -72,6 +72,7 @@ sub supportsWirelessMacAuth { return $TRUE; }
 # disabling special features supported by generic Cisco's but not on Aironet
 sub supportsSaveConfig { return $FALSE; }
 sub supportsCdp { return $FALSE; }
+sub supportsLldp { return $FALSE; }
 
 =item deauthenticateMac
 

--- a/lib/pf/SNMP/Cisco/Aironet.pm
+++ b/lib/pf/SNMP/Cisco/Aironet.pm
@@ -69,8 +69,9 @@ TODO: This list is incomplete
 # access technology supported
 sub supportsWirelessDot1x { return $TRUE; }
 sub supportsWirelessMacAuth { return $TRUE; }
-# special features 
+# disabling special features supported by generic Cisco's but not on Aironet
 sub supportsSaveConfig { return $FALSE; }
+sub supportsCdp { return $FALSE; }
 
 =item deauthenticateMac
 
@@ -179,20 +180,6 @@ sub isDefinedVlan {
     my $logger = Log::Log4perl::get_logger( ref($this) );
     $logger->error("function is NOT implemented");
     return 0;
-}
-
-sub getPhonesDPAtIfIndex {
-    my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
-    my @phones = ();
-    if ( !$this->isVoIPEnabled() ) {
-        $logger->debug( "VoIP not enabled on switch "
-                . $this->{_ip}
-                . ". getPhonesDPAtIfIndex will return empty list." );
-        return @phones;
-    }
-    $logger->debug("no DP is available on Aironet");
-    return @phones;
 }
 
 sub isVoIPEnabled {

--- a/lib/pf/SNMP/Cisco/WLC.pm
+++ b/lib/pf/SNMP/Cisco/WLC.pm
@@ -121,8 +121,9 @@ sub supportsWirelessDot1x { return $TRUE; }
 sub supportsWirelessMacAuth { return $TRUE; }
 sub supportsRoleBasedEnforcement { return $TRUE; }
 
-# special features 
+# disabling special features supported by generic Cisco's but not on WLCs
 sub supportsSaveConfig { return $FALSE; }
+sub supportsCdp { return $FALSE; }
 
 =item deauthenticateMac
     
@@ -287,20 +288,6 @@ sub isDefinedVlan {
     my $logger = Log::Log4perl::get_logger( ref($this) );
     $logger->error("function is NOT implemented");
     return 0;
-}
-
-sub getPhonesDPAtIfIndex {
-    my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
-    my @phones = ();
-    if ( !$this->isVoIPEnabled() ) {
-        $logger->debug( "VoIP not enabled on switch "
-                . $this->{_ip}
-                . ". getPhonesDPAtIfIndex will return empty list." );
-        return @phones;
-    }
-    $logger->debug("no DP is available on Cisco Wireless Controllers");
-    return @phones;
 }
 
 sub isVoIPEnabled {

--- a/lib/pf/SNMP/Cisco/WLC.pm
+++ b/lib/pf/SNMP/Cisco/WLC.pm
@@ -124,6 +124,7 @@ sub supportsRoleBasedEnforcement { return $TRUE; }
 # disabling special features supported by generic Cisco's but not on WLCs
 sub supportsSaveConfig { return $FALSE; }
 sub supportsCdp { return $FALSE; }
+sub supportsLldp { return $FALSE; }
 
 =item deauthenticateMac
     

--- a/lib/pf/SNMP/Dlink/DWS_3026.pm
+++ b/lib/pf/SNMP/Dlink/DWS_3026.pm
@@ -146,20 +146,6 @@ sub isDefinedVlan {
     return 0;
 }
 
-sub getPhonesDPAtIfIndex {
-    my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
-    my @phones = ();
-    if ( !$this->isVoIPEnabled() ) {
-        $logger->debug( "VoIP not enabled on switch "
-                . $this->{_ip}
-                . ". getPhonesDPAtIfIndex will return empty list." );
-        return @phones;
-    }
-    $logger->debug("no DP is available on DWS 3026");
-    return @phones;
-}
-
 sub isVoIPEnabled {
     my ($this) = @_;
     return 0;
@@ -173,7 +159,7 @@ Dominik Gehl <dgehl@inverse.ca>
 
 =head1 COPYRIGHT
 
-Copyright (C) 2009-2011 Inverse inc.
+Copyright (C) 2009-2012 Inverse inc.
 
 =head1 LICENSE
 

--- a/lib/pf/SNMP/MockedSwitch.pm
+++ b/lib/pf/SNMP/MockedSwitch.pm
@@ -90,6 +90,7 @@ sub supportsRadiusVoip { return $TRUE; }
 # special features supported
 sub supportsFloatingDevice { return $TRUE; }
 sub supportsSaveConfig { return $FALSE; }
+sub supportsCdp { return $TRUE; }
 
 
 # first, we are re-implementing all of pf::SNMP that has effects on switches to make sure it doesn't do anything
@@ -1887,18 +1888,6 @@ sub getAllMacs {
         }
     }
     return $ifIndexVlanMacHashRef;
-}
-
-sub getPhonesDPAtIfIndex {
-    my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
-    $logger->debug("fake getPhonesDPAtIfIndex ifIndex: $ifIndex");
-    my @phones;
-    if ( !$this->isVoIPEnabled() ) {
-        $logger->debug("VoIP not enabled on switch ".$this->{_ip}.". getPhonesDPAtIfIndex will return empty list.");
-        return @phones;
-    }
-    return $this->getPhonesCDPAtIfIndex($ifIndex);
 }
 
 # FIXME not properly mocked

--- a/lib/pf/SNMP/Nortel.pm
+++ b/lib/pf/SNMP/Nortel.pm
@@ -52,6 +52,9 @@ use pf::util;
 =cut
 sub supportsFloatingDevice { return $TRUE; }
 
+# special features
+sub supportsLldp { return $TRUE; }
+
 =back
 
 =head1 METHODS
@@ -713,19 +716,6 @@ sub isPortSecurityEnabled {
                 || $s5SbsCurrentPortSecurStatus eq 'noSuchInstance' 
                 || $s5SbsCurrentPortSecurStatus >= 2)
     );
-}
-
-sub getPhonesDPAtIfIndex {
-    my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
-    my @phones;
-    if ( !$this->isVoIPEnabled() ) {
-        $logger->debug( "VoIP not enabled on switch "
-                . $this->{_ip}
-                . ". getPhonesDPAtIfIndex will return empty list." );
-        return @phones;
-    }
-    return $this->getPhonesLLDPAtIfIndex($ifIndex);
 }
 
 sub getPhonesLLDPAtIfIndex {

--- a/lib/pf/SNMP/Nortel/BPS2000.pm
+++ b/lib/pf/SNMP/Nortel/BPS2000.pm
@@ -23,19 +23,9 @@ use Log::Log4perl;
 use Net::SNMP;
 use base ('pf::SNMP::Nortel');
 
-sub getPhonesLLDPAtIfIndex {
-    my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
-    my @phones;
-    if ( !$this->isVoIPEnabled() ) {
-        $logger->debug( "VoIP not enabled on switch "
-                . $this->{_ip}
-                . ". getPhonesLLDPAtIfIndex will return empty list." );
-        return @phones;
-    }
-    $logger->debug("LLDP is not available on BPS2000");
-    return @phones;
-}
+# special features
+# LLDP is not available on BPS2000
+sub supportsLldp { return $FALSE; }
 
 =head1 AUTHOR
 
@@ -45,7 +35,7 @@ Olivier Bilodeau <obilodeau@inverse.ca>
 
 =head1 COPYRIGHT
 
-Copyright (C) 2006-2011 Inverse inc.
+Copyright (C) 2006-2012 Inverse inc.
 
 =head1 LICENSE
 

--- a/lib/pf/SNMP/constants.pm
+++ b/lib/pf/SNMP/constants.pm
@@ -154,6 +154,32 @@ Readonly::Scalar our $DELETE_ON_RESET => 4;
 Readonly::Scalar our $DELETE_ON_TIMEOUT => 5;
 
 =back
+
+=head1 LLDP
+
+=over
+
+=cut
+package SNMP::LLDP;
+
+=item LldpSystemCapabilitiesMap
+
+Defined by IEEE 802.1AB. Values below from LLDP-MIB.
+
+ other(0),
+ repeater(1),
+ bridge(2),
+ wlanAccessPoint(3),
+ router(4),
+ telephone(5),
+ docsisCableDevice(6),
+ stationOnly(7)
+
+=cut
+# only the one in use are defined
+Readonly::Scalar our $TELEPHONE => 5;
+
+=back
  
 =head1 CISCO
 
@@ -201,6 +227,13 @@ Used for NAS-Port to ifIndex translation
 =cut
 Readonly::Scalar our $IFINDEX_OFFSET => 10100;
 Readonly::Scalar our $IFINDEX_PER_STACK => 500;
+
+=item LLDP constants
+
+lldpRemTimeMark is always set to 0 on Cisco's (at least those we tried)
+
+=cut
+Readonly::Scalar our $DEFAULT_LLDP_REMTIMEMARK => 0;
 
 =back
 


### PR DESCRIPTION
Now exposed as a capability although there's no default implementation yet. We'll need to flesh out what most vendors do first.

Implemented Cisco support kept Nortel as is because I was scared of breaking it.

Pending review and field testing.

NEWS

```
New Hardware
 * Support for LLDP-based VoIP discovery on Cisco Catalyst series

Enhancements
 * LLDP IP Telephone Discovery improvements

```
