### PR TITLE
Avoid creating the same switch twice

### DIFF
--- a/t/SwitchFactory.t
+++ b/t/SwitchFactory.t
@@ -4,7 +4,8 @@ use strict;
 use warnings;
 use diagnostics;
 
-use Test::More tests => 44;
+use Scalar::Util qw(refaddr);
+use Test::More tests => 46;
 use lib '/usr/local/pf/lib';
 
 BEGIN {
@@ -85,7 +86,7 @@ isa_ok($switch, 'pf::Switch');
 $switch = $switchFactory->instantiate('01:01:01:01:01:01');
 isa_ok($switch, 'pf::Switch::Cisco::Catalyst_2960',"mac address style switch id");
 
-#Test using mac address 
+#Test using mac address
 $switch = $switchFactory->instantiate({ switch_mac => "01:01:01:01:01:02", switch_ip => "192.168.1.2", controllerIp => "1.1.1.1"});
 isa_ok($switch, 'pf::Switch::Cisco::Catalyst_2960');
 is($switch->{_id}, '01:01:01:01:01:02', "Proper id is set");
@@ -99,6 +100,23 @@ is($switch->{_controllerIp}, '1.2.3.4', "Do not override  controllerIp address i
 $switch = $switchFactory->instantiate({ switch_mac => "ff:01:01:01:01:04", switch_ip => "192.168.0.1", controllerIp => "1.1.1.1"});
 isa_ok( $switch, 'pf::Switch::Cisco::Catalyst_2900XL' );
 is($switch->{_id}, '192.168.0.1', "Proper id is set");
+
+my $switch_1 = $switchFactory->instantiate('01:01:01:01:01:01');
+my $switch_2 = $switchFactory->instantiate('01:01:01:01:01:01');
+
+ok( refaddr($switch_1) == refaddr($switch_2) ,"The same object is used in the same scope");
+
+$switch_1 = undef;
+$switch_2 = undef;
+
+$switch_1 = $switchFactory->instantiate('01:01:01:01:01:01');
+
+my $old_ref = refaddr($switch_1);
+$switch_1 = undef;
+$switch_2 = $switchFactory->instantiate('01:01:01:01:01:01');
+
+ok( $old_ref != refaddr($switch_2) ,"The different object is used after object falls out of scope");
+
 
 
 =head1 AUTHOR

--- a/t/benchmarks/switchCreation.pl
+++ b/t/benchmarks/switchCreation.pl
@@ -1,0 +1,53 @@
+#!/usr/bin/perl -w
+
+use strict;
+use warnings;
+use Benchmark qw(:all);;
+
+use lib '/usr/local/pf/lib';
+
+BEGIN {
+    use lib qw(/usr/local/pf/t);
+    use PfFilePaths;
+}
+
+use pf::SwitchFactory;
+
+my $switchFactory = pf::SwitchFactory->new;
+
+my $switch_1 = $switchFactory->instantiate('01:01:01:01:01:01');
+timethis(
+    0,
+    sub {
+        my $switch_1 = $switchFactory->instantiate('01:01:01:01:01:01');
+    }
+);
+
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2013 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+


### PR DESCRIPTION
## Description

Within the scope of a function call the same switch object will be reused until the switch goes out of scope.
This is done to avoid creating multiple switch object for the same switch id
## Impacts

Any code the uses the pf::SwitchFactory
## NEWS file entries

Enhancements
++++++++++++
Optimize switch creation
## Delete branch after merge

NO
