### PR TITLE
A series of changes to address shortcomings in our MAB EAP support.

### DIFF
--- a/lib/pf/config.pm
+++ b/lib/pf/config.pm
@@ -202,6 +202,7 @@ Readonly our $WEB_ADMIN_ALL => 4294967295;
     'Ethernet-NoEAP'        => $WIRED_MAC_AUTH,
     'SNMP-Traps'            => $WIRED_SNMP_TRAPS,
     'Inline'                => $INLINE,
+    'WIRED_MAC_AUTH'        => $WIRED_MAC_AUTH,
 );
 %connection_group = (
     'Wireless'              => $WIRELESS,
@@ -214,7 +215,7 @@ Readonly our $WEB_ADMIN_ALL => 4294967295;
     $WIRELESS_802_1X => 'Wireless-802.11-EAP',
     $WIRELESS_MAC_AUTH => 'Wireless-802.11-NoEAP',
     $WIRED_802_1X => 'Ethernet-EAP',
-    $WIRED_MAC_AUTH => 'Ethernet-NoEAP',
+    $WIRED_MAC_AUTH => 'WIRED_MAC_AUTH',
     $WIRED_SNMP_TRAPS => 'SNMP-Traps',
     $INLINE => 'Inline',
     $UNKNOWN => '',

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -326,7 +326,7 @@ sub _identifyConnectionType {
                 return $WIRELESS_MAC_AUTH;
             }
     
-        } elsif ($nas_port_type =~ /^Ethernet$/) {
+        } elsif ($nas_port_type eq 'Ethernet' ) {
 
             if ($eap_type) {
 
@@ -334,8 +334,8 @@ sub _identifyConnectionType {
                 # this is still MAC Authentication so we need to cheat a little bit here
                 # TODO: consider moving this logic later once the switch is initialized so we can ask it
                 # (supportsEAPMacAuth?)
-                $mac =~ s/://g;
-                if ($mac eq $user_name) {
+                $mac =~ s/[^[:xdigit:]]//g;
+                if (lc $mac eq lc $user_name) {
                     return $WIRED_MAC_AUTH;
                 } else {
                     return $WIRED_802_1X;

--- a/lib/pf/vlan.pm
+++ b/lib/pf/vlan.pm
@@ -315,7 +315,13 @@ sub getNormalVlan {
     my $role = "";
 
     $logger->debug("Trying to determine VLAN from role.");
-    if (defined $user_name && (($connection_type & $EAP) == $EAP)) {
+
+    # Try MAC_AUTH, then other EAP methods and finally anything else.
+    if ( ( $connection_type & $WIRED_MAC_AUTH ) == $WIRED_MAC_AUTH ) {
+        $logger->info("Connection type is WIRED_MAC_AUTH. Getting role from node_info" );
+        $role = $node_info->{'category'};
+    }
+    elsif (defined $user_name && (($connection_type & $EAP) == $EAP)) {
         my $params =
           {
            username => $user_name,

--- a/lib/pf/vlan/custom.pm
+++ b/lib/pf/vlan/custom.pm
@@ -49,7 +49,13 @@ Sample getNormalVlan, see pf::vlan for getNormalVlan interface description
 #    my $role = "";
 #
 #    $logger->debug("Trying to determine VLAN from role.");
-#    if (defined $user_name && (($connection_type & $EAP) == $EAP)) {
+#
+#    # Try MAC_AUTH, then other EAP methods and finally anything else.
+#    if ( ( $connection_type & $WIRED_MAC_AUTH ) == $WIRED_MAC_AUTH ) {
+#        $logger->info("Connection type is WIRED_MAC_AUTH. Getting role from node_info" );
+#        $role = $node_info->{'category'};
+#    }
+#    elsif (defined $user_name && (($connection_type & $EAP) == $EAP)) {
 #        my $params =
 #          {
 #           username => $user_name,


### PR DESCRIPTION
modified:   lib/pf/config.pm

```
Changed so that an EAP WIRED_MAC_AUTH shows as such in the logs rather
than as ETHERNET-noEAP
```

modified:   lib/pf/radius.pm

```
Changed so that MAC_AUTH detection will work even if MAC separators are
other than ':'.
Comparison between username and mac is now case insensitive.
```

modified:   lib/pf/vlan.pm

```
Changed so that EAP WIRED_MAC_AUTH will get the role from node-info.
This case failed before as it matched the EAP connection type and so we
tried every authentication source with a MAC for username.
```

modified:   lib/pf/vlan/custom.pm

```
Changes reflect new lib/pf/vlan.pm.
```
