### PR TITLE
Default date for create for valid_from

### DIFF
--- a/html/pfappserver/lib/pfappserver/Form/User/Create.pm
+++ b/html/pfappserver/lib/pfappserver/Form/User/Create.pm
@@ -16,6 +16,7 @@ extends 'pfappserver::Base::Form::Authentication::Action';
 use List::Util qw(first);
 use List::MoreUtils qw(none);
 use pf::admin_roles;
+use DateTime;
 has '+source_type' => ( default => 'SQL' );
 
 # Form fields
@@ -23,6 +24,7 @@ has_field 'valid_from' =>
   (
    type => 'DatePicker',
    required => 1,
+   default => DateTime->now->ymd(),
   );
 
 has_field 'expiration' =>


### PR DESCRIPTION
## Description

Set the default date of user  valid_from to the current date
## Impacts

Admin GUI user creation
## NEWS file entries

Enhancements
++++++++++++
- Set the registration start date to the current date when creating a user
## Delete branch after merge

NO
