### PR TITLE
Changed some of the checks to support strings as vlan identifiers as

### DIFF
--- a/lib/pf/SNMP.pm
+++ b/lib/pf/SNMP.pm
@@ -729,10 +729,10 @@ sub getVlanByName {
         return 0;
     }
     
-    if ($this->{'_vlans'}->{$vlanName} !~ /^\d+$/) {
+    if ($this->{'_vlans'}->{$vlanName} !~ /^\w+$/) {
         # is not resolved to a valid VLAN number
         $logger->warn("VLAN $vlanName is not properly configured in switches.conf for the switch " . $this->{_ip} .
-                      ", not a VLAN number");
+                      ", not a VLAN identifier");
         return;
     }   
     return $this->{'_vlans'}->{$vlanName};
@@ -753,9 +753,9 @@ sub setVlanByName {
         return;
     }
 
-    if ($this->{"_".$vlanName} !~ /^\d+$/) {
+    if ($this->{"_".$vlanName} !~ /^\w+$/) {
         # is not resolved to a valid VLAN number
-        $logger->warn("VLAN $vlanName is not properly configured in switches.conf, not a vlan number");
+        $logger->warn("VLAN $vlanName is not properly configured in switches.conf, not a vlan identifier");
         return;
     }
     return $this->setVlan($ifIndex, $this->{"_".$vlanName}, $switch_locker_ref);

--- a/lib/pf/SNMP.pm
+++ b/lib/pf/SNMP.pm
@@ -709,7 +709,7 @@ sub getRoleByName {
 
 =item getVlanByName - get the VLAN number of a given name in switches.conf
  
-Input: vlan name (as in switches.conf)
+Input: VLAN name (as in switches.conf)
 
 =cut                    
 sub getVlanByName {
@@ -740,7 +740,7 @@ sub getVlanByName {
 
 =item setVlanByName - set the ifIndex VLAN to the VLAN identified by given name in switches.conf
 
-Input: ifIndex, vlan name (as in switches.conf), switch lock
+Input: ifIndex, VLAN name (as in switches.conf), switch lock
 
 =cut
 sub setVlanByName {
@@ -755,7 +755,7 @@ sub setVlanByName {
 
     if ($this->{"_".$vlanName} !~ /^\w+$/) {
         # is not resolved to a valid VLAN identifier
-        $logger->warn("VLAN $vlanName is not properly configured in switches.conf, not a vlan identifier");
+        $logger->warn("VLAN $vlanName is not properly configured in switches.conf, not a VLAN identifier");
         return;
     }
     return $this->setVlan($ifIndex, $this->{"_".$vlanName}, $switch_locker_ref);

--- a/lib/pf/SNMP.pm
+++ b/lib/pf/SNMP.pm
@@ -730,7 +730,7 @@ sub getVlanByName {
     }
     
     if ($this->{'_vlans'}->{$vlanName} !~ /^\w+$/) {
-        # is not resolved to a valid VLAN number
+        # is not resolved to a valid VLAN identifier
         $logger->warn("VLAN $vlanName is not properly configured in switches.conf for the switch " . $this->{_ip} .
                       ", not a VLAN identifier");
         return;
@@ -754,7 +754,7 @@ sub setVlanByName {
     }
 
     if ($this->{"_".$vlanName} !~ /^\w+$/) {
-        # is not resolved to a valid VLAN number
+        # is not resolved to a valid VLAN identifier
         $logger->warn("VLAN $vlanName is not properly configured in switches.conf, not a vlan identifier");
         return;
     }

--- a/lib/pf/enforcement.pm
+++ b/lib/pf/enforcement.pm
@@ -196,7 +196,7 @@ sub _should_we_reassign_vlan {
     }
 
     my ($newCorrectVlan,$wasInline) = $vlan_obj->fetchVlanForNode($mac, $switch, $ifIndex, $connection_type, $user_name, $ssid);
-    if ( $newCorrectVlan == -1 ) {
+    if ( $newCorrectVlan eq '-1' ) {
         $logger->info(
             "VLAN reassignment required for $mac (current VLAN = $currentVlan but should be in VLAN $newCorrectVlan)"
         );


### PR DESCRIPTION
supported by RFC 2868.

This change does not claim to be exhaustive. We probably have other
checks like this where we assume the identifier is an integer instead
of a string.
