### PR TITLE
Checkup should only warn that there are no internal networks

### DIFF
--- a/lib/pf/pfcmd/checkup.pm
+++ b/lib/pf/pfcmd/checkup.pm
@@ -200,7 +200,7 @@ check the Netmask objs and make sure a managed and internal interface exist
 sub interfaces {
 
     if ( !scalar(get_internal_devs()) ) {
-        add_problem( $FATAL, "internal network(s) not defined!" );
+        add_problem( $WARN, "internal network(s) not defined!" );
     }
 
     my %seen;


### PR DESCRIPTION
## Description

There are cases where we do not want internal networks like in a pure web auth setup. Adding fake devices makes clustering configuration a pain
## Impacts

Allows PacketFence to start without any internal networks
## NEWS file entries

Enhancements
++++++++++++
- PacketFence will accept to start even if there are no internal networks.
## Delete branch after merge

YES
