### PR TITLE
Added nested groups support for Active Directory Authentication Source

### DIFF
--- a/html/pfappserver/lib/pfappserver/I18N/en.po
+++ b/html/pfappserver/lib/pfappserver/I18N/en.po
@@ -4532,6 +4532,11 @@ msgstr ""
 msgid "memberOf"
 msgstr ""
 
+# pf::Authentication::Source::ADSource (available_attributes)
+# pf::Authentication::Source::LDAPSource (available_attributes)
+msgid "memberOf:1.2.840.113556.1.4.1941:"
+msgstr "nested group"
+
 # html/pfappserver/lib/pfappserver/Form/Field/Duration.pm
 msgid "minutes"
 msgstr ""

--- a/lib/pf/Authentication/Source/ADSource.pm
+++ b/lib/pf/Authentication/Source/ADSource.pm
@@ -16,6 +16,13 @@ extends 'pf::Authentication::Source::LDAPSource';
 
 has '+type' => ( default => 'AD' );
 
+=head2 available_attributes
+
+Available ldap search attributes for Active Directory
+memberOf:1.2.840.113556.1.4.1941: attribute is for nested group, see https://msdn.microsoft.com/en-us/library/aa746475%28v=vs.85%29.aspx
+
+=cut
+
 sub available_attributes {
   my $self = shift;
   my $super_attributes = $self->SUPER::available_attributes;

--- a/lib/pf/Authentication/Source/ADSource.pm
+++ b/lib/pf/Authentication/Source/ADSource.pm
@@ -24,6 +24,7 @@ sub available_attributes {
      { value => "sAMAccountName", type => $Conditions::SUBSTRING },
      { value => "sAMAccountType", type => $Conditions::SUBSTRING },
      { value => "userAccountControl", type => $Conditions::SUBSTRING },
+     { value => "memberOf:1.2.840.113556.1.4.1941:", type => $Conditions::SUBSTRING },
     ];
   
   return [@$super_attributes, @$ad_attributes];


### PR DESCRIPTION
## Description

Added memberOf:1.2.840.113556.1.4.1941: as a filter attribute to be able to search in the chain of group ancestry
## Impacts

No
## NEWS file entries

Added nested groups support for Active Directory
## Delete branch after merge

Yes
