### PR TITLE
Feature/local accounts external sources

### DIFF
--- a/NEWS.asciidoc
+++ b/NEWS.asciidoc
@@ -31,6 +31,7 @@ New Features
 * Added support for Dlink DES3028 switches
 * Added reuse 802.1x credential on the portal profile
 * Added support for Mikrotik access point
+* Added ability to create local accounts when registering with external authentication sources.
 
 Enhancements
 ++++++++++++

--- a/conf/authentication.conf.example
+++ b/conf/authentication.conf.example
@@ -16,6 +16,7 @@ action0=set_access_level=ALL
 description=SMS-based registration
 sms_carriers=100056,100057,100061,100058,100059,100060,100062,100063,100071,100064,100116,100066,100117,100112,100067,100065,100068,100069,100070,100118,100115,100072,100073,100074,100075,100076,100077,100085,100086,100080,100079,100081,100083,100082,100084,100087,100088,100111,100089,100090,100091,100092,100093,100094,100095,100096,100098,100097,100099,100100,100101,100113,100102,100103,100104,100106,100105,100107,100108,100109,100114,100110,100078
 type=SMS
+create_local_account=no
 
 [sms rule catchall]
 description=
@@ -28,6 +29,7 @@ description=Email-based registration
 email_activation_timeout=10m
 type=Email
 allow_localdomain=yes
+create_local_account=no
 
 [email rule catchall]
 description=
@@ -39,6 +41,7 @@ action1=set_access_duration=1D
 description=Sponsor-based registration
 type=SponsorEmail
 allow_localdomain=yes
+create_local_account=no
 
 [sponsor rule catchall]
 description=

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -453,6 +453,17 @@ Sponsors requesting access and access confirmation emails are CC'ed to those
 addresses. Multiple destinations can be comma separated.
 EOT
 
+[guests_self_registration.create_local_account_process]
+type=multi
+options=message|portal
+description=<<EOT
+How do we provide the newly registered user with the created local account if enabled.
+Message means email for pretty much all the external sources with the exception of SMS where
+we send a second SMS message with the pid and password.
+Portal will display a second portal page with created local account information and how to use them.
+Portal will doesn't apply for SMS.
+EOT
+
 [guests_admin_registration.access_duration_choices]
 type=text_with_editable_default
 description=<<EOT

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -453,22 +453,6 @@ Sponsors requesting access and access confirmation emails are CC'ed to those
 addresses. Multiple destinations can be comma separated.
 EOT
 
-[guests_self_registration.create_local_account_on_email_reg]
-type=toggle
-options=enabled|disabled
-description=<<EOT
-Create a local account after guest email registration. This will allow the user to authenticate on 
-the status page or be able to authenticate over an EAP connection (see packetfence-tunnel)
-EOT
-
-[guests_self_registration.create_local_account_on_sponsor_reg]
-type=toggle
-options=enabled|disabled
-description=<<EOT
-Create a local account after guest sponsor registration. This will allow the user to authenticate on 
-the status page or be able to authenticate over an EAP connection (see packetfence-tunnel)
-EOT
-
 [guests_admin_registration.access_duration_choices]
 type=text_with_editable_default
 description=<<EOT

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -453,17 +453,6 @@ Sponsors requesting access and access confirmation emails are CC'ed to those
 addresses. Multiple destinations can be comma separated.
 EOT
 
-[guests_self_registration.create_local_account_process]
-type=multi
-options=message|portal
-description=<<EOT
-How do we provide the newly registered user with the created local account if enabled.
-Message means email for pretty much all the external sources with the exception of SMS where
-we send a second SMS message with the pid and password.
-Portal will display a second portal page with created local account information and how to use them.
-Portal will doesn't apply for SMS.
-EOT
-
 [guests_admin_registration.access_duration_choices]
 type=text_with_editable_default
 description=<<EOT

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -207,6 +207,15 @@ preregistration=disabled
 # Sponsors requesting access and access confirmation emails are CC'ed to this
 # address. Multiple destinations can be comma separated.
 sponsorship_cc=
+#
+# guests_self_registration.create_local_account_process
+#
+# How do we provide the newly registered user with the created local account if enabled.
+# Message means email for pretty much all the external sources with the exception of SMS where
+# we send a second SMS message with the pid and password.
+# Portal will display a second portal page with created local account information and how to use them.
+# Portal will doesn't apply for SMS.
+create_local_account_process=message,portal
 
 [guests_admin_registration]
 #

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -207,15 +207,6 @@ preregistration=disabled
 # Sponsors requesting access and access confirmation emails are CC'ed to this
 # address. Multiple destinations can be comma separated.
 sponsorship_cc=
-#
-# guests_self_registration.create_local_account_process
-#
-# How do we provide the newly registered user with the created local account if enabled.
-# Message means email for pretty much all the external sources with the exception of SMS where
-# we send a second SMS message with the pid and password.
-# Portal will display a second portal page with created local account information and how to use them.
-# Portal will doesn't apply for SMS.
-create_local_account_process=message,portal
 
 [guests_admin_registration]
 #

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -207,20 +207,6 @@ preregistration=disabled
 # Sponsors requesting access and access confirmation emails are CC'ed to this
 # address. Multiple destinations can be comma separated.
 sponsorship_cc=
-#
-# guests_self_registration.create_local_account_on_email_reg
-#
-# Create a local user account on email registration to allow the user
-# to manage his device on the status page or to use the credential
-# over an EAP connection
-create_local_account_on_email_reg=disabled
-#
-# guests_self_registration.create_local_account_on_sponsor_reg
-#
-# Create a local user account on sponsor registration to allow the user
-# to manage his device on the status page or to use the credential
-# over and EAP connection
-create_local_account_on_sponsor_reg=disabled
 
 [guests_admin_registration]
 #

--- a/conf/templates/emails-guest_local_account_creation.txt.tt.example
+++ b/conf/templates/emails-guest_local_account_creation.txt.tt.example
@@ -1,0 +1,13 @@
+Hi,
+
+Just to let you know that we created a user account while registering your device. You may now want to use it for different features (devices registration, status page).
+
+Here are the info.
+
+Username: [% pid %]
+Password: [% password %]
+
+If you have any questions regarding the registration process please contact support.
+
+--
+This is a post only E-mail, please do not reply.

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Activate/Email.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Activate/Email.pm
@@ -161,34 +161,26 @@ sub doEmailRegistration : Private {
                 my $actions = &pf::authentication::match( $source->{id}, $auth_params );
                 my $password = pf::temporary_password::generate( $pid, $actions );
 
-                # We send the user an email with the info of the newly created account (if configured
-                # to do so)
-                if ( is_in_list('message',
-                        $Config{'guests_self_registration'}{'create_local_account_process'}) ) {
-                    my %info = (
-                        'pid'           => $pid,
-                        'password'      => $password,
-                        'email'         => $email,
-                        'subject'       => i18n_format(
-                            "%s: Guest account creation information", $Config{'general'}{'domain'}
-                        ),
-                    );
+                # We send the guest an email with the info of the local account
+                my %info = (
+                    'pid'       => $pid,
+                    'password'  => $password,
+                    'email'     => $email,
+                    'subject'   => i18n_format(
+                        "%s: Guest account creation information", $Config{'general'}{'domain'}
+                    ),
+                );
 
-                    pf::web::guest::send_template_email(
-                        $pf::web::guest::TEMPLATE_EMAIL_LOCAL_ACCOUNT_CREATION, $info{'subject'}, \%info
-                    );
-                }
+                pf::web::guest::send_template_email(
+                    $pf::web::guest::TEMPLATE_EMAIL_LOCAL_ACCOUNT_CREATION, $info{'subject'}, \%info
+                );
 
-                # We displays the user a portal page with the info of the newly created account (if
-                # configured to do so)
-                if ( is_in_list('portal',
-                        $Config{'guests_self_registration'}{'create_local_account_process'}) ) {
-                    $c->stash (
-                        local_account_creation  => $TRUE,
-                        pid => $pid,
-                        password => $password,
-                    );
-                }
+                # We display the local account info on the confirmation portal page
+                $c->stash (
+                    local_account_creation  => $TRUE,
+                    pid => $pid,
+                    password => $password,
+                );
             }
 
             $c->stash(

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Activate/Email.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Activate/Email.pm
@@ -156,6 +156,7 @@ sub doEmailRegistration : Private {
 
             # Create local account for external authentication sources (if configured to do so)
             if ( isenabled($source->{create_local_account}) ) {
+                $logger->debug("External source local account creation is enabled for this source. We proceed");
                 # We create a "temporary password" associated to the email address provided on
                 # authentication which is the pid.
                 my $actions = &pf::authentication::match( $source->{id}, $auth_params );
@@ -181,6 +182,8 @@ sub doEmailRegistration : Private {
                     pid => $pid,
                     password => $password,
                 );
+
+                $logger->info("Local account for external source " . $source->{id} . " created with PID $pid");
             }
 
             $c->stash(
@@ -336,6 +339,7 @@ sub doSponsorRegistration : Private {
 
             # Create local account for external authentication sources (if configured to do so)
             if ( isenabled($source->{create_local_account}) ) {
+                $logger->debug("External source local account creation is enabled for this source. We proceed");
                 # We create a "temporary password" associated to the email address provided on
                 # authentication which is the pid.
                 my $actions = &pf::authentication::match( $source->{id}, $auth_params );
@@ -354,6 +358,8 @@ sub doSponsorRegistration : Private {
                 pf::web::guest::send_template_email(
                     $pf::web::guest::TEMPLATE_EMAIL_LOCAL_ACCOUNT_CREATION, $info{'subject'}, \%info
                 );
+
+                $logger->info("Local account for external source " . $source->{id} . " created with PID $pid");
             }
         }
 

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Activate/Email.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Activate/Email.pm
@@ -190,7 +190,7 @@ sub doEmailRegistration : Private {
                 %info
             );
         }
-        if (isenabled($Config{'guests_self_registration'}{'create_local_account_on_email_reg'})) {
+        if ( isenabled($source->{create_local_account}) ) {
             # Create a local account after guest registration and send the access code
             my %info = (
                 'pid'     => $pid,
@@ -346,7 +346,7 @@ sub doSponsorRegistration : Private {
                 $Config{'general'}{'domain'}
             );
         }
-        if (isenabled($Config{'guests_self_registration'}{'create_local_account_on_sponsor_reg'})) {
+        if ( isenabled($source->{create_local_account}) ) {
             # TO:
             $info{'email'} = $pid;
 

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Activate/Email.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Activate/Email.pm
@@ -175,7 +175,7 @@ sub doEmailRegistration : Private {
                     );
 
                     pf::web::guest::send_template_email(
-                        $pf::web::guest::TEMPLATE_EMAIL_LOCAL_ACCOUNT_CREATION, $info{'subject'}, \$info
+                        $pf::web::guest::TEMPLATE_EMAIL_LOCAL_ACCOUNT_CREATION, $info{'subject'}, \%info
                     );
                 }
 

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Activate/Email.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Activate/Email.pm
@@ -335,13 +335,12 @@ sub doSponsorRegistration : Private {
             $c->forward('Authenticate' => 'postAuthentication');
             $c->forward('CaptivePortal' => 'webNodeRegister', [$pid, %{$c->stash->{info}}]);
 
-            # populating variables used to send email
-            $template =
-              $pf::web::guest::TEMPLATE_EMAIL_GUEST_ON_REGISTRATION;
-            $info{'subject'} = i18n_format(
-                "%s: Guest network access enabled",
-                $Config{'general'}{'domain'}
-            );
+            # We send email to the guest confirming that network access has been enabled
+            $template = $pf::web::guest::TEMPLATE_EMAIL_GUEST_ON_REGISTRATION;
+            $info{'email'} = $info{'pid'};
+            $info{'subject'} = i18n_format("%s: Guest network access enabled", $Config{'general'}{'domain'});
+            pf::web::guest::send_template_email($template, $info{'subject'}, \%info);
+
         } elsif ( defined( $activation_record->{'pid'} ) ) {
 
              # If pid is set in activation record then we are activating a guest who pre-registered

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Activate/Sms.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Activate/Sms.pm
@@ -83,6 +83,28 @@ sub index : Path : Args(0) {
             $c->forward('Authenticate' => 'postAuthentication');
             $c->forward('CaptivePortal' => 'webNodeRegister', [$pid, %{$c->stash->{info}}]);
 
+            # Create local account for external authentication sources (if configured to do so)
+            if ( isenabled($source->{create_local_account}) ) {
+                # We create a "temporary password" associated to the email address provided on
+                # authentication which is the pid. We use the pin as the password.
+                my $actions = &pf::authentication::match( $source->{id}, $auth_params );
+                my $password = pf::temporary_password::generate( $pid, $actions, $request->param("pin") );
+
+                # We send the guest an email with the info of the local account
+                my %info = (
+                    'pid'       => $pid,
+                    'password'  => $password,
+                    'email'     => $pid,
+                    'subject'   => i18n_format(
+                        "%s: Guest account creation information", $Config{'general'}{'domain'}
+                    ),
+                );
+
+                pf::web::guest::send_template_email(
+                    $pf::web::guest::TEMPLATE_EMAIL_LOCAL_ACCOUNT_CREATION, $info{'subject'}, \%info
+                );
+            }
+
             # clear state that redirects to the Enter PIN page
             $c->session->{guest_pid} = undef;
             pf::activation::set_status_verified($request->param('pin'));

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Activate/Sms.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Activate/Sms.pm
@@ -85,6 +85,7 @@ sub index : Path : Args(0) {
 
             # Create local account for external authentication sources (if configured to do so)
             if ( isenabled($source->{create_local_account}) ) {
+                $logger->debug("External source local account creation is enabled for this source. We proceed");
                 # We create a "temporary password" associated to the email address provided on
                 # authentication which is the pid. We use the pin as the password.
                 my $actions = &pf::authentication::match( $source->{id}, $auth_params );
@@ -103,6 +104,8 @@ sub index : Path : Args(0) {
                 pf::web::guest::send_template_email(
                     $pf::web::guest::TEMPLATE_EMAIL_LOCAL_ACCOUNT_CREATION, $info{'subject'}, \%info
                 );
+
+                $logger->info("Local account for external source " . $source->{id} . " created with PID $pid");
             }
 
             # clear state that redirects to the Enter PIN page

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Oauth2.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Oauth2.pm
@@ -2,6 +2,7 @@ package captiveportal::PacketFence::Controller::Oauth2;
 use Moose;
 use namespace::autoclean;
 use pf::config;
+use pf::util qw(isenabled);
 use pf::web;
 use Net::OAuth2::Client;
 

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Oauth2.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Oauth2.pm
@@ -237,6 +237,7 @@ sub oauth2Result : Path : Args(1) {
 
         # Create local account for external authentication sources (if configured to do so)
         if ( isenabled($source->{create_local_account}) ) {
+            $logger->debug("External source local account creation is enabled for this source. We proceed");
             # We create a "temporary password" associated to the email address provided on
             # authentication which is the pid.
             my $actions = &pf::authentication::match( $source->{id}, { username => $pid, user_email => $pid } );
@@ -255,6 +256,8 @@ sub oauth2Result : Path : Args(1) {
             pf::web::guest::send_template_email(
                     $pf::web::guest::TEMPLATE_EMAIL_LOCAL_ACCOUNT_CREATION, $info{'subject'}, \%info
            );
+
+            $logger->info("Local account for external source " . $source->{id} . " created with PID $pid");
         }
     } else {
         $logger->error(

--- a/html/captive-portal/templates/activated.html
+++ b/html/captive-portal/templates/activated.html
@@ -7,6 +7,14 @@
           <p>
             [% i18n_format("Access to the guest network has been granted until %s.", expiration) %]
           </p>
+
+          [% IF local_account_creation %]
+            <h1>[% i18n("Local account creation") %]</h1>
+            <p>[% i18n("A local account has been created to allow access to node status features. Here are the information associated with that account") %].</p>
+            <p>[% i18n("Username") %]: [% pid %]</p>
+            <p>[% i18n("Password") %]: [% password %]</p>
+          [% END %]
+
         </div>
 
 [% INCLUDE footer.html %]

--- a/html/pfappserver/lib/pfappserver/Form/Authentication/Source/Email.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Authentication/Source/Email.pm
@@ -38,6 +38,18 @@ has_field 'allow_localdomain' =>
              help => 'Accept self-registration with email address from the local domain' },
   );
 
+has_field 'create_local_account' => (
+    type => 'Toggle',
+    checkbox_value => 'yes',
+    unchecked_value => 'no',
+    label => 'Create Local Account',
+    default => pf::Authentication::Source::EmailSource->meta->get_attribute('create_local_account')->default,
+    tags => {
+        after_element => \&help,
+        help => 'Create a local account on the PacketFence system based on the email address provided.',
+    },
+);
+
 =head1 COPYRIGHT
 
 Copyright (C) 2013 Inverse inc.

--- a/html/pfappserver/lib/pfappserver/Form/Authentication/Source/Facebook.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Authentication/Source/Facebook.pm
@@ -92,6 +92,17 @@ has_field 'domains' =>
              help => 'Comma separated list of domains that will be resolve with the correct IP addresses.' },
   );
 
+has_field 'create_local_account' => (
+    type => 'Toggle',
+    checkbox_value => 'yes',
+    unchecked_value => 'no',
+    label => 'Create Local Account',
+    default => pf::Authentication::Source::FacebookSource->meta->get_attribute('create_local_account')->default,
+    tags => {
+        after_element => \&help,
+        help => 'Create a local account on the PacketFence system based on the account email address provided.',
+    },
+);
 
 =head1 COPYRIGHT
 

--- a/html/pfappserver/lib/pfappserver/Form/Authentication/Source/Github.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Authentication/Source/Github.pm
@@ -89,6 +89,18 @@ has_field 'domains' =>
              help => 'Comma separated list of domains that will be resolve with the correct IP addresses.' },
   );
 
+has_field 'create_local_account' => (
+    type => 'Toggle',
+    checkbox_value => 'yes',
+    unchecked_value => 'no',
+    label => 'Create Local Account',
+    default => pf::Authentication::Source::GithubSource->meta->get_attribute('create_local_account')->default,
+    tags => {
+        after_element => \&help,
+        help => 'Create a local account on the PacketFence system based on the account email address provided.',
+    },
+);
+
 =head1 COPYRIGHT
 
 Copyright (C) 2012 Inverse inc.

--- a/html/pfappserver/lib/pfappserver/Form/Authentication/Source/Google.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Authentication/Source/Google.pm
@@ -102,6 +102,18 @@ has_field 'domains' =>
              help => 'Comma separated list of domains that will be resolve with the correct IP addresses.' },
   );
 
+has_field 'create_local_account' => (
+    type => 'Toggle',
+    checkbox_value => 'yes',
+    unchecked_value => 'no',
+    label => 'Create Local Account',
+    default => pf::Authentication::Source::GoogleSource->meta->get_attribute('create_local_account')->default,
+    tags => {
+        after_element => \&help,
+        help => 'Create a local account on the PacketFence system based on the account email address provided.',
+    },
+);
+
 =head1 COPYRIGHT
 
 Copyright (C) 2012 Inverse inc.

--- a/html/pfappserver/lib/pfappserver/Form/Authentication/Source/LinkedIn.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Authentication/Source/LinkedIn.pm
@@ -89,6 +89,18 @@ has_field 'domains' =>
              help => 'Comma separated list of domains that will be resolve with the correct IP addresses.' },
   );
 
+has_field 'create_local_account' => (
+    type => 'Toggle',
+    checkbox_value => 'yes',
+    unchecked_value => 'no',
+    label => 'Create Local Account',
+    default => pf::Authentication::Source::LinkedInSource->meta->get_attribute('create_local_account')->default,
+    tags => {
+        after_element => \&help,
+        help => 'Create a local account on the PacketFence system based on the account email address provided.',
+    },
+);
+
 =head1 COPYRIGHT
 
 Copyright (C) 2014 Inverse inc.

--- a/html/pfappserver/lib/pfappserver/Form/Authentication/Source/SMS.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Authentication/Source/SMS.pm
@@ -30,6 +30,18 @@ has_field 'sms_carriers' =>
              help => 'List of phone carriers available to the user' },
   );
 
+has_field 'create_local_account' => (
+    type => 'Toggle',
+    checkbox_value => 'yes',
+    unchecked_value => 'no',
+    label => 'Create Local Account',
+    default => pf::Authentication::Source::SMSSource->meta->get_attribute('create_local_account')->default,
+    tags => {
+        after_element => \&help,
+        help => 'Create a local account on the PacketFence system based on the phone number provided.',
+    },
+);
+
 =head1 METHODS
 
 =head2 options_sms_carriers

--- a/html/pfappserver/lib/pfappserver/Form/Authentication/Source/SponsorEmail.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Authentication/Source/SponsorEmail.pm
@@ -28,6 +28,18 @@ has_field 'allow_localdomain' =>
              help => 'Accept self-registration with email address from the local domain' },
   );
 
+has_field 'create_local_account' => (
+    type => 'Toggle',
+    checkbox_value => 'yes',
+    unchecked_value => 'no',
+    label => 'Create Local Account',
+    default => pf::Authentication::Source::EmailSource->meta->get_attribute('create_local_account')->default,
+    tags => { 
+        after_element => \&help,
+        help => 'Create a local account on the PacketFence system based on the email address provided.',
+    },
+);
+
 =head1 COPYRIGHT
 
 Copyright (C) 2013 Inverse inc.

--- a/html/pfappserver/lib/pfappserver/Form/Authentication/Source/WindowsLive.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Authentication/Source/WindowsLive.pm
@@ -99,6 +99,18 @@ has_field 'domains' =>
              help => 'Comma separated list of domains that will be resolve with the correct IP addresses.' },
   );
 
+has_field 'create_local_account' => (
+    type => 'Toggle',
+    checkbox_value => 'yes',
+    unchecked_value => 'no',
+    label => 'Create Local Account',
+    default => pf::Authentication::Source::WindowsLiveSource->meta->get_attribute('create_local_account')->default,
+    tags => {
+        after_element => \&help,
+        help => 'Create a local account on the PacketFence system based on the account email address provided.',
+    },
+);
+
 =head1 COPYRIGHT
 
 Copyright (C) 2014 Inverse inc.

--- a/html/pfappserver/lib/pfappserver/I18N/i_default.po
+++ b/html/pfappserver/lib/pfappserver/I18N/i_default.po
@@ -788,18 +788,6 @@ msgstr ""
 msgid "Create Users"
 msgstr ""
 
-# conf/documentation.conf (guests_self_registration.create_local_account_on_email_reg)
-msgid ""
-  "Create a local account after guest email registration. This will allow the user to authenticate on "
-  "the status page or be able to authenticate over an EAP connection (see packetfence-tunnel)"
-msgstr ""
-
-# conf/documentation.conf (guests_self_registration.create_local_account_on_sponsor_reg)
-msgid ""
-  "Create a local account after guest sponsor registration. This will allow the user to authenticate on "
-  "the status page or be able to authenticate over an EAP connection (see packetfence-tunnel)"
-msgstr ""
-
 # html/pfappserver/root/configurator/database.tt
 msgid "Create a user in your MySQL server"
 msgstr ""
@@ -4398,8 +4386,6 @@ msgstr ""
 # conf/documentation.conf (captive_portal.secure_redirect options)
 # conf/documentation.conf (expire.httpd_admin options)
 # conf/documentation.conf (expire.httpd_portal options)
-# conf/documentation.conf (guests_self_registration.create_local_account_on_email_reg options)
-# conf/documentation.conf (guests_self_registration.create_local_account_on_sponsor_reg options)
 # conf/documentation.conf (guests_self_registration.preregistration options)
 # conf/documentation.conf (inline.accounting options)
 # conf/documentation.conf (inline.should_reauth_on_vlan_change options)
@@ -4468,8 +4454,6 @@ msgstr "Send email"
 # conf/documentation.conf (captive_portal.secure_redirect options)
 # conf/documentation.conf (expire.httpd_admin options)
 # conf/documentation.conf (expire.httpd_portal options)
-# conf/documentation.conf (guests_self_registration.create_local_account_on_email_reg options)
-# conf/documentation.conf (guests_self_registration.create_local_account_on_sponsor_reg options)
 # conf/documentation.conf (guests_self_registration.preregistration options)
 # conf/documentation.conf (inline.accounting options)
 # conf/documentation.conf (inline.should_reauth_on_vlan_change options)
@@ -4619,14 +4603,6 @@ msgstr "Default access duration"
 # conf/documentation.conf
 msgid "guests_self_registration"
 msgstr "Self registration"
-
-# conf/documentation.conf
-msgid "guests_self_registration.create_local_account_on_email_reg"
-msgstr "Add user on email registration"
-
-# conf/documentation.conf
-msgid "guests_self_registration.create_local_account_on_sponsor_reg"
-msgstr "Add user on sponsor registration"
 
 # conf/documentation.conf
 msgid "guests_self_registration.guest_pid"

--- a/html/pfappserver/lib/pfappserver/I18N/i_default.po
+++ b/html/pfappserver/lib/pfappserver/I18N/i_default.po
@@ -3340,15 +3340,6 @@ msgid ""
   "addresses. Multiple destinations can be comma separated."
 msgstr ""
 
-# conf/documentation.conf (guests_self_registration.create_local_account_process)
-msgid ""
-  "How do we provide the newly registered user with the created local account if enabled."
-  "Message means email for pretty much all the external sources with the exception of SMS where"
-  "we send a second SMS message with the pid and password."
-  "Portal will display a second portal page with created local account information and how to use them."
-  "Portal will doesn't apply for SMS."
-msgstr ""
-
 # html/pfappserver/root/node/view.tt
 # html/pfappserver/root/service/status.tt
 msgid "Start"
@@ -4648,10 +4639,6 @@ msgstr "Preregistration"
 # conf/documentation.conf
 msgid "guests_self_registration.sponsorship_cc"
 msgstr "Sponsorship CC"
-
-# conf/documentation.conf
-msgid "guests_self_registration.create_local_account_process"
-msgstr "Provide user local account info using"
 
 # conf/documentation.conf (interface.type options)
 msgid "high-availability"

--- a/html/pfappserver/lib/pfappserver/I18N/i_default.po
+++ b/html/pfappserver/lib/pfappserver/I18N/i_default.po
@@ -3340,6 +3340,15 @@ msgid ""
   "addresses. Multiple destinations can be comma separated."
 msgstr ""
 
+# conf/documentation.conf (guests_self_registration.create_local_account_process)
+msgid ""
+  "How do we provide the newly registered user with the created local account if enabled."
+  "Message means email for pretty much all the external sources with the exception of SMS where"
+  "we send a second SMS message with the pid and password."
+  "Portal will display a second portal page with created local account information and how to use them."
+  "Portal will doesn't apply for SMS."
+msgstr ""
+
 # html/pfappserver/root/node/view.tt
 # html/pfappserver/root/service/status.tt
 msgid "Start"
@@ -4639,6 +4648,10 @@ msgstr "Preregistration"
 # conf/documentation.conf
 msgid "guests_self_registration.sponsorship_cc"
 msgstr "Sponsorship CC"
+
+# conf/documentation.conf
+msgid "guests_self_registration.create_local_account_process"
+msgstr "Provide user local account info using"
 
 # conf/documentation.conf (interface.type options)
 msgid "high-availability"

--- a/html/pfappserver/root/authentication/source/type/Email.tt
+++ b/html/pfappserver/root/authentication/source/type/Email.tt
@@ -1,2 +1,3 @@
 [% form.field('email_activation_timeout').render %]
 [% form.field('allow_localdomain').render %]
+[% form.field('create_local_account').render %]

--- a/html/pfappserver/root/authentication/source/type/Facebook.tt
+++ b/html/pfappserver/root/authentication/source/type/Facebook.tt
@@ -7,3 +7,4 @@
 [% form.field('protected_resource_url').render %]
 [% form.field('redirect_url').render %]
 [% form.field('domains').render %]
+[% form.field('create_local_account').render %]

--- a/html/pfappserver/root/authentication/source/type/Github.tt
+++ b/html/pfappserver/root/authentication/source/type/Github.tt
@@ -7,3 +7,4 @@
 [% form.field('protected_resource_url').render %]
 [% form.field('redirect_url').render %]
 [% form.field('domains').render %]
+[% form.field('create_local_account').render %]

--- a/html/pfappserver/root/authentication/source/type/Google.tt
+++ b/html/pfappserver/root/authentication/source/type/Google.tt
@@ -9,3 +9,4 @@
 [% form.field('protected_resource_url').render %]
 [% form.field('redirect_url').render %]
 [% form.field('domains').render %]
+[% form.field('create_local_account').render %]

--- a/html/pfappserver/root/authentication/source/type/LinkedIn.tt
+++ b/html/pfappserver/root/authentication/source/type/LinkedIn.tt
@@ -8,3 +8,4 @@
 [% form.field('protected_resource_url').render %]
 [% form.field('redirect_url').render %]
 [% form.field('domains').render %]
+[% form.field('create_local_account').render %]

--- a/html/pfappserver/root/authentication/source/type/SMS.tt
+++ b/html/pfappserver/root/authentication/source/type/SMS.tt
@@ -1,1 +1,2 @@
 [% form.field('sms_carriers').render %]
+[% form.field('create_local_account').render %]

--- a/html/pfappserver/root/authentication/source/type/SponsorEmail.tt
+++ b/html/pfappserver/root/authentication/source/type/SponsorEmail.tt
@@ -1,1 +1,2 @@
 [% form.field('allow_localdomain').render %]
+[% form.field('create_local_account').render %]

--- a/html/pfappserver/root/authentication/source/type/WindowsLive.tt
+++ b/html/pfappserver/root/authentication/source/type/WindowsLive.tt
@@ -9,3 +9,4 @@
 [% form.field('protected_resource_url').render %]
 [% form.field('redirect_url').render %]
 [% form.field('domains').render %]
+[% form.field('create_local_account').render %]

--- a/lib/pf/Authentication/Source/EmailSource.pm
+++ b/lib/pf/Authentication/Source/EmailSource.pm
@@ -18,6 +18,7 @@ has '+type' => (default => 'Email');
 has '+unique' => (default => 1);
 has 'allow_localdomain' => (isa => 'Str', is => 'rw', default => 'yes');
 has 'email_activation_timeout' => (isa => 'Str', is => 'rw', default => '10m');
+has 'create_local_account' => (isa => 'Str', is => 'rw', default => 'no');
 
 =head2 available_attributes
 

--- a/lib/pf/Authentication/Source/FacebookSource.pm
+++ b/lib/pf/Authentication/Source/FacebookSource.pm
@@ -23,6 +23,7 @@ has 'scope' => (isa => 'Str', is => 'rw', default => 'email');
 has 'protected_resource_url' => (isa => 'Str', is => 'rw', default => 'https://graph.facebook.com/me');
 has 'redirect_url' => (isa => 'Str', is => 'rw', required => 1, default => 'https://<hostname>/oauth2/facebook');
 has 'domains' => (isa => 'Str', is => 'rw', required => 1, default => '*.facebook.com,*.fbcdn.net,*.akamaihd.net');
+has 'create_local_account' => (isa => 'Str', is => 'rw', default => 'no');
 
 =head2 available_actions
 

--- a/lib/pf/Authentication/Source/GithubSource.pm
+++ b/lib/pf/Authentication/Source/GithubSource.pm
@@ -23,6 +23,7 @@ has 'access_token_param' => (isa => 'Str', is => 'rw', default => 'access_token'
 has 'protected_resource_url' => (isa => 'Str', is => 'rw', default => 'https://api.github.com/user');
 has 'redirect_url' => (isa => 'Str', is => 'rw', required => 1, default => 'https://<hostname>/oauth2/github');
 has 'domains' => (isa => 'Str', is => 'rw', required => 1, default => 'api.github.com');
+has 'create_local_account' => (isa => 'Str', is => 'rw', default => 'no');
 
 =head2 available_actions
 

--- a/lib/pf/Authentication/Source/GoogleSource.pm
+++ b/lib/pf/Authentication/Source/GoogleSource.pm
@@ -24,6 +24,7 @@ has 'scope' => (isa => 'Str', is => 'rw', default => 'https://www.googleapis.com
 has 'protected_resource_url' => (isa => 'Str', is => 'rw', default => 'https://www.googleapis.com/oauth2/v2/userinfo');
 has 'redirect_url' => (isa => 'Str', is => 'rw', required => 1, default => 'https://<hostname>/oauth2/google');
 has 'domains' => (isa => 'Str', is => 'rw', required => 1, default => '*.google.com,*.gstatic.com,googleapis.com,accounts.youtube.com');
+has 'create_local_account' => (isa => 'Str', is => 'rw', default => 'no');
 
 =head2 available_actions
 

--- a/lib/pf/Authentication/Source/LinkedInSource.pm
+++ b/lib/pf/Authentication/Source/LinkedInSource.pm
@@ -25,6 +25,7 @@ has 'access_token_param' => (isa => 'Str', is => 'rw', default => 'code');
 has 'protected_resource_url' => (isa => 'Str', is => 'rw', default => 'https://api.linkedin.com/v1/people/~/email-address');
 has 'redirect_url' => (isa => 'Str', is => 'rw', required => 1, default => 'https://<hostname>/oauth2/linkedin');
 has 'domains' => (isa => 'Str', is => 'rw', required => 1, default => 'www.linkedin.com,api.linkedin.com,static.licdn.com');
+has 'create_local_account' => (isa => 'Str', is => 'rw', default => 'no');
 
 =head2 available_actions
 

--- a/lib/pf/Authentication/Source/SMSSource.pm
+++ b/lib/pf/Authentication/Source/SMSSource.pm
@@ -19,6 +19,7 @@ has '+class' => (default => 'external');
 has '+type' => (default => 'SMS');
 has '+unique' => (default => 1);
 has 'sms_carriers' => (isa => 'ArrayRef', is => 'rw', default => sub {[]});
+has 'create_local_account' => (isa => 'Str', is => 'rw', default => 'no');
 
 =head1 METHODS
 

--- a/lib/pf/Authentication/Source/SponsorEmailSource.pm
+++ b/lib/pf/Authentication/Source/SponsorEmailSource.pm
@@ -17,6 +17,7 @@ has '+class' => (default => 'external');
 has '+type' => (default => 'SponsorEmail');
 has '+unique' => (default => 1);
 has 'allow_localdomain' => (isa => 'Str', is => 'rw', default => 'yes');
+has 'create_local_account' => (isa => 'Str', is => 'rw', default => 'no');
 
 =head2 available_attributes
 

--- a/lib/pf/Authentication/Source/WindowsLiveSource.pm
+++ b/lib/pf/Authentication/Source/WindowsLiveSource.pm
@@ -24,6 +24,7 @@ has 'scope' => (isa => 'Str', is => 'rw', default => 'wl.basic,wl.emails');
 has 'protected_resource_url' => (isa => 'Str', is => 'rw', default => 'https://apis.live.net/v5.0/me');
 has 'redirect_url' => (isa => 'Str', is => 'rw', required => 1, default => 'https://<hostname>/oauth2/windowslive');
 has 'domains' => (isa => 'Str', is => 'rw', required => 1, default => 'login.live.com,auth.gfx.ms,account.live.com');
+has 'create_local_account' => (isa => 'Str', is => 'rw', default => 'no');
 
 =head2 available_actions
 

--- a/lib/pf/web/guest.pm
+++ b/lib/pf/web/guest.pm
@@ -76,6 +76,7 @@ Readonly our $TEMPLATE_EMAIL_EMAIL_PREREGISTRATION_CONFIRMED => 'guest_email_pre
 Readonly our $TEMPLATE_EMAIL_SPONSOR_PREREGISTRATION => 'guest_sponsor_preregistration';
 Readonly our $TEMPLATE_EMAIL_GUEST_ADMIN_PREREGISTRATION => 'guest_admin_pregistration';
 Readonly our $TEMPLATE_EMAIL_GUEST_ON_REGISTRATION => 'guest_registered';
+Readonly our $TEMPLATE_EMAIL_LOCAL_ACCOUNT_CREATION => 'guest_local_account_creation';
 
 our $EMAIL_FROM = undef;
 

--- a/lib/pf/web/guest.pm
+++ b/lib/pf/web/guest.pm
@@ -381,9 +381,6 @@ sub send_template_email {
     my ($template, $subject, $info) = @_;
     my $logger = Log::Log4perl::get_logger('pf::web::guest');
 
-use Data::Dumper;
-$logger->info("DEREK: Dumper for email " . Dumper($info));
-
     my $smtpserver = $Config{'alerting'}{'smtpserver'};
     # local override (EMAIL_FROM) or pf.conf's value or root@domain
     my $from = $pf::web::guest::EMAIL_FROM || $Config{'alerting'}{'fromaddr'} || 'root@' . $fqdn;

--- a/lib/pf/web/guest.pm
+++ b/lib/pf/web/guest.pm
@@ -381,6 +381,9 @@ sub send_template_email {
     my ($template, $subject, $info) = @_;
     my $logger = Log::Log4perl::get_logger('pf::web::guest');
 
+use Data::Dumper;
+$logger->info("DEREK: Dumper for email " . Dumper($info));
+
     my $smtpserver = $Config{'alerting'}{'smtpserver'};
     # local override (EMAIL_FROM) or pf.conf's value or root@domain
     my $from = $pf::web::guest::EMAIL_FROM || $Config{'alerting'}{'fromaddr'} || 'root@' . $fqdn;


### PR DESCRIPTION
Ability to create a local account in PacketFence for registration using external authentication sources.

Major rework needs to be done in whole guest workflow but that is another project.
For the moment, SMS registration is not able to create local account (will be integrated later after some discussion)

Ready to be merged... Please review
