### PR TITLE
Modified default radiusd configuration to make it more resilient to

### DIFF
--- a/NEWS.asciidoc
+++ b/NEWS.asciidoc
@@ -29,6 +29,7 @@ Enhancements
 * Improvement of Inline Layer 3 (Inline L3 can only be defined behind Inline Layer 2 network)
 * pfbandwidthd is now able to capture on all inline interfaces
 * Added an option to set the timeout value for LDAP connections in authentication sources
+* FreeRADIUS default configuration should now be more scalable and resilient to misbehaving devices.
 
 Bug Fixes
 +++++++++

--- a/conf/radiusd/radiusd.conf.example
+++ b/conf/radiusd/radiusd.conf.example
@@ -27,7 +27,7 @@ rpc_proto  = %%rpc_proto%%
 user = pf
 group = pf
 
-max_request_time = 30
+max_request_time = 10
 cleanup_delay = 5
 max_requests = 20000
 
@@ -77,7 +77,7 @@ $INCLUDE clients.conf
 
 thread pool {
         start_servers = 5
-        max_servers = 32
+        max_servers = 64
         min_spare_servers = 3
         max_spare_servers = 10
         max_requests_per_server = 0
@@ -94,6 +94,7 @@ instantiate {
         expr
         expiration
         logintime
+        sql
         raw
 }
 

--- a/raddb/modules/mschap
+++ b/raddb/modules/mschap
@@ -16,24 +16,24 @@ mschap {
 	# add MS-CHAP-MPPE-Keys for MS-CHAPv1 and
 	# MS-MPPE-Recv-Key/MS-MPPE-Send-Key for MS-CHAPv2
 	#
-#	use_mppe = no
+	use_mppe = yes
 
 	# if mppe is enabled require_encryption makes
 	# encryption moderate
 	#
-#	require_encryption = yes
+	require_encryption = yes
 
 	# require_strong always requires 128 bit key
 	# encryption
 	#
-#	require_strong = yes
+	require_strong = yes
 
 	# Windows sends us a username in the form of
 	# DOMAIN\user, but sends the challenge response
 	# based on only the user portion.  This hack
 	# corrects for that incorrect behavior.
 	#
-#	with_ntdomain_hack = no
+	with_ntdomain_hack = yes
 
 	# The module can perform authentication itself, OR
 	# use a Windows Domain Controller.  This configuration
@@ -62,7 +62,11 @@ mschap {
 	# attribute, and do prefix/suffix checks in order to obtain
 	# the "best" user name for the request.
 	#
-#	ntlm_auth = "/path/to/ntlm_auth --request-nt-key --username=%{%{Stripped-User-Name}:-%{%{User-Name}:-None}} --challenge=%{%{mschap:Challenge}:-00} --nt-response=%{%{mschap:NT-Response}:-00}"
+	ntlm_auth = "/usr/bin/ntlm_auth --request-nt-key --username=%{%{Stripped-User-Name}:-%{%{User-Name}:-None}} --challenge=%{%{mschap:Challenge}:-00} --nt-response=%{%{mschap:NT-Response}:-00}"
+
+    # ntlm_auth should take less than three seconds.
+    # If it takes longer than that, something is probably wrong.
+    ntlm_auth_timeout = 3 
 
 	# For Apple Server, when running on the same machine as
 	# Open Directory.  It has no effect on other systems.
@@ -71,7 +75,8 @@ mschap {
 
 	# On failure, set (or not) the MS-CHAP error code saying
 	# "retries allowed".
-#	allow_retry = yes
+    # Be careful setting this to yes. It could allow a device to hog the thread by never replying.
+	allow_retry = no
 
 	# An optional retry message.
 #	retry_msg = "Re-enter (or reset) the password"


### PR DESCRIPTION
devices that would take too long to authenticate or never reply to a
retry message after ntlm authentiation failures.

Also, configured the mschap module to settings that make the most sense
for PF.
