### PR TITLE
Fix broken registration VLAN handling when registrationVLAN is not integer.

### DIFF
--- a/lib/pf/vlan.pm
+++ b/lib/pf/vlan.pm
@@ -117,7 +117,7 @@ sub fetchVlanForNode {
 
     # there were no violation, now onto registration handling
     ($registration,$role) = $this->getRegistrationVlan($switch, $ifIndex, $mac, $node_info, $connection_type, $user_name, $ssid, $radius_request, $realm, $stripped_user_name, $autoreg);
-    if (defined($registration) && $registration ne 0) {
+    if (defined($registration) && $registration ne "0") {
         if ( $connection_type && ($connection_type & $WIRELESS_MAC_AUTH) == $WIRELESS_MAC_AUTH ) {
             if (isenabled($node_info->{'autoreg'})) {
                 $logger->info("[$mac] Connection type is WIRELESS_MAC_AUTH and the device was coming from a secure SSID with auto registration");

--- a/lib/pf/vlan.pm
+++ b/lib/pf/vlan.pm
@@ -117,7 +117,7 @@ sub fetchVlanForNode {
 
     # there were no violation, now onto registration handling
     ($registration,$role) = $this->getRegistrationVlan($switch, $ifIndex, $mac, $node_info, $connection_type, $user_name, $ssid, $radius_request, $realm, $stripped_user_name, $autoreg);
-    if (defined($registration) && $registration != 0) {
+    if (defined($registration) && $registration ne 0) {
         if ( $connection_type && ($connection_type & $WIRELESS_MAC_AUTH) == $WIRELESS_MAC_AUTH ) {
             if (isenabled($node_info->{'autoreg'})) {
                 $logger->info("[$mac] Connection type is WIRELESS_MAC_AUTH and the device was coming from a secure SSID with auto registration");

--- a/lib/pf/vlan.pm
+++ b/lib/pf/vlan.pm
@@ -108,7 +108,7 @@ sub fetchVlanForNode {
     my ($violation,$registration,$role);
     # violation handling
     ($violation,$role) = $this->getViolationVlan($switch, $ifIndex, $mac, $node_info, $connection_type, $user_name, $ssid, $radius_request, $realm, $stripped_user_name, $autoreg);
-    if (defined($violation) && $violation != 0) {
+    if (defined($violation) && $violation ne "0" ) {
         $pf::StatsD::statsd->end(called() . ".timing" , $start, 0.05 );
         return ( $violation, 0, $role);
     } elsif (!defined($violation)) {
@@ -436,7 +436,7 @@ sub getNormalVlan {
     # FIRST HIT MATCH
     elsif ( defined $user_name && $connection_type && ($connection_type & $EAP) == $EAP ) {
         # Attributes has been computed in getNodeInfoForAutoReg
-        if ((isenabled($node_info->{'autoreg'}) && $autoreg) || isdisabled($profile->dot1xRecomputeRoleFromPortal)) {
+        if ((isenabled($node_info->{'autoreg'}) && $autoreg) && isdisabled($profile->dot1xRecomputeRoleFromPortal)) {
             $logger->info("[$mac] Connection type is EAP. Getting role from node_info" );
             $role = $node_info->{'category'};
         } else {


### PR DESCRIPTION
## Description

Fixes a case where unregistered nodes are sent to getNormalVlan when the registration VLAN is not an integer.
fixes #405 .
## Impacts

VLAN ids can be any string, not just integers (as per the RFC). 
The old code breaks if registrationVLAN is set to anything other than an integer. 
## NEWS file entries

New Features
++++++++++++

Enhancements
++++++++++++

Bug Fixes
+++++++++
- Fixes a case where nodes are not sent to registration VLAN when that VLAN id is not numeric.
## Delete branch after merge

YES 
