### PR TITLE
Feature/custom ldap attr

### DIFF
--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1124,6 +1124,12 @@ description=<<EOT
 Disable Active-Directory domain configuration from within PacketFence
 EOT
 
+[advanced.custom_ldap_attributes]
+type=list
+description=<<EOT
+List of custom LDAP attributes that can be used in the sources configuration
+EOT
+
 [omapi.ip2mac_lookup]
 type=toggle
 options=enabled|disabled

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1124,10 +1124,10 @@ description=<<EOT
 Disable Active-Directory domain configuration from within PacketFence
 EOT
 
-[advanced.custom_ldap_attributes]
-type=list
+[advanced.ldap_attributes]
+type=merged_list
 description=<<EOT
-List of custom LDAP attributes that can be used in the sources configuration
+List of LDAP attributes that can be used in the sources configuration
 EOT
 
 [omapi.ip2mac_lookup]

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -855,7 +855,6 @@ pfcmd_success_color=green
 #
 # The algorithm to use to hash the passwords in the local database.
 hash_passwords=bcrypt
-
 #
 # advanced.hashing_cost
 #
@@ -867,6 +866,11 @@ hashing_cost=8
 #
 # Disable Active-Directory domain configuration from within PacketFence
 disable_pf_domain_auth=disabled
+#
+# advanced.custom_ldap_attributes
+#
+# List of custom LDAP attributes that can be used in the sources configuration
+custom_ldap_attributes=
 
 [omapi]
 #

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -867,10 +867,10 @@ hashing_cost=8
 # Disable Active-Directory domain configuration from within PacketFence
 disable_pf_domain_auth=disabled
 #
-# advanced.custom_ldap_attributes
+# advanced.ldap_attributes
 #
-# List of custom LDAP attributes that can be used in the sources configuration
-custom_ldap_attributes=
+# List of LDAP attributes that can be used in the sources configuration
+ldap_attributes=uid,cn,department,displayName,distinguishedName,givenName,memberOf,sn,eduPersonPrimaryAffiliation,mail,postOfficeBox,description,groupMembership
 
 [omapi]
 #

--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -585,6 +585,8 @@ Then, we add a rule:
 
 NOTE: When a rule is defined as a catch-all, it will always match if the username attribute matches the queried one. This applies for Active Directory, LDAP and Apache htpasswd file sources. Kerberos and RADIUS will act as true catch-all, and accept everything.
 
+NOTE: If you want to use other LDAP attributes in your authentication source, add them in 'Configuration->Advanced->Custom LDAP attributes'. They will then be available in the rules you define.
+
 External API authentication
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/html/pfappserver/lib/pfappserver/I18N/en.po
+++ b/html/pfappserver/lib/pfappserver/I18N/en.po
@@ -3832,8 +3832,8 @@ msgid "advanced.disable_pf_domain_auth"
 msgstr "Disable 802.1x authentication on PF domains" 
 
 # conf/documentation.conf
-msgid "advanced.custom_ldap_attributes"
-msgstr "Custom LDAP attributes" 
+msgid "advanced.ldap_attributes"
+msgstr "LDAP attributes" 
 
 # conf/documentation.conf
 msgid "alerting"

--- a/html/pfappserver/lib/pfappserver/I18N/en.po
+++ b/html/pfappserver/lib/pfappserver/I18N/en.po
@@ -3832,6 +3832,10 @@ msgid "advanced.disable_pf_domain_auth"
 msgstr "Disable 802.1x authentication on PF domains" 
 
 # conf/documentation.conf
+msgid "advanced.custom_ldap_attributes"
+msgstr "Custom LDAP attributes" 
+
+# conf/documentation.conf
 msgid "alerting"
 msgstr "Alerting"
 

--- a/lib/pf/Authentication/Source/LDAPSource.pm
+++ b/lib/pf/Authentication/Source/LDAPSource.pm
@@ -55,9 +55,7 @@ sub available_attributes {
   my $self = shift;
 
   my $super_attributes = $self->SUPER::available_attributes;
-  my @custom_attributes = @{$Config{advanced}->{custom_ldap_attributes}};
-  my @attributes = (@pf::Authentication::constants::LDAP_ATTRIBUTES, @custom_attributes);
-  @attributes = uniq @attributes;
+  my @attributes = @{$Config{advanced}->{ldap_attributes}};
   my @ldap_attributes = map { { value => $_, type => $Conditions::LDAP_ATTRIBUTE } } @attributes;
 
   # We check if our username attribute is present, if not we add it.

--- a/lib/pf/Authentication/Source/LDAPSource.pm
+++ b/lib/pf/Authentication/Source/LDAPSource.pm
@@ -18,6 +18,7 @@ use Net::LDAP;
 use Net::LDAPS;
 use List::Util;
 use Net::LDAP::Util qw(escape_filter_value);
+use pf::config;
 
 use Moose;
 extends 'pf::Authentication::Source';
@@ -53,8 +54,9 @@ sub available_attributes {
   my $self = shift;
 
   my $super_attributes = $self->SUPER::available_attributes;
-  my @ldap_attributes = map { { value => $_, type => $Conditions::LDAP_ATTRIBUTE } }
-    ("uid", "cn", "department", "displayName", "distinguishedName", "givenName", "memberOf", "sn", "eduPersonPrimaryAffiliation", "mail", "postOfficeBox", "description", "groupMembership");
+  my @custom_attributes = @{$Config{advanced}->{custom_ldap_attributes}};
+  my @attributes = (("uid", "cn", "department", "displayName", "distinguishedName", "givenName", "memberOf", "sn", "eduPersonPrimaryAffiliation", "mail", "postOfficeBox", "description", "groupMembership"), @custom_attributes);
+  my @ldap_attributes = map { { value => $_, type => $Conditions::LDAP_ATTRIBUTE } } @attributes;
 
   # We check if our username attribute is present, if not we add it.
   if (not grep {$_->{value} eq $self->{'usernameattribute'} } @ldap_attributes ) {

--- a/lib/pf/Authentication/Source/LDAPSource.pm
+++ b/lib/pf/Authentication/Source/LDAPSource.pm
@@ -56,7 +56,7 @@ sub available_attributes {
 
   my $super_attributes = $self->SUPER::available_attributes;
   my @custom_attributes = @{$Config{advanced}->{custom_ldap_attributes}};
-  my @attributes = (("uid", "cn", "department", "displayName", "distinguishedName", "givenName", "memberOf", "sn", "eduPersonPrimaryAffiliation", "mail", "postOfficeBox", "description", "groupMembership"), @custom_attributes);
+  my @attributes = (@pf::Authentication::constants::LDAP_ATTRIBUTES, @custom_attributes);
   @attributes = uniq @attributes;
   my @ldap_attributes = map { { value => $_, type => $Conditions::LDAP_ATTRIBUTE } } @attributes;
 

--- a/lib/pf/Authentication/Source/LDAPSource.pm
+++ b/lib/pf/Authentication/Source/LDAPSource.pm
@@ -19,6 +19,7 @@ use Net::LDAPS;
 use List::Util;
 use Net::LDAP::Util qw(escape_filter_value);
 use pf::config;
+use List::MoreUtils qw(uniq);
 
 use Moose;
 extends 'pf::Authentication::Source';
@@ -56,6 +57,7 @@ sub available_attributes {
   my $super_attributes = $self->SUPER::available_attributes;
   my @custom_attributes = @{$Config{advanced}->{custom_ldap_attributes}};
   my @attributes = (("uid", "cn", "department", "displayName", "distinguishedName", "givenName", "memberOf", "sn", "eduPersonPrimaryAffiliation", "mail", "postOfficeBox", "description", "groupMembership"), @custom_attributes);
+  @attributes = uniq @attributes;
   my @ldap_attributes = map { { value => $_, type => $Conditions::LDAP_ATTRIBUTE } } @attributes;
 
   # We check if our username attribute is present, if not we add it.

--- a/lib/pf/Authentication/constants.pm
+++ b/lib/pf/Authentication/constants.pm
@@ -16,8 +16,6 @@ use warnings;
 
 use Readonly;
 
-our @LDAP_ATTRIBUTES = ("uid", "cn", "department", "displayName", "distinguishedName", "givenName", "memberOf", "sn", "eduPersonPrimaryAffiliation", "mail", "postOfficeBox", "description", "groupMembership");
-
 =head1 Rules
 
 General constants related to rules.

--- a/lib/pf/Authentication/constants.pm
+++ b/lib/pf/Authentication/constants.pm
@@ -16,6 +16,8 @@ use warnings;
 
 use Readonly;
 
+our @LDAP_ATTRIBUTES = ("uid", "cn", "department", "displayName", "distinguishedName", "givenName", "memberOf", "sn", "eduPersonPrimaryAffiliation", "mail", "postOfficeBox", "description", "groupMembership");
+
 =head1 Rules
 
 General constants related to rules.

--- a/lib/pfconfig/namespaces/config/Pf.pm
+++ b/lib/pfconfig/namespaces/config/Pf.pm
@@ -110,8 +110,6 @@ sub build_child {
         }
     }
     
-    $self->expand_list( $Config{advanced}, qw(custom_ldap_attributes) );
-
     $Config{trapping}{passthroughs} = [ split( /\s*,\s*/, $Config{trapping}{passthroughs} || '' ) ];
 
     # We're looking for the merged_list configurations and we merge the default value with

--- a/lib/pfconfig/namespaces/config/Pf.pm
+++ b/lib/pfconfig/namespaces/config/Pf.pm
@@ -109,6 +109,8 @@ sub build_child {
             $Config{$group}{$item} = File::Spec->catfile( $log_dir, $Config{$group}{$item} );
         }
     }
+    
+    $self->expand_list( $Config{advanced}, qw(custom_ldap_attributes) );
 
     $Config{trapping}{passthroughs} = [ split( /\s*,\s*/, $Config{trapping}{passthroughs} || '' ) ];
 


### PR DESCRIPTION
# Description

Allows the definition of custom LDAP attributes directly in the configuration for use in the authentication rules
# Impacts

Reduces custom code
# Dependencies

feature/merged-list (#664)
# Delete branch after merge

YES
# NEWS file entries
## New Features
- Added the ability to define custom LDAP attributes in the configuration
