### PR TITLE
Added the ability to lookup exclusive authentication rules when getting VLAN.

### DIFF
--- a/NEWS.asciidoc
+++ b/NEWS.asciidoc
@@ -106,6 +106,7 @@ Enhancements
 * Added support to configure high-availability from within the configurator/webadmin
 * Changed the way we're handling DNS blackholing when unregistered in inline enforcement mode (using DNAT rather than REDIRECT)
 * Now handling rogue DHCP servers based both on the server IP and server MAC address
+* We can now match exclusive authentication sources from vlan.pm. This allows using e.g. "NULL" auth and still have complex auhtorization rules. The primary use case is eduroam.
 
 Bug Fixes
 +++++++++

--- a/lib/pf/vlan.pm
+++ b/lib/pf/vlan.pm
@@ -379,7 +379,7 @@ sub getNormalVlan {
     elsif ( defined $user_name && $connection_type && ($connection_type & $EAP) == $EAP ) {
         $logger->debug("[$mac] EAP connection with a username \"$user_name\". Trying to match rules from authentication sources.");
         my $profile = pf::Portal::ProfileFactory->instantiate($mac);
-        my @sources = ($profile->getInternalSources);
+        my @sources = ($profile->getInternalSources, $profile->getExclusiveSources );
         my $params = {
             username => $user_name,
             connection_type => connection_type_to_str($connection_type),


### PR DESCRIPTION
This allows for example an Eduroam SSID to use "NULL"auth and
still get more complex authorization rules, as well as using violations.
