### PR TITLE
Add email html template FR/EN

### DIFF
--- a/conf/templates/emails-billing_confirmation-fr.html
+++ b/conf/templates/emails-billing_confirmation-fr.html
@@ -1,0 +1,31 @@
+<link rel="stylesheet" type="text/css" href="/usr/local/pf/html/pfappserver/root/static/css/email.css">
+<span class="preheader">Informations de payement pour l'enregistrement.</span>
+<table class="main">
+        <tr>
+                <td class="wrapper">
+                        <table>
+                                <tr>
+                                        <td>
+                                                <h1 class="align-center">Responsive iBilling Email</h1>
+                                                <p>Bonjour, [% firstname %] [% lastname %],</p>
+                                                <p>Merci de votre achat.</br>
+                                                [% tier_name %]: [% tier_description %]</br>
+                                                Prix: $[% tier_price %]</br>
+                                                Transaction ID: [% transaction_id %]</p>
+                                        </td>
+                                </tr>
+                        </table>
+                </td>
+        </tr>
+</table>
+<div class="footer">
+        <table>
+                <tr>
+                        <td class="align-center">
+                                <p>-----</br></p>
+                                <p>Si vous souhaitez prolonger votre accès sur le réseau, consultez la page suivante https://[% hostname %].[% domain %][% URL_BILLING %]</p>
+                                <p>Pour des informations sur votre état actuel To view your current network status, please visit https://[% hostname %].[% domain %][% URL_STATUS %]</p>
+                        </td>
+                </tr>
+        </table>
+</div>

--- a/conf/templates/emails-billing_confirmation-fr.html
+++ b/conf/templates/emails-billing_confirmation-fr.html
@@ -1,39 +1,47 @@
 <html>
 <head>
-    <style type="text/css">
-        [% INCLUDE emails.css %]
-    </style>
-    <span class="preheader">Informations de payement pour l'enregistrement.</span>
+  <style type="text/css">
+    [% INCLUDE emails.css %]
+  </style>
 </head>
 <body>
-<table class="main">
-        <tr>
-                <td class="wrapper">
-                        <table>
-                                <tr>
-                                        <td>
-                                                <h1 class="align-center">Email de confirmation de payement</h1>
-                                                <p>Bonjour, [% firstname %] [% lastname %],</p>
-                                                <p>Merci de votre achat.</br>
-                                                [% tier_name %]: [% tier_description %]</br>
-                                                Prix: $[% tier_price %]</br>
-                                                Transaction ID: [% transaction_id %]</p>
-                                        </td>
-                                </tr>
-                        </table>
-                </td>
-        </tr>
+<table class="body-wrap">
+  <tr>
+    <td></td>
+    <td class="container" width="600">
+      <div class="content">
+        <table class="main" width="100%" cellpadding="0" cellspacing="0">
+          <tr>
+            <td class="content-wrap">
+              <table width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td class="content-block">
+                    <h1 class="aligncenter">Email de confirmation de paiement</h1>
+                    <p>Bonjour, [% firstname %] [% lastname %],</p>
+                    <p>Merci de votre achat.</br>
+                    [% tier_name %]: [% tier_description %]</br>
+                    Prix: $[% tier_price %]</br>
+                    Transaction ID: [% transaction_id %]</p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+        </table>
+      </div>
+    </td>
+  </tr>
 </table>
 <div class="footer">
-        <table>
-                <tr>
-                        <td class="align-center">
-                                <p>-----</br></p>
-                                <p>Si vous souhaitez prolonger votre accès sur le réseau, consultez la page suivante https://[% hostname %].[% domain %][% URL_BILLING %]</p>
-                                <p>Pour des informations sur votre état actuel consultez la page suivante https://[% hostname %].[% domain %][% URL_STATUS %]</p>
-                        </td>
-                </tr>
-        </table>
+  <table width="100%">
+    <tr>
+      <td class="aligncenter content-block">
+        <p>-----</br></p>
+        <p>Si vous souhaitez prolonger votre accès sur le réseau, consultez la page suivante <a href="https://[% hostname %].[% domain %][% URL_BILLING %]" class="btn-secondary">Prolonger l'accès</a></p>
+        <p>Pour des informations sur votre état actuel consultez la page suivante <a href="https://[% hostname %].[% domain %][% URL_STATUS %]" class="btn-secondary">Status</a></p>
+      </td>
+    </tr>
+  </table>
 </div>
 </body>
 </html>

--- a/conf/templates/emails-billing_confirmation-fr.html
+++ b/conf/templates/emails-billing_confirmation-fr.html
@@ -16,12 +16,15 @@
               <table width="100%" cellpadding="0" cellspacing="0">
                 <tr>
                   <td class="content-block">
-                    <h1 class="aligncenter">Email de confirmation de paiement</h1>
+                    <h1 class="aligncenter">Confirmation de paiement</h1>
                     <p>Bonjour, [% firstname %] [% lastname %],</p>
                     <p>Merci de votre achat.</br>
                     [% tier_name %]: [% tier_description %]</br>
                     Prix: $[% tier_price %]</br>
                     Transaction ID: [% transaction_id %]</p>
+                    <p>Si vous souhaitez prolonger votre accès sur le réseau, consultez la page suivante <a href="https://[% hostname %].[% domain %][% URL_BILLING %]">Prolonger l'accès</a></p>
+                    <p>Pour des informations sur votre état actuel consultez la page suivante <a href="https://[% hostname %].[% domain %][% URL_STATUS %]">Status</a></p>
+
                   </td>
                 </tr>
               </table>
@@ -37,8 +40,7 @@
     <tr>
       <td class="aligncenter content-block">
         <p>-----</br></p>
-        <p>Si vous souhaitez prolonger votre accès sur le réseau, consultez la page suivante <a href="https://[% hostname %].[% domain %][% URL_BILLING %]" class="btn-secondary">Prolonger l'accès</a></p>
-        <p>Pour des informations sur votre état actuel consultez la page suivante <a href="https://[% hostname %].[% domain %][% URL_STATUS %]" class="btn-secondary">Status</a></p>
+        <p>Ceci est un message automatique, merci de ne pas répondre.</p>
       </td>
     </tr>
   </table>

--- a/conf/templates/emails-billing_confirmation-fr.html
+++ b/conf/templates/emails-billing_confirmation-fr.html
@@ -1,12 +1,18 @@
-<link rel="stylesheet" type="text/css" href="/usr/local/pf/html/pfappserver/root/static/css/email.css">
-<span class="preheader">Informations de payement pour l'enregistrement.</span>
+<html>
+<head>
+    <style type="text/css">
+        [% INCLUDE emails.css %]
+    </style>
+    <span class="preheader">Informations de payement pour l'enregistrement.</span>
+</head>
+<body>
 <table class="main">
         <tr>
                 <td class="wrapper">
                         <table>
                                 <tr>
                                         <td>
-                                                <h1 class="align-center">Responsive iBilling Email</h1>
+                                                <h1 class="align-center">Email de confirmation de payement</h1>
                                                 <p>Bonjour, [% firstname %] [% lastname %],</p>
                                                 <p>Merci de votre achat.</br>
                                                 [% tier_name %]: [% tier_description %]</br>
@@ -24,8 +30,10 @@
                         <td class="align-center">
                                 <p>-----</br></p>
                                 <p>Si vous souhaitez prolonger votre accès sur le réseau, consultez la page suivante https://[% hostname %].[% domain %][% URL_BILLING %]</p>
-                                <p>Pour des informations sur votre état actuel To view your current network status, please visit https://[% hostname %].[% domain %][% URL_STATUS %]</p>
+                                <p>Pour des informations sur votre état actuel consultez la page suivante https://[% hostname %].[% domain %][% URL_STATUS %]</p>
                         </td>
                 </tr>
         </table>
 </div>
+</body>
+</html>

--- a/conf/templates/emails-billing_confirmation.html
+++ b/conf/templates/emails-billing_confirmation.html
@@ -1,12 +1,18 @@
-<link rel="stylesheet" type="text/css" href="/usr/local/pf/html/pfappserver/root/static/css/email.css">
-<span class="preheader">Register Billing informaziones</span>
+<html>
+<head>
+    <style type="text/css">
+        [% INCLUDE emails.css %]
+    </style>
+    <span class="preheader">Register Billing Report</span>
+</head>
+<body>
 <table class="main">
         <tr>
                 <td class="wrapper">
                         <table>
                                 <tr>
                                         <td>
-                                                <h1 class="align-center">Responsive iBilling Email</h1>
+                                                <h1 class="align-center">Billing register infortmations</h1>
                                                 <p>Hello [% firstname %] [% lastname %],</p>
                                                 <p>Thank you for your purchase.</br>
                                                 [% tier_name %]: [% tier_description %]</br>
@@ -29,3 +35,5 @@
                 </tr>
         </table>
 </div>
+</body>
+</html>

--- a/conf/templates/emails-billing_confirmation.html
+++ b/conf/templates/emails-billing_confirmation.html
@@ -1,39 +1,47 @@
 <html>
 <head>
-    <style type="text/css">
-        [% INCLUDE emails.css %]
-    </style>
-    <span class="preheader">Register Billing Report</span>
+  <style type="text/css">
+    [% INCLUDE emails.css %]
+  </style>
 </head>
 <body>
-<table class="main">
-        <tr>
-                <td class="wrapper">
-                        <table>
-                                <tr>
-                                        <td>
-                                                <h1 class="align-center">Billing register infortmations</h1>
-                                                <p>Hello [% firstname %] [% lastname %],</p>
-                                                <p>Thank you for your purchase.</br>
-                                                [% tier_name %]: [% tier_description %]</br>
-                                                Cost: $[% tier_price %]</br>
-                                                Transaction ID: [% transaction_id %]</p>
-                                        </td>
-                                </tr>
-                        </table>
-                </td>
-        </tr>
+<table class="body-wrap">
+  <tr>
+    <td></td>
+    <td class="container" width="600">
+      <div class="content">
+        <table class="main" width="100%" cellpadding="0" cellspacing="0">
+          <tr>
+            <td class="content-wrap">
+              <table width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td class="content-block">
+                    <h1 class="aligncenter">Billing register infortmations</h1>
+                    <p>Hello [% firstname %] [% lastname %],</p>
+                    <p>Thank you for your purchase.</br>
+                    [% tier_name %]: [% tier_description %]</br>
+                    Cost: $[% tier_price %]</br>
+                    Transaction ID: [% transaction_id %]</p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+        </table>
+      </div>
+    </td>
+  </tr>
 </table>
 <div class="footer">
-        <table>
-                <tr>
-                        <td class="align-center">
-                                <p>-----</br></p>
-                                <p>To extend your network access, please visit https://[% hostname %].[% domain %][% URL_BILLING %]</p>
-                                <p>To view your current network status, please visit https://[% hostname %].[% domain %][% URL_STATUS %]</p>
-                        </td>
-                </tr>
-        </table>
+  <table width="100%">
+    <tr>
+      <td class="aligncenter content-block">
+        <p>-----</br></p>
+        <p>To extend your network access, please visit <a href="https://[% hostname %].[% domain %][% URL_BILLING %]" class="btn-secondary">Extend access duration</a></p>
+        <p>To view your current network status, please visit <a href="https://[% hostname %].[% domain %][% URL_STATUS %]" class="btn-secondary">Status</a></p>
+      </td>
+    </tr>
+  </table>
 </div>
 </body>
 </html>

--- a/conf/templates/emails-billing_confirmation.html
+++ b/conf/templates/emails-billing_confirmation.html
@@ -1,0 +1,31 @@
+<link rel="stylesheet" type="text/css" href="/usr/local/pf/html/pfappserver/root/static/css/email.css">
+<span class="preheader">Register Billing informaziones</span>
+<table class="main">
+        <tr>
+                <td class="wrapper">
+                        <table>
+                                <tr>
+                                        <td>
+                                                <h1 class="align-center">Responsive iBilling Email</h1>
+                                                <p>Hello [% firstname %] [% lastname %],</p>
+                                                <p>Thank you for your purchase.</br>
+                                                [% tier_name %]: [% tier_description %]</br>
+                                                Cost: $[% tier_price %]</br>
+                                                Transaction ID: [% transaction_id %]</p>
+                                        </td>
+                                </tr>
+                        </table>
+                </td>
+        </tr>
+</table>
+<div class="footer">
+        <table>
+                <tr>
+                        <td class="align-center">
+                                <p>-----</br></p>
+                                <p>To extend your network access, please visit https://[% hostname %].[% domain %][% URL_BILLING %]</p>
+                                <p>To view your current network status, please visit https://[% hostname %].[% domain %][% URL_STATUS %]</p>
+                        </td>
+                </tr>
+        </table>
+</div>

--- a/conf/templates/emails-billing_confirmation.html
+++ b/conf/templates/emails-billing_confirmation.html
@@ -16,12 +16,14 @@
               <table width="100%" cellpadding="0" cellspacing="0">
                 <tr>
                   <td class="content-block">
-                    <h1 class="aligncenter">Billing register infortmations</h1>
+                    <h1 class="aligncenter">Billing invoice</h1>
                     <p>Hello [% firstname %] [% lastname %],</p>
                     <p>Thank you for your purchase.</br>
                     [% tier_name %]: [% tier_description %]</br>
                     Cost: $[% tier_price %]</br>
                     Transaction ID: [% transaction_id %]</p>
+                    <p>To extend your network access, please visit <a href="https://[% hostname %].[% domain %][% URL_BILLING %]">Extend access duration</a></p>
+                    <p>To view your current network status, please visit <a href="https://[% hostname %].[% domain %][% URL_STATUS %]">Status</a></p>
                   </td>
                 </tr>
               </table>
@@ -37,8 +39,7 @@
     <tr>
       <td class="aligncenter content-block">
         <p>-----</br></p>
-        <p>To extend your network access, please visit <a href="https://[% hostname %].[% domain %][% URL_BILLING %]" class="btn-secondary">Extend access duration</a></p>
-        <p>To view your current network status, please visit <a href="https://[% hostname %].[% domain %][% URL_STATUS %]" class="btn-secondary">Status</a></p>
+        <p>This is a post only E-mail, please do not reply.</p>
       </td>
     </tr>
   </table>

--- a/conf/templates/emails-guest_admin_pregistration-fr.html
+++ b/conf/templates/emails-guest_admin_pregistration-fr.html
@@ -16,7 +16,7 @@
               <table width="100%" cellpadding="0" cellspacing="0">
                 <tr>
                   <td class="content-block">
-                    <h1 class="align-center">Pre-enregistrement par administrateur: informations de connexion</h1>
+                    <h1 class="align-center">Pre-enregistrement</h1>
                   </td>
                 </tr>
                 <tr>

--- a/conf/templates/emails-guest_admin_pregistration-fr.html
+++ b/conf/templates/emails-guest_admin_pregistration-fr.html
@@ -1,0 +1,40 @@
+<html>
+<head>
+    <style type="text/css">
+        [% INCLUDE emails.css %]
+    </style>
+    <span class="preheader">Informations de pre-enregistrement par administrateur</span>
+</head>
+<body>
+<table class="main">
+        <tr>
+                <td class="wrapper">
+                        <table>
+                                <tr>
+                                        <td>
+                                                <h1 class="align-center">Pre-enregistrement par administrateur: informations de connexion</h1>
+                                                <p>Bonjour [% firstname %] [% lastname %],</p>
+                                                <p>Un compte a été crée pour vous permettre l'accès à notre réseau.</p>
+                                                <p>Lorsque vous serez sur place, utilisez les informations suivantes pour vous authentifier sur le portail captif:</p>
+                                                <p>Nom d'utilisateur: [% username %]</br>
+                                                Mot de passe: [% password %]</p>
+                                                <p>Ces identifiants seront valides depuis [% valid_from %]. [% txt_expiration %] [% txt_duration %]</p>
+                                                <p>Si vous n'êtes pas l'émetteur de cette demande, merci d'ignorer ce message.</p>
+                                        </td>
+                                </tr>
+                        </table>
+                </td>
+        </tr>
+</table>
+<div class="footer">
+        <table>
+                <tr>
+                        <td class="align-center">
+                                <p>-----</br></p>
+                                <p>Ceci est un message automatique, merci de ne pas répondre.</p>
+                        </td>
+                </tr>
+        </table>
+</div> 
+</body>
+</html>

--- a/conf/templates/emails-guest_admin_pregistration-fr.html
+++ b/conf/templates/emails-guest_admin_pregistration-fr.html
@@ -1,40 +1,52 @@
 <html>
 <head>
-    <style type="text/css">
-        [% INCLUDE emails.css %]
-    </style>
-    <span class="preheader">Informations de pre-enregistrement par administrateur</span>
+  <style type="text/css">
+    [% INCLUDE emails.css %]
+  </style>
 </head>
 <body>
-<table class="main">
-        <tr>
-                <td class="wrapper">
-                        <table>
-                                <tr>
-                                        <td>
-                                                <h1 class="align-center">Pre-enregistrement par administrateur: informations de connexion</h1>
-                                                <p>Bonjour [% firstname %] [% lastname %],</p>
-                                                <p>Un compte a été crée pour vous permettre l'accès à notre réseau.</p>
-                                                <p>Lorsque vous serez sur place, utilisez les informations suivantes pour vous authentifier sur le portail captif:</p>
-                                                <p>Nom d'utilisateur: [% username %]</br>
-                                                Mot de passe: [% password %]</p>
-                                                <p>Ces identifiants seront valides depuis [% valid_from %]. [% txt_expiration %] [% txt_duration %]</p>
-                                                <p>Si vous n'êtes pas l'émetteur de cette demande, merci d'ignorer ce message.</p>
-                                        </td>
-                                </tr>
-                        </table>
-                </td>
-        </tr>
+<table class="body-wrap">
+  <tr>
+    <td></td>
+    <td class="container" width="600">
+      <div class="content">
+        <table class="main" width="100%" cellpadding="0" cellspacing="0">
+          <tr>
+            <td class="content-wrap">
+              <table width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td class="content-block">
+                    <h1 class="align-center">Pre-enregistrement par administrateur: informations de connexion</h1>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="content-block">                
+                    <p>Bonjour [% firstname %] [% lastname %],</p>
+                    <p>Un compte a été crée pour vous permettre l'accès à notre réseau.</p>
+                    <p>Lorsque vous serez sur place, utilisez les informations suivantes pour vous authentifier sur le portail captif:</p>
+                    <p>Nom d'utilisateur: [% username %]</br>
+                    Mot de passe: [% password %]</p>
+                    <p>Ces identifiants seront valides depuis [% valid_from %]. [% txt_expiration %] [% txt_duration %]</p>
+                    <p>Si vous n'êtes pas l'émetteur de cette demande, merci d'ignorer ce message.</p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+        </table>
+      </div>
+    </td>
+  </tr>
 </table>
 <div class="footer">
-        <table>
-                <tr>
-                        <td class="align-center">
-                                <p>-----</br></p>
-                                <p>Ceci est un message automatique, merci de ne pas répondre.</p>
-                        </td>
-                </tr>
-        </table>
+  <table width="100%">
+    <tr>
+      <td class="aligncenter content-block">
+        <p>-----</br></p>
+        <p>Ceci est un message automatique, merci de ne pas répondre.</p>
+      </td>
+    </tr>
+  </table>
 </div> 
 </body>
 </html>

--- a/conf/templates/emails-guest_admin_pregistration.html
+++ b/conf/templates/emails-guest_admin_pregistration.html
@@ -16,7 +16,7 @@
               <table width="100%" cellpadding="0" cellspacing="0">
                 <tr>
                   <td class="content-block">
-                    <h1 class="aligncenter">Preregistration by an admin: informations</h1>
+                    <h1 class="aligncenter">Preregistration</h1>
                     <p>Hi [% firstname %] [% lastname %],</p>
                     <p>An account has been created for you to access our network.</p>
                     <p>Once you will be on-site, authenticate using the following credentials to our captive portal:</p>

--- a/conf/templates/emails-guest_admin_pregistration.html
+++ b/conf/templates/emails-guest_admin_pregistration.html
@@ -1,0 +1,40 @@
+<html>
+<head>
+    <style type="text/css">
+        [% INCLUDE emails.css %]
+    </style>
+    <span class="preheader">Admin PreRegister informaziones</span>
+</head>
+<body>
+<table class="main">
+        <tr>
+                <td class="wrapper">
+                        <table>
+                                <tr>
+                                        <td>
+                                                <h1 class="align-center">Admin Preregistration Email</h1>
+                                                <p>Hi [% firstname %] [% lastname %],</p>
+                                                <p>An account has been created for you to access our network.</p>
+                                                <p>Once you will be on-site, authenticate using the following credentials to our captive portal:</p>
+                                                <p>Username: [% username %]</br>
+                                                Password: [% password %]</p>
+                                                <p>This username and password will be valid starting [% valid_from %]. [% txt_expiration %] [% txt_duration %]</p>
+                                                <p>Please ignore this request if you have not requested network access.</p>
+                                        </td>
+                                </tr>
+                        </table>
+                </td>
+        </tr>
+</table>
+<div class="footer">
+        <table>
+                <tr>
+                        <td class="align-center">
+                                <p>-----</br></p>
+                                <p>This is a post only E-mail, please do not reply.</p>
+                        </td>
+                </tr>
+        </table>
+</div>
+</body>
+</html>     

--- a/conf/templates/emails-guest_admin_pregistration.html
+++ b/conf/templates/emails-guest_admin_pregistration.html
@@ -1,40 +1,48 @@
 <html>
 <head>
-    <style type="text/css">
-        [% INCLUDE emails.css %]
-    </style>
-    <span class="preheader">Admin PreRegister Informations</span>
+  <style type="text/css">
+    [% INCLUDE emails.css %]
+  </style>
 </head>
 <body>
-<table class="main">
-        <tr>
-                <td class="wrapper">
-                        <table>
-                                <tr>
-                                        <td>
-                                                <h1 class="align-center">Preregistration by an admin: informations</h1>
-                                                <p>Hi [% firstname %] [% lastname %],</p>
-                                                <p>An account has been created for you to access our network.</p>
-                                                <p>Once you will be on-site, authenticate using the following credentials to our captive portal:</p>
-                                                <p>Username: [% username %]</br>
-                                                Password: [% password %]</p>
-                                                <p>This username and password will be valid starting [% valid_from %]. [% txt_expiration %] [% txt_duration %]</p>
-                                                <p>Please ignore this request if you have not requested network access.</p>
-                                        </td>
-                                </tr>
-                        </table>
-                </td>
-        </tr>
+<table class="body-wrap">
+  <tr>
+    <td></td>
+    <td class="container" width="600">
+      <div class="content">
+        <table class="main" width="100%" cellpadding="0" cellspacing="0">
+          <tr>
+            <td class="content-wrap">
+              <table width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td class="content-block">
+                    <h1 class="aligncenter">Preregistration by an admin: informations</h1>
+                    <p>Hi [% firstname %] [% lastname %],</p>
+                    <p>An account has been created for you to access our network.</p>
+                    <p>Once you will be on-site, authenticate using the following credentials to our captive portal:</p>
+                    <p>Username: [% username %]</br>
+                    Password: [% password %]</p>
+                    <p>This username and password will be valid starting [% valid_from %]. [% txt_expiration %] [% txt_duration %]</p>
+                    <p>Please ignore this request if you have not requested network access.</p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+        </table>
+      </div>
+    </td>
+  </tr>
 </table>
 <div class="footer">
-        <table>
-                <tr>
-                        <td class="align-center">
-                                <p>-----</br></p>
-                                <p>This is a post only E-mail, please do not reply.</p>
-                        </td>
-                </tr>
-        </table>
+  <table width="100%">
+    <tr>
+      <td class="aligncenter content-block">
+        <p>-----</br></p>
+        <p>This is a post only E-mail, please do not reply.</p>
+      </td>
+    </tr>
+  </table>
 </div>
 </body>
 </html>     

--- a/conf/templates/emails-guest_admin_pregistration.html
+++ b/conf/templates/emails-guest_admin_pregistration.html
@@ -3,7 +3,7 @@
     <style type="text/css">
         [% INCLUDE emails.css %]
     </style>
-    <span class="preheader">Admin PreRegister informaziones</span>
+    <span class="preheader">Admin PreRegister Informations</span>
 </head>
 <body>
 <table class="main">
@@ -12,7 +12,7 @@
                         <table>
                                 <tr>
                                         <td>
-                                                <h1 class="align-center">Admin Preregistration Email</h1>
+                                                <h1 class="align-center">Preregistration by an admin: informations</h1>
                                                 <p>Hi [% firstname %] [% lastname %],</p>
                                                 <p>An account has been created for you to access our network.</p>
                                                 <p>Once you will be on-site, authenticate using the following credentials to our captive portal:</p>

--- a/conf/templates/emails-guest_email_activation-fr.html
+++ b/conf/templates/emails-guest_email_activation-fr.html
@@ -12,9 +12,9 @@
                         <table>
                                 <tr>
                                         <td>
-                                                <h1 class="align-center">Email d'activation au réseau invité</h1>
+                                                <h1 class="align-center">Activation de votre accès au réseau</h1>
                                                 <p>Bonjour [% firstname %] [% lastname %], </p>
-                                                <p>Une demande d'accès réseau invité a été effectuée en utilisant cette addresse email.</p>
+                                                <p>Une demande d'accès réseau en tant qu'invité a été effectuée en utilisant cette addresse email.</p>
                                                 <a href="[% activation_uri %]" class="btn-primary">Activé votre accès réseau</a>
                                                 <p>Vous disposez de 10 minutes pour activé votre accès réseau ou celui-ci sera révoquer.</p>
                                                 <p>Merci de votre compréhension.</p>

--- a/conf/templates/emails-guest_email_activation-fr.html
+++ b/conf/templates/emails-guest_email_activation-fr.html
@@ -16,10 +16,10 @@
               <table width="100%" cellpadding="0" cellspacing="0">
                 <tr>
                   <td class="content-block">
-                    <h1 class="aligncenter">Activation de votre accès au réseau</h1>
+                    <h1 class="aligncenter">Activation de l'accès réseau</h1>
                     <p>Bonjour [% firstname %] [% lastname %], </p>
                     <p>Une demande d'accès réseau en tant qu'invité a été effectuée en utilisant cette addresse email.</p>
-                    <a href="[% activation_uri %]" class="btn-primary">Activé votre accès réseau</a>
+                    <a href="[% activation_uri %]" class="btn-primary">Activer votre accès réseau</a>
                     <p>Vous disposez de 10 minutes pour activé votre accès réseau ou celui-ci sera révoquer.</p>
                     <p>Merci de votre compréhension.</p>
                     <p>Si vous n'êtes pas l'émetteur de cette demande, merci d'ignorer ce message.</p>

--- a/conf/templates/emails-guest_email_activation-fr.html
+++ b/conf/templates/emails-guest_email_activation-fr.html
@@ -1,40 +1,47 @@
 <html>
 <head>
-    <style type="text/css">
-        [% INCLUDE emails.css %]
-    </style>
-    <span class="preheader">Informations d'activation</span>
+  <style type="text/css">
+    [% INCLUDE emails.css %]
+  </style>
 </head>
 <body>
-<table class="main">
-        <tr>
-                <td class="wrapper">
-                        <table>
-                                <tr>
-                                        <td>
-                                                <h1 class="align-center">Activation de votre accès au réseau</h1>
-                                                <p>Bonjour [% firstname %] [% lastname %], </p>
-                                                <p>Une demande d'accès réseau en tant qu'invité a été effectuée en utilisant cette addresse email.</p>
-                                                <a href="[% activation_uri %]" class="btn-primary">Activé votre accès réseau</a>
-                                                <p>Vous disposez de 10 minutes pour activé votre accès réseau ou celui-ci sera révoquer.</p>
-                                                <p>Merci de votre compréhension.</p>
-                                                <p>Si vous n'êtes pas l'émetteur de cette demande, merci d'ignorer ce message.</p>
-                                        </td>
-                                </tr>
-                        </table>
-                </td>
-        </tr>
-</table>
-
-<div class="footer">
-        <table>
+<table class="body-wrap">
+  <tr>
+    <td></td>
+    <td class="container" width="600">
+      <div class="content">
+        <table class="main" width="100%" cellpadding="0" cellspacing="0">
+          <tr>
+            <td class="content-wrap">
+              <table width="100%" cellpadding="0" cellspacing="0">
                 <tr>
-                        <td class="align-center">
-                                <p>-----</br></p>
-                                <p>Ceci est un message automatique, merci de ne pas répondre.</p>
-                        </td>
+                  <td class="content-block">
+                    <h1 class="aligncenter">Activation de votre accès au réseau</h1>
+                    <p>Bonjour [% firstname %] [% lastname %], </p>
+                    <p>Une demande d'accès réseau en tant qu'invité a été effectuée en utilisant cette addresse email.</p>
+                    <a href="[% activation_uri %]" class="btn-primary">Activé votre accès réseau</a>
+                    <p>Vous disposez de 10 minutes pour activé votre accès réseau ou celui-ci sera révoquer.</p>
+                    <p>Merci de votre compréhension.</p>
+                    <p>Si vous n'êtes pas l'émetteur de cette demande, merci d'ignorer ce message.</p>
+                  </td>
                 </tr>
+              </table>
+            </td>
+          </tr>
         </table>
+      </div>
+    </td>
+  </tr>
+</table>
+<div class="footer">
+  <table>
+    <tr>
+      <td class="align-center">
+        <p>-----</br></p>
+        <p>Ceci est un message automatique, merci de ne pas répondre.</p>
+      </td>
+    </tr>
+  </table>
 </div>
 </body>
 </html>

--- a/conf/templates/emails-guest_email_activation-fr.html
+++ b/conf/templates/emails-guest_email_activation-fr.html
@@ -1,0 +1,40 @@
+<html>
+<head>
+    <style type="text/css">
+        [% INCLUDE emails.css %]
+    </style>
+    <span class="preheader">Informations d'activation</span>
+</head>
+<body>
+<table class="main">
+        <tr>
+                <td class="wrapper">
+                        <table>
+                                <tr>
+                                        <td>
+                                                <h1 class="align-center">Email d'activation au réseau invité</h1>
+                                                <p>Bonjour [% firstname %] [% lastname %], </p>
+                                                <p>Une demande d'accès réseau invité a été effectuée en utilisant cette addresse email.</p>
+                                                <a href="[% activation_uri %]" class="btn-primary">Activé votre accès réseau</a>
+                                                <p>Vous disposez de 10 minutes pour activé votre accès réseau ou celui-ci sera révoquer.</p>
+                                                <p>Merci de votre compréhension.</p>
+                                                <p>Si vous n'êtes pas l'émetteur de cette demande, merci d'ignorer ce message.</p>
+                                        </td>
+                                </tr>
+                        </table>
+                </td>
+        </tr>
+</table>
+
+<div class="footer">
+        <table>
+                <tr>
+                        <td class="align-center">
+                                <p>-----</br></p>
+                                <p>Ceci est un message automatique, merci de ne pas répondre.</p>
+                        </td>
+                </tr>
+        </table>
+</div>
+</body>
+</html>

--- a/conf/templates/emails-guest_email_activation.html
+++ b/conf/templates/emails-guest_email_activation.html
@@ -1,0 +1,40 @@
+<html>
+<head>
+    <style type="text/css">
+        [% INCLUDE emails.css %]
+    </style>
+    <span class="preheader">Activation informaziones</span>
+</head>
+<body>
+<table class="main">
+        <tr>
+                <td class="wrapper">
+                        <table>
+                                <tr>
+                                        <td>
+                                                <h1 class="align-center">Guest Activation Email</h1>
+                                                <p>Hi [% firstname %] [% lastname %], </p>
+                                                <p>Guest access to the network was requested using this email address.</p>
+                                                <a href="[% activation_uri %]" class="btn-primary">Activate your network access</a>
+                                                <p>Failure to do so within 10 minutes will result in a termination of your network access.</p>
+                                                <p>Thank you for your understanding</p>
+                                                <p>Please ignore this request if you have not requested network access.</p>
+                                        </td>
+                                </tr>
+                        </table>
+                </td>
+        </tr>
+</table>
+
+<div class="footer">
+        <table>
+                <tr>
+                        <td class="align-center">
+                                <p>-----</br></p>
+                                <p>This is a post only E-mail, please do not reply.</p>
+                        </td>
+                </tr>
+        </table>
+</div>
+</body>
+</html>

--- a/conf/templates/emails-guest_email_activation.html
+++ b/conf/templates/emails-guest_email_activation.html
@@ -16,7 +16,7 @@
               <table width="100%" cellpadding="0" cellspacing="0">
                 <tr>
                   <td class="content-block">
-                    <h1 class="aligncenter">Guest access activation</h1>
+                    <h1 class="aligncenter">Network access activation</h1>
                     <p>Hi [% firstname %] [% lastname %], </p>
                     <p>Guest access to the network was requested using this email address.</p>
                     <a href="[% activation_uri %]" class="btn-primary">Activate your network access</a>

--- a/conf/templates/emails-guest_email_activation.html
+++ b/conf/templates/emails-guest_email_activation.html
@@ -3,7 +3,7 @@
     <style type="text/css">
         [% INCLUDE emails.css %]
     </style>
-    <span class="preheader">Activation informaziones</span>
+    <span class="preheader">Activation informations</span>
 </head>
 <body>
 <table class="main">
@@ -12,7 +12,7 @@
                         <table>
                                 <tr>
                                         <td>
-                                                <h1 class="align-center">Guest Activation Email</h1>
+                                                <h1 class="align-center">Guest access activation</h1>
                                                 <p>Hi [% firstname %] [% lastname %], </p>
                                                 <p>Guest access to the network was requested using this email address.</p>
                                                 <a href="[% activation_uri %]" class="btn-primary">Activate your network access</a>

--- a/conf/templates/emails-guest_email_activation.html
+++ b/conf/templates/emails-guest_email_activation.html
@@ -1,40 +1,47 @@
 <html>
 <head>
-    <style type="text/css">
-        [% INCLUDE emails.css %]
-    </style>
-    <span class="preheader">Activation informations</span>
+  <style type="text/css">
+    [% INCLUDE emails.css %]
+  </style>
 </head>
 <body>
-<table class="main">
-        <tr>
-                <td class="wrapper">
-                        <table>
-                                <tr>
-                                        <td>
-                                                <h1 class="align-center">Guest access activation</h1>
-                                                <p>Hi [% firstname %] [% lastname %], </p>
-                                                <p>Guest access to the network was requested using this email address.</p>
-                                                <a href="[% activation_uri %]" class="btn-primary">Activate your network access</a>
-                                                <p>Failure to do so within 10 minutes will result in a termination of your network access.</p>
-                                                <p>Thank you for your understanding</p>
-                                                <p>Please ignore this request if you have not requested network access.</p>
-                                        </td>
-                                </tr>
-                        </table>
-                </td>
-        </tr>
-</table>
-
-<div class="footer">
-        <table>
+<table class="body-wrap">
+  <tr>
+    <td></td>
+    <td class="container" width="600">
+      <div class="content">
+        <table class="main" width="100%" cellpadding="0" cellspacing="0">
+          <tr>
+            <td class="content-wrap">
+              <table width="100%" cellpadding="0" cellspacing="0">
                 <tr>
-                        <td class="align-center">
-                                <p>-----</br></p>
-                                <p>This is a post only E-mail, please do not reply.</p>
-                        </td>
+                  <td class="content-block">
+                    <h1 class="aligncenter">Guest access activation</h1>
+                    <p>Hi [% firstname %] [% lastname %], </p>
+                    <p>Guest access to the network was requested using this email address.</p>
+                    <a href="[% activation_uri %]" class="btn-primary">Activate your network access</a>
+                    <p>Failure to do so within 10 minutes will result in a termination of your network access.</p>
+                    <p>Thank you for your understanding</p>
+                    <p>Please ignore this request if you have not requested network access.</p>
+                  </td>
                 </tr>
+              </table>
+            </td>
+          </tr>
         </table>
+      </div>
+    </td>
+  </tr>
+</table>
+<div class="footer">
+  <table width="100%">
+    <tr>
+      <td class="aligncenter content-block">
+        <p>-----</br></p>
+        <p>This is a post only E-mail, please do not reply.</p>
+      </td>
+    </tr>
+  </table>
 </div>
 </body>
 </html>

--- a/conf/templates/emails-guest_email_preregistration-fr.html
+++ b/conf/templates/emails-guest_email_preregistration-fr.html
@@ -1,0 +1,40 @@
+<html>
+<head>
+    <style type="text/css">
+        [% INCLUDE emails.css %]
+    </style>
+    <span class="preheader">Informations de pre-enregistrement</span>
+</head>
+<body>
+<table class="main">
+        <tr>
+                <td class="wrapper">
+                        <table>
+                                <tr>
+                                        <td>
+                                                <h1 class="align-center">Email de pre-enregistrement invité</h1>
+                                                <p>Bonjour [% firstname %] [% lastname %],</p>
+                                                <p>Une demande d'accès réseau invité a été effectuée en utilisant cette addresse email.<p/>
+                                                <a href="[% activation_uri %]" class="btn-primary">Activé votre accès réseau</a>
+                                                <p>Lorsque vous activerez votre accès, vous allez recevoir un nom d'utilisateur et mot de passe à utiliser une fois sur place.</p>
+                                                <p>Merci de votre compréhension.</p>
+                                                <p>Si vous n'êtes pas l'émetteur de cette demande, merci d'ignorer ce message.</p>
+                                        </td>
+                                </tr>
+                        </table>
+                </td>
+        </tr>
+</table>
+
+<div class="footer">
+        <table>
+                <tr>
+                        <td class="align-center">
+                                <p>-----</br></p>
+                                <p>Ceci est un message automatique, merci de ne pas répondre.</p>
+                        </td>
+                </tr>
+        </table>
+</div>
+</body>
+</html>

--- a/conf/templates/emails-guest_email_preregistration-fr.html
+++ b/conf/templates/emails-guest_email_preregistration-fr.html
@@ -1,40 +1,47 @@
 <html>
 <head>
-    <style type="text/css">
-        [% INCLUDE emails.css %]
-    </style>
-    <span class="preheader">Informations de pre-enregistrement</span>
+  <style type="text/css">
+    [% INCLUDE emails.css %]
+  </style>
 </head>
 <body>
-<table class="main">
-        <tr>
-                <td class="wrapper">
-                        <table>
-                                <tr>
-                                        <td>
-                                                <h1 class="align-center">Pre-enregistrement invité</h1>
-                                                <p>Bonjour [% firstname %] [% lastname %],</p>
-                                                <p>Une demande d'accès réseau invité a été effectuée en utilisant cette addresse email.<p/>
-                                                <a href="[% activation_uri %]" class="btn-primary">Activé votre accès réseau</a>
-                                                <p>Lorsque vous activerez votre accès, vous allez recevoir un nom d'utilisateur et mot de passe à utiliser une fois sur place.</p>
-                                                <p>Merci de votre compréhension.</p>
-                                                <p>Si vous n'êtes pas l'émetteur de cette demande, merci d'ignorer ce message.</p>
-                                        </td>
-                                </tr>
-                        </table>
-                </td>
-        </tr>
-</table>
-
-<div class="footer">
-        <table>
+<table class="body-wrap">
+  <tr>
+    <td></td>
+    <td class="container" width="600">
+      <div class="content">
+        <table class="main" width="100%" cellpadding="0" cellspacing="0">
+          <tr>
+            <td class="content-wrap">
+              <table width="100%" cellpadding="0" cellspacing="0">
                 <tr>
-                        <td class="align-center">
-                                <p>-----</br></p>
-                                <p>Ceci est un message automatique, merci de ne pas répondre.</p>
-                        </td>
+                  <td class="content-block">
+                    <h1 class="aligncenter">Pre-enregistrement réseau invité</h1>
+                    <p>Bonjour [% firstname %] [% lastname %],</p>
+                    <p>Une demande d'accès réseau invité a été effectuée en utilisant cette addresse email.<p/>
+                    <a href="[% activation_uri %]" class="btn-primary">Activer votre accès réseau</a>
+                    <p>Lorsque vous activerez votre accès, vous allez recevoir un nom d'utilisateur et mot de passe à utiliser une fois sur place.</p>
+                    <p>Merci de votre compréhension.</p>
+                    <p>Si vous n'êtes pas l'émetteur de cette demande, merci d'ignorer ce message.</p>
+                  </td>
                 </tr>
+              </table>
+            </td>
+          </tr>
         </table>
+      </div>
+    </td>
+  </tr>
+</table>
+<div class="footer">
+  <table width="100%">
+    <tr>
+      <td class="aligncenter content-block">
+        <p>-----</br></p>
+        <p>Ceci est un message automatique, merci de ne pas répondre.</p>
+      </td>
+    </tr>
+  </table>
 </div>
 </body>
 </html>

--- a/conf/templates/emails-guest_email_preregistration-fr.html
+++ b/conf/templates/emails-guest_email_preregistration-fr.html
@@ -12,7 +12,7 @@
                         <table>
                                 <tr>
                                         <td>
-                                                <h1 class="align-center">Email de pre-enregistrement invité</h1>
+                                                <h1 class="align-center">Pre-enregistrement invité</h1>
                                                 <p>Bonjour [% firstname %] [% lastname %],</p>
                                                 <p>Une demande d'accès réseau invité a été effectuée en utilisant cette addresse email.<p/>
                                                 <a href="[% activation_uri %]" class="btn-primary">Activé votre accès réseau</a>

--- a/conf/templates/emails-guest_email_preregistration-fr.html
+++ b/conf/templates/emails-guest_email_preregistration-fr.html
@@ -16,7 +16,7 @@
               <table width="100%" cellpadding="0" cellspacing="0">
                 <tr>
                   <td class="content-block">
-                    <h1 class="aligncenter">Pre-enregistrement réseau invité</h1>
+                    <h1 class="aligncenter">Pre-enregistrement</h1>
                     <p>Bonjour [% firstname %] [% lastname %],</p>
                     <p>Une demande d'accès réseau invité a été effectuée en utilisant cette addresse email.<p/>
                     <a href="[% activation_uri %]" class="btn-primary">Activer votre accès réseau</a>

--- a/conf/templates/emails-guest_email_preregistration.html
+++ b/conf/templates/emails-guest_email_preregistration.html
@@ -3,7 +3,7 @@
     <style type="text/css">
         [% INCLUDE emails.css %]
     </style>
-    <span class="preheader">PreRegister informaziones</span>
+    <span class="preheader">PreRegister informations</span>
 </head>
 <body>
 <table class="main">
@@ -12,7 +12,7 @@
                         <table>
                                 <tr>
                                         <td>
-                                                <h1 class="align-center">Responsive Guest PreRegistration Email</h1>
+                                                <h1 class="align-center">Guest PreRegistration</h1>
                                                 <p>Hi [% firstname %] [% lastname %],</p>
                                                 <p>Guest access to our network was requested using this email address.<p/>
                                                 <a href="[% activation_uri %]" class="btn-primary">Activate your network access</a>

--- a/conf/templates/emails-guest_email_preregistration.html
+++ b/conf/templates/emails-guest_email_preregistration.html
@@ -1,40 +1,47 @@
 <html>
 <head>
-    <style type="text/css">
-        [% INCLUDE emails.css %]
-    </style>
-    <span class="preheader">PreRegister informations</span>
+  <style type="text/css">
+    [% INCLUDE emails.css %]
+  </style>
 </head>
 <body>
-<table class="main">
-        <tr>
-                <td class="wrapper">
-                        <table>
-                                <tr>
-                                        <td>
-                                                <h1 class="align-center">Guest PreRegistration</h1>
-                                                <p>Hi [% firstname %] [% lastname %],</p>
-                                                <p>Guest access to our network was requested using this email address.<p/>
-                                                <a href="[% activation_uri %]" class="btn-primary">Activate your network access</a>
-                                                <p>Once you have activated you will receive a username and password to use once you'll be on-site.</p>
-                                                <p>Thank you for your understanding</p>
-                                                <p>Please ignore this request if you have not requested network access.</p>
-                                        </td>
-                                </tr>
-                        </table>
-                </td>
-        </tr>
-</table>
-
-<div class="footer">
-        <table>
+<table class="body-wrap">
+  <tr>
+    <td></td>
+    <td class="container" width="600">
+      <div class="content">
+        <table class="main" width="100%" cellpadding="0" cellspacing="0">
+          <tr>
+            <td class="content-wrap">
+              <table width="100%" cellpadding="0" cellspacing="0">
                 <tr>
-                        <td class="align-center">
-                                <p>-----</br></p>
-                                <p>This is a post only E-mail, please do not reply.</p>
-                        </td>
+                  <td class="content-block">
+                    <h1 class="aligncenter">Guest PreRegistration</h1>
+                    <p>Hi [% firstname %] [% lastname %],</p>
+                    <p>Guest access to our network was requested using this email address.<p/>
+                    <a href="[% activation_uri %]" class="btn-primary">Activate your network access</a>
+                    <p>Once you have activated you will receive a username and password to use once you'll be on-site.</p>
+                    <p>Thank you for your understanding</p>
+                    <p>Please ignore this request if you have not requested network access.</p>
+                  </td>
                 </tr>
+              </table>
+            </td>
+          </tr>
         </table>
+      </div>
+    </td>
+  </tr>
+</table>
+<div class="footer">
+  <table width="100%">
+    <tr>
+      <td class="aligncenter content-block">
+        <p>-----</br></p>
+        <p>This is a post only E-mail, please do not reply.</p>
+      </td>
+    </tr>
+  </table>
 </div>
 </body>
 </html>

--- a/conf/templates/emails-guest_email_preregistration.html
+++ b/conf/templates/emails-guest_email_preregistration.html
@@ -1,0 +1,40 @@
+<html>
+<head>
+    <style type="text/css">
+        [% INCLUDE emails.css %]
+    </style>
+    <span class="preheader">PreRegister informaziones</span>
+</head>
+<body>
+<table class="main">
+        <tr>
+                <td class="wrapper">
+                        <table>
+                                <tr>
+                                        <td>
+                                                <h1 class="align-center">Responsive Guest PreRegistration Email</h1>
+                                                <p>Hi [% firstname %] [% lastname %],</p>
+                                                <p>Guest access to our network was requested using this email address.<p/>
+                                                <a href="[% activation_uri %]" class="btn-primary">Activate your network access</a>
+                                                <p>Once you have activated you will receive a username and password to use once you'll be on-site.</p>
+                                                <p>Thank you for your understanding</p>
+                                                <p>Please ignore this request if you have not requested network access.</p>
+                                        </td>
+                                </tr>
+                        </table>
+                </td>
+        </tr>
+</table>
+
+<div class="footer">
+        <table>
+                <tr>
+                        <td class="align-center">
+                                <p>-----</br></p>
+                                <p>This is a post only E-mail, please do not reply.</p>
+                        </td>
+                </tr>
+        </table>
+</div>
+</body>
+</html>

--- a/conf/templates/emails-guest_email_preregistration.html
+++ b/conf/templates/emails-guest_email_preregistration.html
@@ -16,7 +16,7 @@
               <table width="100%" cellpadding="0" cellspacing="0">
                 <tr>
                   <td class="content-block">
-                    <h1 class="aligncenter">Guest PreRegistration</h1>
+                    <h1 class="aligncenter">PreRegistration</h1>
                     <p>Hi [% firstname %] [% lastname %],</p>
                     <p>Guest access to our network was requested using this email address.<p/>
                     <a href="[% activation_uri %]" class="btn-primary">Activate your network access</a>

--- a/conf/templates/emails-guest_email_preregistration_confirmed-fr.html
+++ b/conf/templates/emails-guest_email_preregistration_confirmed-fr.html
@@ -16,7 +16,7 @@
               <table width="100%" cellpadding="0" cellspacing="0">
                 <tr>
                   <td class="content-block">
-                    <h1 class="aligncenter">Pre-enregistrement: confirmation</h1>
+                    <h1 class="aligncenter">Confirmation de pre-enregistrement</h1>
                     <p>Bonjour,</p>
                     <p>Votre accès au réseau invité a été confirmé.</p>
                     <p>Lorsque vous serez sur place, selectionné l'accès invité sur le portail captif et utilisez les informations suivantes pour vous authentifier:</p>

--- a/conf/templates/emails-guest_email_preregistration_confirmed-fr.html
+++ b/conf/templates/emails-guest_email_preregistration_confirmed-fr.html
@@ -1,0 +1,40 @@
+<html>
+<head>
+    <style type="text/css">
+        [% INCLUDE emails.css %]
+    </style>
+    <span class="preheader">Confirmation des informations de pre-enregistrement.</span>
+</head>
+<body>
+<table class="main">
+        <tr>
+                <td class="wrapper">
+                        <table>
+                                <tr>
+                                        <td>
+                                                <h1 class="align-center">Pre-enregistrement: email de confirmation</h1>
+                                                <p>Bonjour,</p>
+                                                <p>Votre accès réseau invité a été confirmé.</p>
+                                                <p>Lorsque vous sersez sur place, selectionné l'accès invité sur le portail captif et utilisez les informations suivantes pour vous authntifier:</p>
+                                                <p>Nom d'utilisateur: [% pid %]</br>
+                                                Mot de passe: [% password %]</p>
+                                                <p>Si vous avez des questions concernant le processsus d'enregistrement, merci de contacter le support local.</p>
+                                        </td>
+                                </tr>
+                        </table>
+                </td>
+        </tr>
+</table>
+
+<div class="footer">
+        <table>
+                <tr>
+                        <td class="align-center">
+                                <p>-----</br></p>
+                                <p>Ceci est un message automatique, merci de ne pas répondre.</p>
+                        </td>
+                </tr>
+        </table>
+</div>
+</body>
+</html>

--- a/conf/templates/emails-guest_email_preregistration_confirmed-fr.html
+++ b/conf/templates/emails-guest_email_preregistration_confirmed-fr.html
@@ -12,10 +12,10 @@
                         <table>
                                 <tr>
                                         <td>
-                                                <h1 class="align-center">Pre-enregistrement: email de confirmation</h1>
+                                                <h1 class="align-center">Pre-enregistrement: confirmation</h1>
                                                 <p>Bonjour,</p>
                                                 <p>Votre accès réseau invité a été confirmé.</p>
-                                                <p>Lorsque vous sersez sur place, selectionné l'accès invité sur le portail captif et utilisez les informations suivantes pour vous authntifier:</p>
+                                                <p>Lorsque vous sersez sur place, selectionné l'accès invité sur le portail captif et utilisez les informations suivantes pour vous authentifier:</p>
                                                 <p>Nom d'utilisateur: [% pid %]</br>
                                                 Mot de passe: [% password %]</p>
                                                 <p>Si vous avez des questions concernant le processsus d'enregistrement, merci de contacter le support local.</p>

--- a/conf/templates/emails-guest_email_preregistration_confirmed-fr.html
+++ b/conf/templates/emails-guest_email_preregistration_confirmed-fr.html
@@ -1,40 +1,47 @@
 <html>
 <head>
-    <style type="text/css">
-        [% INCLUDE emails.css %]
-    </style>
-    <span class="preheader">Confirmation des informations de pre-enregistrement.</span>
+  <style type="text/css">
+    [% INCLUDE emails.css %]
+  </style>
 </head>
 <body>
-<table class="main">
-        <tr>
-                <td class="wrapper">
-                        <table>
-                                <tr>
-                                        <td>
-                                                <h1 class="align-center">Pre-enregistrement: confirmation</h1>
-                                                <p>Bonjour,</p>
-                                                <p>Votre accès réseau invité a été confirmé.</p>
-                                                <p>Lorsque vous sersez sur place, selectionné l'accès invité sur le portail captif et utilisez les informations suivantes pour vous authentifier:</p>
-                                                <p>Nom d'utilisateur: [% pid %]</br>
-                                                Mot de passe: [% password %]</p>
-                                                <p>Si vous avez des questions concernant le processsus d'enregistrement, merci de contacter le support local.</p>
-                                        </td>
-                                </tr>
-                        </table>
-                </td>
-        </tr>
-</table>
-
-<div class="footer">
-        <table>
+<table class="body-wrap">
+  <tr>
+    <td></td>
+    <td class="container" width="600">
+      <div class="content">
+        <table class="main" width="100%" cellpadding="0" cellspacing="0">
+          <tr>
+            <td class="content-wrap">
+              <table width="100%" cellpadding="0" cellspacing="0">
                 <tr>
-                        <td class="align-center">
-                                <p>-----</br></p>
-                                <p>Ceci est un message automatique, merci de ne pas répondre.</p>
-                        </td>
+                  <td class="content-block">
+                    <h1 class="aligncenter">Pre-enregistrement: confirmation</h1>
+                    <p>Bonjour,</p>
+                    <p>Votre accès au réseau invité a été confirmé.</p>
+                    <p>Lorsque vous serez sur place, selectionné l'accès invité sur le portail captif et utilisez les informations suivantes pour vous authentifier:</p>
+                    <p>Nom d'utilisateur: [% pid %]</br>
+                    Mot de passe: [% password %]</p>
+                    <p>Si vous avez des questions concernant le processsus d'enregistrement, merci de contacter le support local.</p>
+                  </td>
                 </tr>
+              </table>
+            </td>
+          </tr>
         </table>
+      </div>
+    </td>
+  </tr>
+</table>
+<div class="footer">
+  <table width="100%">
+    <tr>
+      <td class="aligncenter content-block">
+        <p>-----</br></p>
+        <p>Ceci est un message automatique, merci de ne pas répondre.</p>
+      </td>
+    </tr>
+  </table>
 </div>
 </body>
 </html>

--- a/conf/templates/emails-guest_email_preregistration_confirmed.html
+++ b/conf/templates/emails-guest_email_preregistration_confirmed.html
@@ -1,0 +1,40 @@
+<html>
+<head>
+    <style type="text/css">
+        [% INCLUDE emails.css %]
+    </style>
+    <span class="preheader">PreRegister Confirmation informaziones</span>
+</head>
+<body>
+<table class="main">
+        <tr>
+                <td class="wrapper">
+                        <table>
+                                <tr>
+                                        <td>
+                                                <h1 class="align-center">PreRegister Confirmation Email</h1>
+                                                <p>Hi,</p>
+                                                <p>Your guest access to the network was confirmed.</p>
+                                                <p>Once on site, select guest access on the captive portal and use the following username and password to authenticate:</p>
+                                                <p>Username: [% pid %]</br>
+                                                Password: [% password %]</p>
+                                                <p>If you have any questions regarding the registration process please contact support.</p>
+                                        </td>
+                                </tr>
+                        </table>
+                </td>
+        </tr>
+</table>
+
+<div class="footer">
+        <table>
+                <tr>
+                        <td class="align-center">
+                                <p>-----</br></p>
+                                <p>This is a post only E-mail, please do not reply.</p>
+                        </td>
+                </tr>
+        </table>
+</div>
+</body>
+</html>

--- a/conf/templates/emails-guest_email_preregistration_confirmed.html
+++ b/conf/templates/emails-guest_email_preregistration_confirmed.html
@@ -16,7 +16,7 @@
               <table width="100%" cellpadding="0" cellspacing="0">
                 <tr>
                   <td class="content-block">
-                    <h1 class="aligncenter">PreRegister: confirmation</h1>
+                    <h1 class="aligncenter">PreRegister confirmation</h1>
                      <p>Hi,</p>
                      <p>Your guest access to the network was confirmed.</p>
                      <p>Once on site, select guest access on the captive portal and use the following username and password to authenticate:</p>

--- a/conf/templates/emails-guest_email_preregistration_confirmed.html
+++ b/conf/templates/emails-guest_email_preregistration_confirmed.html
@@ -1,40 +1,47 @@
 <html>
 <head>
-    <style type="text/css">
-        [% INCLUDE emails.css %]
-    </style>
-    <span class="preheader">PreRegister Confirmation informations</span>
+  <style type="text/css">
+    [% INCLUDE emails.css %]
+  </style>
 </head>
 <body>
-<table class="main">
-        <tr>
-                <td class="wrapper">
-                        <table>
-                                <tr>
-                                        <td>
-                                                <h1 class="align-center">PreRegister: confirmation</h1>
-                                                <p>Hi,</p>
-                                                <p>Your guest access to the network was confirmed.</p>
-                                                <p>Once on site, select guest access on the captive portal and use the following username and password to authenticate:</p>
-                                                <p>Username: [% pid %]</br>
-                                                Password: [% password %]</p>
-                                                <p>If you have any questions regarding the registration process please contact support.</p>
-                                        </td>
-                                </tr>
-                        </table>
-                </td>
-        </tr>
-</table>
-
-<div class="footer">
-        <table>
+<table class="body-wrap">
+  <tr>
+    <td></td>
+    <td class="container" width="600">
+      <div class="content">
+        <table class="main" width="100%" cellpadding="0" cellspacing="0">
+          <tr>
+            <td class="content-wrap">
+              <table width="100%" cellpadding="0" cellspacing="0">
                 <tr>
-                        <td class="align-center">
-                                <p>-----</br></p>
-                                <p>This is a post only E-mail, please do not reply.</p>
-                        </td>
+                  <td class="content-block">
+                    <h1 class="aligncenter">PreRegister: confirmation</h1>
+                     <p>Hi,</p>
+                     <p>Your guest access to the network was confirmed.</p>
+                     <p>Once on site, select guest access on the captive portal and use the following username and password to authenticate:</p>
+                     <p>Username: [% pid %]</br>
+                     Password: [% password %]</p>
+                     <p>If you have any questions regarding the registration process please contact support.</p>
+                  </td>
                 </tr>
+              </table>
+            </td>
+          </tr>
         </table>
+      </div>
+    </td>
+  </tr>
+</table>
+<div class="footer">
+  <table width="100%">
+    <tr>
+      <td class="aligncenter content-block">
+        <p>-----</br></p>
+        <p>This is a post only E-mail, please do not reply.</p>
+      </td>
+    </tr>
+  </table>
 </div>
 </body>
 </html>

--- a/conf/templates/emails-guest_email_preregistration_confirmed.html
+++ b/conf/templates/emails-guest_email_preregistration_confirmed.html
@@ -3,7 +3,7 @@
     <style type="text/css">
         [% INCLUDE emails.css %]
     </style>
-    <span class="preheader">PreRegister Confirmation informaziones</span>
+    <span class="preheader">PreRegister Confirmation informations</span>
 </head>
 <body>
 <table class="main">
@@ -12,7 +12,7 @@
                         <table>
                                 <tr>
                                         <td>
-                                                <h1 class="align-center">PreRegister Confirmation Email</h1>
+                                                <h1 class="align-center">PreRegister: confirmation</h1>
                                                 <p>Hi,</p>
                                                 <p>Your guest access to the network was confirmed.</p>
                                                 <p>Once on site, select guest access on the captive portal and use the following username and password to authenticate:</p>

--- a/conf/templates/emails-guest_local_account_creation-fr.html
+++ b/conf/templates/emails-guest_local_account_creation-fr.html
@@ -16,9 +16,9 @@
               <table width="100%" cellpadding="0" cellspacing="0">
                 <tr>
                   <td class="content-block">
-                    <h1 class="aligncenter">Création de compte utilisateur local</h1>
+                    <h1 class="aligncenter">Compte utilisateur</h1>
                     <p>Bonjour,</p>
-                    <p>Pendant le processus d'enregistrement nous avons créer un compte utilisateur. Celui-ci vous permet l'enregistrement de nouveaux appareils ou d'accéder à la page de status.</p>
+                    <p>Un compte utilisateur a été créé pendant le processus d'enregistrement. Celui-ci vous permet l'enregistrement de nouveaux appareils ou d'accéder à la page de status.</p>
                     <p>Voici les informations de connexion.</p>
                     <p>Nom d'utilisateur: [% pid %]</br> Mot de passe: [% password %]</p>
                     <p>Si vous avez des questions concernant le proccessus d'enregistrement, merci de contacter votre support local.</p>

--- a/conf/templates/emails-guest_local_account_creation-fr.html
+++ b/conf/templates/emails-guest_local_account_creation-fr.html
@@ -1,0 +1,39 @@
+<html>
+<head>
+    <style type="text/css">
+        [% INCLUDE emails.css %]
+    </style>
+    <span class="preheader">Informations du compte local</span>
+   </head>
+<body>
+<table class="main">
+        <tr>
+                <td class="wrapper">
+                        <table>
+                                <tr>
+                                        <td>
+                                                <h1 class="align-center">Email de création de compte utilisateur</h1>
+                                                <p>Bonjour,</p>
+                                                <p>Pendant le processus d'enregistrement nous avons créer un compte utilisateur. Celui-ci vous permet l'enregistrement de nouveaux appareils ou d'accéder à la page de status.</p>
+                                                <p>Voici les informations de connexion.</p>
+                                                <p>Nom d'utilisateur: [% pid %]</br> Mot de passe: [% password %]</p>
+
+                                                <p>Si vous avez des questions concernant le proccessus d'enregistrement, merci de contacter votre support local.</p>
+                                        </td>
+                                </tr>
+                        </table>
+                </td>
+        </tr>
+</table>
+<div class="footer">
+        <table>
+                <tr>
+                        <td class="align-center">
+                                <p>-----</br></p>
+                                <p>Ceci est un message automatique, merci de ne pas répondre.</p>
+                        </td>
+                </tr>
+        </table>
+</div>
+</body>
+</html>

--- a/conf/templates/emails-guest_local_account_creation-fr.html
+++ b/conf/templates/emails-guest_local_account_creation-fr.html
@@ -1,39 +1,46 @@
 <html>
 <head>
-    <style type="text/css">
-        [% INCLUDE emails.css %]
-    </style>
-    <span class="preheader">Informations du compte local</span>
-   </head>
+  <style type="text/css">
+    [% INCLUDE emails.css %]
+  </style>
+</head>
 <body>
-<table class="main">
-        <tr>
-                <td class="wrapper">
-                        <table>
-                                <tr>
-                                        <td>
-                                                <h1 class="align-center">Création de compte utilisateur local</h1>
-                                                <p>Bonjour,</p>
-                                                <p>Pendant le processus d'enregistrement nous avons créer un compte utilisateur. Celui-ci vous permet l'enregistrement de nouveaux appareils ou d'accéder à la page de status.</p>
-                                                <p>Voici les informations de connexion.</p>
-                                                <p>Nom d'utilisateur: [% pid %]</br> Mot de passe: [% password %]</p>
-
-                                                <p>Si vous avez des questions concernant le proccessus d'enregistrement, merci de contacter votre support local.</p>
-                                        </td>
-                                </tr>
-                        </table>
-                </td>
-        </tr>
+<table class="body-wrap">
+  <tr>
+    <td></td>
+    <td class="container" width="600">
+      <div class="content">
+        <table class="main" width="100%" cellpadding="0" cellspacing="0">
+          <tr>
+            <td class="content-wrap">
+              <table width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td class="content-block">
+                    <h1 class="aligncenter">Création de compte utilisateur local</h1>
+                    <p>Bonjour,</p>
+                    <p>Pendant le processus d'enregistrement nous avons créer un compte utilisateur. Celui-ci vous permet l'enregistrement de nouveaux appareils ou d'accéder à la page de status.</p>
+                    <p>Voici les informations de connexion.</p>
+                    <p>Nom d'utilisateur: [% pid %]</br> Mot de passe: [% password %]</p>
+                    <p>Si vous avez des questions concernant le proccessus d'enregistrement, merci de contacter votre support local.</p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+        </table>
+      </div>
+    </td>
+  </tr>
 </table>
 <div class="footer">
-        <table>
-                <tr>
-                        <td class="align-center">
-                                <p>-----</br></p>
-                                <p>Ceci est un message automatique, merci de ne pas répondre.</p>
-                        </td>
-                </tr>
-        </table>
+  <table width="100%">
+    <tr>
+      <td class="aligncenter content-block">
+        <p>-----</br></p>
+        <p>Ceci est un message automatique, merci de ne pas répondre.</p>
+      </td>
+    </tr>
+  </table>
 </div>
 </body>
 </html>

--- a/conf/templates/emails-guest_local_account_creation-fr.html
+++ b/conf/templates/emails-guest_local_account_creation-fr.html
@@ -12,7 +12,7 @@
                         <table>
                                 <tr>
                                         <td>
-                                                <h1 class="align-center">Email de création de compte utilisateur</h1>
+                                                <h1 class="align-center">Création de compte utilisateur local</h1>
                                                 <p>Bonjour,</p>
                                                 <p>Pendant le processus d'enregistrement nous avons créer un compte utilisateur. Celui-ci vous permet l'enregistrement de nouveaux appareils ou d'accéder à la page de status.</p>
                                                 <p>Voici les informations de connexion.</p>

--- a/conf/templates/emails-guest_local_account_creation.html
+++ b/conf/templates/emails-guest_local_account_creation.html
@@ -1,0 +1,39 @@
+<html>
+<head>
+    <style type="text/css">
+        [% INCLUDE emails.css %]
+    </style>
+    <span class="preheader">New account informaziones</span>
+</head>
+<body>
+<table class="main">
+        <tr>
+                <td class="wrapper">
+                        <table>
+                                <tr>
+                                        <td>
+                                                <h1 class="align-center">Responsive Account Creation Email</h1>
+                                                <p>Hi,</p>
+                                                <p>Just to let you know that we created a user account while registering your device. You may now want to use it for different features (devices registration, status page).</p>
+                                                <p>Here are the info.</p>
+                                                <p>Username: [% pid %]</br> Password: [% password %]</p>
+
+                                                <p>If you have any questions regarding the registration process please contact support.</p>
+                                        </td>
+                                </tr>
+                        </table>
+                </td>
+        </tr>
+</table>
+<div class="footer">
+        <table>
+                <tr>
+                        <td class="align-center">
+                                <p>-----</br></p>
+                                <p>This is a post only E-mail, please do not reply.</p>
+                        </td>
+                </tr>
+        </table>
+</div>
+</body>
+</html>

--- a/conf/templates/emails-guest_local_account_creation.html
+++ b/conf/templates/emails-guest_local_account_creation.html
@@ -3,7 +3,7 @@
     <style type="text/css">
         [% INCLUDE emails.css %]
     </style>
-    <span class="preheader">New account informaziones</span>
+    <span class="preheader">New account informations</span>
 </head>
 <body>
 <table class="main">
@@ -12,7 +12,7 @@
                         <table>
                                 <tr>
                                         <td>
-                                                <h1 class="align-center">Responsive Account Creation Email</h1>
+                                                <h1 class="align-center">Local Account Creation</h1>
                                                 <p>Hi,</p>
                                                 <p>Just to let you know that we created a user account while registering your device. You may now want to use it for different features (devices registration, status page).</p>
                                                 <p>Here are the info.</p>

--- a/conf/templates/emails-guest_local_account_creation.html
+++ b/conf/templates/emails-guest_local_account_creation.html
@@ -1,39 +1,46 @@
 <html>
 <head>
-    <style type="text/css">
-        [% INCLUDE emails.css %]
-    </style>
-    <span class="preheader">New account informations</span>
+  <style type="text/css">
+    [% INCLUDE emails.css %]
+  </style>
 </head>
 <body>
-<table class="main">
-        <tr>
-                <td class="wrapper">
-                        <table>
-                                <tr>
-                                        <td>
-                                                <h1 class="align-center">Local Account Creation</h1>
-                                                <p>Hi,</p>
-                                                <p>Just to let you know that we created a user account while registering your device. You may now want to use it for different features (devices registration, status page).</p>
-                                                <p>Here are the info.</p>
-                                                <p>Username: [% pid %]</br> Password: [% password %]</p>
-
-                                                <p>If you have any questions regarding the registration process please contact support.</p>
-                                        </td>
-                                </tr>
-                        </table>
-                </td>
-        </tr>
+<table class="body-wrap">
+  <tr>
+    <td></td>
+    <td class="container" width="600">
+      <div class="content">
+        <table class="main" width="100%" cellpadding="0" cellspacing="0">
+          <tr>
+            <td class="content-wrap">
+              <table width="100%" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td class="content-block">
+                    <h1 class="aligncenter">Local Account Creation</h1>
+                     <p>Hi,</p>
+                     <p>Just to let you know that we created a user account while registering your device. You may now want to use it for different features (devices registration, status page).</p>
+                     <p>Here are the info.</p>
+                     <p>Username: [% pid %]</br> Password: [% password %]</p>
+                     <p>If you have any questions regarding the registration process please contact support.</p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+        </table>
+      </div>
+    </td>
+  </tr>
 </table>
 <div class="footer">
-        <table>
-                <tr>
-                        <td class="align-center">
-                                <p>-----</br></p>
-                                <p>This is a post only E-mail, please do not reply.</p>
-                        </td>
-                </tr>
-        </table>
+  <table width="100%">
+    <tr>
+      <td class="aligncenter content-block">
+        <p>-----</br></p>
+        <p>This is a post only E-mail, please do not reply.</p>
+      </td>
+    </tr>
+  </table>
 </div>
 </body>
 </html>

--- a/conf/templates/emails-guest_local_account_creation.html
+++ b/conf/templates/emails-guest_local_account_creation.html
@@ -16,9 +16,9 @@
               <table width="100%" cellpadding="0" cellspacing="0">
                 <tr>
                   <td class="content-block">
-                    <h1 class="aligncenter">Local Account Creation</h1>
+                    <h1 class="aligncenter">User Account</h1>
                      <p>Hi,</p>
-                     <p>Just to let you know that we created a user account while registering your device. You may now want to use it for different features (devices registration, status page).</p>
+                     <p>Just to let you know that an user account has been created while registering your device. You may now want to use it for different features (devices registration, status page).</p>
                      <p>Here are the info.</p>
                      <p>Username: [% pid %]</br> Password: [% password %]</p>
                      <p>If you have any questions regarding the registration process please contact support.</p>

--- a/conf/templates/emails-guest_registered-fr.html
+++ b/conf/templates/emails-guest_registered-fr.html
@@ -16,7 +16,7 @@
               <table width="100%" cellpadding="0" cellspacing="0">
                 <tr>
                   <td class="content-block">
-                    <h1 class="aligncenter">Enregistrement d'appareils supplémentaitre pour invité</h1>
+                    <h1 class="aligncenter">Appareils supplémentaitres</h1>
                     <p>Bonjour,</p>
                     <p>Votre accès au réseau invité a été autorisé.</p>
                     <p>Vous pouvez enregistrer des appareils supplémentaires grâce aux informations suivantes:</p>

--- a/conf/templates/emails-guest_registered-fr.html
+++ b/conf/templates/emails-guest_registered-fr.html
@@ -1,39 +1,46 @@
 <html>
 <head>
-    <style type="text/css">
-        [% INCLUDE emails.css %]
-    </style>
-    <span class="preheader">Informations invité enregistrement.</span>
+  <style type="text/css">
+    [% INCLUDE emails.css %]
+  </style>
 </head>
 <body>
-<table class="main">
-        <tr>
-                <td class="wrapper">
-                        <table>
-                                <tr>
-                                        <td>
-                                                <h1 class="align-center">Enregistrement d'appareils supplémentaitre pour invité</h1>
-                                                <p>Bonjour,</p>
-                                                <p>Votre accès au réseau invité a été autorisé.</p>
-                                                <p>Vous pouvez enregistrer des appareils supplémentaires grâce aux informations suivantes:</p>
-                                                <p>Nom d'utilisateur: [% pid %]</br> Mot de passe: [% password %]</p>
-                                                <p>Si vous avez des questions concernant le processsus d'enregistrement, merci de contacter le support local.</p>
-                                        </td>
-                                </tr>
-                        </table>
-                </td>
-        </tr>
-</table>
-
-<div class="footer">
-        <table>
+<table class="body-wrap">
+  <tr>
+    <td></td>
+    <td class="container" width="600">
+      <div class="content">
+        <table class="main" width="100%" cellpadding="0" cellspacing="0">
+          <tr>
+            <td class="content-wrap">
+              <table width="100%" cellpadding="0" cellspacing="0">
                 <tr>
-                        <td class="align-center">
-                                <p>-----</br></p>
-                                <p>Ceci est un message automatique, merci de ne pas répondre.</p>
-                        </td>
+                  <td class="content-block">
+                    <h1 class="aligncenter">Enregistrement d'appareils supplémentaitre pour invité</h1>
+                    <p>Bonjour,</p>
+                    <p>Votre accès au réseau invité a été autorisé.</p>
+                    <p>Vous pouvez enregistrer des appareils supplémentaires grâce aux informations suivantes:</p>
+                    <p>Nom d'utilisateur: [% pid %]</br> Mot de passe: [% password %]</p>
+                    <p>Si vous avez des questions concernant le processsus d'enregistrement, merci de contacter le support local.</p>
+                  </td>
                 </tr>
+              </table>
+            </td>
+          </tr>
         </table>
+      </div>
+    </td>
+  </tr>
+</table>
+<div class="footer">
+  <table width="100%">
+    <tr>
+      <td class="aligncenter content-block">
+        <p>-----</br></p>
+        <p>Ceci est un message automatique, merci de ne pas répondre.</p>
+      </td>
+    </tr>
+  </table>
 </div>
 </body>
 </html>

--- a/conf/templates/emails-guest_registered-fr.html
+++ b/conf/templates/emails-guest_registered-fr.html
@@ -12,7 +12,7 @@
                         <table>
                                 <tr>
                                         <td>
-                                                <h1 class="align-center">Email d'enregistrement pour invité</h1>
+                                                <h1 class="align-center">Enregistrement d'appareils supplémentaitre pour invité</h1>
                                                 <p>Bonjour,</p>
                                                 <p>Votre accès au réseau invité a été autorisé.</p>
                                                 <p>Vous pouvez enregistrer des appareils supplémentaires grâce aux informations suivantes:</p>

--- a/conf/templates/emails-guest_registered-fr.html
+++ b/conf/templates/emails-guest_registered-fr.html
@@ -1,0 +1,39 @@
+<html>
+<head>
+    <style type="text/css">
+        [% INCLUDE emails.css %]
+    </style>
+    <span class="preheader">Informations invité enregistrement.</span>
+</head>
+<body>
+<table class="main">
+        <tr>
+                <td class="wrapper">
+                        <table>
+                                <tr>
+                                        <td>
+                                                <h1 class="align-center">Email d'enregistrement pour invité</h1>
+                                                <p>Bonjour,</p>
+                                                <p>Votre accès au réseau invité a été autorisé.</p>
+                                                <p>Vous pouvez enregistrer des appareils supplémentaires grâce aux informations suivantes:</p>
+                                                <p>Nom d'utilisateur: [% pid %]</br> Mot de passe: [% password %]</p>
+                                                <p>Si vous avez des questions concernant le processsus d'enregistrement, merci de contacter le support local.</p>
+                                        </td>
+                                </tr>
+                        </table>
+                </td>
+        </tr>
+</table>
+
+<div class="footer">
+        <table>
+                <tr>
+                        <td class="align-center">
+                                <p>-----</br></p>
+                                <p>Ceci est un message automatique, merci de ne pas répondre.</p>
+                        </td>
+                </tr>
+        </table>
+</div>
+</body>
+</html>

--- a/conf/templates/emails-guest_registered.html
+++ b/conf/templates/emails-guest_registered.html
@@ -16,7 +16,7 @@
               <table width="100%" cellpadding="0" cellspacing="0">
                 <tr>
                   <td class="content-block">
-                    <h1 class="aligncenter">Register new devices for guest</h1>
+                    <h1 class="aligncenter">New devices</h1>
                     <p>Hi,</p>
                     <p>Your guest access to the network was authorized.</p>
                     <p>You can register additional devices if you need with the following information:</p>

--- a/conf/templates/emails-guest_registered.html
+++ b/conf/templates/emails-guest_registered.html
@@ -1,0 +1,39 @@
+<html>
+<head>
+    <style type="text/css">
+        [% INCLUDE emails.css %]
+    </style>
+    <span class="preheader">Register informaziones</span>
+</head>
+<body>
+<table class="main">
+        <tr>
+                <td class="wrapper">
+                        <table>
+                                <tr>
+                                        <td>
+                                                <h1 class="align-center">Responsive Register Email</h1>
+                                                <p>Hi,</p>
+                                                <p>Your guest access to the network was authorized.</p>
+                                                <p>You can register additional devices if you need with the following information:</p>
+                                                <p>Username: [% pid %]</br> Password: [% password %]</p>
+                                                <p>If you have any questions regarding the registration process please contact support.</p>
+                                        </td>
+                                </tr>
+                        </table>
+                </td>
+        </tr>
+</table>
+
+<div class="footer">
+        <table>
+                <tr>
+                        <td class="align-center">
+                                <p>-----</br></p>
+                                <p>This is a post only E-mail, please do not reply.</p>
+                        </td>
+                </tr>
+        </table>
+</div>
+</body>
+</html>

--- a/conf/templates/emails-guest_registered.html
+++ b/conf/templates/emails-guest_registered.html
@@ -3,7 +3,7 @@
     <style type="text/css">
         [% INCLUDE emails.css %]
     </style>
-    <span class="preheader">Register informaziones</span>
+    <span class="preheader">Register informations</span>
 </head>
 <body>
 <table class="main">
@@ -12,7 +12,7 @@
                         <table>
                                 <tr>
                                         <td>
-                                                <h1 class="align-center">Responsive Register Email</h1>
+                                                <h1 class="align-center">Register new devices for guest</h1>
                                                 <p>Hi,</p>
                                                 <p>Your guest access to the network was authorized.</p>
                                                 <p>You can register additional devices if you need with the following information:</p>

--- a/conf/templates/emails-guest_registered.html
+++ b/conf/templates/emails-guest_registered.html
@@ -1,39 +1,46 @@
 <html>
 <head>
-    <style type="text/css">
-        [% INCLUDE emails.css %]
-    </style>
-    <span class="preheader">Register informations</span>
+  <style type="text/css">
+    [% INCLUDE emails.css %]
+  </style>
 </head>
 <body>
-<table class="main">
-        <tr>
-                <td class="wrapper">
-                        <table>
-                                <tr>
-                                        <td>
-                                                <h1 class="align-center">Register new devices for guest</h1>
-                                                <p>Hi,</p>
-                                                <p>Your guest access to the network was authorized.</p>
-                                                <p>You can register additional devices if you need with the following information:</p>
-                                                <p>Username: [% pid %]</br> Password: [% password %]</p>
-                                                <p>If you have any questions regarding the registration process please contact support.</p>
-                                        </td>
-                                </tr>
-                        </table>
-                </td>
-        </tr>
-</table>
-
-<div class="footer">
-        <table>
+<table class="body-wrap">
+  <tr>
+    <td></td>
+    <td class="container" width="600">
+      <div class="content">
+        <table class="main" width="100%" cellpadding="0" cellspacing="0">
+          <tr>
+            <td class="content-wrap">
+              <table width="100%" cellpadding="0" cellspacing="0">
                 <tr>
-                        <td class="align-center">
-                                <p>-----</br></p>
-                                <p>This is a post only E-mail, please do not reply.</p>
-                        </td>
+                  <td class="content-block">
+                    <h1 class="aligncenter">Register new devices for guest</h1>
+                    <p>Hi,</p>
+                    <p>Your guest access to the network was authorized.</p>
+                    <p>You can register additional devices if you need with the following information:</p>
+                    <p>Username: [% pid %]</br> Password: [% password %]</p>
+                    <p>If you have any questions regarding the registration process please contact support.</p>
+                  </td>
                 </tr>
+              </table>
+            </td>
+          </tr>
         </table>
+      </div>
+    </td>
+  </tr>
+</table>
+<div class="footer">
+  <table width="100%">
+    <tr>
+      <td class="aligncenter content-block">
+        <p>-----</br></p>
+        <p>This is a post only E-mail, please do not reply.</p>
+      </td>
+    </tr>
+  </table>
 </div>
 </body>
 </html>

--- a/conf/templates/emails-guest_sponsor_activation-fr.html
+++ b/conf/templates/emails-guest_sponsor_activation-fr.html
@@ -1,52 +1,56 @@
 <html>
 <head>
-    <style type="text/css">
-        [% INCLUDE emails.css %]
-    </style>
-    <span class="preheader">Informations d'enregistrement pas sponsor.</span>
+  <style type="text/css">
+    [% INCLUDE emails.css %]
+  </style>
 </head>
 <body>
-<table class="main">
-        <tr>
-                <td class="wrapper">
-                        <table>
-                                <tr>
-                                        <td>
-                                                <h1 class="align-center">Demande d'enreigstrement pour sponsor</h1>
-                                                <p>Bonjour,</p>
-                                                <p>[% firstname %] [% lastname %] a fais une demande pour accéder au réseau invité.</p>
-                                                <p>N'autorisez PAS l'accès si vous n'attendez cet invité.</p>
-                                                <p>Voici les informations que l'invité a fourni lors de son enregistrement:</p>          
-                                                <p>Nom: [% firstname %]</br>
-                                                Prénom: [% lastname %]</br>
-                                                Numéro de téléphone: [% telephone %]</br>
-                                                Email: [% pid %]</p>
-
-                                                <a href="[% activation_uri %]" class="btn-primary">Activer l'accès sponsorisé pour l'invité [% firstname %]</a>
-                                                 
-                                                [% IF is_preregistration -%]
-                                                <p>Dès lors que vous cliquez le lien d'activation, l'invité va recevoir par email un nom d'utilisateur et mot de passe à utilisé üne fois sur place pour terminer la procédure d'enregistrement.</p>
-                                                [% ELSE %]
-                                                <p>Tant que vous ne cliquez pas sur le lien, l'utilisateur n'aura PAS d'accès Internet.</p>
-                                                [%- END %]
-
-                                                <p>Merci de votre coopération.</p>
-                                        </td>
-                                </tr>
-                        </table>
-                </td>
-        </tr>
-</table>
-
-<div class="footer">
-        <table>
+<table class="body-wrap">
+  <tr>
+    <td></td>
+    <td class="container" width="600">
+      <div class="content">
+        <table class="main" width="100%" cellpadding="0" cellspacing="0">
+          <tr>
+            <td class="content-wrap">
+              <table width="100%" cellpadding="0" cellspacing="0">
                 <tr>
-                        <td class="align-center">
-                                <p>-----</br></p>
-                                <p>Ceci est un message automatique, merci de ne pas répondre.</p>
-                        </td>
+                  <td class="content-block">                  
+                    <h1 class="aligncenter">Demande d'enregistrement par sponsor</h1>
+                    <p>Bonjour,</p>
+                    <p>[% firstname %] [% lastname %] a fais une demande pour accéder au réseau invité.</p>
+                    <p>N'autorisez PAS l'accès si vous n'attendez cet invité.</p>
+                    <p>Voici les informations que l'invité a fourni lors de son enregistrement:</p>          
+                    <p>Nom: [% firstname %]</br>
+                    Prénom: [% lastname %]</br>
+                    Numéro de téléphone: [% telephone %]</br>
+                    Email: [% pid %]</p>
+                    <a href="[% activation_uri %]" class="btn-primary">Activer l'accès sponsorisé pour l'invité [% firstname %]</a>                    
+                    [% IF is_preregistration -%]
+                    <p>Dès lors que vous cliquez le lien d'activation, l'invité va recevoir par email un nom d'utilisateur et mot de passe à utiliser une fois sur place pour terminer la procédure d'enregistrement.</p>
+                    [% ELSE %]
+                    <p>Tant que vous ne cliquez pas sur le lien, l'utilisateur n'aura PAS d'accès Internet.</p>
+                    [%- END %]
+                    <p>Merci de votre coopération.</p>
+                  </td>
                 </tr>
+              </table>
+            </td>
+          </tr>
         </table>
+      </div>
+    </td>
+  </tr>
+</table>
+<div class="footer">
+  <table width="100%">
+    <tr>
+      <td class="aligncenter content-block">
+        <p>-----</br></p>
+        <p>Ceci est un message automatique, merci de ne pas répondre.</p>
+      </td>
+    </tr>
+  </table>
 </div>
 </body>
 </html>

--- a/conf/templates/emails-guest_sponsor_activation-fr.html
+++ b/conf/templates/emails-guest_sponsor_activation-fr.html
@@ -1,0 +1,52 @@
+<html>
+<head>
+    <style type="text/css">
+        [% INCLUDE emails.css %]
+    </style>
+    <span class="preheader">Informations d'enregistrement pas sponsor.</span>
+</head>
+<body>
+<table class="main">
+        <tr>
+                <td class="wrapper">
+                        <table>
+                                <tr>
+                                        <td>
+                                                <h1 class="align-center">Responsive Sponsor Email</h1>
+                                                <p>Bonjour,</p>
+                                                <p>[% firstname %] [% lastname %] a fais une demande pour accéder au réseau invité.</p>
+                                                <p>N'autorisez PAS l'accès si vous n'attendez cet invité.</p>
+                                                <p>Voici les informations que l'invité a fourni lors de son enregistrement:</p>          
+                                                <p>Nom: [% firstname %]</br>
+                                                Prénom: [% lastname %]</br>
+                                                Numéro de téléphone: [% telephone %]</br>
+                                                Email: [% pid %]</p>
+
+                                                <a href="[% activation_uri %]" class="btn-primary">Activer l'accès sponsorisé pour l'invité [% firstname %]</a>
+                                                 
+                                                [% IF is_preregistration -%]
+                                                <p>Dès lors que vous cliquez le lien d'activation, l'invité va recevoir par email un nom d'utilisateur et mot de passe à utilisé üne fois sur place pour terminer la procédure d'enregistrement.</p>
+                                                [% ELSE %]
+                                                <p>Tant que vous ne cliquez pas sur le lien, l'utilisateur n'aura PAS d'accès Internet.</p>
+                                                [%- END %]
+
+                                                <p>Merci de votre coopération.</p>
+                                        </td>
+                                </tr>
+                        </table>
+                </td>
+        </tr>
+</table>
+
+<div class="footer">
+        <table>
+                <tr>
+                        <td class="align-center">
+                                <p>-----</br></p>
+                                <p>Ceci est un message automatique, merci de ne pas répondre.</p>
+                        </td>
+                </tr>
+        </table>
+</div>
+</body>
+</html>

--- a/conf/templates/emails-guest_sponsor_activation-fr.html
+++ b/conf/templates/emails-guest_sponsor_activation-fr.html
@@ -12,7 +12,7 @@
                         <table>
                                 <tr>
                                         <td>
-                                                <h1 class="align-center">Responsive Sponsor Email</h1>
+                                                <h1 class="align-center">Demande d'enreigstrement pour sponsor</h1>
                                                 <p>Bonjour,</p>
                                                 <p>[% firstname %] [% lastname %] a fais une demande pour accéder au réseau invité.</p>
                                                 <p>N'autorisez PAS l'accès si vous n'attendez cet invité.</p>

--- a/conf/templates/emails-guest_sponsor_activation-fr.html
+++ b/conf/templates/emails-guest_sponsor_activation-fr.html
@@ -16,7 +16,7 @@
               <table width="100%" cellpadding="0" cellspacing="0">
                 <tr>
                   <td class="content-block">                  
-                    <h1 class="aligncenter">Demande d'enregistrement par sponsor</h1>
+                    <h1 class="aligncenter">Demande d'enregistrement</h1>
                     <p>Bonjour,</p>
                     <p>[% firstname %] [% lastname %] a fais une demande pour accéder au réseau invité.</p>
                     <p>N'autorisez PAS l'accès si vous n'attendez cet invité.</p>

--- a/conf/templates/emails-guest_sponsor_activation.html
+++ b/conf/templates/emails-guest_sponsor_activation.html
@@ -1,50 +1,56 @@
 <html>
 <head>
-    <style type="text/css">
-        [% INCLUDE emails.css %]
-    </style>
-    <span class="preheader">Register by sponsor informations</span>
+  <style type="text/css">
+    [% INCLUDE emails.css %]
+  </style>
 </head>
 <body>
-<table class="main">
-        <tr>
-                <td class="wrapper">
-                        <table>
-                                <tr>
-                                        <td>
-                                                <h1 class="align-center">Guest request access by sponsor</h1>
-                                                <p>Hi,</p>
-                                                <p>[% firstname %] [% lastname %] requested guest access to your network.</p>
-                                                <p>Do NOT authorize access if you were not expecting this guest.</p>
-                                                <p>Here is the information the guest provided with registration form:</p>          
-                                                <p>Firstname: [% firstname %]</br>
-                                                Lastname: [% lastname %]</br>
-                                                Phone number: [% telephone %]</br>
-                                                Email: [% pid %]</p>
-
-                                                <a href="[% activation_uri %]" class="btn-primary">Activate the sponsor access for guest [% firstname %]</a>
-                                                 
-                                                [% IF is_preregistration -%]
-                                                <p>Once you click on the activation link the guest will be sent a username and password by email which will allow him to register as a guest in the network once on-site.</p>
-                                                [% ELSE %]
-                                                <p>Until you click on the activation link this guest will have NO Internet access.</p>
-                                                [%- END %]
-
-                                                <p>Thank you for your cooperation.</p>
-                                        </td>
-                                </tr>
-                        </table>
-                </td>
-        </tr>
-</table>
-
-<div class="footer">
-        <table>
+<table class="body-wrap">
+  <tr>
+    <td></td>
+    <td class="container" width="600">
+      <div class="content">
+        <table class="main" width="100%" cellpadding="0" cellspacing="0">
+          <tr>
+            <td class="content-wrap">
+              <table width="100%" cellpadding="0" cellspacing="0">
                 <tr>
-                        <td class="align-center">
-                                <p>-----</br></p>
-                                <p>This is a post only E-mail, please do not reply.</p>
-                        </td>
+                  <td class="content-block">
+                    <h1 class="align-center">Guest request access by sponsor</h1>
+                    <p>Hi,</p>
+                    <p>[% firstname %] [% lastname %] requested guest access to your network.</p>
+                    <p>Do NOT authorize access if you were not expecting this guest.</p>
+                    <p>Here is the information the guest provided with registration form:</p>          
+                    <p>Firstname: [% firstname %]</br>
+                    Lastname: [% lastname %]</br>
+                    Phone number: [% telephone %]</br>
+                    Email: [% pid %]</p>
+                    <a href="[% activation_uri %]" class="btn-primary">Activate the sponsor access for guest [% firstname %]</a>
+                    [% IF is_preregistration -%]
+                    <p>Once you click on the activation link the guest will be sent a username and password by email which will allow him to register as a guest in the network once on-site.</p>
+                    [% ELSE %]
+                    <p>Until you click on the activation link this guest will have NO Internet access.</p>
+                    [%- END %]
+                    <p>Thank you for your cooperation.</p>
+                  </td>
                 </tr>
+              </table>
+            </td>
+          </tr>
         </table>
+      </div>
+    </td>
+  </tr>
+</table>
+<div class="footer">
+  <table width="100%">
+    <tr>
+      <td class="aligncenter content-block">
+        <p>-----</br></p>
+        <p>This is a post only E-mail, please do not reply.</p>
+      </td>
+    </tr>
+  </table>
 </div>
+</body>
+</html>

--- a/conf/templates/emails-guest_sponsor_activation.html
+++ b/conf/templates/emails-guest_sponsor_activation.html
@@ -1,0 +1,44 @@
+<link rel="stylesheet" type="text/css" href="/usr/local/pf/html/pfappserver/root/static/css/email.css">
+<span class="preheader">Register by sponsor informaziones</span>
+<table class="main">
+        <tr>
+                <td class="wrapper">
+                        <table>
+                                <tr>
+                                        <td>
+                                                <h1 class="align-center">Responsive Sponsor Email</h1>
+                                                <p>Hi,</p>
+                                                <p>[% firstname %] [% lastname %] requested guest access to your network.</p>
+                                                <p>Do NOT authorize access if you were not expecting this guest.</p>
+                                                <p>Here is the information the guest provided with registration form:</p>          
+                                                <p>Firstname: [% firstname %]</br>
+                                                Lastname: [% lastname %]</br>
+                                                Phone number: [% telephone %]</br>
+                                                Email: [% pid %]</p>
+
+                                                <a href="[% activation_uri %]" class="btn-primary">Activate the sponsor access for guest [% firstname %]</a>
+                                                 
+                                                [% IF is_preregistration -%]
+                                                <p>Once you click on the activation link the guest will be sent a username and password by email which will allow him to register as a guest in the network once on-site.</p>
+                                                [% ELSE %]
+                                                <p>Until you click on the activation link this guest will have NO Internet access.</p>
+                                                [%- END %]
+
+                                                <p>Thank you for your cooperation.</p>
+                                        </td>
+                                </tr>
+                        </table>
+                </td>
+        </tr>
+</table>
+
+<div class="footer">
+        <table>
+                <tr>
+                        <td class="align-center">
+                                <p>-----</br></p>
+                                <p>This is a post only E-mail, please do not reply.</p>
+                        </td>
+                </tr>
+        </table>
+</div>

--- a/conf/templates/emails-guest_sponsor_activation.html
+++ b/conf/templates/emails-guest_sponsor_activation.html
@@ -16,7 +16,7 @@
               <table width="100%" cellpadding="0" cellspacing="0">
                 <tr>
                   <td class="content-block">
-                    <h1 class="align-center">Guest request access by sponsor</h1>
+                    <h1 class="align-center">Guest request</h1>
                     <p>Hi,</p>
                     <p>[% firstname %] [% lastname %] requested guest access to your network.</p>
                     <p>Do NOT authorize access if you were not expecting this guest.</p>

--- a/conf/templates/emails-guest_sponsor_activation.html
+++ b/conf/templates/emails-guest_sponsor_activation.html
@@ -1,12 +1,18 @@
-<link rel="stylesheet" type="text/css" href="/usr/local/pf/html/pfappserver/root/static/css/email.css">
-<span class="preheader">Register by sponsor informaziones</span>
+<html>
+<head>
+    <style type="text/css">
+        [% INCLUDE emails.css %]
+    </style>
+    <span class="preheader">Register by sponsor informations</span>
+</head>
+<body>
 <table class="main">
         <tr>
                 <td class="wrapper">
                         <table>
                                 <tr>
                                         <td>
-                                                <h1 class="align-center">Responsive Sponsor Email</h1>
+                                                <h1 class="align-center">Guest request access by sponsor</h1>
                                                 <p>Hi,</p>
                                                 <p>[% firstname %] [% lastname %] requested guest access to your network.</p>
                                                 <p>Do NOT authorize access if you were not expecting this guest.</p>

--- a/conf/templates/emails-guest_sponsor_confirmed-fr.html
+++ b/conf/templates/emails-guest_sponsor_confirmed-fr.html
@@ -1,0 +1,37 @@
+<html>
+<head>
+    <style type="text/css">
+        [% INCLUDE emails.css %]
+    </style>
+    <span class="preheader">Confirmation d'informations d'enregistrement par sponsor</span>
+</head>
+<body>
+<table class="main">
+        <tr>
+                <td class="wrapper">
+                        <table>
+                                <tr>
+                                        <td>
+                                                <h1 class="align-center">Email de confirmation d'accès par sponsor</h1>
+                                                <p>Bonjour,</p>
+                                                <p>Votre accès invité au réseau a été autorisé.</p>
+                                                <p>Si vous avez des questions concernant le processsus d'enregistrement, merci de contacter le support local.</p>
+                                        </td>
+                                </tr>
+                        </table>
+                </td>
+        </tr>
+</table>
+
+<div class="footer">
+        <table>
+                <tr>
+                        <td class="align-center">
+                                <p>-----</br></p>
+                                <p>Ceci est un message automatique, merci de ne pas répondre.</p>
+                        </td>
+                </tr>
+        </table>
+</div>
+</body>
+</html>

--- a/conf/templates/emails-guest_sponsor_confirmed-fr.html
+++ b/conf/templates/emails-guest_sponsor_confirmed-fr.html
@@ -12,7 +12,7 @@
                         <table>
                                 <tr>
                                         <td>
-                                                <h1 class="align-center">Email de confirmation d'accès par sponsor</h1>
+                                                <h1 class="align-center">Confirmation d'accès par sponsor</h1>
                                                 <p>Bonjour,</p>
                                                 <p>Votre accès invité au réseau a été autorisé.</p>
                                                 <p>Si vous avez des questions concernant le processsus d'enregistrement, merci de contacter le support local.</p>

--- a/conf/templates/emails-guest_sponsor_confirmed-fr.html
+++ b/conf/templates/emails-guest_sponsor_confirmed-fr.html
@@ -1,37 +1,44 @@
 <html>
 <head>
-    <style type="text/css">
-        [% INCLUDE emails.css %]
-    </style>
-    <span class="preheader">Confirmation d'informations d'enregistrement par sponsor</span>
+  <style type="text/css">
+    [% INCLUDE emails.css %]
+  </style>
 </head>
 <body>
-<table class="main">
-        <tr>
-                <td class="wrapper">
-                        <table>
-                                <tr>
-                                        <td>
-                                                <h1 class="align-center">Confirmation d'accès par sponsor</h1>
-                                                <p>Bonjour,</p>
-                                                <p>Votre accès invité au réseau a été autorisé.</p>
-                                                <p>Si vous avez des questions concernant le processsus d'enregistrement, merci de contacter le support local.</p>
-                                        </td>
-                                </tr>
-                        </table>
-                </td>
-        </tr>
-</table>
-
-<div class="footer">
-        <table>
+<table class="body-wrap">
+  <tr>
+    <td></td>
+    <td class="container" width="600">
+      <div class="content">
+        <table class="main" width="100%" cellpadding="0" cellspacing="0">
+          <tr>
+            <td class="content-wrap">
+              <table width="100%" cellpadding="0" cellspacing="0">
                 <tr>
-                        <td class="align-center">
-                                <p>-----</br></p>
-                                <p>Ceci est un message automatique, merci de ne pas répondre.</p>
-                        </td>
+                  <td class="content-block">
+                    <h1 class="aligncenter">Confirmation d'accès par sponsor</h1>
+                    <p>Bonjour,</p>
+                    <p>Votre accès invité au réseau a été autorisé.</p>
+                    <p>Si vous avez des questions concernant le processsus d'enregistrement, merci de contacter le support local.</p>
+                  </td>
                 </tr>
+              </table>
+            </td>
+          </tr>
         </table>
+      </div>
+    </td>
+  </tr>
+</table>
+<div class="footer">
+  <table width="100%">
+    <tr>
+      <td class="aligncenter content-block">
+        <p>-----</br></p>
+        <p>Ceci est un message automatique, merci de ne pas répondre.</p>
+      </td>
+    </tr>
+  </table>
 </div>
 </body>
 </html>

--- a/conf/templates/emails-guest_sponsor_confirmed-fr.html
+++ b/conf/templates/emails-guest_sponsor_confirmed-fr.html
@@ -16,7 +16,7 @@
               <table width="100%" cellpadding="0" cellspacing="0">
                 <tr>
                   <td class="content-block">
-                    <h1 class="aligncenter">Confirmation d'accès par sponsor</h1>
+                    <h1 class="aligncenter">Accès autorisé</h1>
                     <p>Bonjour,</p>
                     <p>Votre accès invité au réseau a été autorisé.</p>
                     <p>Si vous avez des questions concernant le processsus d'enregistrement, merci de contacter le support local.</p>

--- a/conf/templates/emails-guest_sponsor_confirmed.html
+++ b/conf/templates/emails-guest_sponsor_confirmed.html
@@ -16,7 +16,7 @@
               <table width="100%" cellpadding="0" cellspacing="0">
                 <tr>
                   <td class="content-block">
-                    <h1 class="aligncenter">Sponsor Guest Confiramtion</h1>
+                    <h1 class="aligncenter">Access Authorized</h1>
                     <p>Hi,</p>
                     <p>Your guest access to the network was authorized.</p>
                     <p>If you have any questions regarding the registration process please contact support.</p>

--- a/conf/templates/emails-guest_sponsor_confirmed.html
+++ b/conf/templates/emails-guest_sponsor_confirmed.html
@@ -1,37 +1,44 @@
 <html>
 <head>
-    <style type="text/css">
-        [% INCLUDE emails.css %]
-    </style>
-    <span class="preheader">Register sponsor confirmation informations</span>
+  <style type="text/css">
+    [% INCLUDE emails.css %]
+  </style>
 </head>
 <body>
-<table class="main">
-        <tr>
-                <td class="wrapper">
-                        <table>
-                                <tr>
-                                        <td>
-                                                <h1 class="align-center">Sponsor Guest Confiramtion</h1>
-                                                <p>Hi,</p>
-                                                <p>Your guest access to the network was authorized.</p>
-                                                <p>If you have any questions regarding the registration process please contact support.</p>
-                                        </td>
-                                </tr>
-                        </table>
-                </td>
-        </tr>
-</table>
-
-<div class="footer">
-        <table>
+<table class="body-wrap">
+  <tr>
+    <td></td>
+    <td class="container" width="600">
+      <div class="content">
+        <table class="main" width="100%" cellpadding="0" cellspacing="0">
+          <tr>
+            <td class="content-wrap">
+              <table width="100%" cellpadding="0" cellspacing="0">
                 <tr>
-                        <td class="align-center">
-                                <p>-----</br></p>
-                                <p>This is a post only E-mail, please do not reply.</p>
-                        </td>
+                  <td class="content-block">
+                    <h1 class="aligncenter">Sponsor Guest Confiramtion</h1>
+                    <p>Hi,</p>
+                    <p>Your guest access to the network was authorized.</p>
+                    <p>If you have any questions regarding the registration process please contact support.</p>
+                  </td>
                 </tr>
+              </table>
+            </td>
+          </tr>
         </table>
+      </div>
+    </td>
+  </tr>
+</table>
+<div class="footer">
+  <table width="100%">
+    <tr>
+      <td class="aligncenter content-block">
+        <p>-----</br></p>
+        <p>This is a post only E-mail, please do not reply.</p>
+      </td>
+    </tr>
+  </table>
 </div>
 </body>
 </html>

--- a/conf/templates/emails-guest_sponsor_confirmed.html
+++ b/conf/templates/emails-guest_sponsor_confirmed.html
@@ -1,0 +1,37 @@
+<html>
+<head>
+    <style type="text/css">
+        [% INCLUDE emails.css %]
+    </style>
+    <span class="preheader">Register sponsor confirmation informaziones</span>
+</head>
+<body>
+<table class="main">
+        <tr>
+                <td class="wrapper">
+                        <table>
+                                <tr>
+                                        <td>
+                                                <h1 class="align-center">Responsive Sponsor Guest Confiramtion Email</h1>
+                                                <p>Hi,</p>
+                                                <p>Your guest access to the network was authorized.</p>
+                                                <p>If you have any questions regarding the registration process please contact support.</p>
+                                        </td>
+                                </tr>
+                        </table>
+                </td>
+        </tr>
+</table>
+
+<div class="footer">
+        <table>
+                <tr>
+                        <td class="align-center">
+                                <p>-----</br></p>
+                                <p>This is a post only E-mail, please do not reply.</p>
+                        </td>
+                </tr>
+        </table>
+</div>
+</body>
+</html>

--- a/conf/templates/emails-guest_sponsor_confirmed.html
+++ b/conf/templates/emails-guest_sponsor_confirmed.html
@@ -3,7 +3,7 @@
     <style type="text/css">
         [% INCLUDE emails.css %]
     </style>
-    <span class="preheader">Register sponsor confirmation informaziones</span>
+    <span class="preheader">Register sponsor confirmation informations</span>
 </head>
 <body>
 <table class="main">
@@ -12,7 +12,7 @@
                         <table>
                                 <tr>
                                         <td>
-                                                <h1 class="align-center">Responsive Sponsor Guest Confiramtion Email</h1>
+                                                <h1 class="align-center">Sponsor Guest Confiramtion</h1>
                                                 <p>Hi,</p>
                                                 <p>Your guest access to the network was authorized.</p>
                                                 <p>If you have any questions regarding the registration process please contact support.</p>

--- a/conf/templates/emails-guest_sponsor_preregistration-fr.html
+++ b/conf/templates/emails-guest_sponsor_preregistration-fr.html
@@ -1,40 +1,47 @@
 <html>
 <head>
-    <style type="text/css">
-        [% INCLUDE emails.css %]
-    </style>
-    <span class="preheader">Informations d'enregistrement par sponsor</span>
+  <style type="text/css">
+    [% INCLUDE emails.css %]
+  </style>
 </head>
 <body>
-<table class="main">
-        <tr>
-                <td class="wrapper">
-                        <table>
-                                <tr>
-                                        <td>
-                                                <h1 class="align-center">Confirmation de pre-enregistrement par sponsor</h1>
-                                                <p>Bonjour,</p>
-                                                <p>Votre accès invité au réseau a été autorisé.</p>
-                                                <p>Lorsque vous serez sur palce, utilisez les informations suivantes pour vous authentifier:</p>
-                                                <p>Nom d'utilisateur: [% pid %]</br>
-                                                Mot de passe: [% password %]</p>
-                                                <p>Si vous avez des questions concernant le processsus d'enregistrement, merci de contacter le support local.</p>
-                                        </td>
-                                </tr>
-                        </table>
-                </td>
-        </tr>
-</table>
-
-<div class="footer">
-        <table>
+<table class="body-wrap">
+  <tr>
+    <td></td>
+    <td class="container" width="600">
+      <div class="content">
+        <table class="main" width="100%" cellpadding="0" cellspacing="0">
+          <tr>
+            <td class="content-wrap">
+              <table width="100%" cellpadding="0" cellspacing="0">
                 <tr>
-                        <td class="align-center">
-                                <p>-----</br></p>
-                                <p>Ceci est un message automatique, merci de ne pas répondre.</p>
-                        </td>
+                  <td class="content-block">
+                    <h1 class="align-center">Confirmation de pre-enregistrement par sponsor</h1>
+                    <p>Bonjour,</p>
+                    <p>Votre accès invité au réseau a été autorisé.</p>
+                    <p>Lorsque vous serez sur palce, utilisez les informations suivantes pour vous authentifier:</p>
+                    <p>Nom d'utilisateur: [% pid %]</br>
+                    Mot de passe: [% password %]</p>
+                    <p>Si vous avez des questions concernant le processsus d'enregistrement, merci de contacter le support local.</p>
+                  </td>
                 </tr>
+              </table>
+            </td>
+          </tr>
         </table>
+      </div>
+    </td>
+  </tr>
+</table>
+<div class="footer">
+  <table width="100%">
+    <tr>
+      <td class="aligncenter content-block">
+        <p>-----</br></p>
+        <p>Ceci est un message automatique, merci de ne pas répondre.</p>
+      </td>
+    </tr>
+  </table>
 </div>
 </body>
 </html>

--- a/conf/templates/emails-guest_sponsor_preregistration-fr.html
+++ b/conf/templates/emails-guest_sponsor_preregistration-fr.html
@@ -12,7 +12,7 @@
                         <table>
                                 <tr>
                                         <td>
-                                                <h1 class="align-center">Pre-enregistrement par sponsor</h1>
+                                                <h1 class="align-center">Confirmation de pre-enregistrement par sponsor</h1>
                                                 <p>Bonjour,</p>
                                                 <p>Votre accès invité au réseau a été autorisé.</p>
                                                 <p>Lorsque vous serez sur palce, utilisez les informations suivantes pour vous authentifier:</p>

--- a/conf/templates/emails-guest_sponsor_preregistration-fr.html
+++ b/conf/templates/emails-guest_sponsor_preregistration-fr.html
@@ -1,0 +1,40 @@
+<html>
+<head>
+    <style type="text/css">
+        [% INCLUDE emails.css %]
+    </style>
+    <span class="preheader">Informations d'enregistrement par sponsor</span>
+</head>
+<body>
+<table class="main">
+        <tr>
+                <td class="wrapper">
+                        <table>
+                                <tr>
+                                        <td>
+                                                <h1 class="align-center">Pre-enregistrement par sponsor</h1>
+                                                <p>Bonjour,</p>
+                                                <p>Votre accès invité au réseau a été autorisé.</p>
+                                                <p>Lorsque vous serez sur palce, utilisez les informations suivantes pour vous authentifier:</p>
+                                                <p>Nom d'utilisateur: [% pid %]</br>
+                                                Mot de passe: [% password %]</p>
+                                                <p>Si vous avez des questions concernant le processsus d'enregistrement, merci de contacter le support local.</p>
+                                        </td>
+                                </tr>
+                        </table>
+                </td>
+        </tr>
+</table>
+
+<div class="footer">
+        <table>
+                <tr>
+                        <td class="align-center">
+                                <p>-----</br></p>
+                                <p>Ceci est un message automatique, merci de ne pas répondre.</p>
+                        </td>
+                </tr>
+        </table>
+</div>
+</body>
+</html>

--- a/conf/templates/emails-guest_sponsor_preregistration-fr.html
+++ b/conf/templates/emails-guest_sponsor_preregistration-fr.html
@@ -16,7 +16,7 @@
               <table width="100%" cellpadding="0" cellspacing="0">
                 <tr>
                   <td class="content-block">
-                    <h1 class="align-center">Confirmation de pre-enregistrement par sponsor</h1>
+                    <h1 class="align-center">Compte utilisateur</h1>
                     <p>Bonjour,</p>
                     <p>Votre accès invité au réseau a été autorisé.</p>
                     <p>Lorsque vous serez sur palce, utilisez les informations suivantes pour vous authentifier:</p>

--- a/conf/templates/emails-guest_sponsor_preregistration.html
+++ b/conf/templates/emails-guest_sponsor_preregistration.html
@@ -16,7 +16,7 @@
               <table width="100%" cellpadding="0" cellspacing="0">
                 <tr>
                   <td class="content-block">
-                    <h1 class="align-center">PreRegister Sponsor activation</h1>
+                    <h1 class="align-center">User account</h1>
                     <p>Hi,</p>
                     <p>Your guest access to the network was authorized.</p>
                     <p>Once on site, use the following username and password to authenticate:</p>

--- a/conf/templates/emails-guest_sponsor_preregistration.html
+++ b/conf/templates/emails-guest_sponsor_preregistration.html
@@ -3,7 +3,7 @@
     <style type="text/css">
         [% INCLUDE emails.css %]
     </style>
-    <span class="preheader">Register by sponsor informaziones</span>
+    <span class="preheader">Register by sponsor informations</span>
 </head>
 <body>
 <table class="main">
@@ -12,7 +12,7 @@
                         <table>
                                 <tr>
                                         <td>
-                                                <h1 class="align-center">Responsive Sponsor Email</h1>
+                                                <h1 class="align-center">PreRegister Sponsor activation</h1>
                                                 <p>Hi,</p>
                                                 <p>Your guest access to the network was authorized.</p>
                                                 <p>Once on site, use the following username and password to authenticate:</p>

--- a/conf/templates/emails-guest_sponsor_preregistration.html
+++ b/conf/templates/emails-guest_sponsor_preregistration.html
@@ -1,0 +1,40 @@
+<html>
+<head>
+    <style type="text/css">
+        [% INCLUDE emails.css %]
+    </style>
+    <span class="preheader">Register by sponsor informaziones</span>
+</head>
+<body>
+<table class="main">
+        <tr>
+                <td class="wrapper">
+                        <table>
+                                <tr>
+                                        <td>
+                                                <h1 class="align-center">Responsive Sponsor Email</h1>
+                                                <p>Hi,</p>
+                                                <p>Your guest access to the network was authorized.</p>
+                                                <p>Once on site, use the following username and password to authenticate:</p>
+                                                <p>Username: [% pid %]</br>
+                                                Password: [% password %]</p>
+                                                <p>If you have any questions regarding the registration process please contact support.</p>
+                                        </td>
+                                </tr>
+                        </table>
+                </td>
+        </tr>
+</table>
+
+<div class="footer">
+        <table>
+                <tr>
+                        <td class="align-center">
+                                <p>-----</br></p>
+                                <p>This is a post only E-mail, please do not reply.</p>
+                        </td>
+                </tr>
+        </table>
+</div>
+</body>
+</html>

--- a/conf/templates/emails-guest_sponsor_preregistration.html
+++ b/conf/templates/emails-guest_sponsor_preregistration.html
@@ -1,40 +1,46 @@
 <html>
 <head>
-    <style type="text/css">
-        [% INCLUDE emails.css %]
-    </style>
-    <span class="preheader">Register by sponsor informations</span>
+  <style type="text/css">
+    [% INCLUDE emails.css %]
+  </style>
 </head>
 <body>
-<table class="main">
-        <tr>
-                <td class="wrapper">
-                        <table>
-                                <tr>
-                                        <td>
-                                                <h1 class="align-center">PreRegister Sponsor activation</h1>
-                                                <p>Hi,</p>
-                                                <p>Your guest access to the network was authorized.</p>
-                                                <p>Once on site, use the following username and password to authenticate:</p>
-                                                <p>Username: [% pid %]</br>
-                                                Password: [% password %]</p>
-                                                <p>If you have any questions regarding the registration process please contact support.</p>
-                                        </td>
-                                </tr>
-                        </table>
-                </td>
-        </tr>
-</table>
-
-<div class="footer">
-        <table>
+<table class="body-wrap">
+  <tr>
+    <td></td>
+    <td class="container" width="600">
+      <div class="content">
+        <table class="main" width="100%" cellpadding="0" cellspacing="0">
+          <tr>
+            <td class="content-wrap">
+              <table width="100%" cellpadding="0" cellspacing="0">
                 <tr>
-                        <td class="align-center">
-                                <p>-----</br></p>
-                                <p>This is a post only E-mail, please do not reply.</p>
-                        </td>
+                  <td class="content-block">
+                    <h1 class="align-center">PreRegister Sponsor activation</h1>
+                    <p>Hi,</p>
+                    <p>Your guest access to the network was authorized.</p>
+                    <p>Once on site, use the following username and password to authenticate:</p>
+                    <p>Username: [% pid %]</br>
+                    Password: [% password %]</p>
+                    <p>If you have any questions regarding the registration process please contact support.</p>
                 </tr>
+              </table>
+            </td>
+          </tr>
         </table>
+      </div>
+    </td>
+  </tr>
+</table>
+<div class="footer">
+  <table width="100%">
+    <tr>
+      <td class="aligncenter content-block">
+        <p>-----</br></p>
+        <p>This is a post only E-mail, please do not reply.</p>
+      </td>
+    </tr>
+  </table>
 </div>
 </body>
 </html>

--- a/conf/templates/emails.css
+++ b/conf/templates/emails.css
@@ -1,0 +1,296 @@
+/* -------------------------------------
+    CONFIGURE YOUR VARIABLES
+------------------------------------- */
+/* -------------------------------------
+    GLOBAL RESETS
+------------------------------------- */
+table,
+td,
+div,
+a {
+  box-sizing: border-box;
+}
+
+img {
+  -ms-interpolation-mode: bicubic;
+  max-width: 100%;
+}
+
+body {
+  font-family: "Helvetica Neue", "Helvetica", Helvetica, Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  font-size: 14px;
+  height: 100% !important;
+  line-height: 1.6;
+  margin: 0;
+  padding: 0;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+  width: 100% !important;
+}
+
+table {
+  -premailer-width: 100%;
+  border-collapse: separate !important;
+  mso-table-lspace: 0pt;
+  mso-table-rspace: 0pt;
+}
+table td {
+  vertical-align: top;
+  mso-table-lspace: 0pt;
+  mso-table-rspace: 0pt;
+}
+
+.ExternalClass {
+  width: 100%;
+}
+
+.ExternalClass,
+.ExternalClass p,
+.ExternalClass span,
+.ExternalClass font,
+.ExternalClass td,
+.ExternalClass div {
+  line-height: 100%;
+}
+
+/* -------------------------------------
+    BODY & CONTAINER
+------------------------------------- */
+body {
+  background-color: #f6f6f6;
+}
+
+.body {
+  background-color: #f6f6f6;
+  width: 100%;
+}
+
+/* Set a max-width, and make it display as block so it will automatically stretch to that width, but will also shrink down on a phone or something */
+.container {
+  display: block;
+  margin: 0 auto !important;
+  /* makes it centered */
+  max-width: 580px;
+  padding: 10px;
+  width: auto !important;
+  width: 580px;
+}
+
+/* This should also be a block element, so that it will fill 100% of the .container */
+.content {
+  display: block;
+  margin: 0 auto;
+  max-width: 580px;
+  padding: 10px;
+}
+
+/* -------------------------------------
+    HEADER, FOOTER, MAIN
+------------------------------------- */
+.main {
+  background: #fff;
+  border: 1px solid #e9e9e9;
+  border-radius: 3px;
+  width: 100%;
+}
+
+.wrapper {
+  padding: 30px;
+}
+
+.content-block {
+  padding: 0 0 30px;
+}
+
+.header {
+  margin-bottom: 30px;
+  margin-top: 20px;
+  width: 100%;
+}
+
+.footer {
+  clear: both;
+  width: 100%;
+}
+.footer * {
+  color: #999;
+  font-size: 12px;
+}
+.footer td {
+  padding: 20px 0;
+}
+
+/* -------------------------------------
+    TYPOGRAPHY
+------------------------------------- */
+h1,
+h2,
+h3,
+h4 {
+  color: #000 !important;
+  font-family: "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
+  font-weight: 400;
+  line-height: 1.4;
+  margin: 0;
+  margin-bottom: 30px;
+}
+
+h1 {
+  font-size: 38px;
+  text-transform: capitalize;
+  font-weight: 300;
+}
+
+h2 {
+  font-size: 24px;
+}
+
+h3 {
+  font-size: 18px;
+}
+
+h4 {
+  font-size: 14px;
+  font-weight: 500;
+}
+
+p,
+ul,
+ol {
+  font-family: "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
+  font-size: 14px;
+  font-weight: normal;
+  margin: 0;
+  margin-bottom: 15px;
+}
+p li,
+ul li,
+ol li {
+  list-style-position: inside;
+  margin-left: 5px;
+}
+
+a {
+  color: #348eda;
+  text-decoration: underline;
+}
+
+/* -------------------------------------
+    BUTTONS
+------------------------------------- */
+.btn {
+  margin-bottom: 15px;
+  width: auto;
+  -premailer-width: auto;
+}
+.btn td {
+  background-color: #fff;
+  border-radius: 5px;
+  text-align: center;
+}
+.btn a {
+  background-color: #fff;
+  border: solid 1px #348eda;
+  border-radius: 5px;
+  color: #348eda;
+  cursor: pointer;
+  display: inline-block;
+  font-size: 14px;
+  font-weight: bold;
+  margin: 0;
+  padding: 12px 25px;
+  text-decoration: none;
+  text-transform: capitalize;
+}
+
+.btn-primary td {
+  background-color: #348eda;
+}
+.btn-primary a {
+  background-color: #348eda;
+  border-color: #348eda;
+  color: #fff;
+}
+
+/* -------------------------------------
+    OTHER STYLES THAT MIGHT BE USEFUL
+------------------------------------- */
+.last {
+  margin-bottom: 0;
+}
+
+.first {
+  margin-top: 0;
+}
+
+.align-center {
+  text-align: center;
+}
+
+.align-right {
+  text-align: right;
+}
+
+.align-left {
+  text-align: left;
+}
+
+.clear {
+  clear: both;
+}
+
+.mt0 {
+  margin-top: 0;
+}
+
+.mb0 {
+  margin-bottom: 0;
+}
+
+.preheader {
+  color: transparent;
+  display: none;
+  height: 0;
+  max-height: 0;
+  max-width: 0;
+  opacity: 0;
+  overflow: hidden;
+  mso-hide: all;
+  visibility: hidden;
+  width: 0;
+}
+
+/* -------------------------------------
+    RESPONSIVE AND MOBILE FRIENDLY STYLES
+------------------------------------- */
+@media only screen and (max-width: 620px) {
+  table[class=body] h1,
+  table[class=body] h2,
+  table[class=body] h3,
+  table[class=body] h4 {
+    font-weight: 600 !important;
+  }
+  table[class=body] h1 {
+    font-size: 22px !important;
+  }
+  table[class=body] h2 {
+    font-size: 18px !important;
+  }
+  table[class=body] h3 {
+    font-size: 16px !important;
+  }
+  table[class=body] .content,
+  table[class=body] .wrapper {
+    padding: 10px !important;
+  }
+  table[class=body] .container {
+    padding: 0 !important;
+    width: 100% !important;
+  }
+  table[class=body] .btn {
+    width: 100% !important;
+  }
+}
+
+/*# sourceMappingURL=main.css.map */

--- a/conf/templates/emails.css
+++ b/conf/templates/emails.css
@@ -1,57 +1,29 @@
 /* -------------------------------------
-    CONFIGURE YOUR VARIABLES
+    GLOBAL
 ------------------------------------- */
-/* -------------------------------------
-    GLOBAL RESETS
-------------------------------------- */
-table,
-td,
-div,
-a {
+* {
+  margin: 0;
+  padding: 0;
+  font-family: "Helvetica Neue", "Helvetica", Helvetica, Arial, sans-serif;
   box-sizing: border-box;
+  font-size: 14px;
 }
 
 img {
-  -ms-interpolation-mode: bicubic;
   max-width: 100%;
 }
 
 body {
-  font-family: "Helvetica Neue", "Helvetica", Helvetica, Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
-  font-size: 14px;
-  height: 100% !important;
-  line-height: 1.6;
-  margin: 0;
-  padding: 0;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
+  -webkit-text-size-adjust: none;
   width: 100% !important;
+  height: 100%;
+  line-height: 1.6;
 }
 
-table {
-  -premailer-width: 100%;
-  border-collapse: separate !important;
-  mso-table-lspace: 0pt;
-  mso-table-rspace: 0pt;
-}
+/* Let's make sure all tables have defaults */
 table td {
   vertical-align: top;
-  mso-table-lspace: 0pt;
-  mso-table-rspace: 0pt;
-}
-
-.ExternalClass {
-  width: 100%;
-}
-
-.ExternalClass,
-.ExternalClass p,
-.ExternalClass span,
-.ExternalClass font,
-.ExternalClass td,
-.ExternalClass div {
-  line-height: 100%;
 }
 
 /* -------------------------------------
@@ -61,28 +33,24 @@ body {
   background-color: #f6f6f6;
 }
 
-.body {
+.body-wrap {
   background-color: #f6f6f6;
   width: 100%;
 }
 
-/* Set a max-width, and make it display as block so it will automatically stretch to that width, but will also shrink down on a phone or something */
 .container {
-  display: block;
+  display: block !important;
+  max-width: 600px !important;
   margin: 0 auto !important;
   /* makes it centered */
-  max-width: 580px;
-  padding: 10px;
-  width: auto !important;
-  width: 580px;
+  clear: both !important;
 }
 
-/* This should also be a block element, so that it will fill 100% of the .container */
 .content {
-  display: block;
+  max-width: 600px;
   margin: 0 auto;
-  max-width: 580px;
-  padding: 10px;
+  display: block;
+  padding: 20px;
 }
 
 /* -------------------------------------
@@ -92,54 +60,61 @@ body {
   background: #fff;
   border: 1px solid #e9e9e9;
   border-radius: 3px;
-  width: 100%;
 }
 
-.wrapper {
-  padding: 30px;
+.content-wrap {
+  padding: 20px;
 }
 
 .content-block {
-  padding: 0 0 30px;
+  padding: 0 0 20px;
 }
 
 .header {
-  margin-bottom: 30px;
-  margin-top: 20px;
   width: 100%;
+  margin-bottom: 20px;
 }
 
 .footer {
-  clear: both;
   width: 100%;
-}
-.footer * {
+  clear: both;
   color: #999;
+  padding: 20px;
+}
+.footer a {
+  color: #999;
+}
+.footer p, .footer a, .footer unsubscribe, .footer td {
   font-size: 12px;
 }
-.footer td {
-  padding: 20px 0;
+
+/* -------------------------------------
+    GRID AND COLUMNS
+------------------------------------- */
+.column-left {
+  float: left;
+  width: 50%;
+}
+
+.column-right {
+  float: left;
+  width: 50%;
 }
 
 /* -------------------------------------
     TYPOGRAPHY
 ------------------------------------- */
-h1,
-h2,
-h3,
-h4 {
-  color: #000 !important;
+h1, h2, h3 {
   font-family: "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
+  color: #000;
+  margin: 40px 0 0;
+  line-height: 1.2;
   font-weight: 400;
-  line-height: 1.4;
-  margin: 0;
-  margin-bottom: 30px;
 }
 
 h1 {
-  font-size: 38px;
-  text-transform: capitalize;
-  font-weight: 300;
+  font-size: 32px;
+  font-weight: 500;
 }
 
 h2 {
@@ -152,65 +127,57 @@ h3 {
 
 h4 {
   font-size: 14px;
-  font-weight: 500;
+  font-weight: 600;
 }
 
-p,
-ul,
-ol {
-  font-family: "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
-  font-size: 14px;
+p, ul, ol {
+  margin-bottom: 10px;
   font-weight: normal;
-  margin: 0;
-  margin-bottom: 15px;
 }
-p li,
-ul li,
-ol li {
-  list-style-position: inside;
+p li, ul li, ol li {
   margin-left: 5px;
+  list-style-position: inside;
 }
 
+/* -------------------------------------
+    LINKS & BUTTONS
+------------------------------------- */
 a {
   color: #348eda;
   text-decoration: underline;
 }
 
-/* -------------------------------------
-    BUTTONS
-------------------------------------- */
-.btn {
-  margin-bottom: 15px;
-  width: auto;
-  -premailer-width: auto;
+a:link{
+  color: #fff;
 }
-.btn td {
-  background-color: #fff;
-  border-radius: 5px;
+.btn-primary {
+  text-decoration: none;
+  color: #FFF;
+  background-color: #348eda;
+  border: solid #348eda;
+  border-width: 10px 20px;
+  line-height: 2;
+  font-weight: bold;
   text-align: center;
-}
-.btn a {
-  background-color: #fff;
-  border: solid 1px #348eda;
-  border-radius: 5px;
-  color: #348eda;
   cursor: pointer;
   display: inline-block;
-  font-size: 14px;
-  font-weight: bold;
-  margin: 0;
-  padding: 12px 25px;
-  text-decoration: none;
+  border-radius: 5px;
   text-transform: capitalize;
 }
 
-.btn-primary td {
+.btn-secondary {
+  text-decoration: none;
+  color: #FFF;
   background-color: #348eda;
-}
-.btn-primary a {
-  background-color: #348eda;
-  border-color: #348eda;
-  color: #fff;
+  border: solid #348eda;
+  border-width: 10px 20px;
+  line-height: 1;
+  font-weight: bold;
+  text-align: center;
+  cursor: pointer;
+  display: inline-block;
+  border-radius: 2px;
+  text-transform: capitalize;
 }
 
 /* -------------------------------------
@@ -224,15 +191,19 @@ a {
   margin-top: 0;
 }
 
-.align-center {
+.padding {
+  padding: 10px 0;
+}
+
+.aligncenter {
   text-align: center;
 }
 
-.align-right {
+.alignright {
   text-align: right;
 }
 
-.align-left {
+.alignleft {
   text-align: left;
 }
 
@@ -240,57 +211,86 @@ a {
   clear: both;
 }
 
-.mt0 {
-  margin-top: 0;
+/* -------------------------------------
+    Alerts
+------------------------------------- */
+.alert {
+  font-size: 16px;
+  color: #fff;
+  font-weight: 500;
+  padding: 20px;
+  text-align: center;
+  border-radius: 3px 3px 0 0;
+}
+.alert a {
+  color: #fff;
+  text-decoration: none;
+  font-weight: 500;
+  font-size: 16px;
+}
+.alert.alert-warning {
+  background: #ff9f00;
+}
+.alert.alert-bad {
+  background: #d0021b;
+}
+.alert.alert-good {
+  background: #68b90f;
 }
 
-.mb0 {
-  margin-bottom: 0;
+/* -------------------------------------
+    INVOICE
+------------------------------------- */
+.invoice {
+  margin: 40px auto;
+  text-align: left;
+  width: 80%;
 }
-
-.preheader {
-  color: transparent;
-  display: none;
-  height: 0;
-  max-height: 0;
-  max-width: 0;
-  opacity: 0;
-  overflow: hidden;
-  mso-hide: all;
-  visibility: hidden;
-  width: 0;
+.invoice td {
+  padding: 5px 0;
+}
+.invoice .invoice-items {
+  width: 100%;
+}
+.invoice .invoice-items td {
+  border-top: #eee 1px solid;
+}
+.invoice .invoice-items .total td {
+  border-top: 2px solid #333;
+  border-bottom: 2px solid #333;
+  font-weight: 700;
 }
 
 /* -------------------------------------
     RESPONSIVE AND MOBILE FRIENDLY STYLES
 ------------------------------------- */
-@media only screen and (max-width: 620px) {
-  table[class=body] h1,
-  table[class=body] h2,
-  table[class=body] h3,
-  table[class=body] h4 {
+@media only screen and (max-width: 640px) {
+  h1, h2, h3, h4 {
     font-weight: 600 !important;
+    margin: 20px 0 5px !important;
   }
-  table[class=body] h1 {
+
+  h1 {
     font-size: 22px !important;
   }
-  table[class=body] h2 {
+
+  h2 {
     font-size: 18px !important;
   }
-  table[class=body] h3 {
+
+  h3 {
     font-size: 16px !important;
   }
-  table[class=body] .content,
-  table[class=body] .wrapper {
-    padding: 10px !important;
-  }
-  table[class=body] .container {
-    padding: 0 !important;
+
+  .container {
     width: 100% !important;
   }
-  table[class=body] .btn {
+
+  .content, .content-wrapper {
+    padding: 10px !important;
+  }
+
+  .invoice {
     width: 100% !important;
   }
 }
-
-/*# sourceMappingURL=main.css.map */

--- a/conf/templates/emails.css
+++ b/conf/templates/emails.css
@@ -147,9 +147,6 @@ a {
   text-decoration: underline;
 }
 
-a:link{
-  color: #fff;
-}
 .btn-primary {
   text-decoration: none;
   color: #FFF;
@@ -162,21 +159,6 @@ a:link{
   cursor: pointer;
   display: inline-block;
   border-radius: 5px;
-  text-transform: capitalize;
-}
-
-.btn-secondary {
-  text-decoration: none;
-  color: #FFF;
-  background-color: #348eda;
-  border: solid #348eda;
-  border-width: 10px 20px;
-  line-height: 1;
-  font-weight: bold;
-  text-align: center;
-  cursor: pointer;
-  display: inline-block;
-  border-radius: 2px;
   text-transform: capitalize;
 }
 

--- a/lib/pf/activation.pm
+++ b/lib/pf/activation.pm
@@ -476,8 +476,8 @@ sub send_email {
         To          =>  $info{'contact_info'},
         Cc          =>  $info{'cc'},
         Subject     =>  encode("MIME-Header", $info{'subject'}),
-        Template    =>  "emails-$template.txt.tt",
-        'Content-Type' => 'text/plain; charset="utf-8"',
+        Template    =>  "emails-$template.html",
+        'Content-Type' => 'text/html; charset="utf-8"',
         TmplOptions =>  \%options,
         TmplParams  =>  \%info,
     );


### PR DESCRIPTION
# Description

Redefine email template, to use HTML emails instead of plaintext.
# Impacts

This should not have impact on the PacketFence,  try to open the html email with different client/webmail/device would be the best testing.
# Delete branch after merge

YES
# NEWS file entries
## New Features
- Email are now in HTML format
## Enhancements
- Redefine email to be HTML instead of plaintext, email are now responsive and better looking.
- Added French version of the templates

Used #509 as a ref for the templates.
