### PR TITLE
pfmon should unregister nodes in pending state when unregdate is reached.

### DIFF
--- a/lib/pf/node.pm
+++ b/lib/pf/node.pm
@@ -296,7 +296,9 @@ sub node_db_prepare {
     ];
 
     $node_statements->{'node_expire_unreg_field_sql'} = get_db_handle()->prepare(
-        qq [ select mac from node where status="reg" and unregdate != 0 and unregdate < now() ]);
+        qq [ select mac from node where ( 
+                status="reg" and unregdate != 0 and unregdate < now() ) or (
+                status="pending" and unregdate < now() ) ]);
 
     $node_statements->{'node_expire_lastarp_sql'} = get_db_handle()->prepare(
         qq [ select mac from node where unix_timestamp(last_arp) < (unix_timestamp(now()) - ?) and last_arp!=0 ]);

--- a/lib/pf/node.pm
+++ b/lib/pf/node.pm
@@ -296,9 +296,9 @@ sub node_db_prepare {
     ];
 
     $node_statements->{'node_expire_unreg_field_sql'} = get_db_handle()->prepare(
-        qq [ select mac from node where ( 
-                status="reg" and unregdate != 0 and unregdate < now() ) or (
-                status="pending" and unregdate < now() ) ]);
+        qq [ select mac from node where 
+                ( status="reg" and unregdate != 0 and unregdate < now() ) or 
+                ( status="pending" and unregdate < now() ) ]);
 
     $node_statements->{'node_expire_lastarp_sql'} = get_db_handle()->prepare(
         qq [ select mac from node where unix_timestamp(last_arp) < (unix_timestamp(now()) - ?) and last_arp!=0 ]);


### PR DESCRIPTION
## Description

pfmon needs to check nodes that are in pending state to prevent them from staying in that state indefinitely if the user never actually registers.
## Impacts

Changes the maintenance sql run by pfmon so that pending nodes are also unregistered if their time is up.
## NEWS file entries

Bug Fixes
+++++++++

Devices can no longer remain in "pending" state indefinitely.
## Delete branch after merge

YES 
