### PR TITLE
Use vlan filter in getNodeInfoForAutoReg and create/update person even i...

### DIFF
--- a/NEWS.asciidoc
+++ b/NEWS.asciidoc
@@ -25,6 +25,7 @@ Enhancements
 * Added httpd.aaa service as a new API service for the exclusive use of RADIUS
 * More precisely define which dhcp message types we are listening for
 * Removed dead code referring to 'external' interface type which was, anyway, no longer supported
+* Added vlan filter in getNodeInfoForAutoReg and update/create person even if the device has been autoreg
 
 Bug Fixes
 +++++++++

--- a/conf/vlan_filters.conf.example
+++ b/conf/vlan_filters.conf.example
@@ -1,6 +1,6 @@
 # Vlan filter configuration
 # 
-# you can trigger rule on specific scope (NormalVlan, RegistrationVlan, ViolationVlan, AutoRegister, InlineVlan)
+# you can trigger rule on specific scope (NormalVlan, RegistrationVlan, ViolationVlan, AutoRegister, InlineVlan, NodeInfoForAutoReg)
 #
 # Make a simple rule like this:
 #

--- a/lib/pf/authentication.pm
+++ b/lib/pf/authentication.pm
@@ -452,7 +452,7 @@ If action is set, it will return the value of the action immediately.
 =cut
 
 sub match {
-    my ($source_id, $params, $action) = @_;
+    my ($source_id, $params, $action,$source_ref) = @_;
     my ($actions, @sources);
 
     $logger->debug("Match called with parameters ".join(", ", map { "$_ => $params->{$_}" } keys %$params));
@@ -483,6 +483,7 @@ sub match {
         $actions ||= [];
         $logger->debug("[".$source->id."] Returning actions ".join(', ', map { $_->type." = ".$_->value } @$actions ));
     }
+    $$source_ref = $source->id if defined $source_ref;
 
     return $actions;
 }

--- a/lib/pf/authentication.pm
+++ b/lib/pf/authentication.pm
@@ -448,6 +448,7 @@ This method tries to match a set of params in one or multiple sources.
 
 If action is undef, all actions will be returned.
 If action is set, it will return the value of the action immediately.
+If source_ref is defined then it will be set to the matching source_id
 
 =cut
 

--- a/lib/pf/vlan.pm
+++ b/lib/pf/vlan.pm
@@ -28,6 +28,8 @@ use pf::authentication;
 use pf::Authentication::constants;
 use pf::Portal::ProfileFactory;
 use pf::vlan::filter;
+use pf::person;
+use pf::lookup::person;
 
 our $VERSION = 1.04;
 
@@ -420,8 +422,6 @@ sub getNormalVlan {
                 if (defined $role) {
                     %info = (%info, (category => $role));
                 }
-                require pf::person;
-                require pf::lookup::person;
                 # create a person entry for pid if it doesn't exist
                 if ( !pf::person::person_exist($user_name) ) {
                     $logger->info("creating person $user_name because it doesn't exist");

--- a/lib/pf/vlan.pm
+++ b/lib/pf/vlan.pm
@@ -591,7 +591,7 @@ sub shouldAutoRegister {
         if ($switch->getVlanByName($role) eq -1) {
             return 0;
         } else {
-            return $switch->getVlanByName($role) if $role;
+            return $switch->getVlanByName($role);
         }
     }
 

--- a/lib/pf/vlan.pm
+++ b/lib/pf/vlan.pm
@@ -587,7 +587,13 @@ sub shouldAutoRegister {
     my $node_info = node_attributes($mac);
     my $filter = new pf::vlan::filter;
     my ($result,$role) = $filter->test('AutoRegister',$switch, $port, $mac, $node_info, $conn_type, $user_name, $ssid, $radius_request);
-    return 1 if $role;
+    if ($role) {
+        if ($switch->getVlanByName($role) eq -1) {
+            return 0;
+        } else {
+            return $switch->getVlanByName($role) if $role;
+        }
+    }
 
     # custom example: auto-register 802.1x users
     # Since they already have validated credentials through EAP to do 802.1X


### PR DESCRIPTION
## Description

Added vlan filter in getNodeInfoForAutoReg (set a role to be able to test it in getNormalVlan)
Create or update a person even if the deviced has been registered (Like we did machine auth and after user auth but the pid didn´t changed) 
## Impacts

Autoregistration workflow.
## Delete branch after merge

YES
