### PR TITLE
Fix/parse trap

### DIFF
--- a/NEWS.asciidoc
+++ b/NEWS.asciidoc
@@ -32,6 +32,7 @@ Bug Fixes
 +++++++++
 
 * Fix issue when adding multiple portal profile filters causing the wrong type to be picked
+* Fix issue when a trap is received for a switch that does not implement parseTrap().
 
 
 Version 4.3.0 released on 2014-06-26

--- a/lib/pf/Switch.pm
+++ b/lib/pf/Switch.pm
@@ -2973,9 +2973,21 @@ sub _identifyConnectionType {
     }
 }
 
+=item parseTrap
+
+Unimplemented base method meant to be overriden in switches that support SNMP trap based methods.
+
+=cut 
+
+sub parseTrap {
+    my $self   = shift;
+    my $logger = Log::Log4perl::get_logger( ref($self) );
+    $logger->warn("SNMP trap handling not implemented for this type of switch.");
+    return undef;
+}
+
 
 =back
-
 =head1 AUTHOR
 
 Inverse inc. <info@inverse.ca>


### PR DESCRIPTION
Without this fix, switches that don't implement parseTrap (e.g. Radius only switches) may crash pfsetvlan every time they send a trap. 
