### PR TITLE
Roaming support based on accounting data for Aerohive

### DIFF
--- a/lib/pf/Switch.pm
+++ b/lib/pf/Switch.pm
@@ -187,6 +187,17 @@ sub supportsAccessListBasedEnforcement {
     return $FALSE;
 }
 
+=item supportsRoamingAccounting
+
+=cut
+
+sub supportsRoamingAccounting {
+    my ( $this ) = @_;
+    my $logger = Log::Log4perl::get_logger( ref($this) );
+    $logger->info("Update of the locationlog based on accounting data is not supported on network device type " . ref($this) . ". ");
+    return $FALSE;
+}
+
 =item supportsSaveConfig
 
 =cut

--- a/lib/pf/Switch/AeroHIVE.pm
+++ b/lib/pf/Switch/AeroHIVE.pm
@@ -102,31 +102,8 @@ sub parseTrap {
     my $trapHashRef;
     my $logger = Log::Log4perl::get_logger( ref($this) );
 
-    if ($trapString =~ /\.1\.3\.6\.1\.6\.3\.1\.1\.4\.1\.0 = OID: $AEROHIVE::ahConnectionChangeEvent/ ) {
-        $trapHashRef->{'trapType'} = 'roaming';
-        my @values = split(/\|/, $trapString);
-        my %valeurs;
-        foreach my $val (@values) {
-            my ($oid, $temp) =  split(/ = /, $val);
-            my ($tempo, $value) = split(/: /, $temp);
-            $value =~ s/^\s+|\s+$//g if (defined($value));
-            $valeurs{$oid} = $value;
-        }
-        $trapHashRef->{'trapSSID'} = $valeurs{$AEROHIVE::ahSSID};
-        $trapHashRef->{'trapSSID'} =~ s/"//g;
-        $trapHashRef->{'trapIfIndex'} = $valeurs{$AEROHIVE::ahIfIndex};
-        $trapHashRef->{'trapVlan'} = $valeurs{$AEROHIVE::ahClientVLAN};
-        $trapHashRef->{'trapMac'} = $valeurs{$AEROHIVE::ahRemoteId};
-        $trapHashRef->{'trapClientUserName'} = $valeurs{$AEROHIVE::ahClientUserName};
-        $trapHashRef->{'trapConnectionType'} = $WIRELESS_MAC_AUTH;
-        if ($valeurs{$AEROHIVE::ahClientAuthMethod} eq '6' || $valeurs{$AEROHIVE::ahClientAuthMethod} eq '7') {
-            $trapHashRef->{'trapConnectionType'} = $WIRELESS_802_1X;
-        }
-    }
-    else {
-        $logger->debug("trap currently not handled");
-        $trapHashRef->{'trapType'} = 'unknown';
-    }
+    $logger->debug("trap currently not handled");
+    $trapHashRef->{'trapType'} = 'unknown';
     return $trapHashRef;
 }
 

--- a/lib/pf/Switch/AeroHIVE.pm
+++ b/lib/pf/Switch/AeroHIVE.pm
@@ -94,6 +94,7 @@ sub getVersion {
 =item parseTrap
 
 This is called when we receive an SNMP-Trap for this device
+Old roaming snmp support has been commented if you need to activate it then uncomment it
 
 =cut
 
@@ -102,6 +103,32 @@ sub parseTrap {
     my $trapHashRef;
     my $logger = Log::Log4perl::get_logger( ref($this) );
 
+#    if ($trapString =~ /\.1\.3\.6\.1\.6\.3\.1\.1\.4\.1\.0 = OID: $AEROHIVE::ahConnectionChangeEvent/ ) {
+#        $trapHashRef->{'trapType'} = 'roaming';
+#        my @values = split(/\|/, $trapString);
+#        my %valeurs;
+#        foreach my $val (@values) {
+#            my ($oid, $temp) =  split(/ = /, $val);
+#            my ($tempo, $value) = split(/: /, $temp);
+#            $value =~ s/^\s+|\s+$//g if (defined($value));
+#            $valeurs{$oid} = $value;
+#        }
+#        $trapHashRef->{'trapSSID'} = $valeurs{$AEROHIVE::ahSSID};
+#        $trapHashRef->{'trapSSID'} =~ s/"//g;
+#        $trapHashRef->{'trapIfIndex'} = $valeurs{$AEROHIVE::ahIfIndex};
+#        $trapHashRef->{'trapVlan'} = $valeurs{$AEROHIVE::ahClientVLAN};
+#        $trapHashRef->{'trapMac'} = $valeurs{$AEROHIVE::ahRemoteId};
+#        $trapHashRef->{'trapClientUserName'} = $valeurs{$AEROHIVE::ahClientUserName};
+#        $trapHashRef->{'trapConnectionType'} = $WIRELESS_MAC_AUTH;
+#        if ($valeurs{$AEROHIVE::ahClientAuthMethod} eq '6' || $valeurs{$AEROHIVE::ahClientAuthMethod} eq '7') {
+#            $trapHashRef->{'trapConnectionType'} = $WIRELESS_802_1X;
+#        }
+#    }
+#    else {
+#        $logger->debug("trap currently not handled");
+#        $trapHashRef->{'trapType'} = 'unknown';
+#    }
+#    return $trapHashRef;
     $logger->debug("trap currently not handled");
     $trapHashRef->{'trapType'} = 'unknown';
     return $trapHashRef;

--- a/lib/pf/Switch/AeroHIVE.pm
+++ b/lib/pf/Switch/AeroHIVE.pm
@@ -64,6 +64,8 @@ sub supportsWirelessDot1x { return $TRUE; }
 sub supportsWirelessMacAuth { return $TRUE; }
 # inline capabilities
 sub inlineCapabilities { return ($MAC,$SSID); }
+# locationlog update capabilities
+sub supportsRoamingAccounting { return $TRUE };
 
 =item getVersion
 

--- a/lib/pf/api.pm
+++ b/lib/pf/api.pm
@@ -81,6 +81,21 @@ sub radius_accounting : Public {
     return $return;
 }
 
+sub radius_update_locationlog : Public {
+    my ($class, %radius_request) = @_;
+    my $logger = pf::log::get_logger();
+
+    my $radius = new pf::radius::custom();
+    my $return;
+    eval {
+        $return = $radius->update_locationlog_accounting(\%radius_request);
+    };
+    if ($@) {
+        $logger->logdie("radius update locationlog accounting failed with error: $@");
+    }
+    return $return;
+}
+
 sub soh_authorize : Public {
     my ($class, %radius_request) = @_;
     my $logger = pf::log::get_logger();

--- a/lib/pf/api.pm
+++ b/lib/pf/api.pm
@@ -76,7 +76,7 @@ sub radius_accounting : Public {
         $return = $radius->accounting(\%radius_request);
     };
     if ($@) {
-        $logger->logdie("radius accounting failed with error: $@");
+        $logger->error("radius accounting failed with error: $@");
     }
     return $return;
 }
@@ -91,7 +91,7 @@ sub radius_update_locationlog : Public {
         $return = $radius->update_locationlog_accounting(\%radius_request);
     };
     if ($@) {
-        $logger->logdie("radius update locationlog accounting failed with error: $@");
+        $logger->error("radius update locationlog accounting failed with error: $@");
     }
     return $return;
 }

--- a/lib/pf/locationlog.pm
+++ b/lib/pf/locationlog.pm
@@ -368,6 +368,10 @@ sub locationlog_insert_start {
     $user_name = "" if (!defined($user_name));
     $ssid = "" if (!defined($ssid));
 
+    if (!(defined($vlan)) && defined($locationlog_mac->{'vlan'})) {
+        $vlan = $locationlog_mac->{'vlan'};
+    }
+
     if ( defined($mac) ) {
         db_query_execute(LOCATIONLOG, $locationlog_statements, 'locationlog_insert_start_with_mac_sql',
             lc($mac), $switch, $switch_ip, $switch_mac, $ifIndex, $vlan, $conn_type, $user_name, $ssid, $stripped_user_name, $realm)
@@ -467,7 +471,7 @@ sub locationlog_synchronize {
                 $logger->debug("closing old locationlog entry because something about this node changed");
                 db_query_execute(LOCATIONLOG, $locationlog_statements, 'locationlog_update_end_mac_sql', $mac)
                     || return (0);
-                $mustInsert = 1;
+                locationlog_insert_start($switch, $switch_ip, $switch_mac, $ifIndex, $vlan, $mac, $connection_type, $user_name, $ssid, $stripped_user_name, $realm, $locationlog_mac);
             }
 
         } else {
@@ -561,7 +565,10 @@ sub _is_locationlog_accurate {
     $ssid = '' if (!defined($ssid));
 
     # did something changed
-    my $vlanChanged = ($locationlog_mac->{'vlan'} != $vlan);
+    my $vlanChanged = '0';
+    if (defined($vlan)) {
+        $vlanChanged = ($locationlog_mac->{'vlan'} != $vlan);
+    }
     my $switchChanged = ($locationlog_mac->{'switch'} ne $switch);
     my $conn_typeChanged = ($locationlog_mac->{connection_type} ne connection_type_to_str($connection_type));
     my $userChanged = ($locationlog_mac->{'dot1x_username'} ne $user_name);

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -290,6 +290,46 @@ sub accounting {
     return [ $RADIUS::RLM_MODULE_OK, ('Reply-Message' => "Accounting ok") ];
 }
 
+=item update_locationlog_accounting
+
+Update the location log based on the accounting information
+
+=cut
+
+sub update_locationlog_accounting {
+    my ($this, $radius_request) = @_;
+    my $logger = Log::Log4perl::get_logger(ref($this));
+
+    my ( $switch_mac, $switch_ip, $source_ip, $stripped_user_name, $realm ) = $this->_parseRequest($radius_request);
+
+    $logger->debug("instantiating switch");
+    my $switch = pf::SwitchFactory->getInstance()
+        ->instantiate( { switch_mac => $switch_mac, switch_ip => $switch_ip, controllerIp => $source_ip } );
+
+    # is switch object correct?
+    if ( !$switch ) {
+        $logger->warn( "Can't instantiate switch ($switch_ip). This request will be failed. "
+                . "Are you sure your switches.conf is correct?" );
+        return [ $RADIUS::RLM_MODULE_FAIL, ( 'Reply-Message' => "Switch is not managed by PacketFence" ) ];
+    }
+
+    if ($switch->supportsRoamingAccounting()) {
+        my ($nas_port_type, $eap_type, $mac, $port, $user_name, $nas_port_id, $session_id) = $switch->parseRequest($radius_request);
+        my $connection = pf::Connection->new;
+        $connection->identifyType($nas_port_type, $eap_type, $mac, $user_name, $switch);
+        my $connection_type = $connection->attributesToBackwardCompatible;
+        my $ssid;
+        if (($connection_type & $WIRELESS) == $WIRELESS) {
+            $ssid = $switch->extractSsid($radius_request);
+            $logger->debug("SSID resolved to: $ssid") if (defined($ssid));
+        }
+        my $vlan;
+        $vlan = $radius_request->{'Tunnel-Private-Group-ID'} if ( (defined( $radius_request->{'Tunnel-Type'}) && $radius_request->{'Tunnel-Type'} eq '13') && (defined($radius_request->{'Tunnel-Medium-Type'}) && $radius_request->{'Tunnel-Medium-Type'} eq '6') );
+        $switch->synchronize_locationlog($port, $vlan, $mac, undef, $connection_type, $user_name, $ssid, $stripped_user_name, $realm);
+    }
+    return [ $RADIUS::RLM_MODULE_OK, ('Reply-Message' => "Update locationlog from accounting ok") ];
+}
+
 =item * _parseRequest
 
 Takes FreeRADIUS' RAD_REQUEST hash and process it to return

--- a/raddb/packetfence.pm
+++ b/raddb/packetfence.pm
@@ -293,12 +293,15 @@ sub accounting {
 
         # We only perform a RPC call on stop/update types
         unless ($RAD_REQUEST{'Acct-Status-Type'} eq 'Stop' ||
-                $RAD_REQUEST{'Acct-Status-Type'} eq 'Interim-Update') {
+                $RAD_REQUEST{'Acct-Status-Type'} eq 'Interim-Update' ||
+                $RAD_REQUEST{'Acct-Status-Type'} eq 'Start') {
             return $RADIUS::RLM_MODULE_OK;
         }
 
         my $config = _get_rpc_config();
-        my $data = send_rpc_request($config, "radius_accounting", \%RAD_REQUEST);
+        my $data;
+        $data = send_rpc_request($config, "radius_accounting", \%RAD_REQUEST) if ($RAD_REQUEST{'Acct-Status-Type'} eq 'Stop' || $RAD_REQUEST{'Acct-Status-Type'} eq 'Interim-Update');
+        $data = send_rpc_request($config, "radius_update_locationlog", \%RAD_REQUEST) if ($RAD_REQUEST{'Acct-Status-Type'} eq 'Start');
         if ($data) {
             my $elements = $data->[0];
 

--- a/raddb/sites-available/packetfence
+++ b/raddb/sites-available/packetfence
@@ -40,6 +40,9 @@ server packetfence {
     accounting {
         sql
         attr_filter.accounting_response
+        update request {
+            FreeRADIUS-Client-IP-Address := "%{Packet-Src-IP-Address}"
+        }
         update control {
             PacketFence-RPC-Server = ${rpc_host}
             PacketFence-RPC-Port = ${rpc_port}


### PR DESCRIPTION
## Description

We update the locationlog based on accounting data.
## Impacts

Must activate accounting on the access point.
pfsetvlan and snmptrap will be useless for roaming
## NEWS file entries

Update locationlog from the accounting data (Aerohive access point)
## Delete branch after merge

Yes
