### PR TITLE
Fix pfdetectd not starting because of pid file

### DIFF
--- a/addons/pfdetect_remote/initrd/pfdetectd
+++ b/addons/pfdetect_remote/initrd/pfdetectd
@@ -19,7 +19,7 @@ RETVAL=0
 
 start() {
 	echo -n $"Starting ${prog_base}: "
-	if [ -f /usr/local/pf/var/pfdetect_remote.pid ]; then
+  if [ -f /usr/local/pf/var/pfdetect_remote.pid ] && ps -p $(cat /usr/local/pf/var/pfdetect_remote.pid) > /dev/null; then
 		echo -n $"${prog_base}: already running"
 		echo
 		return 0


### PR DESCRIPTION
Fixes the case where either pfdetect crashes or the server crashes and
the pid file is left in the file system. On reboot or on service restart
the service won't start because it thinks it's running.

Now if the PID file is there it will also check that the pid it contains
is running
