### PR TITLE
fixed destinationUrl when it's PacketFence itself

### DIFF
--- a/html/captive-portal/lib/captiveportal/PacketFence/Model/Portal/Session.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Model/Portal/Session.pm
@@ -146,7 +146,7 @@ sub _build_destinationUrl {
 
     my $host = URI::URL->new($url)->host();
 
-    get_logger->info("User requested URL $url on host $host");
+    get_logger->debug("User requested URL $url on host $host");
     # Return portal profile's redirection URL if destination_url is not set or if redirection URL is forced
     if (!defined($url) || !$url || isenabled($self->profile->forceRedirectURL)) {
         return $self->profile->getRedirectURL;
@@ -154,7 +154,7 @@ sub _build_destinationUrl {
 
     my @portal_hosts = portal_hosts();
     # if the destination URL points to the portal, we put the default URL of the portal profile
-    if (URI::URL->new($url)->host() ~~ @portal_hosts) {
+    if ($host ~~ @portal_hosts) {
         get_logger->info("Replacing destination URL since it points to the captive portal");
         return $self->profile->getRedirectURL;
     }

--- a/lib/pf/config/util.pm
+++ b/lib/pf/config/util.pm
@@ -48,6 +48,7 @@ BEGIN {
     get_internal_macs get_internal_info
     connection_type_to_str str_to_connection_type
     get_translatable_time trappable_mac
+    portal_hosts
   );
 }
 
@@ -351,6 +352,23 @@ sub get_translatable_time {
    } elsif ($unit eq "Y") { return ("year", "years", $value);
    }
    return;
+}
+
+=head2 portal_hosts
+
+Returns the list of host and IP on which the portal is configured to listen
+
+=cut
+sub portal_hosts {
+    my @hosts;
+    foreach my $net (@internal_nets) {
+        push @hosts, $net->{Tip} if defined($net->{Tip});
+        push @hosts, $net->{Tvip} if defined($net->{Tvip});
+    }
+    push @hosts, $management_network->{Tip} if defined($management_network->{Tip});
+    push @hosts, $management_network->{Tvip} if defined($management_network->{Tvip});
+    push @hosts, $fqdn; 
+    return @hosts;
 }
 
 =back


### PR DESCRIPTION
# Description

Prevents the destination URL from being the PF domain name, empty or any IP the portal can listen on
# Impacts

Prevents redirection to the PacketFence portal at the end of the reg process
No more need to force redirection URL when using external portal :D
# Delete branch after merge

YES
# NEWS file entries
## Bug Fixes
- Fixed bad redirection to the portal at the end of the registration process
