### PR TITLE
DHCP sensor on production DHCP server

### DIFF
--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -2787,7 +2787,7 @@ First make sure you have the following packages installed :
 Get the source code of the sensor
 ----
 # mkdir -p ~/udp-reflector && cd ~/udp-reflector
-# wget https://raw.githubusercontent.com/julsemaan/udp-reflector/master/linux/udp_reflector.cpp
+# wget http://inverse.ca/downloads/PacketFence/udp-reflector/udp_reflector.cpp
 # g++ udp_reflector.cpp -o /usr/local/bin/udp_reflector -lpcap
 ----
 

--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -2717,25 +2717,25 @@ Go in Startup/Task Scheduler
 Create a new Task
 
 In General : 
- - Name it dhcp-reflector
- - Select 'Run whether the user is logged on or not'
- - Check 'Run with highest privileges'
+* Name it dhcp-reflector
+* Select 'Run whether the user is logged on or not'
+* Check 'Run with highest privileges'
 
 In Triggers : 
- - Create a new trigger
- - Select 'Begin the task : ', 'At startup'
- - Leave the other options as default and save.
+* Create a new trigger
+* Select 'Begin the task : ', 'At startup'
+* Leave the other options as default and save.
 
 In Actions : 
- - Create a new action
- - Set the action to 'Start a program'
- - In 'Program/script' set it to 'C:\udp-reflector\udp_reflector.exe,
- - In 'Add arguments' put '-s pcap0:67 -d 192.168.1.5:767 -b 25000'
-  - where pcap0 is the interface where your DHCP is listening (use 'C:\udp-reflector\udp_reflector.exe -l' to list interfaces)
-  - where 192.168.1.5 is the management IP of PacketFence
+* Create a new action
+* Set the action to 'Start a program'
+* In 'Program/script' set it to 'C:\udp-reflector\udp_reflector.exe,
+* In 'Add arguments' put '-s pcap0:67 -d 192.168.1.5:767 -b 25000'
+  * where pcap0 is the interface where your DHCP is listening (use 'C:\udp-reflector\udp_reflector.exe -l' to list interfaces)
+  * where 192.168.1.5 is the management IP of PacketFence
 
 In Settings : 
- - Uncheck 'Stop the task if it runs longer than :'
+* Uncheck 'Stop the task if it runs longer than :'
 
 Then press OK and save the task
 
@@ -2778,9 +2778,9 @@ Compiling the sensor from source on a Linux system
 ++++++++++++++++++++++++++++++++++++++++++++++++++
 
 First make sure you have the following packages installed : 
- - libpcap
- - libpcap-devel
- - gcc-c++
+* libpcap
+* libpcap-devel
+* gcc-c++
 
 Get the source code of the sensor
 ----

--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -2692,6 +2692,118 @@ At the bottom, select in the list "Run a new instance in parallel"
 
 Validate with Ok and give the account who will run this task. (Usually _DOMAIN\Administrator_)
 
+DHCP remote sensor
+~~~~~~~~~~~~~~~~~~
+
+The DHCP remote sensor consists of a lightweight binary that is installed on your production DHCP server in order to replicate the DHCP traffic 1 to 1 to the PacketFence server. This solution is more reliable than the DHCP relaying since it receives a copy of all your DHCP traffic and not only the broadcasted DHCP traffic. Supported DHCP servers are Microsoft DHCP server and CentOS 6 and 7.
+
+These sensors work by capturing the packets at the lowest level possible on your DHCP server and forward them to the PacketFence management interface
+
+Microsoft DHCP sensor
+^^^^^^^^^^^^^^^^^^^^^
+
+You will first need to download and install WinPcap available from http://www.winpcap.org/install/
+
+Then get the remote sensor from Inverse's download website http://inverse.ca/downloads/PacketFence/udp-reflector/udp_reflector.exe
+
+Create the directory C:\udp-reflector
+
+Place the file in C:\udp-reflector\udp_reflector.exe
+
+Now we will create a task so the reflector starts on boot.
+
+Go in Startup/Task Scheduler
+
+Create a new Task
+
+In General : 
+- Name it dhcp-reflector
+- Select 'Run whether the user is logged on or not'
+- Check 'Run with highest privileges'
+
+In Triggers : 
+- Create a new trigger
+- Select 'Begin the task : ', 'At startup'
+- Leave the other options as default and save.
+
+In Actions : 
+- Create a new action
+- Set the action to 'Start a program'
+- In 'Program/script' set it to 'C:\udp-reflector\udp_reflector.exe,
+- In 'Add arguments' put '-s pcap0:67 -d 192.168.1.5:767 -b 25000'
+  - where pcap0 is the interface where your DHCP is listening (use 'C:\udp-reflector\udp_reflector.exe -l' to list interfaces)
+  - where 192.168.1.5 is the management IP of PacketFence
+
+In Settings : 
+- Uncheck 'Stop the task if it runs longer than :'
+
+Then press OK and save the task
+
+Now start the task manually by right clicking on it and clicking 'Run'
+
+The DHCP traffic should now be reflected on your PacketFence server
+
+Linux based sensor
+^^^^^^^^^^^^^^^^^^
+
+First download the RPM on your DHCP server.
+
+CentOS 6 and 7 servers
+++++++++++++++++++++++
+
+For CentOS 6
+---
+# for i386
+# wget http://inverse.ca/downloads/PacketFence/CentOS6/extra/i386/RPMS/udp-reflector-1.0-6.1.i686.rpm
+
+# for x86_64
+# wget http://inverse.ca/downloads/PacketFence/CentOS6/extra/x86_64/RPMS/udp-reflector-1.0-6.1.x86_64.rpm
+---
+
+For CentOS 7
+---
+# for i386
+# wget http://inverse.ca/downloads/PacketFence/CentOS7/extra/i386/RPMS/udp-reflector-1.0-6.1.i686.rpm
+
+# for x86_64
+# wget http://inverse.ca/downloads/PacketFence/CentOS7/extra/x86_64/RPMS/udp-reflector-1.0-6.1.x86_64.rpm
+---
+
+Now install the sensor
+---
+# rpm -i udp-reflector-*.rpm
+---
+
+Compiling the sensor from source on a Linux system
+++++++++++++++++++++++++++++++++++++++++++++++++++
+
+First make sure you have the following packages installed : 
+- libpcap
+- libpcap-devel
+- gcc-c++
+
+Get the source code of the sensor
+---
+# mkdir -p ~/udp-reflector && cd ~/udp-reflector
+# wget https://raw.githubusercontent.com/julsemaan/udp-reflector/master/linux/udp_reflector.cpp
+# g++ udp_reflector.cpp -o /usr/local/bin/udp_reflector -lpcap
+---
+
+Configuring the sensor
+++++++++++++++++++++++
+
+Now in /etc/rc.local, place the following line '/usr/local/bin/udp_reflector -s pcap0:67 -d 192.168.1.5:767 -b 25000 &'
+- where pcap0 is the pcap interface where your DHCP server listens on. (List them using 'udp_reflector -l')
+- where 192.168.1.5 is the management IP of your PacketFence server
+
+Now start the sensor with
+---
+# /usr/local/bin/udp_reflector -s pcap0:67 -d 192.168.1.5:767 -b 25000 &
+---
+
+The DHCP traffic should now be reflected on your PacketFence server
+
+
 Firewall SSO
 ------------
 

--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -2766,9 +2766,6 @@ For CentOS 6
 
 For CentOS 7
 ----
-# for i386
-# wget http://inverse.ca/downloads/PacketFence/CentOS7/extra/i386/RPMS/udp-reflector-1.0-6.1.i686.rpm
-
 # for x86_64
 # wget http://inverse.ca/downloads/PacketFence/CentOS7/extra/x86_64/RPMS/udp-reflector-1.0-6.1.x86_64.rpm
 ----

--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -2695,7 +2695,7 @@ Validate with Ok and give the account who will run this task. (Usually _DOMAIN\A
 DHCP remote sensor
 ~~~~~~~~~~~~~~~~~~
 
-The DHCP remote sensor consists of a lightweight binary that is installed on your production DHCP server in order to replicate the DHCP traffic 1 to 1 to the PacketFence server. This solution is more reliable than the DHCP relaying since it receives a copy of all your DHCP traffic and not only the broadcasted DHCP traffic. Supported DHCP servers are Microsoft DHCP server and CentOS 6 and 7.
+The DHCP remote sensor consists of a lightweight binary that is installed on your production DHCP server in order to replicate the DHCP traffic 1 to 1 to the PacketFence server. This solution is more reliable than the DHCP relaying since PacketFence receives a copy of all your DHCP traffic and not only the broadcasted DHCP traffic. Supported DHCP servers are Microsoft DHCP server and CentOS 6 and 7.
 
 These sensors work by capturing the packets at the lowest level possible on your DHCP server and forward them to the PacketFence management interface
 
@@ -2717,25 +2717,25 @@ Go in Startup/Task Scheduler
 Create a new Task
 
 In General : 
-- Name it dhcp-reflector
-- Select 'Run whether the user is logged on or not'
-- Check 'Run with highest privileges'
+ - Name it dhcp-reflector
+ - Select 'Run whether the user is logged on or not'
+ - Check 'Run with highest privileges'
 
 In Triggers : 
-- Create a new trigger
-- Select 'Begin the task : ', 'At startup'
-- Leave the other options as default and save.
+ - Create a new trigger
+ - Select 'Begin the task : ', 'At startup'
+ - Leave the other options as default and save.
 
 In Actions : 
-- Create a new action
-- Set the action to 'Start a program'
-- In 'Program/script' set it to 'C:\udp-reflector\udp_reflector.exe,
-- In 'Add arguments' put '-s pcap0:67 -d 192.168.1.5:767 -b 25000'
+ - Create a new action
+ - Set the action to 'Start a program'
+ - In 'Program/script' set it to 'C:\udp-reflector\udp_reflector.exe,
+ - In 'Add arguments' put '-s pcap0:67 -d 192.168.1.5:767 -b 25000'
   - where pcap0 is the interface where your DHCP is listening (use 'C:\udp-reflector\udp_reflector.exe -l' to list interfaces)
   - where 192.168.1.5 is the management IP of PacketFence
 
 In Settings : 
-- Uncheck 'Stop the task if it runs longer than :'
+ - Uncheck 'Stop the task if it runs longer than :'
 
 Then press OK and save the task
 
@@ -2752,54 +2752,54 @@ CentOS 6 and 7 servers
 ++++++++++++++++++++++
 
 For CentOS 6
----
+----
 # for i386
 # wget http://inverse.ca/downloads/PacketFence/CentOS6/extra/i386/RPMS/udp-reflector-1.0-6.1.i686.rpm
 
 # for x86_64
 # wget http://inverse.ca/downloads/PacketFence/CentOS6/extra/x86_64/RPMS/udp-reflector-1.0-6.1.x86_64.rpm
----
+----
 
 For CentOS 7
----
+----
 # for i386
 # wget http://inverse.ca/downloads/PacketFence/CentOS7/extra/i386/RPMS/udp-reflector-1.0-6.1.i686.rpm
 
 # for x86_64
 # wget http://inverse.ca/downloads/PacketFence/CentOS7/extra/x86_64/RPMS/udp-reflector-1.0-6.1.x86_64.rpm
----
+----
 
 Now install the sensor
----
+----
 # rpm -i udp-reflector-*.rpm
----
+----
 
 Compiling the sensor from source on a Linux system
 ++++++++++++++++++++++++++++++++++++++++++++++++++
 
 First make sure you have the following packages installed : 
-- libpcap
-- libpcap-devel
-- gcc-c++
+ - libpcap
+ - libpcap-devel
+ - gcc-c++
 
 Get the source code of the sensor
----
+----
 # mkdir -p ~/udp-reflector && cd ~/udp-reflector
 # wget https://raw.githubusercontent.com/julsemaan/udp-reflector/master/linux/udp_reflector.cpp
 # g++ udp_reflector.cpp -o /usr/local/bin/udp_reflector -lpcap
----
+----
 
 Configuring the sensor
 ++++++++++++++++++++++
 
 Now in /etc/rc.local, place the following line '/usr/local/bin/udp_reflector -s pcap0:67 -d 192.168.1.5:767 -b 25000 &'
-- where pcap0 is the pcap interface where your DHCP server listens on. (List them using 'udp_reflector -l')
-- where 192.168.1.5 is the management IP of your PacketFence server
+ - where pcap0 is the pcap interface where your DHCP server listens on. (List them using 'udp_reflector -l')
+ - where 192.168.1.5 is the management IP of your PacketFence server
 
 Now start the sensor with
----
+----
 # /usr/local/bin/udp_reflector -s pcap0:67 -d 192.168.1.5:767 -b 25000 &
----
+----
 
 The DHCP traffic should now be reflected on your PacketFence server
 

--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -2717,24 +2717,28 @@ Go in Startup/Task Scheduler
 Create a new Task
 
 In General : 
+[options="compact"]
 * Name it dhcp-reflector
 * Select 'Run whether the user is logged on or not'
 * Check 'Run with highest privileges'
 
 In Triggers : 
+[options="compact"]
 * Create a new trigger
-* Select 'Begin the task : ', 'At startup'
+* In 'Begin the task : ', select At startup
 * Leave the other options as default and save.
 
 In Actions : 
+[options="compact"]
 * Create a new action
 * Set the action to 'Start a program'
-* In 'Program/script' set it to 'C:\udp-reflector\udp_reflector.exe,
-* In 'Add arguments' put '-s pcap0:67 -d 192.168.1.5:767 -b 25000'
-  * where pcap0 is the interface where your DHCP is listening (use 'C:\udp-reflector\udp_reflector.exe -l' to list interfaces)
+* In 'Program/script' set it to ''C:\udp-reflector\udp_reflector.exe'',
+* In 'Add arguments' put ''-s pcap0:67 -d 192.168.1.5:767 -b 25000''
+  * where pcap0 is the interface where your DHCP is listening (use ''C:\udp-reflector\udp_reflector.exe -l'' to list interfaces)
   * where 192.168.1.5 is the management IP of PacketFence
 
 In Settings : 
+[options="compact"]
 * Uncheck 'Stop the task if it runs longer than :'
 
 Then press OK and save the task
@@ -2778,6 +2782,7 @@ Compiling the sensor from source on a Linux system
 ++++++++++++++++++++++++++++++++++++++++++++++++++
 
 First make sure you have the following packages installed : 
+[options="compact"]
 * libpcap
 * libpcap-devel
 * gcc-c++
@@ -2792,9 +2797,12 @@ Get the source code of the sensor
 Configuring the sensor
 ++++++++++++++++++++++
 
-Now in /etc/rc.local, place the following line '/usr/local/bin/udp_reflector -s pcap0:67 -d 192.168.1.5:767 -b 25000 &'
- - where pcap0 is the pcap interface where your DHCP server listens on. (List them using 'udp_reflector -l')
- - where 192.168.1.5 is the management IP of your PacketFence server
+Place the following line in /etc/rc.local 
+* where pcap0 is the pcap interface where your DHCP server listens on. (List them using 'udp_reflector -l')
+* where 192.168.1.5 is the management IP of your PacketFence server
+----
+/usr/local/bin/udp_reflector -s pcap0:67 -d 192.168.1.5:767 -b 25000 &
+----
 
 Now start the sensor with
 ----

--- a/lib/pf/util/dhcp.pm
+++ b/lib/pf/util/dhcp.pm
@@ -299,12 +299,12 @@ create the pcap filter from the supported DHCP Messages Type
 sub make_pcap_filter {
     my (@types) = @_;
     #listen to all if no types are provided
-    return "udp and (port 67 or port 68)" unless @types;
+    return "udp and (port 67 or port 68 or port 767)" unless @types;
     for my $type (@types) {
        die "Unknown message type $type" unless exists $MESSAGE_TYPE{$type} && defined $MESSAGE_TYPE{$type};
     }
     my $type_filter = join(" or ",map { sprintf("(udp[250:1] = 0x%x)",$MESSAGE_TYPE{$_}) } @types);
-    return "(port 67 or port 68) and ( $type_filter )";
+    return "(port 67 or port 68 or port 767) and ( $type_filter )";
 }
 
 


### PR DESCRIPTION
## Description

This adds a new listening port to pfdhcplistener for reflected traffic (767)
This also adds the documentation for the installation of udp-refletor to replicate the DHCP traffic.
## Impacts

Adds new port on pfdhcplistener's pcap filter
## NEWS file entries

New Features
++++++++++++
- Added a new listening port to pfdhcplistener to listen for replicated traffic

Enhancements
++++++++++++

Bug Fixes
+++++++++
## Delete branch after merge

YES
