### PR TITLE
Ensure that the reloading of a config file only happenes once

### DIFF
--- a/addons/dev-helpers/config-reload-loop.pl
+++ b/addons/dev-helpers/config-reload-loop.pl
@@ -2,13 +2,11 @@
 
 =head1 NAME
 
-loop.pl - a script to help test reloading config
-
-=cut
+config-reload-loop.pl - a script to help test reloading config
 
 =head1 DESCRIPTION
 
-loop
+Stress test by refreshing configuration by 30 different processes every 2 seconds
 
 =cut
 

--- a/addons/dev-helpers/config-reload-loop.pl
+++ b/addons/dev-helpers/config-reload-loop.pl
@@ -1,0 +1,103 @@
+#!/usr/bin/perl
+
+=head1 NAME
+
+loop.pl - a script to help test reloading config
+
+=cut
+
+=head1 DESCRIPTION
+
+loop
+
+=cut
+
+use strict;
+use warnings;
+use lib qw(/usr/local/pf/lib);
+use pf::config::cached;
+use pf::ConfigStore::Switch;
+use Cache::Memcached;
+use pf::db;
+
+use POSIX qw(:sys_wait_h pause);
+our %KIDS;
+$SIG{CHLD} = sub { };
+$SIG{INT} = $SIG{TERM} = sub {kill INT => keys %KIDS};
+our $RUNNING = 1;
+our $reloaded = 0;
+$pf::ConfigStore::Switch::switches_cached_config->addFileReloadCallbacks(
+    onfilereload => sub {print STDERR "$$ onfilereload " . time . "\n"});
+$pf::ConfigStore::Switch::switches_cached_config->addCacheReloadCallbacks(
+    oncachereload => sub {print STDERR "$$ oncachereload " . time . "\n"});
+
+{
+    Cache::Memcached->disconnect_all;
+    pf::CHI->clear_memoized_cache_objects;
+    db_disconnect();
+}
+
+for (1 .. 30) {
+    my $pid = fork;
+    last unless defined $pid;
+    if ($pid) {
+        $KIDS{$pid} = undef;
+    }
+    else {
+        $SIG{CHLD} = 'DEFAULT';
+        $SIG{INT} = $SIG{TERM} = sub { $RUNNING = 0; };
+        use pf::log reinit => 1;
+        Log::Log4perl::MDC->put( 'tid', $$ );
+        doReload();   
+        exit;
+    }
+}
+
+sub doReload {
+    while ($RUNNING) {
+#        print "$$ ",time,"\n";
+        pf::config::cached::RefreshConfigs();
+        sleep 2;
+    }
+
+}
+
+print STDERR "Starting waiting\n";
+
+while (1) {
+    pause;
+    while (1) {
+        my $pid = waitpid(-1, WNOHANG);
+        last unless $pid > 0;
+        delete $KIDS{$pid};
+    }
+    last unless keys %KIDS;
+}
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2015 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+

--- a/addons/packages/packetfence.spec
+++ b/addons/packages/packetfence.spec
@@ -227,6 +227,7 @@ Requires: perl(Plack), perl(Plack::Middleware::ReverseProxy)
 Requires: perl(MooseX::Types::LoadableClass)
 Requires: perl(Moose) <= 2.1005
 Requires: perl(CHI) >= 0.59
+Requires: perl(File::FcntlLock)
 Requires: perl(Data::Serializer)
 Requires: perl(Data::Structure::Util)
 Requires: perl(Data::Swap)
@@ -533,9 +534,9 @@ done
 #Make ssl certificate
 if [ ! -f /usr/local/pf/conf/ssl/server.crt ]; then
     openssl req -x509 -new -nodes -days 365 -batch\
-    	-out /usr/local/pf/conf/ssl/server.crt\
-    	-keyout /usr/local/pf/conf/ssl/server.key\
-    	-nodes -config /usr/local/pf/conf/openssl.cnf
+        -out /usr/local/pf/conf/ssl/server.crt\
+        -keyout /usr/local/pf/conf/ssl/server.key\
+        -nodes -config /usr/local/pf/conf/openssl.cnf
 fi
 
 
@@ -755,14 +756,14 @@ fi
                         /usr/local/pf/conf/pf-release
 %config(noreplace)      /usr/local/pf/conf/provisioning.conf
                         /usr/local/pf/conf/provisioning.conf.example
-%dir			/usr/local/pf/conf/radiusd
+%dir                    /usr/local/pf/conf/radiusd
 %config(noreplace)      /usr/local/pf/conf/radiusd/proxy.conf.inc
                         /usr/local/pf/conf/radiusd/proxy.conf.inc.example
-%config(noreplace)	/usr/local/pf/conf/radiusd/eap.conf
+%config(noreplace)      /usr/local/pf/conf/radiusd/eap.conf
                         /usr/local/pf/conf/radiusd/eap.conf.example
-%config(noreplace)	/usr/local/pf/conf/radiusd/radiusd.conf
+%config(noreplace)      /usr/local/pf/conf/radiusd/radiusd.conf
                         /usr/local/pf/conf/radiusd/radiusd.conf.example
-%config(noreplace)	/usr/local/pf/conf/radiusd/sql.conf
+%config(noreplace)      /usr/local/pf/conf/radiusd/sql.conf
                         /usr/local/pf/conf/radiusd/sql.conf.example
 %config(noreplace)      /usr/local/pf/conf/realm.conf
                         /usr/local/pf/conf/realm.conf.example
@@ -788,7 +789,7 @@ fi
 %config                 /usr/local/pf/conf/httpd.conf.d/httpd.webservices
 %config                 /usr/local/pf/conf/httpd.conf.d/httpd.aaa
 %config                 /usr/local/pf/conf/httpd.conf.d/log.conf
-%config(noreplace)	/usr/local/pf/conf/httpd.conf.d/ssl-certificates.conf
+%config(noreplace)      /usr/local/pf/conf/httpd.conf.d/ssl-certificates.conf
                         /usr/local/pf/conf/httpd.conf.d/ssl-certificates.conf.example
 %config(noreplace)      /usr/local/pf/conf/iptables.conf
 %config(noreplace)      /usr/local/pf/conf/listener.msg

--- a/addons/packages/packetfence.spec
+++ b/addons/packages/packetfence.spec
@@ -226,7 +226,7 @@ Requires: perl(File::Slurp)
 Requires: perl(Plack), perl(Plack::Middleware::ReverseProxy)
 Requires: perl(MooseX::Types::LoadableClass)
 Requires: perl(Moose) <= 2.1005
-Requires: perl(CHI) >= 0.56
+Requires: perl(CHI) >= 0.59
 Requires: perl(Data::Serializer)
 Requires: perl(Data::Structure::Util)
 Requires: perl(Data::Swap)

--- a/bin/pfcmd.pl
+++ b/bin/pfcmd.pl
@@ -2472,7 +2472,6 @@ sub configreload {
     require pf::ConfigStore::Wrix;
     require pf::web::filter;
     require pf::vlan::filter;
-    pf::config::cached::updateCacheControl();
     pf::config::cached::ReloadConfigs($force);
     return 0;
 }

--- a/conf/httpd.conf.d/httpd.admin
+++ b/conf/httpd.conf.d/httpd.admin
@@ -60,7 +60,9 @@ AcceptMutex posixsem
 
 PerlSwitches -I/usr/local/pf/lib
 PerlSwitches -I/usr/local/pf/html/pfappserver/lib
-PerlLoadModule pfappserver;
+PerlLoadModule pfappserver
+PerlLoadModule pf::WebAPI::InitHandler
+PerlPostConfigHandler pf::WebAPI::InitHandler::post_config
 
 <Perl>
 BEGIN {

--- a/conf/httpd.conf.d/httpd.portal
+++ b/conf/httpd.conf.d/httpd.portal
@@ -113,6 +113,8 @@ PerlPostConfigRequire /usr/local/pf/lib/pf/web/captiveportal_modperl_require.pl
 PerlLoadModule captiveportal
 PerlLoadModule pf::web::dispatcher
 PerlLoadModule pf::web::release
+PerlLoadModule pf::WebAPI::InitHandler
+PerlPostConfigHandler pf::WebAPI::InitHandler::post_config
 # The TransHandler handles the 'captive-portal' core piece redirecting to the
 # portal if the URL is not otherwised allowed by passthrough or part of the
 # portal itself.

--- a/conf/httpd.conf.d/httpd.webservices
+++ b/conf/httpd.conf.d/httpd.webservices
@@ -67,6 +67,9 @@ PerlSwitches -I/usr/local/pf/lib
 PerlSwitches -I/usr/local/pf/html/pfappserver/lib
 PerlPostConfigRequire /usr/local/pf/lib/pf/web/webservices_modperl_require.pl
 PerlLoadModule pf::WebAPI
+PerlLoadModule pf::WebAPI::InitHandler
+PerlPostConfigHandler pf::WebAPI::InitHandler::post_config
+PerlInitHandler pf::WebAPI::InitHandler
 
 AcceptMutex posixsem
 SSLMutex posixsem
@@ -87,7 +90,6 @@ $Include = $install_dir.'/conf/httpd.conf.d/log.conf';
 $User = "pf";
 $Group = "pf";
 
-$PerlInitHandler = "pf::WebAPI::InitHandler";
 
 if (defined($PfConfig->{'alerting'}{'fromaddr'}) && $PfConfig->{'alerting'}{'fromaddr'} ne '') {
     $ServerAdmin = $PfConfig->{'alerting'}{'fromaddr'};

--- a/debian/control
+++ b/debian/control
@@ -80,7 +80,7 @@ Depends: ${misc:Depends}, vlan, make,
  libauthen-htpasswd-perl, libcatalyst-authentication-credential-http-perl, 
  libcatalyst-authentication-store-htpasswd-perl, libcatalyst-plugin-unicode-encoding-perl,
  libcatalyst-view-tt-perl, libhtml-formfu-perl, libjson-perl, libjson-xs-perl,
- libsort-naturally-perl, libhtml-formhandler-perl (<= 0.40016), libchi-perl (>=0.56),
+ libsort-naturally-perl, libhtml-formhandler-perl (<= 0.40016), libchi-perl (>=0.59),
  libchi-driver-memcached-perl,libcache-memcached-perl, libcache-memcached-getparserxs-perl, libdata-serializer-perl,
  libcache-fastmmap-perl, libmoo-perl (>=1.001000), libterm-size-any-perl,
 # packaging workaround (we don't require it but something in catalyst seem to do)

--- a/debian/control
+++ b/debian/control
@@ -80,7 +80,7 @@ Depends: ${misc:Depends}, vlan, make,
  libauthen-htpasswd-perl, libcatalyst-authentication-credential-http-perl, 
  libcatalyst-authentication-store-htpasswd-perl, libcatalyst-plugin-unicode-encoding-perl,
  libcatalyst-view-tt-perl, libhtml-formfu-perl, libjson-perl, libjson-xs-perl,
- libsort-naturally-perl, libhtml-formhandler-perl (<= 0.40016), libchi-perl (>=0.59),
+ libsort-naturally-perl, libhtml-formhandler-perl (<= 0.40016), libchi-perl (>=0.59),libfile-fcntllock-perl,
  libchi-driver-memcached-perl,libcache-memcached-perl, libcache-memcached-getparserxs-perl, libdata-serializer-perl,
  libcache-fastmmap-perl, libmoo-perl (>=1.001000), libterm-size-any-perl,
 # packaging workaround (we don't require it but something in catalyst seem to do)

--- a/html/captive-portal/lib/captiveportal.pm
+++ b/html/captive-portal/lib/captiveportal.pm
@@ -99,7 +99,7 @@ __PACKAGE__->config(
 );
 
 before handle_request => sub {
-    pf::config::cached::ReloadConfigs();
+    pf::config::cached::RefreshConfigs();
 };
 
 sub loadCustomStatic {

--- a/html/pfappserver/lib/pfappserver.pm
+++ b/html/pfappserver/lib/pfappserver.pm
@@ -230,7 +230,7 @@ sub forms {
 }
 
 before handle_request => sub {
-    pf::config::cached::ReloadConfigs();
+    pf::config::cached::RefreshConfigs();
 };
 
 after finalize => sub {

--- a/html/pfappserver/lib/pfappserver/Base/Model/Config.pm
+++ b/html/pfappserver/lib/pfappserver/Base/Model/Config.pm
@@ -301,13 +301,14 @@ sub sortItems {
 sub commit {
     my ($self) = @_;
     my ($status,$status_msg);
-    if($self->configStore->commit()) {
+    my ($result,$error) = $self->configStore->commit();
+    if($result) {
         $status = HTTP_OK;
         $status_msg = "Changes successfully commited";
     }
     else {
         $status = HTTP_INTERNAL_SERVER_ERROR;
-        $status_msg = "Unable to commit changes to file please run pfcmd fixpermissions and try again";
+        $status_msg = "$error\n";
     }
     return ($status,$status_msg);
 }

--- a/html/pfappserver/lib/pfappserver/Form/Config/Pf.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Pf.pm
@@ -29,7 +29,7 @@ sub field_list {
 
     my $list = [];
     my $section = $self->section;
-    my @section_fields = $cached_pf_default_config->Parameters($section);
+    my @section_fields = $cached_pf_config->{imported}->Parameters($section);
     foreach my $name (@section_fields) {
         my $doc_section_name = "$section.$name";
         my $doc_section = $Doc_Config{$doc_section_name};

--- a/lib/pf/CHI.pm
+++ b/lib/pf/CHI.pm
@@ -63,6 +63,9 @@ Hash::Merge::specify_behavior(
 our @CACHE_NAMESPACES = qw(configfilesdata configfiles httpd.admin httpd.portal pfdns switch.overlay ldap_auth);
 
 our $chi_config = pf::IniFiles->new( -file => $chi_config_file, -allowempty => 1) or die;
+
+our %DATASTORE;
+
 our %DEFAULT_CONFIG = (
     'namespace' => {
         map { $_ => { 'storage' => $_ } } @CACHE_NAMESPACES
@@ -71,7 +74,7 @@ our %DEFAULT_CONFIG = (
     'defaults'              => {'serializer' => 'Sereal'},
     'storage'               => {
         'raw' => {
-            'global' => '1',
+            'datastore' => \%DATASTORE,
             'driver' => 'RawMemory'
         },
         'memcached' => {

--- a/lib/pf/ConfigStore.pm
+++ b/lib/pf/ConfigStore.pm
@@ -388,14 +388,18 @@ sub flatten_list {
 sub commit {
     my ($self) = @_;
     my $result;
+    my $error;
     eval {
         $result = $self->rewriteConfig();
     };
-    get_logger->error($@) if $@;
+    if($@) {
+        $error = $@;
+        get_logger->error($error);
+    }
     unless($result) {
         $self->rollback();
     }
-    return $result;
+    return ($result,$error);
 }
 
 =head2 search

--- a/lib/pf/ConfigStore/Switch.pm
+++ b/lib/pf/ConfigStore/Switch.pm
@@ -34,13 +34,8 @@ $switches_cached_config = pf::config::cached->new(
         on_switches_reload => sub {
             my ( $config, $name ) = @_;
             populateSwitchConfig( $config, $name );
-        },
-    ],
-    -onfilereloadonce => [
-        reload_switches_conf => sub {
-            my ( $config, $name ) = @_;
             freeradius_populate_nas_config( \%SwitchConfig, $config->GetLastModTimestamp );
-        }
+        },
     ],
     -oncachereload => [
         on_cached_overlay_reload => sub {
@@ -48,9 +43,9 @@ $switches_cached_config = pf::config::cached->new(
             my $data = $config->fromCacheForDataUntainted("SwitchConfig");
             if($data) {
                 %SwitchConfig = %$data;
-            } else {
-                #if not found then repopulate switch
-                $config->_callFileReloadCallbacks();
+            }
+            else {
+                populateSwitchConfig( $config, $name );
             }
         },
     ]

--- a/lib/pf/FileLocker.pm
+++ b/lib/pf/FileLocker.pm
@@ -1,0 +1,164 @@
+package pf::FileLocker;
+=head1 NAME
+
+pf::FileLocker add documentation
+
+=cut
+
+=head1 DESCRIPTION
+
+pf::FileLocker
+
+=cut
+
+use strict;
+use warnings;
+use File::FcntlLock;
+use pf::log;
+use Moo;
+use POSIX qw(SIGALRM);
+
+has fcntlLock => (
+    is      => 'ro',
+    default => sub {
+        return File::FcntlLock->new(
+            l_type   => F_WRLCK,
+            l_whence => SEEK_SET,
+            l_start  => 0,
+            l_len    => 0
+        );
+    }
+);
+has fh => ( is => 'rw', required => 1 );
+has blocking => ( is => 'rw', default => sub { 0 } );
+has unlockOnDestroy => ( is => 'rw', default => sub { 0 } );
+has timeout => ( is => 'rw', default => sub { 0 } );
+has lockAcquired => ( is => 'rw', default => sub { 0 } );
+ 
+=head2 DESTROY
+
+TODO: documention
+
+=cut
+
+sub DESTROY {
+    my ($self) = @_;
+    $self->unlock if $self->unlockOnDestroy && $self->lockAcquired;
+}
+
+=head2 unlock
+
+TODO: documention
+
+=cut
+
+sub unlock {
+    return $_[0]->_doRealLock( F_UNLCK );
+}
+
+=head2 _doLock
+
+TODO: documention
+
+=cut
+
+sub _doLock {
+    my ($self, $type) = @_;
+    my $timeout = $self->timeout;
+    my $blocking = $self->blocking;
+    if ($timeout && $blocking) {
+        my $mask      = POSIX::SigSet->new(SIGALRM);
+        my $action    = POSIX::SigAction->new(sub { die "alarm" }, $mask);
+        my $oldaction = POSIX::SigAction->new();
+        my $result;
+        POSIX::sigaction(SIGALRM, $action, $oldaction);
+        eval {
+            alarm $timeout;
+            eval {
+                $result = $self->_doRealLock($type);
+            };
+            alarm 0;
+            POSIX::sigaction(SIGALRM, $oldaction);    # restore original
+        };
+        alarm 0;
+        return $result;
+    }
+    return $self->_doRealLock($type);
+}
+
+=head2 _doRealLock
+
+
+=cut
+
+sub _doRealLock {
+    my ($self,$type) = @_;
+    my $fs = $self->fcntlLock;
+    $fs->l_type($type);
+    my $result = $fs->lock($self->fh, $self->blocking ? F_SETLKW : F_SETLK);
+    $self->lockAcquired($result);
+    return $result;
+}
+
+=head2 writeLock
+
+writeLock 
+
+=cut
+
+sub writeLock {
+    return $_[0]->_doLock(F_WRLCK);
+}
+
+=head2 _doLock
+
+TODO: documention
+
+=cut
+
+sub readLock {
+    return $_[0]->_doLock(F_RDLCK);
+}
+
+=head2 isWriteLockedByAnother
+
+See if there is a write lock on the file by another process
+
+=cut
+
+sub isWriteLockedByAnother {
+    my ($self) = @_;
+    my $fs = $self->fcntlLock;
+    $fs->lock($self->fh, F_GETLK);
+    return F_WRLCK == $fs->l_type && $fs->l_pid != $$;
+}
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2015 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and::or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;
+

--- a/lib/pf/FileLocker.pm
+++ b/lib/pf/FileLocker.pm
@@ -1,13 +1,26 @@
 package pf::FileLocker;
+
 =head1 NAME
 
-pf::FileLocker add documentation
+pf::FileLocker - a class for wrapping file locking
 
 =cut
 
 =head1 DESCRIPTION
 
-pf::FileLocker
+pf::FileLocker encapsulates fcntl file locking
+
+fcntl is prefer to flock based locking since flock can be shared across children
+
+=head1 USAGE
+
+    open(my $fh,"file.lock");
+    {
+        my $fl = pf::FileLocker->new(fh => $fh, unlockOnDestroy => 1, blocking => 1);
+        $fl->writeLock();
+        .... #File is lock during this scope
+    }
+    #File is now unlocked
 
 =cut
 

--- a/lib/pf/FileLocker.pm
+++ b/lib/pf/FileLocker.pm
@@ -34,10 +34,18 @@ has blocking => ( is => 'rw', default => sub { 0 } );
 has unlockOnDestroy => ( is => 'rw', default => sub { 0 } );
 has timeout => ( is => 'rw', default => sub { 0 } );
 has lockAcquired => ( is => 'rw', default => sub { 0 } );
- 
+
 =head2 DESTROY
 
-TODO: documention
+Unlocks the file on destroy of the object
+
+=head3 Usage
+
+    DESTROY()
+
+=head3 Return
+
+    Nothing
 
 =cut
 
@@ -48,7 +56,16 @@ sub DESTROY {
 
 =head2 unlock
 
-TODO: documention
+Unlocks the file handle
+
+=head3 Usage
+
+    $obj->unlock()
+
+=head3 Return
+
+    1 on success
+    0 on failure
 
 =cut
 
@@ -58,7 +75,17 @@ sub unlock {
 
 =head2 _doLock
 
-TODO: documention
+Wraps the (un)locking of the file handle to deal with timeouts
+
+=head3 Usage
+
+    $obj->_doLock()
+
+=head3 Return
+
+    1 on success
+    0 on failure
+
 
 =cut
 
@@ -88,6 +115,17 @@ sub _doLock {
 
 =head2 _doRealLock
 
+Wraps the (un)locking of the file handle to deal with blocking locks
+
+=head3 Usage
+
+    $obj->_doRealLock()
+
+=head3 Return
+
+    1 on success
+    0 on failure
+
 
 =cut
 
@@ -95,14 +133,23 @@ sub _doRealLock {
     my ($self,$type) = @_;
     my $fs = $self->fcntlLock;
     $fs->l_type($type);
-    my $result = $fs->lock($self->fh, $self->blocking ? F_SETLKW : F_SETLK);
+    my $result = $fs->lock($self->fh, $self->blocking ? F_SETLKW : F_SETLK) ? 1 : 0;
     $self->lockAcquired($result);
     return $result;
 }
 
 =head2 writeLock
 
-writeLock 
+Get the write lock on the file handle
+
+=head3 Usage
+
+    $obj->writeLock()
+
+=head3 Return
+
+    1 on success
+    0 on failure
 
 =cut
 
@@ -110,9 +157,18 @@ sub writeLock {
     return $_[0]->_doLock(F_WRLCK);
 }
 
-=head2 _doLock
+=head2 readLock
 
-TODO: documention
+Get the read lock on the file handle
+
+=head3 Usage
+
+    $obj->readLock()
+
+=head3 Return
+
+    1 on success
+    0 on failure
 
 =cut
 
@@ -122,7 +178,16 @@ sub readLock {
 
 =head2 isWriteLockedByAnother
 
-See if there is a write lock on the file by another process
+Check if a write lock is own by another process for the file handle
+
+=head3 Usage
+
+    $obj->isWriteLockedByAnother()
+
+=head3 Return
+
+    1 on success
+    0 on failure
 
 =cut
 

--- a/lib/pf/WebAPI/InitHandler.pm
+++ b/lib/pf/WebAPI/InitHandler.pm
@@ -16,12 +16,31 @@ use warnings;
 
 use Apache2::RequestRec ();
 use pf::config::cached;
+use pf::db;
+use pf::CHI;
+use Cache::Memcached;
 
 use Apache2::Const -compile => 'OK';
 
 sub handler {
     my $r = shift;
-    pf::config::cached::ReloadConfigs();
+    pf::config::cached::RefreshConfigs();
+    return Apache2::Const::OK;
+}
+
+
+=head2 post_config
+
+Reset all cached connections before initializing children
+
+=cut
+
+sub post_config {
+    my ($conf_pool, $log_pool, $temp_pool, $s) = @_;
+    pf::config::cached::RefreshConfigs();
+    db_disconnect();
+    pf::CHI->clear_memoized_cache_objects;
+    Cache::Memcached->disconnect_all;
     return Apache2::Const::OK;
 }
 

--- a/lib/pf/authentication.pm
+++ b/lib/pf/authentication.pm
@@ -216,7 +216,7 @@ sub readAuthenticationConfigFile {
         $cached_profiles_config->addPostReloadCallbacks(update_profiles_guest_modes => \&update_profiles_guest_modes);
 
     } else {
-        $cached_authentication_config->ReadConfig();
+        $cached_authentication_config->ReloadConfig();
     }
 }
 

--- a/lib/pf/config.pm
+++ b/lib/pf/config.pm
@@ -50,7 +50,7 @@ our (
     @internal_nets, @routed_isolation_nets, @routed_registration_nets, @inline_nets,
     @inline_enforcement_nets, @vlan_enforcement_nets, $management_network,
 #pf.conf.default variables
-    %Default_Config, $cached_pf_default_config,
+    %Default_Config,
 #pf.conf variables
     %Config, $cached_pf_config,
 #network.conf variables
@@ -118,7 +118,7 @@ BEGIN {
         @Profile_Filters %Profiles_Config $cached_profiles_config
         $cached_pf_config $cached_network_config $cached_floating_device_config
         %ConfigFirewallSSO $cached_firewall_sso
-        $cached_pf_default_config $cached_pf_doc_config @stored_config_files
+        $cached_pf_doc_config @stored_config_files
         $OS
         %Doc_Config
         %ConfigRealm $cached_realm
@@ -501,33 +501,32 @@ sub readPfDocConfigFiles {
 sub readPfConfigFiles {
 
     # load default and override by local config (most common case)
-    $cached_pf_default_config = pf::config::cached->new(
-                -file => $default_config_file,
-                -onfilereload => [
-                    onfile_pf_defaults_reload => sub {
-                        my ( $config, $name ) = @_;
-                        $config->toHash(\%Default_Config);
-                        $config->cleanupWhitespace(\%Default_Config);
-                        $config->cacheForData->set( "Default_Config", \%Default_Config );
-                    },
-                ],
-                -oncachereload => [
-                    oncache_pf_defaults_reload => sub {
-                        my ( $config, $name ) = @_;
-                        my $data = $config->fromCacheForDataUntainted("Default_Config");
-                        if($data) {
-                            %Default_Config = %$data;
-                        } else {
-                            $config->_callFileReloadCallbacks();
-                        }
-                    },
-                ],
-    );
 
     if ( -e $default_config_file || -e $config_file ) {
         $cached_pf_config = pf::config::cached->new(
             -file   => $config_file,
-            -import => $cached_pf_default_config,
+            -import => pf::config::cached->new(
+                        -file => $default_config_file,
+                        -onfilereload => [
+                            onfile_pf_defaults_reload => sub {
+                                my ( $config, $name ) = @_;
+                                $config->toHash(\%Default_Config);
+                                $config->cleanupWhitespace(\%Default_Config);
+                                $config->cacheForData->set( "Default_Config", \%Default_Config );
+                            },
+                        ],
+                        -oncachereload => [
+                            oncache_pf_defaults_reload => sub {
+                                my ( $config, $name ) = @_;
+                                my $data = $config->fromCacheForDataUntainted("Default_Config");
+                                if($data) {
+                                    %Default_Config = %$data;
+                                } else {
+                                    $config->_callFileReloadCallbacks();
+                                }
+                            },
+                        ],
+            ),
             -allowempty => 1,
             -onfilereload => [
                 onfile_pf_reload => sub {
@@ -550,6 +549,7 @@ sub readPfConfigFiles {
             ],
             -onpostreload => [ 'reload_pf_config' =>  sub {
                 my ($config) = @_;
+                $config->{imported}->ReloadConfig();
                 #clearing older interfaces infor
                 $monitor_int = $management_network = '';
                 @listen_ints = @dhcplistener_ints = @ha_ints =

--- a/lib/pf/config/cached.pm
+++ b/lib/pf/config/cached.pm
@@ -396,7 +396,7 @@ sub RewriteConfig {
         die "Config $file was modified from last loading\n";
     }
     my $locker = _lockFileForOnReload($file);
-    if($self->IsGlobalReloadWriteLocked || $self->GetReloadWriteLock ) {
+    if($self->IsGlobalReloadWriteLocked || !$self->GetReloadWriteLock ) {
         die "Config $file is currently being reloaded into the cache please retry after reloading is done\n";
     }
     my $result;

--- a/lib/pf/config/cached.pm
+++ b/lib/pf/config/cached.pm
@@ -712,7 +712,7 @@ sub ReloadConfig {
     );
 
     $reloaded_from_cache = refaddr($self) != refaddr($new_self);
-    
+
     if($reloaded_from_cache) {
         $self->_swap_data($new_self);
     }
@@ -728,7 +728,7 @@ Swap the data with cached data
 
 sub _swap_data {
     my ($self,$new_self) = @_;
-    Data::Swap::swap($self,$new_self); 
+    Data::Swap::swap($self,$new_self);
     $self->addToLoadedConfigs();
     #Setting no_destroy to avoid removal of call back data
     $new_self->{no_destroy} = 1;
@@ -879,7 +879,7 @@ Check if the current process has an existing write lock
 sub GetReloadWriteLock {
     my ($self) = @_;
     my $locker = _lockFileForOnReload($self->GetFileName);
-    $locker->blocking(0); 
+    $locker->blocking(0);
     return $locker->writeLock;
 }
 
@@ -924,8 +924,10 @@ refresh configs from the cache that have changed
 
 sub RefreshConfigs {
     my $logger = get_logger();
+    return if IsGlobalReloadWriteLocked();
     $logger->trace("Started Refreshing all configs");
     foreach my $config (@LOADED_CONFIGS{@LOADED_CONFIGS_FILE}) {
+        last if IsGlobalReloadWriteLocked();
         next unless $config;
         next unless $config->LockFileHasChanged;
         $config->ReloadConfig();

--- a/lib/pf/config/cached.pm
+++ b/lib/pf/config/cached.pm
@@ -918,24 +918,32 @@ sub cacheForData {
 
 =head2 RefreshConfigs
 
-refresh configs and call any register callbacks 
+refresh configs from the cache that have changed
 
 =cut
 
 sub RefreshConfigs {
     my $logger = get_logger();
-    $logger->trace("Started Reloading all configs");
+    $logger->trace("Started Refreshing all configs");
     foreach my $config (@LOADED_CONFIGS{@LOADED_CONFIGS_FILE}) {
         next unless $config;
         next unless $config->LockFileHasChanged;
         $config->ReloadConfig();
     }
-    $logger->trace("Finished Reloading all configs");
+    $logger->trace("Finished Refreshing all configs");
 }
 
 =head2 ReloadConfigs
 
-ReloadConfigs reload all configs and call any register callbacks
+ReloadConfigs reload all expired configs from the cache or filesystem
+
+=head3 Usage
+
+    ReloadConfigs($force_expiration);
+
+=head3 Return
+
+    Nothing
 
 =cut
 

--- a/lib/pf/config/cached.pm
+++ b/lib/pf/config/cached.pm
@@ -447,6 +447,7 @@ sub Rollback {
     $cache->l1_cache->remove($file);
     my $old_config = $cache->get($file);
     $self->_swap_data($old_config);
+    undef $old_config;
     $self->doCallbacks(0,1);
 }
 
@@ -716,6 +717,7 @@ sub ReloadConfig {
 
     if($reloaded_from_cache) {
         $self->_swap_data($new_self);
+        undef $new_self;
     }
     $self->doCallbacks($reloaded_from_file,$reloaded_from_cache,$force);
     return $result;

--- a/lib/pf/config/cached.pm
+++ b/lib/pf/config/cached.pm
@@ -395,7 +395,8 @@ sub RewriteConfig {
     if( $self->HasChanged(1) ) {
         die "Config $file was modified from last loading\n";
     }
-    if($self->IsGlobalReloadWriteLocked || $self->IsReloadWriteLocked) {
+    my $locker = _lockFileForOnReload($file);
+    if($self->IsGlobalReloadWriteLocked || $self->GetReloadWriteLock ) {
         die "Config $file is currently being reloaded into the cache please retry after reloading is done\n";
     }
     my $result;
@@ -929,6 +930,7 @@ sub RefreshConfigs {
     foreach my $config (@LOADED_CONFIGS{@LOADED_CONFIGS_FILE}) {
         last if IsGlobalReloadWriteLocked();
         next unless $config;
+        next if $config->IsReloadWriteLocked();
         next unless $config->LockFileHasChanged;
         $config->ReloadConfig();
     }

--- a/sbin/pfdetect
+++ b/sbin/pfdetect
@@ -138,8 +138,8 @@ while (<$snortpipe_fh>) {
         $logger->warn(
             "pfdetect: $srcip MAC NOT FOUND for violation $sid [$descr]");
     }
-    #reload all cached configs after each iteration
-    pf::config::cached::ReloadConfigs();
+    #refresh all cached configs after each iteration
+    pf::config::cached::RefreshConfigs();
 }
 
 END {

--- a/sbin/pfdhcplistener
+++ b/sbin/pfdhcplistener
@@ -174,8 +174,8 @@ sub dhcp_detector {
 sub process_pkt {
     my ( $user_data, $hdr, $pkt ) = @_;
     listen_dhcp( $pkt, $user_data );
-    #reload all cached configs after each iteration
-    pf::config::cached::ReloadConfigs();
+    #refresh all cached configs after each iteration
+    pf::config::cached::RefreshConfigs();
     #Only perform stats when in debug mode
     $logger->debug( sub {
         my $pcap = $user_data->[1];

--- a/sbin/pfdns
+++ b/sbin/pfdns
@@ -140,7 +140,7 @@ END {
 
 sub response_handler {
     my ($qname, $qclass, $qtype, $peerhost,$query,$conn) = @_;
-    pf::config::cached::ReloadConfigs();
+    pf::config::cached::RefreshConfigs();
     my $ip = new NetAddr::IP::Lite clean_ip($peerhost);
     foreach my $network (@routed_registration_nets_named) {
         if ($network->contains($ip)) {

--- a/sbin/pfmon
+++ b/sbin/pfmon
@@ -332,7 +332,7 @@ sub _runtask {
     my ($id,$parameter,$task) = @_;
     $0 = "pfmon - $id";
     while ($running) {
-        pf::config::cached::ReloadConfigs();
+        pf::config::cached::RefreshConfigs();
         my $interval = $Config{'maintenance'}{$parameter};
         unless ($interval) {
             $logger->trace("task $id is disabled");

--- a/sbin/pfsetvlan
+++ b/sbin/pfsetvlan
@@ -2053,9 +2053,8 @@ sub getSwitch {
     my $lockLogger = Log::Log4perl->get_logger('pfsetvlan::locking');
     {
         lock $switchFactory_locker;
-    #    $pf::ConfigStore::SwitchOverlay::switches_overlay_cached_config->ReadConfig();
         $lockLogger->trace("locking - obtained lock on switchFactory_locker");
-        pf::config::cached::ReloadConfigs();
+        pf::config::cached::RefreshConfigs();
         $switch = $switchFactory->instantiate($switch_id);
         if($switch) {
             add_to_switch_locker($switch->{_id});

--- a/t/config-cached.t
+++ b/t/config-cached.t
@@ -100,7 +100,7 @@ if($pid == 0) {
 }
 waitpid ($pid,0);
 
-$config->ReadConfig();
+$config->ReloadConfig();
 
 ok("newval" eq $DATA1{"section1"}{"param2"},"on reload was called");
 


### PR DESCRIPTION
## DESCRIPTION

Ensure that configuration files are only reloaded once to avoid reparsing
## Impacts

This impact all services that use configuration
bin/pfcmd configreload
bin/pfcmd configreload hard
## NEWS file entries

Bug Fixes
+++++++++
Fixed issue with cache reloading increasing memory usage while reloading the cache
## Delete branch after merge

NO
