### PR TITLE
httpd.portal configuration improvements

### DIFF
--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -656,7 +656,7 @@ httpd listening port for PacketFence Status webservice
 EOT
 
 [ports.httpd_portal_modstatus]
-type=test
+type=text
 description=<<EOT
 Port the mod_status for httpd.portal listens on.
 EOT

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -655,6 +655,12 @@ description=<<EOT
 httpd listening port for PacketFence Status webservice
 EOT
 
+[ports.httpd_portal_modstatus]
+type=test
+description=<<EOT
+Port the mod_status for httpd.portal listens on.
+EOT
+
 [interface.ip]
 type=text
 description=<<EOT

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -670,7 +670,7 @@ EOT
 
 [interface.type]
 type=multi
-options=internal|management|managed|monitor|dhcplistener|dhcp-listener|high-availability
+options=internal|management|managed|monitor|dhcplistener|dhcp-listener|high-availability|portal
 description=<<EOT
 Describes type of the named interface.
  * "internal" describes interfaces where PacketFence will enforce network access.
@@ -678,6 +678,7 @@ Describes type of the named interface.
  * "monitor" is the interface that snort listens on.
  * "dhcp-listener" is an interface where the DHCP traffic is coming in either via a network SPAN or IP-Helpers configuration.
  * "high-availability" is for an interface between two PacketFence servers dedicated to high-availability (drbd, corosync).
+ * "portal" interface have the captive-portal running on them without the need of having any enforcement mecanism.
 EOT
 
 [interface.enforcement]

--- a/conf/httpd.conf.d/httpd.portal
+++ b/conf/httpd.conf.d/httpd.portal
@@ -264,18 +264,23 @@ if ($allowed_from_all_urls) {
     );
 }
 
+# Generate vhosts for each interfaces configured accordingly (portal_ints)
+# internal_nets is kept for backward compatibility
 foreach my $interface ( uniq @internal_nets, @portal_ints ) {
-    if (defined($interface->{'Tip'}) && $interface->{'Tip'} ne '') {
-        if (defined($interface->{'Tvip'}) && $interface->{'Tvip'} ne '') {
-            $vhost = $interface->{'Tvip'};
-        } else {
-            $vhost = $interface->{'Tip'};
-       }
+
+    # Handling virtual IP
+    if (defined($interface->{'Tvip'}) && $interface->{'Tvip'} ne '') {
+        $vhost = $interface->{'Tvip'};
+    } else {
+        $vhost = $interface->{'Tip'};
     }
+
     push (@Listen,$vhost.":80");
     push (@Listen,$vhost.":443");
     push (@NameVirtualHost,$vhost.":80");
     push (@NameVirtualHost,$vhost.":443");
+
+    # Unsecure captive-portal (http)
     push (@{ $VirtualHost{$vhost.":80"} }, gen_conf(
          ServerName   => $PfConfig->{'general'}{'hostname'}.".".$PfConfig->{'general'}{'domain'},
          DocumentRoot => "${install_dir}/html/captive-portal/lib",
@@ -312,6 +317,8 @@ foreach my $interface ( uniq @internal_nets, @portal_ints ) {
              @allowed_from_all_options,
          ),
     ));
+
+    # Secure captive-portal (https)
     push (@{ $VirtualHost{$vhost.":443"} }, gen_conf(
          ServerName   => $PfConfig->{'general'}{'hostname'}.".".$PfConfig->{'general'}{'domain'},
          DocumentRoot => "${install_dir}/html/captive-portal/lib",

--- a/conf/httpd.conf.d/httpd.portal
+++ b/conf/httpd.conf.d/httpd.portal
@@ -152,6 +152,7 @@ use pf::web::constants();
 use Tie::DxHash;
 use pf::services::manager::httpd();
 use Apache::SSLLookup;
+use List::MoreUtils qw(uniq);
 
 sub gen_conf {
     my %conf;
@@ -264,7 +265,7 @@ if ($allowed_from_all_urls) {
     );
 }
 
-foreach my $interface (@internal_nets) {
+foreach my $interface ( uniq @internal_nets, @portal_ints ) {
     if (defined($interface->{'Tip'}) && $interface->{'Tip'} ne '') {
         if (defined($interface->{'Tvip'}) && $interface->{'Tvip'} ne '') {
             $vhost = $interface->{'Tvip'};

--- a/conf/httpd.conf.d/httpd.portal
+++ b/conf/httpd.conf.d/httpd.portal
@@ -163,6 +163,7 @@ sub gen_conf {
 } 
 
 my $PfConfig = \%pf::config::Config;
+my $management_network = $pf::config::management_network;
 my $install_dir = $pf::config::install_dir;
 my $var_dir = $pf::config::var_dir;
 my @internal_nets = @pf::config::internal_nets;
@@ -357,6 +358,35 @@ foreach my $interface ( uniq @internal_nets, @portal_ints ) {
          SSLEngine         => 'on',
          SSLProxyEngine    => 'on',
          Include           => "${var_dir}/conf/ssl-certificates.conf",
+    ));
+}
+
+# VHOST for diagnostic purposes (mod_status)
+if (defined($management_network->{'Tip'}) && $management_network->{'Tip'} ne '') {
+    # Handling virtual IP
+    if (defined($management_network->{'Tvip'}) && $management_network->{'Tvip'} ne '') {
+        $vhost = $management_network->{'Tvip'};
+    } else {
+        $vhost = $management_network->{'Tip'};
+    }
+
+    push (@Listen,$vhost.":".$PfConfig->{'ports'}{'httpd_portal_modstatus'});
+    push (@NameVirtualHost,$vhost.":".$PfConfig->{'ports'}{'httpd_portal_modstatus'});
+
+    push (@{ $VirtualHost{$vhost.":".$PfConfig->{'ports'}{'httpd_portal_modstatus'}} }, gen_conf(
+        ServerName   => $PfConfig->{'general'}{'hostname'}.".".$PfConfig->{'general'}{'domain'},
+        DocumentRoot => "${install_dir}/html/captive-portal/lib",
+        ErrorLog     => "${install_dir}/logs/httpd.portal.error",
+        CustomLog    => "${install_dir}/logs/httpd.portal.access combined",
+        Location     => {
+            "/modstatus" => {
+                SetHandler => 'server-status',
+            },
+        },
+
+        SSLEngine => 'on',
+        SSLProxyEngine    => 'on',
+        Include      => "${var_dir}/conf/ssl-certificates.conf",
     ));
 }
 

--- a/conf/httpd.conf.d/httpd.portal
+++ b/conf/httpd.conf.d/httpd.portal
@@ -167,6 +167,7 @@ my $management_network = $pf::config::management_network;
 my $install_dir = $pf::config::install_dir;
 my $var_dir = $pf::config::var_dir;
 my @internal_nets = @pf::config::internal_nets;
+my @portal_ints = @pf::config::portal_ints;
 my $host;
 my $vhost;
 

--- a/conf/httpd.conf.d/httpd.portal
+++ b/conf/httpd.conf.d/httpd.portal
@@ -163,12 +163,10 @@ sub gen_conf {
 } 
 
 my $PfConfig = \%pf::config::Config;
-my $management_network = $pf::config::management_network;
 my $install_dir = $pf::config::install_dir;
 my $var_dir = $pf::config::var_dir;
 my @internal_nets = @pf::config::internal_nets;
 my @portal_ints = @pf::config::portal_ints;
-my $host;
 my $vhost;
 
 $PidFile = $install_dir.'/var/run/httpd.portal.pid';
@@ -354,106 +352,5 @@ foreach my $interface ( uniq @internal_nets, @portal_ints ) {
          Include           => "${var_dir}/conf/ssl-certificates.conf",
     ));
 }
-
-if (defined($management_network->{'Tip'}) && $management_network->{'Tip'} ne '') {
-    if (defined($management_network->{'Tvip'}) && $management_network->{'Tvip'} ne '') {
-        $host = $management_network->{'Tvip'};
-    } else {
-        $host = $management_network->{'Tip'};
-    }
-
-    push (@Listen,$host.":80");
-    push (@Listen,$host.":443");
-    push (@NameVirtualHost,$host.":80");
-    push (@NameVirtualHost,$host.":443");
-
-    push @{ $VirtualHost{$host.":80"} }, gen_conf(
-         ServerName   => $PfConfig->{'general'}{'hostname'}.".".$PfConfig->{'general'}{'domain'},
-         DocumentRoot => "${install_dir}/html/captive-portal/lib",
-         ErrorLog     => "${install_dir}/logs/httpd.portal.error",
-         CustomLog    => "${install_dir}/logs/httpd.portal.access combined",
-         Include => "${var_dir}/conf/captive-portal-common.conf",
-         AllowEncodedSlashes => "on",
-         Alias        => "/static ${install_dir}/html/captiveportal/root/static",
-         Alias        => "/common ${install_dir}/html/common",
-         PerlModule   => 'captiveportal',
-         PerlTransHandler => 'pf::web::dispatcher::custom',
-         Location     => gen_conf(
-             "/" => {
-                 "Order" => "deny,allow",
-                 "Deny" => "from all",
-                 "Allow" => "from $routedNets $loadbalancersIp 127.0.0.1 ",
-                 SetHandler => 'modperl',
-                 PerlResponseHandler => 'captiveportal',
-             },
-             "/static" => {
-                 "Order" => "deny,allow",
-                 "Deny" => "from all",
-                 "Allow" => "from $routedNets $loadbalancersIp 127.0.0.1 ",
-                 SetHandler => 'default-handler',
-             },
-             "/common" => {
-                 "Allow" => "from all",
-                 SetHandler => 'default-handler',
-             },
-             "/content" => {
-                "Allow" => "from all",
-             },
-             '~ "/|/status"' => {
-                "Allow"             => "from all",
-                SetHandler          => 'modperl',
-                PerlResponseHandler => 'captiveportal',
-             },
-             @allowed_from_all_options,
-             "/apache_status/" => {
-                 SetHandler => 'server-status',
-             },
-         ),
-    );
-    push @{ $VirtualHost{$host.":443"} }, gen_conf(
-         ServerName   => $PfConfig->{'general'}{'hostname'}.".".$PfConfig->{'general'}{'domain'},
-         DocumentRoot => "${install_dir}/html/captive-portal/lib",
-         ErrorLog     => "${install_dir}/logs/httpd.portal.error",
-         CustomLog    => "${install_dir}/logs/httpd.portal.access combined",
-         Include => "${var_dir}/conf/captive-portal-common.conf",
-         AllowEncodedSlashes => "on",
-         Alias        => "/static ${install_dir}/html/captiveportal/root/static",
-         Alias        => "/common ${install_dir}/html/common",
-         PerlModule   => 'captiveportal',
-         PerlTransHandler => 'pf::web::dispatcher::custom',
-         Location     => gen_conf(
-             "/" => {
-                 "Order" => "deny,allow",
-                 "Deny" => "from all",
-                 "Allow" => "from $routedNets $loadbalancersIp 127.0.0.1 ",
-                 SetHandler => 'modperl',
-                 PerlResponseHandler => 'captiveportal',
-             },
-             "/static" => {
-                 "Order" => "deny,allow",
-                 "Deny" => "from all",
-                 "Allow" => "from $routedNets $loadbalancersIp 127.0.0.1 ",
-                 SetHandler => 'default-handler',
-             },
-             "/common" => {
-                 "Allow" => "from all",
-                 SetHandler => 'default-handler',
-             },
-             "/content" => {
-                "Allow" => "from all",
-             },
-             '~ "/|/status"' => {
-                "Allow"             => "from all",
-                SetHandler          => 'modperl',
-                PerlResponseHandler => 'captiveportal',
-             },
-             @allowed_from_all_options,
-         ),
-         SSLEngine         => 'on',
-         SSLProxyEngine    => 'on',
-         Include           => "${var_dir}/conf/ssl-certificates.conf",
-    );
-
-} 
 
 </Perl>

--- a/conf/iptables.conf.example
+++ b/conf/iptables.conf.example
@@ -25,6 +25,8 @@
 -A input-management-if --protocol tcp --match tcp --dport %%aaa_port%% --jump ACCEPT
 # PacketFence Status
 -A input-management-if --protocol tcp --match tcp --dport %%status_port%% --jump ACCEPT
+# httpd.portal modstatus
+-A input-management-if --protocol tcp --match tcp --dport %%httpd_portal_modstatus%% --jump ACCEPT
 # haproxy stats (uncomment if activating the haproxy dashboard)
 #-A input-management-if --protocol tcp --match tcp --dport 1025 --jump ACCEPT
 # GRAPHITE-WEB

--- a/conf/iptables.conf.example
+++ b/conf/iptables.conf.example
@@ -53,6 +53,10 @@
 # Mysql
 -A input-management-if --protocol tcp --match tcp --dport 3306 --jump ACCEPT
 
+:input-portal-if - [0:0]
+-A input-portal-if --protocol tcp --match tcp --dport 80  --jump ACCEPT
+-A input-portal-if --protocol tcp --match tcp --dport 443 --jump ACCEPT
+
 :input-internal-vlan-if - [0:0]
 # DNS
 -A input-internal-vlan-if --protocol tcp --match tcp --dport 53  --jump ACCEPT

--- a/conf/monitoring/collectd.conf.debian.example
+++ b/conf/monitoring/collectd.conf.debian.example
@@ -69,7 +69,7 @@ LoadPlugin write_graphite
 ##############################################################################
 <Plugin apache>
   <Instance "portal">
-    URL "http://%%management_ip%%/apache_status/?auto"
+    URL "https://%%management_ip%%:%%httpd_portal_modstatus_port%%/modstatus/?auto"
   </Instance>
 </Plugin>
 

--- a/conf/monitoring/collectd.conf.rhel.example
+++ b/conf/monitoring/collectd.conf.rhel.example
@@ -69,7 +69,7 @@ LoadPlugin write_graphite
 ##############################################################################
 <Plugin apache>
   <Instance "portal">
-    URL "http://%%management_ip%%/apache_status/?auto"
+    URL "https://%%management_ip%%:%%httpd_portal_modstatus_port%%/modstatus/?auto"
   </Instance>
 </Plugin>
 

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -279,6 +279,11 @@ aaa=7070
 #
 # Port of the packetfence status http interface listends on.
 pf_status=9191
+#
+# ports.httpd_portal_modstatus
+#
+# Port the mod_status for httpd.portal listens on.
+httpd_portal_modstatus=1444
 
 [scan]
 #

--- a/html/pfappserver/lib/pfappserver/Model/Enforcement.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Enforcement.pm
@@ -19,12 +19,13 @@ use namespace::autoclean;
 extends 'Catalyst::Model';
 
 # TODO: Should migrate theses into a database table with some flags for the mechanisms
-my @mechanisms           = qw/vlan inline option/;
+my @mechanisms           = qw/vlan inline option webauth/;
 # TODO once we display option we should move 'other' over to there
 my %types   = (
     vlan        => [ 'management', 'vlan-registration', 'vlan-isolation' ],
     inline      => [ 'management', 'inline', 'inlinel2', 'inlinel3' ], # inline is kept for backwards compat.
 #    option      => [ 'high-availability', 'dhcp-listener', 'monitor' ],
+    webauth     => ['management', 'portal'],
 );
 
 =head1 METHODS

--- a/html/pfappserver/lib/pfappserver/Model/Interface.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Interface.pm
@@ -444,7 +444,7 @@ sub setType {
                                     $self->_prepare_interface_for_pfconf($interface, $interface_ref, $type));
 
         # Update networks.conf
-        if ( $type =~ /^management$/ ) {
+        if ( $type =~ /^management$|^portal$/ ) {
             # management interfaces must not appear in networks.conf
             $models->{network}->remove($interface_ref->{network}) if ($interface_ref->{network});
         }

--- a/html/pfappserver/root/configurator/enforcement.tt
+++ b/html/pfappserver/root/configurator/enforcement.tt
@@ -29,11 +29,14 @@
               <table class="table">
                 <thead>
                   <tr>
-                    <th width="50%">
+                    <th>
                       <input type="checkbox" name="enforcement" value="inline"[% IF c.session.enforcements.inline %] checked=""[% END %]> [% l('Inline enforcement') %]
                     </th>
                     <th>
                       <input type="checkbox" name="enforcement" value="vlan"[% IF c.session.enforcements.vlan %] checked=""[% END %]> [% l('VLAN enforcement') %]
+                    </th>
+                    <th>
+                      <input type="checkbox" name="enforcement" value="hotspot"[% IF c.session.enforcements.hotspot %] checked=""[% END %]> [% l('WebAuth enforcement') %]
                     </th>
                   </tr>
                 </thead>
@@ -45,12 +48,18 @@
                     <td>
                       [% l('PacketFence is the server that assigns the VLAN (or roles) to the devices. This is the prefered enforcement mechanism for manageable equipment.') %]
                     </td>
+                    <td>
+                      [% l('PacketFence is the server that assigns the Role (or ACL) to the devices. This mode is for web authentication.') %]
+                    </td>
                   </tr>
                   <tr>
                     <td class="graph">
                       <img src="[% c.uri_for('/static/configurator/enforcement-inline.png') %]">
                     </td>
                     <td class="graph">
+                      <img src="[% c.uri_for('/static/configurator/enforcement-vlan.png') %]">
+                    </td>
+                   <td class="graph">
                       <img src="[% c.uri_for('/static/configurator/enforcement-vlan.png') %]">
                     </td>
                   </tr>

--- a/html/pfappserver/root/configurator/enforcement.tt
+++ b/html/pfappserver/root/configurator/enforcement.tt
@@ -36,7 +36,7 @@
                       <input type="checkbox" name="enforcement" value="vlan"[% IF c.session.enforcements.vlan %] checked=""[% END %]> [% l('VLAN enforcement') %]
                     </th>
                     <th>
-                      <input type="checkbox" name="enforcement" value="hotspot"[% IF c.session.enforcements.hotspot %] checked=""[% END %]> [% l('WebAuth enforcement') %]
+                      <input type="checkbox" name="enforcement" value="webauth"[% IF c.session.enforcements.hotspot %] checked=""[% END %]> [% l('WebAuth enforcement') %]
                     </th>
                   </tr>
                 </thead>

--- a/html/pfappserver/root/static/configurator/common.css
+++ b/html/pfappserver/root/static/configurator/common.css
@@ -39,7 +39,11 @@ form[name="enforcement"] .table td {
 form[name="enforcement"] .table tr th:first-child,
 form[name="enforcement"] .table tr td:first-child {
     border-right: 1px solid #ddd;
-    width: 50%;
+    width: 33%;
+}
+form[name="enforcement"] .table tr td:last-child {
+    border-left: 1px solid #ddd;
+    width: 33%;
 }
 form[name="enforcement"] .table .graph {
     text-align: center;

--- a/lib/pf/config.pm
+++ b/lib/pf/config.pm
@@ -82,7 +82,7 @@ use pf::util;
 # Categorized by feature, pay attention when modifying
 our (
     @listen_ints, @dhcplistener_ints, @ha_ints, $monitor_int,
-    @internal_nets, @routed_isolation_nets, @routed_registration_nets, @inline_nets,
+    @internal_nets, @routed_isolation_nets, @routed_registration_nets, @inline_nets, @portal_ints,
     @inline_enforcement_nets, @vlan_enforcement_nets, $management_network,
 #pf.conf.default variables
     %Default_Config,
@@ -125,7 +125,7 @@ BEGIN {
     # Categorized by feature, pay attention when modifying
     @EXPORT = qw(
         @listen_ints @dhcplistener_ints @ha_ints $monitor_int
-        @internal_nets @routed_isolation_nets @routed_registration_nets @inline_nets $management_network
+        @internal_nets @routed_isolation_nets @routed_registration_nets @inline_nets $management_network @portal_ints
         @inline_enforcement_nets @vlan_enforcement_nets
         $IPTABLES_MARK_UNREG $IPTABLES_MARK_REG $IPTABLES_MARK_ISOLATION
         $IPSET_VERSION %mark_type_to_str %mark_type
@@ -177,6 +177,7 @@ if($cluster_enabled) {
     tie @listen_ints, 'pfconfig::cached_array', "interfaces::listen_ints($host_id)";
     tie @inline_enforcement_nets, 'pfconfig::cached_array', "interfaces::inline_enforcement_nets($host_id)";
     tie @internal_nets, 'pfconfig::cached_array', "interfaces::internal_nets($host_id)";
+    tie @portal_ints, 'pfconfig::cached_array', "interfaces::portal_ints($host_id)";
     tie @vlan_enforcement_nets, 'pfconfig::cached_array', "interfaces::vlan_enforcement_nets($host_id)";
     tie $management_network, 'pfconfig::cached_scalar', "interfaces::management_network($host_id)";
     tie $monitor_int, 'pfconfig::cached_scalar', "interfaces::monitor_int($host_id)";
@@ -191,6 +192,7 @@ else {
     tie @listen_ints, 'pfconfig::cached_array', "interfaces::listen_ints";
     tie @inline_enforcement_nets, 'pfconfig::cached_array', "interfaces::inline_enforcement_nets";
     tie @internal_nets, 'pfconfig::cached_array', "interfaces::internal_nets";
+    tie @portal_ints, 'pfconfig::cached_array', "interfaces::portal_ints";
     tie @vlan_enforcement_nets, 'pfconfig::cached_array', "interfaces::vlan_enforcement_nets";
     tie $management_network, 'pfconfig::cached_scalar', "interfaces::management_network";
     tie $monitor_int, 'pfconfig::cached_scalar', "interfaces::monitor_int";

--- a/lib/pf/iptables.pm
+++ b/lib/pf/iptables.pm
@@ -105,6 +105,7 @@ sub iptables_generate {
     $tags{'webservices_port'} = $Config{'ports'}{'soap'};
     $tags{'aaa_port'} = $Config{'ports'}{'aaa'};
     $tags{'status_port'} = $Config{'ports'}{'pf_status'};
+    $tags{'httpd_portal_modstatus'} = $Config{'ports'}{'httpd_portal_modstatus'};
     # FILTER
     # per interface-type pointers to pre-defined chains
     $tags{'filter_if_src_to_chain'} .= $self->generate_filter_if_src_to_chain();

--- a/lib/pf/iptables.pm
+++ b/lib/pf/iptables.pm
@@ -47,7 +47,8 @@ use pf::ConfigStore::Domain;
 
 # This is the content that needs to match in the iptable rules for the service
 # to be considered as running
-Readonly our $FW_FILTER_INPUT_MGMT => 'input-management-if';
+Readonly our $FW_FILTER_INPUT_MGMT      => 'input-management-if';
+Readonly our $FW_FILTER_INPUT_PORTAL    => 'input-portal-if';
 
 Readonly my $FW_TABLE_FILTER => 'filter';
 Readonly my $FW_TABLE_MANGLE => 'mangle';
@@ -200,6 +201,12 @@ sub generate_filter_if_src_to_chain {
         } else {
             $logger->warn("Didn't assign any firewall rules to interface $dev.");
         }
+    }
+
+    # 'portal' interfaces handling
+    foreach my $portal_interface ( @portal_ints ) {
+        my $dev = $portal_interface->tag("int");
+        $rules .= "-A INPUT --in-interface $dev --jump $FW_FILTER_INPUT_PORTAL\n";
     }
 
     # management interface handling

--- a/lib/pf/pfcmd/checkup.pm
+++ b/lib/pf/pfcmd/checkup.pm
@@ -183,7 +183,7 @@ sub interfaces_defined {
             }
         }
 
-        my $int_types = qr/(?:internal|management|managed|monitor|dhcplistener|dhcp-listener|high-availability)/;
+        my $int_types = qr/(?:internal|management|managed|monitor|dhcplistener|dhcp-listener|high-availability|portal)/;
         if (defined($int_conf{'type'}) && $int_conf{'type'} !~ /$int_types/) {
             add_problem( $FATAL, "invalid network type $int_conf{'type'} for $interface" );
         }

--- a/lib/pf/services/manager/collectd.pm
+++ b/lib/pf/services/manager/collectd.pm
@@ -54,6 +54,7 @@ sub generateCollectd {
     $tags{'db_username'}   = "$Config{'database'}{'user'}";
     $tags{'db_password'}   = "$Config{'database'}{'pass'}";
     $tags{'db_database'}   = "$Config{'database'}{'db'}";
+    $tags{'httpd_portal_modstatus_port'} = "$Config{'ports'}{'httpd_portal_modstatus'}";
 
     parse_template( \%tags, "$tags{'template'}", "$install_dir/var/conf/collectd.conf" );
 }

--- a/lib/pfconfig/namespaces/interfaces.pm
+++ b/lib/pfconfig/namespaces/interfaces.pm
@@ -35,6 +35,7 @@ sub init {
         internal_nets           => [],
         inline_enforcement_nets => [],
         vlan_enforcement_nets   => [],
+        portal_ints             => [],
         monitor_int             => '',
         management_network      => '',
     };
@@ -43,6 +44,7 @@ sub init {
         'interfaces::ha_ints',                 'interfaces::internal_nets',
         'interfaces::inline_enforcement_nets', 'interfaces::vlan_enforcement_nets',
         'interfaces::monitor_int',             'interfaces::management_network',
+        'interfaces::portal_ints',
     ];
     if($host_id){
         @{$self->{child_resources}} = map { "$_($host_id)" } @{$self->{child_resources}}; 
@@ -86,7 +88,7 @@ sub build {
         }
 
         die "Missing mandatory element ip or netmask on interface $int"
-            if ( $type =~ /internal|managed|management/ && !defined($int_obj) );
+            if ( $type =~ /internal|managed|management|portal/ && !defined($int_obj) );
 
         foreach my $type ( split( /\s*,\s*/, $type ) ) {
             if ( $type eq 'internal' ) {
@@ -120,6 +122,10 @@ sub build {
             }
             elsif ( $type eq 'high-availability' ) {
                 push @{ $self->{_interfaces}->{ha_ints} }, $int;
+            }
+            elsif ( $type eq 'portal' ) {
+                $int_obj->tag( "vip", $self->_fetch_virtual_ip( $int, $interface ) );
+                push @{ $self->{_interfaces}->{portal_ints} }, $int_obj;
             }
         }
     }

--- a/lib/pfconfig/namespaces/interfaces/portal_ints.pm
+++ b/lib/pfconfig/namespaces/interfaces/portal_ints.pm
@@ -1,0 +1,65 @@
+package pfconfig::namespaces::interfaces::portal_ints;
+
+=head1 NAME
+
+pfconfig::namespaces::interfaces::portal_ints
+
+=cut
+
+=head1 DESCRIPTION
+
+pfconfig::namespaces::interfaces::portal_ints
+
+=cut
+
+use strict;
+use warnings;
+
+use base 'pfconfig::namespaces::interfaces';
+
+sub init {
+    my ($self, $host_id) = @_;
+    $self->{_interfaces} = defined($host_id) ? $self->{cache}->get_cache("interfaces($host_id)") : $self->{cache}->get_cache("interfaces");
+}
+
+sub build {
+    my ($self) = @_;
+
+    return $self->{_interfaces}->{portal_ints};
+}
+
+=back
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2015 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;
+
+# vim: set shiftwidth=4:
+# vim: set expandtab:
+# vim: set backspace=indent,eol,start:
+


### PR DESCRIPTION
# Description
- Cleaning up a bit httpd.portal config
- New configuration parameter for 'portal' interface type
- New configuration parameter for httpd.portal 'modstatus' port
# Impacts
- Webauth flow since we now need to add the 'portal' type to management interface if needed...
- httpd.portal since Apache configuration is modified
# Delete branch after merge

YES
# NEWS file entries
## New Features
- Introduced new 'portal' interface type to spawn a captive-portal instance on selected interface
- Introduced new 'ports.httpd_portal_modstatus' configuration parameter
## Enhancements
- Specific vhost for httpd.portal diagnostics
