### PR TITLE
Allow access to Active Directory from the registration vlan

### DIFF
--- a/html/pfappserver/lib/pfappserver/Form/Config/Domain.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Domain.pm
@@ -101,7 +101,7 @@ has_field 'registration' =>
    type => 'Checkbox',
    label => 'Allow on registration',
    tags => { after_element => \&help,
-             help => 'If this option is enabled, the device will be able to reach the Active Directory from the registration.' },
+             help => 'If this option is enabled, the device will be able to reach the Active Directory from the registration VLAN.' },
   );
 
 =over

--- a/html/pfappserver/lib/pfappserver/Form/Config/Domain.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Domain.pm
@@ -96,6 +96,14 @@ has_field 'dns_name' =>
              help => 'The DNS name (FQDN) of the domain.' },
   );
 
+has_field 'registration' =>
+  (
+   type => 'Checkbox',
+   label => 'Allow on registration',
+   tags => { after_element => \&help,
+             help => 'If this option is enabled, the device will be able to reach the Active Directory from the registration.' },
+  );
+
 =over
 
 =back

--- a/html/pfappserver/root/config/domain/view.tt
+++ b/html/pfappserver/root/config/domain/view.tt
@@ -17,6 +17,7 @@
         [% form.field('dns_server').render | none %]
         [% form.field('bind_dn').render | none %]
         [% form.field('bind_pass').render | none %]
+        [% form.field('registration').render %]
   </div><!--modal-body-->
 
   <div class="modal-footer">

--- a/html/pfappserver/root/config/domain/view.tt
+++ b/html/pfappserver/root/config/domain/view.tt
@@ -17,7 +17,7 @@
         [% form.field('dns_server').render | none %]
         [% form.field('bind_dn').render | none %]
         [% form.field('bind_pass').render | none %]
-        [% form.field('registration').render %]
+        [% form.field('registration').render | none %]
   </div><!--modal-body-->
 
   <div class="modal-footer">

--- a/lib/pfconfig/namespaces/resource/domain_dns_servers.pm
+++ b/lib/pfconfig/namespaces/resource/domain_dns_servers.pm
@@ -1,47 +1,41 @@
-package pfconfig::namespaces::config::Domain;
+package pfconfig::namespaces::resource::domain_dns_servers;
 
 =head1 NAME
 
-pfconfig::namespaces::config::Domain
+pfconfig::namespaces::resource::domain_dns_servers
 
 =cut
 
 =head1 DESCRIPTION
 
-pfconfig::namespaces::config::Domain
+pfconfig::namespaces::resource::domain_dns_servers
 
-This module creates the configuration hash associated to domain.conf
+This module create an associative hash between a domain and it's DNS server
 
 =cut
 
-
 use strict;
 use warnings;
+use pf::util;
 
-use pfconfig::namespaces::config;
-use Data::Dumper;
-use pfconfig::log;
-use pf::file_paths;
-
-use base 'pfconfig::namespaces::config';
+use base 'pfconfig::namespaces::resource';
 
 sub init {
     my ($self) = @_;
-    $self->{file} = $domain_config_file;
-    $self->{child_resources} = [ 'resource::domain_dns_servers' ];
+
+    # we depend on the switch configuration object (russian doll style)
+    $self->{domains} = $self->{cache}->get_cache('config::Domain');
 }
 
-sub build_child {
+sub build {
     my ($self) = @_;
-
-    my %tmp_cfg = %{$self->{cfg}}; 
-
-    $self->{cfg} = \%tmp_cfg;
-
-    return \%tmp_cfg;
-
+    my %ConfigDomain = %{$self->{domains}};
+    my %domain_dns_servers;
+    foreach my $key ( keys %ConfigDomain ) {
+        $domain_dns_servers{$ConfigDomain{$key}->{dns_name}} = $ConfigDomain{$key}->{dns_server} if (isenabled($ConfigDomain{$key}->{registration}));
+    }
+    return \%domain_dns_servers;
 }
-
 
 =back
 

--- a/sbin/pfdns
+++ b/sbin/pfdns
@@ -141,7 +141,7 @@ foreach my $network ( keys %ConfigNetworks ) {
 # Instantiate dns_hash
 my %dns_hash;
 foreach my $key ( keys %ConfigDomain ) {
-    $dns_hash{$ConfigDomain{$key}->{dns_name}} = $ConfigDomain{$key}->{dns_server};
+    $dns_hash{$ConfigDomain{$key}->{dns_name}} = $ConfigDomain{$key}->{dns_server} if (isenabled($ConfigDomain{$key}->{registration}));
 }
 
 populate_ipset_cache($IPSET_SESSION);

--- a/sbin/pfdns
+++ b/sbin/pfdns
@@ -195,7 +195,7 @@ sub regzone {
         if ( ($qname =~ /$OAUTH::ALLOWED_OAUTH_DOMAINS/o && $OAUTH::ALLOWED_OAUTH_DOMAINS ne '') || ($qname =~ /$PASSTHROUGH::ALLOWED_PASSTHROUGH_DOMAINS/o && $PASSTHROUGH::ALLOWED_PASSTHROUGH_DOMAINS ne '') ) {
             my ($ttl, $rdata);
             my $res   = Net::DNS::Resolver->new;
-            my $query = $CHI_CACHE->get($qname);
+            my $query = $CHI_CACHE->compute($qname, sub { $res->search($qname) });
             if ($query) {
                 add_answers_to_ipset($query,$IPSET_SESSION,$HTTP_PORT,$HTTPS_PORT);
                 foreach my $rr ($query->answer) {
@@ -220,8 +220,7 @@ sub regzone {
         } else {
             #Check if the answer already exist
             my ($ttl, $rdata);
-            my $res   = Net::DNS::Resolver->new;
-            my $query = $CHI_CACHE->compute($qname, sub { $res->search($qname) });
+            my $query = $CHI_CACHE->get($qname);
             if ($query) {
                 foreach my $rr ($query->answer) {
                     next unless $rr->type eq "A";

--- a/sbin/pfdns
+++ b/sbin/pfdns
@@ -254,13 +254,14 @@ sub regzone {
         #Handle SRV record to be able to contact Active Directory in the reg vlan
         $rcode = "NXDOMAIN";
         foreach my $key ( keys %dns_hash ) {
-            if ($qname =~ /(.*)_msdcs.$key/) {
+            if ($qname =~ /(.*)_msdcs.$key/i) {
                 my $resolver = new Net::DNS::Resolver(nameservers => [$dns_hash{$key}]);
                 my $reply = $resolver->search($qname, $qtype);
                 foreach my $answer ($reply->answer) {
                     my $query = $CHI_CACHE->compute($answer->target, sub { $resolver->search($answer->target, 'A') });
                     if ($query) {
-                        add_answers_to_ipset($query,$IPSET_SESSION,$answer->port, 'udp:88', 'udp:123', 'udp:135', '135', 'udp:137', 'udp:138', '139', 'udp:389', 'udp:445', '445', 'udp:464', '464', '49155', '49156', '49172');
+                        get_logger->info("Resolved $qname as an Active Directory domain name. Adding passthroughs into ipset.");
+                        add_answers_to_ipset($query,$IPSET_SESSION,$answer->port, 'udp:88', 'udp:123', 'udp:135', '135', 'udp:137', 'udp:138', '139', 'udp:389', 'udp:445', '445', 'udp:464', '464', 'tcp:1025', '49155', '49156', '49172');
                     }
                 }
                 $rcode = "NOERROR";

--- a/sbin/pfdns
+++ b/sbin/pfdns
@@ -260,7 +260,7 @@ sub regzone {
                 foreach my $answer ($reply->answer) {
                     my $query = $CHI_CACHE->compute($answer->target, sub { $resolver->search($answer->target, 'A') });
                     if ($query) {
-                        add_answers_to_ipset($query,$IPSET_SESSION,$answer->port, '135', '464');
+                        add_answers_to_ipset($query,$IPSET_SESSION,$answer->port, 'udp:88', 'udp:123', 'udp:135', '135', 'udp:137', 'udp:138', '139', 'udp:389', 'udp:445', '445', 'udp:464', '464', '49155', '49156', '49172');
                     }
                 }
                 $rcode = "NOERROR";

--- a/sbin/pfdns
+++ b/sbin/pfdns
@@ -25,6 +25,7 @@ use POSIX qw(:signal_h);
 use Try::Tiny;
 use Net::DNS::Nameserver;
 use NetAddr::IP;
+use Net::DNS::Resolver;
 
 BEGIN {
     # log4perl init
@@ -137,6 +138,12 @@ foreach my $network ( keys %ConfigNetworks ) {
     }
 }
 
+# Instantiate dns_hash
+my %dns_hash;
+foreach my $key ( keys %ConfigDomain ) {
+    $dns_hash{$ConfigDomain{$key}->{dns_name}} = $ConfigDomain{$key}->{dns_server};
+}
+
 populate_ipset_cache($IPSET_SESSION);
 
 my $ns = new Net::DNS::Nameserver(
@@ -211,13 +218,30 @@ sub regzone {
             push @ans, $rr;
             $rcode = "NOERROR";
         } else {
-            my ($ttl, $rdata) = ($TTL, $Config{'general'}{'hostname'}.".".$Config{'general'}{'domain'}.".");
-            my $rr = new Net::DNS::RR("$qname $ttl IN CNAME $rdata");
-            my $rdata2 = (defined($loadb_ip->{$conn->{sockhost}})) ? $loadb_ip->{$conn->{sockhost}} : $conn->{sockhost};
-            my $rr2 = new Net::DNS::RR("$rdata $ttl $qclass $qtype $rdata2");
-            push @ans, $rr;
-            push @ans, $rr2;
-            $rcode = "NOERROR";
+            #Check if the answer already exist
+            my ($ttl, $rdata);
+            my $res   = Net::DNS::Resolver->new;
+            my $query = $CHI_CACHE->compute($qname, sub { $res->search($qname) });
+            if ($query) {
+                foreach my $rr ($query->answer) {
+                    next unless $rr->type eq "A";
+                    $rdata= $rr->address;
+                    push @ans, new Net::DNS::RR("$qname $TTL $qclass $qtype $rdata");
+                }
+                if(@ans) {
+                    $rcode = "NOERROR";
+                } else {
+                    $rcode = "NXDOMAIN";
+                }
+            } else {
+                my ($ttl, $rdata) = ($TTL, $Config{'general'}{'hostname'}.".".$Config{'general'}{'domain'}.".");
+                my $rr = new Net::DNS::RR("$qname $ttl IN CNAME $rdata");
+                my $rdata2 = (defined($loadb_ip->{$conn->{sockhost}})) ? $loadb_ip->{$conn->{sockhost}} : $conn->{sockhost};
+                my $rr2 = new Net::DNS::RR("$rdata $ttl $qclass $qtype $rdata2");
+                push @ans, $rr;
+                push @ans, $rr2;
+                $rcode = "NOERROR";
+            }
         }
     } elsif ($qtype eq "NS") {
         my $rr = new Net::DNS::RR(
@@ -227,6 +251,23 @@ sub regzone {
         );
         push @ans, $rr;
         $rcode = "NOERROR";
+    } elsif ($qtype eq "SRV") {
+        #Handle SRV record to be able to contact Active Directory in the reg vlan
+        $rcode = "NXDOMAIN";
+        foreach my $key ( keys %dns_hash ) {
+            if ($qname =~ /(.*)_msdcs.$key/) {
+                my $resolver = new Net::DNS::Resolver(nameservers => [$dns_hash{$key}]);
+                my $reply = $resolver->search($qname, $qtype);
+                foreach my $answer ($reply->answer) {
+                    my $query = $CHI_CACHE->compute($answer->target, sub { $resolver->search($answer->target, 'A') });
+                    if ($query) {
+                        add_answers_to_ipset($query,$IPSET_SESSION,$answer->port, '135', '464');
+                    }
+                }
+                $rcode = "NOERROR";
+                push @ans, $reply->answer;
+            }
+        }
     } else{
         $rcode = "NXDOMAIN";
     }
@@ -357,4 +398,3 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
 USA.
 
 =cut
-

--- a/sbin/pfdns
+++ b/sbin/pfdns
@@ -138,11 +138,7 @@ foreach my $network ( keys %ConfigNetworks ) {
     }
 }
 
-# Instantiate dns_hash
-my %dns_hash;
-foreach my $key ( keys %ConfigDomain ) {
-    $dns_hash{$ConfigDomain{$key}->{dns_name}} = $ConfigDomain{$key}->{dns_server} if (isenabled($ConfigDomain{$key}->{registration}));
-}
+tie our %domain_dns_servers, 'pfconfig::cached_hash', 'resource::domain_dns_servers';
 
 populate_ipset_cache($IPSET_SESSION);
 
@@ -253,9 +249,9 @@ sub regzone {
     } elsif ($qtype eq "SRV") {
         #Handle SRV record to be able to contact Active Directory in the reg vlan
         $rcode = "NXDOMAIN";
-        foreach my $key ( keys %dns_hash ) {
+        foreach my $key ( keys %domain_dns_servers ) {
             if ($qname =~ /(.*)_msdcs.$key/i) {
-                my $resolver = new Net::DNS::Resolver(nameservers => [$dns_hash{$key}]);
+                my $resolver = new Net::DNS::Resolver(nameservers => [$domain_dns_servers{$key}]);
                 my $reply = $resolver->search($qname, $qtype);
                 foreach my $answer ($reply->answer) {
                     my $query = $CHI_CACHE->compute($answer->target, sub { $resolver->search($answer->target, 'A') });

--- a/sbin/pfdns
+++ b/sbin/pfdns
@@ -195,7 +195,7 @@ sub regzone {
         if ( ($qname =~ /$OAUTH::ALLOWED_OAUTH_DOMAINS/o && $OAUTH::ALLOWED_OAUTH_DOMAINS ne '') || ($qname =~ /$PASSTHROUGH::ALLOWED_PASSTHROUGH_DOMAINS/o && $PASSTHROUGH::ALLOWED_PASSTHROUGH_DOMAINS ne '') ) {
             my ($ttl, $rdata);
             my $res   = Net::DNS::Resolver->new;
-            my $query = $CHI_CACHE->compute($qname, sub { $res->search($qname) });
+            my $query = $CHI_CACHE->get($qname);
             if ($query) {
                 add_answers_to_ipset($query,$IPSET_SESSION,$HTTP_PORT,$HTTPS_PORT);
                 foreach my $rr ($query->answer) {


### PR DESCRIPTION
# Description

Allow windows devices on the registration vlan to be able to reach Active Directory
# Impacts

No
# Delete branch after merge

YES
# NEWS file entries
## New Features
- Windows devices on the registration vlan are now able to reach there Active Directory (Must be configure in PacketFence's domain section)
