### PR TITLE
Fix case mismatch when updating a user in the database.

### DIFF
--- a/NEWS.asciidoc
+++ b/NEWS.asciidoc
@@ -53,6 +53,7 @@ Bug Fixes
 * Fix missing files in logrotate file
 * Fix issue when setting a port in trunk on a Cisco Catalyst 3560, 3750 and 3750G would fail
 * Fix admin roles for bulk actions for nodes/users
+* fix issue where person was not updated in the database because of a case (non) match.
 
 
 Version 4.3.0 released on 2014-06-26

--- a/lib/pf/person.pm
+++ b/lib/pf/person.pm
@@ -332,7 +332,7 @@ sub person_modify {
     my $new_pid   = $existing->{'pid'};
 
     # compare pid case insensitively to prevent juser from not matching Juser
-    if ( $pid !~ /$new_pid/i && person_exist($new_pid) ) {
+    if ( lc $pid ne lc $new_pid && person_exist($new_pid) ) {
         $logger->error(
             "modify of pid $pid to $new_pid conflicts with existing person");
         return (0);

--- a/lib/pf/person.pm
+++ b/lib/pf/person.pm
@@ -331,7 +331,8 @@ sub person_modify {
     }
     my $new_pid   = $existing->{'pid'};
 
-    if ( $pid ne $new_pid && person_exist($new_pid) ) {
+    # compare pid case insensitively to prevent juser from not matching Juser
+    if ( $pid !~ /$new_pid/i && person_exist($new_pid) ) {
         $logger->error(
             "modify of pid $pid to $new_pid conflicts with existing person");
         return (0);


### PR DESCRIPTION
modified:   lib/pf/person.pm

Fixes case where a person does not get updated in the DB when the
username send over 802.1x or through the portal differs from the one in
the DB by case only.

E.g. Juser does not match juser.
