### PR TITLE
Added LOGging of USER/IP/MAC right after successfull login

### DIFF
--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Authenticate.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Authenticate.pm
@@ -530,6 +530,8 @@ sub authenticationLogin : Private {
                 "source_id" => $source_id,
                 "source_match" => $source_id,
             );
+            # Logging USER/IP/MAC of the just-authenticated user
+            $logger->info("Successfully authenticated ".$username."/".$portalSession->clientIp."/".$portalSession->clientMac);
         } else {
             $c->error($message);
         }


### PR DESCRIPTION
A very simple addition to LOG the MAC-address of the succesfully authenticated user, together with username and IP. This is useful, expecially in InlineL2 scenarios, to retrieve the MAC address of a successfully-authenticated user, without the need of the SQL database. 
