### PR TITLE
PacketFence FreeRADIUS should not deal with NAS login requests

### DIFF
--- a/NEWS.asciidoc
+++ b/NEWS.asciidoc
@@ -47,6 +47,7 @@ Enhancements
 * Create a single ldap connection when matching against multiple rules
 * Reduce the numbers of entries in iplog table (update end_time instead of closing and inserting a new line)
 * Now matching on language and not only language/country combination for violation templates (See UPGRADE guide)
+* PacketFence FreeRADIUS will return reject on "NAS-Prompt-User" Service-Type requests. (Console login using RADIUS as backend)
 
 Bug Fixes
 +++++++++

--- a/raddb/users
+++ b/raddb/users
@@ -1,1 +1,5 @@
+# PacketFence FreeRADIUS should not deal with NAS login requests (login into a switch)
+DEFAULT Service-Type == "NAS-Prompt-User", Auth-Type := Reject
+
+# Default user. IMPORTANT, DO NOT MODIFY
 DEFAULT EAP-Message !* "", Auth-Type := Accept


### PR DESCRIPTION
## Description

In some cases, equipment vendors does not allow the configuration of multiple radius group to be used either for login request or NAS-login (login into a switch / console)
If you have MAB or 802.1x configured on your switch, you have the PacketFence IP as RADIUS server.
If you also use RADIUS as backend for authenticating console login, the request may end to the PacketFence FreeRADIUS and will be accepted, which means that any user / password will work.
## Impacts

No real impacts... unless some vendors are using the "NAS-Prompt-User" Service-Type for other purposes...
## Delete branch after merge

YES
