### PR TITLE
Firewall should allow 443 on management interface when pre-registration ...

### DIFF
--- a/NEWS.asciidoc
+++ b/NEWS.asciidoc
@@ -26,6 +26,7 @@ Enhancements
 Bug Fixes
 +++++++++
 * Fix old MAC addresses being left on port-security enabled ports in a RADIUS + port-security environment
+* Fix firewall rule that allows httpd.portal to be reach on management IP when pre-registration enabled
 
 Version 4.5.0 released on 2014-10-22
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/NEWS.asciidoc
+++ b/NEWS.asciidoc
@@ -26,7 +26,7 @@ Enhancements
 Bug Fixes
 +++++++++
 * Fix old MAC addresses being left on port-security enabled ports in a RADIUS + port-security environment
-* Fix firewall rule that allows httpd.portal to be reach on management IP when pre-registration enabled
+* Fix firewall rule that allows httpd.portal to be reached on management IP when pre-registration enabled
 
 Version 4.5.0 released on 2014-10-22
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/pf/iptables.pm
+++ b/lib/pf/iptables.pm
@@ -133,10 +133,12 @@ sub iptables_generate {
 
     # per-feature firewall rules
     # self-registered guest by email or sponsored or gaming registration
+    # pre-registration guest
     my $device_registration_enabled = isenabled($Config{'registration'}{'device_registration'});
+    my $pre_registration_enabled    = isenabled($Config{'guests_self_registration'}{'preregistration'});
     my $email_enabled = $guest_self_registration{$SELFREG_MODE_EMAIL};
     my $sponsor_enabled = $guest_self_registration{$SELFREG_MODE_SPONSOR};
-    if ( $email_enabled || $sponsor_enabled || $device_registration_enabled ) {
+    if ( $email_enabled || $sponsor_enabled || $device_registration_enabled || $pre_registration_enabled ) {
         $tags{'input_mgmt_guest_rules'} =
             "-A $FW_FILTER_INPUT_MGMT --protocol tcp --match tcp --dport 443 --jump ACCEPT"
         ;


### PR DESCRIPTION
## Description

Punch a hole in the iptables firewall of PacketFence to allow the httpd.portal server to be reach on the management ip, port 443, when pre-registration is enabled.
## Impacts

Shouldn't have any...
