### PR TITLE
fix portal uri profiles

### DIFF
--- a/NEWS.asciidoc
+++ b/NEWS.asciidoc
@@ -49,6 +49,7 @@ Bug Fixes
 * Added a cleanup of trailing and leading spaces of the posted username during the login
 * Fix wrong regex to detect ifindex in Cisco switches
 * Honor order of profiles when matching profile filters
+* Fixed URI based portal profiles
 
 Version 4.5.1 released on 2014-11-10
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/html/captive-portal/lib/captiveportal/PacketFence/Model/Portal/Session.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Model/Portal/Session.pm
@@ -92,6 +92,8 @@ has [qw(forwardedFor guestNodeMac)] => ( is => 'rw', );
 sub ACCEPT_CONTEXT {
     my ( $self, $c, @args ) = @_;
     my $class = ref $self || $self;
+    my $previous_model = $c->session->{$class};
+    return $previous_model if(defined($previous_model) && $previous_model->{options}->{in_uri_portal});
     my $model;
     my $request       = $c->request;
     my $r = $request->{'env'}->{'psgi.input'};
@@ -104,9 +106,10 @@ sub ACCEPT_CONTEXT {
     my $mgmt_ip = $management_network->{'Tvip'} || $management_network->{'Tip'} if $management_network;
     $destination_url = $request->param('destination_url') if defined($request->param('destination_url'));
 
-    if( $r->isa('Apache2::Request') &&  defined ( my $last_uri = $r->pnotes('last_uri') )) {
+    if( defined ( my $last_uri = $r->pnotes('last_uri') )) {
         $options = {
             'last_uri' => $last_uri,
+            'in_uri_portal' => 1,
         };
     } elsif ( $c->controller->isa('captiveportal::Controller::Activate::Email') && $c->action->name eq 'code' ) {
         my $code = $c->request->arguments->[0];
@@ -127,6 +130,7 @@ sub ACCEPT_CONTEXT {
         destination_url => $destination_url,
         @args,
     );
+    $c->session->{$class} = $model;
     return $model;
 }
 


### PR DESCRIPTION
Once approved and merged, should hit the maintenance branch.
## Description

Fixes the URI portal profiles by caching the portal profile only when using a uri based portal profile.
Switching between two profiles is still working except when using the URI based filter
## Impacts

Fixes the URI portals. Doesn't break the current behavior
## Delete branch after merge

Yes.
