### PR TITLE
OAuth sources refactor

### DIFF
--- a/lib/pf/Authentication/Source/FacebookSource.pm
+++ b/lib/pf/Authentication/Source/FacebookSource.pm
@@ -26,6 +26,12 @@ has 'redirect_url' => (isa => 'Str', is => 'rw', required => 1, default => 'http
 has 'domains' => (isa => 'Str', is => 'rw', required => 1, default => '*.facebook.com,*.fbcdn.net,*.akamaihd.net');
 has 'create_local_account' => (isa => 'Str', is => 'rw', default => 'no');
 
+=head2 lookup_from_provider_info
+
+Lookup the person information from the authentication hash received during the OAuth process
+
+=cut
+
 sub lookup_from_provider_info {
     my ( $self, $pid, $info ) = @_;
     my $logger = get_logger();

--- a/lib/pf/Authentication/Source/FacebookSource.pm
+++ b/lib/pf/Authentication/Source/FacebookSource.pm
@@ -8,10 +8,11 @@ pf::Authentication::Source::FacebookSource
 
 =cut
 
+use pf::person;
+use pf::log;
 use Moose;
-extends 'pf::Authentication::Source';
+extends 'pf::Authentication::Source::OAuthSource';
 
-has '+class' => (default => 'external');
 has '+type' => (default => 'Facebook');
 has '+unique' => (default => 1);
 has 'client_id' => (isa => 'Str', is => 'rw', required => 1);
@@ -25,44 +26,11 @@ has 'redirect_url' => (isa => 'Str', is => 'rw', required => 1, default => 'http
 has 'domains' => (isa => 'Str', is => 'rw', required => 1, default => '*.facebook.com,*.fbcdn.net,*.akamaihd.net');
 has 'create_local_account' => (isa => 'Str', is => 'rw', default => 'no');
 
-=head2 available_actions
+sub lookup_from_provider_info {
+    my ( $self, $pid, $info ) = @_;
+    my $logger = get_logger();
 
-For an oauth2 source, we limit the available actions to B<set role>, B<set access duration>, and B<set unreg date>.
-
-=cut
-
-sub available_actions {
-    return [
-            $Actions::SET_ROLE,
-            $Actions::SET_ACCESS_DURATION,
-            $Actions::SET_UNREG_DATE,
-           ];
-}
-
-=head2 available_attributes
-
-=cut
-
-sub available_attributes {
-    my $self = shift;
-    return([@{$self->SUPER::available_attributes}, {value => 'username', type => $Conditions::SUBSTRING }]);
-}
-
-=head2 match_in_subclass
-
-=cut
-
-sub match_in_subclass {
-    my ($self, $params, $rule, $own_conditions, $matching_conditions) = @_;
-    my $username =  $params->{'username'};
-    foreach my $condition (@{ $own_conditions }) {
-        if ($condition->{'attribute'} eq "username") {
-            if ( $condition->matches("username", $username) ) {
-                push(@{ $matching_conditions }, $condition);
-            }
-        }
-    }
-    return $username;
+    person_modify( $pid, firstname => $info->{first_name}, lastname => $info->{last_name} );
 }
 
 =head1 AUTHOR

--- a/lib/pf/Authentication/Source/FacebookSource.pm
+++ b/lib/pf/Authentication/Source/FacebookSource.pm
@@ -35,7 +35,6 @@ Lookup the person information from the authentication hash received during the O
 
 sub lookup_from_provider_info {
     my ( $self, $pid, $info ) = @_;
-    my $logger = get_logger();
 
     person_modify( $pid, firstname => $info->{first_name}, lastname => $info->{last_name} );
 }

--- a/lib/pf/Authentication/Source/FacebookSource.pm
+++ b/lib/pf/Authentication/Source/FacebookSource.pm
@@ -14,6 +14,7 @@ use Moose;
 extends 'pf::Authentication::Source::OAuthSource';
 
 has '+type' => (default => 'Facebook');
+has '+class' => (default => 'external');
 has '+unique' => (default => 1);
 has 'client_id' => (isa => 'Str', is => 'rw', required => 1);
 has 'client_secret' => (isa => 'Str', is => 'rw', required => 1);

--- a/lib/pf/Authentication/Source/GithubSource.pm
+++ b/lib/pf/Authentication/Source/GithubSource.pm
@@ -14,6 +14,7 @@ use Moose;
 extends 'pf::Authentication::Source::OAuthSource';
 
 has '+type' => (default => 'Github');
+has '+class' => (default => 'external');
 has '+unique' => (default => 1);
 has 'client_id' => (isa => 'Str', is => 'rw', required => 1);
 has 'client_secret' => (isa => 'Str', is => 'rw', required => 1);

--- a/lib/pf/Authentication/Source/GithubSource.pm
+++ b/lib/pf/Authentication/Source/GithubSource.pm
@@ -26,6 +26,12 @@ has 'redirect_url' => (isa => 'Str', is => 'rw', required => 1, default => 'http
 has 'domains' => (isa => 'Str', is => 'rw', required => 1, default => 'api.github.com,*.github.com,github.com');
 has 'create_local_account' => (isa => 'Str', is => 'rw', default => 'no');
 
+=head2 lookup_from_provider_info
+
+Lookup the person information from the authentication hash received during the OAuth process
+
+=cut
+
 sub lookup_from_provider_info {
     my ( $self, $pid, $info ) = @_;
     my $logger = get_logger();

--- a/lib/pf/Authentication/Source/GithubSource.pm
+++ b/lib/pf/Authentication/Source/GithubSource.pm
@@ -8,10 +8,11 @@ pf::Authentication::Source::GithubSource
 
 =cut
 
+use pf::person;
+use pf::log;
 use Moose;
-extends 'pf::Authentication::Source';
+extends 'pf::Authentication::Source::OAuthSource';
 
-has '+class' => (default => 'external');
 has '+type' => (default => 'Github');
 has '+unique' => (default => 1);
 has 'client_id' => (isa => 'Str', is => 'rw', required => 1);
@@ -22,47 +23,14 @@ has 'access_token_path' => (isa => 'Str', is => 'rw', default => '/login/oauth/a
 has 'access_token_param' => (isa => 'Str', is => 'rw', default => 'access_token');
 has 'protected_resource_url' => (isa => 'Str', is => 'rw', default => 'https://api.github.com/user');
 has 'redirect_url' => (isa => 'Str', is => 'rw', required => 1, default => 'https://<hostname>/oauth2/github');
-has 'domains' => (isa => 'Str', is => 'rw', required => 1, default => 'api.github.com');
+has 'domains' => (isa => 'Str', is => 'rw', required => 1, default => 'api.github.com,*.github.com,github.com');
 has 'create_local_account' => (isa => 'Str', is => 'rw', default => 'no');
 
-=head2 available_actions
-
-For an oauth2 source, we limit the available actions to B<set role>, B<set access duration>, and B<set unreg date>.
-
-=cut
-
-sub available_actions {
-    return [
-            $Actions::SET_ROLE,
-            $Actions::SET_ACCESS_DURATION,
-            $Actions::SET_UNREG_DATE,
-           ];
-}
-
-=head2 available_attributes
-
-=cut
-
-sub available_attributes {
-    my $self = shift;
-    return([@{$self->SUPER::available_attributes}, {value => 'username', type => $Conditions::SUBSTRING }]);
-}
-
-=head2 match_in_subclass
-
-=cut
-
-sub match_in_subclass {
-    my ($self, $params, $rule, $own_conditions, $matching_conditions) = @_;
-    my $username =  $params->{'username'};
-    foreach my $condition (@{ $own_conditions }) {
-        if ($condition->{'attribute'} eq "username") {
-            if ( $condition->matches("username", $username) ) {
-                push(@{ $matching_conditions }, $condition);
-            }
-        }
-    }
-    return $username;
+sub lookup_from_provider_info {
+    my ( $self, $pid, $info ) = @_;
+    my $logger = get_logger();
+    my ($first_name, $last_name) = split(' ', $info->{name});
+    person_modify( $pid, firstname => $first_name, lastname => $last_name );
 }
 
 =head1 AUTHOR

--- a/lib/pf/Authentication/Source/GithubSource.pm
+++ b/lib/pf/Authentication/Source/GithubSource.pm
@@ -9,7 +9,6 @@ pf::Authentication::Source::GithubSource
 =cut
 
 use pf::person;
-use pf::log;
 use Moose;
 extends 'pf::Authentication::Source::OAuthSource';
 
@@ -35,7 +34,6 @@ Lookup the person information from the authentication hash received during the O
 
 sub lookup_from_provider_info {
     my ( $self, $pid, $info ) = @_;
-    my $logger = get_logger();
     my ($first_name, $last_name) = split(' ', $info->{name});
     person_modify( $pid, firstname => $first_name, lastname => $last_name );
 }

--- a/lib/pf/Authentication/Source/GoogleSource.pm
+++ b/lib/pf/Authentication/Source/GoogleSource.pm
@@ -8,10 +8,11 @@ pf::Authentication::Source::GoogleSource
 
 =cut
 
+use pf::person;
+use pf::log;
 use Moose;
-extends 'pf::Authentication::Source';
+extends 'pf::Authentication::Source::OAuthSource';
 
-has '+class' => (default => 'external');
 has '+type' => (default => 'Google');
 has '+unique' => (default => 1);
 has 'client_id' => (isa => 'Str', is => 'rw', required => 1, default => 'YOUR_API_ID.apps.googleusercontent.com');
@@ -26,46 +27,12 @@ has 'redirect_url' => (isa => 'Str', is => 'rw', required => 1, default => 'http
 has 'domains' => (isa => 'Str', is => 'rw', required => 1, default => '*.google.com,*.gstatic.com,googleapis.com,accounts.youtube.com');
 has 'create_local_account' => (isa => 'Str', is => 'rw', default => 'no');
 
-=head2 available_actions
+sub lookup_from_provider_info {
+    my ( $self, $pid, $info ) = @_;
+    my $logger = get_logger();
 
-For an oauth2 source, we limit the available actions to B<set role>, B<set access duration>, and B<set unreg date>.
-
-=cut
-
-sub available_actions {
-    return [
-            $Actions::SET_ROLE,
-            $Actions::SET_ACCESS_DURATION,
-            $Actions::SET_UNREG_DATE,
-           ];
+    person_modify( $pid, firstname => $info->{given_name}, lastname => $info->{family_name} );
 }
-
-=head2 available_attributes
-
-=cut
-
-sub available_attributes {
-    my $self = shift;
-    return([@{$self->SUPER::available_attributes}, {value => 'username', type => $Conditions::SUBSTRING }]);
-}
-
-=head2 match_in_subclass
-
-=cut
-
-sub match_in_subclass {
-    my ($self, $params, $rule, $own_conditions, $matching_conditions) = @_;
-    my $username =  $params->{'username'};
-    foreach my $condition (@{ $own_conditions }) {
-        if ($condition->{'attribute'} eq "username") {
-            if ( $condition->matches("username", $username) ) {
-                push(@{ $matching_conditions }, $condition);
-            }
-        }
-    }
-    return $username;
-}
-
 
 =head1 AUTHOR
 

--- a/lib/pf/Authentication/Source/GoogleSource.pm
+++ b/lib/pf/Authentication/Source/GoogleSource.pm
@@ -14,6 +14,7 @@ use Moose;
 extends 'pf::Authentication::Source::OAuthSource';
 
 has '+type' => (default => 'Google');
+has '+class' => (default => 'external');
 has '+unique' => (default => 1);
 has 'client_id' => (isa => 'Str', is => 'rw', required => 1, default => 'YOUR_API_ID.apps.googleusercontent.com');
 has 'client_secret' => (isa => 'Str', is => 'rw', required => 1);

--- a/lib/pf/Authentication/Source/GoogleSource.pm
+++ b/lib/pf/Authentication/Source/GoogleSource.pm
@@ -27,6 +27,12 @@ has 'redirect_url' => (isa => 'Str', is => 'rw', required => 1, default => 'http
 has 'domains' => (isa => 'Str', is => 'rw', required => 1, default => '*.google.com,*.gstatic.com,googleapis.com,accounts.youtube.com');
 has 'create_local_account' => (isa => 'Str', is => 'rw', default => 'no');
 
+=head2 lookup_from_provider_info
+
+Lookup the person information from the authentication hash received during the OAuth process
+
+=cut
+
 sub lookup_from_provider_info {
     my ( $self, $pid, $info ) = @_;
     my $logger = get_logger();

--- a/lib/pf/Authentication/Source/GoogleSource.pm
+++ b/lib/pf/Authentication/Source/GoogleSource.pm
@@ -9,7 +9,6 @@ pf::Authentication::Source::GoogleSource
 =cut
 
 use pf::person;
-use pf::log;
 use Moose;
 extends 'pf::Authentication::Source::OAuthSource';
 
@@ -36,8 +35,6 @@ Lookup the person information from the authentication hash received during the O
 
 sub lookup_from_provider_info {
     my ( $self, $pid, $info ) = @_;
-    my $logger = get_logger();
-
     person_modify( $pid, firstname => $info->{given_name}, lastname => $info->{family_name} );
 }
 

--- a/lib/pf/Authentication/Source/LinkedInSource.pm
+++ b/lib/pf/Authentication/Source/LinkedInSource.pm
@@ -14,6 +14,7 @@ use Moose;
 extends 'pf::Authentication::Source::OAuthSource';
 
 has '+type' => (default => 'LinkedIn');
+has '+class' => (default => 'external');
 has '+unique' => (default => 1);
 has 'client_id' => (isa => 'Str', is => 'rw', required => 1);
 has 'client_secret' => (isa => 'Str', is => 'rw', required => 1);

--- a/lib/pf/Authentication/Source/LinkedInSource.pm
+++ b/lib/pf/Authentication/Source/LinkedInSource.pm
@@ -11,9 +11,8 @@ pf::Authentication::Source::LinkedInSource
 use WWW::Curl::Easy;
 use JSON qw( decode_json );
 use Moose;
-extends 'pf::Authentication::Source';
+extends 'pf::Authentication::Source::OAuthSource';
 
-has '+class' => (default => 'external');
 has '+type' => (default => 'LinkedIn');
 has '+unique' => (default => 1);
 has 'client_id' => (isa => 'Str', is => 'rw', required => 1);
@@ -26,47 +25,6 @@ has 'protected_resource_url' => (isa => 'Str', is => 'rw', default => 'https://a
 has 'redirect_url' => (isa => 'Str', is => 'rw', required => 1, default => 'https://<hostname>/oauth2/linkedin');
 has 'domains' => (isa => 'Str', is => 'rw', required => 1, default => 'www.linkedin.com,api.linkedin.com,static.licdn.com');
 has 'create_local_account' => (isa => 'Str', is => 'rw', default => 'no');
-
-=head2 available_actions
-
-For an oauth2 source, we limit the available actions to B<set role>, B<set access duration>, and B<set unreg date>.
-
-=cut
-
-sub available_actions {
-    return [
-            $Actions::SET_ROLE,
-            $Actions::SET_ACCESS_DURATION,
-            $Actions::SET_UNREG_DATE,
-           ];
-}
-
-=head2 available_attributes
-
-=cut
-
-sub available_attributes {
-    my $self = shift;
-    return([@{$self->SUPER::available_attributes}, {value => 'username', type => $Conditions::SUBSTRING }]);
-}
-
-=head2 match_in_subclass
-
-=cut
-
-sub match_in_subclass {
-    my ($self, $params, $rule, $own_conditions, $matching_conditions) = @_;
-    my $username =  $params->{'username'};
-    foreach my $condition (@{ $own_conditions }) {
-        if ($condition->{'attribute'} eq "username") {
-            if ( $condition->matches("username", $username) ) {
-                push(@{ $matching_conditions }, $condition);
-            }
-        }
-    }
-    return $username;
-}
-
 
 =head1 AUTHOR
 

--- a/lib/pf/Authentication/Source/OAuthSource.pm
+++ b/lib/pf/Authentication/Source/OAuthSource.pm
@@ -1,0 +1,97 @@
+package pf::Authentication::Source::OAuthSource;
+
+=head1 NAME
+
+pf::Authentication::Source::FacebookSource
+
+=head1 DESCRIPTION
+
+=cut
+
+use pf::log;
+use Moose;
+extends 'pf::Authentication::Source';
+
+has '+class' => (default => 'external');
+has '+type' => (default => 'OAuth');
+has '+unique' => (default => 1);
+
+=head2 available_actions
+
+For an oauth2 source, we limit the available actions to B<set role>, B<set access duration>, and B<set unreg date>.
+
+=cut
+
+sub available_actions {
+    return [
+            $Actions::SET_ROLE,
+            $Actions::SET_ACCESS_DURATION,
+            $Actions::SET_UNREG_DATE,
+           ];
+}
+
+=head2 available_attributes
+
+=cut
+
+sub available_attributes {
+    my $self = shift;
+    return([@{$self->SUPER::available_attributes}, {value => 'username', type => $Conditions::SUBSTRING }]);
+}
+
+=head2 match_in_subclass
+
+=cut
+
+sub match_in_subclass {
+    my ($self, $params, $rule, $own_conditions, $matching_conditions) = @_;
+    my $username =  $params->{'username'};
+    foreach my $condition (@{ $own_conditions }) {
+        if ($condition->{'attribute'} eq "username") {
+            if ( $condition->matches("username", $username) ) {
+                push(@{ $matching_conditions }, $condition);
+            }
+        }
+    }
+    return $username;
+}
+
+sub lookup_from_provider_info {
+    my ( $self, $pid, $info ) = @_;
+    my $logger = get_logger;
+    $logger->warn("Provider information lookup is not implemented on this OAuth source.");
+}
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2013 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+__PACKAGE__->meta->make_immutable;
+1;
+
+# vim: set shiftwidth=4:
+# vim: set expandtab:
+# vim: set backspace=indent,eol,start:

--- a/lib/pf/Authentication/Source/OAuthSource.pm
+++ b/lib/pf/Authentication/Source/OAuthSource.pm
@@ -2,9 +2,11 @@ package pf::Authentication::Source::OAuthSource;
 
 =head1 NAME
 
-pf::Authentication::Source::FacebookSource
+pf::Authentication::Source::OAuthSource
 
 =head1 DESCRIPTION
+
+Abstract class for OAuth sources.
 
 =cut
 

--- a/lib/pf/Authentication/Source/OAuthSource.pm
+++ b/lib/pf/Authentication/Source/OAuthSource.pm
@@ -56,6 +56,12 @@ sub match_in_subclass {
     return $username;
 }
 
+=head2 lookup_from_provider_info
+
+Lookup the person information from the authentication hash received during the OAuth process
+
+=cut
+
 sub lookup_from_provider_info {
     my ( $self, $pid, $info ) = @_;
     my $logger = get_logger;
@@ -68,7 +74,7 @@ Inverse inc. <info@inverse.ca>
 
 =head1 COPYRIGHT
 
-Copyright (C) 2005-2013 Inverse inc.
+Copyright (C) 2005-2015 Inverse inc.
 
 =head1 LICENSE
 

--- a/lib/pf/Authentication/Source/OAuthSource.pm
+++ b/lib/pf/Authentication/Source/OAuthSource.pm
@@ -12,7 +12,7 @@ use pf::log;
 use Moose;
 extends 'pf::Authentication::Source';
 
-has '+class' => (default => 'external');
+has '+class' => (default => 'abstact');
 has '+type' => (default => 'OAuth');
 has '+unique' => (default => 1);
 

--- a/lib/pf/Authentication/Source/WindowsLiveSource.pm
+++ b/lib/pf/Authentication/Source/WindowsLiveSource.pm
@@ -9,7 +9,6 @@ pf::Authentication::Source::WindowsLiveSource
 =cut
 
 use pf::person;
-use pf::log;
 use Moose;
 extends 'pf::Authentication::Source::OAuthSource';
 
@@ -36,8 +35,6 @@ Lookup the person information from the authentication hash received during the O
 
 sub lookup_from_provider_info {
     my ( $self, $pid, $info ) = @_;
-    my $logger = get_logger();
-
     person_modify( $pid, firstname => $info->{first_name}, lastname => $info->{last_name} );
 }
 

--- a/lib/pf/Authentication/Source/WindowsLiveSource.pm
+++ b/lib/pf/Authentication/Source/WindowsLiveSource.pm
@@ -27,6 +27,12 @@ has 'redirect_url' => (isa => 'Str', is => 'rw', required => 1, default => 'http
 has 'domains' => (isa => 'Str', is => 'rw', required => 1, default => 'login.live.com,auth.gfx.ms,account.live.com');
 has 'create_local_account' => (isa => 'Str', is => 'rw', default => 'no');
 
+=head2 lookup_from_provider_info
+
+Lookup the person information from the authentication hash received during the OAuth process
+
+=cut
+
 sub lookup_from_provider_info {
     my ( $self, $pid, $info ) = @_;
     my $logger = get_logger();

--- a/lib/pf/Authentication/Source/WindowsLiveSource.pm
+++ b/lib/pf/Authentication/Source/WindowsLiveSource.pm
@@ -8,10 +8,11 @@ pf::Authentication::Source::WindowsLiveSource
 
 =cut
 
+use pf::person;
+use pf::log;
 use Moose;
-extends 'pf::Authentication::Source';
+extends 'pf::Authentication::Source::OAuthSource';
 
-has '+class' => (default => 'external');
 has '+type' => (default => 'WindowsLive');
 has '+unique' => (default => 1);
 has 'client_id' => (isa => 'Str', is => 'rw', required => 1);
@@ -26,44 +27,11 @@ has 'redirect_url' => (isa => 'Str', is => 'rw', required => 1, default => 'http
 has 'domains' => (isa => 'Str', is => 'rw', required => 1, default => 'login.live.com,auth.gfx.ms,account.live.com');
 has 'create_local_account' => (isa => 'Str', is => 'rw', default => 'no');
 
-=head2 available_actions
+sub lookup_from_provider_info {
+    my ( $self, $pid, $info ) = @_;
+    my $logger = get_logger();
 
-For an oauth2 source, we limit the available actions to B<set role>, B<set access duration>, and B<set unreg date>.
-
-=cut
-
-sub available_actions {
-    return [
-            $Actions::SET_ROLE,
-            $Actions::SET_ACCESS_DURATION,
-            $Actions::SET_UNREG_DATE,
-           ];
-}
-
-=head2 available_attributes
-
-=cut
-
-sub available_attributes {
-    my $self = shift;
-    return([@{$self->SUPER::available_attributes}, {value => 'username', type => $Conditions::SUBSTRING }]);
-}
-
-=head2 match_in_subclass
-
-=cut
-
-sub match_in_subclass {
-    my ($self, $params, $rule, $own_conditions, $matching_conditions) = @_;
-    my $username =  $params->{'username'};
-    foreach my $condition (@{ $own_conditions }) {
-        if ($condition->{'attribute'} eq "username") {
-            if ( $condition->matches("username", $username) ) {
-                push(@{ $matching_conditions }, $condition);
-            }
-        }
-    }
-    return $username;
+    person_modify( $pid, firstname => $info->{first_name}, lastname => $info->{last_name} );
 }
 
 =head1 AUTHOR

--- a/lib/pf/Authentication/Source/WindowsLiveSource.pm
+++ b/lib/pf/Authentication/Source/WindowsLiveSource.pm
@@ -14,6 +14,7 @@ use Moose;
 extends 'pf::Authentication::Source::OAuthSource';
 
 has '+type' => (default => 'WindowsLive');
+has '+class' => (default => 'external');
 has '+unique' => (default => 1);
 has 'client_id' => (isa => 'Str', is => 'rw', required => 1);
 has 'client_secret' => (isa => 'Str', is => 'rw', required => 1);


### PR DESCRIPTION
## Description

Rework the OAuth sources to add person lookup and to lighten copy paste in the sources.
## Impacts
- Makes the code cleaner and more maintainable
- Adds information to the OAuth registered users in the person table
- Fixes the Github Oauth source, which from what I saw never actually worked
## NEWS file entries

New Features
++++++++++++
- The information available from an OAuth source (first name, last name, ...) are now added to the person when registering

Bug Fixes
++++++++
- Fixed Github authentication source.
