### PR TITLE
Allow HTTP and HTTPS in iptables on management interface

### DIFF
--- a/conf/iptables.conf.example
+++ b/conf/iptables.conf.example
@@ -46,9 +46,6 @@
 # Mysql
 -A input-management-if --protocol tcp --match tcp --dport 3306 --jump ACCEPT
 
-# HTTPS for email confirmation or sponsor activation on the captive portal (if enabled)
-%%input_mgmt_guest_rules%%
-
 :input-internal-vlan-if - [0:0]
 # DNS
 -A input-internal-vlan-if --protocol tcp --match tcp --dport 53  --jump ACCEPT

--- a/conf/iptables.conf.example
+++ b/conf/iptables.conf.example
@@ -14,6 +14,9 @@
 :input-management-if - [0:0]
 # SSH
 -A input-management-if --match state --state NEW --match tcp --protocol tcp --dport 22 --jump ACCEPT
+# HTTP and HTTPS for the portal
+-A input-management-if --protocol tcp --match tcp --dport 80 --jump ACCEPT
+-A input-management-if --protocol tcp --match tcp --dport 443 --jump ACCEPT
 # Web Admin
 -A input-management-if --protocol tcp --match tcp --dport %%web_admin_port%% --jump ACCEPT
 # Webservices

--- a/lib/pf/iptables.pm
+++ b/lib/pf/iptables.pm
@@ -132,23 +132,6 @@ sub iptables_generate {
         );
     }
 
-    # per-feature firewall rules
-    # self-registered guest by email or sponsored or gaming registration
-    # pre-registration guest
-    my $device_registration_enabled = isenabled($Config{'registration'}{'device_registration'});
-    my $pre_registration_enabled    = isenabled($Config{'guests_self_registration'}{'preregistration'});
-    my $email_enabled = $guest_self_registration{$SELFREG_MODE_EMAIL};
-    my $sponsor_enabled = $guest_self_registration{$SELFREG_MODE_SPONSOR};
-    my $chained_enabled = $guest_self_registration{$SELFREG_MODE_CHAINED};
-    if ( $email_enabled || $sponsor_enabled || $chained_enabled || $device_registration_enabled || $pre_registration_enabled ) {
-        $tags{'input_mgmt_guest_rules'} =
-            "-A $FW_FILTER_INPUT_MGMT --protocol tcp --match tcp --dport 443 --jump ACCEPT"
-        ;
-    }
-    else {
-        $tags{'input_mgmt_guest_rules'} = '';
-    }
-
     chomp(
         $tags{'filter_if_src_to_chain'}, $tags{'filter_forward_inline'},
         $tags{'mangle_if_src_to_chain'}, $tags{'mangle_prerouting_inline'},


### PR DESCRIPTION
## Description

Allows access to the captive portal on the management interface by default for web authentication, status page, etc
## Impacts

Allows access to the captive portal from the production network by default
## NEWS file entries

None required I think
## Delete branch after merge

YES
