### PR TITLE
Renamed timeout into connection_timeout to distinguish from possible search timeout.

### DIFF
--- a/html/pfappserver/lib/pfappserver/Form/Authentication/Source/LDAP.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Authentication/Source/LDAP.pm
@@ -29,10 +29,10 @@ has_field 'port' =>
    element_class => ['input-mini'],
    element_attr => {'placeholder' => '389'},
   );
-has_field 'timeout' =>
+has_field 'connection_timeout' =>
   (
    type => 'PosInteger',
-   label => 'Timeout',
+   label => 'Connection timeout',
    element_attr => {'placeholder' => '5'},
   );
 has_field 'encryption' =>

--- a/html/pfappserver/root/authentication/source/type/AD.tt
+++ b/html/pfappserver/root/authentication/source/type/AD.tt
@@ -4,7 +4,7 @@
             [% form.field('host').render_element %]:[% form.field('port').render_element %] [% form.field('encryption').render_element %]
           </div>
         </div>
-[% form.field('timeout').render %]
+[% form.field('connection_timeout').render %]
 [% form.field('basedn').render %]
 [% form.field('scope').render %]
 [% form.field('usernameattribute').render %]

--- a/html/pfappserver/root/authentication/source/type/LDAP.tt
+++ b/html/pfappserver/root/authentication/source/type/LDAP.tt
@@ -4,7 +4,7 @@
             [% form.field('host').render_element %]:[% form.field('port').render_element %] [% form.field('encryption').render_element %] 
           </div>
         </div>
-[% form.field('timeout').render %]
+[% form.field('connection_timeout').render %]
 [% form.field('basedn').render %]
 [% form.field('scope').render %]
 [% form.field('usernameattribute').render %]

--- a/lib/pf/Authentication/Source/LDAPSource.pm
+++ b/lib/pf/Authentication/Source/LDAPSource.pm
@@ -27,11 +27,11 @@ use constant {
     TLS => "starttls",
 };
 
-has '+type'   => ( default => 'LDAP' );
-has 'host'    => ( isa     => 'Maybe[Str]', is => 'rw', default => '127.0.0.1' );
-has 'port'    => ( isa     => 'Maybe[Int]', is => 'rw', default => 389 );
-has 'timeout' => ( isa     => 'Int', is => 'rw', default => 5 );
-has 'basedn'  => ( isa     => 'Str', is => 'rw', required => 1 );
+has '+type'              => ( default => 'LDAP' );
+has 'host'               => ( isa     => 'Maybe[Str]', is => 'rw', default => '127.0.0.1' );
+has 'port'               => ( isa     => 'Maybe[Int]', is => 'rw', default => 389 );
+has 'connection_timeout' => ( isa     => 'Int', is => 'rw', default => 5 );
+has 'basedn'             => ( isa     => 'Str', is => 'rw', required => 1 );
 has 'binddn'            => ( isa => 'Maybe[Str]', is => 'rw' );
 has 'password'          => ( isa => 'Maybe[Str]', is => 'rw' );
 has 'encryption'        => ( isa => 'Str',        is => 'rw', required => 1 );
@@ -141,9 +141,9 @@ sub _connect {
     $LDAPServerPort //=  $self->{'port'} ;
 
     if ( $self->{'encryption'} eq SSL ) {
-        $connection = Net::LDAPS->new($LDAPServer, port =>  $LDAPServerPort, timeout => $self->{'timeout'} );
+        $connection = Net::LDAPS->new($LDAPServer, port =>  $LDAPServerPort, timeout => $self->{'connection_timeout'} );
     } else {
-        $connection = Net::LDAP->new($LDAPServer, port =>  $LDAPServerPort, timeout => $self->{'timeout'} );
+        $connection = Net::LDAP->new($LDAPServer, port =>  $LDAPServerPort, timeout => $self->{'connection_timeout'} );
     }
     if (! defined($connection)) {
       $logger->warn("[$self->{'id'}] Unable to connect to $LDAPServer");


### PR DESCRIPTION
As requested by our dear Leader, I renamed the LDAP authentication source 'timeout' attribute into 'connection_timeout'. 
That leaves open the possibility to have a 'search_timeout' in the future.
