### PR TITLE
Added a cleanup of the posted username on /login.

### DIFF
--- a/NEWS.asciidoc
+++ b/NEWS.asciidoc
@@ -46,6 +46,7 @@ Bug Fixes
 * Fix previewing templates in the admin GUI
 * Fix bulk applying of roles and violations in the admin GUI
 * Fix importing of nodes when no pid is given
+* Added a cleanup of trailing and leading spaces of the posted username during the login
 
 Version 4.5.1 released on 2014-11-10
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Authenticate.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Authenticate.pm
@@ -452,7 +452,7 @@ sub authenticationLogin : Private {
 
     my @sources = $self->getSources($c);
 
-    my $username = $request->param("username");
+    my $username = _clean_username($request->param("username"));
     my $password = $request->param("password");
 
     if(isenabled($profile->reuseDot1xCredentials)) {
@@ -536,6 +536,16 @@ sub showLogin : Private {
         oauth2_win_live => is_in_list( $SELFREG_MODE_WIN_LIVE, $guestModes ),
         guest_allowed   => $guest_allowed,
     );
+}
+
+sub _clean_username {
+    my ($username) = @_;
+    # Do cleaning that could be related to a human error input ( like a space after the username )
+
+    # This removes trailing and leading whitespaces
+    $username =~ s/^\s+|\s+$//g ;
+
+    return $username;
 }
 
 =head1 AUTHOR


### PR DESCRIPTION
Cleans up the username that's sent during the post to /login

Removes leading + trailing whitespaces.

Had reports of tablets auto-completing the username with a space at the end causing this issue

Should we merge this or ignore it since it's caused by a bug on the client side ?
