### PR TITLE
Change how we strip username when reuse_dot1x_credentials is enabled

### DIFF
--- a/NEWS.asciidoc
+++ b/NEWS.asciidoc
@@ -39,6 +39,7 @@ Enhancements
 * The ability to restricts the roles, access levels and access durations for an admin users based on their admin role/access level
 * Reduce deadlocks caused by the cleaning of the iplog table
 * Reduce deadlocks caused by the cleaning of the locationlog table
+* Only strip user name for machine auth
 
 Bug Fixes
 +++++++++

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Authenticate.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Authenticate.pm
@@ -463,6 +463,7 @@ sub authenticationLogin : Private {
         #TODO Do we config stripping the username for machine and user auth
         if ( $username =~ /^[^\/]+\/(.*)$/ ) {
             $username = $1;
+            $logger->warn("Reuse Dot1x has been enabled on this portal, here the username from 802.1x connection ".$node_info->{'last_dot1x_username'}." , here the stripped username $username");
         }
         $c->session(
             "username"  => $username,

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Authenticate.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Authenticate.pm
@@ -459,7 +459,9 @@ sub authenticationLogin : Private {
         my $mac       = $portalSession->clientMac;
         my $node_info = node_view($mac);
         my $username = $node_info->{'last_dot1x_username'};
-        if ($username =~ /^(.*)@/ || $username =~ /^[^\/]+\/(.*)$/ ) {
+        #Strip the username when using machine auth
+        #TODO Do we config stripping the username for machine and user auth
+        if ( $username =~ /^[^\/]+\/(.*)$/ ) {
             $username = $1;
         }
         $c->session(


### PR DESCRIPTION
## Description

Change how we strip username when reuse_dot1x_credentials is enabled 
## Impacts

We are changing the existing workflow for authentication when reuse_dot1x_credentials is enabled
Should we do the one or a mix of the following
- Only strip name when using machine auth
- Make it configurable user/machine auth
- Extend the node/person to add a field with a stripped username
## Delete branch after merge

YES | NO
