### PR TITLE
Fix to show the current IP in the node list

### DIFF
--- a/lib/pf/node.pm
+++ b/lib/pf/node.pm
@@ -247,7 +247,7 @@ sub node_db_prepare {
             LEFT JOIN os_type ON dhcp_fingerprint.os_id = os_type.os_id
             LEFT JOIN violation ON node.mac=violation.mac AND violation.status = 'open'
             LEFT JOIN locationlog ON node.mac=locationlog.mac AND end_time IS NULL
-            LEFT JOIN iplog ON node.mac=iplog.mac AND iplog.end_time = '0000-00-00 00:00:00'
+            LEFT JOIN iplog ON node.mac=iplog.mac AND (iplog.end_time = '0000-00-00 00:00:00' OR iplog.end_time > NOW())
         GROUP BY node.mac
     ];
 


### PR DESCRIPTION
In the node list, the IP address of the node is not displayed even when the node is active and has an IP.

The origin of the problem is that the query only joins the iplog table when the _end_time_ = _'0000-00-00 00:00:00'_.
In reality, the _end_time_ of most nodes is the expiration of the dhcp lease which is a date in the future.

The proposed fix is to also join when the _end_time_ is greater than _NOW()_
