### PR TITLE
Assigned LC_CTYPE to C during postinstall script on debian

### DIFF
--- a/debian/packetfence.postinst
+++ b/debian/packetfence.postinst
@@ -17,6 +17,10 @@ set -e
 # for details, see http://www.debian.org/doc/debian-policy/ or
 # the debian-policy package
 
+# Force the LC_CTYPE to C to avoid i18n problems during postinstallation.
+LC_CTYPE=C
+export LC_CTYPE
+
 
 case "$1" in
     configure)


### PR DESCRIPTION
i18n issues during installation.
## Description

Assigned LC_CTYPE to C during postinstall script on debian to prevent i18n issues during installation.
## Impacts

Fixes issue 347
## NEWS file entries

Bug Fixes
+++++++++

Assigned LC_CTYPE to C during postinstall script on debian to prevent i18n issues during installation.
## Delete branch after merge

YES
