### PR TITLE
Make OS selection explicit in the provisioners

### DIFF
--- a/html/pfappserver/lib/pfappserver/Form/Config/Provisioning/mobileconfig.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Provisioning/mobileconfig.pm
@@ -26,7 +26,7 @@ has_field 'ca_cert_path' =>
 
 has_block definition =>
   (
-   render_list => [ qw(id type description category ssid ca_cert_path) ],
+   render_list => [ qw(id type description oses category ssid ca_cert_path) ],
   );
 
 =head1 COPYRIGHT

--- a/lib/pf/provisioner.pm
+++ b/lib/pf/provisioner.pm
@@ -85,7 +85,7 @@ The oses to match against
 
 =cut
 
-#has oses => (is => 'rw', default => sub { [] } );
+has oses => (is => 'rw', default => sub { [] } );
 
 =head2 enforce
 

--- a/lib/pf/provisioner.pm
+++ b/lib/pf/provisioner.pm
@@ -85,7 +85,7 @@ The oses to match against
 
 =cut
 
-has oses => (is => 'rw', default => sub { [] } );
+#has oses => (is => 'rw', default => sub { [] } );
 
 =head2 enforce
 

--- a/lib/pf/provisioner/android.pm
+++ b/lib/pf/provisioner/android.pm
@@ -16,16 +16,6 @@ use warnings;
 use Moo;
 extends 'pf::provisioner::mobileconfig';
 
-=head1 Atrributes
-
-=head2 oses
-
-The set the default OS Andriod
-
-=cut
-
-has oses => (is => 'rw', default => sub { [qw(Android)] });
-
 =head1 AUTHOR
 
 Inverse inc. <info@inverse.ca>

--- a/lib/pf/provisioner/mobileconfig.pm
+++ b/lib/pf/provisioner/mobileconfig.pm
@@ -18,14 +18,6 @@ extends 'pf::provisioner';
 
 =head1 Atrributes
 
-=head2 oses
-
-The set the default OS to IOS
-
-=cut
-
-has oses => (is => 'rw', default => sub { ['Apple iPod, iPhone or iPad'] });
-
 =head2 ssid
 
 The ssid

--- a/lib/pf/provisioner/windows.pm
+++ b/lib/pf/provisioner/windows.pm
@@ -16,16 +16,6 @@ use warnings;
 use Moo;
 extends 'pf::provisioner::mobileconfig';
 
-=head1 Atrributes
-
-=head2 oses
-
-The set the default Windows OS
-
-=cut
-
-has oses => (is => 'rw', default => sub { [qw(Windows)] });
-
 =head1 AUTHOR
 
 Inverse inc. <info@inverse.ca>


### PR DESCRIPTION
## Please review + merge quickly as this should go in 4.6
## Description

Fixes the OS detection in the provisioners
## Impacts

Fixes the OS detection in the provisioners
## NEWS file entries

New Features
++++++++++++

Enhancements
++++++++++++

Bug Fixes
+++++++++
- Make provisioner OS selection always explicit to prevent bad overiding of the default OS for mobileconfig and Android
## Delete branch after merge

YES
