### PR TITLE
make WLC_http hybrid (802.1x vlan + web auth)

### DIFF
--- a/lib/pf/Switch/Cisco/WLC_http.pm
+++ b/lib/pf/Switch/Cisco/WLC_http.pm
@@ -163,8 +163,9 @@ sub returnRadiusAccessAccept {
     }
 
 
-    # if Roles aren't configured, return VLAN information
-    if (isenabled($this->{_VlanMap}) ) {
+    # if vlan assignement is activated, then we use it for 802.1x connections
+    # we don't return a VLAN for MAC auth since that's why the other WLC modules are there
+    if (isenabled($this->{_VlanMap}) && !($connection_type eq $WIRELESS_MAC_AUTH)) {
 
         $radius_reply_ref = {
             %$radius_reply_ref,


### PR DESCRIPTION
## Description

Makes the WLC http able to do web auth for mac authentication and do vlan assignment for 802.1x connections if vlan mapping is activated.

This should suit the most common case, where an open SSID will be used with web authentication and a secure SSID used with autoregistration and VLAN assignment.

In the case that 802.1x clients need to go though the portal, disabling vlan map will do the trick.

If VLAN assignment should be used for mac auth clients, then that's why the other wlc modules are there.
## Impacts

Changes the flow of secure vs insecure wireless connections in the WLC_http module
## NEWS file entries

New Features
++++++++++++
- Added the possibility to do VLAN assignment and Web authentication on the Cisco WLC

Enhancements
++++++++++++

Bug Fixes
+++++++++
## Delete branch after merge

YES
