### PR TITLE
Fix unresolved user defined role

### DIFF
--- a/lib/pf/SNMP.pm
+++ b/lib/pf/SNMP.pm
@@ -742,6 +742,14 @@ sub getVlanByName {
     my ($this, $vlanName) = @_;
     my $logger = Log::Log4perl::get_logger(ref($this));
 
+    if (defined($this->{'_roles'}) && defined($this->{'_roles'}->{$vlanName})){
+        $logger->info("Resolved user defined role $vlanName as $this->{'_roles'}->{$vlanName}");
+        $vlanName = $this->{'_roles'}->{$vlanName};
+    }
+    else{
+        $logger->info("Couldn't resolve role. This is normal if node isn't assigned a user defined role.");
+    }
+    
     if (!defined($this->{'_vlans'}) || !defined($this->{'_vlans'}->{$vlanName})) {
         # VLAN name doesn't exist
         $logger->warn("No parameter ${vlanName}Vlan found in conf/switches.conf for the switch " . $this->{_ip});

--- a/lib/pf/SNMP.pm
+++ b/lib/pf/SNMP.pm
@@ -741,7 +741,11 @@ Input: VLAN name (as in switches.conf)
 sub getVlanByName {
     my ($this, $vlanName) = @_;
     my $logger = Log::Log4perl::get_logger(ref($this));
-
+    
+    if (defined($vlanName) && $vlanName eq ''){
+        $logger->warn("No vlan name or role was provided. Using default");
+        $vlanName = 'default';
+    }
     if (defined($this->{'_roles'}) && defined($this->{'_roles'}->{$vlanName})){
         $logger->info("Resolved user defined role $vlanName as $this->{'_roles'}->{$vlanName}");
         $vlanName = $this->{'_roles'}->{$vlanName};


### PR DESCRIPTION
Fixes a bug where a user defined role wouldn't be resolved to a vlan category if passed directly to getVlanByName

Happens with module Catalyst_2950 using port-security.

Not sure it's the correct way to fix it but it works.
