### PR TITLE
Set the max message size to 4096 octets instead of the default 1472 (…

### DIFF
--- a/bin/pfcmd_vlan
+++ b/bin/pfcmd_vlan
@@ -318,7 +318,8 @@ if ($reevaluateAccess) {
                 -authprotocol => $switch->{_SNMPAuthProtocolRead},
                 -authpassword => $switch->{_SNMPAuthPasswordRead},
                 -privprotocol => $switch->{_SNMPPrivProtocolRead},
-                -privpassword => $switch->{_SNMPPrivPasswordRead}
+                -privpassword => $switch->{_SNMPPrivPasswordRead},
+                -maxmsgsize => 4096
             );
         } else {
             ( $session, $error ) = Net::SNMP->session(
@@ -326,7 +327,8 @@ if ($reevaluateAccess) {
                 -version   => $switch->{_SNMPVersion},
                 -timeout   => 2,
                 -retries   => 1,
-                -community => $switch->{_SNMPCommunityRead}
+                -community => $switch->{_SNMPCommunityRead},
+                -maxmsgsize => 4096
             );
         }
         my $type      = 'unknown';

--- a/lib/pf/Switch.pm
+++ b/lib/pf/Switch.pm
@@ -450,7 +450,8 @@ sub connectRead {
             -authprotocol => $this->{_SNMPAuthProtocolRead},
             -authpassword => $this->{_SNMPAuthPasswordRead},
             -privprotocol => $this->{_SNMPPrivProtocolRead},
-            -privpassword => $this->{_SNMPPrivPasswordRead}
+            -privpassword => $this->{_SNMPPrivPasswordRead},
+            -maxmsgsize => 4096
         );
     } else {
         ( $this->{_sessionRead}, $this->{_error} ) = Net::SNMP->session(
@@ -458,7 +459,8 @@ sub connectRead {
             -version   => $this->{_SNMPVersion},
             -timeout   => 2,
             -retries   => 1,
-            -community => $this->{_SNMPCommunityRead}
+            -community => $this->{_SNMPCommunityRead},
+            -maxmsgsize => 4096,
         );
     }
     if ( !defined( $this->{_sessionRead} ) ) {
@@ -528,7 +530,8 @@ sub connectWriteTo {
             -authprotocol => $this->{_SNMPAuthProtocolWrite},
             -authpassword => $this->{_SNMPAuthPasswordWrite},
             -privprotocol => $this->{_SNMPPrivProtocolWrite},
-            -privpassword => $this->{_SNMPPrivPasswordWrite}
+            -privpassword => $this->{_SNMPPrivPasswordWrite},
+            -maxmsgsize => 4096,
         );
     } else {
         ( $this->{$sessionKey}, $this->{_error} ) = Net::SNMP->session(
@@ -537,7 +540,8 @@ sub connectWriteTo {
             -version   => $this->{_SNMPVersion},
             -timeout   => 2,
             -retries   => 1,
-            -community => $this->{_SNMPCommunityWrite}
+            -community => $this->{_SNMPCommunityWrite},
+            -maxmsgsize => 4096,
         );
     }
 

--- a/lib/pf/Switch/Cisco.pm
+++ b/lib/pf/Switch/Cisco.pm
@@ -221,6 +221,7 @@ sub parseTrap {
                         -version   => $this->{_SNMPVersion},
                         -retries   => 1,
                         -timeout   => 2,
+                        -maxmsgsize => 4096,
                         -community => $this->{_SNMPCommunityRead} . '@'
                             . $currentVlan
                         );
@@ -696,6 +697,7 @@ sub getMacBridgePortHash {
             -version   => $this->{_SNMPVersion},
             -retries   => 1,
             -timeout   => 2,
+            -maxmsgsize => 4096,
             -community => $this->{_SNMPCommunityRead} . '@' . $vlan
         );
 
@@ -794,6 +796,7 @@ sub getIfIndexForThisMac {
                 -version   => $this->{_SNMPVersion},
                 -retries   => 1,
                 -timeout   => 2,
+                -maxmsgsize => 4096,
                 -community => $this->{_SNMPCommunityRead} . '@' . $vlan
                 );
 
@@ -874,6 +877,7 @@ sub isMacInAddressTableAtIfIndex {
             -version   => $this->{_SNMPVersion},
             -retries   => 1,
             -timeout   => 2,
+            -maxmsgsize => 4096,
             -community => $this->{_SNMPCommunityRead} . '@' . $vlan
         );
 
@@ -1262,6 +1266,7 @@ sub getAllMacs {
                     -version   => $this->{_SNMPVersion},
                     -retries   => 1,
                     -timeout   => 2,
+                    -maxmsgsize => 4096,
                     -community => $this->{_SNMPCommunityRead} . '@' . $vlan
                     );
 

--- a/lib/pf/Switch/Extricom.pm
+++ b/lib/pf/Switch/Extricom.pm
@@ -122,7 +122,8 @@ sub connectWrite {
             -authprotocol => $this->{_SNMPAuthProtocolWrite},
             -authpassword => $this->{_SNMPAuthPasswordWrite},
             -privprotocol => $this->{_SNMPPrivProtocolWrite},
-            -privpassword => $this->{_SNMPPrivPasswordWrite}
+            -privpassword => $this->{_SNMPPrivPasswordWrite},
+            -maxmsgsize => 4096
         );
     } else {
         ( $this->{_sessionWrite}, $this->{_error} ) = Net::SNMP->session(
@@ -130,7 +131,8 @@ sub connectWrite {
             -version   => $this->{_SNMPVersion},
             -timeout   => 2,
             -retries   => 1,
-            -community => $this->{_SNMPCommunityWrite}
+            -community => $this->{_SNMPCommunityWrite},
+            -maxmsgsize => 4096
         );
     }
     if ( !defined( $this->{_sessionWrite} ) ) {

--- a/lib/pf/Switch/PacketFence.pm
+++ b/lib/pf/Switch/PacketFence.pm
@@ -35,7 +35,8 @@ sub connectWrite {
         -hostname  => '127.0.0.1',
         -version   => 1,
         -port      => '162',
-        -community => $this->{_SNMPCommunityTrap}
+        -community => $this->{_SNMPCommunityTrap},
+        -maxmsgsize => 4096
     );
     if ( !defined( $this->{_sessionWrite} ) ) {
         $logger->error( "error creating SNMP v1 connection to 127.0.0.1: "


### PR DESCRIPTION
# Description

Define the max message size because sometimes if we request something on a switch stack the size can be greatter than the default and packetfence is not able to detect voip phones.
# Impacts

No
# Fixes issue

Fixes #738 
# Delete branch after merge

Yes
# NEWS file entries
## Bug Fixes
- Define the max messages size that snmp get can return (fix voip lldp/cdp detection on switch stack)
