### PR TITLE
Fix catalyst 3xxx inheritance and setModeTrunk

### DIFF
--- a/NEWS.asciidoc
+++ b/NEWS.asciidoc
@@ -49,6 +49,7 @@ Bug Fixes
 * Fix issue when a role is changed in the administration interface and the node's access is not reevaluated
 * Fix issue when a passthough is not able to be resolved and would generate an invalid DNS response
 * Fix missing files in logrotate file
+* Fix issue when setting a port in trunk on a Cisco Catalyst 3560, 3750 and 3750G would fail
 
 
 Version 4.3.0 released on 2014-06-26

--- a/lib/pf/Switch/Cisco/Catalyst_3560G.pm
+++ b/lib/pf/Switch/Cisco/Catalyst_3560G.pm
@@ -66,12 +66,12 @@ use Net::SNMP;
 
 use pf::config;
 
-use base ('pf::Switch::Cisco::Catalyst_2960');
+use base ('pf::Switch::Cisco::Catalyst_3560');
 
 sub description { 'Cisco Catalyst 3560G' }
 
 # CAPABILITIES
-# inherited from 2960
+# inherited from 3560
 
 =item NasPortToIfIndex
 

--- a/lib/pf/Switch/Cisco/Catalyst_3750.pm
+++ b/lib/pf/Switch/Cisco/Catalyst_3750.pm
@@ -42,12 +42,12 @@ use Net::SNMP;
 use pf::config;
 use pf::Switch::constants;
 
-use base ('pf::Switch::Cisco::Catalyst_2960');
+use base ('pf::Switch::Cisco::Catalyst_3560');
 
 sub description { 'Cisco Catalyst 3750' }
 
 # CAPABILITIES
-# inherited from 2960
+# inherited from 3560
 
 =head1 SUBROUTINES
 

--- a/lib/pf/Switch/Cisco/Catalyst_3750G.pm
+++ b/lib/pf/Switch/Cisco/Catalyst_3750G.pm
@@ -42,12 +42,12 @@ use Net::SNMP;
 use pf::config;
 use pf::Switch::constants;
 
-use base ('pf::Switch::Cisco::Catalyst_2960');
+use base ('pf::Switch::Cisco::Catalyst_3750');
 
 sub description { 'Cisco Catalyst 3750G' }
 
 # CAPABILITIES
-# inherited from 2960
+# inherited from 3560
 
 =head1 SUBROUTINES
 

--- a/lib/pf/Switch/Cisco/Catalyst_3750G.pm
+++ b/lib/pf/Switch/Cisco/Catalyst_3750G.pm
@@ -47,7 +47,7 @@ use base ('pf::Switch::Cisco::Catalyst_3750');
 sub description { 'Cisco Catalyst 3750G' }
 
 # CAPABILITIES
-# inherited from 3560
+# inherited from 3750
 
 =head1 SUBROUTINES
 

--- a/lib/pf/Switch/constants.pm
+++ b/lib/pf/Switch/constants.pm
@@ -323,6 +323,15 @@ Readonly::Scalar our $DEFAULT_LLDP_REMTIMEMARK => 0;
 
 =back
 
+=item Trunk encapsulation constants
+
+Used to set the encapsulation of a trunk 
+
+=cut
+
+Readonly::Scalar our $TRUNK_DOT1Q => 4;
+Readonly::Scalar our $TRUNK_AUTO => 5;
+
 =head1 EXTREME
 
 Extreme Networks constants


### PR DESCRIPTION
Changes the inheritance of the Catalyst_3xxx so they inherit their capabilities
Fixes the setModeTrunk for the Catalysts 3xxx since they need the trunk encapsulation to be set before being in trunk mode

For review + merge
