### PR TITLE
make default parseTrap return unknown type

### DIFF
--- a/lib/pf/Switch.pm
+++ b/lib/pf/Switch.pm
@@ -3024,7 +3024,9 @@ sub parseTrap {
     my $self   = shift;
     my $logger = Log::Log4perl::get_logger( ref($self) );
     $logger->warn("SNMP trap handling not implemented for this type of switch.");
-    return undef;
+    my $trapHashRef;
+    $trapHashRef->{'trapType'} = 'unknown';
+    return $trapHashRef;
 }
 
 =item identifyConnectionType


### PR DESCRIPTION
Just waiting on the confirmation that it works before merging it

News file : 
Bug fixes
++++++++
- Fixed broken default behavior when receiving an SNMP trap.
