### PR TITLE
Switch range definition in switch configuration

### DIFF
--- a/conf/switches.conf.example
+++ b/conf/switches.conf.example
@@ -104,3 +104,8 @@ uplink = 23,24
 #SNMPPrivProtocolTrap = DES
 #SNMPPrivPasswordTrap = privpwdread
 
+[192.168.1.0/24]
+description=Test Range Switch
+type = Cisco::Catalyst_2900XL
+mode = production
+uplink = 23,24

--- a/db/pf-schema-X.Y.Z.sql
+++ b/db/pf-schema-X.Y.Z.sql
@@ -505,6 +505,8 @@ CREATE TABLE radius_nas (
   community varchar(50),
   description varchar(200) default 'RADIUS Client',
   config_timestamp BIGINT,
+  start_ip INT DEFAULT 0,
+  end_ip INT DEFAULT 0,
   PRIMARY KEY nasname (nasname)
 ) ENGINE=InnoDB;
 

--- a/db/pf-schema-X.Y.Z.sql
+++ b/db/pf-schema-X.Y.Z.sql
@@ -496,7 +496,6 @@ VALUES
 -- Adding RADIUS nas client table
 
 CREATE TABLE radius_nas (
-  position int(5),
   nasname varchar(128) NOT NULL,
   shortname varchar(32),
   type varchar(30) default 'other',
@@ -505,8 +504,9 @@ CREATE TABLE radius_nas (
   community varchar(50),
   description varchar(200) default 'RADIUS Client',
   config_timestamp BIGINT,
-  start_ip INT DEFAULT 0,
-  end_ip INT DEFAULT 0,
+  start_ip INT UNSIGNED DEFAULT 0,
+  end_ip INT UNSIGNED DEFAULT 0,
+  range_length INT DEFAULT 0,
   PRIMARY KEY nasname (nasname)
 ) ENGINE=InnoDB;
 

--- a/db/pf-schema-X.Y.Z.sql
+++ b/db/pf-schema-X.Y.Z.sql
@@ -496,6 +496,7 @@ VALUES
 -- Adding RADIUS nas client table
 
 CREATE TABLE radius_nas (
+  position int(5),
   nasname varchar(128) NOT NULL,
   shortname varchar(32),
   type varchar(30) default 'other',

--- a/db/upgrade-X.X.X-X.Y.Z.sql
+++ b/db/upgrade-X.X.X-X.Y.Z.sql
@@ -50,7 +50,7 @@ VALUES
 -- Add a column to radius_nas to order the nas list
 --
 
-ALTER TABLE radius_nas ADD `position` INT FIRST, ADD start_ip INT DEFAULT 0, ADD end_ip INT DEFAULT 0;
+ALTER TABLE radius_nas ADD start_ip INT UNSIGNED DEFAULT 0, ADD end_ip INT UNSIGNED DEFAULT 0, ADD range_length INT DEFAULT 0;
 
 
 -- IMPORTANT: KEEP THIS AT THE BOTTOM OF THIS FILE.

--- a/db/upgrade-X.X.X-X.Y.Z.sql
+++ b/db/upgrade-X.X.X-X.Y.Z.sql
@@ -50,7 +50,7 @@ VALUES
 -- Add a column to radius_nas to order the nas list
 --
 
-ALTER TABLE radius_nas ADD `position` INT FIRST;
+ALTER TABLE radius_nas ADD `position` INT FIRST, ADD start_ip INT DEFAULT 0, ADD end_ip INT DEFAULT 0;
 
 
 -- IMPORTANT: KEEP THIS AT THE BOTTOM OF THIS FILE.

--- a/db/upgrade-X.X.X-X.Y.Z.sql
+++ b/db/upgrade-X.X.X-X.Y.Z.sql
@@ -46,6 +46,12 @@ VALUES
     (100120, 'Orange (CH)', '%s@orange.net', now()),
     (100121, 'Sunrise', '%s@gsm.sunrise.ch', now());
 
+--
+-- Add a column to radius_nas to order the nas list
+--
+
+ALTER TABLE radius_nas ADD `position` INT FIRST;
+
 
 -- IMPORTANT: KEEP THIS AT THE BOTTOM OF THIS FILE.
 -- TO BE EXECUTED AFTER EVERYTHING ELSE.

--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -607,7 +607,7 @@ The `/usr/local/pf/conf/switches.conf` configuration file contains a default sec
 and a switch section for each switch (managed by PacketFence) including:
 
 [options="compact"]
-* Switch IP
+* Switch IP/Mac/Range
 * Switch vendor/type
 * Switch uplink ports (trunks and non-managed IfIndex)
 * per-switch re-definition of the VLANs (if required)

--- a/html/pfappserver/lib/pfappserver/Form/Config/Switch.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Switch.pm
@@ -30,10 +30,10 @@ has 'placeholders' => ( is => 'ro' );
 has_field 'id' =>
   (
    type => 'SwitchID',
-   label => 'IP Address/MAC Address',
+   label => 'IP Address/MAC Address/Range (CIDR)',
    accept => ['default'],
    required => 1,
-   messages => { required => 'Please specify the IP address/MAC address of the switch.' },
+   messages => { required => 'Please specify the IP address/MAC address/Range (CIDR) of the switch.' },
   );
 has_field 'description' =>
   (

--- a/html/pfappserver/lib/pfappserver/Form/Field/SwitchID.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Field/SwitchID.pm
@@ -39,6 +39,7 @@ apply
         check => sub {
             my ( $value, $field ) = @_;
             return 1 if ($field->accept && grep { $_ eq $value } @{$field->accept});
+            return 1 if valid_ip_range( $value );
             return valid_mac_or_ip( $value );
         }
     },

--- a/lib/pf/SwitchFactory.pm
+++ b/lib/pf/SwitchFactory.pm
@@ -87,7 +87,7 @@ sub instantiate {
             last;
         }
     }
-    if ($requestedSwitch) {
+    if (!$requestedSwitch) {
         foreach my $search (@requestedSwitches){
             next if (valid_mac($search));
             foreach my $switch ( keys (%SwitchConfig) ) {

--- a/lib/pf/SwitchFactory.pm
+++ b/lib/pf/SwitchFactory.pm
@@ -80,16 +80,14 @@ sub instantiate {
     });
 
     my $switch_data;
-    my $i = 1;
     foreach my $search (@requestedSwitches){
         if($SwitchConfig{$search}){
             $requestedSwitch = $search;
             $switch_data = $SwitchConfig{$search};
-            $i = 0;
             last;
         }
     }
-    if ($i) {
+    if ($requestedSwitch) {
         foreach my $search (@requestedSwitches){
             next if (valid_mac($search));
             foreach my $switch ( keys (%SwitchConfig) ) {

--- a/lib/pf/SwitchFactory.pm
+++ b/lib/pf/SwitchFactory.pm
@@ -90,10 +90,11 @@ sub instantiate {
         }
     }
     if (!$requestedSwitch) {
+        my @SwitchConfigOrder = sort { NetAddr::IP->new($b)->masklen <=> NetAddr::IP->new($a)->masklen } keys %SwitchRanges;
         foreach my $search (@requestedSwitches){
             next if (valid_mac($search));
-            foreach my $switch ( keys (%SwitchRanges) ) {
-                my $network = NetAddr::IP->new($switch); 
+            foreach my $switch ( @SwitchConfigOrder ) {
+                my $network = NetAddr::IP->new($switch);
                 my $ip = new NetAddr::IP::Lite clean_ip($search);
                 if ($network->contains($ip)) {
                     $requestedSwitch = $search;

--- a/lib/pf/SwitchFactory.pm
+++ b/lib/pf/SwitchFactory.pm
@@ -31,6 +31,8 @@ use NetAddr::IP;
 
 our %SwitchConfig;
 tie %SwitchConfig, 'pfconfig::cached_hash', 'config::Switch';
+my %SwitchRanges;
+tie %SwitchRanges, 'pfconfig::cached_hash', 'resource::switches_ranges';
 
 =head1 METHODS
 
@@ -90,9 +92,8 @@ sub instantiate {
     if (!$requestedSwitch) {
         foreach my $search (@requestedSwitches){
             next if (valid_mac($search));
-            foreach my $switch ( keys (%SwitchConfig) ) {
-                my $network = NetAddr::IP->new($switch);
-                next if (!defined($network) || ($network->num eq 1));
+            foreach my $switch ( keys (%SwitchRanges) ) {
+                my $network = NetAddr::IP->new($switch); 
                 my $ip = new NetAddr::IP::Lite clean_ip($search);
                 if ($network->contains($ip)) {
                     $requestedSwitch = $search;

--- a/lib/pf/SwitchFactory.pm
+++ b/lib/pf/SwitchFactory.pm
@@ -25,14 +25,16 @@ use pf::file_paths;
 use Time::HiRes qw(gettimeofday);
 use Benchmark qw(:all);
 use List::Util qw(first);
+use List::MoreUtils qw(any);
 use pf::CHI;
 use pfconfig::cached_hash;
+use pfconfig::cached_array;
 use NetAddr::IP;
 
 our %SwitchConfig;
 tie %SwitchConfig, 'pfconfig::cached_hash', 'config::Switch';
-my %SwitchRanges;
-tie %SwitchRanges, 'pfconfig::cached_hash', 'resource::switches_ranges';
+my @SwitchRanges;
+tie @SwitchRanges, 'pfconfig::cached_array', 'resource::switches_ranges';
 
 =head1 METHODS
 
@@ -90,15 +92,15 @@ sub instantiate {
         }
     }
     if (!$requestedSwitch) {
-        my @SwitchConfigOrder = sort { NetAddr::IP->new($b)->masklen <=> NetAddr::IP->new($a)->masklen } keys %SwitchRanges;
-        foreach my $search (@requestedSwitches){
-            next if (valid_mac($search));
-            foreach my $switch ( @SwitchConfigOrder ) {
-                my $network = NetAddr::IP->new($switch);
-                my $ip = new NetAddr::IP::Lite clean_ip($search);
-                if ($network->contains($ip)) {
+        #Switch ranges is an order array of [NetAddr::IP object of switch,switch_id]
+        if(@SwitchRanges) {
+            foreach my $search (@requestedSwitches) {
+                next if (valid_mac($search));
+                my $ip = NetAddr::IP->new($search);
+                #Find the first switch that matches it's network range
+                if (my $rangeConfig = first { $ip->within($_->[0]) } @SwitchRanges) {
                     $requestedSwitch = $search;
-                    $switch_data = $SwitchConfig{$switch};
+                    $switch_data     = $SwitchConfig{$rangeConfig->[1]};
                     last;
                 }
             }

--- a/lib/pf/freeradius.pm
+++ b/lib/pf/freeradius.pm
@@ -27,6 +27,7 @@ use Log::Log4perl;
 use Readonly;
 use List::MoreUtils qw(natatime);
 use Time::HiRes qw(time);
+use NetAddr::IP;
 
 use constant FREERADIUS => 'freeradius';
 use constant SWITCHES_CONF => '/switches.conf';
@@ -178,7 +179,7 @@ sub freeradius_populate_nas_config {
     while (my @ids = $it->() ) {
         my @rows = map {
             my $data = $switch_config->{$_};
-            [ $_, $_, $data->{radiusSecret}, $_ . " (" . $data->{'type'} .")", $timestamp ]
+            [ NetAddr::IP->new($_)->cidr, $_, $data->{radiusSecret}, $_ . " (" . $data->{'type'} .")", $timestamp ]
         } @ids;
         # insert NAS
         _insert_nas_bulk( @rows );

--- a/lib/pf/freeradius.pm
+++ b/lib/pf/freeradius.pm
@@ -179,7 +179,7 @@ sub freeradius_populate_nas_config {
     while (my @ids = $it->() ) {
         my @rows = map {
             my $data = $switch_config->{$_};
-            [ NetAddr::IP->new($_)->cidr, $_, $data->{radiusSecret}, $_ . " (" . $data->{'type'} .")", $timestamp ]
+            [ $_, $_, $data->{radiusSecret}, $_ . " (" . $data->{'type'} .")", $timestamp ]
         } @ids;
         # insert NAS
         _insert_nas_bulk( @rows );

--- a/lib/pf/freeradius.pm
+++ b/lib/pf/freeradius.pm
@@ -27,7 +27,6 @@ use Log::Log4perl;
 use Readonly;
 use List::MoreUtils qw(natatime);
 use Time::HiRes qw(time);
-use NetAddr::IP;
 
 use constant FREERADIUS => 'freeradius';
 use constant SWITCHES_CONF => '/switches.conf';

--- a/lib/pf/freeradius.pm
+++ b/lib/pf/freeradius.pm
@@ -128,7 +128,7 @@ sub _insert_nas_bulk {
     my $logger = Log::Log4perl::get_logger('pf::freeradius');
     return 0 unless @rows;
     my $row_count = @rows;
-    my $sql = "REPLACE INTO radius_nas ( position, nasname, shortname, secret, description, config_timestamp) VALUES ( ?, ?, ?, ?, ?, ?)" . ",( ?, ?, ?, ?, ?, ?)" x ($row_count -1)    ;
+    my $sql = "REPLACE INTO radius_nas ( nasname, shortname, secret, description, config_timestamp, start_ip, end_ip, range_length) VALUES ( ?, ?, ?, ?, ?, ?, ?, ?)" . ",( ?, ?, ?, ?, ?, ?, ?, ?)" x ($row_count -1)    ;
     $freeradius_statements->{'freeradius_insert_nas_bulk'} = $sql;
 
     db_query_execute(
@@ -167,37 +167,46 @@ sub freeradius_populate_nas_config {
     my %skip = (default => undef, '127.0.0.1' => undef );
     my $radiusSecret;
 
+    #Only switches with a secert except default and 127.0.0.1
     my @switches = grep {
             !exists $skip{$_}
-          && !valid_mac($_)
           && defined( $radiusSecret = $switch_config->{$_}{radiusSecret} )
           && $radiusSecret =~ /\S/
     } keys %$switch_config;
-
-    my @switchesMac = grep {
-            !exists $skip{$_}
-          && valid_mac($_)
-          && defined( $radiusSecret = $switch_config->{$_}{radiusSecret} )
-          && $radiusSecret =~ /\S/
-    } keys %$switch_config;
-    return unless (@switches || @switchesMac);
+    return unless @switches;
+    #Should be handled in code above this
     unless (defined $timestamp ) {
         $timestamp = int (time * 1000000);
     }
-    my @SwitchOrder = sort { NetAddr::IP->new($b)->masklen <=> NetAddr::IP->new($a)->masklen } @switches;
-    @SwitchOrder = (@SwitchOrder,@switchesMac);
-
-    my $it = natatime 100,@SwitchOrder;
-    my $i = 0;
+    #Looping through all the switches 100 at a time
+    my $it = natatime 100,@switches;
     while (my @ids = $it->() ) {
         my @rows = map {
-            my $data = $switch_config->{$_};
-            [ $i++, $_, $_, $data->{radiusSecret}, $_ . " (" . $data->{'type'} .")", $timestamp ]
+            _build_radius_nas_row($_,$switch_config->{$_},$timestamp)
         } @ids;
         # insert NAS
         _insert_nas_bulk( @rows );
     }
     _delete_expired($timestamp);
+}
+
+=item _build_radius_nas_row
+
+=cut
+
+sub _build_radius_nas_row {
+    my ($id,$data,$timestamp) = @_;
+    my $start_ip = 0;
+    my $end_ip = 0;
+    my $range_length = 0;
+    unless (valid_mac($id)) {
+        if(my $netaddr = NetAddr::IP->new($id)) {
+            $start_ip = $netaddr->first->numeric;
+            $end_ip = $netaddr->last->numeric;
+            $range_length = $end_ip - $start_ip + 1;
+        }
+    }
+    [ $id, $id, $data->{radiusSecret}, $id . " (" . $data->{'type'} .")", $timestamp, $start_ip ,$end_ip, $range_length ]
 }
 
 =back

--- a/lib/pf/pfcmd/checkup.pm
+++ b/lib/pf/pfcmd/checkup.pm
@@ -849,7 +849,7 @@ sub switches {
             }
         }
         # check for valid switch IP
-        unless ( valid_mac_or_ip($section) ) {
+        unless ( valid_mac_or_ip($section) || valid_ip_range($section) ) {
             add_problem( $WARN, "switches.conf | Switch IP is invalid for switch $section" );
         }
 

--- a/lib/pf/util.pm
+++ b/lib/pf/util.pm
@@ -28,6 +28,7 @@ use File::Slurp qw(read_dir);
 use List::MoreUtils qw(all);
 use Try::Tiny;
 use pf::file_paths;
+use NetAddr::IP;
 
 our ( %local_mac );
 
@@ -57,6 +58,7 @@ BEGIN {
         normalize_time
         search_hash
         is_prod_interface
+        valid_ip_range
     );
 }
 
@@ -876,10 +878,20 @@ sub valid_mac_or_ip {
         my ($mac) = clean_mac($mac_or_ip);
         return 1 if($mac && $mac !~ $NON_VALID_MAC_REGEX && $mac =~ $VALID_PF_MAC_REGEX);
     }
-    get_logger()->error("invalid MAC or IP: $mac_or_ip");
+    get_logger()->warn("invalid MAC or IP: $mac_or_ip");
     return 0;
 }
 
+=item valid_ip_range
+
+Test if it's an ip and it's range of ip address
+
+=cut
+
+sub valid_ip_range {
+    my ($ip) =@_;
+    return 1 if (defined(NetAddr::IP->new($ip)));
+}
 
 =item read_dir_recursive
 

--- a/lib/pf/util.pm
+++ b/lib/pf/util.pm
@@ -878,7 +878,7 @@ sub valid_mac_or_ip {
         my ($mac) = clean_mac($mac_or_ip);
         return 1 if($mac && $mac !~ $NON_VALID_MAC_REGEX && $mac =~ $VALID_PF_MAC_REGEX);
     }
-    get_logger()->warn("invalid MAC or IP: $mac_or_ip");
+    get_logger()->debug("invalid MAC or IP: $mac_or_ip");
     return 0;
 }
 

--- a/lib/pfconfig/namespaces/config/Switch.pm
+++ b/lib/pfconfig/namespaces/config/Switch.pm
@@ -27,7 +27,7 @@ use base 'pfconfig::namespaces::config';
 sub init {
     my ($self) = @_;
     $self->{file}            = $switches_config_file;
-    $self->{child_resources} = [ 'resource::default_switch', ];
+    $self->{child_resources} = [ 'resource::default_switch', 'resource::switches_ranges' ];
 }
 
 sub build_child {

--- a/lib/pfconfig/namespaces/resource/switches_ranges.pm
+++ b/lib/pfconfig/namespaces/resource/switches_ranges.pm
@@ -23,25 +23,21 @@ use NetAddr::IP;
 
 sub init {
     my ($self) = @_;
-
     # we depend on the switch configuration object (russian doll style)
     $self->{switches} = $self->{cache}->get_cache('config::Switch');
 }
 
 sub build {
     my ($self) = @_;
-    my %ranges;
-    my %SwitchConfig = %{$self->{switches}};
-
-    foreach my $switch ( keys (%SwitchConfig) ) {
+    my @ranges;
+    foreach my $switch ( keys %{$self->{switches}} ) {
         my $network = NetAddr::IP->new($switch);
         next if (!defined($network) || ($network->num eq 1) || $switch eq "default");
-        $ranges{$switch} = $SwitchConfig{$switch};
+        push @ranges,[$network,$switch];
     }
-    return \%ranges;
+    my @ordered_ranges = sort { $b->[0]->masklen <=> $a->[0]->masklen } @ranges ;
+    return \@ordered_ranges;
 }
-
-=back
 
 =head1 AUTHOR
 

--- a/lib/pfconfig/namespaces/resource/switches_ranges.pm
+++ b/lib/pfconfig/namespaces/resource/switches_ranges.pm
@@ -1,0 +1,78 @@
+package pfconfig::namespaces::resource::switches_ranges;
+
+=head1 NAME
+
+pfconfig::namespaces::resource::switches_ranges
+
+=cut
+
+=head1 DESCRIPTION
+
+pfconfig::namespaces::resource::switches_ranges
+
+This module creates the configuration hash of all the switches ranges (ex : 192.168.1.0/24)
+
+=cut
+
+use strict;
+use warnings;
+
+use base 'pfconfig::namespaces::resource';
+
+use NetAddr::IP;
+
+sub init {
+    my ($self) = @_;
+
+    # we depend on the switch configuration object (russian doll style)
+    $self->{switches} = $self->{cache}->get_cache('config::Switch');
+}
+
+sub build {
+    my ($self) = @_;
+    my %ranges;
+    my %SwitchConfig = %{$self->{switches}};
+
+    foreach my $switch ( keys (%SwitchConfig) ) {
+        my $network = NetAddr::IP->new($switch);
+        next if (!defined($network) || ($network->num eq 1) || $switch eq "default");
+        $ranges{$switch} = $SwitchConfig{$switch};
+    }
+    return \%ranges;
+}
+
+=back
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2015 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;
+
+# vim: set shiftwidth=4:
+# vim: set expandtab:
+# vim: set backspace=indent,eol,start:
+

--- a/raddb/sites-available/dynamic-clients
+++ b/raddb/sites-available/dynamic-clients
@@ -118,76 +118,47 @@ server dynamic_client_server {
 		#  Example 3: Look the clients up in SQL.
 		#
 		#  This requires the SQL module to be configured, of course.
+        #
+        #  The order of matching 
+        #  * The mac set in the Called-Station-Id
+        #  * The ip address of the client
+        #  * The ip range of the client
+        #
                 if("%{raw:Called-Station-Id}" =~ /^%{config:policy.mac-addr}(:(.+))?$/i) {
                     update control {
-                        Tmp-String-9 = "%{tolower:%{1}:%{2}:%{3}:%{4}:%{5}:%{6}}"
+                        Tmp-String-8 = "%{sql: SELECT nasname FROM radius_nas WHERE nasname = '%{tolower:%{1}:%{2}:%{3}:%{4}:%{5}:%{6}}'}"
                     }
-                    if("%{control:Tmp-String-9}") {
-                        update control {
-                            Tmp-String-8 = "%{sql: SELECT nasname FROM radius_nas WHERE nasname in ('%{control:Tmp-String-9}','%{Packet-Src-IP-Address}')}"
-                        }
-                    }
-                    if ("%{control:Tmp-String-8}") {
-                        update control {
-                            #
-                            # Echo the IP.
-                            FreeRADIUS-Client-IP-Address = "%{Packet-Src-IP-Address}"
+                }
 
-                            #
-                            # Do multiple SELECT statements to grab
-                            # the various definitions.
-                            FreeRADIUS-Client-Shortname = "%{sql: SELECT shortname FROM radius_nas WHERE nasname = '%{control:Tmp-String-8}'}"
-
-                            FreeRADIUS-Client-Secret = "%{sql: SELECT secret FROM radius_nas WHERE nasname = '%{control:Tmp-String-8}'}"
-
-                            FreeRADIUS-Client-NAS-Type = "%{sql: SELECT type FROM radius_nas WHERE nasname = '%{control:Tmp-String-8}'}"
-
-                        }
-                        ok
-
-                    }
+                if (!"%{control:Tmp-String-8}") {
                     update control {
-                        Tmp-String-7 = "%{sql: SELECT nasname FROM radius_nas WHERE nasname = '%{Packet-Src-IP-Address}'}"
+                        Tmp-String-8 = "%{sql: SELECT nasname FROM radius_nas WHERE nasname = '%{Packet-Src-IP-Address}'}"
                     }
-                    if ("%{control:Tmp-String-7}") {
-                        update control {
-                            #
-                            # Echo the IP.
-                            FreeRADIUS-Client-IP-Address = "%{Packet-Src-IP-Address}"
 
-                            #
-                            # Do multiple SELECT statements to grab
-                            # the various definitions.
-                            FreeRADIUS-Client-Shortname = "%{sql: SELECT shortname FROM radius_nas WHERE nasname = '%{control:Tmp-String-7}'}"
-
-                            FreeRADIUS-Client-Secret = "%{sql: SELECT secret FROM radius_nas WHERE nasname = '%{control:Tmp-String-7}'}"
-
-                            FreeRADIUS-Client-NAS-Type = "%{sql: SELECT type FROM radius_nas WHERE nasname = '%{control:Tmp-String-7}'}"
-
-                        }
-                    ok
-                    }
+                }
+                if (!"%{control:Tmp-String-8}") {
                     update control {
-                        Tmp-String-6 = "%{sql: SELECT nasname FROM radius_nas WHERE (inet_aton('%{Packet-Src-IP-Address}') & ((power(2, 32) - power(2, (32 - (SUBSTRING_INDEX(nasname, '/', -1)))))) = inet_aton(SUBSTRING_INDEX(nasname, '/', 1))) ORDER BY position LIMIT 1}"
+                        Tmp-String-8 = "%{sql: SELECT nasname from radius_nas WHERE start_ip <= INET_ATON('%{Packet-Src-IP-Address}') and INET_ATON('%{Packet-Src-IP-Address}') <= end_ip order by range_length limit 1}";
                     }
-                    if ("%{control:Tmp-String-6}") {
-                        update control {
-                            #
-                            # Echo the IP.
-                            FreeRADIUS-Client-IP-Address = "%{Packet-Src-IP-Address}"
+                        #
+                }
+                if ("%{control:Tmp-String-8}") {
+                    update control {
+                        #
+                        # Echo the IP.
+                        FreeRADIUS-Client-IP-Address = "%{Packet-Src-IP-Address}"
 
-                            #
-                            # Do multiple SELECT statements to grab
-                            # the various definitions.
-                            FreeRADIUS-Client-Shortname = "%{sql: SELECT shortname FROM radius_nas WHERE nasname = '%{control:Tmp-String-6}'}"
+                        #
+                        # Do multiple SELECT statements to grab
+                        # the various definitions.
+                        FreeRADIUS-Client-Shortname = "%{sql: SELECT shortname FROM radius_nas WHERE nasname = '%{control:Tmp-String-8}'}"
 
-                            FreeRADIUS-Client-Secret = "%{sql: SELECT secret FROM radius_nas WHERE nasname = '%{control:Tmp-String-6}'}"
+                        FreeRADIUS-Client-Secret = "%{sql: SELECT secret FROM radius_nas WHERE nasname = '%{control:Tmp-String-8}'}"
 
-                            FreeRADIUS-Client-NAS-Type = "%{sql: SELECT type FROM radius_nas WHERE nasname = '%{control:Tmp-String-6}'}"
+                        FreeRADIUS-Client-NAS-Type = "%{sql: SELECT type FROM radius_nas WHERE nasname = '%{control:Tmp-String-8}'}"
 
-                        }
+                    }
                     ok
-                    }
                 }
 		# Do an LDAP lookup in the elements OU, check to see if
 		# the Packet-Src-IP-Address object has a "ou"

--- a/raddb/sites-available/dynamic-clients
+++ b/raddb/sites-available/dynamic-clients
@@ -146,12 +146,10 @@ server dynamic_client_server {
                         ok
 
                     }
-                }
-                else {
                     update control {
-                        Tmp-String-8 = "%{sql: SELECT nasname FROM radius_nas WHERE nasname = '%{Packet-Src-IP-Address}'}"
+                        Tmp-String-7 = "%{sql: SELECT nasname FROM radius_nas WHERE nasname = '%{Packet-Src-IP-Address}'}"
                     }
-                    if ("%{control:Tmp-String-8}") {
+                    if ("%{control:Tmp-String-7}") {
                         update control {
                             #
                             # Echo the IP.
@@ -160,17 +158,37 @@ server dynamic_client_server {
                             #
                             # Do multiple SELECT statements to grab
                             # the various definitions.
-                            FreeRADIUS-Client-Shortname = "%{sql: SELECT shortname FROM radius_nas WHERE nasname = '%{control:Tmp-String-8}'}"
+                            FreeRADIUS-Client-Shortname = "%{sql: SELECT shortname FROM radius_nas WHERE nasname = '%{control:Tmp-String-7}'}"
 
-                            FreeRADIUS-Client-Secret = "%{sql: SELECT secret FROM radius_nas WHERE nasname = '%{control:Tmp-String-8}'}"
+                            FreeRADIUS-Client-Secret = "%{sql: SELECT secret FROM radius_nas WHERE nasname = '%{control:Tmp-String-7}'}"
 
-                            FreeRADIUS-Client-NAS-Type = "%{sql: SELECT type FROM radius_nas WHERE nasname = '%{control:Tmp-String-8}'}"
+                            FreeRADIUS-Client-NAS-Type = "%{sql: SELECT type FROM radius_nas WHERE nasname = '%{control:Tmp-String-7}'}"
+
+                        }
+                    ok
+                    }
+                    update control {
+                        Tmp-String-6 = "%{sql: SELECT nasname FROM radius_nas WHERE (inet_aton('%{Packet-Src-IP-Address}') & ((power(2, 32) - power(2, (32 - (SUBSTRING_INDEX(nasname, '/', -1)))))) = inet_aton(SUBSTRING_INDEX(nasname, '/', 1))) ORDER BY position LIMIT 1}"
+                    }
+                    if ("%{control:Tmp-String-6}") {
+                        update control {
+                            #
+                            # Echo the IP.
+                            FreeRADIUS-Client-IP-Address = "%{Packet-Src-IP-Address}"
+
+                            #
+                            # Do multiple SELECT statements to grab
+                            # the various definitions.
+                            FreeRADIUS-Client-Shortname = "%{sql: SELECT shortname FROM radius_nas WHERE nasname = '%{control:Tmp-String-6}'}"
+
+                            FreeRADIUS-Client-Secret = "%{sql: SELECT secret FROM radius_nas WHERE nasname = '%{control:Tmp-String-6}'}"
+
+                            FreeRADIUS-Client-NAS-Type = "%{sql: SELECT type FROM radius_nas WHERE nasname = '%{control:Tmp-String-6}'}"
 
                         }
                     ok
                     }
                 }
-
 		# Do an LDAP lookup in the elements OU, check to see if
 		# the Packet-Src-IP-Address object has a "ou"
 		# attribute, if it does continue.  Change "ACME.COM" to

--- a/t/SwitchFactory.t
+++ b/t/SwitchFactory.t
@@ -5,7 +5,7 @@ use warnings;
 use diagnostics;
 
 use lib '/usr/local/pf/lib';
-use Test::More tests => 53;
+use Test::More tests => 54;
 use Test::NoWarnings;
 
 BEGIN {

--- a/t/SwitchFactory.t
+++ b/t/SwitchFactory.t
@@ -102,7 +102,7 @@ is($switch->{_id}, '192.168.0.1', "Proper id is set");
 #Test using ip address in a range
 $switch = pf::SwitchFactory->instantiate('192.168.3.1');
 isa_ok($switch, 'pf::Switch::Cisco::Catalyst_2960');
-is($switch->{_id}, '192.168.3.1', "Proper id is set 192.168.3.1");
+is($switch->{_id}, '192.168.3.1', "Proper id is set for 192.168.3.1");
 
 $switch = pf::SwitchFactory->instantiate('192.168.3.2');
 isa_ok($switch, 'pf::Switch::Cisco::Catalyst_2960G');

--- a/t/SwitchFactory.t
+++ b/t/SwitchFactory.t
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use diagnostics;
 
-use Test::More tests => 46;
+use Test::More tests => 48;
 use lib '/usr/local/pf/lib';
 
 BEGIN {
@@ -100,9 +100,13 @@ isa_ok( $switch, 'pf::Switch::Cisco::Catalyst_2900XL' );
 is($switch->{_id}, '192.168.0.1', "Proper id is set");
 
 #Test using ip address in a range
-$switch = pf::SwitchFactory->instantiate('193.168.3.1');
+$switch = pf::SwitchFactory->instantiate('192.168.3.1');
 isa_ok($switch, 'pf::Switch::Cisco::Catalyst_2960');
-is($switch->{_id}, '192.168.3.0/24', "Proper id is set");
+is($switch->{_id}, '192.168.3.1', "Proper id is set 192.168.3.1");
+
+$switch = pf::SwitchFactory->instantiate('192.168.3.2');
+isa_ok($switch, 'pf::Switch::Cisco::Catalyst_2960G');
+is($switch->{_id}, '192.168.3.2', "Proper id is set for 192.168.3.2");
 
 
 =head1 AUTHOR

--- a/t/SwitchFactory.t
+++ b/t/SwitchFactory.t
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use diagnostics;
 
-use Test::More tests => 44;
+use Test::More tests => 46;
 use lib '/usr/local/pf/lib';
 
 BEGIN {
@@ -98,6 +98,11 @@ is($switch->{_controllerIp}, '1.2.3.4', "Do not override  controllerIp address i
 $switch = pf::SwitchFactory->instantiate({ switch_mac => "ff:01:01:01:01:04", switch_ip => "192.168.0.1", controllerIp => "1.1.1.1"});
 isa_ok( $switch, 'pf::Switch::Cisco::Catalyst_2900XL' );
 is($switch->{_id}, '192.168.0.1', "Proper id is set");
+
+#Test using ip address in a range
+$switch = pf::SwitchFactory->instantiate('193.168.3.1');
+isa_ok($switch, 'pf::Switch::Cisco::Catalyst_2960');
+is($switch->{_id}, '192.168.3.0/24', "Proper id is set");
 
 
 =head1 AUTHOR

--- a/t/SwitchFactory.t
+++ b/t/SwitchFactory.t
@@ -4,14 +4,16 @@ use strict;
 use warnings;
 use diagnostics;
 
-use Test::More tests => 48;
 use lib '/usr/local/pf/lib';
+use Test::More tests => 53;
+use Test::NoWarnings;
 
 BEGIN {
     use lib qw(/usr/local/pf/t);
     use PfFilePaths;
     use_ok('pf::SwitchFactory');
 }
+
 
 
 my $switch = pf::SwitchFactory->instantiate('192.168.0.1');
@@ -97,16 +99,23 @@ is($switch->{_controllerIp}, '1.2.3.4', "Do not override  controllerIp address i
 
 $switch = pf::SwitchFactory->instantiate({ switch_mac => "ff:01:01:01:01:04", switch_ip => "192.168.0.1", controllerIp => "1.1.1.1"});
 isa_ok( $switch, 'pf::Switch::Cisco::Catalyst_2900XL' );
-is($switch->{_id}, '192.168.0.1', "Proper id is set");
+is($switch->{_id}, '192.168.0.1', "Proper id is set for 192.168.0.1");
 
 #Test using ip address in a range
-$switch = pf::SwitchFactory->instantiate('192.168.3.1');
-isa_ok($switch, 'pf::Switch::Cisco::Catalyst_2960');
-is($switch->{_id}, '192.168.3.1', "Proper id is set for 192.168.3.1");
+$switch = pf::SwitchFactory->instantiate('172.16.3.1');
+isa_ok($switch, 'pf::Switch::Cisco::Catalyst_3750G');
+is("pf::Switch::Cisco::Catalyst_3750G",ref $switch, "Got the correct switch type");
+is($switch->{_id}, '172.16.3.1', "Proper id is set for 172.16.3.1");
 
-$switch = pf::SwitchFactory->instantiate('192.168.3.2');
+$switch = pf::SwitchFactory->instantiate('172.16.3.2');
 isa_ok($switch, 'pf::Switch::Cisco::Catalyst_2960G');
-is($switch->{_id}, '192.168.3.2', "Proper id is set for 192.168.3.2");
+is('pf::Switch::Cisco::Catalyst_2960G', ref $switch,"Got the proper switch type for 172.16.3.2");
+is($switch->{_id}, '172.16.3.2', "Proper id is set for 172.16.3.2");
+
+$switch = pf::SwitchFactory->instantiate('172.16.0.1');
+isa_ok($switch, 'pf::Switch::Cisco::Catalyst_2960');
+is("pf::Switch::Cisco::Catalyst_2960",ref $switch, "Got the correct switch type for 172.16.0.1");
+is($switch->{_id}, '172.16.0.1', "Proper id is set for 172.16.0.1");
 
 
 =head1 AUTHOR

--- a/t/data/switches.conf
+++ b/t/data/switches.conf
@@ -172,3 +172,6 @@ type=Cisco::Catalyst_2960
 [01:01:01:01:01:03]
 type=Cisco::Catalyst_2960
 controllerIp=1.2.3.4
+
+[192.168.3.0/24]
+type=Cisco::Catalyst_2960

--- a/t/data/switches.conf
+++ b/t/data/switches.conf
@@ -173,8 +173,11 @@ type=Cisco::Catalyst_2960
 type=Cisco::Catalyst_2960
 controllerIp=1.2.3.4
 
-[192.168.3.0/24]
+[172.16.0.0/16]
 type=Cisco::Catalyst_2960
 
-[192.168.3.2]
+[172.16.3.0/24]
+type=Cisco::Catalyst_3750G
+
+[172.16.3.2]
 type=Cisco::Catalyst_2960G

--- a/t/data/switches.conf
+++ b/t/data/switches.conf
@@ -175,3 +175,6 @@ controllerIp=1.2.3.4
 
 [192.168.3.0/24]
 type=Cisco::Catalyst_2960
+
+[192.168.3.2]
+type=Cisco::Catalyst_2960G


### PR DESCRIPTION
## Description

It's now possible to add a switch range (cird format) for the switch ip address configuration parameter.
It's usefull if on the same network you have multiples switch/ap with the same configuration, you just have to define one.
## Impacts

No impacts
## Delete branch after merge

YES
## NEWS file entries

New Features
+++++++++++
- Define range of network switches in switch configuration
