### PR TITLE
Correcting few bugs in inline mode

### DIFF
--- a/conf/iptables.conf
+++ b/conf/iptables.conf
@@ -60,8 +60,8 @@
 -A input-internal-inline-if --protocol udp --match udp --dport 53  --match mark --mark 0x1 --jump DROP
 # HTTP (captive-portal) 
 # prevent registered users from reaching it
--A input-internal-inline-if --protocol tcp --match tcp --dport 80  --match mark --mark 0x1 --jump DROP
--A input-internal-inline-if --protocol tcp --match tcp --dport 443 --match mark --mark 0x1 --jump DROP
+#-A input-internal-inline-if --protocol tcp --match tcp --dport 80  --match mark --mark 0x1 --jump DROP
+#-A input-internal-inline-if --protocol tcp --match tcp --dport 443 --match mark --mark 0x1 --jump DROP
 # allow everyone else behind inline interface (not registered, isolated, etc.)
 -A input-internal-inline-if --protocol tcp --match tcp --dport 80  --jump ACCEPT
 -A input-internal-inline-if --protocol tcp --match tcp --dport 443 --jump ACCEPT

--- a/lib/pf/enforcement.pm
+++ b/lib/pf/enforcement.pm
@@ -82,16 +82,7 @@ sub reevaluate_access {
 
             my $inline = new pf::inline::custom();
             if ($inline->isInlineEnforcementRequired($mac)) {
-
-                # TODO avoidable load?
-                my $trapSender = pf::SwitchFactory->getInstance()->instantiate('127.0.0.1');
-                if ($trapSender) {
-                    $logger->debug("sending a local firewallRequest trap to force firewall change");
-                    $trapSender->sendLocalFirewallRequestTrap('127.0.0.1', $mac);
-                } else {
-                    $logger->error("Can't instantiate switch 127.0.0.1! It's critical for internal messages!");
-                }
-
+                $inline->performInlineEnforcement($mac);
             } else {
                 $logger->debug("MAC: $mac is already properly enforced in firewall, no change required");
             }


### PR DESCRIPTION
For review:
- Updating iptables rules for captive portal to be reachable even for registered users (needed for "progress-bar redirect", for email validation, etc...)
- Applying patch (#1655 in BTS) for updating ipset in inline mode

Thanks.
