### PR TITLE
Hide passwords value in Switch configuration

### DIFF
--- a/html/pfappserver/lib/pfappserver/Form/Config/Switch.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Switch.pm
@@ -162,8 +162,9 @@ has_block 'radius' =>
   );
 has_field 'radiusSecret' =>
   (
-   type => 'Text',
+   type => 'Password',
    label => 'Secret Passphrase',
+   password => 0,
   );
 
 ## SNMP
@@ -261,8 +262,9 @@ has_field 'SNMPAuthProtocolRead' =>
   );
 has_field 'SNMPAuthPasswordRead' =>
   (
-   type => 'Text',
+   type => 'Password',
    label => 'Auth Password Read',
+   password => 0,
   );
 has_field 'SNMPPrivProtocolRead' =>
   (
@@ -271,8 +273,9 @@ has_field 'SNMPPrivProtocolRead' =>
   );
 has_field 'SNMPPrivPasswordRead' =>
   (
-   type => 'Text',
+   type => 'Password',
    label => 'Priv Password Read',
+   password => 0,
   );
 has_field 'SNMPUserNameWrite' =>
   (
@@ -286,8 +289,9 @@ has_field 'SNMPAuthProtocolWrite' =>
   );
 has_field 'SNMPAuthPasswordWrite' =>
   (
-   type => 'Text',
+   type => 'Password',
    label => 'Auth Password Write',
+   password => 0,
   );
 has_field 'SNMPPrivProtocolWrite' =>
   (
@@ -296,8 +300,9 @@ has_field 'SNMPPrivProtocolWrite' =>
   );
 has_field 'SNMPPrivPasswordWrite' =>
   (
-   type => 'Text',
+   type => 'Password',
    label => 'Priv Password Write',
+   password => 0,
   );
 has_field 'SNMPVersionTrap' =>
   (
@@ -323,8 +328,9 @@ has_field 'SNMPAuthProtocolTrap' =>
   );
 has_field 'SNMPAuthPasswordTrap' =>
   (
-   type => 'Text',
+   type => 'Password',
    label => 'Auth Password Trap',
+   password => 0,
   );
 has_field 'SNMPPrivProtocolTrap' =>
   (
@@ -333,8 +339,9 @@ has_field 'SNMPPrivProtocolTrap' =>
   );
 has_field 'SNMPPrivPasswordTrap' =>
   (
-   type => 'Text',
+   type => 'Password',
    label => 'Priv Password Trap',
+   password => 0,
   );
 
 ## CLI
@@ -361,14 +368,16 @@ has_field 'cliUser' =>
   );
 has_field 'cliPwd' =>
   (
-   type => 'Text',
+   type => 'Password',
    label => 'Password',
+   password => 0,
   );
 
 has_field 'cliEnablePwd' =>
   (
-   type => 'Text',
+   type => 'Password',
    label => 'Enable Password',
+   password => 0,
   );
 
 ## Web Services
@@ -394,8 +403,9 @@ has_field 'wsUser' =>
   );
 has_field 'wsPwd' =>
   (
-   type => 'Text',
+   type => 'Password',
    label => 'Password',
+   password => 0,
   );
 
 has_field controllerIp =>


### PR DESCRIPTION
# Description

Hide passwords value in Switch configuration
# Impacts

Hides passwords
# Issue

fixes #663
# Delete branch after merge

YES
# NEWS file entries
## Enhancements
- Password values are obfuscated in administration interface switch configuration
