### PR TITLE
Match realm with machine auth

### DIFF
--- a/raddb/packetfence-multi-domain.pm
+++ b/raddb/packetfence-multi-domain.pm
@@ -56,13 +56,13 @@ sub authorize {
 
     my $start = Time::HiRes::gettimeofday();
     # We try to find the realm that's configured in PacketFence
-   my $realm;
-   my $user_name = $RAD_REQUEST{'TLS-Client-Cert-Common-Name'} || $RAD_REQUEST{'User-Name'};
-   if ($user_name =~ /^host\/([0-9a-zA-Z-]+)\.(.*)$/) {
-       $realm = $ConfigRealm{$2};
-   } else {
-       $realm = $ConfigRealm{$RAD_REQUEST{"Realm"}};
-   }
+    my $realm;
+    my $user_name = $RAD_REQUEST{'TLS-Client-Cert-Common-Name'} || $RAD_REQUEST{'User-Name'};
+    if ($user_name =~ /^host\/([0-9a-zA-Z-]+)\.(.*)$/) {
+        $realm = $ConfigRealm{$2};
+    } else {
+        $realm = $ConfigRealm{$RAD_REQUEST{"Realm"}};
+    }
 
     #use Data::Dumper;
     #&radiusd::radlog($RADIUS::L_INFO, Dumper($realm));

--- a/raddb/packetfence-multi-domain.pm
+++ b/raddb/packetfence-multi-domain.pm
@@ -56,7 +56,13 @@ sub authorize {
 
     my $start = Time::HiRes::gettimeofday();
     # We try to find the realm that's configured in PacketFence
-    my $realm = $ConfigRealm{$RAD_REQUEST{"Realm"}};
+   my $realm;
+   my $user_name = $RAD_REQUEST{'TLS-Client-Cert-Common-Name'} || $RAD_REQUEST{'User-Name'};
+   if ($user_name =~ /^host\/([0-9a-zA-Z-]+)\.(.*)$/) {
+       $realm = $ConfigRealm{$2};
+   } else {
+       $realm = $ConfigRealm{$RAD_REQUEST{"Realm"}};
+   }
 
     #use Data::Dumper;
     #&radiusd::radlog($RADIUS::L_INFO, Dumper($realm));


### PR DESCRIPTION
# Description

Try to match the realm configured in packetfence to ask the correct domain for machine auth
# Impacts

No
# Delete branch after merge

Yes
# NEWS file entries

Enhancements
++++++++++++
- Use the correct domain configured in PacketFence to do machine authentication (Realm detection)
