### PR TITLE
Show better error messages when auth doesn't give proper role or unregdate

### DIFF
--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Activate/Email.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Activate/Email.pm
@@ -312,7 +312,8 @@ sub doSponsorRegistration : Private {
 
             $c->session->{"username"} = $pid;
             $c->session->{source_id} = $source->{id};
-            $c->stash->{info}=\%info;
+            $c->session->{source_match} = undef;
+            $c->stash->{info}=\%info; 
             $c->forward('Authenticate' => 'postAuthentication');
             $c->forward('Authenticate' => 'createLocalAccount', [$auth_params]) if ( isenabled($source->{create_local_account}) );
             $c->forward('CaptivePortal' => 'webNodeRegister', [$pid, %{$c->stash->{info}}]);

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Authenticate.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Authenticate.pm
@@ -319,7 +319,8 @@ sub setRole : Private {
         $logger->debug("Got role '$value' for username \"$pid\"");
         $info->{category} = $value;
     } else {
-        $logger->debug("Got no role for username \"$pid\"");
+        $logger->info("Got no role for username \"$pid\"");
+        $self->showError($c, "The username you have used does not match any configured role.");
     }
 
 }
@@ -352,6 +353,10 @@ sub setUnRegDate : Private {
     if ( defined $value ) {
         $logger->debug("Got unregdate $value for username \"$pid\"");
         $info->{unregdate} = $value;
+    }
+    else {
+        $logger->info("Got no unregdate for username \"$pid\"");
+        $self->showError($c, "The username you have used does not match any configured unregistration date.");
     }
 
     # We put the unregistration date in session since we may want to use it later in the flow

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Authenticate.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Authenticate.pm
@@ -320,7 +320,7 @@ sub setRole : Private {
         $info->{category} = $value;
     } else {
         $logger->info("Got no role for username \"$pid\"");
-        $self->showError($c, "The username you have used does not match any configured role.");
+        $self->showError($c, "You do not have the permission to register a device with this username.");
     }
 
 }

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Authenticate.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Authenticate.pm
@@ -309,6 +309,7 @@ sub setRole : Private {
     my $info = $c->stash->{info};
     my $pid = $info->{pid};
     my $source_match = $session->{source_match} || $session->{source_id};
+
     # obtain node information provided by authentication module. We need to get the role (category here)
     # as web_node_register() might not work if we've reached the limit
     my $value =

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Signup.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Signup.pm
@@ -167,6 +167,7 @@ sub doEmailSelfRegistration : Private {
         'username'   => $pid,
         'user_email' => $email
     };
+    $c->stash->{matchParams} = $auth_params;
     
     $c->stash->{pid} = $pid;
     $c->stash->{info} = \%info;
@@ -284,6 +285,7 @@ sub doSponsorSelfRegistration : Private {
     my $auth_params = $c->stash->{matchParams};
     $auth_params->{username} = $pid;
     $auth_params->{user_email} = $email;
+    $c->stash->{matchParams} = $auth_params;
 
     # form valid, adding person (using modify in case person already exists)
     person_modify(
@@ -399,51 +401,52 @@ sub doSmsSelfRegistration : Private {
     }
     # User chose to register by SMS
     $logger->info("registering $mac  guest by SMS $phone @ $mobileprovider");
+
+    $info{'pid'} = $pid;
+
+    $logger->info("redirecting to mobile confirmation page");
+    my $sms_type =
+      pf::Authentication::Source::SMSSource->getDefaultOfType;
+    my $source = $profile->getSourceByType($sms_type) || $profile->getSourceByTypeForChained($sms_type);
+    my $auth_params = {
+        'username'    => $pid,
+        'phonenumber' => $phone
+    };
+    $c->stash->{matchParams} = $auth_params;
+
+    # form valid, adding person (using modify in case person already exists)
+    $logger->info("Adding guest person $pid ($phone)");
+    person_modify(
+        $pid,
+        (   map { $_ => $c->session->{$_} }
+              qw(firstname lastname company  email)
+        ),
+        (   'telephone' => $phone,
+            'notes'     => 'sms confirmation. Date of arrival: '
+              . time2str( "%Y-%m-%d %H:%M:%S", time ),
+            'portal'    => $profile->getName,
+            'source'    => $source->{id},
+        )
+    );
+
+    # fetch role for this user
+    $c->stash->{pid} = $pid;
+    $c->stash->{info} = \%info;
+    $session->{source_id} = $source->{id};
+    $c->forward(Authenticate => 'setRole');
+
     my ( $auth_return, $err, $errargs_ref ) =
       pf::activation::sms_activation_create_send( $mac, $pid, $phone, $profile->getName, $mobileprovider );
-    if ($auth_return) {
 
-        $info{'pid'} = $pid;
-
-        $logger->info("redirecting to mobile confirmation page");
-        my $sms_type =
-          pf::Authentication::Source::SMSSource->getDefaultOfType;
-        my $source = $profile->getSourceByType($sms_type) || $profile->getSourceByTypeForChained($sms_type);
-        my $auth_params = {
-            'username'    => $pid,
-            'phonenumber' => $phone
-        };
-
-        # form valid, adding person (using modify in case person already exists)
-        $logger->info("Adding guest person $pid ($phone)");
-        person_modify(
-            $pid,
-            (   map { $_ => $c->session->{$_} }
-                  qw(firstname lastname company  email)
-            ),
-            (   'telephone' => $phone,
-                'notes'     => 'sms confirmation. Date of arrival: '
-                  . time2str( "%Y-%m-%d %H:%M:%S", time ),
-                'portal'    => $profile->getName,
-                'source'    => $source->{id},
-            )
-        );
-
-        # fetch role for this user
-        $c->stash->{pid} = $pid;
-        $c->stash->{info} = \%info;
-        $session->{source_id} = $source->{id};
-        $c->forward(Authenticate => 'setRole');
-
-
-        # set node in pending mode with the appropriate role
-        $info{'status'} = $pf::node::STATUS_PENDING;
-        node_modify( $portalSession->clientMac(), %info );
-        $c->detach( 'Activate::Sms' => 'showSmsConfirmation' );
-
-    } else {
+    unless ($auth_return) {
         $self->validationError( $c, $err );
-    }
+    } 
+
+    # set node in pending mode with the appropriate role
+    $info{'status'} = $pf::node::STATUS_PENDING;
+    node_modify( $portalSession->clientMac(), %info );
+    $c->detach( 'Activate::Sms' => 'showSmsConfirmation' );
+
 }    # SMS
 
 sub checkGuestModes : Private {

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Signup.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Signup.pm
@@ -170,6 +170,7 @@ sub doEmailSelfRegistration : Private {
     
     $c->stash->{pid} = $pid;
     $c->stash->{info} = \%info;
+    $session->{source_id} = $source->{id};
     $c->forward(Authenticate => 'setRole');
 
     # form valid, adding person (using modify in case person already exists)
@@ -258,6 +259,7 @@ sub doSponsorSelfRegistration : Private {
     my $logger        = get_logger;
     my $profile       = $c->profile;
     my $request       = $c->request;
+    my $session       = $c->session;
     my $portalSession = $c->portalSession;
     my %info;
     $logger->info(
@@ -303,6 +305,7 @@ sub doSponsorSelfRegistration : Private {
     # fetch role for this user
     $c->stash->{pid} = $pid;
     $c->stash->{info} = \%info;
+    $session->{source_id} = $source->{id};
     $c->forward('Authenticate' => 'setRole');
 
     # Setting access timeout and role (category) dynamically
@@ -429,6 +432,7 @@ sub doSmsSelfRegistration : Private {
         # fetch role for this user
         $c->stash->{pid} = $pid;
         $c->stash->{info} = \%info;
+        $session->{source_id} = $source->{id};
         $c->forward(Authenticate => 'setRole');
 
 

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Signup.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Signup.pm
@@ -169,7 +169,7 @@ sub doEmailSelfRegistration : Private {
     };
     
     $c->stash->{pid} = $pid;
-    $c->stash->{info} = %info;
+    $c->stash->{info} = \%info;
     $c->forward(Authenticate => 'setRole');
 
     # form valid, adding person (using modify in case person already exists)
@@ -302,7 +302,7 @@ sub doSponsorSelfRegistration : Private {
 
     # fetch role for this user
     $c->stash->{pid} = $pid;
-    $c->stash->{info} = %info;
+    $c->stash->{info} = \%info;
     $c->forward('Authenticate' => 'setRole');
 
     # Setting access timeout and role (category) dynamically
@@ -428,7 +428,7 @@ sub doSmsSelfRegistration : Private {
 
         # fetch role for this user
         $c->stash->{pid} = $pid;
-        $c->stash->{info} = %info;
+        $c->stash->{info} = \%info;
         $c->forward(Authenticate => 'setRole');
 
 

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Signup.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Signup.pm
@@ -169,8 +169,8 @@ sub doEmailSelfRegistration : Private {
     };
     
     $c->stash->{pid} = $pid;
-    $c->stash->{info} = $info;
-    $c->forward('setRole');
+    $c->stash->{info} = %info;
+    $c->forward(Authenticate => 'setRole');
 
     # form valid, adding person (using modify in case person already exists)
     person_modify(
@@ -302,8 +302,8 @@ sub doSponsorSelfRegistration : Private {
 
     # fetch role for this user
     $c->stash->{pid} = $pid;
-    $c->stash->{info} = $info;
-    $c->forward('setRole');
+    $c->stash->{info} = %info;
+    $c->forward('Authenticate' => 'setRole');
 
     # Setting access timeout and role (category) dynamically
     $info{'unregdate'} =
@@ -428,8 +428,8 @@ sub doSmsSelfRegistration : Private {
 
         # fetch role for this user
         $c->stash->{pid} = $pid;
-        $c->stash->{info} = $info;
-        $c->forward('setRole');
+        $c->stash->{info} = %info;
+        $c->forward(Authenticate => 'setRole');
 
 
         # set node in pending mode with the appropriate role

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Signup.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Signup.pm
@@ -167,9 +167,10 @@ sub doEmailSelfRegistration : Private {
         'username'   => $pid,
         'user_email' => $email
     };
-    $info{'category'} =
-      &pf::authentication::match( $source->{id}, $auth_params,
-        $Actions::SET_ROLE );
+    
+    $c->stash->{pid} = $pid;
+    $c->stash->{info} = $info;
+    $c->forward('setRole');
 
     # form valid, adding person (using modify in case person already exists)
     person_modify(
@@ -300,9 +301,9 @@ sub doSponsorSelfRegistration : Private {
     $logger->info( "Adding guest person " . $c->session->{'guest_pid'} );
 
     # fetch role for this user
-    $info{'category'} =
-      &pf::authentication::match( $source->{id}, $auth_params,
-        $Actions::SET_ROLE );
+    $c->stash->{pid} = $pid;
+    $c->stash->{info} = $info;
+    $c->forward('setRole');
 
     # Setting access timeout and role (category) dynamically
     $info{'unregdate'} =
@@ -402,8 +403,6 @@ sub doSmsSelfRegistration : Private {
         $info{'pid'} = $pid;
 
         $logger->info("redirecting to mobile confirmation page");
-
-        # fetch role for this user
         my $sms_type =
           pf::Authentication::Source::SMSSource->getDefaultOfType;
         my $source = $profile->getSourceByType($sms_type) || $profile->getSourceByTypeForChained($sms_type);
@@ -427,9 +426,11 @@ sub doSmsSelfRegistration : Private {
             )
         );
 
-        $info{'category'} =
-          &pf::authentication::match( $source->{id}, $auth_params,
-            $Actions::SET_ROLE );
+        # fetch role for this user
+        $c->stash->{pid} = $pid;
+        $c->stash->{info} = $info;
+        $c->forward('setRole');
+
 
         # set node in pending mode with the appropriate role
         $info{'status'} = $pf::node::STATUS_PENDING;


### PR DESCRIPTION
## Description

Show accurate error message while trying to auth on a source that doesn't have role or unregdate matching your login username(instead of max devices reached).
fixes #380
## Impacts

Authentication with a source that does not have role or unregdate setup. 
## NEWS file entries

Bug Fixes
+++++++++

Fix error messages.
## Delete branch after merge

NO
