### PR TITLE
Feature/mab floating device

### DIFF
--- a/NEWS.asciidoc
+++ b/NEWS.asciidoc
@@ -16,7 +16,7 @@ Version x.x.x released on xxxx-xx-xx
 
 New Features
 ++++++++++++
-
+* Added support for MAC authentication floating devices on Juniper EX series, and on the Cisco Catalyst series
 
 Enhancements
 ++++++++++++

--- a/docs/PacketFence_Network_Devices_Configuration_Guide.asciidoc
+++ b/docs/PacketFence_Network_Devices_Configuration_Guide.asciidoc
@@ -2293,6 +2293,45 @@ Ctrl-D
 # commit comment "packetfenced dot1x"
 ----
 
+Configuration for MAC authentication floating devices
++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+To support floating devices on a Juniper switch you need to configure the 'flap-on-disconnect' option on each interface individually and remove it from the access-ports group.
+
+----
+# load replace terminal
+[Type ^D at a new line to end input]
+protocols {
+    dot1x {
+        authenticator {
+            authentication-profile-name packetfence;
+            interface {
+                ge-0/0/1.0 {
+                    mac-radius{
+                        flap-on-disconnect;
+                    }
+                }
+                 ge-0/0/2.0 {
+                    mac-radius{
+                        flap-on-disconnect;
+                    }
+                }
+                .....
+
+                access-ports {
+                    supplicant multiple;
+                    mac-radius {
+                        restrict; 
+                    }
+                }
+            }
+        }
+    }
+}
+Ctrl-D
+# commit comment "configured for floating devices"
+----
+
 LG-Ericsson
 ~~~~~~~~~~~
 

--- a/lib/pf/Switch.pm
+++ b/lib/pf/Switch.pm
@@ -3037,6 +3037,31 @@ sub identifyConnectionType {
     return;
 }
 
+=item disableMABByIfIndex
+
+Disables mac authentication bypass on the specified port
+
+=cut
+
+sub disableMABByIfIndex{
+    my ($this, $ifIndex) = @_;
+    my $logger = Log::Log4perl::get_logger( ref($self) );
+    $logger->error("This function is unimplemented.");
+    return 0; 
+} 
+
+=item enableMABByIfIndex
+
+Enables mac authentication bypass on the specified port
+
+=cut
+
+sub enableMABByIfIndex{
+    my ($this, $ifIndex) = @_;
+    my $logger = Log::Log4perl::get_logger( ref($self) );
+    $logger->error("This function is unimplemented.");
+    return 0; 
+}
 
 =back
 

--- a/lib/pf/Switch.pm
+++ b/lib/pf/Switch.pm
@@ -234,6 +234,12 @@ sub supportsRadiusDynamicVlanAssignment { return $TRUE; }
 # inline capabilities
 sub inlineCapabilities { return; }
 
+sub supportsMABFloatingDevices{
+    my ( $this ) = @_;
+    my $logger = Log::Log4perl::get_logger( ref($this) );
+    return $FALSE;
+}
+
 sub new {
     my ( $class, %argv ) = @_;
     my $this = bless {
@@ -1426,6 +1432,18 @@ sub isDynamicPortSecurityEnabled {
 sub isStaticPortSecurityEnabled {
     my ( $this, $ifIndex ) = @_;
     return ( 0 == 1 );
+}
+
+sub enableMABFloatingDevice{
+    my ($this, $ifIndex) = @_; 
+    my $logger = Log::Log4perl::get_logger( ref($this) );
+    $logger->warn("Cannot enable floating device on $this->{ip} on $ifIndex because this function is not implemented");
+}
+
+sub disableMABFloatingDevice{
+    my ($this, $ifIndex) = @_;
+    my $logger = Log::Log4perl::get_logger( ref($this) );
+    $logger->warn("Cannot disable floating device on $this->{ip} on $ifIndex because this function is not implemented");
 }
 
 =item getPhonesDPAtIfIndex

--- a/lib/pf/Switch.pm
+++ b/lib/pf/Switch.pm
@@ -3044,7 +3044,7 @@ Disables mac authentication bypass on the specified port
 =cut
 
 sub disableMABByIfIndex{
-    my ($this, $ifIndex) = @_;
+    my ($self, $ifIndex) = @_;
     my $logger = Log::Log4perl::get_logger( ref($self) );
     $logger->error("This function is unimplemented.");
     return 0; 
@@ -3057,7 +3057,7 @@ Enables mac authentication bypass on the specified port
 =cut
 
 sub enableMABByIfIndex{
-    my ($this, $ifIndex) = @_;
+    my ($self, $ifIndex) = @_;
     my $logger = Log::Log4perl::get_logger( ref($self) );
     $logger->error("This function is unimplemented.");
     return 0; 

--- a/lib/pf/Switch.pm
+++ b/lib/pf/Switch.pm
@@ -1434,12 +1434,22 @@ sub isStaticPortSecurityEnabled {
     return ( 0 == 1 );
 }
 
+=item enableMABFloatingDevice
+
+Connects to the switch and configures the specified port to be RADIUS floating device ready
+
+=cut
 sub enableMABFloatingDevice{
     my ($this, $ifIndex) = @_; 
     my $logger = Log::Log4perl::get_logger( ref($this) );
     $logger->warn("Cannot enable floating device on $this->{ip} on $ifIndex because this function is not implemented");
 }
 
+=item disableMABFloatingDevice
+
+Connects to the switch and removes the RADIUS floating device configuration
+
+=cut
 sub disableMABFloatingDevice{
     my ($this, $ifIndex) = @_;
     my $logger = Log::Log4perl::get_logger( ref($this) );

--- a/lib/pf/Switch/Cisco/Catalyst_2960.pm
+++ b/lib/pf/Switch/Cisco/Catalyst_2960.pm
@@ -587,7 +587,6 @@ sub enableMABByIfIndex {
 }
 
 =back
->>>>>>> Added support for classic floating devices triggered by RADIUS
 
 =head1 AUTHOR
 

--- a/lib/pf/Switch/Cisco/Catalyst_2960.pm
+++ b/lib/pf/Switch/Cisco/Catalyst_2960.pm
@@ -544,6 +544,51 @@ sub returnAccessListAttribute {
     return "ip:inacl#101";
 }
 
+sub disableMABByIfIndex {
+    my ( $this, $ifIndex ) = @_;
+    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+
+    if ( !$this->isProductionMode() ) {
+        $logger->warn("Should set cafPortAuthorizeControl on $ifIndex to 3:forceAuthorized but the s");
+        return 1;
+    }
+
+    if ( !$this->connectWrite() ) {
+        return 0;
+    }
+
+    my $OID_cafPortAuthorizeControl = '1.3.6.1.4.1.9.9.656.1.2.1.1.5';
+
+    $logger->trace("SNMP set_request for cafPortAuthorizeControl: $OID_cafPortAuthorizeControl");
+    my $result = $this->{_sessionWrite}->set_request(
+        -varbindlist => [ "$OID_cafPortAuthorizeControl.$ifIndex", Net::SNMP::INTEGER, 3 ] );
+    return ( defined($result) );
+}
+
+sub enableMABByIfIndex {
+    my ( $this, $ifIndex ) = @_;
+    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+
+    if ( !$this->isProductionMode() ) {
+        $logger->warn("Should set cafPortAuthorizeControl on $ifIndex to 2:auto but the switch is no");
+        return 1;
+    }
+
+    if ( !$this->connectWrite() ) {
+        return 0;
+    }
+
+    my $OID_cafPortAuthorizeControl = '1.3.6.1.4.1.9.9.656.1.2.1.1.5';
+
+    $logger->trace("SNMP set_request for cafPortAuthorizeControl: $OID_cafPortAuthorizeControl");
+    my $result = $this->{_sessionWrite}->set_request(
+        -varbindlist => [ "$OID_cafPortAuthorizeControl.$ifIndex", Net::SNMP::INTEGER, 2 ] );
+    return ( defined($result) );
+}
+
+=back
+>>>>>>> Added support for classic floating devices triggered by RADIUS
+
 =head1 AUTHOR
 
 Inverse inc. <info@inverse.ca>

--- a/lib/pf/Switch/Juniper/EX2200.pm
+++ b/lib/pf/Switch/Juniper/EX2200.pm
@@ -284,6 +284,11 @@ sub wiredeauthTechniques {
 
 }
 
+=item enableMABFloatingDevice
+
+Connects to the switch and configures the specified port to be RADIUS floating device ready
+
+=cut
 sub enableMABFloatingDevice{
     my ($this, $ifIndex) = @_; 
     my $logger = Log::Log4perl::get_logger( ref($this) );
@@ -337,6 +342,11 @@ sub enableMABFloatingDevice{
 
 }
 
+=item disableMABFloatingDevice
+
+Connects to the switch and removes the RADIUS floating device configuration
+
+=cut
 sub disableMABFloatingDevice{
     my ($this, $ifIndex) = @_; 
     my $logger = Log::Log4perl::get_logger( ref($this) );

--- a/lib/pf/Switch/Juniper/EX2200.pm
+++ b/lib/pf/Switch/Juniper/EX2200.pm
@@ -43,6 +43,7 @@ use pf::util;
 sub supportsWiredMacAuth { return $TRUE; }
 sub supportsRadiusVoip { return $TRUE; }
 # special features
+sub supportsFloatingDevice {return $TRUE}
 sub supportsMABFloatingDevices { return $TRUE }
 sub supportsLldp { return $TRUE; }
 sub isVoIPEnabled {return $TRUE; }

--- a/lib/pf/floatingdevice.pm
+++ b/lib/pf/floatingdevice.pm
@@ -202,6 +202,48 @@ sub disablePortConfig {
     return 1;
 }
 
+sub enableMABMacLimit {
+    my ( $this, $switch, $ifIndex ) = @_;
+    if($switch->supportsMABFloatingDevices){
+        if($switch->disableMABFloatingDevice($ifIndex)){
+            return 1;
+        }
+        else{
+            return 0;
+        }
+    }
+}
+
+sub disableMABMacLimit{
+    my ( $this, $switch, $ifIndex ) = @_;
+    my $logger = Log::Log4perl::get_logger('pf::floatingdevice');
+    if($switch->supportsMABFloatingDevices){
+        if($switch->enableMABFloatingDevice($ifIndex)){
+            return 1;
+        }
+        else{
+            return 0;
+        }
+    }
+}
+
+sub portHasFloatingDevice {
+    my ($this, $switch, $switch_port) = @_;
+    my $logger = Log::Log4perl::get_logger('pf::floatingdevice');
+
+    $logger->debug("Determining if there is a floating device on $switch port $switch_port");
+    my @locationlog_switchport = pf::locationlog::locationlog_view_open_switchport_no_VoIP($switch, $switch_port);
+    if (@locationlog_switchport && scalar(@locationlog_switchport) > 0){ 
+        my $mac = $locationlog_switchport[0]->{'mac'}; 
+        if( exists($ConfigFloatingDevices{$mac}) ){
+            $logger->info("There is a floating device on $switch port $switch_port");
+            return $mac;
+        }
+    }
+    return 0;
+
+}
+
 =back
 
 =head1 AUTHOR

--- a/lib/pf/floatingdevice.pm
+++ b/lib/pf/floatingdevice.pm
@@ -202,7 +202,12 @@ sub disablePortConfig {
     return 1;
 }
 
-sub enableMABMacLimit {
+=item disableMABFloating
+
+Removes the MAB floating device mode on the switchport
+
+=cut
+sub disableMABFloating {
     my ( $this, $switch, $ifIndex ) = @_;
     if($switch->supportsMABFloatingDevices){
         if($switch->disableMABFloatingDevice($ifIndex)){
@@ -214,7 +219,12 @@ sub enableMABMacLimit {
     }
 }
 
-sub disableMABMacLimit{
+=item enableMABFloating
+
+Puts the switchport in MAB floating device mode
+
+=cut
+sub enableMABFloating{
     my ( $this, $switch, $ifIndex ) = @_;
     my $logger = Log::Log4perl::get_logger('pf::floatingdevice');
     if($switch->supportsMABFloatingDevices){
@@ -227,6 +237,11 @@ sub disableMABMacLimit{
     }
 }
 
+=item portHasFloatingDevice
+
+Verifies if there is a floating device plugged into the switchport in the locationlog
+
+=cut
 sub portHasFloatingDevice {
     my ($this, $switch, $switch_port) = @_;
     my $logger = Log::Log4perl::get_logger('pf::floatingdevice');

--- a/lib/pf/locationlog.pm
+++ b/lib/pf/locationlog.pm
@@ -17,6 +17,7 @@ use strict;
 use warnings;
 use Log::Log4perl;
 use Log::Log4perl::Level;
+use pf::floatingdevice::custom;
 
 use constant LOCATIONLOG => 'locationlog';
 
@@ -482,6 +483,11 @@ sub locationlog_synchronize {
     # if we are in a wired environment, close any conflicting switchport entry
     # but paying attention to VoIP vs non-VoIP entries (we close the same type that we are asked to add)
     if ($connection_type && ($connection_type & $WIRED) == $WIRED) {
+        my $floatingDeviceManager = new pf::floatingdevice::custom();
+        if( $floatingDeviceManager->portHasFloatingDevice($switch_ip, $ifIndex) ){
+            $logger->info("Not adding locationlog entry for mac $mac because it's plugged in a floating device enabled port");
+            return 1;
+        }
 
         my @locationlog_switchport = locationlog_view_open_switchport($switch, $ifIndex, $voip_status);
         if (!(@locationlog_switchport && scalar(@locationlog_switchport) > 0)) {

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -247,6 +247,9 @@ sub accounting {
 
     if ($isStop || $isUpdate) {
         my($switch_mac, $switch_ip,$source_ip) = $this->_parseRequest($radius_request);
+        my ($nas_port_type, $eap_type, $mac, $port, $user_name, $nas_port_id, $session_id) = $switch->parseRequest($radius_request);
+        my $connection_type = $switch->_identifyConnectionType($nas_port_type, $eap_type, $mac, $user_name);
+        $port = $switch->getIfIndexByNasPortId($nas_port_id) || $this->_translateNasPortToIfIndex($connection_type, $switch, $port); 
 
         $logger->debug("instantiating switch");
         my $switch = pf::SwitchFactory->getInstance()->instantiate({ switch_mac => $switch_mac, switch_ip => $switch_ip, controllerIp => $source_ip});
@@ -266,7 +269,6 @@ sub accounting {
         }
 
         # On accounting stop/update, check the usage duration of the node
-        my ($nas_port_type, $eap_type, $mac, $port, $user_name, $nas_port_id, $session_id) = $switch->parseRequest($radius_request);
         if ($mac && $user_name) {
             my $session_time = int $radius_request->{'Acct-Session-Time'};
             if ($session_time > 0) {

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -246,22 +246,9 @@ sub accounting {
     my $isUpdate = $radius_request->{'Acct-Status-Type'} eq 'Interim-Update';
 
     if ($isStop || $isUpdate) {
-        my($switch_mac, $switch_ip,$source_ip) = $this->_parseRequest($radius_request);
         my ($nas_port_type, $eap_type, $mac, $port, $user_name, $nas_port_id, $session_id) = $switch->parseRequest($radius_request);
         my $connection_type = $switch->_identifyConnectionType($nas_port_type, $eap_type, $mac, $user_name);
         $port = $switch->getIfIndexByNasPortId($nas_port_id) || $this->_translateNasPortToIfIndex($connection_type, $switch, $port); 
-
-        $logger->debug("instantiating switch");
-        my $switch = pf::SwitchFactory->getInstance()->instantiate({ switch_mac => $switch_mac, switch_ip => $switch_ip, controllerIp => $source_ip});
-
-        # is switch object correct?
-        if (!$switch) {
-            $logger->warn(
-               "Can't instantiate switch $switch_ip. This request will be failed. "
-                ."Are you sure your switches.conf is correct?"
-            );
-            return [ $RADIUS::RLM_MODULE_FAIL, ('Reply-Message' => "Switch is not managed by PacketFence") ];
-        }
 
         if($isStop){
             #handle radius floating devices

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -587,7 +587,7 @@ sub _handleAccessFloatingDevices{
     my $logger = Log::Log4perl::get_logger(ref($this));
     if( exists( $ConfigFloatingDevices{$mac} ) ){
         my $floatingDeviceManager = new pf::floatingdevice::custom();
-        $floatingDeviceManager->enableMABFloating($switch, $port);
+        $floatingDeviceManager->enableMABFloating($mac, $switch, $port);
     } 
 }
 

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -584,9 +584,6 @@ sub _handleAccessFloatingDevices{
     my ($this, $switch, $mac, $port) = @_;
     my $logger = Log::Log4perl::get_logger(ref($this));
     if( exists( $ConfigFloatingDevices{$mac} ) ){
-        # close additionnal entries that could have been opened (a device talked before the floating)
-        locationlog_update_end_switchport_no_VoIP($switch->{_ip}, $port); 
-        
         my $floatingDeviceManager = new pf::floatingdevice::custom();
         $floatingDeviceManager->enableMABFloating($switch, $port);
     } 

--- a/lib/pf/vlan.pm
+++ b/lib/pf/vlan.pm
@@ -87,12 +87,11 @@ sub fetchVlanForNode {
             return $floating_config->{'pvid'};
         }
         my $floating_mac = $floatingDeviceManager->portHasFloatingDevice($switch->{_ip}, $ifIndex);
-        $logger->info("portHasFloatingDevice? $floating_mac");
         if($floating_mac){
-            $logger->info("Device is plugged into a floating enabled port. Determining if trunk.");
+            $logger->debug("Device $mac is plugged into a floating enabled port (Device $floating_mac). Determining if trunk.");
             my $floating_config = $ConfigFloatingDevices{$floating_mac};
             if( ! $floating_config->{'trunkPort'} ){
-                $logger->info("MAC $mac, PID: $node_info->{pid} has just plugged in a floating device enabled port. Returned VLAN $floating_config->{pvid}");
+                $logger->info("MAC $mac, PID: $node_info->{pid} has just plugged in an access floating device enabled port. Returned VLAN $floating_config->{pvid}");
                 return $floating_config->{'pvid'};
             }
         }

--- a/lib/pf/vlan.pm
+++ b/lib/pf/vlan.pm
@@ -24,6 +24,7 @@ use pf::node qw(node_attributes node_exist node_modify);
 use pf::Switch::constants;
 use pf::util;
 use pf::violation qw(violation_count_trap violation_exist_open violation_view_top violation_trigger);
+use pf::floatingdevice::custom;
 
 use pf::authentication;
 use pf::Authentication::constants;
@@ -75,6 +76,26 @@ sub fetchVlanForNode {
         my $inline = $this->getInlineVlan($switch, $ifIndex, $mac, $node_info, $connection_type, $user_name, $ssid, $radius_request);
         $logger->info("[$mac] PID: \"" .$node_info->{pid}. "\", Status: " .$node_info->{status}. ". Returned VLAN: $inline");
         return ( $inline, 1 );
+    }
+
+    # radius floating device handling
+    if( $switch->supportsMABFloatingDevices ){
+        my $floatingDeviceManager = new pf::floatingdevice::custom();
+        if (exists($ConfigFloatingDevices{$mac})){
+            my $floating_config = $ConfigFloatingDevices{$mac};
+            $logger->info("Floating device $mac has plugged into $switch->{_ip} port $ifIndex. Returned VLAN : $floating_config->{pvid}");
+            return $floating_config->{'pvid'};
+        }
+        my $floating_mac = $floatingDeviceManager->portHasFloatingDevice($switch->{_ip}, $ifIndex);
+        $logger->info("portHasFloatingDevice? $floating_mac");
+        if($floating_mac){
+            $logger->info("Device is plugged into a floating enabled port. Determining if trunk.");
+            my $floating_config = $ConfigFloatingDevices{$floating_mac};
+            if( ! $floating_config->{'trunkPort'} ){
+                $logger->info("MAC $mac, PID: $node_info->{pid} has just plugged in a floating device enabled port. Returned VLAN $floating_config->{pvid}");
+                return $floating_config->{'pvid'};
+            }
+        }
     }
 
     my ($violation,$registration,$role);


### PR DESCRIPTION
RADIUS floating device support for PacketFence.

For review, discussion and merge.

See : https://wiki.inverse.ca/focus/PacketFence/Devel/RnD/2014/FloatingDevicesImprovement

Works on Juniper EX4200

Detection :
- On an Access-Request of a floating device it disconnects then deletes the macs present in the location log in case another device triggered a request before it.
- It configures the switch to accept an unlimited number of devices on the floating device port and leaves mac auth enabled.
- Then PF will know there is a floating device on this port from the location log entry.
- When other devices connect to this port it returns the configured PVID or the normalVlan depending on the mode of the floating device (see below).
- When the switch sends the accounting stop for the floating device, the port is unconfigured from the floating device mode and it's locationlog entry closed.

Additionnal devices connecting to the port (access floating):
- When the floating device is not configured in trunk in PacketFence, this flow applies.
- PF will receive a RADIUS request and if a floating device is in the location log for that interface it will accept it with the PVID of the floating device.
- In this mode, all devices connecting to this port are accepted with the floating device VLAN.

Additionnal devices connecting to the port (trunk floating):
- PF will receive a RADIUS request and if a floating device is in they location log for that interface it will lookup the VLAN tag to return as it does normally (registration, isolation or normal)
- In this mode access control is done directly by PacketFence. The port becomes a 'sub-switch'.

Detection and flow for switches that don't support multiple untagged vlan per port:
- They will be detected using the RADIUS access request.
- That will trigger the 'classic' flow of the floating devices.
- MAB will be removed on the port and put in either the access vlan it should or in trunk mode
- up traps will be activated
- Once the up trap is received, pf will reactivate MAB on the port

Current limitations :
- In order to not open multiple location log entries per port PF doesn't keep the location of the devices connected behind the floating device. This means in trunk mode there can't be any deauth in case a MAC needs VLAN reevaluation. Access mode works fine since it never needs deauth.
- Devices connected before the floating need to be disconnected to have them on the correct VLAN and this is not done asynchronously. This shouldn't be a big issue since the mac limit on the switch will make us deauth one client in the worst case.
- If a switch is a floating device in trunk mode then the devices in different VLANs behind it could have communications problems between them. Since they are on two different networks outside of the floating but on the same in the floating, a switch could forward the packets between both devices that are on different IP subnets. Tested with a Cisco 2950 as a floating and didn't get this behavior (SSH + ping working fine between devices connected in the floating).
- (Juniper) The flap-on-disconnect option has to be deactivated programaticaly by PF. Because of the way the Juniper switch has to be configured, the flap-on-disconnect cannot be configured through inheritance on Juniper. Doesn't change the behavior but makes ugly switch configs
