### PR TITLE
Added a optional paramater to be able to change the host in the activation link (Email/Sponsor)

### DIFF
--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Signup.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Signup.pm
@@ -175,6 +175,8 @@ sub doEmailSelfRegistration : Private {
     $session->{source_id} = $source->{id};
     $c->forward(Authenticate => 'setRole');
 
+    $info{'activation_domain'} = $source->{activation_domain} if (defined($source->{activation_domain}));
+
     # form valid, adding person (using modify in case person already exists)
     person_modify(
         $pid,

--- a/html/pfappserver/lib/pfappserver/Form/Config/Authentication/Source/Email.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Authentication/Source/Email.pm
@@ -50,6 +50,17 @@ has_field 'create_local_account' => (
     },
 );
 
+has_field 'activation_domain' =>
+  (
+   type => 'Text',
+   label => 'Host in activation link',
+   required => 0,
+    tags => {
+        after_element => \&help,
+        help => 'Set this value if you want to change the hostname in the validation link.',
+    },
+  );
+
 =head1 COPYRIGHT
 
 Copyright (C) 2005-2015 Inverse inc.

--- a/html/pfappserver/lib/pfappserver/Form/Config/Authentication/Source/SponsorEmail.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Authentication/Source/SponsorEmail.pm
@@ -40,6 +40,17 @@ has_field 'create_local_account' => (
     },
 );
 
+has_field 'activation_domain' =>
+  (
+   type => 'Text',
+   label => 'Host in activation link',
+   required => 0,
+    tags => {
+        after_element => \&help,
+        help => 'Set this value if you want to change the hostname in the validation link.',
+    },
+  );
+
 =head1 COPYRIGHT
 
 Copyright (C) 2005-2015 Inverse inc.

--- a/html/pfappserver/root/authentication/source/type/Email.tt
+++ b/html/pfappserver/root/authentication/source/type/Email.tt
@@ -1,3 +1,4 @@
+[% form.field('activation_domain').render %]
 [% form.field('email_activation_timeout').render %]
 [% form.field('allow_localdomain').render %]
 [% form.field('create_local_account').render %]

--- a/html/pfappserver/root/authentication/source/type/SponsorEmail.tt
+++ b/html/pfappserver/root/authentication/source/type/SponsorEmail.tt
@@ -1,2 +1,3 @@
+[% form.field('activation_domain').render %]
 [% form.field('allow_localdomain').render %]
 [% form.field('create_local_account').render %]

--- a/lib/pf/Authentication/Source/EmailSource.pm
+++ b/lib/pf/Authentication/Source/EmailSource.pm
@@ -19,7 +19,8 @@ has '+unique' => (default => 1);
 has 'allow_localdomain' => (isa => 'Str', is => 'rw', default => 'yes');
 has 'email_activation_timeout' => (isa => 'Str', is => 'rw', default => '10m');
 has 'create_local_account' => (isa => 'Str', is => 'rw', default => 'no');
-
+has 'activation_domain' => (isa => 'Maybe[Str]', is => 'rw');
+ 
 =head2 available_attributes
 
 Allow to make a condition on the user's email address.

--- a/lib/pf/Authentication/Source/SponsorEmailSource.pm
+++ b/lib/pf/Authentication/Source/SponsorEmailSource.pm
@@ -18,6 +18,7 @@ has '+type' => (default => 'SponsorEmail');
 has '+unique' => (default => 1);
 has 'allow_localdomain' => (isa => 'Str', is => 'rw', default => 'yes');
 has 'create_local_account' => (isa => 'Str', is => 'rw', default => 'no');
+has 'activation_domain' => (isa => 'Maybe[Str]', is => 'rw');
 
 =head2 available_attributes
 


### PR DESCRIPTION
## Description

New activation_domain feature to allow to expose a different domain than packetfence's name in email templates
## Impacts

No impact
## Delete branch after merge

YES
## NEWS file entries

New Features
++++++++++++
New activation_domain feature to allow to expose a different domain than packetfence's name in email templates
