### PR TITLE
No autocorrect / uppercasing on login field

### DIFF
--- a/html/captive-portal/templates/device-login.html
+++ b/html/captive-portal/templates/device-login.html
@@ -61,7 +61,7 @@ document.observe("dom:loaded", function() {
           [%# User / Pass %]
           <div class="input">
             <span>[% i18n("Username") %]</span>
-	    <input class="field" name="username" id="username" type="text" value="[% username %]" />
+	    <input class="field" name="username" id="username" type="text" autocorrect="off" autocapitalize="off" value="[% username %]" />
           </div>
           <div class="input">
             <span>[% i18n("Password") %]</span><input class="field" name="password" type="password" />

--- a/html/captive-portal/templates/gaming-login.html
+++ b/html/captive-portal/templates/gaming-login.html
@@ -61,7 +61,7 @@ document.observe("dom:loaded", function() {
           [%# User / Pass %]
           <div class="input">
             <span>[% i18n("Username") %]</span>
-	    <input class="field" name="username" id="username" type="text" value="[% username %]" />
+	    <input class="field" name="username" id="username" type="text" autocorrect="off" autocapitalize="off" value="[% username %]" />
           </div>
           <div class="input">
             <span>[% i18n("Password") %]</span><input class="field" name="password" type="password" />

--- a/html/captive-portal/templates/guest/sponsor_login.html
+++ b/html/captive-portal/templates/guest/sponsor_login.html
@@ -18,7 +18,7 @@
           [%# User / Pass %]
           <div class="input">
             <span>[% i18n("Username") %]</span>
-            <input class="field first" name="username" id="login" type="text" value="[% username | html %]" />
+            <input class="field first" name="username" id="login" type="text" autocorrect="off" autocapitalize="off" value="[% username | html %]" />
           </div>
           <div class="input">
             <span>[% i18n("Password") %]</span><input class="field" name="password" type="password" />

--- a/html/captive-portal/templates/login.html
+++ b/html/captive-portal/templates/login.html
@@ -63,7 +63,7 @@ document.observe("dom:loaded", function() {
           [% UNLESS no_username %]
           <div class="input">
             <span>[% IF null_source %][% i18n("Email") %] [% ELSE %] [% i18n("Username") %][% END %]</span>
-	    <input class="field" name="username" id="username" type="text" value="[% username %]" />
+	    <input class="field" name="username" id="username" type="text" autocorrect="off" autocapitalize="off" value="[% username %]" />
           </div>
           [% END %]
           [% UNLESS null_source || no_password %]


### PR DESCRIPTION
## Description

We should tell the device (iPad per example) not to autocorrect / uppercasing login field
## Impacts

None... Except if not supported by some browsers
## NEWS file entries

New Features
++++++++++++

Enhancements
++++++++++++
- Device will avoid autocorrect / uppercasing the login field in the captive portal

Bug Fixes
+++++++++
## Delete branch after merge

YES
