### PR TITLE
allow pfdns to run only on vip in cluster

### DIFF
--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1397,6 +1397,13 @@ description=<<EOT
 The virtual router id for keepalive. Leave untouched unless you have another keepalive cluster in this network.
 EOT
 
+[active_active.dns_on_vip_only]
+type=toggle
+options=enabled|disabled
+description=<<EOT
+Activate so the clients in registration and isolation are pointed to the VIP of the server instead of all the servers.
+EOT
+
 [monitoring.graphite_host]
 type=text
 description=<<EOT

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1401,7 +1401,7 @@ EOT
 type=toggle
 options=enabled|disabled
 description=<<EOT
-Activate so the clients in registration and isolation are pointed to the VIP of the server instead of all the servers.
+Set the name server option in DHCP replies to point only to the VIP in cluster mode rather than to all servers in the cluster.
 EOT
 
 [monitoring.graphite_host]

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -1096,7 +1096,7 @@ virtual_router_id=50
 #
 # active_active.dns_on_vip_only
 #
-# Activate so the clients in registration and isolation are pointed to the VIP of the server instead of all the servers.
+# Set the name server option in DHCP replies to point only to the VIP in cluster mode rather than to all servers in the cluster.
 dns_on_vip_only=disabled
 
 [monitoring]

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -1093,6 +1093,11 @@ password=1234
 #
 # Shared KEY for vrrp protocol (Must be the same on all members).
 virtual_router_id=50
+#
+# active_active.dns_on_vip_only
+#
+# Activate so the clients in registration and isolation are pointed to the VIP of the server instead of all the servers.
+dns_on_vip_only=disabled
 
 [monitoring]
 #

--- a/lib/pf/services/manager/dhcpd.pm
+++ b/lib/pf/services/manager/dhcpd.pm
@@ -98,18 +98,25 @@ EOT
             }
             my $active = '0';
             my $dns ='0';
-            foreach my $interface (@listen_ints) {
-                my $cfg             = $Config{"interface $interface"};
-                my $current_network = NetAddr::IP->new($cfg->{'ip'}, $cfg->{'mask'});
-                my @active_members  = values %{pf::cluster::members_ips($interface)};
-                my $members         = join(',', @active_members);
-                if ($members) {
-                    if ($current_network->contains($ip)) {
-                        $dns = $members;
-                        $active =
-                          defined($net{next_hop})
-                          ? NetAddr::IP::Lite->new($net{'next_hop'}, $cfg->{'mask'})
-                          : NetAddr::IP::Lite->new($cfg->{'ip'},     $cfg->{'mask'});
+            if($cluster_enabled){
+                foreach my $interface ( @listen_ints ) {
+                    my $cfg = $Config{"interface $interface"};
+                    my $current_network = NetAddr::IP->new( $cfg->{'ip'}, $cfg->{'mask'} );
+                    my $members;
+                    if(isenabled($Config{active_active}{dns_on_vip_only})){
+                        $members = pf::cluster::cluster_ip($interface);
+                    }
+                    else {
+                        my @active_members = values %{pf::cluster::members_ips($interface)};
+                        $members = join(',',@active_members);
+                    }
+                    if ($members) {
+                        if ($current_network->contains($ip)) {
+                            $dns = $members;
+                        $active = defined($net{next_hop}) ? 
+                                 NetAddr::IP::Lite->new($net{'next_hop'}, $cfg->{'mask'}) :
+                                 NetAddr::IP::Lite->new($cfg->{'ip'}, $cfg->{'mask'});
+                        }
                     }
                 }
             }

--- a/lib/pf/services/manager/dhcpd.pm
+++ b/lib/pf/services/manager/dhcpd.pm
@@ -103,7 +103,8 @@ EOT
                     my $cfg = $Config{"interface $interface"};
                     my $current_network = NetAddr::IP->new( $cfg->{'ip'}, $cfg->{'mask'} );
                     my $members;
-                    if(isenabled($Config{active_active}{dns_on_vip_only})){
+                    # If we use passthroughs we only use management for DNS server as ipset sessions are not replicated
+                    if( isenabled($Config{active_active}{dns_on_vip_only}) || isenabled($Config{trapping}{passthrough}) ){
                         $members = pf::cluster::cluster_ip($interface);
                     }
                     else {


### PR DESCRIPTION
# Description

Allows to push only the VIP in the DHCP options when using active/active.

Defaults to the current behavior
# Issue

fixes #820 
# Impacts

active/active clustering
# Delete branch after merge

YES
# NEWS file entries
## Bug fixes
- Made dhcp point DNS only on cluster IP if passthroughs are enabled in active/active clusters (#820)
## New Features
- Added the option to use only the management node as the DNS server in Active/Active clustering
