### PR TITLE
remove delete button from node view

### DIFF
--- a/html/pfappserver/root/node/view.tt
+++ b/html/pfappserver/root/node/view.tt
@@ -183,7 +183,6 @@
         </div><!--modal-body-->
 
         <div class="modal-footer">
-          [% IF can_access("NODES_DELETE") %]<a href="[% c.uri_for(c.controller('Node').action_for('delete'), [ node.mac ]) %]" id="deleteNode" class="btn btn-danger pull-left"><i class="icon-trash icon-white"></i> [% l('Delete') %]</a>[% END %]
           [% IF can_access("NODES_UPDATE") %]<a href="[% c.uri_for(c.controller('Node').action_for('reevaluate_access'), [ node.mac ]) %]" id="reevaluateNode" class="btn btn-warning pull-left"> [% l('Reevaluate access') %]</a>[% END %]
           <a href="#" class="btn" data-dismiss="modal">[% l('Close') %]</a>
           [% IF can_access("NODES_UPDATE") %]<button type="submit" class="btn btn-primary" data-loading-text="[% l('Saving') %]">[% l('Save') %]</button>[% END %]


### PR DESCRIPTION
## Description

Removes the delete button from node view since it can't be pressed unless there is no locationlog entry opened for that node which practically never happens. Nodes should be delete/expired using pfmon.
## Impacts

Removes the option of deleting a node (how much was it used ?)
## NEWS file entries

New Features
++++++++++++

Enhancements
++++++++++++

Bug Fixes
+++++++++
- Removed the node delete button.
