### PR TITLE
Allow a chained source to continue processing it's authentication source

### DIFF
--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Authenticate.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Authenticate.pm
@@ -272,20 +272,20 @@ sub checkIfChainedAuth : Private {
     }
 }
 
-=head2 continue_chained_auth
+=head2 skip_chained_auth
 
-Allow the chained auth source to continue login using it's auth source
+Allow to skip the chained auth source to continue login using the chained source auth source
 
 =cut
 
-sub continue_chained_auth : Local {
+sub skip_chained_auth : Local {
     my ($self, $c) = @_;
     my $source_id = $c->session->{chained_source};
     unless ($source_id) {
         $self->showError($c, "You do not have permission to continue");
     }
     my $source = getAuthenticationSource($source_id);
-    unless($source && $source->type eq 'Chained' && $source->authentication_source_can_continue) {
+    unless($source && $source->type eq 'Chained' && $source->skip_chained_auth) {
         #if not a chained auth leave
         $self->showError($c, "You do not have permission to continue");
     }

--- a/html/pfappserver/lib/pfappserver/Form/Config/Authentication/Source/Chained.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Authentication/Source/Chained.pm
@@ -38,6 +38,11 @@ has_field 'authentication_source' =>
              help => 'The internal source used to authenticate' },
   );
 
+has_field authentication_source_can_continue => (
+    type => 'Checkbox',
+    checked_value => 1,
+);
+
 our %ALLOWED_CHAINED_SOURCES = (
     SMS          => undef,
     Email        => undef,

--- a/html/pfappserver/lib/pfappserver/Form/Config/Authentication/Source/Chained.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Authentication/Source/Chained.pm
@@ -38,7 +38,7 @@ has_field 'authentication_source' =>
              help => 'The internal source used to authenticate' },
   );
 
-has_field authentication_source_can_continue => (
+has_field skip_chained_auth => (
     type => 'Checkbox',
     checked_value => 1,
 );

--- a/html/pfappserver/root/authentication/source/type/Chained.tt
+++ b/html/pfappserver/root/authentication/source/type/Chained.tt
@@ -1,3 +1,3 @@
 [% form.field('authentication_source').render | none %]
 [% form.field('chained_authentication_source').render | none %]
-[% form.field('authentication_source_can_continue').render | none %]
+[% form.field('skip_chained_auth').render | none %]

--- a/html/pfappserver/root/authentication/source/type/Chained.tt
+++ b/html/pfappserver/root/authentication/source/type/Chained.tt
@@ -1,2 +1,3 @@
 [% form.field('authentication_source').render | none %]
 [% form.field('chained_authentication_source').render | none %]
+[% form.field('authentication_source_can_continue').render | none %]

--- a/lib/pf/Authentication/Source/ChainedSource.pm
+++ b/lib/pf/Authentication/Source/ChainedSource.pm
@@ -34,7 +34,7 @@ has '+type' => (default => 'Chained');
 has '+unique' => (default => 1 );
 has chained_authentication_source => ( is => 'rw', required => 1 );
 has authentication_source => ( is => 'rw', required => 1 );
-has authentication_source_can_continue => ( is => 'rw', default => 0, isa => 'Bool');
+has skip_chained_auth => ( is => 'rw', default => 0, isa => 'Bool');
 
 =head2 has_authentication_rules
 

--- a/lib/pf/Authentication/Source/ChainedSource.pm
+++ b/lib/pf/Authentication/Source/ChainedSource.pm
@@ -34,6 +34,7 @@ has '+type' => (default => 'Chained');
 has '+unique' => (default => 1 );
 has chained_authentication_source => ( is => 'rw', required => 1 );
 has authentication_source => ( is => 'rw', required => 1 );
+has authentication_source_can_continue => ( is => 'rw', default => 0, isa => 'Bool');
 
 =head2 has_authentication_rules
 


### PR DESCRIPTION
## Description

Allow a chained source to continue processing it's authentication source
## Impacts

The portal workflow for a chained source.
## NEWS file entries

New Features
++++++++++++
- Chained sources can now continue processing it's authentication source in addition to it's chained source
## Delete branch after merge

NO
