### PR TITLE
Moved provisioner_compliance_poll to sbin/pfmon to avoid circular dependency between pf::factory::provisioner and pf::provisioner

### DIFF
--- a/lib/pf/provisioner.pm
+++ b/lib/pf/provisioner.pm
@@ -174,22 +174,6 @@ sub match {
     return $self->matchOS($os) && $self->matchCategory($node_attributes);
 }
 
-=head2 provisioner_compliance_poll
-
-=cut
-
-sub provisioner_compliance_poll {
-    use Data::Dumper;
-    use pf::ConfigStore::Provisioning;
-    use pf::factory::provisioner;
-    foreach my $id (@{pf::ConfigStore::Provisioning->new->readAllIds}) {
-        my $provisioner = pf::factory::provisioner->new($id);
-        if($provisioner->supportsPolling){
-            $provisioner->pollAndEnforce($Config{maintenance}{provisioning_compliance_poll_interval});
-        }
-    }
-} 
-
 =head1 AUTHOR
 
 Inverse inc. <info@inverse.ca>

--- a/sbin/pfmon
+++ b/sbin/pfmon
@@ -46,7 +46,8 @@ use pf::traplog;
 use pf::util;
 use pf::services::util;
 use pf::violation qw(violation_maintenance);
-use pf::provisioner;
+use pf::ConfigStore::Provisioning;
+use pf::factory::provisioner;
 
 # initialization
 # --------------
@@ -210,7 +211,7 @@ sub registertasks  {
     );
     register_task(
         'provisioner polling enforcement','provisioning_compliance_poll_interval',sub {
-            pf::provisioner::provisioner_compliance_poll();
+            provisioner_compliance_poll();
         }
     );
     register_task(
@@ -275,6 +276,21 @@ sub purge_cache {
             eval {
                 $cache->remove($key);
             };
+        }
+    }
+}
+
+=head2 provisioner_compliance_poll
+
+Polls each provisioner to enforce compliance
+
+=cut
+
+sub provisioner_compliance_poll {
+    foreach my $id (@{pf::ConfigStore::Provisioning->new->readAllIds}) {
+        my $provisioner = pf::factory::provisioner->new($id);
+        if($provisioner->supportsPolling){
+            $provisioner->pollAndEnforce($Config{maintenance}{provisioning_compliance_poll_interval});
         }
     }
 }


### PR DESCRIPTION
## Description

There is a circular dependency between pf-provisioner and the pf:: factory::provisioner.
By having it there it make it difficult to create unittest for individual provisioner classes.

pf:: factory::provisioner
- loads all pf::provisioner

pf::provisioner
- loads pf:: factory::provisioner
## Impacts

pfmon provisioner polling
## NEWS file entries

Bug Fixes
+++++++++
Removed circular dependency in pf::provisioner
## Delete branch after merge

NO
