### PR TITLE
Removed action validation for start and end date of temporary password

### DIFF
--- a/lib/pf/temporary_password.pm
+++ b/lib/pf/temporary_password.pm
@@ -324,14 +324,6 @@ sub _update_from_actions {
     my ($data, $actions) = @_;
 
     _update_field_for_action(
-        $data,$actions,'valid_from',
-        'valid_from',undef
-    );
-    _update_field_for_action(
-        $data,$actions,'expiration',
-        'expiration',"0000-00-00 00:00:00"
-    );
-    _update_field_for_action(
         $data,$actions,$Actions::MARK_AS_SPONSOR,
         'sponsor',0
     );


### PR DESCRIPTION
The actions 'valid_from' and 'expiration' don't seem to exist in the authentication module. That prevents the temporary password from being valid since there is no registration window when doing a preregistration.

For review and merge please
