### PR TITLE
Fix ignored ldap condition when using a regex

### DIFF
--- a/lib/pf/Authentication/Source/LDAPSource.pm
+++ b/lib/pf/Authentication/Source/LDAPSource.pm
@@ -317,7 +317,7 @@ sub ldap_filter_for_conditions {
     my $value = escape_filter_value($condition->{'value'});
     my $attribute = $condition->{'attribute'};
 
-    if ($operator eq $Conditions::EQUALS) {
+    if ($operator eq $Conditions::EQUALS or $operator eq $Conditions::MATCHES) {
       $str = "${attribute}=${value}";
     } elsif ($operator eq $Conditions::CONTAINS) {
       $str = "${attribute}=*${value}*";


### PR DESCRIPTION
Option is there in the web UI to use a regex on a ldap attribute but it's not implemented in the model. This applies the regex in the ldap filter.
