### PR TITLE
Use the host header if define to redirect the device after the registration instead of the fqdn of packetfence

### DIFF
--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Release.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Release.pm
@@ -27,9 +27,10 @@ sub index : Path : Args(0) {
     my ( $self, $c ) = @_;
     my $request = $c->request;
     if ( $request->secure ) {
-        $c->response->redirect( "http://"
-              . $Config{'general'}{'hostname'} . "."
-              . $Config{'general'}{'domain'}
+        my $host = ( defined($request->{'headers'}{'host'}) ? $request->{'headers'}{'host'} :
+              $Config{'general'}{'hostname'} . "."
+              . $Config{'general'}{'domain'} );
+        $c->response->redirect( "http://$host"
               . '/access?destination_url='
               . uri_escape( $c->stash->{destination_url} ) );
     } else {


### PR DESCRIPTION
## Description

At the end of the portal profile if we use https portal then the http redirection will use the host header instead of packetfence fqdn. (Usefull for external captive portal)  
## Impacts

NO
## Delete branch after merge

YES
## NEWS file entries

New Features
++++++++++++

Enhancements
++++++++++++
- Adapt the end process redirection on the portal
