### PR TITLE
Add option to centralize deauth to management node

### DIFF
--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1404,6 +1404,13 @@ description=<<EOT
 Set the name server option in DHCP replies to point only to the VIP in cluster mode rather than to all servers in the cluster.
 EOT
 
+[active_active.centralized_deauth]
+type=toggle
+options=enabled|disabled
+description=<<EOT
+Centralize the deauthentication to the management node of the cluster.
+EOT
+
 [monitoring.graphite_host]
 type=text
 description=<<EOT

--- a/conf/httpd.conf.d/httpd.webservices
+++ b/conf/httpd.conf.d/httpd.webservices
@@ -80,14 +80,13 @@ AcceptMutex posixsem
 SSLMutex posixsem
 <Perl>
 use pf::config qw();
+use pf::cluster qw();
 
 
 my $PfConfig = \%pf::config::Config;
 my $management_network = $pf::config::management_network;
 my $install_dir = $pf::config::install_dir;
 my $var_dir = $pf::config::var_dir;
-my $host;
-
 $PidFile = $install_dir.'/var/run/httpd.webservices.pid';
 
 $Include = $install_dir.'/conf/httpd.conf.d/log.conf';
@@ -133,36 +132,46 @@ $ErrorLog = $install_dir.'/logs/httpd.webservices.error';
 $NameVirtualHost => "*:$PfConfig->{'ports'}{'soap'}";
 
 if (defined($management_network->{'Tip'}) && $management_network->{'Tip'} ne '') {
-    if (defined($management_network->{'Tvip'}) && $management_network->{'Tvip'} ne '') {
-        $host = $management_network->{'Tvip'};
-    } else {
-        $host = $management_network->{'Tip'};
-    }
-    @Listen =  ("127.0.0.1:".$PfConfig->{'ports'}{'soap'},$host.":".$PfConfig->{'ports'}{'soap'});
-
+    my @hosts;
+    @Listen =  ("127.0.0.1:".$PfConfig->{'ports'}{'soap'});
     push (@NameVirtualHost,"127.0.0.1:".$PfConfig->{'ports'}{'soap'});
-    push (@NameVirtualHost,$host.":".$PfConfig->{'ports'}{'soap'});
+    if (defined($management_network->{'Tvip'}) && $management_network->{'Tvip'} ne '') {
+        push(@hosts, $management_network->{'Tvip'});
+        push (@Listen, $management_network->{'Tvip'}.":".$PfConfig->{'ports'}{'soap'});
+    } else {
+        push(@hosts, $management_network->{'Tip'});
+        push (@Listen, $management_network->{'Tip'}.":".$PfConfig->{'ports'}{'soap'});
+    }
+
+
+    if($pf::cluster::cluster_enabled){
+        push (@Listen, pf::cluster::management_cluster_ip().":".$PfConfig->{'ports'}{'soap'});
+        push (@NameVirtualHost,pf::cluster::management_cluster_ip().":".$PfConfig->{'ports'}{'soap'});
+        push (@hosts, pf::cluster::management_cluster_ip());
+    }
 
     #Generate Virtualhost for management interface (ssl enabled and auth enabled)
-    push @{ $VirtualHost{$host.":".$PfConfig->{'ports'}{'soap'}} },
-        {
-             ServerName          => $PfConfig->{'general'}{'hostname'}.".".$PfConfig->{'general'}{'domain'},
-             DocumentRoot        => $install_dir.'/html/pfappserver/lib',
-             ErrorLog            => $install_dir.'/logs/httpd.webservices.error',
-             CustomLog           => $install_dir.'/logs/httpd.webservices.access combined',
-             SSLEngine           => 'on',
-             Include             => $var_dir.'/conf/ssl-certificates.conf',
-             Location     => {
-                  "/" => {
-                      SetHandler          => 'modperl',
-                      PerlResponseHandler => 'pf::WebAPI',
-                      PerlAuthenHandler   => 'pf::WebAPI::AuthenHandler',
-                      AuthName            => "PacketFence_Authentication",
-                      AuthType            => 'Basic',
-                      require             => 'valid-user',
-                  },
-             },
-       };
+    foreach my $host (@hosts){
+        push @{ $VirtualHost{$host.":".$PfConfig->{'ports'}{'soap'}} },
+            {
+                 ServerName          => $PfConfig->{'general'}{'hostname'}.".".$PfConfig->{'general'}{'domain'},
+                 DocumentRoot        => $install_dir.'/html/pfappserver/lib',
+                 ErrorLog            => $install_dir.'/logs/httpd.webservices.error',
+                 CustomLog           => $install_dir.'/logs/httpd.webservices.access combined',
+                 SSLEngine           => 'on',
+                 Include             => $var_dir.'/conf/ssl-certificates.conf',
+                 Location     => {
+                      "/" => {
+                          SetHandler          => 'modperl',
+                          PerlResponseHandler => 'pf::WebAPI',
+                          PerlAuthenHandler   => 'pf::WebAPI::AuthenHandler',
+                          AuthName            => "PacketFence_Authentication",
+                          AuthType            => 'Basic',
+                          require             => 'valid-user',
+                      },
+                 },
+           };
+      }
 
 
 } else {

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -1098,6 +1098,11 @@ virtual_router_id=50
 #
 # Set the name server option in DHCP replies to point only to the VIP in cluster mode rather than to all servers in the cluster.
 dns_on_vip_only=disabled
+#
+# active_active.centralized_deauth
+#
+# Centralize the deauthentication to the management node of the cluster.
+centralized_deauth=disabled
 
 [monitoring]
 #

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -1102,7 +1102,7 @@ dns_on_vip_only=disabled
 # active_active.centralized_deauth
 #
 # Centralize the deauthentication to the management node of the cluster.
-centralized_deauth=disabled
+centralized_deauth=enabled
 
 [monitoring]
 #

--- a/lib/pf/Switch.pm
+++ b/lib/pf/Switch.pm
@@ -27,6 +27,7 @@ use pf::constants;
 use pf::config;
 use pf::locationlog;
 use pf::node;
+use pf::cluster;
 # RADIUS constants (RADIUS:: namespace)
 use pf::radius::constants;
 use pf::roles::custom $ROLE_API_LEVEL;

--- a/lib/pf/Switch.pm
+++ b/lib/pf/Switch.pm
@@ -2775,7 +2775,7 @@ sub radiusDisconnect {
         my $connection_info = {
             nas_ip => $send_disconnect_to,
             secret => $self->{'_radiusSecret'},
-            LocalAddr => $management_network->tag('vip'),
+            LocalAddr => $self->deauth_source_ip(),
         };
 
         if (defined($self->{'_controllerPort'}) && $self->{'_controllerPort'} ne '') {
@@ -3089,6 +3089,25 @@ sub enableMABByIfIndex {
     $logger->error("This function is unimplemented.");
     return 0;
 }
+
+=item deauth_source_ip
+
+Computes which IP should be used as source IP address for the deauthentication
+
+Takes into account the active/active clustering and centralized deauth
+
+=cut
+
+sub deauth_source_ip {
+    my ($self) = @_;
+    if($cluster_enabled){
+        return isenabled($Config{active_active}{centralized_deauth}) ? pf::cluster::management_cluster_ip() : pf::cluster::current_server->{management_ip};
+    }
+    else {
+        return $management_network->tag('vip');
+    }
+}
+
 
 =back
 

--- a/lib/pf/Switch/Alcatel.pm
+++ b/lib/pf/Switch/Alcatel.pm
@@ -184,7 +184,7 @@ sub radiusDisconnect {
         my $connection_info = {
             nas_ip => $send_disconnect_to,
             secret => $self->{'_radiusSecret'},
-            LocalAddr => $management_network->tag('vip'),
+            LocalAddr => $self->deauth_source_ip(),
         };
 
         my $node_info = node_attributes($mac);

--- a/lib/pf/Switch/Aruba.pm
+++ b/lib/pf/Switch/Aruba.pm
@@ -511,7 +511,7 @@ sub radiusDisconnect {
         my $connection_info = {
             nas_ip => $send_disconnect_to,
             secret => $self->{'_radiusSecret'},
-            LocalAddr => $management_network->tag('vip'),
+            LocalAddr => $self->deauth_source_ip(),
         };
 
         $logger->debug("network device supports roles. Evaluating role to be returned");

--- a/lib/pf/Switch/ArubaSwitch.pm
+++ b/lib/pf/Switch/ArubaSwitch.pm
@@ -238,7 +238,7 @@ sub radiusDisconnect {
         my $connection_info = {
             nas_ip => $send_disconnect_to,
             secret => $self->{'_radiusSecret'},
-            LocalAddr => $management_network->tag('vip'),
+            LocalAddr => $self->deauth_source_ip(),
         };
 
         $logger->debug("[$self->{'_ip'}] Network device supports roles. Evaluating role to be returned.");

--- a/lib/pf/Switch/Avaya.pm
+++ b/lib/pf/Switch/Avaya.pm
@@ -470,7 +470,7 @@ sub radiusDisconnect {
         my $connection_info = {
             nas_ip => $send_disconnect_to,
             secret => $self->{'_radiusSecret'},
-            LocalAddr => $management_network->tag('vip'),
+            LocalAddr => $self->deauth_source_ip(),
         };
 
         $logger->debug("network device supports roles. Evaluating role to be returned");

--- a/lib/pf/Switch/Cisco.pm
+++ b/lib/pf/Switch/Cisco.pm
@@ -1544,7 +1544,7 @@ sub _radiusBounceMac {
         my $connection_info = {
             nas_ip => $self->{'_controllerIp'} || $self->{'_ip'},
             secret => $self->{'_radiusSecret'},
-            LocalAddr => $management_network->tag('vip'),
+            LocalAddr => $self->deauth_source_ip(),
         };
 
         $response = perform_coa( $connection_info,

--- a/lib/pf/Switch/Cisco/Aironet_1600.pm
+++ b/lib/pf/Switch/Cisco/Aironet_1600.pm
@@ -101,7 +101,7 @@ sub radiusDisconnect {
         my $connection_info = {
             nas_ip => $send_disconnect_to,
             secret => $self->{'_radiusSecret'},
-            LocalAddr => $management_network->tag('vip'),
+            LocalAddr => $self->deauth_source_ip(),
         };
 
         $logger->debug("[$mac] network device (".$self->{'_id'}.") supports roles. Evaluating role to be returned");

--- a/lib/pf/Switch/Cisco/Catalyst_2960.pm
+++ b/lib/pf/Switch/Cisco/Catalyst_2960.pm
@@ -403,7 +403,7 @@ sub radiusDisconnect {
         my $connection_info = {
             nas_ip => $send_disconnect_to,
             secret => $self->{'_radiusSecret'},
-            LocalAddr => $management_network->tag('vip'),
+            LocalAddr => $self->deauth_source_ip(),
         };
 
         $logger->debug("[$mac] network device (".$self->{'_id'}.") supports roles. Evaluating role to be returned");

--- a/lib/pf/Switch/Cisco/Catalyst_2960_http.pm
+++ b/lib/pf/Switch/Cisco/Catalyst_2960_http.pm
@@ -226,7 +226,7 @@ sub radiusDisconnect {
         my $connection_info = {
             nas_ip => $send_disconnect_to,
             secret => $self->{'_radiusSecret'},
-            LocalAddr => $management_network->tag('vip'),
+            LocalAddr => $self->deauth_source_ip(),
             nas_port => '3799',
         };
 
@@ -263,7 +263,7 @@ sub radiusDisconnect {
             $connection_info = {
                 nas_ip => $send_disconnect_to,
                 secret => $self->{'_radiusSecret'},
-                LocalAddr => $management_network->tag('vip'),
+                LocalAddr => $self->deauth_source_ip(),
                 nas_port => '3799',
             };
             $response = perform_disconnect($connection_info, $attributes_ref);

--- a/lib/pf/Switch/Cisco/WLC_http.pm
+++ b/lib/pf/Switch/Cisco/WLC_http.pm
@@ -234,7 +234,7 @@ sub radiusDisconnect {
         my $connection_info = {
             nas_ip => $send_disconnect_to,
             secret => $self->{'_radiusSecret'},
-            LocalAddr => $management_network->tag('vip'),
+            LocalAddr => $self->deauth_source_ip(),
             nas_port => '1700',
         };
 
@@ -291,7 +291,7 @@ sub radiusDisconnect {
             $connection_info = {
                 nas_ip => $send_disconnect_to,
                 secret => $self->{'_radiusSecret'},
-                LocalAddr => $management_network->tag('vip'),
+                LocalAddr => $self->deauth_source_ip(),
                 nas_port => '3799',
             };
             $response = perform_disconnect($connection_info, $attributes_ref);

--- a/lib/pf/Switch/Enterasys/V2110.pm
+++ b/lib/pf/Switch/Enterasys/V2110.pm
@@ -159,7 +159,7 @@ sub radiusDisconnect {
         my $connection_info = {
             nas_ip => $send_disconnect_to,
             secret => $self->{'_radiusSecret'},
-            LocalAddr => $management_network->tag('vip'),
+            LocalAddr => $self->deauth_source_ip(),
         };
 
         # transforming MAC to the expected format 00-11-22-33-CA-FE

--- a/lib/pf/Switch/Hostapd.pm
+++ b/lib/pf/Switch/Hostapd.pm
@@ -160,7 +160,7 @@ sub radiusDisconnect {
         my $connection_info = {
             nas_ip => $send_disconnect_to,
             secret => $self->{'_radiusSecret'},
-            LocalAddr => $management_network->tag('vip'),
+            LocalAddr => $self->deauth_source_ip(),
         };
 
         # transforming MAC to the expected format 00-11-22-33-CA-FE

--- a/lib/pf/Switch/Huawei.pm
+++ b/lib/pf/Switch/Huawei.pm
@@ -162,7 +162,7 @@ sub radiusDisconnect {
         my $connection_info = {
             nas_ip => $send_disconnect_to,
             secret => $self->{'_radiusSecret'},
-            LocalAddr => $management_network->tag('vip'),
+            LocalAddr => $self->deauth_source_ip(),
         };
 
         # transforming MAC to the expected format 00-11-22-33-CA-FE

--- a/lib/pf/Switch/Juniper/EX2200.pm
+++ b/lib/pf/Switch/Juniper/EX2200.pm
@@ -125,7 +125,7 @@ sub radiusDisconnect {
         my $connection_info = {
             nas_ip => $send_disconnect_to,
             secret => $self->{'_radiusSecret'},
-            LocalAddr => $management_network->tag('vip'),
+            LocalAddr => $self->deauth_source_ip(),
         };
        
         my $acctsessionid = node_accounting_current_sessionid($mac);

--- a/lib/pf/Switch/Mikrotik.pm
+++ b/lib/pf/Switch/Mikrotik.pm
@@ -152,7 +152,7 @@ sub radiusDisconnect {
         my $connection_info = {
             nas_ip => $send_disconnect_to,
             secret => $self->{'_radiusSecret'},
-            LocalAddr => $management_network->tag('vip'),
+            LocalAddr => $self->deauth_source_ip(),
         };
 
         # transforming MAC to the expected format 00-11-22-33-CA-FE

--- a/lib/pf/Switch/Xirrus.pm
+++ b/lib/pf/Switch/Xirrus.pm
@@ -201,7 +201,7 @@ sub radiusDisconnect {
         my $connection_info = {
             nas_ip => $send_disconnect_to,
             secret => $self->{'_radiusSecret'},
-            LocalAddr => $management_network->tag('vip'),
+            LocalAddr => $self->deauth_source_ip(),
         };
 
         # transforming MAC to the expected format 00-11-22-33-CA-FE

--- a/lib/pf/client.pm
+++ b/lib/pf/client.pm
@@ -16,6 +16,7 @@ use warnings;
 use pf::config;
 use List::MoreUtils qw(any);
 use Module::Pluggable search_path => 'pf::api', sub_name => 'modules', require => 1;
+use pf::cluster;
 
 my @MODULES = __PACKAGE__->modules;
 
@@ -42,6 +43,10 @@ gets the currently configured client
 
 sub getClient {
     $CURRENT_CLIENT->new;
+}
+
+sub getManagementClient {
+    $CURRENT_CLIENT->new(proto => 'https', host => pf::cluster::management_cluster_ip());
 }
  
 =head1 AUTHOR

--- a/lib/pf/enforcement.pm
+++ b/lib/pf/enforcement.pm
@@ -46,6 +46,7 @@ use pf::util;
 use pf::config::util;
 use pf::vlan::custom $VLAN_API_LEVEL;
 use pf::client;
+use pf::cluster;
 
 use Readonly;
 
@@ -125,7 +126,13 @@ sub _vlan_reevaluation {
                 . "connection type: "
                 . $connection_type_explained{$conn_type} );
 
-        my $client = pf::client::getClient();
+        my $client;
+        if ($cluster_enabled && isenabled($Config{active_active}{centralized_deauth})){
+            $client = pf::client::getManagementClient();
+        }
+        else {
+            $client = pf::client::getClient();
+        }
         my %data = (
             'switch'           => $switch_id,
             'mac'              => $mac,


### PR DESCRIPTION
# Description

Adds an option to centralize deauth to management node of active/active cluster
# Impacts

Deauthentication in active/active cluster
Adds a listen interface of the webservices to the management IP
# Issue

fixes #757
# Delete branch after merge

YES
# NEWS file entries
## New Features
- Added an option to centralize deauthentication on the management node of an active/active cluster
