### PR TITLE
Reworked vlan.pm for autoregistration and added a new configuration parameter on the portal to recompute or no the role in case of 802.1x connection

### DIFF
--- a/html/pfappserver/lib/pfappserver/Form/Config/ProfileCommon.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/ProfileCommon.pm
@@ -35,7 +35,7 @@ The main definition block
 
 has_block 'definition' =>
   (
-    render_list => [qw(id description reuse_dot1x_credentials billing_engine)],
+    render_list => [qw(id description reuse_dot1x_credentials dot1x_recompute_role_from_portal billing_engine)],
   );
 
 =head2 captive_portal

--- a/html/pfappserver/lib/pfappserver/Form/Config/ProfileCommon.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/ProfileCommon.pm
@@ -232,6 +232,21 @@ has_field 'reuse_dot1x_credentials' =>
     unchecked_value => 'disabled',
   );
 
+=head2 dot1x_recompute_role_from_portal
+
+=cut
+
+has_field 'dot1x_recompute_role_from_portal' =>
+  (
+    type => 'Checkbox',
+    checkbox_value => 'enabled',
+    unchecked_value => 'disabled',
+    default => 'enabled',
+    tags => { after_element => \&help,
+             help => 'When enabled PacketFence will not use the role initialy computed on the portal but will use the dot1x username to recompute the role.' },
+  );
+
+
 =head2 nbregpages
 
 =cut

--- a/html/pfappserver/lib/pfappserver/Form/Config/ProfileCommon.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/ProfileCommon.pm
@@ -243,7 +243,7 @@ has_field 'dot1x_recompute_role_from_portal' =>
     unchecked_value => 'disabled',
     default => 'enabled',
     tags => { after_element => \&help,
-             help => 'When enabled PacketFence will not use the role initialy computed on the portal but will use the dot1x username to recompute the role.' },
+             help => 'When enabled, PacketFence will not use the role initialy computed on the portal but will use the dot1x username to recompute the role.' },
   );
 
 

--- a/lib/pf/Portal/Profile.pm
+++ b/lib/pf/Portal/Profile.pm
@@ -404,6 +404,17 @@ sub findProvisioner {
     return first { $_->match($os,$node_attributes) } $self->provisionerObjects;
 }
 
+=item dot1xRecomputeRoleFromPortal
+
+Reuse dot1x credentials when authenticating
+
+=cut
+
+sub dot1xRecomputeRoleFromPortal {
+    my ($self) = @_;
+    return $self->{'_dot1x_recompute_role_from_portal'};
+}
+
 =back
 
 =head1 AUTHOR

--- a/lib/pf/node.pm
+++ b/lib/pf/node.pm
@@ -833,7 +833,7 @@ sub node_register {
     }
     pf::person::person_modify($pid,
                     'source'  => $info{'source'},
-                    'portal'     => $info{'portal'},
+                    'portal'  => $info{'portal'},
     );
     delete $info{'source'};
     delete $info{'portal'};

--- a/lib/pf/pfcmd/checkup.pm
+++ b/lib/pf/pfcmd/checkup.pm
@@ -972,7 +972,7 @@ sub portal_profiles {
         billing_engine|description|sources|redirecturl|always_use_redirecturl|
         mandatory_fields|nbregpages|allowed_devices|allow_android_devices|
         reuse_dot1x_credentials|provisioners|filter_match_style|sms_pin_retry_limit|
-        sms_request_limit|login_attempt_limit|block_interval)/x;
+        sms_request_limit|login_attempt_limit|block_interval|dot1x_recompute_role_from_portal)/x;
 
     foreach my $portal_profile ( $cached_profiles_config->Sections) {
         my $data = $Profiles_Config{$portal_profile};

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -151,10 +151,11 @@ sub authorize {
     my $isPhone = $switch->isPhoneAtIfIndex($mac, $port);
 
     my $vlan_obj = new pf::vlan::custom();
+    my $autoreg = 0;
     # should we auto-register? let's ask the VLAN object
     if ($vlan_obj->shouldAutoRegister($mac, $switch->isRegistrationMode(), 0, $isPhone,
         $connection_type, $user_name, $ssid, $eap_type, $switch, $port, $radius_request)) {
-
+        $autoreg = 1;
         # automatic registration
         my %autoreg_node_defaults = $vlan_obj->getNodeInfoForAutoReg($switch, $port,
             $mac, undef, $switch->isRegistrationMode(), $FALSE, $isPhone, $connection_type, $user_name, $ssid, $eap_type, $radius_request, $realm, $stripped_user_name);
@@ -185,7 +186,7 @@ sub authorize {
     $this->_handleAccessFloatingDevices($switch, $mac, $port);
 
     # Fetch VLAN depending on node status
-    my ($vlan, $wasInline, $user_role) = $vlan_obj->fetchVlanForNode($mac, $switch, $port, $connection_type, $user_name, $ssid, $radius_request, $realm, $stripped_user_name);
+    my ($vlan, $wasInline, $user_role) = $vlan_obj->fetchVlanForNode($mac, $switch, $port, $connection_type, $user_name, $ssid, $radius_request, $realm, $stripped_user_name, $autoreg);
 
     # should this node be kicked out?
     if (defined($vlan) && $vlan == -1) {

--- a/lib/pf/vlan.pm
+++ b/lib/pf/vlan.pm
@@ -28,8 +28,6 @@ use pf::authentication;
 use pf::Authentication::constants;
 use pf::Portal::ProfileFactory;
 use pf::vlan::filter;
-use pf::person;
-use pf::lookup::person;
 
 our $VERSION = 1.04;
 
@@ -519,18 +517,7 @@ sub getNodeInfoForAutoReg {
             if (defined $role) {
                 %node_info = (%node_info, (category => $role));
             }
-            # create a person entry for pid if it doesn't exist
-            if ( !pf::person::person_exist($user_name) ) {
-                $logger->info("creating person $user_name because it doesn't exist");
-                pf::person::person_add($user_name);
-                pf::lookup::person::lookup_person($user_name,$source);
-            } else {
-                $logger->debug("person $user_name already exists");
-            }
-            pf::person::person_modify($user_name,
-                'source'  => $source,
-                'portal'  => $profile->getName,
-            );
+            %node_info = (%node_info, (source  => $source, portal => $profile->getName));
         }
         $node_info{'pid'} = $user_name;
     }

--- a/lib/pf/vlan.pm
+++ b/lib/pf/vlan.pm
@@ -402,7 +402,7 @@ sub getNormalVlan {
     # FIRST HIT MATCH
     elsif ( defined $user_name && $connection_type && ($connection_type & $EAP) == $EAP ) {
         # Attributes has been computed in getNodeInfoForAutoReg
-        if (isenabled($node_info->{'autoreg'})) {
+        if (isenabled($node_info->{'autoreg'}) || isenabled($profile->dot1xRecomputeRoleFromPortal)) {
             $logger->info("[$mac] Connection type is EAP. Getting role from node_info" );
             $role = $node_info->{'category'};
         } else {

--- a/lib/pf/vlan.pm
+++ b/lib/pf/vlan.pm
@@ -299,9 +299,9 @@ sub getRegistrationVlan {
     if (!defined($node_info)) {
         # Vlan Filter
         my ($result,$role) = $filter->test('RegistrationVlan',$switch, $ifIndex, $mac, undef, $connection_type, $user_name, $ssid, $radius_request);
-        if $result {
+        if ($result) {
             $logger->info("[$mac] doesn't have a node entry; belongs into $role VLAN");
-            return ($result,$role) if $result;
+            return ($result,$role);
         }
         $logger->info("[$mac] doesn't have a node entry; belongs into registration VLAN");
         my $vlan = $switch->getVlanByName('registration');
@@ -312,9 +312,9 @@ sub getRegistrationVlan {
     if ($n_status eq $pf::node::STATUS_UNREGISTERED || $n_status eq $pf::node::STATUS_PENDING) {
         # Vlan Filter
         my ($result,$role) = $filter->test('RegistrationVlan',$switch, $ifIndex, $mac, $node_info, $connection_type, $user_name, $ssid, $radius_request);
-        if $result {
+        if ($result) {
             $logger->info("[$mac] is of status $n_status; belongs into $role VLAN");
-            return ($result,$role) if $result;
+            return ($result,$role);
         }
         $logger->info("[$mac] is of status $n_status; belongs into registration VLAN");
         my $vlan = $switch->getVlanByName('registration');

--- a/lib/pf/vlan.pm
+++ b/lib/pf/vlan.pm
@@ -621,11 +621,11 @@ sub shouldAutoRegister {
     my $node_info = node_attributes($mac);
     my $filter = new pf::vlan::filter;
     my ($result,$role) = $filter->test('AutoRegister',$switch, $port, $mac, $node_info, $conn_type, $user_name, $ssid, $radius_request);
-    if ($role) {
-        if ($switch->getVlanByName($role) eq -1) {
+    if ($result) {
+        if ($switch->getVlanByName($role) eq '-1') {
             return 0;
         } else {
-            return $switch->getVlanByName($role);
+            return $result;
         }
     }
 

--- a/lib/pf/vlan.pm
+++ b/lib/pf/vlan.pm
@@ -402,7 +402,7 @@ sub getNormalVlan {
     # FIRST HIT MATCH
     elsif ( defined $user_name && $connection_type && ($connection_type & $EAP) == $EAP ) {
         # Attributes has been computed in getNodeInfoForAutoReg
-        if ((isenabled($node_info->{'autoreg'}) && $autoreg) || !(isenabled($profile->dot1xRecomputeRoleFromPortal))) {
+        if ((isenabled($node_info->{'autoreg'}) && $autoreg) || isdisabled($profile->dot1xRecomputeRoleFromPortal)) {
             $logger->info("[$mac] Connection type is EAP. Getting role from node_info" );
             $role = $node_info->{'category'};
         } else {
@@ -622,7 +622,7 @@ sub shouldAutoRegister {
     my $filter = new pf::vlan::filter;
     my ($result,$role) = $filter->test('AutoRegister',$switch, $port, $mac, $node_info, $conn_type, $user_name, $ssid, $radius_request);
     if ($result) {
-        if ($switch->getVlanByName($role) eq '-1') {
+        if ($switch->getVlanByName($role) == -1) {
             return 0;
         } else {
             return $result;

--- a/lib/pf/vlan.pm
+++ b/lib/pf/vlan.pm
@@ -556,9 +556,9 @@ sub getNodeInfoForAutoReg {
         }
         else {
             $value = &pf::authentication::match([@sources], $params, $Actions::SET_UNREG_DATE);
+            $value = pf::config::dynamic_unreg_date($value);
         }
         if (defined $value) {
-            $value = pf::config::dynamic_unreg_date($value);
             $node_info{'unregdate'} = $value;
             if (defined $role) {
                 %node_info = (%node_info, (category => $role));

--- a/lib/pf/vlan/filter.pm
+++ b/lib/pf/vlan/filter.pm
@@ -65,6 +65,7 @@ sub test {
                     if ( defined($ConfigVlanFilters{$rule}->{'role'}) && $ConfigVlanFilters{$rule}->{'role'} ne '' ) {
                         my $role = $ConfigVlanFilters{$rule}->{'role'};
                         my $vlan = $switch->getVlanByName($role);
+                        return (1,$role) if ($scope eq 'AutoRegister');
                         return ($vlan, $role);
                     } else {
                         return (0,0);


### PR DESCRIPTION
## Description

Moved code from getNormalVlan to getNodeInfoForAutoreg.
If we configure autoregistration then the role and access duration will be compute in getNodeInfoForAutoreg instead of in getNormalVlan.  With that we will be able to create vlan filter rules in getNormalVlan based on the role of the device. 
Added a new parameter in the portal profile to compute or not the role based on the 802.1x userid (registration has been made on the portal)
Added a test to be sure that even if the node has been autoregistered on a 802.1x connection it pass in autoreg section (if no then we compute the role on the portal profile) 
## Impacts

Simplify getNormalVlan 
## NEWS file entries

Refactored autoregistration workflow in getNormalVlan and getNodeInfoForAutoreg
## Delete branch after merge

Yes
