### PR TITLE
Time based profile filters

### DIFF
--- a/html/pfappserver/lib/pfappserver/I18N/i_default.po
+++ b/html/pfappserver/lib/pfappserver/I18N/i_default.po
@@ -6040,6 +6040,10 @@ msgid "pf::profile::filter::connection_type"
 msgstr "Connection Type"
 
 # pf::filter (Portal Profile Filters)
+msgid "pf::profile::filter::day_of_week"
+msgstr "Day Of Week"
+
+# pf::filter (Portal Profile Filters)
 msgid "pf::profile::filter::network"
 msgstr "Network"
 

--- a/html/pfappserver/lib/pfappserver/I18N/i_default.po
+++ b/html/pfappserver/lib/pfappserver/I18N/i_default.po
@@ -6041,7 +6041,7 @@ msgstr "Connection Type"
 
 # pf::filter (Portal Profile Filters)
 msgid "pf::profile::filter::day_of_week"
-msgstr "Day Of Week"
+msgstr "Day of week"
 
 # pf::filter (Portal Profile Filters)
 msgid "pf::profile::filter::network"

--- a/html/pfappserver/lib/pfappserver/I18N/i_default.po
+++ b/html/pfappserver/lib/pfappserver/I18N/i_default.po
@@ -6068,6 +6068,10 @@ msgid "pf::profile::filter::switch_port"
 msgstr "Switch Port"
 
 # pf::filter (Portal Profile Filters)
+msgid "pf::profile::filter::time_of_day"
+msgstr "Time of day"
+
+# pf::filter (Portal Profile Filters)
 msgid "pf::profile::filter::uri"
 msgstr "URI"
 

--- a/lib/pf/profile/filter.pm
+++ b/lib/pf/profile/filter.pm
@@ -43,7 +43,7 @@ $filter->match({ k1 => 'v1', k2 => 'v2' });
     =head2 match
 
         Matches the time of day against the value
-        The value is expected to be in the following format 
+        The value is expected to be in the following format
         Start-End
         From midnight to 6am
         00:00-06:00
@@ -64,7 +64,7 @@ $filter->match({ k1 => 'v1', k2 => 'v2' });
     You can also see pf::profile::filter::network as another example
 
 =head2 Configuring in admin gui
-    
+
     The new type is automatically picked up by the admin gui as long is it under the namespace pf::profile::filter.
     If any special formating is need the gui refer to the form field pfappserver::Form::Field::ProfileFilter
 

--- a/lib/pf/profile/filter/day_of_week.pm
+++ b/lib/pf/profile/filter/day_of_week.pm
@@ -1,0 +1,101 @@
+package pf::profile::filter::day_of_week;
+=head1 NAME
+
+pf::profile::filter::day_of_week add documentation
+
+=cut
+
+=head1 DESCRIPTION
+
+pf::profile::filter::day_of_week
+
+=cut
+
+use strict;
+use warnings;
+use Date::Format;
+use Moo;
+extends 'pf::profile::filter';
+
+=head1 ATTRIBUTES
+
+=head2 allowed_days
+
+The allowed days of the week
+
+=cut
+
+has allowed_days => ( is => 'rw' );
+
+=head2 value
+
+add a trigger to the value to create update allowed_days
+
+=cut
+
+has '+value' => ( trigger => 1 );
+
+=head1 METHODS
+
+=head2 match
+
+    Return true if the current day of week matches the values provided
+    The value is expected to be in the following format
+    1,3,5
+    Where the number is the day of the week
+    1 - Monday
+    2 - Tuesday
+    3 - Wednesday
+    4 - Thursday
+    5 - Friday
+    6 - Saturday
+    7 - Sunday
+
+=cut
+
+sub match {
+    my ($self) = @_;
+    my $current = time2str("%W",time);
+    return exists ${$self->allowed_days}{$current};
+}
+
+=head2 _trigger_value
+
+Set allowed_days from the value
+
+=cut
+
+sub _trigger_value {
+    my ($self) = @_;
+    my %allowed_days = map { $_ => undef} split /\s*,\s*/ ,$self->value;
+    $self->allowed_days(\%allowed_days);
+}
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2014 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and::or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;

--- a/lib/pf/profile/filter/day_of_week.pm
+++ b/lib/pf/profile/filter/day_of_week.pm
@@ -1,7 +1,7 @@
 package pf::profile::filter::day_of_week;
 =head1 NAME
 
-pf::profile::filter::day_of_week add documentation
+pf::profile::filter::day_of_week - Day of week filter for profiles
 
 =cut
 
@@ -29,7 +29,7 @@ has allowed_days => ( is => 'rw' );
 
 =head2 value
 
-add a trigger to the value to create update allowed_days
+add a trigger to the value to create/update allowed_days
 
 =cut
 
@@ -56,7 +56,7 @@ has '+value' => ( trigger => 1 );
 sub match {
     my ($self) = @_;
     my $current = time2str("%W",time);
-    return exists ${$self->allowed_days}{$current};
+    return ${$self->allowed_days}{$current};
 }
 
 =head2 _trigger_value
@@ -67,7 +67,7 @@ Set allowed_days from the value
 
 sub _trigger_value {
     my ($self) = @_;
-    my %allowed_days = map { $_ => undef} split /\s*,\s*/ ,$self->value;
+    my %allowed_days = map { $_ => 1 } split /\s*,\s*/ ,$self->value;
     $self->allowed_days(\%allowed_days);
 }
 
@@ -77,7 +77,7 @@ Inverse inc. <info@inverse.ca>
 
 =head1 COPYRIGHT
 
-Copyright (C) 2005-2014 Inverse inc.
+Copyright (C) 2005-2015 Inverse inc.
 
 =head1 LICENSE
 

--- a/lib/pf/profile/filter/day_of_week.pm
+++ b/lib/pf/profile/filter/day_of_week.pm
@@ -33,7 +33,7 @@ add a trigger to the value to create/update allowed_days
 
 =cut
 
-has '+value' => ( trigger => 1 );
+has '+value' => ( trigger => 1, isa => sub { $_[0] =~ /^[1-7](\s*,\s*[1-7])*$/ || die "value is not a comma separated list of number 1-7" } );
 
 =head1 METHODS
 

--- a/lib/pf/profile/filter/time_of_day.pm
+++ b/lib/pf/profile/filter/time_of_day.pm
@@ -1,0 +1,69 @@
+package pf::profile::filter::time_of_day;
+=head1 NAME
+
+pf::profile::filter::time_of_day add documentation
+
+=cut
+
+=head1 DESCRIPTION
+
+pf::profile::filter::time_of_day
+
+=cut
+
+use strict;
+use warnings;
+use Date::Format;
+use Moo;
+extends 'pf::profile::filter';
+
+
+=head1 METHODS
+
+=head2 match
+
+    Matches the time of day against the value
+    The value is expected to be in the following format 
+    Start-End
+    From midnight to 6am
+    00:00-06:00
+    All time must be in the format HH::MM
+
+=cut
+
+sub match {
+    my ($self) = @_;
+    my ($start,$end) = split(/-/,$self->value);
+    my $current = time2str("%H:%M",time);
+    return ($start le $current) && ($current le $end);
+}
+ 
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2014 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and::or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;
+

--- a/lib/pf/profile/filter/time_of_day.pm
+++ b/lib/pf/profile/filter/time_of_day.pm
@@ -17,6 +17,23 @@ use Date::Format;
 use Moo;
 extends 'pf::profile::filter';
 
+=head1 ATTRIBUTES
+
+=head2 start_time/end_time
+
+The start and end time
+
+=cut
+
+has [qw(start_time end_time)] => ( is => 'rw' );
+
+=head2 value
+
+add a trigger to the value
+
+=cut
+
+has '+value' => ( trigger => 1 );
 
 =head1 METHODS
 
@@ -33,11 +50,23 @@ extends 'pf::profile::filter';
 
 sub match {
     my ($self) = @_;
-    my ($start,$end) = split(/-/,$self->value);
     my $current = time2str("%H:%M",time);
-    return ($start le $current) && ($current le $end);
+    return ($self->start_time le $current) && ($current le $self->end_time);
 }
  
+=head2 _trigger_value
+
+Set start_time and end_time from the value
+
+=cut
+
+sub _trigger_value {
+    my ($self) = @_;
+    my ($start,$end) = split(/-/,$self->value);
+    $self->start_time($start);
+    $self->end_time($end);
+}
+
 =head1 AUTHOR
 
 Inverse inc. <info@inverse.ca>

--- a/lib/pf/profile/filter/time_of_day.pm
+++ b/lib/pf/profile/filter/time_of_day.pm
@@ -1,7 +1,7 @@
 package pf::profile::filter::time_of_day;
 =head1 NAME
 
-pf::profile::filter::time_of_day add documentation
+pf::profile::filter::time_of_day - Time of day filter for profiles
 
 =cut
 
@@ -29,7 +29,7 @@ has [qw(start_time end_time)] => ( is => 'rw' );
 
 =head2 value
 
-add a trigger to the value
+add a trigger to the value to create/update start_time and end_time
 
 =cut
 
@@ -40,7 +40,7 @@ has '+value' => ( trigger => 1 );
 =head2 match
 
     Matches the time of day against the value
-    The value is expected to be in the following format 
+    The value is expected to be in the following format
     Start-End
     From midnight to 6am
     00:00-06:00
@@ -53,7 +53,7 @@ sub match {
     my $current = time2str("%H:%M",time);
     return ($self->start_time le $current) && ($current le $self->end_time);
 }
- 
+
 =head2 _trigger_value
 
 Set start_time and end_time from the value
@@ -73,7 +73,7 @@ Inverse inc. <info@inverse.ca>
 
 =head1 COPYRIGHT
 
-Copyright (C) 2005-2014 Inverse inc.
+Copyright (C) 2005-2015 Inverse inc.
 
 =head1 LICENSE
 

--- a/lib/pf/profile/filter/time_of_day.pm
+++ b/lib/pf/profile/filter/time_of_day.pm
@@ -33,7 +33,7 @@ add a trigger to the value to create/update start_time and end_time
 
 =cut
 
-has '+value' => ( trigger => 1 );
+has '+value' => ( trigger => 1, isa => sub { $_[0] =~ /^\d{2}:\d{2}-\d{2}:\d{2}$/ || die "value is not in the form HH:MM-HH:MM" } );
 
 =head1 METHODS
 


### PR DESCRIPTION
## Description

Allow a profile to be filtered by time of day or days of the week
## Impacts

The captive portal profile filtering
## NEWS file entries

New Features
++++++++++++
- Added the ability to filter a profile by the time of the day
- Added the ability to filter a profile by the days of the week
## Delete branch after merge

NO
