### PR TITLE
Fix/mac class

### DIFF
--- a/lib/pf/MAC.pm
+++ b/lib/pf/MAC.pm
@@ -6,6 +6,7 @@ pf::MAC
 
 =head1 DESCRIPTION
 pf::MAC implements a class that instantiates MAC addresses objects.
+
 At the moment it is rather minimalist, inheriting from Net::MAC which already does 
 90% of what PacketFence needs.
 
@@ -15,7 +16,8 @@ Net::MAC's implementation.
 Since passing the Net::MAC object to a function actually passes the string version of the constructors 
 initial argument, it should be safe to keps calling things like `mac2oid($mac)'.
 
-The get_* methods are idempotent. They do not modify the object.
+The get_* methods return a string or integer.
+
 The as_* methods return a new pf::MAC object with the given notation as constructor.
 
 =over
@@ -30,6 +32,7 @@ use base 'Net::MAC';
 =item clean
 
 Cleans a MAC address. 
+
 Returns an untainted pf::MAC with MAC in format: XX:XX:XX:XX:XX:XX (uppercased).
 
 =cut
@@ -49,6 +52,7 @@ sub clean {
 }
 
 =item get_stripped
+
 Returns the MAC address stripped of any delimiter (base is preserved).
 
 =cut
@@ -61,6 +65,7 @@ sub get_stripped {
 }
 
 =item get_hex_stripped
+
 Returns a string containing the MAC address in hex base, stripped of any delimiter (uppercased).
 
 =cut
@@ -72,26 +77,8 @@ sub get_hex_stripped {
     return $IEEE_mac;
 }
 
-=item format_for_acct
-Returns an uppercased, hex based and : delimited pf::MAC object.
-Intended for backward compatibility with pf::util::format_mac_for_acct.
+=item get_dec_stripped
 
-=cut 
-
-sub format_for_acct {
-    my $self = shift;
-    return pf::MAC->new( mac => $self->get_hex_stripped() );
-}
-
-=item as_Cisco
-Returns a new pf::MAC object formatted for Cisco ( example: 0002.03aa.abff ).
-See Net::MAC for implementation.
-
-=cut
-
-#sub as_Cisco {};
-
-=item as_integer
 Returns a string with the MAC as a decimal without delimiter.
 
 =cut
@@ -106,7 +93,9 @@ sub get_dec_stripped {
 }
 
 =item get_oui
+
 Returns the OUI for the MAC as an uppercased hex string with - delimiters.
+
 This is the format the IEEE uses.
 
 =cut
@@ -118,6 +107,7 @@ sub get_oui {
 }
 
 =item get_dec_oui
+
 Returns a decimal value of the OUI stripped of any delimiters.
 
 =cut
@@ -129,20 +119,63 @@ sub get_dec_oui {
     return hex($oui);
 }
 
+=item as_oid 
+
+Returns a pf::MAC object with the MAC formatted as an SNMP OID.
+
+example: '00-12-f0-13-32-ba' -> '0.18.240.19.50.186'
+
+=cut
+
+sub as_oid {
+    my $self = shift;
+    return $self->convert( base => 10, bit_group => 8, delimiter => '.' );
+}
+
+
+=item as_Cisco
+
+Returns a new pf::MAC object formatted for Cisco ( example: 0002.03aa.abff ).
+
+Documented here for consistency with the other methods implementing functions from pf::util.
+
+See Net::MAC for implementation.
+
+=cut
+
+#sub as_Cisco {};
 
 =item macoui2nb
+
 Provided for backwards compatibility with pf::util::macoui2nb.
+
 Equivalent to get_dec_oui().
 
 =cut 
+
 sub macoui2nb { return $_[0]->get_dec_oui(@_); }
 
 =item mac2nb
+
 Provided for backwards compatibility with pf::util::mac2nb.
+
 Equivalent to get_dec_stripped().
 
 =cut
+
 sub mac2nb { return $_[0]->get_dec_stripped(@_); }
 
+=item format_for_acct
+
+Returns an uppercased, hex based and : delimited pf::MAC object.
+
+Intended for backward compatibility with pf::util::format_mac_for_acct.
+
+=cut 
+
+sub format_for_acct {
+    my $self = shift;
+    return pf::MAC->new( mac => $self->get_hex_stripped() );
+}
 
 1;

--- a/lib/pf/MAC.pm
+++ b/lib/pf/MAC.pm
@@ -64,7 +64,8 @@ Returns a string containing the MAC address in hex base, stripped of any delimit
 =cut
 sub get_hex_stripped {
     my $self = shift;
-    my $IEEE_mac = $self->as_IEEE()->get_mac();
+    # we clone the object so that the original is not modified.
+    my $IEEE_mac = pf::MAC->new( mac => $self)->as_IEEE->get_mac();
     $IEEE_mac =~ s/[^[:xdigit:]]//g;
     return $IEEE_mac;
 }

--- a/lib/pf/MAC.pm
+++ b/lib/pf/MAC.pm
@@ -178,4 +178,37 @@ sub format_for_acct {
     return pf::MAC->new( mac => $self->get_hex_stripped() );
 }
 
+=back
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2013 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
 1;
+
+# vim: set shiftwidth=4:
+# vim: set expandtab:
+# vim: set backspace=indent,eol,start:

--- a/lib/pf/MAC.pm
+++ b/lib/pf/MAC.pm
@@ -48,7 +48,7 @@ sub clean {
 }
 
 =item get_stripped
-Returns the MAC address stripped of any delimiter.
+Returns the MAC address stripped of any delimiter (base is preserved).
 
 =cut
 sub get_stripped {
@@ -79,5 +79,23 @@ sub format_for_acct {
     return pf::MAC->new( mac => $self->get_hex_stripped() );
 }
 
+=item as_Cisco
+Returns a new pf::MAC object formatted for Cisco ( example: 0002.03aa.abff ).
+See Net::MAC for implementation.
+
+=cut
+#sub as_Cisco {};
+
+=item as_integer
+Returns a string with the MAC as a decimal without delimiter.
+
+=cut
+sub get_dec_stripped {
+    my $self = shift;
+    # disabling warnings in this scope because a MAC address (48bit) is larger than an int on 32bit systems
+    #     # and perl warns about it but gives the right value.
+    no warnings;
+    return hex( $self->get_hex_stripped() );
+}
 
 1;

--- a/lib/pf/MAC.pm
+++ b/lib/pf/MAC.pm
@@ -33,8 +33,9 @@ Cleans a MAC address.
 Returns an untainted pf::MAC with MAC in format: XX:XX:XX:XX:XX:XX (uppercased).
 
 =cut
+
 sub clean {
-    my $self = shift;
+    my $self    = shift;
     my $hex_mac = $self->as_IEEE();
 
     # untaint $hex_mac
@@ -51,9 +52,10 @@ sub clean {
 Returns the MAC address stripped of any delimiter (base is preserved).
 
 =cut
+
 sub get_stripped {
     my $self = shift;
-    my $mac = $self->get_mac();
+    my $mac  = $self->get_mac();
     $mac =~ s/[^[:xdigit:]]//g;
     return $mac;
 }
@@ -62,10 +64,10 @@ sub get_stripped {
 Returns a string containing the MAC address in hex base, stripped of any delimiter (uppercased).
 
 =cut
+
 sub get_hex_stripped {
-    my $self = shift;
-    # we clone the object so that the original is not modified.
-    my $IEEE_mac = pf::MAC->new( mac => $self)->as_IEEE->get_mac();
+    my $self     = shift;
+    my $IEEE_mac = $self->as_IEEE->get_mac();
     $IEEE_mac =~ s/[^[:xdigit:]]//g;
     return $IEEE_mac;
 }
@@ -75,6 +77,7 @@ Returns an uppercased, hex based and : delimited pf::MAC object.
 Intended for backward compatibility with pf::util::format_mac_for_acct.
 
 =cut 
+
 sub format_for_acct {
     my $self = shift;
     return pf::MAC->new( mac => $self->get_hex_stripped() );
@@ -85,39 +88,61 @@ Returns a new pf::MAC object formatted for Cisco ( example: 0002.03aa.abff ).
 See Net::MAC for implementation.
 
 =cut
+
 #sub as_Cisco {};
 
 =item as_integer
 Returns a string with the MAC as a decimal without delimiter.
 
 =cut
+
 sub get_dec_stripped {
     my $self = shift;
+
     # disabling warnings in this scope because a MAC address (48bit) is larger than an int on 32bit systems
-    #     # and perl warns about it but gives the right value.
+    # and perl warns about it but gives the right value.
     no warnings;
     return hex( $self->get_hex_stripped() );
 }
-
 
 =item get_oui
 Returns the OUI for the MAC as an uppercased hex string with - delimiters.
 This is the format the IEEE uses.
 
 =cut
+
 sub get_oui {
-    my $self = shift;
-    # we clone the object so that the original is not modified.
-    my $IEEE_mac = pf::MAC->new( mac => $self)->as_Microsoft->get_mac();
-    return substr($IEEE_mac, 0, 8);
+    my $self     = shift;
+    my $IEEE_mac = $self->as_Microsoft->get_mac();
+    return substr( $IEEE_mac, 0, 8 );
 }
 
+=item get_dec_oui
+Returns a decimal value of the OUI stripped of any delimiters.
+
+=cut
 
 sub get_dec_oui {
     my $self = shift;
-    my $oui = $self->get_oui();
+    my $oui  = $self->get_oui();
     $oui =~ s/-//g;
     return hex($oui);
 }
+
+
+=item macoui2nb
+Provided for backwards compatibility with pf::util::macoui2nb.
+Equivalent to get_dec_oui().
+
+=cut 
+sub macoui2nb { return $_[0]->get_dec_oui(@_); }
+
+=item mac2nb
+Provided for backwards compatibility with pf::util::mac2nb.
+Equivalent to get_dec_stripped().
+
+=cut
+sub mac2nb { return $_[0]->get_dec_stripped(@_); }
+
 
 1;

--- a/lib/pf/MAC.pm
+++ b/lib/pf/MAC.pm
@@ -132,6 +132,15 @@ sub as_oid {
     return $self->convert( base => 10, bit_group => 8, delimiter => '.' );
 }
 
+=item as_acct
+
+Returns an uppercased, hex based and : delimited pf::MAC object (formatted for PacketFence acounting).
+
+=cut
+sub as_acct {
+    my $self = shift;
+    return pf::MAC->new( mac => $self->get_hex_stripped() );
+}
 
 =item as_Cisco
 
@@ -167,16 +176,13 @@ sub mac2nb { return $_[0]->get_dec_stripped(@_); }
 
 =item format_for_acct
 
-Returns an uppercased, hex based and : delimited pf::MAC object.
-
 Intended for backward compatibility with pf::util::format_mac_for_acct.
+
+Equivalent to as_acct();
 
 =cut 
 
-sub format_for_acct {
-    my $self = shift;
-    return pf::MAC->new( mac => $self->get_hex_stripped() );
-}
+sub format_for_acct { return $_[0]->as_acct(@_); }
 
 =back
 

--- a/lib/pf/MAC.pm
+++ b/lib/pf/MAC.pm
@@ -99,4 +99,25 @@ sub get_dec_stripped {
     return hex( $self->get_hex_stripped() );
 }
 
+
+=item get_oui
+Returns the OUI for the MAC as an uppercased hex string with - delimiters.
+This is the format the IEEE uses.
+
+=cut
+sub get_oui {
+    my $self = shift;
+    # we clone the object so that the original is not modified.
+    my $IEEE_mac = pf::MAC->new( mac => $self)->as_Microsoft->get_mac();
+    return substr($IEEE_mac, 0, 8);
+}
+
+
+sub get_dec_oui {
+    my $self = shift;
+    my $oui = $self->get_oui();
+    $oui =~ s/-//g;
+    return hex($oui);
+}
+
 1;

--- a/lib/pf/MAC.pm
+++ b/lib/pf/MAC.pm
@@ -1,0 +1,8 @@
+package pf::MAC
+{
+use Moose;
+
+has 'address', is => 'ro', 'isa' => 'Int';
+
+}
+1;

--- a/lib/pf/MAC.pm
+++ b/lib/pf/MAC.pm
@@ -162,7 +162,7 @@ Equivalent to get_dec_oui().
 
 =cut 
 
-sub macoui2nb { return $_[0]->get_dec_oui(@_); }
+*macoui2nb = \&get_dec_oui;
 
 =item mac2nb
 
@@ -172,7 +172,7 @@ Equivalent to get_dec_stripped().
 
 =cut
 
-sub mac2nb { return $_[0]->get_dec_stripped(@_); }
+*mac2nb = \&get_dec_stripped;
 
 =item format_for_acct
 
@@ -182,7 +182,7 @@ Equivalent to as_acct();
 
 =cut 
 
-sub format_for_acct { return $_[0]->as_acct(@_); }
+*format_for_acct = \&as_acct;
 
 =back
 

--- a/lib/pf/MAC.pm
+++ b/lib/pf/MAC.pm
@@ -1,8 +1,27 @@
-package pf::MAC
-{
-use Moose;
+package pf::MAC;
 
-has 'address', is => 'ro', 'isa' => 'Int';
+=head1 NAME
 
-}
+pf::MAC
+
+=head1 DESCRIPTION
+pf::MAC implements a class that instantiates MAC addresses objects.
+At the moment it is rather minimalist, inheriting from Net::MAC which already does 
+90% of what PacketFence needs.
+
+The purpose of this class is to allow us to extend it or later rewrite it without worrying about 
+Net::MAC's implementation.
+
+Since passing the Net::MAC object to a function actually passes the string version of the constructors 
+initial argument, it should be safe to keps calling things like `mac2oid($mac)'.
+
+=over
+
+=cut
+
+use strict;
+use warnings;
+
+use base 'Net::MAC';
+
 1;

--- a/t/MAC.t
+++ b/t/MAC.t
@@ -3,35 +3,42 @@ use warnings;
 
 use Test::More 'no_plan';
 
-use_ok( 'pf::MAC' ) or die;
+use_ok('pf::MAC') or die;
 use pf::MAC;
-
-my $mac = pf::MAC->new( mac => '00:12:F0:13:32:BA' );
-isa_ok( $mac, 'Net::MAC');
-isa_ok( $mac, 'pf::MAC');
-
-is( "MAC: " . $mac, "MAC: 00:12:F0:13:32:BA",  "String concatenation works");
 use pf::util;
-is( mac2oid( $mac ), '0.18.240.19.50.186', "mac2oid returns correct notation");
 
-is( clean_mac($mac), '00:12:f0:13:32:ba', "pf::util::clean_mac returns valid MAC");
+my $mac = pf::MAC->new( mac => '00:12:f0:13:32:BA' );
+isa_ok( $mac, 'Net::MAC' );
+isa_ok( $mac, 'pf::MAC' );
+
+like( "MAC: " . $mac, qr/MAC: 00:12:F0:13:32:BA/i, "String concatenation works" );
+is( mac2oid($mac), '0.18.240.19.50.186', "mac2oid returns correct notation" );
+
+is( clean_mac($mac), '00:12:f0:13:32:ba', "pf::util::clean_mac returns valid MAC" );
 
 my $cleaned_mac = $mac->clean();
-is( $cleaned_mac, '00:12:f0:13:32:ba', "clean() returns valid MAC");
+is( $cleaned_mac, '00:12:f0:13:32:ba', "clean() returns valid MAC" );
 
 is( $mac->get_hex_stripped(), "0012F01332BA", "stripping returns string without delimiters" );
 my $acct_mac = $mac->format_for_acct();
-is( $acct_mac, "0012F01332BA", "format_for_acct returns valid MAC");
-is( $acct_mac, format_mac_for_acct($mac), "pf::MAC::format_for_acct() and pf::util::format_for_acct return the same values.");
+is( $acct_mac, "0012F01332BA", "format_for_acct returns valid MAC" );
+is( $acct_mac,
+    format_mac_for_acct($mac),
+    "pf::MAC::format_for_acct() and pf::util::format_for_acct return the same values."
+);
 
 my $dash_mac = pf::MAC->new( mac => '00-12-f0-13-32-ba' );
-is( $dash_mac->get_stripped(), "0012f01332ba", "get_stripped returns MAC without delimiters");
+is( $dash_mac->get_stripped(), "0012f01332ba", "get_stripped returns MAC without delimiters" );
 
-is( $mac->get_dec_stripped(), '81337201338', "MAC is returned as an integer" );
-is( $mac->get_dec_stripped(), mac2nb($mac), "get_dec_stripped() and mac2nb return the same values" );
+like( $mac->get_dec_stripped(), qr/^\d+$/, "MAC is returned as decimal integer" );
+is( $mac->get_dec_stripped(),
+    mac2nb($mac), "get_dec_stripped() and pf::util::mac2nb() return the same values" );
+is( $mac->get_dec_stripped(), $mac->mac2nb(), "get_dec_stripped() and mac2nb() return the same values" );
 
-is( $mac->get_oui(), "00-12-F0", "get oui() extracts the OUI from the MAC");
+is( $mac->get_oui(), "00-12-F0", "get oui() extracts the OUI from the MAC" );
 
-like( $mac->get_dec_oui(), qr/^\d+$/, "get_dec_oui() returns a decimal integer");
-is( $mac->get_dec_oui(), macoui2nb($mac), "get_dec_oui() and macoui2nb return the same values");
+like( $mac->get_dec_oui(), qr/^\d+$/, "get_dec_oui() returns a decimal integer" );
+is( $mac->get_dec_oui(), macoui2nb($mac),   "get_dec_oui() and pf::util::macoui2nb return the same values" );
+is( $mac->get_dec_oui(), $mac->macoui2nb(), "get_dec_oui() and macoui2nb() return the same values" );
 
+is( valid_mac($mac), 1, "pf::util::valid_mac() accepts our pf::MAC object" );

--- a/t/MAC.t
+++ b/t/MAC.t
@@ -20,12 +20,6 @@ my $cleaned_mac = $mac->clean();
 is( $cleaned_mac, '00:12:f0:13:32:ba', "clean() returns valid MAC" );
 
 is( $mac->get_hex_stripped(), "0012F01332BA", "stripping returns string without delimiters" );
-my $acct_mac = $mac->format_for_acct();
-is( $acct_mac, "0012F01332BA", "format_for_acct returns valid MAC" );
-is( $acct_mac,
-    format_mac_for_acct($mac),
-    "pf::MAC::format_for_acct() and pf::util::format_for_acct return the same values."
-);
 
 my $dash_mac = pf::MAC->new( mac => '00-12-f0-13-32-ba' );
 is( $dash_mac->get_stripped(), "0012f01332ba", "get_stripped returns MAC without delimiters" );
@@ -45,3 +39,10 @@ is( valid_mac($mac), 1, "pf::util::valid_mac() accepts our pf::MAC object" );
 
 is( $mac->as_oid, "0.18.240.19.50.186", "pf::MAC::as_oid returns the correct OID." );
 is( $mac->as_oid, mac2oid($mac),        "pf::MAC::as_oid and pf::util::mac2oid return the same values" );
+
+is( $mac->as_acct(), "0012F01332BA", "as_acct() returns valid MAC" );
+is( $mac->as_acct(),
+    format_mac_for_acct($mac),
+    "pf::MAC::as_acct() and pf::util::format_for_acct return the same values."
+);
+is( $mac->as_acct(), $mac->format_for_acct(), "as_acct() and format_for_acct() return the same values" );

--- a/t/MAC.t
+++ b/t/MAC.t
@@ -7,6 +7,7 @@ use_ok( 'pf::MAC' ) or die;
 use pf::MAC;
 
 my $mac = pf::MAC->new( mac => '00:12:F0:13:32:BA' );
+isa_ok( $mac, 'Net::MAC');
 isa_ok( $mac, 'pf::MAC');
 
 is( "MAC: " . $mac, "MAC: 00:12:F0:13:32:BA",  "String concatenation works");
@@ -21,8 +22,11 @@ is( $cleaned_mac, '00:12:f0:13:32:ba', "clean() returns valid MAC");
 is( $mac->get_hex_stripped(), "0012F01332BA", "stripping returns string without delimiters" );
 my $acct_mac = $mac->format_for_acct();
 is( $acct_mac, "0012F01332BA", "format_for_acct returns valid MAC");
+is( $acct_mac, format_mac_for_acct($mac), "pf::MAC::format_for_acct() and pf::util::format_for_acct return the same values.");
 
 my $dash_mac = pf::MAC->new( mac => '00-12-f0-13-32-ba' );
 is( $dash_mac->get_stripped(), "0012f01332ba", "get_stripped returns MAC without delimiters");
 
+is( $mac->get_dec_stripped(), '81337201338', "MAC is returned as an integer" );
+is( $mac->get_dec_stripped(), mac2nb($mac), "get_dec_stripped() and mac2nb return the same values" );
 

--- a/t/MAC.t
+++ b/t/MAC.t
@@ -6,8 +6,23 @@ use Test::More 'no_plan';
 use_ok( 'pf::MAC' ) or die;
 use pf::MAC;
 
-my $mac = pf::MAC->new( mac => '00:12:f0:13:32:ba' );
+my $mac = pf::MAC->new( mac => '00:12:F0:13:32:BA' );
 isa_ok( $mac, 'pf::MAC');
 
+is( "MAC: " . $mac, "MAC: 00:12:F0:13:32:BA",  "String concatenation works");
 use pf::util;
 is( mac2oid( $mac ), '0.18.240.19.50.186', "mac2oid returns correct notation");
+
+is( clean_mac($mac), '00:12:f0:13:32:ba', "pf::util::clean_mac returns valid MAC");
+
+my $cleaned_mac = $mac->clean();
+is( $cleaned_mac, '00:12:f0:13:32:ba', "clean() returns valid MAC");
+
+is( $mac->get_hex_stripped(), "0012F01332BA", "stripping returns string without delimiters" );
+my $acct_mac = $mac->format_for_acct();
+is( $acct_mac, "0012F01332BA", "format_for_acct returns valid MAC");
+
+my $dash_mac = pf::MAC->new( mac => '00-12-f0-13-32-ba' );
+is( $dash_mac->get_stripped(), "0012f01332ba", "get_stripped returns MAC without delimiters");
+
+

--- a/t/MAC.t
+++ b/t/MAC.t
@@ -42,3 +42,6 @@ is( $mac->get_dec_oui(), macoui2nb($mac),   "get_dec_oui() and pf::util::macoui2
 is( $mac->get_dec_oui(), $mac->macoui2nb(), "get_dec_oui() and macoui2nb() return the same values" );
 
 is( valid_mac($mac), 1, "pf::util::valid_mac() accepts our pf::MAC object" );
+
+is( $mac->as_oid, "0.18.240.19.50.186", "pf::MAC::as_oid returns the correct OID." );
+is( $mac->as_oid, mac2oid($mac),        "pf::MAC::as_oid and pf::util::mac2oid return the same values" );

--- a/t/MAC.t
+++ b/t/MAC.t
@@ -1,0 +1,13 @@
+use strict;
+use warnings;
+
+use Test::More 'no_plan';
+
+use_ok( 'pf::MAC' ) or die;
+use pf::MAC;
+
+my $mac = pf::MAC->new( mac => '00:12:f0:13:32:ba' );
+isa_ok( $mac, 'pf::MAC');
+
+use pf::util;
+is( mac2oid( $mac ), '0.18.240.19.50.186', "mac2oid returns correct notation");

--- a/t/MAC.t
+++ b/t/MAC.t
@@ -30,3 +30,8 @@ is( $dash_mac->get_stripped(), "0012f01332ba", "get_stripped returns MAC without
 is( $mac->get_dec_stripped(), '81337201338', "MAC is returned as an integer" );
 is( $mac->get_dec_stripped(), mac2nb($mac), "get_dec_stripped() and mac2nb return the same values" );
 
+is( $mac->get_oui(), "00-12-F0", "get oui() extracts the OUI from the MAC");
+
+like( $mac->get_dec_oui(), qr/^\d+$/, "get_dec_oui() returns a decimal integer");
+is( $mac->get_dec_oui(), macoui2nb($mac), "get_dec_oui() and macoui2nb return the same values");
+


### PR DESCRIPTION
A class to implement MAC addresses with some utility methods.
Meant to replace MAC related functions in pf::util and make possible comparisons between MAC addresses in different notations.
Also makes conversions easier ( see as_Cisco, as_Microsoft, as_oid etc.)
