### PR TITLE
Fix/xml encode

### DIFF
--- a/raddb/packetfence-soh.pm
+++ b/raddb/packetfence-soh.pm
@@ -35,6 +35,7 @@ use warnings;
 
 use WWW::Curl::Easy;
 use XML::Simple;
+use HTML::Entities;
 
 use lib '/usr/local/pf/lib/';
 
@@ -114,6 +115,7 @@ sub authorize {
                 $request_content = $request_content .
                     "<c-gensym$counter xsi:type=\"xsd:string\">$key</c-gensym$counter>";
                 foreach my $array_value ( @{$RAD_REQUEST{$key}} ) {
+                    encode_entities($array_value);
                     $array_counter += 1;    # that one is actually important...
                     $array_content = $array_content . "<item xsi:type=\"xsd:string\">$array_value</item>";
                     $counter += 1;  # looks like this one is not mandatory, we still use it to keep track of keys/values
@@ -123,10 +125,11 @@ sub authorize {
                 $request_content = $request_content . $array_content;
                 $request_content = $request_content . "</soapenc:Array>";
             } else {
+                my $value = encode_entities($RAD_REQUEST{$key});
                 $request_content = $request_content .
                     "<c-gensym$counter xsi:type=\"xsd:string\">$key</c-gensym$counter>";
                 $request_content = $request_content .
-                    "<c-gensym$counter xsi:type=\"xsd:string\">$RAD_REQUEST{$key}</c-gensym$counter>";
+                    "<c-gensym$counter xsi:type=\"xsd:string\">$value</c-gensym$counter>";
                 $counter += 1;  # looks like this one is not mandatory, we still use it to keep track of keys/values
             }
         }

--- a/raddb/packetfence.pm
+++ b/raddb/packetfence.pm
@@ -35,6 +35,7 @@ use warnings;
 
 use WWW::Curl::Easy;
 use XML::Simple;
+use HTML::Entities;
 
 use lib '/usr/local/pf/lib/';
 
@@ -152,6 +153,7 @@ sub post_auth {
                 $request_content = $request_content .
                     "<c-gensym$counter xsi:type=\"xsd:string\">$key</c-gensym$counter>";
                 foreach my $array_value ( @{$RAD_REQUEST{$key}} ) {
+                    encode_entities($array_value);
                     $array_counter += 1;    # that one is actually important...
                     $array_content = $array_content . "<item xsi:type=\"xsd:string\">$array_value</item>";
                     $counter += 1;  # looks like this one is not mandatory, we still use it to keep track of keys/values
@@ -161,10 +163,11 @@ sub post_auth {
                 $request_content = $request_content . $array_content;
                 $request_content = $request_content . "</soapenc:Array>";
             } else {
+                my $value = encode_entities($RAD_REQUEST{$key});
                 $request_content = $request_content .
                     "<c-gensym$counter xsi:type=\"xsd:string\">$key</c-gensym$counter>";
                 $request_content = $request_content .
-                    "<c-gensym$counter xsi:type=\"xsd:string\">$RAD_REQUEST{$key}</c-gensym$counter>";
+                    "<c-gensym$counter xsi:type=\"xsd:string\">$value</c-gensym$counter>";
                 $counter += 1;  # looks like this one is not mandatory, we still use it to keep track of keys/values
             }
 


### PR DESCRIPTION
Fixes a bug seen with a client who had RADIUS attributes such as "Business & Accounting" (i.e. with an unencoded XML reserved character ).
