### PR TITLE
Feature/internal traps

### DIFF
--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -804,6 +804,14 @@ shut will shut the port on the switch and will also send an email even if email 
 specified.
 EOT
 
+[vlan.wait_for_redirect]
+type=numeric
+description<<EOT
+How many seconds the webservice should wait before deassociating or reassigning VLAN.
+If we don't wait, the device may switch VLAN before it has a chance to load the 
+redirection page.
+EOT
+
 [inline.ports_redirect]
 type=text
 description=<<EOT

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -321,6 +321,14 @@ based on VLAN enforcement techniques. Inline enforcement only users could
 lower the value.
 EOT
 
+[trapping.wait_for_redirect]
+type=numeric
+description<<EOT
+How many seconds the webservice should wait before deassociating or reassigning VLAN.
+If we don't wait, the device may switch VLAN before it has a chance to load the 
+redirection page.
+EOT
+
 [trapping.range]
 type=list
 description=<<EOT
@@ -802,14 +810,6 @@ Action that PacketFence will take if the vlan.trap_limit_threshold is reached.
 Defaults to none. email will send an email every hour if the limit's still reached.
 shut will shut the port on the switch and will also send an email even if email is not
 specified.
-EOT
-
-[vlan.wait_for_redirect]
-type=numeric
-description<<EOT
-How many seconds the webservice should wait before deassociating or reassigning VLAN.
-If we don't wait, the device may switch VLAN before it has a chance to load the 
-redirection page.
 EOT
 
 [inline.ports_redirect]

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -102,6 +102,13 @@ registration=enabled
 # based on VLAN enforcement techniques. Inline enforcement only users could
 # lower the value.
 redirtimer=20s
+# 
+# trapping.wait_for_redirect
+#
+# How many seconds should the WebAPI sleep before actually triggering the VLAN change.
+# This is meant to give the device enough time to fetch the redirection page before 
+# switching VLAN.
+wait_for_redirect = 1
 #
 # trapping.whitelist
 #
@@ -616,13 +623,6 @@ trap_limit_threshold = 100
 # shut will shut the port on the switch and will also send an email even if email is not
 # specified.
 trap_limit_action = 
-
-# vlan.wait_for_redirect
-#
-# How many seconds should the WebAPI sleep before actually triggering the VLAN change.
-# This is meant to give the device enough time to fetch the redirection page before 
-# switching VLAN.
-wait_for_redirect = 1
 
 [inline]
 #

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -581,12 +581,12 @@ closelocationlogonstop=disabled
 # vlan.nbtraphandlerthreads
 #
 # Number of trap handler threads pfsetvlan should start
-nbtraphandlerthreads = 20
+nbtraphandlerthreads = 5
 #
 # vlan.nbtrapparserthreads
 #
 # Number of trap parser threads pfsetvlan should start
-nbtrapparserthreads = 5
+nbtrapparserthreads = 3
 #
 # vlan.bounce_duration
 #
@@ -616,6 +616,13 @@ trap_limit_threshold = 100
 # shut will shut the port on the switch and will also send an email even if email is not
 # specified.
 trap_limit_action = 
+
+# vlan.wait_for_redirect
+#
+# How many seconds should the WebAPI sleep before actually triggering the VLAN change.
+# This is meant to give the device enough time to fetch the redirection page before 
+# switching VLAN.
+wait_for_redirect = 1
 
 [inline]
 #

--- a/html/pfappserver/lib/pfappserver/I18N/en.po
+++ b/html/pfappserver/lib/pfappserver/I18N/en.po
@@ -1356,9 +1356,16 @@ msgstr ""
 
 # conf/documentation.conf (trapping.redirtimer)
 msgid ""
-  "How long to display the progress bar during trap release. Default value is "
-  "based on VLAN enforcement techniques. Inline enforcement only users could"
+  "how long to display the progress bar during trap release. default value is "
+  "based on vlan enforcement techniques. inline enforcement only users could"
   "lower the value."
+msgstr ""
+
+# conf/documentation.conf (trapping.wait_for_redirect)
+msgid ""
+   "How many seconds the webservice should wait before deassociating or reassigning "
+   "VLAN. If we don't wait, the device may switch VLAN before it has a chance to "
+   "load the redirection page."
 msgstr ""
 
 # conf/documentation.conf (scan.openvas_reportformatid)
@@ -4970,6 +4977,10 @@ msgstr "Addresses ranges"
 # conf/documentation.conf
 msgid "trapping.redirtimer"
 msgstr "Redirection delay"
+
+# conf/documentation.conf
+msgid "trapping.wait_for_redirect"
+msgstr "Wait for redirect"
 
 # conf/documentation.conf
 msgid "trapping.registration"

--- a/lib/pf/api.pm
+++ b/lib/pf/api.pm
@@ -194,7 +194,7 @@ sub ReAssignVlan {
 
     my $switch = pf::SwitchFactory->getInstance()->instantiate( $postdata{'switch'} );
 
-    sleep $pf::config::Config{'vlan'}{'wait_for_redirect'}; 
+    sleep $pf::config::Config{'trapping'}{'wait_for_redirect'}; 
 
     # SNMP traps connections need to be handled specially to account for port-security etc.
     if ( ($postdata{'connection_type'} & $pf::config::WIRED_SNMP_TRAPS) == $pf::config::WIRED_SNMP_TRAPS ) {
@@ -219,7 +219,7 @@ sub desAssociate {
     my ($switchdeauthMethod, $deauthTechniques) = $switch->deauthTechniques($switch->{'_deauthMethod'});
 
     # sleep long enough to give the device enough time to fetch the redirection page.
-    sleep $pf::config::Config{'vlan'}{'wait_for_redirect'}; 
+    sleep $pf::config::Config{'trapping'}{'wait_for_redirect'}; 
 
     $logger->info("DesAssociating mac $postdata{'mac'} on switch " . $switch->{_id});
     $switch->$deauthTechniques($postdata{'mac'});

--- a/lib/pf/api.pm
+++ b/lib/pf/api.pm
@@ -218,7 +218,7 @@ sub desAssociate {
 
     my ($switchdeauthMethod, $deauthTechniques) = $switch->deauthTechniques($switch->{'_deauthMethod'});
 
-    # sleep long enought to give the device enough time to fetch the redirection page.
+    # sleep long enough to give the device enough time to fetch the redirection page.
     sleep $pf::config::Config{'vlan'}{'wait_for_redirect'}; 
 
     $logger->info("DesAssociating mac $postdata{'mac'} on switch " . $switch->{_id});

--- a/lib/pf/api.pm
+++ b/lib/pf/api.pm
@@ -194,6 +194,8 @@ sub ReAssignVlan {
 
     my $switch = pf::SwitchFactory->getInstance()->instantiate( $postdata{'switch'} );
 
+    sleep $pf::config::Config{'vlan'}{'wait_for_redirect'}; 
+
     # SNMP traps connections need to be handled specially to account for port-security etc.
     if ( ($postdata{'connection_type'} & $pf::config::WIRED_SNMP_TRAPS) == $pf::config::WIRED_SNMP_TRAPS ) {
         _reassignSNMPConnections($switch, $postdata{'mac'}, $postdata{'ifIndex'}, $postdata{'connection_type'} );
@@ -215,6 +217,9 @@ sub desAssociate {
     my $switch = pf::SwitchFactory->getInstance()->instantiate($postdata{'switch'});
 
     my ($switchdeauthMethod, $deauthTechniques) = $switch->deauthTechniques($switch->{'_deauthMethod'});
+
+    # sleep long enought to give the device enough time to fetch the redirection page.
+    sleep $pf::config::Config{'vlan'}{'wait_for_redirect'}; 
 
     $logger->info("DesAssociating mac $postdata{'mac'} on switch " . $switch->{_id});
     $switch->$deauthTechniques($postdata{'mac'});

--- a/lib/pf/enforcement.pm
+++ b/lib/pf/enforcement.pm
@@ -30,8 +30,8 @@ use Log::Log4perl;
 BEGIN {
     use Exporter ();
     our ( @ISA, @EXPORT, @EXPORT_OK );
-    @ISA = qw(Exporter);
-    @EXPORT = qw();
+    @ISA       = qw(Exporter);
+    @EXPORT    = qw();
     @EXPORT_OK = qw(reevaluate_access);
 }
 
@@ -43,6 +43,9 @@ use pf::node;
 use pf::SwitchFactory;
 use pf::util;
 use pf::vlan::custom $VLAN_API_LEVEL;
+use pf::api::jsonrpcclient;
+
+use Readonly;
 
 =head1 SUBROUTINES
 
@@ -64,40 +67,38 @@ sub reevaluate_access {
     $mac = clean_mac($mac);
 
     # function must be in advanced.reevaluate_access_reasons list otherwise bail out
-    if ( none { $_ eq $function } split(/\s*,\s*/, $Config{'advanced'}{'reevaluate_access_reasons'}) ) {
+    if ( none { $_ eq $function } split( /\s*,\s*/, $Config{'advanced'}{'reevaluate_access_reasons'} ) ) {
         $logger->info("access re-evaluation requested but denied by configuration");
         return $FALSE;
     }
 
     $logger->info("re-evaluating access for node $mac ($function called)");
     my $locationlog_entry = locationlog_view_open_mac($mac);
-    if (!$locationlog_entry) {
+    if ( !$locationlog_entry ) {
         $logger->warn("Can't re-evaluate access for mac $mac because no open locationlog entry was found");
         return;
 
-    } else {
+    }
+    else {
 
-        my $conn_type = str_to_connection_type($locationlog_entry->{'connection_type'});
-        if ($conn_type == $INLINE) {
+        my $conn_type = str_to_connection_type( $locationlog_entry->{'connection_type'} );
+        if ( $conn_type == $INLINE ) {
 
+            my $json_client = pf::api::jsonrpcclient->new();
             my $inline = new pf::inline::custom();
-            if ($inline->isInlineEnforcementRequired($mac)) {
-
-                # TODO avoidable load?
-                my $trapSender = pf::SwitchFactory->getInstance()->instantiate('127.0.0.1');
-                if ($trapSender) {
-                    $logger->debug("sending a local firewallRequest trap to force firewall change");
-                    $trapSender->sendLocalFirewallRequestTrap($trapSender, $mac);
-                } else {
-                    $logger->error("Can't instantiate switch 127.0.0.1! It's critical for internal messages!");
-                }
-
-            } else {
+            my %data = (
+                'switch'           => '127.0.0.1',
+                'mac'              => $mac,
+            );
+            if ( $inline->isInlineEnforcementRequired($mac) ) {
+                $json_client->notify( 'firewall', %data );
+            }
+            else {
                 $logger->debug("MAC: $mac is already properly enforced in firewall, no change required");
             }
-
-        } else {
-            return _vlan_reevaluation($mac, $locationlog_entry, %opts);
+        }
+        else {
+            return _vlan_reevaluation( $mac, $locationlog_entry, %opts );
         }
 
     }
@@ -110,55 +111,38 @@ Sends local SNMP traps to pfsetvlan if we should reevaluate the VLAN of a node.
 =cut
 
 sub _vlan_reevaluation {
-    my ($mac, $locationlog_entry, %opts) = @_;
+    my ( $mac, $locationlog_entry, %opts ) = @_;
     my $logger = Log::Log4perl::get_logger('pf::enforcement');
 
-    if ( _should_we_reassign_vlan($mac, $locationlog_entry, %opts) ) {
+    if ( _should_we_reassign_vlan( $mac, $locationlog_entry, %opts ) ) {
 
         my $switch_id = $locationlog_entry->{'switch'} || 'unknown';
-        my $ifIndex = $locationlog_entry->{'port'} || 'unknown';
-        my $conn_type = str_to_connection_type($locationlog_entry->{'connection_type'});
-        $logger->info(
-            "switch port for $mac is $switch_id ifIndex $ifIndex "
-            . "connection type: " . $connection_type_explained{$conn_type}
+        my $ifIndex   = $locationlog_entry->{'port'}   || 'unknown';
+        my $conn_type = str_to_connection_type( $locationlog_entry->{'connection_type'} );
+        $logger->info( "switch port for $mac is $switch_id ifIndex $ifIndex "
+                . "connection type: "
+                . $connection_type_explained{$conn_type} );
+
+        my $json_client = pf::api::jsonrpcclient->new();
+        my %data = (
+            'switch'           => $switch_id,
+            'mac'              => $mac,
+            'connection_type'  => $conn_type,
+            'ifIndex'          => $ifIndex
         );
+        if ( ( $conn_type & $WIRED ) == $WIRED ) {
+            $logger->debug("Calling json WebAPI with ReAssign request on switch $switch_id for mac $mac");
+            $json_client->notify( 'ReAssignVlan', %data );
 
-        # TODO avoidable load?
-        my $trapSender = pf::SwitchFactory->getInstance()->instantiate('127.0.0.1');
-        my $switch = pf::SwitchFactory->getInstance()->instantiate($switch_id);
-        if ($trapSender) {
-            if ($conn_type == $UNKNOWN) {
-                $logger->warn("Unknown connection type! We won't perform VLAN reassignment since node never connected");
+        }
+        elsif ( ( $conn_type & $WIRELESS ) == $WIRELESS ) {
+            $logger->debug("Calling json WebAPI with desAssociate request on switch $switch_id for mac $mac");
+            $json_client->notify( 'desAssociate', %data );
 
-            } elsif ($conn_type == $WIRED_SNMP_TRAPS) {
-                $logger->debug("sending a local reAssignVlan trap to force VLAN change");
-                $trapSender->sendLocalReAssignVlanTrap($switch, $ifIndex, $conn_type, $mac);
-
-            } elsif ($conn_type == $WIRELESS_MAC_AUTH) {
-                $logger->debug("sending a local desAssociate trap to force deassociation "
-                    . "(client will reconnect getting a new VLAN)");
-                $trapSender->sendLocalDesAssociateTrap($switch, $mac, $conn_type);
-
-            } elsif ($conn_type == $WIRELESS_802_1X) {
-                $logger->debug(
-                    "sending a local desAssociate trap to force deassociation. Client will reconnect getting a new VLAN"
-                );
-                $logger->info(
-                    "trying to dissociate a wireless 802.1x user, this might not work depending on hardware support. "
-                    . "If its your case please file a bug"
-                );
-                $trapSender->sendLocalDesAssociateTrap($switch, $mac, $conn_type)
-
-            } elsif ($conn_type == $WIRED_802_1X) {
-                $logger->debug("sending a local reAssignVlan trap to force VLAN change");
-                $trapSender->sendLocalReAssignVlanTrap($switch, $ifIndex, $conn_type, $mac);
-
-            } elsif ($conn_type == $WIRED_MAC_AUTH) {
-                $logger->debug("sending a local reAssignVlan trap to force VLAN change");
-                $trapSender->sendLocalReAssignVlanTrap($switch, $ifIndex, $conn_type, $mac);
-            }
-        } else {
-            $logger->error("Can't instantiate switch 127.0.0.1! Check your configuration!");
+        }
+        else {
+            $logger->error("Connection type is neither wired nor wireless. Cannot reevaluate VLAN");
+            return 0;
         }
 
     }
@@ -174,40 +158,44 @@ Evaluates node's VLAN through L<pf::vlan>'s fetchVlanForNode (which can be redef
 =cut
 
 sub _should_we_reassign_vlan {
-    my ($mac, $locationlog_entry, %opts) = @_;
+    my ( $mac, $locationlog_entry, %opts ) = @_;
     my $logger = Log::Log4perl::get_logger('pf::enforcement');
     return $TRUE;
-    if ($opts{'force'}) {
+    if ( $opts{'force'} ) {
         $logger->info("$mac VLAN reassignment is forced.");
         return $TRUE;
     }
 
-    my $switch_id = $locationlog_entry->{'switch'};
-    my $switch_ip = $locationlog_entry->{'switch_ip'};
-    my $switch_mac = $locationlog_entry->{'switch_mac'};
-    my $ifIndex = $locationlog_entry->{'port'};
-    my $currentVlan = $locationlog_entry->{'vlan'};
-    my $connection_type = str_to_connection_type($locationlog_entry->{'connection_type'});
-    my $user_name = $locationlog_entry->{'dot1x_username'};
-    my $ssid = $locationlog_entry->{'ssid'};
+    my $switch_id       = $locationlog_entry->{'switch'};
+    my $switch_ip       = $locationlog_entry->{'switch_ip'};
+    my $switch_mac      = $locationlog_entry->{'switch_mac'};
+    my $ifIndex         = $locationlog_entry->{'port'};
+    my $currentVlan     = $locationlog_entry->{'vlan'};
+    my $connection_type = str_to_connection_type( $locationlog_entry->{'connection_type'} );
+    my $user_name       = $locationlog_entry->{'dot1x_username'};
+    my $ssid            = $locationlog_entry->{'ssid'};
 
-    $logger->info( "$mac is currentlog connected at $switch_ip ifIndex $ifIndex in VLAN $currentVlan" );
+    $logger->info("$mac is currentlog connected at $switch_ip ifIndex $ifIndex in VLAN $currentVlan");
 
     my $vlan_obj = new pf::vlan::custom();
+
     # TODO avoidable load?
-    my $switch = pf::SwitchFactory->getInstance()->instantiate({switch_mac => $switch_mac, switch_ip =>$switch_ip});
-    if (!$switch) {
+    my $switch = pf::SwitchFactory->getInstance()
+        ->instantiate( { switch_mac => $switch_mac, switch_ip => $switch_ip } );
+    if ( !$switch ) {
         $logger->error("Can't instantiate switch $switch_ip! Check your configuration!");
         return $FALSE;
     }
 
-    my ($newCorrectVlan,$wasInline) = $vlan_obj->fetchVlanForNode($mac, $switch, $ifIndex, $connection_type, $user_name, $ssid);
+    my ( $newCorrectVlan, $wasInline )
+        = $vlan_obj->fetchVlanForNode( $mac, $switch, $ifIndex, $connection_type, $user_name, $ssid );
     if ( $newCorrectVlan eq '-1' ) {
         $logger->info(
             "VLAN reassignment required for $mac (current VLAN = $currentVlan but should be in VLAN $newCorrectVlan)"
         );
         return $TRUE;
-    } elsif ( $newCorrectVlan ne $currentVlan ) {
+    }
+    elsif ( $newCorrectVlan ne $currentVlan ) {
         $logger->info(
             "VLAN reassignment required for $mac (current VLAN = $currentVlan but should be in VLAN $newCorrectVlan)"
         );


### PR DESCRIPTION
For testing and inclusion in 4.4.

Adds the code changes to enable internal traps through the WebAPI. 
Adds the GUI setting to control the delay before VLAN reassignment or deassociation.
