### PR TITLE
Updated the epel repository url

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -15,6 +15,8 @@ For a list of compatibility related changes see the UPGRADE file.
 --------------------------------------------------------------------------------
 Version <stableRelease> released on <releaseDate>
 
+Bug Fixes
+ * Portal Profile fix (#1595)
 --------------------------------------------------------------------------------
 Version 3.6.0 released on 2012-10-25
 

--- a/addons/logrotate
+++ b/addons/logrotate
@@ -7,6 +7,7 @@
     compress
     delaycompress
     sharedscripts
+    create 644 pf pf
     postrotate
         # uncomment the crm statements if you are running packetfence in a corosync cluster
         #/usr/sbin/crm resource unmanage PacketFence

--- a/conf/httpd.conf.d/captive-portal-cleanurls.conf
+++ b/conf/httpd.conf.d/captive-portal-cleanurls.conf
@@ -3,28 +3,27 @@
 
 #
 # clean urls handling
-#
 # template variables described in pf::web::constants
-RewriteRule ^%%URL_ACCESS%%$ /cgi-perl/register.cgi?mode=release [PT,QSA]
-RewriteRule ^%%URL_AUP%%$ /cgi-perl/register.cgi?mode=aup [PT,QSA]
-RewriteRule ^%%URL_AUTHENTICATE%%$ /cgi-perl/register.cgi [PT]
-RewriteRule ^%%URL_CAPTIVE_PORTAL%%$ /cgi-perl/redir.cgi [PT]
-RewriteRule ^%%URL_ENABLER%%$ /cgi-perl/redir.cgi?enable_menu=1 [PT,QSA]
-RewriteRule ^%%URL_RELEASE%%$ /perl/release [PT]
-RewriteRule ^%%URL_WIRELESS_PROFILE%%$ /cgi-perl/wireless-profile.cgi [PT]
-RewriteRule ^%%URL_OAUTH2_AUTH%% /cgi-perl/oauth2.cgi$1 [PT,QSA]
-RewriteRule ^%%URL_OAUTH2_GOOGLE%% /cgi-perl/oauth2.cgi?result=google$1 [PT,QSA]
-RewriteRule ^%%URL_OAUTH2_FCBK%% /cgi-perl/oauth2.cgi?result=facebook$1 [PT,QSA]
-RewriteRule ^%%URL_OAUTH2_GITHUB%% /cgi-perl/oauth2.cgi?result=github$1 [PT,QSA]
 
-# Guest related
-# /activate/email/<code> confirms your email address
-RewriteRule ^%%URL_EMAIL_ACTIVATION%%([0-9a-z]+)$ %%URL_EMAIL_ACTIVATION_UGLY%%?code=$1 [PT,QSA]
-RewriteRule ^%%URL_SMS_ACTIVATION%%$ /cgi-perl/mobile-confirmation.cgi [PT]
-# /preregister forces pre-registration
-RewriteRule ^%%URL_PREREGISTER%%$ %%URL_SIGNUP_UGLY%%?preregistration=forced$1 [PT,QSA]
+# normal flow
+RewriteRule ^%%URL_ACCESS%%$                /cgi-perl/register.cgi?mode=release [PT,QSA]
+RewriteRule ^%%URL_AUTHENTICATE%%$          /cgi-perl/register.cgi [PT]
+RewriteRule ^%%URL_AUP%%$                   /cgi-perl/register.cgi?mode=aup [PT,QSA]
+RewriteRule ^%%URL_BILLING%%$               /cgi-perl/billing-engine.cgi [PT]
+RewriteRule ^%%URL_CAPTIVE_PORTAL%%$        /cgi-perl/redir.cgi [PT]
+RewriteRule ^%%URL_ENABLER%%$               /cgi-perl/redir.cgi?enable_menu=1 [PT,QSA]
+RewriteRule ^%%URL_OAUTH2%%                 /cgi-perl/oauth2.cgi$1 [PT,QSA]
+RewriteRule ^%%URL_OAUTH2_FACEBOOK%%        /cgi-perl/oauth2.cgi?result=facebook$1 [PT,QSA]
+RewriteRule ^%%URL_OAUTH2_GITHUB%%          /cgi-perl/oauth2.cgi?result=github$1 [PT,QSA]
+RewriteRule ^%%URL_OAUTH2_GOOGLE%%          /cgi-perl/oauth2.cgi?result=google$1 [PT,QSA]
+RewriteRule ^%%URL_RELEASE%%$               /perl/release [PT]
+RewriteRule ^%%URL_WIRELESS_PROFILE%%$      /cgi-perl/wireless-profile.cgi [PT]
+
+# guest related
 # /signup detects if user is local or remote and performs adequate guest [pre-]registration
-RewriteRule ^%%URL_SIGNUP%%$ %%URL_SIGNUP_UGLY%% [PT]
-
-# Billing engine related
-RewriteRule ^%%URL_BILLING%%$ /cgi-perl/billing-engine.cgi [PT]
+RewriteRule ^%%URL_SIGNUP%%$                        %%CGI_SIGNUP%% [PT]
+# /preregister forces pre-registration
+RewriteRule ^%%URL_PREREGISTER%%$                   %%CGI_SIGNUP%%?preregistration=forced$1 [PT,QSA]
+# /activate/email/<code> confirms your email address
+RewriteRule ^%%URL_EMAIL_ACTIVATION%%([0-9a-z]+)$   %%CGI_EMAIL_ACTIVATION%%?code=$1 [PT,QSA]
+RewriteRule ^%%URL_SMS_ACTIVATION%%$                /cgi-perl/mobile-confirmation.cgi [PT]

--- a/debian/control
+++ b/debian/control
@@ -14,7 +14,7 @@ Architecture: all
 Pre-Depends:  freeradius, freeradius-ldap, freeradius-postgresql,
  freeradius-mysql, freeradius-krb5
 Depends: ${misc:Depends}, vlan, make,
- openssl, openssl-blacklist, openssl-blacklist-extra, snort,
+ openssl, openssl-blacklist, openssl-blacklist-extra, snort | suricata,
  mysql-server,
  snmp, snmptrapfmt,
 # apache related

--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -228,7 +228,7 @@ Install the proper repositories in `yum` so it can directly lookup for packages:
 .For RHEL 6.x / CentOS 6.x
 
   # rpm -Uvh http://pkgs.repoforge.org/rpmforge-release/rpmforge-release-0.5.2-2.el6.rf.`uname -m`.rpm
-  # rpm -Uvh http://download.fedoraproject.org/pub/epel/6/`uname -i`/epel-release-6-7.noarch.rpm
+  # rpm -Uvh http://download.fedoraproject.org/pub/epel/6/`uname -i`/epel-release-6-8.noarch.rpm
   # rpm -Uvh http://repo.openfusion.net/centos6-`uname -i`/openfusion-release-0.6.2-1.of.el6.noarch.rpm
 
 Then disable these repositories by default. Under `/etc/yum.repos.d/` edit `rpmforge.repo`, `epel.repo` and `openfusion.repo` and set `enabled` to 0 under every section like this:

--- a/lib/pf/Portal/ProfileFactory.pm
+++ b/lib/pf/Portal/ProfileFactory.pm
@@ -62,11 +62,11 @@ sub instantiate {
     my $node_info = node_view($mac);
     my $last_ssid = $node_info->{'last_ssid'};
     my $last_vlan = $node_info->{'last_vlan'};
-    return pf::Portal::Profile->new(_default_profile()) if (!(defined($last_ssid)) || defined($last_vlan) );
+    return pf::Portal::Profile->new(_default_profile()) if (!(defined($last_ssid)) && !( defined($last_vlan) ));
 
     foreach my $last_info ("last_ssid","last_vlan") {
         foreach my $filter ( keys %filters ) {
-            if ( $filter eq $last_ssid ) {
+            if ( ($filter eq $last_ssid) || ($filter eq $last_vlan) ) {
                 $logger->info("instantiating new portal profile of type " . $filters{$filter});
                 return pf::Portal::Profile->new(_custom_profile($filters{$filter}));
             }

--- a/lib/pf/services/apache.pm
+++ b/lib/pf/services/apache.pm
@@ -96,14 +96,14 @@ sub generate_httpd_conf {
     my $guest_regist_allowed = $guest_self_registration{'enabled'};
     if ($guest_regist_allowed && isenabled($Config{'guests_self_registration'}{'preregistration'})) {
         # | is for a regexp "or" as this is pulled from a 'Location ~' statement 
-        $tags{'allowed_from_all_urls'} .= "|$WEB::URL_SIGNUP|$WEB::ACL_SIGNUP_CGI|$WEB::URL_PREREGISTER";
+        $tags{'allowed_from_all_urls'} .= "|$WEB::URL_SIGNUP|$WEB::CGI_SIGNUP|$WEB::URL_PREREGISTER";
     }
     # /activate/email allowed if sponsor or email mode enabled
     my $email_enabled = $guest_self_registration{$SELFREG_MODE_EMAIL};
     my $sponsor_enabled = $guest_self_registration{$SELFREG_MODE_SPONSOR};
     if ($guest_regist_allowed && ($email_enabled || $sponsor_enabled)) {
         # | is for a regexp "or" as this is pulled from a 'Location ~' statement 
-        $tags{'allowed_from_all_urls'} .= "|$WEB::URL_EMAIL_ACTIVATION|$WEB::ACL_EMAIL_ACTIVATION_CGI";
+        $tags{'allowed_from_all_urls'} .= "|$WEB::URL_EMAIL_ACTIVATION|$WEB::CGI_EMAIL_ACTIVATION";
     }
 
     my ($pt_http, $pt_https, $remediation);

--- a/lib/pf/web.pm
+++ b/lib/pf/web.pm
@@ -415,7 +415,7 @@ sub web_node_register {
     }
 
     # we are good, push the registration
-    return _sanitize_and_register($portalSession, $mac, $pid, %info);
+    return _sanitize_and_register($portalSession->session, $mac, $pid, %info);
 }
 
 sub _sanitize_and_register {
@@ -425,7 +425,7 @@ sub _sanitize_and_register {
     $logger->info("performing node registration MAC: $mac pid: $pid");
     node_register( $mac, $pid, %info );
 
-     unless ( defined($session->getCgi->param("do_not_deauth")) && $session->getCgi->param("do_not_deauth") == $TRUE ) {
+     unless ( defined($session->param("do_not_deauth")) && $session->param("do_not_deauth") == $TRUE ) {
         reevaluate_access( $mac, 'manage_register' );
     }
 

--- a/lib/pf/web.pm
+++ b/lib/pf/web.pm
@@ -415,7 +415,7 @@ sub web_node_register {
     }
 
     # we are good, push the registration
-    return _sanitize_and_register($portalSession->session, $mac, $pid, %info);
+    return _sanitize_and_register($portalSession, $mac, $pid, %info);
 }
 
 sub _sanitize_and_register {
@@ -425,7 +425,7 @@ sub _sanitize_and_register {
     $logger->info("performing node registration MAC: $mac pid: $pid");
     node_register( $mac, $pid, %info );
 
-    unless ( defined($session->param("do_not_deauth")) && $session->param("do_not_deauth") == $TRUE ) {
+     unless ( defined($session->getCgi->param("do_not_deauth")) && $session->getCgi->param("do_not_deauth") == $TRUE ) {
         reevaluate_access( $mac, 'manage_register' );
     }
 

--- a/lib/pf/web/constants.pm
+++ b/lib/pf/web/constants.pm
@@ -56,40 +56,35 @@ CGI they map.
 
 =cut
 # normal flow
-Readonly::Scalar our $URL_CAPTIVE_PORTAL => '/captive-portal';
-Readonly::Scalar our $URL_AUP => '/aup';
-Readonly::Scalar our $URL_AUTHENTICATE => '/authenticate';
-Readonly::Scalar our $URL_ACCESS => '/access';
-Readonly::Scalar our $URL_RELEASE => '/release';
-Readonly::Scalar our $URL_OAUTH2_AUTH => '/oauth2/auth';
-Readonly::Scalar our $URL_OAUTH2_GOOGLE => '/oauth2/google';
-Readonly::Scalar our $URL_OAUTH2_FCBK => '/oauth2/facebook';
-Readonly::Scalar our $URL_OAUTH2_GITHUB => '/oauth2/github';
-
-# violation-related
-Readonly::Scalar our $URL_ENABLER => '/enabler';
-Readonly::Scalar our $URL_REMEDIATION => '/remediation.php(.*)';
+Readonly::Scalar our $URL_ACCESS                => '/access';
+Readonly::Scalar our $URL_AUTHENTICATE          => '/authenticate';
+Readonly::Scalar our $URL_AUP                   => '/aup';
+Readonly::Scalar our $URL_BILLING               => '/pay';
+Readonly::Scalar our $URL_CAPTIVE_PORTAL        => '/captive-portal';
+Readonly::Scalar our $URL_ENABLER               => '/enabler';
+Readonly::Scalar our $URL_OAUTH2                => '/oauth2/auth';
+Readonly::Scalar our $URL_OAUTH2_FACEBOOK       => '/oauth2/facebook';
+Readonly::Scalar our $URL_OAUTH2_GITHUB         => '/oauth2/github';
+Readonly::Scalar our $URL_OAUTH2_GOOGLE         => '/oauth2/google';
+Readonly::Scalar our $URL_RELEASE               => '/release';
+Readonly::Scalar our $URL_WIRELESS_PROFILE      => '/wireless-profile.mobileconfig';
 
 # guest related
-Readonly::Scalar our $URL_SIGNUP => '/signup';
-Readonly::Scalar our $URL_EMAIL_ACTIVATION => '/activate/email/';
-Readonly::Scalar our $URL_SMS_ACTIVATION => '/activate/sms';
-Readonly::Scalar our $URL_PREREGISTER => '/preregister';
-Readonly::Scalar our $URL_SIGNUP_UGLY => '/guest-selfregistration.cgi';
-Readonly::Scalar our $URL_ADMIN_MANAGE_GUESTS => '/guests/manage';
+Readonly::Scalar our $URL_SIGNUP                => '/signup';
+Readonly::Scalar our $CGI_SIGNUP                => '/cgi-perl/guest-selfregistration.cgi';
+Readonly::Scalar our $URL_EMAIL_ACTIVATION      => '/activate/email/';
+Readonly::Scalar our $CGI_EMAIL_ACTIVATION      => '/cgi-perl/email_activation.cgi';
+Readonly::Scalar our $URL_SMS_ACTIVATION        => '/activate/sms';
+Readonly::Scalar our $URL_PREREGISTER           => '/preregister';
+Readonly::Scalar our $URL_ADMIN_MANAGE_GUESTS   => '/guests/manage';
 
-# billing engine
-Readonly::Scalar our $URL_BILLING => '/pay';
-
-# wireless auto-config
-Readonly::Scalar our $URL_WIRELESS_PROFILE => '/wireless-profile.mobileconfig';
-
-# required for specific Apache config ACL whitelisting
-Readonly::Scalar our $ACL_EMAIL_ACTIVATION_CGI => '/cgi-perl/email_activation.cgi';
-Readonly::Scalar our $ACL_SIGNUP_CGI => '/cgi-perl/guest-selfregistration.cgi';
-
-# wispr mod_perl engine
-Readonly::Scalar our $MOD_PERL_WISPR => '/wispr';
+# TODO: Temp... migration process. Should be kept since it breaks the portal on removal
+# dwuelfrath@inverse.ca - 2012.11.12
+Readonly::Scalar our $URL_REMEDIATION           => '/remediation.php(.*)';
+Readonly::Scalar our $URL_SIGNUP_UGLY           => '/guest-selfregistration.cgi';
+Readonly::Scalar our $ACL_EMAIL_ACTIVATION_CGI  => '/cgi-perl/email_activation.cgi';
+Readonly::Scalar our $ACL_SIGNUP_CGI            => '/cgi-perl/guest-selfregistration.cgi';
+Readonly::Scalar our $MOD_PERL_WISPR            => '/wispr';
 
 =head2 Apache Config related
 


### PR DESCRIPTION
In Chapter 4, OS Installation, the url to the epel-release rpm is outdated.

The version is now 6-8, 6-7 is no longer available on the mirror.

This is so devel.
