### PR TITLE
Force sending JSON if accept header is requesting it

### DIFF
--- a/html/pfappserver/lib/pfappserver/PacketFence/Controller/Root.pm
+++ b/html/pfappserver/lib/pfappserver/PacketFence/Controller/Root.pm
@@ -70,6 +70,9 @@ Attempt to render a view, if needed.
 
 sub end : ActionClass('RenderView') {
     my ( $self, $c ) = @_;
+    if (defined($c->req->header('accept')) && $c->req->header('accept') eq 'application/json'){
+        $c->stash->{current_view} = 'JSON';
+    }
     if (scalar @{$c->error}) {
         for my $error ( @{ $c->error } ) {
             $c->log->error($error);


### PR DESCRIPTION
# Description

If a client is explicitally requesting JSON through the Accept header, we should enforce that since it it removes code duplication by creating new actions just for that
# Impacts

Shouldn't be any for existing code.
# Delete branch after merge

NO (required for cloud)
# NEWS file entries
## Enhancements
- Force a JSON response if the Accept header is set to 'application/json'
