### PR TITLE
Reevaluate access after a role change in web ui

### DIFF
--- a/html/pfappserver/lib/pfappserver/Model/Node.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Node.pm
@@ -251,6 +251,14 @@ sub update {
             # Node has been registered or deregistered
             reevaluate_access($mac, "node_modify");
         }
+        elsif (defined $previous_node_ref->{category} != defined $node_ref->{category}){
+            # Node role has been changed from null to defined or defined to null
+            reevaluate_access($mac, "node_modify");
+        }
+        elsif (defined $previous_node_ref->{category} && $previous_node_ref->{category} ne $node_ref->{category}){
+            # Node role has changed
+            reevaluate_access($mac, "node_modify");
+        }
     }
     else {
         $status = $STATUS::INTERNAL_SERVER_ERROR;

--- a/html/pfappserver/lib/pfappserver/Model/Node.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Node.pm
@@ -247,7 +247,7 @@ sub update {
         $result = node_modify($mac, %{$node_ref});
     }
     if ($result) {
-        if ($previous_node_ref->{status} ne $node_ref->{status}) {
+        if ($previous_node_ref->{status} ne $node_ref->{status} || $previous_node_ref->{category} ne $node_ref->{category}) {
             # Node has been registered or deregistered
             reevaluate_access($mac, "node_modify");
         }


### PR DESCRIPTION
Makes packetfence reevaluate the access of a node when it's role is changed in the web ui like it did in PF3
