### PR TITLE
Updated the epel repository url

### DIFF
--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -228,7 +228,7 @@ Install the proper repositories in `yum` so it can directly lookup for packages:
 .For RHEL 6.x / CentOS 6.x
 
   # rpm -Uvh http://pkgs.repoforge.org/rpmforge-release/rpmforge-release-0.5.2-2.el6.rf.`uname -m`.rpm
-  # rpm -Uvh http://download.fedoraproject.org/pub/epel/6/`uname -i`/epel-release-6-7.noarch.rpm
+  # rpm -Uvh http://download.fedoraproject.org/pub/epel/6/`uname -i`/epel-release-6-8.noarch.rpm
   # rpm -Uvh http://repo.openfusion.net/centos6-`uname -i`/openfusion-release-0.6.2-1.of.el6.noarch.rpm
 
 Then disable these repositories by default. Under `/etc/yum.repos.d/` edit `rpmforge.repo`, `epel.repo` and `openfusion.repo` and set `enabled` to 0 under every section like this:


### PR DESCRIPTION
In Chapter 4, OS Installation, the url to the epel-release rpm is outdated.

The version is now 6-8, 6-7 is no longer available on the mirror.
