### PR TITLE
Fix the Net::Appliance::Session SSH bug for wired deauth

### DIFF
--- a/bin/pfcmd_vlan
+++ b/bin/pfcmd_vlan
@@ -52,7 +52,8 @@ pfcmd_vlan command [options]
                          4 : trace
    -vlan                VLAN id
    -vlanName            VLAN name (as in switches.conf)
-
+   -connectionType      Type of connection (see lib/pf/config.pm)
+ 
 =head1 DESCRIPTION
 
 This script allows to execute the following commands related to switches and VLANs:
@@ -112,6 +113,7 @@ my $vlan             = 0;
 my $vlanName         = '';
 my $mac              = undef;
 my $alias            = '';
+my $connectionType   = undef;
 my $cmd              = '';
 my $help;
 my $man;
@@ -147,6 +149,7 @@ my $wiredDeauth;
 
 GetOptions(
     "alias:s"             => \$alias,
+    "connectionType:i"    => \$connectionType,
     "deauthenticate"      => \$deauthenticate,
     "deauthenticateDot1x" => \$deauthenticateDot1x,
     "getAlias"            => \$getAlias,
@@ -181,7 +184,7 @@ GetOptions(
     "switch:s"            => \$switchDescRegExp,
     "verbose:i"           => \$logLevel,
     "vlan:i"              => \$vlan,
-    "vlanName:s"          => \$vlanName
+    "vlanName:s"          => \$vlanName,
     "wiredDeauth"         => \$wiredDeauth,
 ) or pod2usage( -verbose => 1 );
 
@@ -692,12 +695,14 @@ if ($reevaluateAccess) {
     $logger->debug("finished handling 'getLocation' command");
 
 } elsif ($wiredDeauth) {
-
     if (!defined($mac) || $mac eq '') {
         exit_wrong_args("the MAC argument is necessary");
     }
-    if (!defined($ifIndex) || $mac eq '') {
+    if (!defined($ifIndex) || $ifIndex eq '') {
         exit_wrong_args("the ifindex argument is necessary");
+    }
+    if (!defined($connectionType) || $connectionType eq '') {
+        exit_wrong_args("the connectionType argument is necessary");
     }
     if ( $switchDescRegExp eq '' ) {
         exit_wrong_args("the switch argument is necessary");
@@ -707,7 +712,7 @@ if ($reevaluateAccess) {
         exit_wrong_args("unknown switch $switchDescRegExp");
     } else {
         $logger->debug("start handling 'wiredDeauth' command");
-        $switch->wiredDeauthenticateMac($ifIndex, $mac);
+        $switch->wiredDeauthenticateMac($ifIndex, $mac, $connectionType);
         $logger->debug("finished handling 'wiredDeauth' command");
     }
 

--- a/bin/pfcmd_vlan
+++ b/bin/pfcmd_vlan
@@ -35,6 +35,7 @@ pfcmd_vlan command [options]
    -setIfAdminStatus    set the admin status of the specified switch port
    -setVlan             set VLAN on the specified switch port
    -setVlanAllPort      set VLAN on all non-UpLink ports of the specified switch
+   -wiredDeauth         de-authenticate a wired client
 
  Options:
    -alias               switch port description
@@ -142,6 +143,7 @@ my $deauthenticateDot1x;
 my $reAssignVlan;
 my $reevaluateAccess;
 my $runSwitchMethod;
+my $wiredDeauth;
 
 GetOptions(
     "alias:s"             => \$alias,
@@ -180,6 +182,7 @@ GetOptions(
     "verbose:i"           => \$logLevel,
     "vlan:i"              => \$vlan,
     "vlanName:s"          => \$vlanName
+    "wiredDeauth"         => \$wiredDeauth,
 ) or pod2usage( -verbose => 1 );
 
 pod2usage( -verbose => 2 ) if $man;
@@ -687,6 +690,26 @@ if ($reevaluateAccess) {
         print "MAC $mac cannot be found\n";
     }
     $logger->debug("finished handling 'getLocation' command");
+
+} elsif ($wiredDeauth) {
+
+    if (!defined($mac) || $mac eq '') {
+        exit_wrong_args("the MAC argument is necessary");
+    }
+    if (!defined($ifIndex) || $mac eq '') {
+        exit_wrong_args("the ifindex argument is necessary");
+    }
+    if ( $switchDescRegExp eq '' ) {
+        exit_wrong_args("the switch argument is necessary");
+    }
+    my $switch = $switchFactory->instantiate($switchDescRegExp);
+    if (!$switch) {
+        exit_wrong_args("unknown switch $switchDescRegExp");
+    } else {
+        $logger->debug("start handling 'wiredDeauth' command");
+        $switch->wiredDeauthenticateMac($ifIndex, $mac);
+        $logger->debug("finished handling 'wiredDeauth' command");
+    }
 
 } else {
     pod2usage( -verbose => 1 );

--- a/lib/pf/Switch.pm
+++ b/lib/pf/Switch.pm
@@ -2416,6 +2416,19 @@ sub deauthenticateMac {
     $this->$deauthTechniques($mac);
 }
 
+=item deauthenticateMac - performs wired deauthentication
+
+mac - mac address to deauthenticate
+
+=cut
+
+sub wiredDeauthenticateMac {
+    my ($this, $ifIndex, $mac) = @_;
+    my $logger = Log::Log4perl::get_logger(ref($this));
+    my ($switchdeauthMethod, $deauthTechniques) = $this->wiredeauthTechniques($this->{_deauthMethod});
+    $this->$deauthTechniques($mac);
+}
+
 =item dot1xPortReauthenticate
 
 Forces 802.1x re-authentication of a given ifIndex

--- a/lib/pf/Switch.pm
+++ b/lib/pf/Switch.pm
@@ -2423,10 +2423,10 @@ mac - mac address to deauthenticate
 =cut
 
 sub wiredDeauthenticateMac {
-    my ($this, $ifIndex, $mac) = @_;
+    my ($this, $ifIndex, $mac, $connectionType) = @_;
     my $logger = Log::Log4perl::get_logger(ref($this));
-    my ($switchdeauthMethod, $deauthTechniques) = $this->wiredeauthTechniques($this->{_deauthMethod});
-    $this->$deauthTechniques($mac);
+    my ($switchdeauthMethod, $deauthTechniques) = $this->wiredeauthTechniques($this->{_deauthMethod}, $connectionType);
+    $this->$deauthTechniques($ifIndex, $mac);
 }
 
 =item dot1xPortReauthenticate

--- a/sbin/pfsetvlan
+++ b/sbin/pfsetvlan
@@ -1612,10 +1612,10 @@ sub handleTrap {
             if (($switchdeauthMethod eq $SNMP::SSH) || ($switchdeauthMethod eq $SNMP::TELNET)) {
                 # we spawn a shell to workaround a thread safety bug in Net::Appliance::Session when using SSH transport
                 # http://www.cpanforum.com/threads/6909
-                pf_run("/usr/local/pf/bin/pfcmd_vlan -$command -switch $switchId -ifIndex $ifIndex -mac $trapMac");
+                pf_run("/usr/local/pf/bin/pfcmd_vlan -$command -switch $switchId -ifIndex $switch_port -mac $trapMac -connectionType $connection_type");
             }
             else {
-                $switch->$deauthTechniques($ifIndex, $trapMac);
+                $switch->$deauthTechniques($switch_port, $trapMac);
             }
         } else {
 

--- a/sbin/pfsetvlan
+++ b/sbin/pfsetvlan
@@ -1605,10 +1605,18 @@ sub handleTrap {
     } elsif ( $trapType eq 'reAssignVlan' ) {
         my $connection_type = $trapOperation; # WARNING: I used trapOperation to carry the connection type
         $logger->info("$trapType trap received on $switch_id ifIndex $switch_port");
-
+        my $command = "wiredDeauth";
+        my $switchId = $switch->{_id};
         if (defined($connection_type) && ($connection_type == $WIRED_802_1X || $connection_type == $WIRED_MAC_AUTH) ) {
             my ($switchdeauthMethod, $deauthTechniques) = $switch->wiredeauthTechniques($switch->{_deauthMethod},$connection_type);
-            $switch->$deauthTechniques($switch_port,$trapMac);
+            if (($switchdeauthMethod eq $SNMP::SSH) || ($switchdeauthMethod eq $SNMP::TELNET)) {
+                # we spawn a shell to workaround a thread safety bug in Net::Appliance::Session when using SSH transport
+                # http://www.cpanforum.com/threads/6909
+                pf_run("/usr/local/pf/bin/pfcmd_vlan -$command -switch $switchId -ifIndex $ifIndex -mac $trapMac");
+            }
+            else {
+                $switch->$deauthTechniques($ifIndex, $trapMac);
+            }
         } else {
 
             my @locationlog = locationlog_view_open_switchport_no_VoIP( $switch_id, $switch_port );


### PR DESCRIPTION
- Adds a pfcmd_vlan command to do the wired deauth outside of Packetfence.
- Plugs pf_run in the flow of pfsetvlan when doing wired deauth with SSH or Telnet
- Adds a method in Switch to manage the deauthentication like in wireless deauth 

For review and merge (target 4.3 ?)
