### PR TITLE
Disabled startup when updating on RHEL.

### DIFF
--- a/addons/packages/packetfence.spec
+++ b/addons/packages/packetfence.spec
@@ -640,16 +640,19 @@ echo "Disabling SELinux..."
 setenforce 0
 sed -i 's/^SELINUX=.*/SELINUX=disabled/g' /etc/selinux/config
 
-#Starting Packetfence.
-echo "Starting Packetfence..."
-#removing old cache
-rm -rf /usr/local/pf/var/cache/ 
-/usr/local/pf/bin/pfcmd configreload
-/sbin/service packetfence start
+# skip if this is an update
+if [ ! -e /usr/local/pf/conf/currently-at ]; then 
+    #Starting Packetfence.
+    echo "Starting Packetfence..."
+    #removing old cache
+    rm -rf /usr/local/pf/var/cache/ 
+    /usr/local/pf/bin/pfcmd configreload
+    /sbin/service packetfence start
 
-echo Installation complete
-echo "  * Please fire up your Web browser and go to https://@ip_packetfence:1443/configurator to complete your PacketFence configuration."
-echo "  * Please stop your iptables service if you don't have access to configurator."
+    echo Installation complete
+    echo "  * Please fire up your Web browser and go to https://@ip_packetfence:1443/configurator to complete your PacketFence configuration."
+    echo "  * Please stop your iptables service if you don't have access to configurator."
+fi
 
 %post -n %{real_name}-remote-snort-sensor
 echo "Adding PacketFence remote Snort Sensor startup script"


### PR DESCRIPTION
# Description

PacketFence should not be started automatically post upgrade.
# Impacts

PF should only start automatically after a clean install, based on the presence or absence of the currently-at file.
There seems to be no other easy way to do it with rpms.
# Issue

(OPTIONAL. REMOVE IF NOT NEEDED)
fixes #546 
# Delete branch after merge

YES
# NEWS file entries
## Bug Fixes
- PacketFence will no longer automatically start after an upgrade. This prevents problems in an active/active configuration. (#546)
