### PR TITLE
pf.conf merged lists

### DIFF
--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -514,7 +514,7 @@ to be effective.
 EOT
 
 [trapping.proxy_passthroughs]
-type=list
+type=merged_list
 description=<<EOT
 Comma-delimited list of domains to be used with apache passthroughs. 
 The configuration parameter "passthrough" must be enabled for passthroughs 

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -153,7 +153,7 @@ passthroughs=
 # trapping.proxy_passthroughs
 #
 # Comma-delimited list of domains to be use for apache passthrough
-proxy_passthroughs=
+proxy_passthroughs=crl.geotrust.com,ocsp.geotrust.com,crl.thawte.com,ocsp.thawte.com,crl.comodoca.com,ocsp.comodoca.com,crl.incommon.org,ocsp.incommon.org,crl.usertrust.com,ocsp.usertrust.com,mscrl.microsoft.com,crl.microsoft.com,ocsp.apple.com,ocsp.digicert.com,ocsp.entrust.com,srvintl-crl.verisign.com,ocsp.verisign.com,ctldl.windowsupdate.com,crl.globalsign.net,pki.google.com,www.microsoft.com,crl.godaddy.com,ocsp.godaddy.com,certificates.godaddy.com
 #
 # trapping.interception_proxy
 #

--- a/html/pfappserver/lib/pfappserver/Base/Form/Role/Defaults.pm
+++ b/html/pfappserver/lib/pfappserver/Base/Form/Role/Defaults.pm
@@ -1,0 +1,59 @@
+package pfappserver::Base::Form::Role::Defaults;
+
+=head1 NAME
+
+pfappserver::Base::Form::Role::Defaults
+
+=head1 DESCRIPTION
+
+This roles provides defaults
+
+=cut
+
+use namespace::autoclean;
+use HTML::FormHandler::Moose::Role;
+
+=head2 defaults_list
+
+Format the default values for a list (CSV)
+
+=cut
+
+sub defaults_list {
+    my $self = shift;
+
+    my $id = $self->_localize($self->label);
+    my $content;
+    foreach my $element (split(',', $self->get_tag('defaults'))){
+        $content .= "<span class=\"label label-info\" >$element</span>";
+    }
+    if ($self->get_tag('defaults')) {
+        return sprintf("<div class='list-defaults alert alert-info'><strong>Built-in $id :</strong> %s</div>", $content);
+    }
+}
+
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2015 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;

--- a/html/pfappserver/lib/pfappserver/Form/Config/Pf.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Pf.pm
@@ -78,6 +78,7 @@ sub field_list {
                 last;
             };
             $type eq 'merged_list' && do {
+                delete $field->{element_attr}->{placeholder};
                 $field->{tags}  = { before_element => \&defaults_list,
               defaults => $defaults->{$name} },
 

--- a/html/pfappserver/lib/pfappserver/Form/Config/Pf.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Pf.pm
@@ -13,6 +13,7 @@ Form definition to create or update a section of pf.conf.
 use HTML::FormHandler::Moose;
 extends 'pfappserver::Base::Form';
 with 'pfappserver::Base::Form::Role::Help';
+with 'pfappserver::Base::Form::Role::Defaults';
 use pf::config;
 use pf::IniFiles;
 use pf::file_paths;
@@ -74,6 +75,14 @@ sub field_list {
                 # the value to the default value when no value is defined (see pf::ConfigStore::Pf::cleanupAfterRead)
                 # $field->{element_attr}->{placeholder} = join("\n",split( /\s*,\s*/, $field->{element_attr}->{placeholder} ))
                 #   if $field->{element_attr}->{placeholder};
+                last;
+            };
+            $type eq 'merged_list' && do {
+                $field->{tags}  = { before_element => \&defaults_list,
+              defaults => $defaults->{$name} },
+
+                $field->{type} = 'TextArea';
+                $field->{element_class} = ['input-xxlarge'];
                 last;
             };
             $type eq 'numeric' && do {

--- a/html/pfappserver/root/static/admin/common.css
+++ b/html/pfappserver/root/static/admin/common.css
@@ -139,3 +139,7 @@ li.drop-row,
   -o-transition: all 0.5s ease;
   transition: all 0.5s ease;
 }
+
+.list-defaults {
+  margin-left:170px
+}

--- a/html/pfappserver/root/static/admin/common.css
+++ b/html/pfappserver/root/static/admin/common.css
@@ -143,3 +143,7 @@ li.drop-row,
 .list-defaults {
   margin-left:170px
 }
+
+.list-defaults span {
+  margin:3px;
+}

--- a/lib/pf/ConfigStore/Pf.pm
+++ b/lib/pf/ConfigStore/Pf.pm
@@ -69,7 +69,7 @@ sub cleanupAfterRead {
             my $value = $data->{$key};
             my @values = split( /\s*,\s*/, $value ) if $value;
             $data->{$key} = \@values;
-        } elsif ($type eq 'list' || $type eq 'merged_list') {
+        } elsif ($type eq 'list') {
             my $value = $data->{$key};
             if ($value) {
                 $data->{$key} = join("\n", split( /\s*,\s*/, $value));
@@ -77,6 +77,14 @@ sub cleanupAfterRead {
             elsif ($defaults->{$key}) {
                 # No custom value, use default value
                 $data->{$key} = join("\n", split( /\s*,\s*/, $defaults->{$key}));
+            }
+        } elsif ( $type eq 'merged_list' ) { 
+            my $value = $data->{$key};
+            if ($value ne $defaults->{$key}) {
+                $data->{$key} = join("\n", split( /\s*,\s*/, $value));
+            }
+            else {
+                $data->{$key} = undef;
             }
         } elsif ($type eq 'text_with_editable_default') {
             my $value = $data->{$key};

--- a/lib/pf/ConfigStore/Pf.pm
+++ b/lib/pf/ConfigStore/Pf.pm
@@ -69,7 +69,7 @@ sub cleanupAfterRead {
             my $value = $data->{$key};
             my @values = split( /\s*,\s*/, $value ) if $value;
             $data->{$key} = \@values;
-        } elsif ($type eq 'list') {
+        } elsif ($type eq 'list' || $type eq 'merged_list') {
             my $value = $data->{$key};
             if ($value) {
                 $data->{$key} = join("\n", split( /\s*,\s*/, $value));
@@ -99,7 +99,7 @@ sub cleanupBeforeCommit {
         if (exists $Doc_Config{$doc_section} ) {
             my $doc = $Doc_Config{$doc_section};
             my $type = $doc->{type} || "text";
-            if($type eq 'list') {
+            if($type eq 'list' || $type eq 'merged_list' ) {
                 my $value = $assignment->{$key};
                 $assignment->{$key} = join(",",split( /\v+/, $value )) if $value;
             }

--- a/lib/pfconfig/namespaces/config/Pf.pm
+++ b/lib/pfconfig/namespaces/config/Pf.pm
@@ -23,6 +23,7 @@ use pfconfig::log;
 use pf::file_paths;
 use pf::util;
 use JSON;
+use List::MoreUtils qw(uniq);
 
 use base 'pfconfig::namespaces::config';
 
@@ -111,17 +112,20 @@ sub build_child {
 
     $Config{trapping}{passthroughs} = [ split( /\s*,\s*/, $Config{trapping}{passthroughs} || '' ) ];
 
+    # We're looking for the merged_list configurations and we merge the default value with
+    # the user defined value
     while( my( $key, $value ) = each %Doc_Config ){
         if(defined($value->{type}) && $value->{type} eq "merged_list"){
             my ($category, $attribute) = split /\./, $key;
             $Config{$category}{$attribute} = [ split( /\s*,\s*/, $Default_Config{$category}{$attribute}), split( /\s*,\s*/, $Config{$category}{$attribute}) ];
+            $Config{$category}{$attribute} = [ uniq @{$Config{$category}{$attribute}} ];
         }
     }
 
     $Config{network}{dhcp_filter_by_message_types}
         = [ split( /\s*,\s*/, $Config{network}{dhcp_filter_by_message_types} || '' ) ],
 
-        return \%Config;
+    return \%Config;
 
 }
 

--- a/lib/pfconfig/namespaces/config/Pf.pm
+++ b/lib/pfconfig/namespaces/config/Pf.pm
@@ -110,31 +110,14 @@ sub build_child {
     }
 
     $Config{trapping}{passthroughs} = [ split( /\s*,\s*/, $Config{trapping}{passthroughs} || '' ) ];
-    if ( isenabled( $Config{'trapping'}{'passthrough'} ) ) {
-        $Config{trapping}{proxy_passthroughs} = [
-            split( /\s*,\s*/, $Config{trapping}{proxy_passthroughs} || '' ),
-            qw(
-                crl.geotrust.com ocsp.geotrust.com crl.thawte.com ocsp.thawte.com
-                crl.comodoca.com ocsp.comodoca.com crl.incommon.org ocsp.incommon.org
-                crl.usertrust.com ocsp.usertrust.com mscrl.microsoft.com crl.microsoft.com
-                ocsp.apple.com ocsp.digicert.com ocsp.entrust.com srvintl-crl.verisign.com
-                ocsp.verisign.com ctldl.windowsupdate.com crl.globalsign.net pki.google.com
-                www.microsoft.com crl.godaddy.com ocsp.godaddy.com certificates.godaddy.com
-                )
-        ];
+
+    while( my( $key, $value ) = each %Doc_Config ){
+        if(defined($value->{type}) && $value->{type} eq "merged_list"){
+            my ($category, $attribute) = split /\./, $key;
+            $Config{$category}{$attribute} = [ split( /\s*,\s*/, $Default_Config{$category}{$attribute}), split( /\s*,\s*/, $Config{$category}{$attribute}) ];
+        }
     }
-    else {
-        $Config{trapping}{proxy_passthroughs} = [
-            qw(
-                crl.geotrust.com ocsp.geotrust.com crl.thawte.com ocsp.thawte.com
-                crl.comodoca.com ocsp.comodoca.com crl.incommon.org ocsp.incommon.org
-                crl.usertrust.com ocsp.usertrust.com mscrl.microsoft.com crl.microsoft.com
-                ocsp.apple.com ocsp.digicert.com ocsp.entrust.com srvintl-crl.verisign.com
-                ocsp.verisign.com ctldl.windowsupdate.com crl.globalsign.net pki.google.com
-                www.microsoft.com crl.godaddy.com ocsp.godaddy.com certificates.godaddy.com
-                )
-        ];
-    }
+
     $Config{network}{dhcp_filter_by_message_types}
         = [ split( /\s*,\s*/, $Config{network}{dhcp_filter_by_message_types} || '' ) ],
 

--- a/lib/pfconfig/namespaces/config/Pf.pm
+++ b/lib/pfconfig/namespaces/config/Pf.pm
@@ -117,7 +117,8 @@ sub build_child {
     while( my( $key, $value ) = each %Doc_Config ){
         if(defined($value->{type}) && $value->{type} eq "merged_list"){
             my ($category, $attribute) = split /\./, $key;
-            $Config{$category}{$attribute} = [ split( /\s*,\s*/, $Default_Config{$category}{$attribute}), split( /\s*,\s*/, $Config{$category}{$attribute}) ];
+            my $additionnal = $Config{$category}{$attribute} || '';
+            $Config{$category}{$attribute} = [ split( /\s*,\s*/, $Default_Config{$category}{$attribute}), split( /\s*,\s*/, $additionnal ) ];
             $Config{$category}{$attribute} = [ uniq @{$Config{$category}{$attribute}} ];
         }
     }

--- a/t/PfFilePaths.pm
+++ b/t/PfFilePaths.pm
@@ -30,6 +30,7 @@ BEGIN {
     $pf::file_paths::authentication_config_file = catfile($test_dir,'data/authentication.conf');
     $pf::file_paths::log_config_file = catfile($test_dir,'log.conf');
     $pf::file_paths::vlan_filters_config_file = catfile($test_dir,'data/vlan_filters.conf');
+    $pf::file_paths::pf_config_file = catfile($test_dir,'data/pf.conf');
 }
 
 # we need to load the proper data in pfconfig

--- a/t/unittest/merged_list.t
+++ b/t/unittest/merged_list.t
@@ -1,0 +1,79 @@
+=head1 NAME
+
+merged_list
+
+=cut
+
+=head1 DESCRIPTION
+
+merged_list
+
+=cut
+
+use strict;
+use warnings;
+# pf core libs
+use lib '/usr/local/pf/lib';
+
+BEGIN {
+    use lib qw(/usr/local/pf/t);
+    use PfFilePaths;
+}
+use Test::More tests => 6;
+
+use Test::NoWarnings;
+use Test::Exception;
+
+use_ok('pf::config');
+
+my @default_proxy_passthroughs = split /\s*,\s*/, $pf::config::Default_Config{trapping}{proxy_passthroughs};
+# We use proxy_passthroughs to test the mergeable lists
+ok(@default_proxy_passthroughs ~~ $pf::config::Config{trapping}{proxy_passthroughs}, "Not overriden passthroughs are equal to the default ones.");
+
+use_ok('pf::ConfigStore::Pf');
+
+my @additionnal = (
+    "www.dinde.ca", 
+    "www.zamm.it",
+);
+
+my $cs = pf::ConfigStore::Pf->new;
+$cs->update('trapping', {'proxy_passthroughs' => join ',', @additionnal});
+$cs->commit();
+
+ok(!(@default_proxy_passthroughs ~~ $pf::config::Config{trapping}{proxy_passthroughs}), "Merged passthroughs are not equal to the default ones.");
+
+ok(([@default_proxy_passthroughs, @additionnal] ~~ $pf::config::Config{trapping}{proxy_passthroughs}), "Merged passthroughs are actually merged");
+
+$cs->update('trapping', {'proxy_passthroughs' => undef});
+$cs->commit();
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2015 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;
+


### PR DESCRIPTION
# Description

Adds the possibility to create fields that are a list merged from pf.conf.defaults to pf.conf
Would allow a progressive move of user related constants to pf.conf.defaults so they can be shown cleanly in the admin
# Impacts

Changes proxy_passthroughs creation for now. Other configurations are not affected
# Issue

ie: fixes #598
# Delete branch after merge

YES
# NEWS file entries
## Enhancements
- Added merged_list configuration type which is the result of a configuration list merge between pf.conf.defaults and pf.conf
