### PR TITLE
Use a binary protocol for receiving sereal data from pfconfig

### DIFF
--- a/lib/pf/util/networking.pm
+++ b/lib/pf/util/networking.pm
@@ -1,0 +1,101 @@
+package pf::util::networking;
+=head1 NAME
+
+pf::util::networking
+
+=cut
+
+=head1 DESCRIPTION
+
+pf::util::networking
+
+=cut
+
+use strict;
+use warnings;
+use Errno qw(EINTR EAGAIN);
+
+use base qw(Exporter);
+
+our @EXPORT_OK = qw(syswrite_all sysread_all);
+
+=head2 syswrite_all
+
+A wrapper around syswrite to ensure all bytes are written to a socket
+
+=cut
+
+sub syswrite_all {
+    my ($socket,$buffer) = @_;
+    my $bytes_to_send = length $buffer;
+    my $offset = 0;
+    my $total_written = 0;
+    while ($bytes_to_send) {
+        my $bytes_sent = syswrite($socket, $buffer, $bytes_to_send, $offset);
+        unless (defined $bytes_sent) {
+            next if $! == EINTR;
+            last;
+        }
+        return $offset unless $bytes_sent;
+        $offset += $bytes_sent;
+        $bytes_to_send -= $bytes_sent;
+    }
+    return $offset;
+}
+
+=head2 sysread_all
+
+A wrapper around sysread to ensure all bytes are read from a socket
+
+=cut
+
+
+sub sysread_all {
+    my $socket = $_[0];
+    our $buf;
+    local *buf = \$_[1];    # alias
+    my $bytes_to_read = $_[2];
+    my $offset = 0;
+    $buf = '';
+    while($bytes_to_read) {
+        my $bytes_read = sysread($socket,$buf,$bytes_to_read,$offset);
+        unless (defined $bytes_read) {
+            next if $! == EINTR;
+            last;
+        }
+        return $offset unless $bytes_read;
+        $bytes_to_read -= $bytes_read;
+        $offset += $bytes_read;
+    }
+    return $offset;
+}
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2015 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;
+

--- a/lib/pf/util/networking.pm
+++ b/lib/pf/util/networking.pm
@@ -81,7 +81,7 @@ sub send_data_with_length {
     my $bytes_to_send = length $packed_data;
     my $bytes_sent = syswrite_all($socket, $packed_data);
     if(defined $bytes_sent && $bytes_sent > 4) {
-        #substracting the four bytes appened to the begining
+        #substracting the four bytes appended to the begining
         $bytes_sent -= 4;
     }
     return $bytes_sent;

--- a/lib/pfconfig/cached.pm
+++ b/lib/pfconfig/cached.pm
@@ -39,6 +39,7 @@ use pfconfig::constants;
 use Sereal::Encoder;
 use Sereal::Decoder;
 use Time::HiRes qw(stat time);
+use bytes;
 
 =head2 ENCODER
 
@@ -282,7 +283,6 @@ sub CLONE {
     $ENCODER = Sereal::Encoder->new;
     $DECODER = Sereal::Decoder->new;
 }
-
 
 =head1 AUTHOR
 

--- a/lib/pfconfig/util.pm
+++ b/lib/pfconfig/util.pm
@@ -18,7 +18,7 @@ use strict;
 use warnings;
 use base qw(Exporter);
 use pf::constants::config qw(%NET_INLINE_TYPES);
-use pf::util::networking qw(syswrite_all sysread_all);
+use pf::util::networking qw(syswrite_all sysread_all read_data_with_length);
 use pfconfig::constants;
 use pfconfig::undef_element;
 use pfconfig::log;
@@ -45,11 +45,7 @@ sub fetch_socket {
     # we ask the cachemaster for our namespaced key
     $payload .= "\n";
     my $bytes_sent = syswrite_all($socket,$payload);
-
-    #Get the first four bytes to find out the length of the sereal buffer
-    sysread_all($socket,my $sereal_buff_size,4);
-    my $bytes_to_read = unpack("V",$sereal_buff_size);
-    sysread_all($socket, my $sereal_buffer,$bytes_to_read);
+    read_data_with_length($socket,my $sereal_buffer);
     return $sereal_buffer;
 }
 

--- a/lib/pfconfig/util.pm
+++ b/lib/pfconfig/util.pm
@@ -42,12 +42,17 @@ sub fetch_socket {
     #pfconfig::log::get_logger->info("Doing request to pfconfig with payload : '$payload'");
 
     # we ask the cachemaster for our namespaced key
-    print $socket "$payload\n";
-
+    my $bytes_to_send = length $payload;
+    my $offset = 0;
+    while($bytes_to_send > 0) {
+        my $bytes_sent = $socket->syswrite($payload,$bytes_to_send,$offset);
+        $offset += $bytes_sent;
+        $bytes_to_send -= $bytes_sent;
+    }
     #Get the first for bytes to find out the length of the sereal buffer
     my $bytes_to_read = 4;
     my $buffer = '';
-    my $offset = 0;
+    $offset = 0;
     while($bytes_to_read) {
         my $bytes_read = $socket->sysread($buffer,$bytes_to_read,$offset);
         $bytes_to_read -= $bytes_read;

--- a/sbin/pfconfig
+++ b/sbin/pfconfig
@@ -43,7 +43,9 @@ use POSIX qw(:signal_h);
 use pf::services::util;
 use pfconfig::constants;
 use Sereal::Encoder;
-use Errno qw(EINTR);
+use Errno qw(EINTR EAGAIN);
+use bytes;
+use pf::util::networking qw(syswrite_all sysread_all);
 $pfconfig::timeme::VERBOSE = 0;
 our $RUNNING = 1;
 
@@ -363,12 +365,10 @@ sub send_output {
     #appending a little endian integer in front of the data
     my $packed_data = pack("V/a*",$encoded_data);
     my $bytes_to_send = length $packed_data;
-    my $offset = 0;
-    while($bytes_to_send > 0) {
-        my $bytes_sent = $socket->syswrite($packed_data,$bytes_to_send,$offset);
-        $offset += $bytes_sent;
-        $bytes_to_send -= $bytes_sent;
-     }
+    my $bytes_sent = syswrite_all($socket, $packed_data);
+    if($bytes_to_send != $bytes_sent) {
+        $logger->error("Could not send all bytes the client. $bytes_sent of $bytes_to_send sent");
+    }
 }
 
 =head2 server_sleep

--- a/sbin/pfconfig
+++ b/sbin/pfconfig
@@ -161,7 +161,7 @@ while($RUNNING) {
     };
     if($@){
         print STDERR "$line : $@";
-        send_output("undef", $socket) if $socket;
+        send_output(undef, $socket) if $socket;
     }
 }
 
@@ -223,7 +223,7 @@ sub get_hash_element {
         else{
             print STDERR "Unknown key $query->{key}";
             $logger->error("Unknown key $query->{key}");
-            $elem = "undef";
+            $elem = undef;
         }
     }
     else{
@@ -242,7 +242,7 @@ sub get_from_cache_or_croak {
     else{
         print STDERR "Unknown key in cache $key \n";
         $logger->error("Unknown key $key");
-        send_output("undef", $socket);
+        send_output(undef, $socket);
         return undef;
     }
 
@@ -319,7 +319,7 @@ sub get_array_element {
         else{
             print STDERR "Unknown index in $query->{key}";
             $logger->error("Unknown index in $query->{key}");
-            $elem = "undef";
+            $elem = undef;
         }
     }
     else {
@@ -359,17 +359,16 @@ sub encode_output {
 
 sub send_output {
     my ($data, $socket) = @_;
-    unless($data eq "undef"){
-        my $data = encode_output($data);
-        my $lines = $data =~ tr/\n// || 0;
-        $lines += 1;
-        print $socket $lines."\n";
-        print $socket $data;
-    }
-    else{
-        print $socket "1\n";
-        print $socket "$data";
-    }
+    my $encoded_data = encode_output($data);
+    #appending a little endian integer in front of the data
+    my $packed_data = pack("V/a*",$encoded_data);
+    my $bytes_to_send = length $packed_data;
+    my $offset = 0;
+    while($bytes_to_send > 0) {
+        my $bytes_sent = $socket->syswrite($packed_data,$bytes_to_send,$offset);
+        $offset += $bytes_sent;
+        $bytes_to_send -= $bytes_sent;
+     }
 }
 
 =head2 server_sleep

--- a/sbin/pfconfig
+++ b/sbin/pfconfig
@@ -45,7 +45,7 @@ use pfconfig::constants;
 use Sereal::Encoder;
 use Errno qw(EINTR EAGAIN);
 use bytes;
-use pf::util::networking qw(syswrite_all sysread_all);
+use pf::util::networking qw(send_data_with_length);
 $pfconfig::timeme::VERBOSE = 0;
 our $RUNNING = 1;
 
@@ -362,10 +362,8 @@ sub encode_output {
 sub send_output {
     my ($data, $socket) = @_;
     my $encoded_data = encode_output($data);
-    #appending a little endian integer in front of the data
-    my $packed_data = pack("V/a*",$encoded_data);
-    my $bytes_to_send = length $packed_data;
-    my $bytes_sent = syswrite_all($socket, $packed_data);
+    my $bytes_to_send = length($encoded_data);
+    my $bytes_sent  = send_data_with_length($socket,$encoded_data);
     if($bytes_to_send != $bytes_sent) {
         $logger->error("Could not send all bytes the client. $bytes_sent of $bytes_to_send sent");
     }

--- a/t/unittest/util/networking.t
+++ b/t/unittest/util/networking.t
@@ -22,7 +22,7 @@ BEGIN {
     use PfFilePaths;
 }
 
-use Test::More tests => 7;
+use Test::More tests => 10;
 #This test will running last
 use Test::NoWarnings;
 use Socket;
@@ -38,6 +38,21 @@ my $data = "1" x (1024*64);
     is(pf::util::networking::syswrite_all($client,$data),length($data),"Writing all the bytes to a socket");
 
     is(pf::util::networking::sysread_all($server,my $read_buf, length($data)),length($data),"Reading all the bytes from a socket");
+
+    is($read_buf,$data,"Bytes written to socket is equal to the bytes read from a socket");
+
+    shutdown($client,2);
+    shutdown($server,2);
+    close($client);
+    close($server);
+}
+
+{
+    socketpair(my $client, my $server, AF_UNIX, SOCK_STREAM, PF_UNSPEC) or BAILOUT("Cannot create socketpair $!");
+
+    is(pf::util::networking::send_data_with_length($client,$data),length($data),"Writing data with embedded length to a socket");
+
+    is(pf::util::networking::read_data_with_length($server,my $read_buf),length($data),"Reading data with embedded length to a socket");
 
     is($read_buf,$data,"Bytes written to socket is equal to the bytes read from a socket");
 

--- a/t/unittest/util/networking.t
+++ b/t/unittest/util/networking.t
@@ -1,18 +1,17 @@
 =head1 NAME
 
-example pf test
+util::networking test
 
 =cut
 
 =head1 DESCRIPTION
 
-example pf test script
+util::networking test
 
 =cut
 
 use strict;
 use warnings;
-#
 use lib '/usr/local/pf/lib';
 
 BEGIN {
@@ -112,5 +111,3 @@ USA.
 =cut
 
 1;
-
-

--- a/t/unittest/util/networking.t
+++ b/t/unittest/util/networking.t
@@ -1,0 +1,101 @@
+=head1 NAME
+
+example pf test
+
+=cut
+
+=head1 DESCRIPTION
+
+example pf test script
+
+=cut
+
+use strict;
+use warnings;
+#
+use lib '/usr/local/pf/lib';
+
+BEGIN {
+    #include test libs
+    use lib qw(/usr/local/pf/t);
+    #Module for overriding configuration paths
+    use PfFilePaths;
+}
+
+use Test::More tests => 7;
+#This test will running last
+use Test::NoWarnings;
+use Socket;
+
+
+use_ok("pf::util::networking");
+
+my $data = "1" x (1024*64);
+
+{
+    socketpair(my $client, my $server, AF_UNIX, SOCK_STREAM, PF_UNSPEC) or BAILOUT("Cannot create socketpair $!");
+
+    is(pf::util::networking::syswrite_all($client,$data),length($data),"Writing all the bytes to a socket");
+
+    is(pf::util::networking::sysread_all($server,my $read_buf, length($data)),length($data),"Reading all the bytes from a socket");
+
+    is($read_buf,$data,"Bytes written to socket is equal to the bytes read from a socket");
+
+    shutdown($client,2);
+    shutdown($server,2);
+    close($client);
+    close($server);
+}
+
+{
+    socketpair(my $client, my $server, AF_UNIX, SOCK_STREAM, PF_UNSPEC) or BAILOUT("Cannot create socketpair $!");
+    my $pid = fork;
+    BAILOUT("Cannot fork") unless defined $pid;
+    if($pid) {
+        is(pf::util::networking::sysread_all($server,my $read_buf, length($data)),length($data),"Reading all the bytes from a socket sent one byte at a time");
+        is($read_buf,$data,"Bytes written to socket is equal to the bytes read from a socket sent one byte at a time");
+    }
+    else {
+        my $data_length = length($data);
+        #Writing to the buffer one byte at a time
+        for (my $i = 0;$i < $data_length;$i++) {
+            syswrite($client,$data,1,$i);
+        }
+        exit;
+    }
+    shutdown($client,2);
+    shutdown($server,2);
+    close($client);
+    close($server);
+}
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2015 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;
+
+


### PR DESCRIPTION
## Description

Use a binary protocol for receiving sereal data for pfconfig.
This was done to improve the speed in which we send and retrieve data
## Impacts

pfconfig
## NEWS file entries

New Features
++++++++++++

Enhancements
++++++++++++
- Improve the pfconfig protocol

Bug Fixes
+++++++++
## Delete branch after merge

NO
