### PR TITLE
Ensure that the file permissions of the pfconfig socket is correct

### DIFF
--- a/sbin/pfconfig
+++ b/sbin/pfconfig
@@ -33,12 +33,17 @@ our $PROGRAM_NAME = $0 = basename($0);
 my $socket_path = $pfconfig::constants::SOCKET_PATH;
 unlink($socket_path);
 
+#Ensure that the file permissions of the socket is correct 0770
+umask(0007);
+
 my $listner = IO::Socket::UNIX->new(
    Type   => SOCK_STREAM,
    Local  => $socket_path,
    Listen => SOMAXCONN,
 )
    or die("Can't create server socket: $!\n");
+
+umask(0);
 
 my $cache = pfconfig::manager->new;
 $cache->preload_all();


### PR DESCRIPTION
## Description

The file permissions of the socket was being set to 0644.
Which means any non root process could read from the socket.
## Impacts

pfconfig file permissions
## NEWS file entries

New Features
++++++++++++

Enhancements
++++++++++++

Bug Fixes
+++++++++
## Delete branch after merge

NO
