### PR TITLE
Fixed VLAN format to comply with RFC 2868.

### DIFF
--- a/NEWS.asciidoc
+++ b/NEWS.asciidoc
@@ -53,7 +53,7 @@ Bug Fixes
 * Fixed SQL join with iplog in advanced search of nodes
 * Fixed unreg date calculation in Catalyst captive portal
 * Fixed allowed_device_types array in device registration page (bugid:1809)
-* Fixed VLAN format to comply with RFC 2868.
+* Fixed VLAN format to comply with RFC 2868
 
 Version 4.2.2 released on 2014-05-29
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/NEWS.asciidoc
+++ b/NEWS.asciidoc
@@ -53,6 +53,7 @@ Bug Fixes
 * Fixed SQL join with iplog in advanced search of nodes
 * Fixed unreg date calculation in Catalyst captive portal
 * Fixed allowed_device_types array in device registration page (bugid:1809)
+* Fixed VLAN format to comply with RFC 2868.
 
 Version 4.2.2 released on 2014-05-29
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/pf/Switch.pm
+++ b/lib/pf/Switch.pm
@@ -774,7 +774,7 @@ sub getVlanByName {
         return 0;
     }
 
-    if ($this->{'_vlans'}->{$vlanName} !~ /^-?\w+$/) {
+    if (length $this->{'_vlans'}->{$vlanName} < 1 ) {
         # is not resolved to a valid VLAN identifier
         $logger->warn("VLAN $vlanName is not properly configured in switches.conf for the switch " . $this->{_id} .
                       ", not a VLAN identifier");


### PR DESCRIPTION
The RFC states that "There is no restriction on the format of group IDs".
We now only make sure that the VLAN has a length of at least one byte.
