### PR TITLE
Generating the same password multiple times

### DIFF
--- a/conf/httpd.conf.d/httpd.admin
+++ b/conf/httpd.conf.d/httpd.admin
@@ -60,7 +60,9 @@ AcceptMutex posixsem
 
 PerlSwitches -I/usr/local/pf/lib
 PerlSwitches -I/usr/local/pf/html/pfappserver/lib
-PerlLoadModule pfappserver;
+PerlLoadModule pfappserver
+PerlLoadModule pf::WebAPI::InitHandler
+PerlChildInitHandler  pf::WebAPI::InitHandler::child_init
 
 <Perl>
 BEGIN {

--- a/lib/pf/WebAPI/InitHandler.pm
+++ b/lib/pf/WebAPI/InitHandler.pm
@@ -25,6 +25,19 @@ sub handler {
     return Apache2::Const::OK;
 }
 
+=head2 child_init
+
+Initialize the child process
+
+=cut
+
+sub child_init {
+    my ($child_pool, $s) = @_;
+    #Avoid child processes having the same random seed
+    srand();
+    return Apache2::Const::OK;
+}
+
 =head1 AUTHOR
 
 Inverse inc. <info@inverse.ca>


### PR DESCRIPTION
## Description

When generating a password each apache process has the same random seed
Which would cause every apache process to create the exact same password
## Impacts

Creating users in the httpd.admin
## NEWS file entries

Bug Fixes
+++++++++
Fixed issue where the same password can be generated multiple times
## Delete branch after merge

NO
