### PR TITLE
Feature/ntlm auth wrapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ bin/pfcmd: src/pfcmd.c
 	$(CC) -O2 -g -std=c99  -Wall $< -o $@
 
 bin/ntlm_auth_wrapper: src/ntlm_auth_wrap.c
-	cc  -std=c99  -Wall  src/ntlm_auth_wrap.c -o bin/ntlm_auth_wrapper
+	cc -g -std=c99  -Wall  src/ntlm_auth_wrap.c -o bin/ntlm_auth_wrapper
 
 .PHONY:permissions
 

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,9 @@ conf/pf_omapi_key:
 bin/pfcmd: src/pfcmd.c
 	$(CC) -O2 -g -std=c99  -Wall $< -o $@
 
+bin/ntlm_auth_wrapper: src/ntlm_auth_wrap.c
+	cc  -std=c99  -Wall  src/ntlm_auth_wrap.c -o bin/ntlm_auth_wrapper
+
 .PHONY:permissions
 
 /etc/sudoers.d/packetfence.sudoers: packetfence.sudoers
@@ -90,6 +93,7 @@ bin/pfcmd: src/pfcmd.c
 .PHONY:sudo
 
 sudo:/etc/sudoers.d/packetfence.sudoers
+
 
 permissions:
 	./bin/pfcmd fixpermissions

--- a/NEWS.asciidoc
+++ b/NEWS.asciidoc
@@ -302,6 +302,8 @@ New Features
 Enhancements
 ++++++++++++
 
+* New ntlm_auth wrapper will log authentication latency to StatsD automatically.
+
 Bug Fixes
 +++++++++
 

--- a/addons/packages/packetfence.spec
+++ b/addons/packages/packetfence.spec
@@ -101,6 +101,7 @@ Requires: mysql, mysql-server, perl(DBD::mysql)
 Requires: perl >= %{perl_version}
 # replaces the need for perl-suidperl which was deprecated in perl 5.12 (Fedora 14)
 Requires(pre): %{real_name}-pfcmd-suid
+Requires(pre): %{real_name}-ntlm-wrapper
 Requires: perl(Bit::Vector)
 Requires: perl(CGI::Session), perl(CGI::Session::Driver::chi) >= 1.0.3, perl(JSON), perl(JSON::XS)
 Requires: perl(Apache2::Request)
@@ -355,6 +356,15 @@ Summary: a C wrapper around ntlm_auth which allows logging or sending to StatsD 
 
 %description -n %{real_name}-ntlm_auth_wrapper
 The %{real_name}-ntlm_auth_wrapper is a C wrapper around ntlm_auth that allows logging and/or sending to StatsD the authentication latency.
+
+%package -n %{real_name}-ntlm-wrapper
+Group: System Environment/Daemons
+BuildRequires: gcc
+AutoReqProv: 0
+Summary: C wrapper for logging ntlm_auth latency.
+
+%description -n %{real_name}-ntlm-wrapper
+The %{real_name}-ntlm-wrapper is a C wrapper around the ntlm_auth utility to log authentication times and success/failures. It can either/both log to syslog and send metrics to a StatsD server.
 
 %package -n %{real_name}-config
 Group: System Environment/Daemons
@@ -1159,6 +1169,9 @@ fi
 %attr(6755, root, root) /usr/local/pf/bin/pfcmd
 
 %files -n %{real_name}-ntlm_auth_wrapper 
+%attr(0755, root, root) /usr/local/pf/bin/ntlm_auth_wrapper
+
+%files -n %{real_name}-ntlm-wrapper
 %attr(0755, root, root) /usr/local/pf/bin/ntlm_auth_wrapper
 
 %files -n %{real_name}-config

--- a/addons/packages/packetfence.spec
+++ b/addons/packages/packetfence.spec
@@ -348,15 +348,6 @@ Summary: Replace pfcmd by a C wrapper for suid
 The %{real_name}-pfcmd-suid is a C wrapper to replace perl-suidperl dependency.
 See https://bugzilla.redhat.com/show_bug.cgi?id=611009
 
-%package -n %{real_name}-ntlm_auth_wrapper
-Group: System Environment/Daemons
-BuildRequires: gcc
-AutoReqProv: 0
-Summary: a C wrapper around ntlm_auth which allows logging or sending to StatsD authentication latency.
-
-%description -n %{real_name}-ntlm_auth_wrapper
-The %{real_name}-ntlm_auth_wrapper is a C wrapper around ntlm_auth that allows logging and/or sending to StatsD the authentication latency.
-
 %package -n %{real_name}-ntlm-wrapper
 Group: System Environment/Daemons
 BuildRequires: gcc
@@ -1167,9 +1158,6 @@ fi
 
 %files -n %{real_name}-pfcmd-suid
 %attr(6755, root, root) /usr/local/pf/bin/pfcmd
-
-%files -n %{real_name}-ntlm_auth_wrapper 
-%attr(0755, root, root) /usr/local/pf/bin/ntlm_auth_wrapper
 
 %files -n %{real_name}-ntlm-wrapper
 %attr(0755, root, root) /usr/local/pf/bin/ntlm_auth_wrapper

--- a/addons/packages/packetfence.spec
+++ b/addons/packages/packetfence.spec
@@ -347,6 +347,15 @@ Summary: Replace pfcmd by a C wrapper for suid
 The %{real_name}-pfcmd-suid is a C wrapper to replace perl-suidperl dependency.
 See https://bugzilla.redhat.com/show_bug.cgi?id=611009
 
+%package -n %{real_name}-ntlm_auth_wrapper
+Group: System Environment/Daemons
+BuildRequires: gcc
+AutoReqProv: 0
+Summary: a C wrapper around ntlm_auth which allows logging or sending to StatsD authentication latency.
+
+%description -n %{real_name}-ntlm_auth_wrapper
+The %{real_name}-ntlm_auth_wrapper is a C wrapper around ntlm_auth that allows logging and/or sending to StatsD the authentication latency.
+
 %package -n %{real_name}-config
 Group: System Environment/Daemons
 Requires: perl(Cache::BDB)
@@ -393,6 +402,8 @@ done
 %endif
 # build pfcmd C wrapper
 gcc -g0 src/pfcmd.c -o bin/pfcmd
+# build ntlm_auth_wrapper
+make bin/ntlm_auth_wrapper
 # Define git_commit_id
 echo %{git_commit} > conf/git_commit_id
 
@@ -1146,6 +1157,9 @@ fi
 
 %files -n %{real_name}-pfcmd-suid
 %attr(6755, root, root) /usr/local/pf/bin/pfcmd
+
+%files -n %{real_name}-ntlm_auth_wrapper 
+%attr(0755, root, root) /usr/local/pf/bin/ntlm_auth_wrapper
 
 %files -n %{real_name}-config
 %defattr(-, pf, pf)

--- a/conf/radiusd/packetfence-tunnel.example
+++ b/conf/radiusd/packetfence-tunnel.example
@@ -42,6 +42,7 @@ authorize {
 
 authenticate {
         Auth-Type MS-CHAP {
+            packetfence     # increment the StatsD counter
             if(PacketFence-Domain){
                 chrooted_mschap
             }

--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Package: packetfence
 Architecture: all
 # TODO: We can probably move these in Depends since 3.5.0 (managed RADIUS feature)
 Pre-Depends:  ca-certificates, freeradius (>= 2.2.5), freeradius-ldap, freeradius-postgresql,
- freeradius-mysql, freeradius-krb5, dhcp3-server, ca-certificates, packetfence-pfcmd-suid (>= ${Source-Version}), packetfence-config (>= ${Source-Version}),
+ freeradius-mysql, freeradius-krb5, dhcp3-server, ca-certificates, packetfence-pfcmd-suid (>= ${Source-Version}), packetfence-config (>= ${Source-Version}), packetfence-ntlm-wrapper (>= ${Source-Version})
  fingerbank (>= 1.0.4), graphite-web, winbind,
 # wmi
  libnet-wmiclient-perl, libwmiclient1, wmi-client
@@ -160,6 +160,12 @@ Replaces: packetfence (<< 3.6.0)
 Breaks: packetfence (<< 3.6.0)
 Description: C wrapper that replace perl-suid dependence
  perl 5.12 dropped suidperl support (packaged as suid-perl)
+
+Package: packetfence-ntlm-wrapper
+Architecture: any
+Depends: ${misc:Depends}, ${shlibs:Depends}
+Description: C wrapper around the ntlm_auth utility to log authentication latency and success/failure.
+
 
 Package: packetfence-remote-arp-sensor
 Architecture: all

--- a/debian/rules
+++ b/debian/rules
@@ -114,6 +114,10 @@ install: build
 	#PacketFence pfcmd suid
 	install -d -m0755 $(CURDIR)/debian/packetfence-pfcmd-suid$(PREFIX)/$(NAME)/bin
 	gcc src/pfcmd.c -o $(CURDIR)/debian/packetfence-pfcmd-suid$(PREFIX)/$(NAME)/bin/pfcmd
+	# ntlm-wrapper
+	install -d -m0755 $(CURDIR)/debian/packetfence-ntlm-wrapper$(PREFIX)/$(NAME)/bin
+	make bin/ntlm_auth_wrapper
+	mv bin/ntlm_auth_wrapper $(CURDIR)/debian/packetfence-ntlm-wrapper$(PREFIX)/$(NAME)/bin
 	install -d $(CURDIR)/debian/packetfence-config$(PREFIX)/$(NAME)/sbin
 	install -d -m0700 $(CURDIR)/debian/packetfence-config$(PREFIX)/$(NAME)/conf
 	install -d -m2770 $(CURDIR)/debian/packetfence-config$(PREFIX)/$(NAME)/var/cache/pfconfig

--- a/html/pfappserver/lib/pfappserver/PacketFence/Controller/Graph.pm
+++ b/html/pfappserver/lib/pfappserver/PacketFence/Controller/Graph.pm
@@ -408,20 +408,21 @@ sub dashboard :Local :AdminRole('REPORTS') {
                {
                 'description' => 'NTLM call timing',
                 'vtitle' => 'ms',
-                'target' => 'aliasByNode(stats.timers.*.ntlm_auth.timing.mean_90,2)',
+                'target' => 'aliasByNode(stats.timers.*.ntlm_auth.time.mean_90,2)',
                 'columns' => 1
                },
                {
                 'description' => 'NTLM authentication failures',
-                'vtitle' => 'failures',
+                'vtitle' => 'failures/s',
                 'target' => 'aliasByNode(stats.counters.*.ntlm_auth.failures.count,2)',
                 'columns' => 1
                },
                {
                 'description' => 'NTLM authentication timeouts',
-                'vtitle' => 'timeouts',
+                'vtitle' => 'timeouts/s',
                 'target' => _generate_timeout_group(),
-                'columns' => 1
+                'columns' => 1,
+                'drawNullAsZero' => 'true'
                },
                {
                 'description' => 'Portal Open Connections per server',
@@ -789,7 +790,7 @@ sub _generate_timeout_group {
     my @group_members;
     for my $host (_generate_hosts()) {
         push @group_members,
-                         "diffSeries(stats.counters.$host.freeradius__main__authenticate.count.count,stats.timers.$host.ntlm_auth.time.count)"
+                         "removeBelowValue(diffSeries(stats.counters.$host.freeradius__main__authenticate.count.count,stats.timers.$host.ntlm_auth.time.count),0)"
 ;
     }
 

--- a/html/pfappserver/lib/pfappserver/PacketFence/Controller/Graph.pm
+++ b/html/pfappserver/lib/pfappserver/PacketFence/Controller/Graph.pm
@@ -406,6 +406,18 @@ sub dashboard :Local :AdminRole('REPORTS') {
                 'columns' => 1
                },
                {
+                'description' => 'NTLM call timing',
+                'vtitle' => 'ms',
+                'target' => 'aliasByNode(stats.timers.*.ntlm_auth.timing.mean_90,2)',
+                'columns' => 1
+               },
+               {
+                'description' => 'NTLM authentication count',
+                'vtitle' => 'failures/s',
+                'target' => 'aliasByNode(stats.timers.*.ntlm_auth.timing.count,2)',
+                'columns' => 1
+               },
+               {
                 'description' => 'Portal Open Connections per server',
                 'vtitle' => 'connections',
                 'target' => 'aliasByNode(*.apache-portal.apache_connections,0)',

--- a/html/pfappserver/lib/pfappserver/PacketFence/Controller/Graph.pm
+++ b/html/pfappserver/lib/pfappserver/PacketFence/Controller/Graph.pm
@@ -412,9 +412,15 @@ sub dashboard :Local :AdminRole('REPORTS') {
                 'columns' => 1
                },
                {
-                'description' => 'NTLM authentication count',
-                'vtitle' => 'failures/s',
-                'target' => 'aliasByNode(stats.timers.*.ntlm_auth.timing.count,2)',
+                'description' => 'NTLM authentication failures',
+                'vtitle' => 'failures',
+                'target' => 'aliasByNode(stats.counters.*.ntlm_auth.failures.count,2)',
+                'columns' => 1
+               },
+               {
+                'description' => 'NTLM authentication timeouts',
+                'vtitle' => 'timeouts',
+                'target' => _generate_timeout_group(),
                 'columns' => 1
                },
                {
@@ -777,6 +783,17 @@ sub _generate_hosts {
     }
     map {  s/\./_/g } @hosts;
     return @hosts;
+}
+
+sub _generate_timeout_group {
+    my @group_members;
+    for my $host (_generate_hosts()) {
+        push @group_members,
+                         "diffSeries(stats.counters.$host.freeradius__main__authenticate.count.count,stats.timers.$host.ntlm_auth.time.count)"
+;
+    }
+
+    return 'aliasByNode( group(' . join( ', ', @group_members ) . ') ,2)';
 }
 
 

--- a/raddb/modules/mschap
+++ b/raddb/modules/mschap
@@ -62,6 +62,8 @@ mschap {
 	# attribute, and do prefix/suffix checks in order to obtain
 	# the "best" user name for the request.
 	#
+    # Call ntlm_auth through the logging wrapper. Make sure to preserve the -- separator to distinguish between
+    # the args to the wrapper and those to the ntlm_auth executable itself
 	ntlm_auth = "/usr/local/pf/bin/ntlm_auth_wrapper -- \
         --request-nt-key --username=%{%{Stripped-User-Name}:-%{mschap:User-Name:-None}} --challenge=%{mschap:Challenge:-00} --nt-response=%{mschap:NT-Response:-00}"
 
@@ -141,6 +143,8 @@ mschap chrooted_mschap {
 	# attribute, and do prefix/suffix checks in order to obtain
 	# the "best" user name for the request.
 	#
+    # Call ntlm_auth through the logging wrapper. Make sure to preserve the -- separator to distinguish between
+    # the args to the wrapper and those to the ntlm_auth executable itself
 	ntlm_auth = "/usr/bin/sudo /usr/sbin/chroot /chroots/%{PacketFence-Domain} /usr/local/pf/bin/ntlm_auth_wrapper -- \
         --request-nt-key --username=%{%{Stripped-User-Name}:-%{mschap:User-Name:-None}} --challenge=%{mschap:Challenge:-00} --nt-response=%{mschap:NT-Response:-00}"	
 	

--- a/raddb/modules/mschap
+++ b/raddb/modules/mschap
@@ -62,7 +62,8 @@ mschap {
 	# attribute, and do prefix/suffix checks in order to obtain
 	# the "best" user name for the request.
 	#
-	ntlm_auth = "/usr/bin/ntlm_auth --request-nt-key --username=%{%{Stripped-User-Name}:-%{mschap:User-Name:-None}} --challenge=%{mschap:Challenge:-00} --nt-response=%{mschap:NT-Response:-00}"
+	ntlm_auth = "/usr/local/pf/bin/ntlm_auth_wrapper -- \
+        --request-nt-key --username=%{%{Stripped-User-Name}:-%{mschap:User-Name:-None}} --challenge=%{mschap:Challenge:-00} --nt-response=%{mschap:NT-Response:-00}"
 
 	# ntlm_auth should take less than three seconds.
 	# If it takes longer than that, something is probably wrong.
@@ -140,8 +141,9 @@ mschap chrooted_mschap {
 	# attribute, and do prefix/suffix checks in order to obtain
 	# the "best" user name for the request.
 	#
-	ntlm_auth = "/usr/bin/sudo /usr/sbin/chroot /chroots/%{PacketFence-Domain} /usr/bin/ntlm_auth --request-nt-key --username=%{%{Stripped-User-Name}:-%{mschap:User-Name:-None}} --challenge=%{mschap:Challenge:-00} --nt-response=%{mschap:NT-Response:-00}"	
-
+	ntlm_auth = "/usr/bin/sudo /usr/sbin/chroot /chroots/%{PacketFence-Domain} /usr/local/pf/bin/ntlm_auth_wrapper -- \
+        --request-nt-key --username=%{%{Stripped-User-Name}:-%{mschap:User-Name:-None}} --challenge=%{mschap:Challenge:-00} --nt-response=%{mschap:NT-Response:-00}"	
+	
 	# ntlm_auth should take less than three seconds.
 	# If it takes longer than that, something is probably wrong.
 	#

--- a/raddb/packetfence.pm
+++ b/raddb/packetfence.pm
@@ -299,6 +299,11 @@ sub is_eap_mac_authentication {
 
 # Function to handle authenticate
 sub authenticate {
+    # For debugging purposes only
+    # &log_request_attributes;
+    # We only increment a counter to know how often this has been called.
+    $pf::StatsD::statsd->increment("freeradius::" . called() . ".count" );                                         
+    return $RADIUS::RLM_MODULE_NOOP;
 
 }
 

--- a/src/ntlm_auth_wrap.c
+++ b/src/ntlm_auth_wrap.c
@@ -44,7 +44,6 @@ const char *argp_program_bug_address = "<info@inverse.ca>";
 
 // These have to be initialized early so they can be used in the signal handler.
 pid_t pid = 0 ; // initialize the child pid 
-int TIMEOUT = 199;
 
 /* Program documentation. */
 static char doc[] =
@@ -55,127 +54,127 @@ static char args_doc[] = "[arguments passed to ntlm_auth]";
 
 /* The options we understand. */
 static struct argp_option options[] = {
-	{"binary", 'b', "path", 0,
-	 "ntlm_auth binary path. Defaults to /usr/bin/ntlm_auth."},
-	{"host", 'h', "hostname or ip", 0,
-	 "StatsD host. Default is localhost."},
-	{"port", 'p', "port", 0, "StatsD port. Default is 8125."},
-	{"insecure", 'i', 0, 0, "Log insecure arguments such as the password."},
-	{"nostatsd", 's', 0, 0, "Don't send performance counters to statsd."},
-	{"noresolv", 'n', 0, 0, "Do not resolve value for host and port."},
-	{"log", 'l', 0, 0, "Send results to syslog."},
-	{"logfacility", 'f', "facility", 0,
-	 "Syslog facility. Default is local5."},
-	{"loglevel", 'd', "level", 0, "Syslog level. Default is info."},
-	{0}
+    {"binary", 'b', "path", 0,
+     "ntlm_auth binary path. Defaults to /usr/bin/ntlm_auth."},
+    {"host", 'h', "hostname or ip", 0,
+     "StatsD host. Default is localhost."},
+    {"port", 'p', "port", 0, "StatsD port. Default is 8125."},
+    {"insecure", 'i', 0, 0, "Log insecure arguments such as the password."},
+    {"nostatsd", 's', 0, 0, "Don't send performance counters to statsd."},
+    {"noresolv", 'n', 0, 0, "Do not resolve value for host and port."},
+    {"log", 'l', 0, 0, "Send results to syslog."},
+    {"logfacility", 'f', "facility", 0,
+     "Syslog facility. Default is local5."},
+    {"loglevel", 'd', "level", 0, "Syslog level. Default is info."},
+    {0}
 };
 
 /* Used by main to communicate with parse_opt. */
 struct arguments {
-	int insecure, nostatsd, noresolv, log, facility, level;
-	char *binary;
-	char *host;
-	char *port;
-	char *args[];		// Arguments to ntlm_auth itself
+    int insecure, nostatsd, noresolv, log, facility, level;
+    char *binary;
+    char *host;
+    char *port;
+    char *args[];       // Arguments to ntlm_auth itself
 };
 
 /* Parse a single option. */
 static error_t parse_opt(int key, char *arg, struct argp_state *state)
 {
-	/* Get the input argument from argp_parse, which we
-	   know is a pointer to our arguments structure. */
-	struct arguments *arguments = state->input;
+    /* Get the input argument from argp_parse, which we
+       know is a pointer to our arguments structure. */
+    struct arguments *arguments = state->input;
 
-	switch (key) {
-	case 'i':
-		arguments->insecure = 1;
-		break;
-	case 's':
-		arguments->nostatsd = 1;
-		break;
-	case 'n':
-		arguments->noresolv = 1;
-		break;
-	case 'l':
-		arguments->log = 1;
-		break;
-	case 'b':
-		arguments->binary = arg;
-		break;
-	case 'h':
-		arguments->host = arg;
-		break;
-	case 'p':
-		arguments->port = arg;
-		break;
-	case 'f':
-		if (strcasecmp(arg, "auth") == 0) {
-			arguments->facility = LOG_AUTHPRIV;
-		} else if (strcasecmp(arg, "authpriv") == 0) {
-			arguments->facility = LOG_AUTHPRIV;
-		} else if (strcasecmp(arg, "daemon") == 0) {
-			arguments->facility = LOG_DAEMON;
-		} else if (strcasecmp(arg, "user") == 0) {
-			arguments->facility = LOG_USER;
-		} else if (strcasecmp(arg, "local0") == 0) {
-			arguments->facility = LOG_LOCAL0;
-		} else if (strcasecmp(arg, "local1") == 0) {
-			arguments->facility = LOG_LOCAL1;
-		} else if (strcasecmp(arg, "local2") == 0) {
-			arguments->facility = LOG_LOCAL2;
-		} else if (strcasecmp(arg, "local3") == 0) {
-			arguments->facility = LOG_LOCAL3;
-		} else if (strcasecmp(arg, "local4") == 0) {
-			arguments->facility = LOG_LOCAL4;
-		} else if (strcasecmp(arg, "local5") == 0) {
-			arguments->facility = LOG_LOCAL5;
-		} else if (strcasecmp(arg, "local6") == 0) {
-			arguments->facility = LOG_LOCAL6;
-		} else if (strcasecmp(arg, "local7") == 0) {
-			arguments->facility = LOG_LOCAL7;
-		} else {
-			return ARGP_ERR_UNKNOWN;
-		}
-		break;
+    switch (key) {
+    case 'i':
+        arguments->insecure = 1;
+        break;
+    case 's':
+        arguments->nostatsd = 1;
+        break;
+    case 'n':
+        arguments->noresolv = 1;
+        break;
+    case 'l':
+        arguments->log = 1;
+        break;
+    case 'b':
+        arguments->binary = arg;
+        break;
+    case 'h':
+        arguments->host = arg;
+        break;
+    case 'p':
+        arguments->port = arg;
+        break;
+    case 'f':
+        if (strcasecmp(arg, "auth") == 0) {
+            arguments->facility = LOG_AUTHPRIV;
+        } else if (strcasecmp(arg, "authpriv") == 0) {
+            arguments->facility = LOG_AUTHPRIV;
+        } else if (strcasecmp(arg, "daemon") == 0) {
+            arguments->facility = LOG_DAEMON;
+        } else if (strcasecmp(arg, "user") == 0) {
+            arguments->facility = LOG_USER;
+        } else if (strcasecmp(arg, "local0") == 0) {
+            arguments->facility = LOG_LOCAL0;
+        } else if (strcasecmp(arg, "local1") == 0) {
+            arguments->facility = LOG_LOCAL1;
+        } else if (strcasecmp(arg, "local2") == 0) {
+            arguments->facility = LOG_LOCAL2;
+        } else if (strcasecmp(arg, "local3") == 0) {
+            arguments->facility = LOG_LOCAL3;
+        } else if (strcasecmp(arg, "local4") == 0) {
+            arguments->facility = LOG_LOCAL4;
+        } else if (strcasecmp(arg, "local5") == 0) {
+            arguments->facility = LOG_LOCAL5;
+        } else if (strcasecmp(arg, "local6") == 0) {
+            arguments->facility = LOG_LOCAL6;
+        } else if (strcasecmp(arg, "local7") == 0) {
+            arguments->facility = LOG_LOCAL7;
+        } else {
+            return ARGP_ERR_UNKNOWN;
+        }
+        break;
 
-	case 'd':
-		if (strcasecmp(arg, "debug") == 0) {
-			arguments->level = LOG_DEBUG;
-		} else if (strcasecmp(arg, "notice") == 0) {
-			arguments->level = LOG_NOTICE;
-		} else if (strcasecmp(arg, "info") == 0) {
-			arguments->level = LOG_INFO;
-		} else if (strcasecmp(arg, "warning") == 0) {
-			arguments->level = LOG_WARNING;
-		} else if (strcasecmp(arg, "error") == 0) {
-			arguments->level = LOG_ERR;
-		} else if (strcasecmp(arg, "critical") == 0) {
-			arguments->level = LOG_CRIT;
-		} else if (strcasecmp(arg, "alert") == 0) {
-			arguments->level = LOG_ALERT;
-		} else if (strcasecmp(arg, "emerg") == 0) {
-			arguments->level = LOG_ALERT;
-		} else {
-			return ARGP_ERR_UNKNOWN;
-		}
-		break;
+    case 'd':
+        if (strcasecmp(arg, "debug") == 0) {
+            arguments->level = LOG_DEBUG;
+        } else if (strcasecmp(arg, "notice") == 0) {
+            arguments->level = LOG_NOTICE;
+        } else if (strcasecmp(arg, "info") == 0) {
+            arguments->level = LOG_INFO;
+        } else if (strcasecmp(arg, "warning") == 0) {
+            arguments->level = LOG_WARNING;
+        } else if (strcasecmp(arg, "error") == 0) {
+            arguments->level = LOG_ERR;
+        } else if (strcasecmp(arg, "critical") == 0) {
+            arguments->level = LOG_CRIT;
+        } else if (strcasecmp(arg, "alert") == 0) {
+            arguments->level = LOG_ALERT;
+        } else if (strcasecmp(arg, "emerg") == 0) {
+            arguments->level = LOG_ALERT;
+        } else {
+            return ARGP_ERR_UNKNOWN;
+        }
+        break;
 
-	case ARGP_KEY_ARG:
-		if (state->arg_num >= 32)
-			/* Way too many arguments. */
-			argp_usage(state);
-		break;
+    case ARGP_KEY_ARG:
+        if (state->arg_num >= 32)
+            /* Way too many arguments. */
+            argp_usage(state);
+        break;
 
-	case ARGP_KEY_END:
-		if (state->arg_num < 2)
-			/* Not enough arguments. */
-			argp_usage(state);
-		break;
+    case ARGP_KEY_END:
+        if (state->arg_num < 2)
+            /* Not enough arguments. */
+            argp_usage(state);
+        break;
 
-	default:
-		return ARGP_ERR_UNKNOWN;
-	}
-	return 0;
+    default:
+        return ARGP_ERR_UNKNOWN;
+    }
+    return 0;
 }
 
 /* Our argp parser. */
@@ -184,95 +183,95 @@ static struct argp argp = { options, parse_opt, args_doc, doc };
 // send results to syslog
 void
 log_result(int argc, char **argv, const struct arguments args, int status,
-	   double elapsed, int ppid)
+       double elapsed, int ppid)
 {
-	openlog("radius-debug", LOG_PID, args.facility);
-	// build the log message
-	char *log_msg;
-	asprintf(&log_msg, "%s", args.binary);
+    openlog("radius-debug", LOG_PID, args.facility);
+    // build the log message
+    char *log_msg;
+    asprintf(&log_msg, "%s", args.binary);
 
-	// concatenate the command with all argv args separated by sep
+    // concatenate the command with all argv args separated by sep
     int i = 1; 
     while (i < argc ) {
-		// split the argument on = and check the first part to reject excluded args.
-		if (!args.insecure)
-			if ((strncmp
-			     (argv[i], "--password", strlen("--password")) == 0)
-			    ||
-			    (strncmp
-			     (argv[i], "--challenge", strlen("--challenge")) == 0)) 
+        // split the argument on = and check the first part to reject excluded args.
+        if (!args.insecure)
+            if ((strncmp
+                 (argv[i], "--password", strlen("--password")) == 0)
+                ||
+                (strncmp
+                 (argv[i], "--challenge", strlen("--challenge")) == 0)) 
             { 
-			    i=i+2; // will skip the next argument
+                i=i+2; // will skip the next argument
                 continue;
             }
 
-		char *tmpstr = log_msg;
-		log_msg = NULL;
-		asprintf(&log_msg, "%s %s ", tmpstr, argv[i]);
+        char *tmpstr = log_msg;
+        log_msg = NULL;
+        asprintf(&log_msg, "%s %s ", tmpstr, argv[i]);
         i++;
-	}
-	syslog(args.level, "%s time: %g ms, status: %i, exiting pid: %i",
-	       log_msg, elapsed, status, ppid);
-	closelog();
+    }
+    syslog(args.level, "%s time: %g ms, status: %i, exiting pid: %i",
+           log_msg, elapsed, WEXITSTATUS(status), ppid);
+    closelog();
 }
 
 // send to statsd 
 void send_statsd(const struct arguments args , int status, double elapsed)
 {
-	struct addrinfo *ailist;
-	struct addrinfo hint;
-	int sockfd, err;
-	memset(&hint, 0, sizeof(hint));
-	hint.ai_socktype = SOCK_DGRAM;
-	hint.ai_family = AF_INET;
-	if (args.noresolv)
-		hint.ai_flags = AI_NUMERICHOST | AI_NUMERICSERV;
-	hint.ai_canonname = NULL;
-	hint.ai_addr = NULL;
-	hint.ai_next = NULL;
-	if ((err = getaddrinfo(args.host, args.port, &hint, &ailist)) != 0) {
-		sprintf("getaddrinfo error: %s", gai_strerror(err));
+    struct addrinfo *ailist;
+    struct addrinfo hint;
+    int sockfd, err;
+    memset(&hint, 0, sizeof(hint));
+    hint.ai_socktype = SOCK_DGRAM;
+    hint.ai_family = AF_INET;
+    if (args.noresolv)
+        hint.ai_flags = AI_NUMERICHOST | AI_NUMERICSERV;
+    hint.ai_canonname = NULL;
+    hint.ai_addr = NULL;
+    hint.ai_next = NULL;
+    if ((err = getaddrinfo(args.host, args.port, &hint, &ailist)) != 0) {
+        sprintf("getaddrinfo error: %s", gai_strerror(err));
     } 
 
-	if ((sockfd = socket(ailist->ai_family, SOCK_DGRAM, 0)) < 0) {
-		err = errno;
-		fprintf(stderr, "cannot contact %s:%s: %s\n", args.host,
-			args.port, strerror(err));
+    if ((sockfd = socket(ailist->ai_family, SOCK_DGRAM, 0)) < 0) {
+        err = errno;
+        fprintf(stderr, "cannot contact %s:%s: %s\n", args.host,
+            args.port, strerror(err));
     }
 
-	connect(sockfd, ailist->ai_addr, ailist->ai_addrlen);
+//  connect(sockfd, ailist->ai_addr, ailist->ai_addrlen);
     char *buf;
     char hostname[MAX_STR_LENGTH];
     gethostname(hostname, sizeof(hostname));
 
     asprintf(&buf, "%s.ntlm_auth.time:%g|ms\n", hostname, elapsed);
 
-    send(sockfd, buf, strlen(buf), 0);
+    sendto(sockfd, buf, strlen(buf), 0, ailist->ai_addr, ailist->ai_addrlen);
 
     // increment counter if auth failed
     if (status == SIGTERM) {
         asprintf(&buf, "%s.ntlm_auth.timeout:1|c\n", hostname);
-        send(sockfd, buf, strlen(buf), 0);
+        sendto(sockfd, buf, strlen(buf), 0, ailist->ai_addr, ailist->ai_addrlen);
     } else if (status > 0) {
         asprintf(&buf, "%s.ntlm_auth.failures:1|c\n", hostname);
-        send(sockfd, buf, strlen(buf), 0);
+        sendto(sockfd, buf, strlen(buf), 0, ailist->ai_addr, ailist->ai_addrlen);
     }
 }
 
 double howlong(struct timeval t1)
 {
-	struct timeval end;
-	double elapsed;
-	gettimeofday(&end, NULL);
-	elapsed = (end.tv_sec - t1.tv_sec) * 1000.0;	// sec to ms
-	elapsed += (end.tv_usec - t1.tv_usec) / 1000.0;	// us to ms
+    struct timeval end;
+    double elapsed;
+    gettimeofday(&end, NULL);
+    elapsed = (end.tv_sec - t1.tv_sec) * 1000.0;    // sec to ms
+    elapsed += (end.tv_usec - t1.tv_usec) / 1000.0; // us to ms
 
-	return elapsed;
+    return elapsed;
 }
 
 void
 log_timeouts(int argc, char **argv, const struct arguments args,
-	     struct timeval start)
+         struct timeval start)
 {
     double elapsed;
     elapsed = howlong(start);
@@ -290,13 +289,13 @@ log_timeouts(int argc, char **argv, const struct arguments args,
 // If it isn't, well... too bad. We _exit anyway.
 static void handler(int sig)
 {
-	if (sig == SIGTERM) {
+    if (sig == SIGTERM) {
         if (pid == 0) _exit(SIGTERM); // we haven't forked yet or we are still in the child pre exec
-        kill(pid, SIGTERM);
+        kill(pid, SIGKILL);
         alarm(1) ; // wake us up in one second, giving us just enough time to finish logging 
-	}
+    }
     if (sig == SIGALRM ) { 
-        kill(pid, SIGTERM); // just in case we may have forked in the meantime
+        kill(pid, SIGKILL); // just in case we may have forked in the meantime
         _exit(SIGTERM); // we waited long enough
     }
 }
@@ -306,40 +305,40 @@ int argc;
 char **argv, **envp;
 {
 
-	/* Default values. */
-	struct arguments arguments;
-	arguments.insecure = 0;
-	arguments.nostatsd = 0;
-	arguments.noresolv = 0;
-	arguments.log = 0;
-	arguments.binary = "/usr/bin/ntlm_auth";
-	arguments.host = "localhost";
-	arguments.port = "8125";
-	arguments.facility = LOG_LOCAL5;
-	arguments.level = LOG_INFO;
-	/* Parse our arguments; every option seen by parse_opt will
-	   be reflected in arguments. */
-	argp_parse(&argp, argc, argv, 0, 0, &arguments);
+    /* Default values. */
+    struct arguments arguments;
+    arguments.insecure = 0;
+    arguments.nostatsd = 0;
+    arguments.noresolv = 0;
+    arguments.log = 0;
+    arguments.binary = "/usr/bin/ntlm_auth";
+    arguments.host = "localhost";
+    arguments.port = "8125";
+    arguments.facility = LOG_LOCAL5;
+    arguments.level = LOG_INFO;
+    /* Parse our arguments; every option seen by parse_opt will
+       be reflected in arguments. */
+    argp_parse(&argp, argc, argv, 0, 0, &arguments);
 
-	struct timeval t1;
-	double elapsed;
-	gettimeofday(&t1, NULL);
+    struct timeval t1;
+    double elapsed;
+    gettimeofday(&t1, NULL);
 
-	// set the signal handler
-	struct sigaction sa;
-	sigemptyset(&sa.sa_mask);
-	sa.sa_flags = 0;
-	sa.sa_handler = handler;
-	if (sigaction(SIGTERM, &sa, NULL) == -1) {
-		fprintf(stderr,
-			"Error: could not register TERM signal handler. Exiting.");
-		exit(1);
-	}
-	if (sigaction(SIGALRM, &sa, NULL) == -1) {
-		fprintf(stderr,
-			"Error: could not register ALRM signal handler. Exiting.");
-		exit(1);
-	}
+    // set the signal handler
+    struct sigaction sa;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = 0;
+    sa.sa_handler = handler;
+    if (sigaction(SIGTERM, &sa, NULL) == -1) {
+        fprintf(stderr,
+            "Error: could not register TERM signal handler. Exiting.");
+        exit(1);
+    }
+    if (sigaction(SIGALRM, &sa, NULL) == -1) {
+        fprintf(stderr,
+            "Error: could not register ALRM signal handler. Exiting.");
+        exit(1);
+    }
 
     // Find the -- separator if any and reset the argv accordingly
     // so it does not get passed to the execed program.
@@ -359,36 +358,37 @@ char **argv, **envp;
         argc = argc - opt_end;
     }
 
-	// Fork a process, exec it and then wait for the exit.
-	pid_t  ppid;
-	ppid = getpid();
-	int status;
-	if ((pid = fork()) < 0) {
-		perror(argv[0]);
-		exit(1);
-	} else if (pid == 0) {	// child
-		execve(arguments.binary, argv, envp);
-		perror(argv[0]);
-		exit(127);
-	}
+    // Fork a process, exec it and then wait for the exit.
+    pid_t  ppid;
+    ppid = getpid();
+    int status;
+    if ((pid = fork()) < 0) {
+        perror(argv[0]);
+        exit(1);
+    } else if (pid == 0) {  // child
+        execve(arguments.binary, argv, envp);
+        perror(argv[0]);
+        exit(127);
+    }
     
-	if (waitpid(pid, &status, 0) != pid) {	// wait for child
+    if (waitpid(pid, &status, 0) != pid) {  // wait for child
         if (errno == EINTR) {  // we received a signal
+            wait(NULL); // reap to prevent zombies
             status = SIGTERM;
         }
         else {
-		    perror(argv[0]);
-		    exit(1);
+            perror(argv[0]);
+            exit(1);
         }
-	}
+    }
 
-	elapsed = howlong(t1);
+    elapsed = howlong(t1);
 
-	if (arguments.log)
-		log_result(argc, argv, arguments, status, elapsed, ppid);
-	// open socket to StatsD server and send message
-	if (!arguments.nostatsd)
-		send_statsd(arguments, status, elapsed);
+    if (arguments.log)
+        log_result(argc, argv, arguments, status, elapsed, ppid);
+    // open socket to StatsD server and send message
+    if (!arguments.nostatsd)
+        send_statsd(arguments, status, elapsed);
 
-	exit(WEXITSTATUS(status));
+    exit(WEXITSTATUS(status));
 }

--- a/src/ntlm_auth_wrap.c
+++ b/src/ntlm_auth_wrap.c
@@ -210,8 +210,19 @@ log_result(int argc, char **argv, const struct arguments args, int status,
         asprintf(&log_msg, "%s %s ", tmpstr, argv[i]);
         i++;
     }
+
+    if ( status == SIGTERM) {
+        (void) 0; // no op
+    }
+    else if ( WIFEXITED(status) ) {
+        status =  WEXITSTATUS(status); 
+    } 
+    else { 
+        status = 1;
+    }
+
     syslog(args.level, "%s time: %g ms, status: %i, exiting pid: %i",
-           log_msg, elapsed, WEXITSTATUS(status), ppid);
+           log_msg, elapsed, status, ppid);
     closelog();
 }
 
@@ -390,5 +401,6 @@ char **argv, **envp;
     if (!arguments.nostatsd)
         send_statsd(arguments, status, elapsed);
 
-    exit(WEXITSTATUS(status));
+    if (WIFEXITED(status)) exit(WEXITSTATUS(status));
+    exit(1); // Just in case the child exited abnormally.
 }

--- a/src/ntlm_auth_wrap.c
+++ b/src/ntlm_auth_wrap.c
@@ -4,8 +4,7 @@ WARNING: We cheat and do no bother to free memory allocated to strings here.
 The process is meant to be very short lived an never reused. */
 
 #define _POSIX_C_SOURCE 200809L 
-#define COMMAND "/bin/echo"
-//#define COMMAND "/usr/bin/ntlm_auth"
+#define COMMAND "/usr/bin/ntlm_auth"
 #define MAX_STR_LENGTH 1023
 #include <syslog.h>
 #include <string.h>
@@ -15,6 +14,7 @@ The process is meant to be very short lived an never reused. */
 #include <sys/time.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <errno.h>
 
 int main(argc,argv,envp) int argc; char **argv, **envp;
 {
@@ -58,8 +58,10 @@ int main(argc,argv,envp) int argc; char **argv, **envp;
     else if (pid == 0) { // child
         argv[0] = COMMAND;
         execve(COMMAND, argv, envp);
+        perror("exec error: " COMMAND); 
+        exit(1);
     }
-    if (wait(&status) != pid)  // wait for child
+    if (waitpid(pid, &status, 0) != pid)  // wait for child
         fprintf(stderr, "wait error"); 
 
     gettimeofday(&t2, NULL);

--- a/src/ntlm_auth_wrap.c
+++ b/src/ntlm_auth_wrap.c
@@ -53,16 +53,19 @@ int main(argc,argv,envp) int argc; char **argv, **envp;
     pid_t pid; 
     int status;
     if ((pid = fork()) < 0) { 
-        fprintf(stderr, "fork error!");
+        perror(argv[0]);
+        exit(1);
     }
     else if (pid == 0) { // child
         argv[0] = COMMAND;
         execve(COMMAND, argv, envp);
-        perror("exec error: " COMMAND); 
+        perror(argv[0]); 
         exit(1);
     }
-    if (waitpid(pid, &status, 0) != pid)  // wait for child
-        fprintf(stderr, "wait error"); 
+    if (waitpid(pid, &status, 0) != pid) { // wait for child
+        perror(argv[0]); 
+        exit(1);
+    }
 
     gettimeofday(&t2, NULL);
     elapsed = (t2.tv_sec - t1.tv_sec) * 1000.0;      // sec to ms

--- a/src/ntlm_auth_wrap.c
+++ b/src/ntlm_auth_wrap.c
@@ -402,5 +402,7 @@ char **argv, **envp;
         send_statsd(arguments, status, elapsed);
 
     if (WIFEXITED(status)) exit(WEXITSTATUS(status));
-    exit(1); // Just in case the child exited abnormally.
+    status == SIGTERM ? 
+        exit(SIGTERM) :
+        exit(1); // Just in case the child exited abnormally.
 }

--- a/src/ntlm_auth_wrap.c
+++ b/src/ntlm_auth_wrap.c
@@ -250,13 +250,13 @@ void send_statsd(const struct arguments args , int status, double elapsed)
             args.port, strerror(err));
     }
 
-//  connect(sockfd, ailist->ai_addr, ailist->ai_addrlen);
     char *buf;
     char hostname[MAX_STR_LENGTH];
     char tmphostname[MAX_STR_LENGTH];
 
     gethostname(tmphostname, sizeof(tmphostname));
 
+    // escape the dots in the hostname. StatsD uses dots as namespace sep.
     char c;
     int i=0;
     while ( c != '\0' ) {

--- a/src/ntlm_auth_wrap.c
+++ b/src/ntlm_auth_wrap.c
@@ -253,7 +253,22 @@ void send_statsd(const struct arguments args , int status, double elapsed)
 //  connect(sockfd, ailist->ai_addr, ailist->ai_addrlen);
     char *buf;
     char hostname[MAX_STR_LENGTH];
-    gethostname(hostname, sizeof(hostname));
+    char tmphostname[MAX_STR_LENGTH];
+
+    gethostname(tmphostname, sizeof(tmphostname));
+
+    char c;
+    int i=0;
+    while ( c != '\0' ) {
+        c =  tmphostname[i];
+        if ( c == '.' ) { 
+            hostname[i] = '_';
+        } 
+        else {
+            hostname[i] = c;
+        }
+        i++;
+    }
 
     asprintf(&buf, "%s.ntlm_auth.time:%g|ms\n", hostname, elapsed);
 

--- a/src/ntlm_auth_wrap.c
+++ b/src/ntlm_auth_wrap.c
@@ -23,7 +23,7 @@ The process is meant to be very short lived an never reused. */
 */
 
 #define _POSIX_C_SOURCE 200809L 
-#define COMMAND "/usr/bin/ntlm_auth"
+#define COMMAND "/usr/bin/ntlm_auth.real"
 #define MAX_STR_LENGTH 1023
 #include <syslog.h>
 #include <string.h>
@@ -43,7 +43,7 @@ int main(argc,argv,envp) int argc; char **argv, **envp;
     char log_msg[ MAX_STR_LENGTH + 1 ] = COMMAND;
     char *sep = " ";
 
-    openlog("radius-debug", LOG_PID, LOG_LOCAL4);
+    openlog("radius-debug", LOG_PID, LOG_LOCAL5);
 
     // concatenate the command with all argv args separated by sep
     for (int i = 1; i < argc; i++){
@@ -90,7 +90,7 @@ int main(argc,argv,envp) int argc; char **argv, **envp;
     elapsed = (t2.tv_sec - t1.tv_sec) * 1000.0;      // sec to ms
     elapsed += (t2.tv_usec - t1.tv_usec) / 1000.0;   // us to ms
 
-    syslog(LOG_INFO, "%s time: %g ms", log_msg, elapsed);
+    syslog(LOG_INFO, "%s time: %g ms, status: %i", log_msg, elapsed, WEXITSTATUS(status));
     closelog();
 
     exit(WEXITSTATUS(status));

--- a/src/ntlm_auth_wrap.c
+++ b/src/ntlm_auth_wrap.c
@@ -1,5 +1,7 @@
 /* A wrapper around ntlm_auth to log arguments and 
-running time */
+running time. 
+WARNING: We cheat and do no bother to free memory allocated to strings here. 
+The process is meant to be very short lived an never reused. */
 
 #define COMMAND "/usr/bin/ntlm_auth"
 #define MAX_STR_LENGTH 1023
@@ -15,19 +17,34 @@ int main(argc,argv,envp) int argc; char **argv, **envp;
     struct timeval t1, t2;
     double elapsed;
     char cmd[ MAX_STR_LENGTH + 1 ] = COMMAND;
+    char log_msg[ MAX_STR_LENGTH + 1 ] = COMMAND;
     char *sep = " ";
     int ret = 1 ; // return code
-
 
     openlog("radius-debug", LOG_PID, LOG_LOCAL4);
 
     // concatenate the command with all argv args separated by sep
-    int i;
-    for (i = 1; i < argc; i++){
+    for (int i = 1; i < argc; i++){
+
         // truncate any string longer than MAX_STR_LENGTH + sep + \0
         int space_left  = ( MAX_STR_LENGTH - ( strlen(cmd) + strlen(sep)) ); 
         strncat(cmd, sep, 1);
         strncat(cmd,argv[i], space_left - 1 );
+
+        // split the argument on = and check the first part to reject excluded args.
+        char *del = "=" ;
+        char *arg = strdup(argv[i]);
+        char *arg1 = strtok( arg, del );
+        // skip the excluded args
+        if (( strcmp(arg1, "--password\0" )  == 0 ) ||
+            ( strcmp(arg1, "--challenge\0" ) == 0 )) 
+            continue;
+
+        // build the log message
+        space_left  = ( MAX_STR_LENGTH - ( strlen(log_msg) + strlen(sep)) ); 
+        strncat(log_msg, sep, 1);
+        strncat(log_msg, argv[i], space_left - 1 );
+
     }
 
     gettimeofday(&t1, NULL);
@@ -37,7 +54,7 @@ int main(argc,argv,envp) int argc; char **argv, **envp;
     elapsed = (t2.tv_sec - t1.tv_sec) * 1000.0;      // sec to ms
     elapsed += (t2.tv_usec - t1.tv_usec) / 1000.0;   // us to ms
 
-    syslog(LOG_INFO, "%s time: %g ms", cmd, elapsed);
+    syslog(LOG_INFO, "%s time: %g ms", log_msg, elapsed);
     closelog();
 
     exit(ret);

--- a/src/ntlm_auth_wrap.c
+++ b/src/ntlm_auth_wrap.c
@@ -4,7 +4,7 @@ WARNING: We cheat and do no bother to free memory allocated to strings here.
 The process is meant to be very short lived an never reused. */
 
 /*  
-  Copyright (C) 2014 Inverse inc.
+  Copyright (C) 2015 Inverse inc.
   
   This program is free software; you can redistribute it and/or
   modify it under the terms of the GNU General Public License
@@ -22,9 +22,11 @@ The process is meant to be very short lived an never reused. */
   USA.
 */
 
-#define _POSIX_C_SOURCE 200809L 
-#define COMMAND "/usr/bin/ntlm_auth.real"
+#define _POSIX_C_SOURCE 200809L
+#define _GNU_SOURCE
+#define COMMAND "/usr/bin/ntlm_auth"
 #define MAX_STR_LENGTH 1023
+#define STATSD_BUFLEN 128
 #include <syslog.h>
 #include <string.h>
 #include <unistd.h>
@@ -34,67 +36,107 @@ The process is meant to be very short lived an never reused. */
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <errno.h>
+#include <netdb.h>
+#include <sys/socket.h>
 
-int main(argc,argv,envp) int argc; char **argv, **envp;
+int
+main (argc, argv, envp)
+     int argc;
+     char **argv, **envp;
 {
-    struct timeval t1, t2;
-    double elapsed;
-    char cmd[ MAX_STR_LENGTH + 1 ] = COMMAND;
-    char log_msg[ MAX_STR_LENGTH + 1 ] = COMMAND;
-    char *sep = " ";
+  struct timeval t1, t2;
+  double elapsed;
+  char cmd[MAX_STR_LENGTH + 1] = COMMAND;
+  char log_msg[MAX_STR_LENGTH + 1] = COMMAND;
+  char *sep = " ";
 
-    openlog("radius-debug", LOG_PID, LOG_LOCAL5);
+  openlog ("radius-debug", LOG_PID, LOG_LOCAL5);
 
-    // concatenate the command with all argv args separated by sep
-    for (int i = 1; i < argc; i++){
+  // concatenate the command with all argv args separated by sep
+  for (int i = 1; i < argc; i++)
+    {
 
-        // truncate any string longer than MAX_STR_LENGTH + sep + \0
-        int space_left  = ( MAX_STR_LENGTH - ( strlen(cmd) + strlen(sep)) ); 
-        strncat(cmd, sep, 1);
-        strncat(cmd,argv[i], space_left - 1 );
+      // truncate any string longer than MAX_STR_LENGTH + sep + \0
+      int space_left = (MAX_STR_LENGTH - (strlen (cmd) + strlen (sep)));
+      strncat (cmd, sep, 1);
+      strncat (cmd, argv[i], space_left - 1);
 
-        // split the argument on = and check the first part to reject excluded args.
-        // skip the excluded args
-        if (( strncmp(argv[i], "--password", strlen("--password"))  == 0 ) ||
-            ( strncmp(argv[i], "--challenge", strlen("--challenge") ) == 0 )) 
-            continue;
+      // split the argument on = and check the first part to reject excluded args.
+      // skip the excluded args
+      if ((strncmp (argv[i], "--password", strlen ("--password")) == 0) ||
+	  (strncmp (argv[i], "--challenge", strlen ("--challenge")) == 0))
+	continue;
 
-        // build the log message
-        space_left  = ( MAX_STR_LENGTH - ( strlen(log_msg) + strlen(sep)) ); 
-        strncat(log_msg, sep, 1);
-        strncat(log_msg, argv[i], space_left - 1 );
+      // build the log message
+      space_left = (MAX_STR_LENGTH - (strlen (log_msg) + strlen (sep)));
+      strncat (log_msg, sep, 1);
+      strncat (log_msg, argv[i], space_left - 1);
 
     }
 
-    gettimeofday(&t1, NULL);
+  gettimeofday (&t1, NULL);
 
-    // Fork a process, exec it and then wait for the exit.
-    pid_t pid, ppid; 
-    ppid = getpid();
+  // Fork a process, exec it and then wait for the exit.
+  pid_t pid, ppid;
+  ppid = getpid ();
 
-    int status;
-    if ((pid = fork()) < 0) { 
-        perror(argv[0]);
-        exit(1);
+  int status;
+  if ((pid = fork ()) < 0)
+    {
+      perror (argv[0]);
+      exit (1);
     }
-    else if (pid == 0) { // child
-        argv[0] = COMMAND;
-        execve(COMMAND, argv, envp);
-        perror(argv[0]); 
-        exit(1);
+  else if (pid == 0)
+    {				// child
+      argv[0] = COMMAND;
+      execve (COMMAND, argv, envp);
+      perror (argv[0]);
+      exit (1);
     }
-    if (waitpid(pid, &status, 0) != pid) { // wait for child
-        perror(argv[0]); 
-        exit(1);
+  if (waitpid (pid, &status, 0) != pid)
+    {				// wait for child
+      perror (argv[0]);
+      exit (1);
     }
 
-    gettimeofday(&t2, NULL);
-    elapsed = (t2.tv_sec - t1.tv_sec) * 1000.0;      // sec to ms
-    elapsed += (t2.tv_usec - t1.tv_usec) / 1000.0;   // us to ms
+  gettimeofday (&t2, NULL);
+  elapsed = (t2.tv_sec - t1.tv_sec) * 1000.0;	// sec to ms
+  elapsed += (t2.tv_usec - t1.tv_usec) / 1000.0;	// us to ms
 
-    syslog(LOG_INFO, "%s time: %g ms, status: %i, exiting pid: %i", log_msg, elapsed, WEXITSTATUS(status), ppid);
-    closelog();
+  syslog (LOG_INFO, "%s time: %g ms, status: %i, exiting pid: %i", log_msg,
+	  elapsed, WEXITSTATUS (status), ppid);
+  closelog ();
 
-    exit(WEXITSTATUS(status));
+  // open socket to StatsD server and send message
+  struct addrinfo *ailist;
+  struct addrinfo hint;
+  int sockfd, err;
+  memset (&hint, 0, sizeof (hint));
+  hint.ai_socktype = SOCK_DGRAM;
+  hint.ai_family = AF_INET;
+  hint.ai_flags = AI_NUMERICHOST | AI_NUMERICSERV;
+  hint.ai_canonname = NULL;
+  hint.ai_addr = NULL;
+  hint.ai_next = NULL;
+  if ((err = getaddrinfo ("127.0.0.1", "8125", &hint, &ailist)) != 0)
+    sprintf ("getaddrinfo error: %s", gai_strerror (err));
+
+  if ((sockfd = socket (ailist->ai_family, SOCK_DGRAM, 0)) < 0)
+    {
+      err = errno;
+      fprintf (stderr, "cannot contact %s: %s\n", "127.0.0.1:8125",
+	       strerror (err));
+    }
+  else
+    {
+      char *buf;
+      char hostname[255];
+      gethostname (hostname, sizeof (hostname));
+      asprintf (&buf, "%s.ntlm_auth.time:%g|ms\n", hostname, elapsed);
+
+      if (sendto (sockfd, buf, strlen (buf), 0, ailist->ai_addr, ailist->ai_addrlen) < 0)
+	    fprintf (stderr, "sendto error");
+    }
+
+  exit (WEXITSTATUS (status));
 }
-

--- a/src/ntlm_auth_wrap.c
+++ b/src/ntlm_auth_wrap.c
@@ -3,6 +3,25 @@ running time.
 WARNING: We cheat and do no bother to free memory allocated to strings here. 
 The process is meant to be very short lived an never reused. */
 
+/*  
+  Copyright (C) 2014 Inverse inc.
+  
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+  
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+  
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+  USA.
+*/
+
 #define _POSIX_C_SOURCE 200809L 
 #define COMMAND "/usr/bin/ntlm_auth"
 #define MAX_STR_LENGTH 1023
@@ -76,3 +95,4 @@ int main(argc,argv,envp) int argc; char **argv, **envp;
 
     exit(WEXITSTATUS(status));
 }
+

--- a/src/ntlm_auth_wrap.c
+++ b/src/ntlm_auth_wrap.c
@@ -100,7 +100,6 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state)
 		arguments->port = arg;
 		break;
 	case 'f':
-		printf("case F, arg is : %s\n", arg);
 		if (strcasecmp(arg, "auth") == 0) {
 			arguments->facility = LOG_AUTHPRIV;
 		} else if (strcasecmp(arg, "authpriv") == 0) {

--- a/src/ntlm_auth_wrap.c
+++ b/src/ntlm_auth_wrap.c
@@ -24,7 +24,6 @@ The process is meant to be very short lived an never reused. */
 
 #define _POSIX_C_SOURCE 200809L
 #define _GNU_SOURCE
-#define COMMAND "/usr/bin/ntlm_auth"
 #define MAX_STR_LENGTH 1023
 #include <syslog.h>
 #include <string.h>
@@ -38,113 +37,225 @@ The process is meant to be very short lived an never reused. */
 #include <netdb.h>
 #include <sys/socket.h>
 #include "/root/apue.3e/include/apue.h"
+#include <argp.h>
 
-int
-main (argc, argv, envp)
-     int argc;
-     char **argv, **envp;
+const char *argp_program_version = "ntlm_auth_wrapper 1.0";
+const char *argp_program_bug_address = "<info@inverse.ca>";
+
+/* Program documentation. */
+static char doc[] = "ntm_auth_wrapper: \tA performance logging wrapper for ntlm_auth";
+
+/* A description of the arguments we accept. */
+static char args_doc[] = "[arguments passed to ntlm_auth]";
+
+/* The options we understand. */
+static struct argp_option options[] = {
+	{"binary", 'b', "path", 0, "ntlm_auth binary path. Defaults to /usr/bin/ntlm_auth."},
+	{"host", 'h', "hostname or ip", 0, "StatsD host. Default is localhost."},
+	{"port", 'p', "port", 0, "StatsD port. Default is 8125."},
+	{"insecure", 'i', 0, 0, "Log insecure arguments such as the password."},
+	{"nostatsd", 's', 0, 0, "Don't send performance counters to statsd."},
+	{"noresolv", 'n', 0, 0, "Do not resolve value for host and port."},
+	{"log", 'l', 0, 0, "Send results to syslog."},
+	{"logfacility", 'f', "facility", 0, "Syslog facility. Default is local5."},
+	{"loglevel", 'd', "level", 0, "Syslog level. Default is info."},
+	{0}
+};
+
+/* Used by main to communicate with parse_opt. */
+struct arguments {
+	int insecure, nostatsd, noresolv, log, facility, level;
+	char *binary;
+	char *host;
+	char *port;
+	char *args[];		// Arguments to ntlm_auth itself
+};
+
+/* Parse a single option. */
+static error_t parse_opt(int key, char *arg, struct argp_state *state)
 {
-  struct timeval t1, t2;
-  double elapsed;
-  char cmd[MAX_STR_LENGTH + 1] = COMMAND;
-  char log_msg[MAX_STR_LENGTH + 1] = COMMAND;
-  char *sep = " ";
+	/* Get the input argument from argp_parse, which we
+	   know is a pointer to our arguments structure. */
+	struct arguments *arguments = state->input;
 
-  openlog ("radius-debug", LOG_PID, LOG_LOCAL5);
+	switch (key) {
+	case 'i':
+		arguments->insecure = 1;
+		break;
+	case 's':
+		arguments->nostatsd = 1;
+		break;
+	case 'n':
+		arguments->noresolv = 1;
+		break;
+	case 'l':
+		arguments->log = 1;
+		break;
+	case 'b':
+		arguments->binary = arg;
+		break;
+	case 'h':
+		arguments->host = arg;
+		break;
+	case 'p':
+		arguments->port = arg;
+		break;
+	case 'f':
+		arguments->facility = arg;
+		break;
+	case 'd':
+		arguments->level = arg;
+		break;
 
-  // concatenate the command with all argv args separated by sep
-  for (int i = 1; i < argc; i++)
-    {
+	case ARGP_KEY_ARG:
+		if (state->arg_num >= 8)
+			/* Too many arguments. */
+			argp_usage(state);
 
-      // truncate any string longer than MAX_STR_LENGTH + sep + \0
-      int space_left = (MAX_STR_LENGTH - (strlen (cmd) + strlen (sep)));
-      strncat (cmd, sep, 1);
-      strncat (cmd, argv[i], space_left - 1);
+		arguments->args[state->arg_num] = arg;
 
-      // split the argument on = and check the first part to reject excluded args.
-      // skip the excluded args
-      if ((strncmp (argv[i], "--password", strlen ("--password")) == 0) ||
-	  (strncmp (argv[i], "--challenge", strlen ("--challenge")) == 0))
-	continue;
+		break;
 
-      // build the log message
-      space_left = (MAX_STR_LENGTH - (strlen (log_msg) + strlen (sep)));
-      strncat (log_msg, sep, 1);
-      strncat (log_msg, argv[i], space_left - 1);
+	case ARGP_KEY_END:
+		if (state->arg_num < 2)
+			/* Not enough arguments. */
+			argp_usage(state);
+		break;
 
-    }
+	default:
+		return ARGP_ERR_UNKNOWN;
+	}
+	return 0;
+}
 
-  gettimeofday (&t1, NULL);
+/* Our argp parser. */
+static struct argp argp = { options, parse_opt, args_doc, doc };
 
-  // Fork a process, exec it and then wait for the exit.
-  pid_t pid, ppid;
-  ppid = getpid ();
+int main(argc, argv, envp)
+int argc;
+char **argv, **envp;
+{
 
-  int status;
-  if ((pid = fork ()) < 0)
-    {
-      perror (argv[0]);
-      exit (1);
-    }
-  else if (pid == 0)
-    {				// child
-      argv[0] = COMMAND;
-      execve (COMMAND, argv, envp);
-      perror (argv[0]);
-      exit (1);
-    }
-  if (waitpid (pid, &status, 0) != pid)
-    {				// wait for child
-      perror (argv[0]);
-      exit (1);
-    }
+	/* Default values. */
+	struct arguments arguments;
+	arguments.insecure = 0;
+	arguments.nostatsd = 0;
+	arguments.noresolv = 0;
+	arguments.log = 0;
+	arguments.binary = "/usr/bin/ntlm_auth";
+	arguments.host = "localhost";
+	arguments.port = "8125";
+	arguments.facility = LOG_LOCAL5;
+	arguments.level = LOG_INFO;
+	/* Parse our arguments; every option seen by parse_opt will
+	   be reflected in arguments. */
+	argp_parse(&argp, argc, argv, 0, 0, &arguments);
 
-  gettimeofday (&t2, NULL);
-  elapsed = (t2.tv_sec - t1.tv_sec) * 1000.0;	// sec to ms
-  elapsed += (t2.tv_usec - t1.tv_usec) / 1000.0;	// us to ms
+	struct timeval t1, t2;
+	double elapsed;
+	gettimeofday(&t1, NULL);
 
-  syslog (LOG_INFO, "%s time: %g ms, status: %i, exiting pid: %i", log_msg,
-	  elapsed, WEXITSTATUS (status), ppid);
-  closelog ();
+	// Fork a process, exec it and then wait for the exit.
+	pid_t pid, ppid;
+	ppid = getpid();
 
-  // open socket to StatsD server and send message
-  struct addrinfo *ailist;
-  struct addrinfo hint;
-  int sockfd, err;
-  memset (&hint, 0, sizeof (hint));
-  hint.ai_socktype = SOCK_DGRAM;
-  hint.ai_family = AF_INET;
-  hint.ai_flags = AI_NUMERICHOST | AI_NUMERICSERV;
-  hint.ai_canonname = NULL;
-  hint.ai_addr = NULL;
-  hint.ai_next = NULL;
-  if ((err = getaddrinfo ("127.0.0.1", "8125", &hint, &ailist)) != 0)
-    sprintf ("getaddrinfo error: %s", gai_strerror (err));
+	int status;
+	if ((pid = fork()) < 0) {
+		perror(argv[0]);
+		exit(1);
+	} else if (pid == 0) {	// child
+		// Find the -- separator if any and reset the argv accordingly
+		// so it does not get passed to the execed program.
+		int opt_end = 0;
+		for (int i = 1; i < argc; i++) {
+			if ((strncmp(argv[i], "--", strlen("--"))) == 0) {
+				opt_end = i;
+				break;
+			}
+		}
+		if (opt_end)
+			argv += opt_end;
 
-  if ((sockfd = socket (ailist->ai_family, SOCK_DGRAM, 0)) < 0)
-    {
-      err = errno;
-      fprintf (stderr, "cannot contact %s: %s\n", "127.0.0.1:8125",
-	       strerror (err));
-    }
-  else
-    {
-      char *buf;
-      char hostname[MAX_STR_LENGTH];
-      gethostname (hostname, sizeof (hostname));
-      connect (sockfd, ailist->ai_addr, ailist->ai_addrlen);
+		argv[0] = arguments.binary;
+		execve(arguments.binary, argv, envp);
+		perror(argv[0]);
+		exit(1);
+	}
+	if (waitpid(pid, &status, 0) != pid) {	// wait for child
+		perror(argv[0]);
+		exit(1);
+	}
 
-      asprintf (&buf, "%s.ntlm_auth.time:%g|ms\n", hostname, elapsed);
+	gettimeofday(&t2, NULL);
+	elapsed = (t2.tv_sec - t1.tv_sec) * 1000.0;	// sec to ms
+	elapsed += (t2.tv_usec - t1.tv_usec) / 1000.0;	// us to ms
 
-      send (sockfd, buf, strlen (buf), 0);
+	if (arguments.log) {
+		openlog("radius-debug", LOG_PID, arguments.facility);
+		// build the log message
+		char *log_msg = arguments.binary;
+		char *sep = " ";
 
-      // increment counter if auth failed
-      if ( status > 0 ) { 
-        asprintf (&buf, "%s.ntlm_auth.failures:1|c\n", hostname);
-        send (sockfd, buf, strlen (buf), 0);
-      }
+		// concatenate the command with all argv args separated by sep
+		for (int i = 1; i < argc; i++) {
 
-    }
+			// truncate any string longer than MAX_STR_LENGTH + sep + \0
+			int space_left =
+			    (MAX_STR_LENGTH - (strlen(arguments.binary) + strlen(sep)));
+			strncat(arguments.binary, sep, 1);
+			strncat(arguments.binary, argv[i], space_left - 1);
 
-  exit (WEXITSTATUS (status));
+			// split the argument on = and check the first part to reject excluded args.
+			// skip the excluded args
+			if ((strncmp(argv[i], "--password", strlen("--password")) == 0) ||
+			    (strncmp(argv[i], "--challenge", strlen("--challenge")) == 0))
+				continue;
+
+			space_left = (MAX_STR_LENGTH - (strlen(log_msg) + strlen(sep)));
+			strncat(log_msg, sep, 1);
+			strncat(log_msg, argv[i], space_left - 1);
+
+		}
+		syslog(arguments.level, "%s time: %g ms, status: %i, exiting pid: %i", log_msg,
+		       elapsed, WEXITSTATUS(status), ppid);
+		closelog();
+	}
+	// open socket to StatsD server and send message
+	struct addrinfo *ailist;
+	struct addrinfo hint;
+	int sockfd, err;
+	memset(&hint, 0, sizeof(hint));
+	hint.ai_socktype = SOCK_DGRAM;
+	hint.ai_family = AF_INET;
+	if (arguments.noresolv)
+		hint.ai_flags = AI_NUMERICHOST | AI_NUMERICSERV;
+	//hint.ai_flags = NULL;
+	hint.ai_canonname = NULL;
+	hint.ai_addr = NULL;
+	hint.ai_next = NULL;
+	if ((err = getaddrinfo(arguments.host, arguments.port, &hint, &ailist)) != 0)
+		sprintf("getaddrinfo error: %s", gai_strerror(err));
+
+	if ((sockfd = socket(ailist->ai_family, SOCK_DGRAM, 0)) < 0) {
+		err = errno;
+		fprintf(stderr, "cannot contact %s: %s\n", "127.0.0.1:8125", strerror(err));
+	} else {
+		char *buf;
+		char hostname[MAX_STR_LENGTH];
+		gethostname(hostname, sizeof(hostname));
+		connect(sockfd, ailist->ai_addr, ailist->ai_addrlen);
+
+		asprintf(&buf, "%s.ntlm_auth.time:%g|ms\n", hostname, elapsed);
+
+		send(sockfd, buf, strlen(buf), 0);
+
+		// increment counter if auth failed
+		if (status > 0) {
+			asprintf(&buf, "%s.ntlm_auth.failures:1|c\n", hostname);
+			send(sockfd, buf, strlen(buf), 0);
+		}
+
+	}
+
+	exit(WEXITSTATUS(status));
 }

--- a/src/ntlm_auth_wrap.c
+++ b/src/ntlm_auth_wrap.c
@@ -1,0 +1,44 @@
+/* A wrapper around ntlm_auth to log arguments and 
+running time */
+
+#define COMMAND "/usr/bin/ntlm_auth"
+#define MAX_STR_LENGTH 1023
+#include <syslog.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <sys/time.h>
+
+int main(argc,argv,envp) int argc; char **argv, **envp;
+{
+    struct timeval t1, t2;
+    double elapsed;
+    char cmd[ MAX_STR_LENGTH + 1 ] = COMMAND;
+    char *sep = " ";
+    int ret = 1 ; // return code
+
+
+    openlog("radius-debug", LOG_PID, LOG_LOCAL4);
+
+    // concatenate the command with all argv args separated by sep
+    int i;
+    for (i = 1; i < argc; i++){
+        // truncate any string longer than MAX_STR_LENGTH + sep + \0
+        int space_left  = ( MAX_STR_LENGTH - ( strlen(cmd) + strlen(sep)) ); 
+        strncat(cmd, sep, 1);
+        strncat(cmd,argv[i], space_left - 1 );
+    }
+
+    gettimeofday(&t1, NULL);
+    ret = system(cmd);
+
+    gettimeofday(&t2, NULL);
+    elapsed = (t2.tv_sec - t1.tv_sec) * 1000.0;      // sec to ms
+    elapsed += (t2.tv_usec - t1.tv_usec) / 1000.0;   // us to ms
+
+    syslog(LOG_INFO, "%s time: %g ms", cmd, elapsed);
+    closelog();
+
+    exit(ret);
+}

--- a/src/ntlm_auth_wrap.c
+++ b/src/ntlm_auth_wrap.c
@@ -253,13 +253,14 @@ void send_statsd(const struct arguments args , int status, double elapsed)
     }
 
     char *buf;
-    char hostname[MAX_STR_LENGTH];
-    char tmphostname[MAX_STR_LENGTH];
+    char hostname[MAX_STR_LENGTH] = "";
+    char tmphostname[MAX_STR_LENGTH] = "";
+
 
     gethostname(tmphostname, sizeof(tmphostname));
 
     // escape the dots in the hostname. StatsD uses dots as namespace sep.
-    char c;
+    char c='9'; // just a placeholder to make sure it's initialized
     int i=0;
     while ( c != '\0' ) {
         c =  tmphostname[i];

--- a/src/ntlm_auth_wrap.c
+++ b/src/ntlm_auth_wrap.c
@@ -254,23 +254,20 @@ void send_statsd(const struct arguments args , int status, double elapsed)
 
     char *buf;
     char hostname[MAX_STR_LENGTH] = "";
-    char tmphostname[MAX_STR_LENGTH] = "";
 
+    if ((gethostname(hostname, sizeof(hostname))) < 0 ) { 
+        err = errno;
+        fprintf(stderr, "cannot get my own hostname: %s\n", strerror(err));
+        return;
+    }
 
-    gethostname(tmphostname, sizeof(tmphostname));
-
-    // escape the dots in the hostname. StatsD uses dots as namespace sep.
-    char c='9'; // just a placeholder to make sure it's initialized
-    int i=0;
-    while ( c != '\0' ) {
-        c =  tmphostname[i];
+    // replace the dots in the hostname with underscores. StatsD uses dots as namespace sep.
+    char c;
+    for ( int i=0; i < strlen(hostname); i++ ) { 
+        c =  hostname[i];
         if ( c == '.' ) { 
             hostname[i] = '_';
         } 
-        else {
-            hostname[i] = c;
-        }
-        i++;
     }
 
     asprintf(&buf, "%s.ntlm_auth.time:%g|ms\n", hostname, elapsed);

--- a/src/ntlm_auth_wrap.c
+++ b/src/ntlm_auth_wrap.c
@@ -69,7 +69,9 @@ int main(argc,argv,envp) int argc; char **argv, **envp;
     gettimeofday(&t1, NULL);
 
     // Fork a process, exec it and then wait for the exit.
-    pid_t pid; 
+    pid_t pid, ppid; 
+    ppid = getpid();
+
     int status;
     if ((pid = fork()) < 0) { 
         perror(argv[0]);
@@ -90,7 +92,7 @@ int main(argc,argv,envp) int argc; char **argv, **envp;
     elapsed = (t2.tv_sec - t1.tv_sec) * 1000.0;      // sec to ms
     elapsed += (t2.tv_usec - t1.tv_usec) / 1000.0;   // us to ms
 
-    syslog(LOG_INFO, "%s time: %g ms, status: %i", log_msg, elapsed, WEXITSTATUS(status));
+    syslog(LOG_INFO, "%s time: %g ms, status: %i, exiting pid: %i", log_msg, elapsed, WEXITSTATUS(status), ppid);
     closelog();
 
     exit(WEXITSTATUS(status));


### PR DESCRIPTION
# Description

Adds a wrapper to ntlm_auth calls made from FreeRADIUS so that authentication times are sent to StatsD.
# Impacts

Creates a new packetfence-ntlm_auth_wrapper package.
Modifies raddb/module/mschap to call the wrapper instead of ntlm_auth directly.
# Delete branch after merge

YES 
# NEWS file entries
## Enhancements
- New ntlm_auth wrapper will log authentication latency to StatsD automatically. 
