### PR TITLE
Restricts the allowed ciphers to prevent FREAK SSL attack.

### DIFF
--- a/conf/httpd.conf.d/httpd.aaa
+++ b/conf/httpd.conf.d/httpd.aaa
@@ -29,6 +29,9 @@
   <IfModule !mod_status.c>
     LoadModule status_module /usr/lib/apache2/modules/mod_status.so
   </IfModule>
+  <IfModule !mod_headers.c>
+    LoadModule headers_module /usr/lib/apache2/modules/mod_headers.so
+  </IfModule>
 </IfDefine>
 
 #RHEL Specific
@@ -59,6 +62,9 @@
   </IfModule>
   <IfModule !mod_status.c>
     LoadModule status_module modules/mod_status.so
+  </IfModule>
+  <IfModule !mod_headers.c>
+    LoadModule headers_module modules/mod_headers.so
   </IfModule>
 </IfDefine>
 
@@ -115,8 +121,8 @@ $SSLRandomSeed = "startup builtin";
 $SSLRandomSeed = "startup file:/dev/urandom 1024";
 $SSLRandomSeed = "connect builtin";
 $SSLRandomSeed = "connect file:/dev/urandom 1024";
-$SSLProtocol = "All -SSLv2";
-$SSLCipherSuite = "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-ECDSA-RC4-SHA:AES128:AES256:RC4-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!3DES:!MD5:!PSK";
+$SSLProtocol = "All -SSLv2 -SSLv3";
+$SSLCipherSuite = "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA";
 $SSLHonorCipherOrder = "on";
 
 $ErrorLog = $install_dir.'/logs/httpd.aaa.error';
@@ -143,6 +149,8 @@ if (defined($management_network->{'Tip'}) && $management_network->{'Tip'} ne '')
              CustomLog           => $install_dir.'/logs/httpd.aaa.access combined',
              SSLEngine           => 'on',
              Include             => $var_dir.'/conf/ssl-certificates.conf',
+             # HSTS (mod_headers is required) (15768000 seconds = 6 months)
+             Header             =>  'always add Strict-Transport-Security "max-age=15768000"'
              Location     => {
                   "/" => {
                       SetHandler          => 'modperl',

--- a/conf/httpd.conf.d/httpd.admin
+++ b/conf/httpd.conf.d/httpd.admin
@@ -26,6 +26,9 @@
   <IfModule !mod_apreq2.c>
     LoadModule apreq_module /usr/lib/apache2/modules/mod_apreq2.so
   </IfModule>
+  <IfModule !mod_headers.c>
+    LoadModule headers_module /usr/lib/apache2/modules/mod_headers.so
+  </IfModule>
 </IfDefine>
 
 #RHEL specific
@@ -53,6 +56,9 @@
   </IfModule>
   <IfModule !mod_apreq2.c>
     LoadModule apreq_module modules/mod_apreq2.so
+  </IfModule>
+  <IfModule !mod_headers.c>
+    LoadModule headers_module modules/mod_headers.so
   </IfModule>
 </IfDefine>
 
@@ -125,8 +131,8 @@ $SSLRandomSeed = "startup builtin";
 $SSLRandomSeed = "startup file:/dev/urandom 1024";
 $SSLRandomSeed = "connect builtin";
 $SSLRandomSeed = "connect file:/dev/urandom 1024";
-$SSLProtocol = "All -SSLv2";
-$SSLCipherSuite = "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-ECDSA-RC4-SHA:AES128:AES256:RC4-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!3DES:!MD5:!PSK";
+$SSLProtocol = "All -SSLv2 -SSLv3";
+$SSLCipherSuite = "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA";
 $SSLHonorCipherOrder = "on";
 
 $ErrorLog = $install_dir.'/logs/httpd.admin.error';
@@ -142,6 +148,8 @@ push @{ $VirtualHost{$vhost} },
          SSLEngine    => 'on',
          Include      => $var_dir.'/conf/ssl-certificates.conf',
          SSLProxyEngine    => 'on',
+         # HSTS (mod_headers is required) (15768000 seconds = 6 months)
+         Header             =>  'always add Strict-Transport-Security "max-age=15768000"'
          PerlModule        => 'pf::web::admin',
          PerlTransHandler  => 'pf::web::admin->proxy_portal',
          ProxyRequests     => 'off',

--- a/conf/httpd.conf.d/httpd.portal
+++ b/conf/httpd.conf.d/httpd.portal
@@ -212,8 +212,8 @@ $SSLRandomSeed = "startup builtin";
 $SSLRandomSeed = "startup file:/dev/urandom 1024";
 $SSLRandomSeed = "connect builtin";
 $SSLRandomSeed = "connect file:/dev/urandom 1024";
-$SSLProtocol = "All -SSLv2";
-$SSLCipherSuite = "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-ECDSA-RC4-SHA:AES128:AES256:RC4-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!3DES:!MD5:!PSK";
+$SSLProtocol = "All -SSLv2 -SSLv3";
+$SSLCipherSuite = "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA";
 $SSLHonorCipherOrder = "on";
 
 $ErrorLog = $install_dir.'/logs/portal_error_log';
@@ -360,9 +360,11 @@ foreach my $interface (@internal_nets) {
              @status_options,
              @allowed_from_all_options,
          ),
-         SSLEngine => 'on',
+         SSLEngine         => 'on',
          SSLProxyEngine    => 'on',
-         Include      => "${var_dir}/conf/ssl-certificates.conf",
+         Include           => "${var_dir}/conf/ssl-certificates.conf",
+         # HSTS (mod_headers is required) (15768000 seconds = 6 months)
+         Header            =>  'always add Strict-Transport-Security "max-age=15768000"'
     ));
 }
 
@@ -476,9 +478,11 @@ if (defined($management_network->{'Tip'}) && $management_network->{'Tip'} ne '')
              },
              @allowed_from_all_options,
          ),
-         SSLEngine => 'on',
+         SSLEngine         => 'on',
          SSLProxyEngine    => 'on',
-         Include      => "${var_dir}/conf/ssl-certificates.conf",
+         Include           => "${var_dir}/conf/ssl-certificates.conf",
+         # HSTS (mod_headers is required) (15768000 seconds = 6 months)
+         Header            =>  'always add Strict-Transport-Security "max-age=15768000"'
     );
 
 } 

--- a/conf/httpd.conf.d/httpd.proxy
+++ b/conf/httpd.conf.d/httpd.proxy
@@ -156,6 +156,17 @@ foreach my $port (split(',',$PfConfig->{'trapping'}{'interception_proxy_port'}))
     push (@NameVirtualHost,"*:".$port);
 }
 
+$SSLPassPhraseDialog = "builtin";
+$SSLSessionCache = "shm:".$install_dir."/var/ssl_wcache(512000)";
+$SSLSessionCacheTimeout = "300";
+$SSLRandomSeed = "startup builtin";
+$SSLRandomSeed = "startup file:/dev/urandom 1024";
+$SSLRandomSeed = "connect builtin";
+$SSLRandomSeed = "connect file:/dev/urandom 1024";
+$SSLProtocol = "All -SSLv2 -SSLv3";
+$SSLCipherSuite = "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA";
+$SSLHonorCipherOrder = "on";
+
 push (@NameVirtualHost,"*:444");
 push (@Listen,"127.0.0.1:444");
 push @{ $VirtualHost{'*:444'} }, gen_conf(

--- a/conf/httpd.conf.d/httpd.webservices
+++ b/conf/httpd.conf.d/httpd.webservices
@@ -29,6 +29,9 @@
   <IfModule !mod_status.c>
     LoadModule status_module /usr/lib/apache2/modules/mod_status.so
   </IfModule>
+  <IfModule !mod_headers.c>
+    LoadModule headers_module /usr/lib/apache2/modules/mod_headers.so
+  </IfModule>
 </IfDefine>
 
 #RHEL Specific
@@ -59,6 +62,9 @@
   </IfModule>
   <IfModule !mod_status.c>
     LoadModule status_module modules/mod_status.so
+  </IfModule>
+  <IfModule !mod_headers.c>
+    LoadModule headers_module modules/mod_headers.so
   </IfModule>
 </IfDefine>
 
@@ -115,8 +121,8 @@ $SSLRandomSeed = "startup builtin";
 $SSLRandomSeed = "startup file:/dev/urandom 1024";
 $SSLRandomSeed = "connect builtin";
 $SSLRandomSeed = "connect file:/dev/urandom 1024";
-$SSLProtocol = "All -SSLv2";
-$SSLCipherSuite = "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-ECDSA-RC4-SHA:AES128:AES256:RC4-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!3DES:!MD5:!PSK";
+$SSLProtocol = "All -SSLv2 -SSLv3";
+$SSLCipherSuite = "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA";
 $SSLHonorCipherOrder = "on";
 
 $ErrorLog = $install_dir.'/logs/httpd.webservices.error';
@@ -143,6 +149,8 @@ if (defined($management_network->{'Tip'}) && $management_network->{'Tip'} ne '')
              CustomLog           => $install_dir.'/logs/httpd.webservices.access combined',
              SSLEngine           => 'on',
              Include             => $var_dir.'/conf/ssl-certificates.conf',
+             # HSTS (mod_headers is required) (15768000 seconds = 6 months)
+             Header             =>  'always add Strict-Transport-Security "max-age=15768000"'
              Location     => {
                   "/" => {
                       SetHandler          => 'modperl',


### PR DESCRIPTION
## Description

Restricts the allowed ciphers to prevent FREAK SSL attack (CVE-2015-0204).
Turns on HSTS.

Fixes #411 .
## Impacts

This restricts what ciphers can be used on TLS webservers.
Note that it will prevent legacy browsers from working (i.e. IE 7 and older). 

Please test that all TLS using services still work. 
## NEWS file entries

Enhancements
++++++++++++
- Http server will no longer allow downgrade to legacy "export" cipher suites and will not accept SSLv3.
## Delete branch after merge

YES
