### PR TITLE
The upgrade script duplicates changes to the locationlog that are

### DIFF
--- a/NEWS.asciidoc
+++ b/NEWS.asciidoc
@@ -58,6 +58,7 @@ Bug Fixes
 * Fixed unreg date calculation in Catalyst captive portal
 * Fixed allowed_device_types array in device registration page (bugid:1809)
 * Fixed VLAN format to comply with RFC 2868
+* Fixed db upgrade script to avoid duplicate changes to locationlog table
 
 Version 4.2.2 released on 2014-05-29
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/db/upgrade-4.1.0-4.2.0.sql
+++ b/db/upgrade-4.1.0-4.2.0.sql
@@ -69,15 +69,6 @@ ALTER TABLE radius_nas
     ADD PRIMARY KEY (nasname)
 ;
 
---
--- Add new columns to store the switch IP and MAC when using dynamic controllers
---
-
-ALTER TABLE locationlog 
-    ADD `switch_ip` varchar(17) DEFAULT NULL,
-    ADD `switch_mac` varchar(17) DEFAULT NULL;
-
-UPDATE locationlog SET switch_ip = switch;
 
 --
 -- Table structure for wrix


### PR DESCRIPTION
already in the 4.0-4.1 script.

This causes an error where the last statements are never run and thus
the wrix is never added.
