### PR TITLE
Fix infinite dynamic unreg date breaking the registration process

### DIFF
--- a/lib/pf/config.pm
+++ b/lib/pf/config.pm
@@ -901,6 +901,11 @@ sub dynamic_unreg_date {
     my $current_date = time;
     my $unreg_date;
 
+    if($trigger =~ /0000-00-00/){
+      $logger->debug("Stopping dynamic unreg date handling because unreg date is set to infinite : $trigger");
+      return $trigger;
+    }
+
     my ($year,$month,$day) = $trigger =~ /(\d{1,4})?-?(\d{2})-(\d{2})/;
     my $current_year = POSIX::strftime("%Y",localtime($current_date));
 


### PR DESCRIPTION
## Description

Fixes the dynamic unregdate handling of '0000-00-00'
## Impacts

Unbreaks stuff
## NEWS file entries

New Features
++++++++++++

Enhancements
++++++++++++

Bug Fixes
+++++++++
- Fix dynamic unregdate breaking when handling the infinite unregdate '0000-00-00'
