### PR TITLE
Added LOGGING of MAC and IP address in addition to the USERNAME, after succesfull authentication

### DIFF
--- a/lib/pf/authentication.pm
+++ b/lib/pf/authentication.pm
@@ -218,6 +218,11 @@ sub authenticate {
 
     $logger->debug(sub {"Authenticating '$display_username' from source(s) ".join(', ', map { $_->id } @sources) });
 
+    # Fetching IP and MAC from Portal Session, as to properly LOG them together with the USERNAME 
+	my $portalSession = pf::Portal::Session->new();
+	my $ip = $portalSession->getClientIp();
+	my $mac = $portalSession->getClientMac();
+
     foreach my $current_source (@sources) {
         my ($result, $message);
         $logger->trace("Trying to authenticate '$display_username' with source '".$current_source->id."'");
@@ -226,7 +231,7 @@ sub authenticate {
         };
         # First match wins!
         if ($result) {
-            $logger->info("Authentication successful for $display_username in source ".$current_source->id." (".$current_source->type.")");
+            $logger->info("Authentication successful for ".$display_username."/".$ip."/".$mac." in source ".$current_source->id." (".$current_source->type.")");
             return ($result, $message, $current_source->id);
         }
     }


### PR DESCRIPTION
I've added three lines of code to fetch IP-address and MAC-address from PortalSession within the authentication.pm module, so to being able to LOG them (IP/MAC) in addition to what is currently logged (USERNAME).
This is relevent, expecially in "inline L2" deployments, as thanks to this it will be very easy to keep an historical mapping between USERNAME<=>MAC address, regardless of the historical data stored in MySQL, thanks to what's reported in LOG-files.
Probably it will be also useful in other "vlan-enforcement" deployments.
