### PR TITLE
/status page only on the production network

### DIFF
--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -944,8 +944,8 @@ EOT
 type=toggle
 options=enabled|disabled
 description=<<EOT
-If status only onproduction is enabled, the /status page will only be available on the
-production network. This is disabled by default
+When enabled the /status page will only be available on the
+production network. By default this is disabled
 EOT
 
 [advanced.reevaluate_access_reasons]

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -940,6 +940,14 @@ description=<<EOT
 Force the captive portal to use HTTPS when redirecting captured clients.
 EOT
 
+[captive_portal.status_only_on_production]
+type=toggle
+options=enabled|disabled
+description=<<EOT
+If status only onproduction is enabled, the /status page will only be available on the
+production network. This is disabled by default
+EOT
+
 [advanced.reevaluate_access_reasons]
 type=multi
 options=node_modify|manage_register|manage_deregister|manage_vclose|manage_vopen|violation_modify|violation_add|violation_delete|redir.cgi|pfcmd_vlan

--- a/conf/httpd.conf.d/httpd.portal
+++ b/conf/httpd.conf.d/httpd.portal
@@ -220,7 +220,23 @@ $ErrorLog = $install_dir.'/logs/portal_error_log';
 
 my $routedNets = join(" ", pf::util::get_routed_isolation_nets(), pf::util::get_routed_registration_nets() , pf::util::get_inline_nets());
 my $loadbalancersIp = join(" ", keys %{$pf::config::CAPTIVE_PORTAL{'loadbalancers_ip'}});
-my $allowed_from_all_urls = "|$WEB::URL_STATUS";
+my $status_only_on_production = pf::config::isenabled ($PfConfig->{captive_portal}{status_only_on_production});
+my $allowed_from_all_urls = '';
+my @status_options;
+if($status_only_on_production) {
+    @status_options = (
+        "/status" => {
+            "Order"             => "allow,deny",
+            "Deny"              => "from $routedNets $loadbalancersIp 127.0.0.1 ",
+            "Allow"             => "from all",
+            SetHandler          => 'modperl',
+            PerlResponseHandler => 'captiveportal',
+        },
+    );
+}
+else {
+    $allowed_from_all_urls = "|$WEB::URL_STATUS";
+}
 # signup and preregister if pre-registration is allowed
 my $guest_regist_allowed = scalar keys %pf::authentication::guest_self_registration;
 if ($guest_regist_allowed && isenabled($pf::config::Config{'guests_self_registration'}{'preregistration'})) {
@@ -233,6 +249,16 @@ my $sponsor_enabled = $pf::authentication::guest_self_registration{$SELFREG_MODE
 if ($guest_regist_allowed && ($email_enabled || $sponsor_enabled)) {
     # | is for a regexp "or" as this is pulled from a 'Location ~' statement
     $allowed_from_all_urls .= "|$WEB::URL_EMAIL_ACTIVATION";
+}
+my @allowed_from_all_options;
+if ($allowed_from_all_urls) {
+    @allowed_from_all_options = (
+        "~ \"/$allowed_from_all_urls\"" => {
+            "Allow"             => "from all",
+            SetHandler          => 'modperl',
+            PerlResponseHandler => 'captiveportal',
+        },
+    );
 }
 
 foreach my $interface (@internal_nets) {
@@ -287,11 +313,8 @@ foreach my $interface (@internal_nets) {
              "/content" => {
                 "Allow" => "from all",
              },
-             "~ \"/$allowed_from_all_urls\"" => {
-                "Allow" => "from all",
-                 SetHandler => 'modperl',
-                 PerlResponseHandler => 'captiveportal',
-             },
+             @status_options,
+             @allowed_from_all_options,
          },
     ));
     push (@{ $VirtualHost{$vhost.":443"} }, gen_conf(
@@ -334,11 +357,8 @@ foreach my $interface (@internal_nets) {
              "/content" => {
                 "Allow" => "from all",
              },
-             "~ \"/$allowed_from_all_urls\"" => {
-                "Allow" => "from all",
-                 SetHandler => 'modperl',
-                 PerlResponseHandler => 'captiveportal',
-             },
+             @status_options,
+             @allowed_from_all_options,
          },
          SSLEngine => 'on',
          SSLProxyEngine    => 'on',
@@ -398,11 +418,8 @@ if (defined($management_network->{'Tip'}) && $management_network->{'Tip'} ne '')
              "/content" => {
                 "Allow" => "from all",
              },
-             "~ \"/$allowed_from_all_urls\"" => {
-                "Allow" => "from all",
-                 SetHandler => 'modperl',
-                 PerlResponseHandler => 'captiveportal',
-             }, 
+             @status_options,
+             @allowed_from_all_options,
              "/apache_status/" => {
                  SetHandler => 'server-status',
              },
@@ -448,11 +465,8 @@ if (defined($management_network->{'Tip'}) && $management_network->{'Tip'} ne '')
              "/content" => {
                 "Allow" => "from all",
              },
-             "~ \"/$allowed_from_all_urls\"" => {
-                "Allow" => "from all",
-                 SetHandler => 'modperl',
-                 PerlResponseHandler => 'captiveportal',
-             },
+             @status_options,
+             @allowed_from_all_options,
          },
          SSLEngine => 'on',
          SSLProxyEngine    => 'on',

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -729,6 +729,12 @@ loadbalancers_ip=
 # If secure_redirect is enabled, the captive portal uses HTTPS when redirecting
 # captured clients. This is the default behavior.
 secure_redirect=enabled
+#
+# captive_portal.status_only_on_production
+#
+# If status_only_on_production is enabled, the /status page will only be available on the
+# production network. This is disabled by default
+status_only_on_production=disabled
 
 [advanced]
 #

--- a/html/pfappserver/lib/pfappserver/I18N/i_default.po
+++ b/html/pfappserver/lib/pfappserver/I18N/i_default.po
@@ -1813,6 +1813,12 @@ msgid ""
   "forward to the captive portal."
 msgstr ""
 
+# conf/documentation.conf (captive_portal.status_only_on_production)
+msgid ""
+  "If status only onproduction is enabled, the /status page will only be available on the"
+  "production network. This is disabled by default"
+msgstr ""
+
 # conf/documentation.conf (captive_portal.loadbalancers_ip)
 msgid ""
   "If the captive portal is put behind load-balancer(s) that act at Layer 7 "
@@ -5051,6 +5057,10 @@ msgstr "IP"
 msgid "captive_portal.secure_redirect"
 msgstr "Secure redirect"
 
+# conf/documentation.conf
+msgid "captive_portal.status_only_on_production"
+msgstr "Status URI only on production network"
+
 # html/pfappserver/root/admin/users.tt
 # pfappserver::Form::Config::ProfileCommon (mandatory fields)
 msgid "cell_phone"
@@ -5209,6 +5219,7 @@ msgstr ""
 
 # conf/documentation.conf (captive_portal.network_detection options)
 # conf/documentation.conf (captive_portal.secure_redirect options)
+# conf/documentation.conf (captive_portal.status_only_on_production options)
 # conf/documentation.conf (expire.httpd_admin options)
 # conf/documentation.conf (expire.httpd_portal options)
 # conf/documentation.conf (expire.ldap_auth options)
@@ -5282,6 +5293,7 @@ msgstr "Send email"
 
 # conf/documentation.conf (captive_portal.network_detection options)
 # conf/documentation.conf (captive_portal.secure_redirect options)
+# conf/documentation.conf (captive_portal.status_only_on_production options)
 # conf/documentation.conf (expire.httpd_admin options)
 # conf/documentation.conf (expire.httpd_portal options)
 # conf/documentation.conf (expire.ldap_auth options)

--- a/html/pfappserver/lib/pfappserver/I18N/i_default.po
+++ b/html/pfappserver/lib/pfappserver/I18N/i_default.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 4.6.0\n"
 "POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"PO-Revision-Date: 2015-02-02 14:12-0400\n"
+"PO-Revision-Date: 2015-02-02 14:16-0400\n"
 "Last-Translator: Inverse inc. <info@inverse.ca>\n"
 "Language-Team: English\n"
 "Language: en\n"
@@ -1811,12 +1811,6 @@ msgstr ""
 msgid ""
   "If enabled, we will intercept proxy request on the specified ports to "
   "forward to the captive portal."
-msgstr ""
-
-# conf/documentation.conf (captive_portal.status_only_on_production)
-msgid ""
-  "If status only onproduction is enabled, the /status page will only be available on the"
-  "production network. This is disabled by default"
 msgstr ""
 
 # conf/documentation.conf (captive_portal.loadbalancers_ip)
@@ -4676,6 +4670,12 @@ msgstr ""
 # html/pfappserver/root/graph/line.tt
 # html/pfappserver/root/graph/pie.tt
 msgid "What's going on?"
+msgstr ""
+
+# conf/documentation.conf (captive_portal.status_only_on_production)
+msgid ""
+  "When enabled the /status page will only be available on the"
+  "production network. By default this is disabled"
 msgstr ""
 
 # conf/documentation.conf (trapping.passthrough)

--- a/lib/pf/services/manager/httpd.pm
+++ b/lib/pf/services/manager/httpd.pm
@@ -90,7 +90,6 @@ sub generateConfig {
 
     # Guest related URLs allowed through Apache ACL's
     my $status_only_on_production = isenabled($Config{captive_portal}{status_only_on_production});
-    print "$status_only_on_production\n";
     my $allowed_from_all_urls = '';
     unless ($status_only_on_production) {
         $allowed_from_all_urls .= "|$WEB::URL_STATUS";


### PR DESCRIPTION
## Description

Only allow /status page to be accessed from the production network
## Impacts

Impacts the access to the status page from the different networks
## NEWS file entries

New Features
++++++++++++
Add the ability to restrict the /status page to the production network
## Delete branch after merge

NO
