### PR TITLE
Move packetfence sudoers entries to their own file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,22 +76,6 @@ conf/ssl/server.crt:
 bin/pfcmd: src/pfcmd.c
 	$(CC) -O2 -g -std=c99  -Wall $< -o $@
 
-.PHONY:sudo
-
-sudo:
-	if (grep "^Defaults.*requiretty" /etc/sudoers > /dev/null  ) ;\
-		then sed -i 's/^Defaults.*requiretty/#Defaults requiretty/g' /etc/sudoers;\
-	fi
-	if (grep "^pf ALL=NOPASSWD:.*/sbin/iptables.*/usr/sbin/ipset" /etc/sudoers > /dev/null  ) ;\
-		then sed -i 's/^\(pf ALL=NOPASSWD:.*\/sbin\/iptables.*\/usr\/sbin\/ipset\)/#\1/g' /etc/sudoers;\
-	fi
-	if ! (grep "^pf ALL=NOPASSWD:.*/sbin/iptables.*/usr/sbin/ipset.*/sbin/ip.*/sbin/vconfig.*/sbin/route.*/sbin/service.*/usr/bin/tee.*/usr/local/pf/sbin/pfdhcplistener.*/bin/kill.*/usr/sbin/dhcpd.*/usr/sbin/radiusd.*/usr/sbin/snort.*/usr/sbin/suricata.*/usr/sbin/chroot.*/usr/local/pf/bin/pfcmd" /etc/sudoers > /dev/null  ) ; then\
-		echo "pf ALL=NOPASSWD: /sbin/iptables, /usr/sbin/ipset, /sbin/ip, /sbin/vconfig, /sbin/route, /sbin/service, /usr/bin/tee, /usr/local/pf/sbin/pfdhcplistener, /bin/kill, /usr/sbin/dhcpd, /usr/sbin/radiusd, /usr/sbin/snort, /usr/bin/suricata, /usr/sbin/chroot, /usr/local/pf/bin/pfcmd" >> /etc/sudoers;\
-	fi
-	if ! ( grep '^Defaults:pf.*!requiretty' /etc/sudoers > /dev/null ) ; then\
-		echo 'Defaults:pf !requiretty' >> /etc/sudoers;\
-	fi
-
 .PHONY:permissions
 
 permissions:

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,13 @@ bin/pfcmd: src/pfcmd.c
 
 .PHONY:permissions
 
+/etc/sudoers.d/packetfence.sudoers: packetfence.sudoers
+	cp packetfence.sudoers /etc/sudoers.d/packetfence.sudoers
+
+.PHONY:sudo
+
+sudo:/etc/sudoers.d/packetfence.sudoers
+
 permissions:
 	./bin/pfcmd fixpermissions
 

--- a/addons/packages/packetfence.spec
+++ b/addons/packages/packetfence.spec
@@ -418,6 +418,7 @@ done
 %{__install} -d $RPM_BUILD_ROOT/usr/local/pf/var/session
 %{__install} -d $RPM_BUILD_ROOT/usr/local/pf/var/webadmin_cache
 %{__install} -d $RPM_BUILD_ROOT/usr/local/pf/var/control
+%{__install} -d $RPM_BUILD_ROOT/etc/sudoers.d
 touch $RPM_BUILD_ROOT/usr/local/pf/var/cache_control
 cp Makefile $RPM_BUILD_ROOT/usr/local/pf/
 cp -r bin $RPM_BUILD_ROOT/usr/local/pf/
@@ -443,6 +444,7 @@ cp -r raddb $RPM_BUILD_ROOT/usr/local/pf/
 mv addons/pfdetect_remote/initrd/pfdetectd $RPM_BUILD_ROOT%{_initrddir}/
 mv addons/pfdetect_remote/sbin/pfdetect_remote $RPM_BUILD_ROOT/usr/local/pf/sbin
 mv addons/pfdetect_remote/conf/pfdetect_remote.conf $RPM_BUILD_ROOT/usr/local/pf/conf
+mv packetfence.sudoers $RPM_BUILD_ROOT/etc/sudoers.d/
 rmdir addons/pfdetect_remote/sbin
 rmdir addons/pfdetect_remote/initrd
 rmdir addons/pfdetect_remote/conf
@@ -623,21 +625,6 @@ else
   echo "pf.conf already exists, won't touch it!"
 fi
 
-#Add for sudo 
-if (grep "^Defaults.*requiretty" /etc/sudoers > /dev/null  ) ; then
-  sed -i 's/^Defaults.*requiretty/#Defaults requiretty/g' /etc/sudoers
-fi
-if (grep "^pf ALL=NOPASSWD:.*/sbin/iptables.*/usr/sbin/ipset" /etc/sudoers > /dev/null  ) ; then
-  # Comment out entry from a previous version of PF (< 4.0)
-  sed -i 's/^\(pf ALL=NOPASSWD:.*\/sbin\/iptables.*\/usr\/sbin\/ipset\)/#\1/g' /etc/sudoers
-fi
-if ! (grep "^pf ALL=NOPASSWD:.*/sbin/iptables.*/usr/sbin/ipset.*/sbin/ip.*/sbin/vconfig.*/sbin/route.*/sbin/service.*/usr/bin/tee.*/usr/local/pf/sbin/pfdhcplistener.*/bin/kill.*/usr/sbin/dhcpd.*/usr/sbin/radiusd.*/usr/sbin/snort.*/usr/sbin/suricata.*/usr/sbin/chroot.*/usr/local/pf/bin/pfcmd.*/usr/sbin/conntrack" /etc/sudoers > /dev/null  ) ; then
-  echo "pf ALL=NOPASSWD: /sbin/iptables, /usr/sbin/ipset, /sbin/ip, /sbin/vconfig, /sbin/route, /sbin/service, /usr/bin/tee, /usr/local/pf/sbin/pfdhcplistener, /bin/kill, /usr/sbin/dhcpd, /usr/sbin/radiusd, /usr/sbin/snort, /usr/bin/suricata, /usr/sbin/chroot, /usr/local/pf/bin/pfcmd, /usr/sbin/conntrack" >> /etc/sudoers
-fi
-if ! ( grep '^Defaults:pf.*!requiretty' /etc/sudoers > /dev/null ) ; then
-  echo 'Defaults:pf !requiretty' >> /etc/sudoers
-fi
-
 # dashboard symlinks and permissions
 ln -sf /usr/local/pf/var/conf/local_settings.py /usr/lib/python2.6/site-packages/graphite/local_settings.py
 chmod g+w /var/lib/carbon
@@ -740,6 +727,8 @@ fi
 %defattr(-, pf, pf)
 %attr(0755, root, root) %{_initrddir}/packetfence
 %dir                    %{_sysconfdir}/logrotate.d
+%dir                    %{_sysconfdir}/sudoers.d
+%config %attr(0440,root,root) %{_sysconfdir}/sudoers.d/packetfence.sudoers
 %config                 %{_sysconfdir}/logrotate.d/packetfence
 
 %dir                    /usr/local/pf

--- a/debian/packetfence.conffiles
+++ b/debian/packetfence.conffiles
@@ -1,3 +1,4 @@
+/etc/sudoers.d/packetfence.sudoers
 /usr/local/pf/conf/adminroles.conf
 /usr/local/pf/conf/apache_filters.conf
 /usr/local/pf/conf/authentication.conf

--- a/debian/packetfence.postinst
+++ b/debian/packetfence.postinst
@@ -113,18 +113,6 @@ case "$1" in
         update-rc.d mysql defaults
 
         /sbin/ldconfig
-
-        # add sudo entry
-        if (grep "^pf ALL=NOPASSWD:.*/sbin/iptables.*/usr/sbin/ipset" /etc/sudoers > /dev/null  ) ; then
-            # Comment out entry from a previous version of PF (< 4.0)
-            sed -i 's/^\(pf ALL=NOPASSWD:.*\/sbin\/iptables.*\/usr\/sbin\/ipset\)/#\1/g' /etc/sudoers
-        fi
-        if ! (grep "^pf ALL=NOPASSWD:.*/sbin/iptables.*/usr/sbin/ipset.*/sbin/ipset.*/sbin/ip.*/sbin/vconfig.*/sbin/route.*/sbin/service.*/usr/bin/tee.*/usr/local/pf/sbin/pfdhcplistener.*/bin/kill.*/usr/sbin/dhcpd.*/usr/sbin/freeradius.*/usr/sbin/snort.*/usr/sbin/suricata.*/usr/sbin/chroot.*/usr/local/pf/bin/pfcmd.*/usr/sbin/conntrack" /etc/sudoers > /dev/null  ) ; then
-            echo "pf ALL=NOPASSWD: /sbin/iptables, /usr/sbin/ipset, /sbin/ipset, /sbin/ip, /sbin/vconfig, /sbin/route, /sbin/service, /usr/bin/tee, /usr/local/pf/sbin/pfdhcplistener, /bin/kill, /usr/sbin/dhcpd, /usr/sbin/freeradius, /usr/sbin/snort, /usr/bin/suricata, /usr/sbin/chroot, /usr/local/pf/bin/pfcmd, /usr/sbin/conntrack" >> /etc/sudoers
-        fi
-        if ! ( grep '^Defaults:pf.*!requiretty' /etc/sudoers > /dev/null ) ; then
-            echo 'Defaults:pf !requiretty' >> /etc/sudoers
-        fi
         update-rc.d packetfence defaults 60 || exit 0
         #Starting Packetfence.
         echo "Starting Packetfence Administration GUI..."

--- a/debian/rules
+++ b/debian/rules
@@ -94,6 +94,9 @@ install: build
 	#Configurator integration
 	install -d -m0700 $(CURDIR)/debian/packetfence/etc/init.d
 	install -d -m0700 $(CURDIR)/debian/packetfence/etc/default
+	#Sudoer
+	install -d -m0750 $(CURDIR)/debian/packetfence/etc/sudoers.d
+	install -m0440 packetfence.sudoers $(CURDIR)/debian/packetfence/etc/sudoers.d/packetfence.sudoers
 	#PacketFence remote Snort sensor
 	install -d -m0700 $(CURDIR)/debian/packetfence-remote-snort-sensor$(PREFIX)/$(NAME)/conf
 	install -d $(CURDIR)/debian/packetfence-remote-snort-sensor$(PREFIX)/$(NAME)/var

--- a/packetfence.sudoers
+++ b/packetfence.sudoers
@@ -1,0 +1,3 @@
+pf ALL=NOPASSWD: /sbin/iptables, /usr/sbin/ipset, /sbin/ip, /sbin/vconfig, /sbin/route, /sbin/service, /usr/bin/tee, /usr/local/pf/sbin/pfdhcplistener, /bin/kill, /usr/sbin/dhcpd, /usr/sbin/radiusd, /usr/sbin/snort, /usr/bin/suricata, /usr/sbin/chroot, /usr/local/pf/bin/pfcmd, /usr/sbin/conntrack
+Defaults:pf !requiretty
+


### PR DESCRIPTION
## Description

No longer manipulate the sudoers file
## Impacts

Packaging
## NEWS file entries

New Features
++++++++++++

Enhancements
++++++++++++
- Improve handling of updating the /etc/sudoers file in packaging

Bug Fixes
+++++++++
## Delete branch after merge

NO
