### PR TITLE
Stopped pfsetvlan+snmptrapd by default

### DIFF
--- a/UPGRADE.asciidoc
+++ b/UPGRADE.asciidoc
@@ -16,6 +16,12 @@ Upgrading from a version prior to X.Y.Z
 
 Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence X.Y.Z).
 
+pfsetvlan and snmptrapd
+^^^^^^^^^^^^^^^^^^^^^^^
+
+These two services have been disabled by default. 
+If you are using SNMP traps enforcement on your switches (like port-security), make sure you re-enable them in 'Configuration->Services'.
+
 
 Upgrading from a version prior to 5.0.0
 ---------------------------------------

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -506,12 +506,12 @@ httpd_proxy=enabled
 # services.pfsetvlan
 #
 # Should pfsetvlan be managed by PacketFence?
-pfsetvlan=enabled
+pfsetvlan=disabled
 #
 # services.snmptrapd
 #
 # Should snmptrapd be managed by PacketFence?
-snmptrapd=enabled
+snmptrapd=disabled
 #
 # services.pfmon
 #


### PR DESCRIPTION
## Description

Stops pfsetvlan and snmptrapd by default in PacketFence
## Impacts

Will stop eating RAM for no reason
## Issue

fixes #489 
## Delete branch after merge

YES
## NEWS file entries

Enhancements
++++++++++++
- pfsetvlan and snmptrapd are now stopped by default
