### PR TITLE
Proper external portal detection in the catalyst portal

### DIFF
--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/CaptivePortal.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/CaptivePortal.pm
@@ -340,7 +340,7 @@ sub unknownState : Private {
 
     my $server_addr = $c->request->{env}->{SERVER_ADDR};
     my $management_ip = $pf::config::management_network->{'Tvip'} || $pf::config::management_network->{'Tip'};
-    if( $server_addr eq $management_ip){
+    if( $server_addr eq $management_ip && !$c->portalSession->dispatcherSession->{is_external_portal} ){
         $logger->error("Hitting unknownState on the management address ($server_addr)");
         $self->showError($c, "You hit the captive portal on the management interface. The management console is on port 1443.");
     }

--- a/html/captive-portal/lib/captiveportal/PacketFence/Model/Portal/Session.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Model/Portal/Session.pm
@@ -94,6 +94,12 @@ has destinationUrl => (
     lazy => 1,
 );
 
+has dispatcherSession => (
+    is      => 'rw',
+    builder => '_build_dispatcherSession',
+    lazy => 1,
+);
+
 has [qw(forwardedFor guestNodeMac)] => ( is => 'rw', );
 
 sub ACCEPT_CONTEXT {
@@ -229,6 +235,20 @@ sub _build_profile {
     my $options =  $self->options;
     $options->{'last_ip'} = $self->clientIp;
     return pf::Portal::ProfileFactory->instantiate( $self->clientMac, $options );
+}
+
+sub _build_dispatcherSession {
+    my ($self) = @_;
+    my $session = new pf::Portal::Session()->session;
+    my %session_data;
+    foreach my $key ($session->param) {
+        get_logger->debug("Adding session parameter from dispatcher session to Catalyst session : $key : ".$session->param($key));
+        $session_data{$key} = $session->param($key);
+    }
+    get_logger->info("External captive portal detected !") if($session_data{is_external_portal});
+
+    return \%session_data;
+    return 1;
 }
 
 sub templateIncludePath {


### PR DESCRIPTION
# Description

Allows access to the dispatcher session from the Catalyst portal
Also fixes the management message showing in unknown state when using the external portal
# Impacts

Modifies the Catalyst session and external portal release flow
# Delete branch after merge

YES
# NEWS file entries
## Bug Fixes
- Fixed bad error message when an external portal authenticated device hits the unknown state
