### PR TITLE
Refactor all the logging to use pf::log instead of Log::Log4perl directly

### DIFF
--- a/addons/database-cleaner.pl
+++ b/addons/database-cleaner.pl
@@ -32,16 +32,8 @@ use strict;
 use warnings;
 
 use lib '/usr/local/pf/lib';
-use pf::db;
-use DBI;
-use Data::Dumper;
-use Getopt::Long;
-use pf::log;
-use Pod::Usage;
-
 BEGIN {
-  use Log::Log4perl;
-  use pf::log();
+  use Log::Log4perl qw(get_logger);
   my $log_conf = q(
   log4perl.rootLogger              = INFO, SCREEN
   log4perl.appender.SCREEN         = Log::Log4perl::Appender::Screen
@@ -51,6 +43,13 @@ BEGIN {
   );
   Log::Log4perl::init(\$log_conf);
 }
+
+use pf::db;
+use DBI;
+use Data::Dumper;
+use Getopt::Long;
+use Pod::Usage;
+
 
 =head2 new
 
@@ -89,7 +88,7 @@ sub seed_data {
     my $sth = $self->{dbh}->prepare("INSERT INTO `radacct` (`acctsessionid`, `acctuniqueid`, `acctstarttime`) VALUES (?,?,?)");
 
     foreach my $i (1..10000) {
-        $sth->bind_param(1, int(rand(10000))); 
+        $sth->bind_param(1, int(rand(10000)));
         $sth->bind_param(2, "dinde");
         $sth->bind_param(3, "2014-01-01");
         $sth->execute();
@@ -151,7 +150,7 @@ Main method/entry point of the script.
 sub execute {
     my %options = ();
     GetOptions (
-      \%options, 
+      \%options,
       "h!",
       "table=s",
       "date-field=s",

--- a/bin/cluster/management_update
+++ b/bin/cluster/management_update
@@ -21,7 +21,7 @@ use pf::log;
 use Net::Interface;
 use Socket;
 
-my $logger = get_logger;
+my $logger = get_logger();
 
 $logger->info("Refreshing services for management mode");
 

--- a/bin/cluster/sync
+++ b/bin/cluster/sync
@@ -7,15 +7,15 @@ Script to synchronize cluster either as the master node or as a slave node
 =head1 SYNOPSIS
 
   To push out the configuration to the other nodes :
-   sync --as-master 
+   sync --as-master
 
-  Options : 
+  Options :
    --file : use with --as-master to push out only a single file
-   --with-fingerbank-db : use with --as-master to push the Fingerbank 
-                          database during the sync (can be long) 
+   --with-fingerbank-db : use with --as-master to push the Fingerbank
+                          database during the sync (can be long)
 
   To sync the configuration from a master server to this server :
-   sync --from=<master-ip> --api-user=<master-api-user> --api-password=<master-api-password> 
+   sync --from=<master-ip> --api-user=<master-api-user> --api-password=<master-api-password>
 
 Add files to /usr/local/pf/conf/cluster-files.txt (one per line) to sync additionnal files during the cluster synchronization.
 
@@ -33,20 +33,8 @@ use constant INSTALL_DIR => '/usr/local/pf';
 use lib INSTALL_DIR . "/lib";
 
 
-use pf::api::jsonrpcclient;
-use Getopt::Long;
-use pf::api::jsonrpcclient;
-use pf::config::cached;
-use pfconfig::constants;
-use pf::file_paths;
-use pf::cluster;
-use fingerbank::FilePath;
-use pf::log;
-use Pod::Usage;
-
 BEGIN {
-  use Log::Log4perl;
-  use pf::log();
+  use Log::Log4perl qw(get_logger);
   my $log_conf = q(
   log4perl.rootLogger              = INFO, SCREEN
   log4perl.appender.SCREEN         = Log::Log4perl::Appender::Screen
@@ -57,16 +45,27 @@ BEGIN {
   Log::Log4perl::init(\$log_conf);
 }
 
+use pf::api::jsonrpcclient;
+use Getopt::Long;
+use pf::api::jsonrpcclient;
+use pf::config::cached;
+use pfconfig::constants;
+use pf::file_paths;
+use pf::cluster;
+use fingerbank::FilePath;
+use Pod::Usage;
+
+
 my ($master_server, $as_master, $api_user, $api_password, $with_fingerbank_db, $file, $help);
 GetOptions (
-    "from=s"   => \$master_server, 
+    "from=s"   => \$master_server,
     "api-user=s" => \$api_user,
     "api-password=s" => \$api_password,
     "as-master" => \$as_master,
     "with-fingerbank-db" => \$with_fingerbank_db,
     "file=s" => \$file,
     "h" => \$help,
-); 
+);
 
 if($help){
   pod2usage( -verbose => 1 );
@@ -99,8 +98,8 @@ foreach my $store (@tmp_stores){
 my @files = ($server_cert, $server_key, $server_pem, $pfconfig::constants::CONFIG_FILE_PATH, "$conf_dir/iptables.conf", $fingerbank::FilePath::CONF_FILE, $fingerbank::FilePath::LOCAL_DB_FILE);
 
 if (-e '/usr/local/pf/conf/cluster-files.txt') {
-    open(my $fh, '<', '/usr/local/pf/conf/cluster-files.txt') 
-      or get_logger->warn("Couldn't open the list of additionnal files to sync."); 
+    open(my $fh, '<', '/usr/local/pf/conf/cluster-files.txt')
+      or get_logger->warn("Couldn't open the list of additionnal files to sync.");
 
     while (my $row = <$fh>) {
         chomp $row;
@@ -135,7 +134,7 @@ if($as_master){
 
 if($master_server){
     get_logger->info("Synching this server from node $master_server");
-    
+
     my $apiclient = pf::api::jsonrpcclient->new(host => $master_server, proto => 'https', username => $api_user, password => $api_password);
 
     foreach my $store (@stores) {

--- a/bin/cluster/sync
+++ b/bin/cluster/sync
@@ -76,7 +76,7 @@ unless($master_server || $as_master){
     exit;
 }
 
-my $logger = get_logger;
+my $logger = get_logger();
 
 use Module::Pluggable
   'search_path' => [qw(pf::ConfigStore)],

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Activate/Email.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Activate/Email.pm
@@ -4,7 +4,6 @@ use namespace::autoclean;
 
 BEGIN { extends 'captiveportal::Base::Controller'; }
 
-use pf::log;
 use POSIX;
 
 use pf::constants;
@@ -317,7 +316,7 @@ sub doSponsorRegistration : Private {
             $c->session->{"username"} = $pid;
             $c->session->{source_id} = $source->{id};
             $c->session->{source_match} = undef;
-            $c->stash->{info}=\%info; 
+            $c->stash->{info}=\%info;
             $c->forward('Authenticate' => 'createLocalAccount', [$auth_params]) if ( isenabled($source->{create_local_account}) );
             $c->forward('CaptivePortal' => 'webNodeRegister', [$pid, %{$c->stash->{info}}]);
 

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Activate/Email.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Activate/Email.pm
@@ -4,7 +4,7 @@ use namespace::autoclean;
 
 BEGIN { extends 'captiveportal::Base::Controller'; }
 
-use Log::Log4perl;
+use pf::log;
 use POSIX;
 
 use pf::constants;

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Activate/Email.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Activate/Email.pm
@@ -55,7 +55,7 @@ sub code : Path : Args(1) {
     my $profile       = $c->profile;
     my $node_mac;
     my $request = $c->request;
-    my $logger  = get_logger;
+    my $logger  = get_logger();
 
     # validate code
     my $activation_record = pf::activation::validate_code($code);
@@ -123,7 +123,7 @@ TODO: documention
 sub doEmailRegistration : Private {
     my ( $self, $c, $code ) = @_;
     my $request           = $c->request;
-    my $logger            = get_logger;
+    my $logger            = get_logger();
     my $activation_record = $c->stash->{activation_record};
     my $profile           = $c->profile;
     my $node_mac          = $c->portalSession->guestNodeMac;
@@ -223,7 +223,7 @@ TODO: documention
 
 sub doSponsorRegistration : Private {
     my ( $self, $c, $code ) = @_;
-    my $logger            = get_logger;
+    my $logger            = get_logger();
     my $request           = $c->request;
     my $activation_record = $c->stash->{activation_record};
     my $portalSession     = $c->portalSession;

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Activate/Sms.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Activate/Sms.pm
@@ -1,7 +1,6 @@
 package captiveportal::PacketFence::Controller::Activate::Sms;
 use Moose;
 use namespace::autoclean;
-use pf::log;
 use POSIX;
 use URI::Escape::XS qw(uri_escape);
 

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Activate/Sms.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Activate/Sms.pm
@@ -1,7 +1,7 @@
 package captiveportal::PacketFence::Controller::Activate::Sms;
 use Moose;
 use namespace::autoclean;
-use Log::Log4perl;
+use pf::log;
 use POSIX;
 use URI::Escape::XS qw(uri_escape);
 

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/CaptivePortal.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/CaptivePortal.pm
@@ -89,7 +89,7 @@ Records the user agent information
 sub nodeRecordUserAgent : Private {
     my ( $self, $c ) = @_;
     my $user_agent    = $c->request->user_agent;
-    my $logger        = get_logger;
+    my $logger        = get_logger();
     my $portalSession = $c->portalSession;
     my $mac           = $portalSession->clientMac;
     unless ($user_agent) {
@@ -392,7 +392,7 @@ sub unknownState : Private {
 
 sub endPortalSession : Private {
     my ( $self, $c ) = @_;
-    my $logger        = get_logger;
+    my $logger        = get_logger();
     my $portalSession = $c->portalSession;
     my $profile       = $c->profile;
 

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/CaptivePortal.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/CaptivePortal.pm
@@ -453,7 +453,7 @@ See F<pf::web::custom> for examples.
 
 sub webNodeRegister : Private {
     my ($self, $c, $pid, %info ) = @_;
-    my $logger        = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger        = get_logger();
     my $portalSession = $c->portalSession;
 
     # FIXME quick and hackish fix for #1505. A proper, more intrusive, API changing, fix should hit devel.

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/DeviceRegistration.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/DeviceRegistration.pm
@@ -41,7 +41,7 @@ sub begin : Private {
 
 sub index : Path : Args(0) {
     my ( $self, $c ) = @_;
-    my $logger  = get_logger;
+    my $logger  = get_logger();
     my $pid     = $c->session->{"username"};
     my $request = $c->request;
 

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Root.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Root.pm
@@ -81,7 +81,7 @@ Add all the common variables in the stash
 
 sub setupCommonStash : Private {
     my ( $self, $c ) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
     my $portalSession   = $c->portalSession;
     my $destination_url = $portalSession->destinationUrl;
 
@@ -115,7 +115,7 @@ Define the locale
 
 sub setupLanguage : Private {
     my ($self, $c) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
     my ($locales) = $c->forward('getLanguages');
 
     my $locale = shift @$locales;
@@ -153,7 +153,7 @@ of the configuration is returned.
 
 sub getLanguages :Private {
     my ($self, $c) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
     my $portalSession = $c->portalSession;
 
     my ($lang, @languages);

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Signup.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Signup.pm
@@ -148,7 +148,7 @@ TODO: documention
 
 sub doEmailSelfRegistration : Private {
     my ( $self, $c ) = @_;
-    my $logger        = get_logger;
+    my $logger        = get_logger();
     my $portalSession = $c->portalSession;
     my $session       = $c->session;
     my $profile       = $c->profile;
@@ -257,7 +257,7 @@ TODO: documention
 
 sub doSponsorSelfRegistration : Private {
     my ( $self, $c ) = @_;
-    my $logger        = get_logger;
+    my $logger        = get_logger();
     my $profile       = $c->profile;
     my $request       = $c->request;
     my $session       = $c->session;
@@ -367,7 +367,7 @@ sub doSmsSelfRegistration : Private {
     my %info;
     my $profile        = $c->profile;
     my $request        = $c->request;
-    my $logger         = get_logger;
+    my $logger         = get_logger();
     my $session        = $c->session;
     my $mac            = $portalSession->clientMac;
     my $mobileprovider = $request->param("mobileprovider");
@@ -552,7 +552,7 @@ TODO: documention
 
 sub validateMandatoryFields : Private {
     my ( $self, $c ) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
 
     my ( $error_code, @error_args );
 
@@ -613,7 +613,7 @@ sub authenticateSelfRegistration : Private {
 
 sub showSelfRegistrationPage : Private {
     my ( $self, $c ) = @_;
-    my $logger  = get_logger;
+    my $logger  = get_logger();
     my $profile = $c->profile;
     my $request = $c->request;
     my @sources = $profile->getExternalSources;

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/TLSProfile.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/TLSProfile.pm
@@ -43,7 +43,7 @@ Collect information about the user and the certificate to generate
 sub index : Path : Args(0) {
     my ($self, $c) = @_;
     my $username = $c->session->{username};
-    my $logger  = get_logger;
+    my $logger  = get_logger();
     my $profile = $c->profile;
     my $request = $c->request;
     my $mac = $c->portalSession->clientMac;

--- a/html/captive-portal/lib/captiveportal/PacketFence/Model/Portal/Session.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Model/Portal/Session.pm
@@ -171,7 +171,7 @@ sub _build_destinationUrl {
 
 sub _build_clientIp {
     my ($self) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
 
     # we fetch CGI's remote address
     # if user is behind a proxy it's not sufficient since we'll get the proxy's IP

--- a/html/pfappserver/lib/pfappserver/Authentication/Store/PacketFence/User.pm
+++ b/html/pfappserver/lib/pfappserver/Authentication/Store/PacketFence/User.pm
@@ -10,7 +10,6 @@ use pf::constants;
 use pf::config qw($WEB_ADMIN_ALL);
 use pf::authentication;
 use pf::Authentication::constants;
-use pf::log;
 use List::MoreUtils qw(all);
 
 BEGIN { __PACKAGE__->mk_accessors(qw/_user _store _roles/) }

--- a/html/pfappserver/lib/pfappserver/Base/Controller/Crud/Config.pm
+++ b/html/pfappserver/lib/pfappserver/Base/Controller/Crud/Config.pm
@@ -17,7 +17,7 @@ use warnings;
 use HTTP::Status qw(:constants is_error is_success);
 use MooseX::MethodAttributes::Role;
 use namespace::autoclean;
-use Log::Log4perl qw(get_logger);
+use pf::log;
 use HTML::FormHandler::Params;
 
 with 'pfappserver::Base::Controller::Crud';

--- a/html/pfappserver/lib/pfappserver/Base/Controller/Crud/DB.pm
+++ b/html/pfappserver/lib/pfappserver/Base/Controller/Crud/DB.pm
@@ -17,7 +17,7 @@ use warnings;
 use HTTP::Status qw(:constants is_error is_success);
 use MooseX::MethodAttributes::Role;
 use namespace::autoclean;
-use Log::Log4perl qw(get_logger);
+use pf::log;
 use HTML::FormHandler::Params;
 BEGIN {
     with 'pfappserver::Base::Controller::Crud' => {

--- a/html/pfappserver/lib/pfappserver/Base/Controller/Crud/DB.pm
+++ b/html/pfappserver/lib/pfappserver/Base/Controller/Crud/DB.pm
@@ -17,7 +17,6 @@ use warnings;
 use HTTP::Status qw(:constants is_error is_success);
 use MooseX::MethodAttributes::Role;
 use namespace::autoclean;
-use pf::log;
 use HTML::FormHandler::Params;
 BEGIN {
     with 'pfappserver::Base::Controller::Crud' => {

--- a/html/pfappserver/lib/pfappserver/Base/Controller/Crud/Fingerbank.pm
+++ b/html/pfappserver/lib/pfappserver/Base/Controller/Crud/Fingerbank.pm
@@ -17,7 +17,7 @@ use warnings;
 use HTTP::Status qw(:constants is_error is_success);
 use MooseX::MethodAttributes::Role;
 use namespace::autoclean;
-use Log::Log4perl qw(get_logger);
+use pf::log;
 use HTML::FormHandler::Params;
 use fingerbank::Config;
 use pf::fingerbank;

--- a/html/pfappserver/lib/pfappserver/Base/Controller/Crud/Fingerbank.pm
+++ b/html/pfappserver/lib/pfappserver/Base/Controller/Crud/Fingerbank.pm
@@ -17,7 +17,6 @@ use warnings;
 use HTTP::Status qw(:constants is_error is_success);
 use MooseX::MethodAttributes::Role;
 use namespace::autoclean;
-use pf::log;
 use HTML::FormHandler::Params;
 use fingerbank::Config;
 use pf::fingerbank;

--- a/html/pfappserver/lib/pfappserver/Base/Controller/Crud/Pagination.pm
+++ b/html/pfappserver/lib/pfappserver/Base/Controller/Crud/Pagination.pm
@@ -17,7 +17,7 @@ use warnings;
 use HTTP::Status qw(:constants is_error is_success);
 use MooseX::MethodAttributes::Role;
 use namespace::autoclean;
-use Log::Log4perl qw(get_logger);
+use pf::log;
 use HTML::FormHandler::Params;
 
 =head2 Methods

--- a/html/pfappserver/lib/pfappserver/Base/Controller/Crud/Pagination.pm
+++ b/html/pfappserver/lib/pfappserver/Base/Controller/Crud/Pagination.pm
@@ -17,7 +17,6 @@ use warnings;
 use HTTP::Status qw(:constants is_error is_success);
 use MooseX::MethodAttributes::Role;
 use namespace::autoclean;
-use pf::log;
 use HTML::FormHandler::Params;
 
 =head2 Methods

--- a/html/pfappserver/lib/pfappserver/Base/Model/Config.pm
+++ b/html/pfappserver/lib/pfappserver/Base/Model/Config.pm
@@ -16,7 +16,6 @@ Is the Generic class for the cached config
 use Moose;
 use namespace::autoclean;
 use pf::config::cached;
-use pf::log;
 use HTTP::Status qw(:constants :is);
 
 BEGIN { extends 'Catalyst::Model'; }

--- a/html/pfappserver/lib/pfappserver/Form/Config/AdminRoles.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/AdminRoles.pm
@@ -18,7 +18,6 @@ with 'pfappserver::Base::Form::Role::Help';
 
 use pf::admin_roles;
 use pf::constants::admin_roles qw(@ADMIN_ACTIONS);
-use pf::log;
 
 has roles => ( is => 'rw', default => sub { [] } );
 

--- a/html/pfappserver/lib/pfappserver/Form/Config/Profile.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Profile.pm
@@ -18,7 +18,6 @@ extends 'pfappserver::Base::Form';
 with 'pfappserver::Form::Config::ProfileCommon';
 
 use pf::config;
-use pf::log;
 use List::MoreUtils qw(uniq);
 
 =head1 FIELDS

--- a/html/pfappserver/lib/pfappserver/Model/Admin.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Admin.pm
@@ -41,7 +41,7 @@ Returns the version of Fingerbank from conf/dhcp_fingerprins.conf
 =cut
 
 sub fingerbank_version {
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my ($filehandler, $line, $version);
     open( $filehandler, '<', "$conf_dir/dhcp_fingerprints.conf" )
         || $logger->error("Unable to open $conf_dir/dhcp_fingerprints.conf: $!");

--- a/html/pfappserver/lib/pfappserver/Model/Authentication.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Authentication.pm
@@ -16,6 +16,7 @@ use warnings;
 use Moose;
 use namespace::autoclean;
 
+use pf::log;
 use pf::authentication;
 use pf::error qw(is_error is_success);
 use pf::ConfigStore::Authentication;
@@ -28,7 +29,7 @@ sub update {
     my ($self, $sources) = @_;
 
     my $logger = get_logger();
-    
+
     # Update sources order
     my %valid_sources = map { $_->{id} => $_ } @pf::ConfigStore::auth_sources;
     my @sorted_sources;

--- a/html/pfappserver/lib/pfappserver/Model/Authentication.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Authentication.pm
@@ -27,7 +27,7 @@ use pf::ConfigStore::Authentication;
 sub update {
     my ($self, $sources) = @_;
 
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     
     # Update sources order
     my %valid_sources = map { $_->{id} => $_ } @pf::ConfigStore::auth_sources;

--- a/html/pfappserver/lib/pfappserver/Model/Authentication/Source.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Authentication/Source.pm
@@ -16,6 +16,7 @@ use warnings;
 use Moose;
 use namespace::autoclean;
 
+use pf::log;
 use pf::authentication;
 use pf::error qw(is_error is_success);
 use pf::ConfigStore::Authentication;

--- a/html/pfappserver/lib/pfappserver/Model/Authentication/Source.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Authentication/Source.pm
@@ -27,7 +27,7 @@ use pf::ConfigStore::Authentication;
 sub update {
     my ($self, $source_id, $source_obj, $def_ref) = @_;
 
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     unless ($source_id) {
         # Add a new source

--- a/html/pfappserver/lib/pfappserver/Model/Config/Fingerbank/Combination.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Config/Fingerbank/Combination.pm
@@ -16,7 +16,6 @@ use fingerbank::Model::Combination();
 use Moose;
 use namespace::autoclean;
 use pf::config::cached;
-use pf::log;
 use HTTP::Status qw(:constants :is);
 
 extends 'pfappserver::Base::Model::Fingerbank';

--- a/html/pfappserver/lib/pfappserver/Model/Config/Fingerbank/DHCP_Fingerprint.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Config/Fingerbank/DHCP_Fingerprint.pm
@@ -16,7 +16,6 @@ use fingerbank::Model::DHCP_Fingerprint();
 use Moose;
 use namespace::autoclean;
 use pf::config::cached;
-use pf::log;
 use HTTP::Status qw(:constants :is);
 
 extends 'pfappserver::Base::Model::Fingerbank';

--- a/html/pfappserver/lib/pfappserver/Model/Config/Fingerbank/DHCP_Vendor.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Config/Fingerbank/DHCP_Vendor.pm
@@ -16,7 +16,6 @@ use fingerbank::Model::DHCP_Vendor();
 use Moose;
 use namespace::autoclean;
 use pf::config::cached;
-use pf::log;
 use HTTP::Status qw(:constants :is);
 
 extends 'pfappserver::Base::Model::Fingerbank';

--- a/html/pfappserver/lib/pfappserver/Model/Config/Fingerbank/Device.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Config/Fingerbank/Device.pm
@@ -16,7 +16,6 @@ use fingerbank::Model::Device();
 use Moose;
 use namespace::autoclean;
 use pf::config::cached;
-use pf::log;
 use HTTP::Status qw(:constants :is);
 
 extends 'pfappserver::Base::Model::Fingerbank';

--- a/html/pfappserver/lib/pfappserver/Model/Config/Fingerbank/MAC_Vendor.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Config/Fingerbank/MAC_Vendor.pm
@@ -16,7 +16,6 @@ use fingerbank::Model::MAC_Vendor();
 use Moose;
 use namespace::autoclean;
 use pf::config::cached;
-use pf::log;
 use HTTP::Status qw(:constants :is);
 
 extends 'pfappserver::Base::Model::Fingerbank';

--- a/html/pfappserver/lib/pfappserver/Model/Config/Fingerbank/User_Agent.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Config/Fingerbank/User_Agent.pm
@@ -16,7 +16,6 @@ use fingerbank::Model::User_Agent();
 use Moose;
 use namespace::autoclean;
 use pf::config::cached;
-use pf::log;
 use HTTP::Status qw(:constants :is);
 
 extends 'pfappserver::Base::Model::Fingerbank';

--- a/html/pfappserver/lib/pfappserver/Model/Config/Pfconfig.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Config/Pfconfig.pm
@@ -15,7 +15,6 @@ This doesn't use the ConfigStore
 use Moose;
 use namespace::autoclean;
 use pfconfig::config;
-use pf::log;
 use pfconfig::constants;
 use Config::IniFiles;
 

--- a/html/pfappserver/lib/pfappserver/Model/Config/System.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Config/System.pm
@@ -14,6 +14,7 @@ use Moose;
 use namespace::autoclean;
 use Net::Netmask;
 
+use pf::log;
 use pf::error qw(is_error is_success);
 use pf::util;
 

--- a/html/pfappserver/lib/pfappserver/Model/Config/System.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Config/System.pm
@@ -27,7 +27,7 @@ extends 'Catalyst::Model';
 
 sub check_mysqld_status {
     my ( $self ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     # -x: this causes the program to also return process id's of shells running the named scripts.
     my $pid;
@@ -44,7 +44,7 @@ sub check_mysqld_status {
 
 sub getDefaultGateway {
     my ($self) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my $default_gateway = (split(" ", `LANG=C sudo ip route show to 0/0`))[2];
     $logger->debug("Default gateway: " . $default_gateway);
@@ -58,7 +58,7 @@ sub getDefaultGateway {
 
 sub getInterfaceForGateway {
     my ( $self, $interfaces_ref, $gateway ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     foreach my $interface ( sort keys(%$interfaces_ref) ) {
         next if ( !($interfaces_ref->{$interface}->{'is_running'}) );
@@ -79,7 +79,7 @@ sub getInterfaceForGateway {
 
 sub setDefaultRoute {
     my ($self, $gateway) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my $_EXIT_CODE_EXISTS = 7;
 
@@ -116,7 +116,7 @@ sub setDefaultRoute {
 
 sub start_mysqld_service {
     my ( $self ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my ($status, $status_msg);
 
@@ -154,7 +154,7 @@ sub start_mysqld_service {
 
 sub restart_pfconfig {
     my ( $self ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my ($status, $status_msg);
 
@@ -183,7 +183,7 @@ sub restart_pfconfig {
 
 sub write_network_persistent {
     my ( $self, $interfaces_ref, $gateway ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my ($status, $status_msg, $systemObj);
 
@@ -261,7 +261,7 @@ Obtain a system object suited for your system.
 
 sub getSystem {
     my ( $self ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my $status_msg;
 
@@ -331,7 +331,7 @@ our $var_dir              = "/usr/local/pf/var/";
 
 sub writeNetworkConfigs {
     my ( $this, $interfaces_ref, $gateway, $gateway_interface ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my $status_msg;
 
@@ -432,7 +432,7 @@ our $var_dir              ="/usr/local/pf/var/";
 
 sub writeNetworkConfigs {
     my ( $this, $interfaces_ref, $gateway, $gateway_interface ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my $status_msg;
 

--- a/html/pfappserver/lib/pfappserver/Model/Configurator.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Configurator.pm
@@ -18,6 +18,7 @@ use Moose;
 use Readonly;
 use namespace::autoclean;
 
+use pf::log;
 use pf::config;
 use pf::error;
 use pf::util;

--- a/html/pfappserver/lib/pfappserver/Model/Configurator.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Configurator.pm
@@ -39,7 +39,7 @@ Readonly::Scalar our $UPGRADE => 'upgrade';
 
 sub checkForRootUser {
     my ( $self ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my $status_msg;
 
@@ -58,7 +58,7 @@ sub checkForRootUser {
 
 sub checkForUpgrade {
     my ( $self ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my $filehandler;
 
@@ -105,7 +105,7 @@ sub checkForUpgrade {
 
 sub update_currently_at {
     my ( $self ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     open PFRELEASE, '<', "$conf_dir/pf-release";
     my @pfrelease  = <PFRELEASE>;

--- a/html/pfappserver/lib/pfappserver/Model/DB.pm
+++ b/html/pfappserver/lib/pfappserver/Model/DB.pm
@@ -17,6 +17,7 @@ use DBI;
 use Moose;
 use namespace::autoclean;
 
+use pf::log;
 use pf::config;
 use pf::error;
 use pf::util;
@@ -39,7 +40,7 @@ sub assign {
 
     my $status_msg;
 
-    my $graphitedb = $dbHandler->quote_identifier($db . "_graphite");   
+    my $graphitedb = $dbHandler->quote_identifier($db . "_graphite");
     $db = $dbHandler->quote_identifier($db);
 
     # Create global PF user
@@ -69,7 +70,7 @@ sub assign {
     $status_msg = ["Successfully created the user [_1] on database [_2]",$user,$db];
 
     # Create pf_graphite database
-    $db = $graphitedb; 
+    $db = $graphitedb;
     foreach my $host ("'%'","localhost") {
         my $sql_query = "GRANT ALL PRIVILEGES ON $db.* TO ?\@${host} IDENTIFIED BY ?";
         $dbHandler->do($sql_query, undef, $user, $password);
@@ -270,7 +271,7 @@ sub resetUserPassword {
           [ "The password of [_1] was successfully modified.", $user ];
         return ( $STATUS::OK, $status_msg );
     }
-    else {                                                                                                            
+    else {
         $logger->warn("Error while changing the password of $user");
         $status_msg = [ "Error while changing the password of [_1].", $user ];
         return ( $STATUS::INTERNAL_SERVER_ERROR, $status_msg );

--- a/html/pfappserver/lib/pfappserver/Model/DB.pm
+++ b/html/pfappserver/lib/pfappserver/Model/DB.pm
@@ -35,7 +35,7 @@ our $dbHandler;
 
 sub assign {
     my ( $self, $db, $user, $password ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my $status_msg;
 
@@ -97,7 +97,7 @@ sub assign {
 
 sub connect {
     my ( $self, $db, $user, $password ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my $status_msg;
 
@@ -118,7 +118,7 @@ sub connect {
 
 sub create {
     my ( $self, $db, $root_user, $root_password ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my ( $status_msg, $result );
 
@@ -157,7 +157,7 @@ sub create {
 
 sub secureInstallation {
     my ( $self, $root_user, $root_password ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my ($status, $status_msg);
 
@@ -202,7 +202,7 @@ TODO: sanitize parameters going into pf_run with strict regex
 
 sub schema {
     my ( $self, $db, $root_user, $root_password ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my ( $status_msg, $result );
     $root_user = quotemeta ($root_user);
@@ -251,7 +251,7 @@ sub schema {
 
 sub resetUserPassword {
     my ( $self, $user, $password ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my ( $status, $status_msg );
     # Making sure username/password are "ok"

--- a/html/pfappserver/lib/pfappserver/Model/Graph.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Graph.pm
@@ -43,7 +43,7 @@ sub _round {
 
 sub countAll {
     my ($self, $module, $params) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my ($status, $status_msg);
     my (@results, $result);
@@ -80,7 +80,7 @@ TODO: restore the interval parameter (day/month/year)
 
 sub timeBase {
     my ($self, $graph, $startDate, $endDate, $options) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my ($status, $status_msg);
 
     my $first_time = undef;
@@ -442,7 +442,7 @@ See bin/pfcmd (report)
 
 sub ratioBase {
     my ( $self, $report, $startDate, $endDate, $options ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my ( $status, $status_msg );
 
     my $function = \&{"pf::pfcmd::report::report_${report}"};

--- a/html/pfappserver/lib/pfappserver/Model/Graph.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Graph.pm
@@ -14,6 +14,7 @@ use Moose;
 use namespace::autoclean;
 
 use Date::Parse;
+use pf::log;
 use pf::config::ui;
 use pf::error qw(is_error is_success);
 use pf::pfcmd::graph;

--- a/html/pfappserver/lib/pfappserver/Model/Interface.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Interface.pm
@@ -222,7 +222,7 @@ and phy.vlan (eth0.100) if there's a vlan interface.
 
 sub get {
     my ( $self, $interface) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
     my $models = $self->{models};
 
     # Put requested interfaces into an array
@@ -420,7 +420,7 @@ sub getType {
 
 sub setType {
     my ($self, $interface, $interface_ref) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
     my $models = $self->{models};
 
     my $type = $interface_ref->{type} || 'none';
@@ -619,7 +619,7 @@ Process parameters to build a proper pf.conf interface section.
 # this might imply a rework of this out of the controller into the model
 sub _prepare_interface_for_pfconf {
     my ($self, $int, $int_model, $type) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
 
     my $int_config_ref = {
         ip => $int_model->{'ipaddress'},

--- a/html/pfappserver/lib/pfappserver/Model/Interface.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Interface.pm
@@ -31,7 +31,7 @@ extends 'Catalyst::Model';
 
 sub create {
     my ( $self, $interface ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my ($status, $status_msg);
 
@@ -79,7 +79,7 @@ sub create {
 sub delete {
     my ($self, $interface, $host) = @_;
     my $models = $self->{models};
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my ($status, $status_msg);
 
@@ -137,7 +137,7 @@ sub delete {
 
 sub down {
     my ( $self, $interface, $host ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my ($status, $status_msg);
 
@@ -271,7 +271,7 @@ sub get {
 sub update {
     my ($self, $interface, $interface_ref) = @_;
     my $models = $self->{models};
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my ($ipaddress, $netmask, $status, $status_msg);
 
@@ -494,7 +494,7 @@ sub interfaceForDestination {
 
     my @interfaces = $self->_listInterfaces('all');
 
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     foreach my $interface ( @interfaces ) {
         next if ( "$interface" eq "lo" );
 
@@ -660,7 +660,7 @@ sub _prepare_interface_for_pfconf {
 
 sub up {
     my ( $self, $interface ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my ($status, $status_msg);
 

--- a/html/pfappserver/lib/pfappserver/Model/MacAddress.pm
+++ b/html/pfappserver/lib/pfappserver/Model/MacAddress.pm
@@ -20,6 +20,7 @@ use namespace::autoclean;
 use Time::localtime;
 use Time::Local;
 
+use pf::log;
 use pf::config;
 use pf::error qw(is_error is_success);
 use pf::util qw(download_oui load_oui);

--- a/html/pfappserver/lib/pfappserver/Model/MacAddress.pm
+++ b/html/pfappserver/lib/pfappserver/Model/MacAddress.pm
@@ -49,7 +49,7 @@ count all mac addresses that match search parameters
 sub countAll {
     my ( $self, %params ) = @_;
 
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my ( $status_msg, $count );
     eval {
         my $greper = sub {1};
@@ -84,7 +84,7 @@ find all all mac addresses that match search parameters
 sub search {
     my ( $self, %params ) = @_;
     load_oui();
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my ( $status, $status_msg );
     my $items;
     eval {

--- a/html/pfappserver/lib/pfappserver/Model/Node.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Node.pm
@@ -30,7 +30,7 @@ use pf::node;
 use pf::nodecategory;
 use pf::iplog;
 use pf::locationlog;
-use Log::Log4perl qw(get_logger);
+use pf::log;
 use pf::node;
 use pf::person;
 use pf::enforcement qw(reevaluate_access);
@@ -227,7 +227,7 @@ Create and register a node
 sub create {
     my ($self, $data) = @_;
 
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my ($status, $result) = ($STATUS::CREATED);
     my $mac = $data->{mac};
     my $pid = $data->{pid} || $default_pid;
@@ -301,7 +301,7 @@ See pf::import::nodes
 sub importCSV {
     my ($self, $data, $user) = @_;
 
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my ($status, $message);
     my $filename = $data->{nodes_file}->filename;
     my $tmpfilename = $data->{nodes_file}->tempname;

--- a/html/pfappserver/lib/pfappserver/Model/PfConfigAdapter.pm
+++ b/html/pfappserver/lib/pfappserver/Model/PfConfigAdapter.pm
@@ -6,6 +6,7 @@ extends 'Catalyst::Model';
 
 use Try::Tiny;
 
+use pf::log;
 use pf::constants;
 use pf::config;
 use pfconfig::manager;

--- a/html/pfappserver/lib/pfappserver/Model/PfConfigAdapter.pm
+++ b/html/pfappserver/lib/pfappserver/Model/PfConfigAdapter.pm
@@ -30,7 +30,7 @@ Will prefer returning the virtual IP if there's one.
 
 sub getWebAdminIp {
     my ($self) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my $mgmt_net = $management_network;
     my $ip = undef;
@@ -49,7 +49,7 @@ Returns the port on which the Web Administration interface runs.
 
 sub getWebAdminPort {
     my ($self) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     return $Config{'ports'}{'admin'};
 }
@@ -62,7 +62,7 @@ Tell pf::config to reload its configuration.
 
 sub reloadConfiguration {
     my ($self) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     $logger->info("reloading PacketFence configuration");
 

--- a/html/pfappserver/lib/pfappserver/Model/Roles.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Roles.pm
@@ -16,6 +16,7 @@ use warnings;
 use Moose;
 use namespace::autoclean;
 
+use pf::log;
 use pf::error qw(is_error is_success);
 use pf::nodecategory;
 

--- a/html/pfappserver/lib/pfappserver/Model/Roles.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Roles.pm
@@ -28,7 +28,7 @@ use pf::nodecategory;
 sub exists {
     my ( $self, $id ) = @_;
 
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my ($status, $status_msg);
 
     my $result = ();
@@ -56,7 +56,7 @@ sub exists {
 sub list {
     my ( $self ) = @_;
 
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my ($status, $status_msg);
 
     my @categories;
@@ -79,7 +79,7 @@ sub list {
 sub read {
     my ($self, $role_id) = @_;
 
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my ($status, $status_msg) = ($STATUS::OK);
 
     eval {
@@ -105,7 +105,7 @@ sub read {
 sub create {
   my ($self, $name, $max_nodes_per_pid, $notes) = @_;
 
-  my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+  my $logger = get_logger();
   my ($status, $status_msg) = ($STATUS::OK, 'The role was succesfully created.');
 
   eval {
@@ -127,7 +127,7 @@ sub create {
 sub delete {
     my ($self, $role_ref) = @_;
 
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my ($status, $status_msg) = ($STATUS::OK);
 
     eval {
@@ -149,7 +149,7 @@ sub delete {
 sub update {
     my ($self, $role_ref, $name, $max_nodes_per_pid, $notes) = @_;
 
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my ($status, $status_msg) = ($STATUS::OK);
     $logger->debug("category: $role_ref->{category_id}");
     eval {

--- a/html/pfappserver/lib/pfappserver/Model/Search/Node.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Search/Node.pm
@@ -29,7 +29,7 @@ extends 'pfappserver::Base::Model::Search';
 
 sub search {
     my ($self, $params, $pageNum, $perPage) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my $builder = $self->make_builder;
     $params->{page_num} = $pageNum;
     $params->{per_page} = $perPage;

--- a/html/pfappserver/lib/pfappserver/Model/Search/Node.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Search/Node.pm
@@ -16,6 +16,7 @@ use strict;
 use warnings;
 use Moose;
 use pfappserver::Base::Model::Search;
+use pf::log;
 use pf::SearchBuilder;
 use pf::node qw(node_custom_search);
 use HTTP::Status qw(:constants);

--- a/html/pfappserver/lib/pfappserver/Model/Search/User.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Search/User.pm
@@ -15,6 +15,7 @@ use strict;
 use warnings;
 use Moose;
 use pfappserver::Base::Model::Search;
+use pf::log;
 use pf::SearchBuilder;
 use pf::person qw(person_custom_search);
 use HTTP::Status qw(is_success :constants);

--- a/html/pfappserver/lib/pfappserver/Model/Search/User.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Search/User.pm
@@ -47,7 +47,7 @@ sub make_builder {
 
 sub search {
     my ($self,$params) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my $builder = $self->make_builder;
     $self->setup_query($builder,$params);
     my $results = $self->do_query($builder,$params);
@@ -122,7 +122,7 @@ sub setup_query {
 
 sub do_query {
     my ($self,$builder,$params) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my %results = %$params;
     my $sql = $builder->sql;
     my ($per_page, $page_num) = @{$params}{qw(per_page page_num)};

--- a/html/pfappserver/lib/pfappserver/Model/Services.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Services.pm
@@ -8,7 +8,7 @@ use pf::config;
 use pf::error;
 use pf::util;
 use pf::services;
-use Log::Log4perl qw(get_logger);
+use pf::log;
 use HTTP::Status qw(:constants :is);
 
 =head1 NAME

--- a/html/pfappserver/lib/pfappserver/Model/SoH.pm
+++ b/html/pfappserver/lib/pfappserver/Model/SoH.pm
@@ -16,6 +16,7 @@ use warnings;
 use Moose;
 use namespace::autoclean;
 
+use pf::log;
 use pf::config;
 use pf::error qw(is_error is_success);
 use pf::soh;

--- a/html/pfappserver/lib/pfappserver/Model/SoH.pm
+++ b/html/pfappserver/lib/pfappserver/Model/SoH.pm
@@ -32,7 +32,7 @@ This method must be called before any CRUD method.
 sub read {
     my ($self, $filter_id) = @_;
 
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my ($status, $status_msg) = ($STATUS::OK);
 
     eval {
@@ -59,7 +59,7 @@ sub read {
 sub filters {
     my ($self) = @_;
 
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my ($status, $status_msg) = ($STATUS::OK);
 
     eval {
@@ -82,7 +82,7 @@ sub filters {
 sub update {
     my ($self, $configViolationsModel, $filter_ref, $name, $action, $vid, $rules_ref) = @_;
 
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my ($status, $status_msg) = ($STATUS::OK);
 
     eval {
@@ -125,7 +125,7 @@ sub update {
 sub delete {
     my ($self, $configViolationsModel, $filter_ref) = @_;
 
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my ($status, $status_msg) = ($STATUS::OK);
 
     eval {
@@ -152,7 +152,7 @@ sub delete {
 sub create {
     my ($self, $configViolationsModel, $name, $action, $vid, $rules_ref) = @_;
 
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my ($status, $status_msg) = ($STATUS::OK);
 
     eval {

--- a/html/pfappserver/lib/pfappserver/Model/User.pm
+++ b/html/pfappserver/lib/pfappserver/Model/User.pm
@@ -350,7 +350,7 @@ sub createSingle {
     unless ($self->_userRoleAllowedForUser($data, $user)) {
         return ($STATUS::INTERNAL_SERVER_ERROR, 'Do not have permission to add the ALL role to a user');
     }
-   
+
 
     # Adding person (using modify in case person already exists)
     $result = person_modify($pid,
@@ -370,7 +370,7 @@ sub createSingle {
         # Add the registration window to the actions
         push(@{$data->{actions}}, { type => 'valid_from', value => $data->{valid_from} });
         push(@{$data->{actions}}, { type => 'expiration', value => $data->{expiration} });
-        $result = pf::password::generate($pid, 
+        $result = pf::password::generate($pid,
                                                    $data->{actions},
                                                    $data->{password});
         if ($result) {
@@ -395,7 +395,7 @@ sub _userRoleAllowedForUser {
     my ($self, $data, $user) = @_;
     #If the user has the ALL role then they are good
     return 1 if any { 'ALL' eq $_ } $user->roles;
-    #User does not have the role of ALL then it cannot create a user with the same role 
+    #User does not have the role of ALL then it cannot create a user with the same role
     return none { __doesActionHaveAllAccessLevel($_) } @{$data->{actions} || []};
 }
 
@@ -451,7 +451,7 @@ sub createMultiple {
             # Add the registration window to the actions
             push(@{$data->{actions}}, { type => 'valid_from', value => $data->{valid_from} });
             push(@{$data->{actions}}, { type => 'expiration', value => $data->{expiration} });
-            $result = pf::password::generate($pid, 
+            $result = pf::password::generate($pid,
                                                        $data->{actions});
             if ($result) {
                 push(@users, { pid => $pid, email => $data->{email}, password => $result });
@@ -544,7 +544,7 @@ sub importCSV {
                 # The registration window is add to the actions
                 push(@{$data->{actions}}, { type => 'valid_from', value => $data->{valid_from} });
                 push(@{$data->{actions}}, { type => 'expiration', value => $data->{expiration} });
-                $result = pf::password::generate($pid, 
+                $result = pf::password::generate($pid,
                                                            $data->{actions},
                                                            $row->[$index{'c_password'}]);
                 push(@users, { pid => $pid, email => $person{email}, password => $result });
@@ -631,7 +631,7 @@ sub bulkApplyRole {
 sub bulkApplyViolation {
     my ($self, $violation_id, @ids) = @_;
     my $count = 0;
-    my $logger = get_logger;
+    my $logger = get_logger();
     foreach my $mac (map {$_->{mac}} map {person_nodes($_)} @ids  ) {
         my ($last_id) = violation_add( $mac, $violation_id);
         $count++ if $last_id > 0;;

--- a/html/pfappserver/lib/pfappserver/Model/User.pm
+++ b/html/pfappserver/lib/pfappserver/Model/User.pm
@@ -119,7 +119,7 @@ sub _make_actions {
 sub countAll {
     my ( $self, %params ) = @_;
 
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my ($status, $status_msg);
 
     my $count;
@@ -143,7 +143,7 @@ sub countAll {
 sub search {
     my ( $self, %params ) = @_;
 
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my ($status, $status_msg);
 
     my @users;
@@ -168,7 +168,7 @@ Return the nodes associated to the person ID.
 sub nodes {
     my ( $self, $pid ) = @_;
 
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my ($status, $status_msg);
 
     my @nodes;
@@ -193,7 +193,7 @@ Return the violations associated to the person ID.
 sub violations {
     my ($self, $pid) = @_;
 
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my ($status, $status_msg);
 
     my @violations;
@@ -216,7 +216,7 @@ sub violations {
 
 sub update {
     my ($self, $pid, $user_ref, $user) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     unless ($self->_userRoleAllowedForUser($user_ref, $user)) {
         return ($STATUS::INTERNAL_SERVER_ERROR, 'Do not have permission to add the ALL role to a user');
     }
@@ -245,7 +245,7 @@ sub update {
 sub update_actions {
     my ($self, $pid, $actions) = @_;
 
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my ($status, $status_msg) = ($STATUS::OK);
     my $tp = pf::password::view($pid);
     # Only update the actions if the user has an entry in password
@@ -264,7 +264,7 @@ sub update_actions {
 sub mail {
     my ($self, $c, $pids) = @_;
 
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my ($status, $status_msg) = ($STATUS::OK);
     my @users;
 
@@ -314,7 +314,7 @@ sub mail {
 sub delete {
     my ($self, $pid) = @_;
 
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my ($status, $status_msg) = ($STATUS::OK, 'The user was successfully deleted.');
 
     eval {
@@ -342,7 +342,7 @@ pf::web::guest::preregister
 sub createSingle {
     my ($self, $data, $user) = @_;
 
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my ($status, $result) = ($STATUS::CREATED);
     my $pid = $data->{pid};
     my @users = ();
@@ -421,7 +421,7 @@ pf::web::guest::preregister_multiple
 sub createMultiple {
     my ($self, $data, $user) = @_;
 
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     unless ($self->_userRoleAllowedForUser($data, $user)) {
         return ($STATUS::INTERNAL_SERVER_ERROR, 'Do not have permission to add the ALL role to a user');
     }
@@ -477,7 +477,7 @@ pf::web::guest::import_csv
 sub importCSV {
     my ($self, $data, $user) = @_;
 
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     unless ($self->_userRoleAllowedForUser($data, $user)) {
         return ($STATUS::INTERNAL_SERVER_ERROR, 'Do not have permission to add the ALL role to a user');
     }

--- a/html/pfappserver/lib/pfappserver/Model/UserAgent.pm
+++ b/html/pfappserver/lib/pfappserver/Model/UserAgent.pm
@@ -41,7 +41,7 @@ sub field_names {
 sub countAll {
     my ( $self,  %params ) = @_;
 
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my ( $status, $status_msg );
     my $count;
     eval {
@@ -63,7 +63,7 @@ sub countAll {
 sub search {
     my ( $self, %params ) = @_;
 
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my ($status, $status_msg);
 
     my @items;

--- a/html/pfappserver/lib/pfappserver/Model/UserAgent.pm
+++ b/html/pfappserver/lib/pfappserver/Model/UserAgent.pm
@@ -19,6 +19,7 @@ use namespace::autoclean;
 use Time::localtime;
 use Time::Local;
 
+use pf::log;
 use pf::config;
 use pf::error qw(is_error is_success);
 use pf::useragent qw(node_useragent_count_searchable node_useragent_view_all_searchable);

--- a/html/pfappserver/lib/pfappserver/PacketFence/Controller/Config/Authentication.pm
+++ b/html/pfappserver/lib/pfappserver/PacketFence/Controller/Config/Authentication.pm
@@ -18,7 +18,7 @@ use Moose;
 use namespace::autoclean;
 use POSIX;
 
-use Log::Log4perl qw(get_logger);
+use pf::log;
 use pf::authentication;
 use pfappserver::Form::Config::Authentication;
 

--- a/html/pfappserver/lib/pfappserver/PacketFence/Controller/Config/Fingerbank/Settings.pm
+++ b/html/pfappserver/lib/pfappserver/PacketFence/Controller/Config/Fingerbank/Settings.pm
@@ -14,6 +14,7 @@ Customizations can be made using L<pfappserver::Controller::Config::Fingerbank::
 
 use Moose;  # automatically turns on strict and warnings
 use namespace::autoclean;
+use pf::log;
 use fingerbank::Config;
 use pf::fingerbank;
 
@@ -27,7 +28,7 @@ BEGIN { extends 'pfappserver::Base::Controller'; }
 
 sub check_for_api_key :Private {
     my ( $self, $c ) = @_;
-    my $logger = pf::log::get_logger;
+    my $logger = get_logger;
 
     if ( !fingerbank::Config::is_api_key_configured ) {
         $logger->warn("Fingerbank API key is not configured. Running with limited features");
@@ -38,7 +39,7 @@ sub check_for_api_key :Private {
 
 sub onboard :Local :Args(0) :AdminRole('FINGERBANK_UPDATE') {
     my ( $self, $c ) = @_;
-    my $logger = pf::log::get_logger;
+    my $logger = get_logger;
 
     $c->forward('index') if ( fingerbank::Config::is_api_key_configured );
 
@@ -84,7 +85,7 @@ sub onboard :Local :Args(0) :AdminRole('FINGERBANK_UPDATE') {
 
 sub index :Path :Args(0) :AdminRole('FINGERBANK_READ') {
     my ( $self, $c ) = @_;
-    my $logger = pf::log::get_logger;
+    my $logger = get_logger;
 
     $c->forward('check_for_api_key');
 

--- a/html/pfappserver/lib/pfappserver/PacketFence/Controller/Config/Fingerbank/Settings.pm
+++ b/html/pfappserver/lib/pfappserver/PacketFence/Controller/Config/Fingerbank/Settings.pm
@@ -28,7 +28,7 @@ BEGIN { extends 'pfappserver::Base::Controller'; }
 
 sub check_for_api_key :Private {
     my ( $self, $c ) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
 
     if ( !fingerbank::Config::is_api_key_configured ) {
         $logger->warn("Fingerbank API key is not configured. Running with limited features");
@@ -39,7 +39,7 @@ sub check_for_api_key :Private {
 
 sub onboard :Local :Args(0) :AdminRole('FINGERBANK_UPDATE') {
     my ( $self, $c ) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
 
     $c->forward('index') if ( fingerbank::Config::is_api_key_configured );
 
@@ -85,7 +85,7 @@ sub onboard :Local :Args(0) :AdminRole('FINGERBANK_UPDATE') {
 
 sub index :Path :Args(0) :AdminRole('FINGERBANK_READ') {
     my ( $self, $c ) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
 
     $c->forward('check_for_api_key');
 

--- a/html/pfappserver/lib/pfappserver/PacketFence/Controller/Configuration.pm
+++ b/html/pfappserver/lib/pfappserver/PacketFence/Controller/Configuration.pm
@@ -19,7 +19,7 @@ use Moose;
 use namespace::autoclean;
 use POSIX;
 use URI::Escape::XS;
-use Log::Log4perl qw(get_logger);
+use pf::log;
 
 use pf::util qw(load_oui download_oui);
 # imported only for the $TIME_MODIFIER_RE regex. Ideally shouldn't be

--- a/lib/pf/Authentication/Condition.pm
+++ b/lib/pf/Authentication/Condition.pm
@@ -9,6 +9,7 @@ pf::Authentication::Condition
 =cut
 
 use Moose;
+use pf::log;
 
 use pf::Authentication::constants;
 
@@ -52,7 +53,7 @@ sub matches {
             $time_v = int(sprintf("%d%02d%02d", $vyear, $vmon, $vday));
         }
 
-        my $logger = Log::Log4perl->get_logger( __PACKAGE__ );
+        my $logger = get_logger();
         $logger->trace(sprintf("Matching condition '%s %s %s' for value '$v'", $self->{'attribute'}, $self->{'operator'}, $self->{'value'}, $v));
 
         if ($self->{'operator'} eq $Conditions::EQUALS ||
@@ -97,7 +98,7 @@ sub matches {
             }
         }
         else {
-            my $logger = Log::Log4perl->get_logger( __PACKAGE__ );
+            my $logger = get_logger();
             $logger->error("Support for operator " . $self->{operator} . " is not implemented.");
         }
     }

--- a/lib/pf/Authentication/Source.pm
+++ b/lib/pf/Authentication/Source.pm
@@ -10,6 +10,7 @@ We must at least always have one rule defined, the fallback one.
 
 =cut
 
+use pf::log;
 use pf::config;
 use pf::constants;
 use Moose;
@@ -150,7 +151,7 @@ sub match {
     my ($self, $params) = @_;
 
     my $common_attributes = $self->common_attributes();
-    my $logger = Log::Log4perl->get_logger( __PACKAGE__ );
+    my $logger = get_logger();
 
     # Add current date & time to the list of parameters
     my ($sec,$min,$hour,$mday,$mon,$year) = localtime(time);
@@ -240,7 +241,6 @@ sub match_condition {
 
 sub search_attributes {
     my ($self,$username) = @_;
-    my $logger = Log::Log4perl->get_logger( __PACKAGE__ );
     my $realm;
     ($username,$realm) = strip_username($username) if isenabled($self->{'stripped_user_name'});
     return $self->search_attributes_in_subclass($username);
@@ -255,7 +255,7 @@ Returns a hashref that will be injected in pf::person::modify or 0 ($FALSE) if i
 =cut
 
 sub search_attributes_in_subclass {
-    my $logger = Log::Log4perl->get_logger( __PACKAGE__ );
+    my $logger = get_logger();
     $logger->debug("search_attributes_in_subclass is not supported on this source.");
     return $FALSE;
 }

--- a/lib/pf/Authentication/Source/HTTPSource.pm
+++ b/lib/pf/Authentication/Source/HTTPSource.pm
@@ -48,7 +48,7 @@ Method used to build a basic curl object
 
 sub _post_curl {
     my ($self, $uri, $post_fields) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
 
     $uri = $self->protocol."://".$self->host.":".$self->port."/".$uri;
 
@@ -104,6 +104,7 @@ sub available_attributes {
 Encodes a hash into URL/BODY parameters
 
 =cut
+
 sub encode_params {
     my %hash = @_;
     my @pairs;

--- a/lib/pf/Authentication/Source/HtpasswdSource.pm
+++ b/lib/pf/Authentication/Source/HtpasswdSource.pm
@@ -13,6 +13,7 @@ use pf::Authentication::constants;
 use pf::constants::authentication::messages;
 use pf::Authentication::Source;
 use pf::util;
+use pf::log;
 
 use Apache::Htpasswd;
 
@@ -45,7 +46,7 @@ sub available_attributes {
 sub authenticate {
     my ($self, $username, $password) = @_;
 
-    my $logger = Log::Log4perl->get_logger('pf::authentication');
+    my $logger = get_logger();
     my $password_file = $self->{'path'};
 
     if (! -r $password_file) {

--- a/lib/pf/Authentication/Source/KickboxSource.pm
+++ b/lib/pf/Authentication/Source/KickboxSource.pm
@@ -40,7 +40,7 @@ has '+email_required' => (isa => 'Str', is => 'rw', default => 'yes');
 
 sub authenticate {
     my ($self, $username, $password) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
 
     my $uri = $KICKBOX_HOST.$VERIFY_URI;
 

--- a/lib/pf/Authentication/Source/LDAPSource.pm
+++ b/lib/pf/Authentication/Source/LDAPSource.pm
@@ -8,6 +8,7 @@ pf::Authentication::Source::LDAPSource
 
 =cut
 
+use pf::log;
 use pf::constants qw($TRUE $FALSE);
 use pf::constants::authentication::messages;
 use pf::Authentication::constants;
@@ -59,6 +60,8 @@ has 'stripped_user_name' => (isa => 'Str', is => 'rw', default => 'yes');
 has '_cached_connection' => (is => 'rw');
 has 'cache_match' => ( isa => 'Bool', is => 'rw', default => 0 );
 
+our $logger = get_logger();
+
 =head1 METHODS
 
 =head2 available_attributes
@@ -86,7 +89,6 @@ sub available_attributes {
 
 sub authenticate {
   my ( $self, $username, $password ) = @_;
-  my $logger = Log::Log4perl->get_logger(__PACKAGE__);
 
   my ($connection, $LDAPServer, $LDAPServerPort ) = $self->_connect();
 
@@ -145,7 +147,6 @@ if all connections fail
 sub _connect {
   my $self = shift;
   my $connection;
-  my $logger = Log::Log4perl::get_logger(__PACKAGE__);
 
   my @LDAPServers = split(/\s*,\s*/, $self->{'host'});
   # uncomment the next line if you want the servers to be tried in random order
@@ -249,7 +250,6 @@ sub match_in_subclass {
 
     my ($self, $params, $rule, $own_conditions, $matching_conditions) = @_;
 
-    my $logger = Log::Log4perl->get_logger(__PACKAGE__);
     my $cached_connection = $self->_cached_connection;
     unless ( $cached_connection ) {
         return undef;
@@ -356,7 +356,6 @@ Test if we can bind and search to the LDAP server
 
 sub test {
   my ($self) = @_;
-  my $logger = Log::Log4perl->get_logger( __PACKAGE__ );
 
   # Connect
   my ( $connection, $LDAPServer, $LDAPServerPort ) = $self->_connect();
@@ -469,7 +468,6 @@ sub bind_with_credentials {
 
 sub search_attributes_in_subclass {
     my ($self, $username) = @_;
-    my $logger = Log::Log4perl->get_logger( __PACKAGE__ );
     my ($connection, $LDAPServer, $LDAPServerPort ) = $self->_connect();
     if (!defined($connection)) {
       return ($FALSE, $COMMUNICATION_ERROR_MSG);
@@ -493,7 +491,7 @@ sub search_attributes_in_subclass {
     else {
          $logger->info("User: '$username' found in the directory");
     }
-    
+
     my $info = {};
     foreach my $attrs (keys %ATTRIBUTES_MAP){
         foreach my $attr (split('\|',$ATTRIBUTES_MAP{$attrs})) {
@@ -530,7 +528,6 @@ Setup any resouces need for matching
 
 sub preMatchProcessing {
     my ($self) = @_;
-    my $logger = Log::Log4perl->get_logger(__PACKAGE__);
     my ( $connection, $LDAPServer, $LDAPServerPort ) = $self->_connect();
     if (! defined($connection)) {
         return undef;

--- a/lib/pf/Authentication/Source/OAuthSource.pm
+++ b/lib/pf/Authentication/Source/OAuthSource.pm
@@ -73,7 +73,7 @@ Lookup the person information from the authentication hash received during the O
 
 sub lookup_from_provider_info {
     my ( $self, $pid, $info ) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
     $logger->warn("Provider information lookup is not implemented on this OAuth source.");
 }
 

--- a/lib/pf/Authentication/Source/RADIUSSource.pm
+++ b/lib/pf/Authentication/Source/RADIUSSource.pm
@@ -11,6 +11,7 @@ pf::Authentication::Source::RADIUSSource
 use pf::constants qw($TRUE $FALSE);
 use pf::Authentication::constants;
 use pf::constants::authentication::messages;
+use pf::log;
 
 use Authen::Radius;
 
@@ -40,7 +41,7 @@ sub authenticate {
 
   my ( $self, $username, $password ) = @_;
 
-  my $logger = Log::Log4perl->get_logger('pf::authentication');
+  my $logger = get_logger();
 
   my $radius = new Authen::Radius(
     Host => "$self->{'host'}:$self->{'port'}",

--- a/lib/pf/Authentication/Source/SMSSource.pm
+++ b/lib/pf/Authentication/Source/SMSSource.pm
@@ -11,7 +11,6 @@ pf::Authentication::Source::SMSSource
 use pf::constants qw($TRUE $FALSE);
 use pf::Authentication::constants;
 
-use Log::Log4perl qw(get_logger);
 use Moose;
 extends 'pf::Authentication::Source';
 

--- a/lib/pf/ConfigStore.pm
+++ b/lib/pf/ConfigStore.pm
@@ -17,7 +17,7 @@ Is the Base class for accessing pf::config::cached
 use Moo;
 use namespace::autoclean;
 use pf::config::cached;
-use Log::Log4perl qw(get_logger);
+use pf::log;
 use List::MoreUtils qw(uniq);
 use pfconfig::manager;
 use pf::api::jsonrpcclient;

--- a/lib/pf/ConfigStore/Authentication.pm
+++ b/lib/pf/ConfigStore/Authentication.pm
@@ -83,7 +83,7 @@ deleted.
 
 sub deleteSource {
     my $id = shift;
-    my $logger = get_logger;
+    my $logger = get_logger();
 
     my %Profiles_Config;
     tie %Profiles_Config, 'pfconfig::cached_hash', 'config::Profiles';
@@ -110,7 +110,7 @@ Write the configuration file to disk
 
 sub writeAuthenticationConfigFile {
     my ($self) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
     my $cached_authentication_config = $self->cachedConfig;
     # Remove deleted sections
     my %new_sources = map { $_->id => undef } @auth_sources;

--- a/lib/pf/ConfigStore/Network.pm
+++ b/lib/pf/ConfigStore/Network.pm
@@ -14,6 +14,7 @@ pf::ConfigStore::Network
 
 use Moo;
 use namespace::autoclean;
+use pf::log;
 use pf::config;
 use pf::util qw(isenabled);
 use pf::file_paths;
@@ -75,7 +76,7 @@ For example
 
 sub getTypes {
     my ( $self, $interfaces_ref ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my %types;
     foreach my $interface ( sort keys(%$interfaces_ref) ) {
         # skip if we don't have a network address set
@@ -109,7 +110,7 @@ sub getNetworkAddress {
 
 sub cleanupNetworks {
     my ($self, $interfaces) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my $networks = $self->readAllIds();
     my %unused = map { $_ => 1 } @$networks;
     foreach my $interface (@$interfaces) {

--- a/lib/pf/Portal/ProfileFactory.pm
+++ b/lib/pf/Portal/ProfileFactory.pm
@@ -17,7 +17,7 @@ instantiate the objects.
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 
 use pf::config;
 use pf::node;
@@ -40,7 +40,7 @@ tie our $PROFILE_FILTER_ENGINE , 'pfconfig::cached_scalar' => 'FilterEngine::Pro
 
 sub instantiate {
     my ( $self, $mac, $options ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     $options ||= {};
     if (defined($options->{'portal'})) {
         $logger->info("Instantiate profile ".$options->{'portal'});

--- a/lib/pf/Portal/Session.pm
+++ b/lib/pf/Portal/Session.pm
@@ -24,7 +24,7 @@ use CGI::Session::Driver::chi;
 use pf::CHI;
 use HTML::Entities;
 use Locale::gettext qw(bindtextdomain textdomain bind_textdomain_codeset);
-use Log::Log4perl;
+use pf::log;
 use POSIX qw(locale_h); #qw(setlocale);
 use Readonly;
 use URI::Escape::XS qw(uri_escape uri_unescape);
@@ -61,7 +61,7 @@ our $EXPIRES_IN = pf::CHI->config->{"storage"}{"httpd.portal"}{"expires_in"};
 
 sub new {
     my ( $class, %argv ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     $logger->debug("instantiating new ". __PACKAGE__ . " object");
 
     my $self = bless {}, $class;
@@ -191,7 +191,7 @@ sub _initializeStash {
 
 sub _initializeI18n {
     my ($self) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my ($locale) = $self->getLanguages();
     $logger->debug("Setting locale to $locale");
@@ -233,7 +233,7 @@ Either directly connected or through a proxy.
 
 sub _resolveIp {
     my ($self) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     $logger->trace("resolving client IP");
 
     # we fetch CGI's remote address
@@ -531,7 +531,7 @@ of the configuration is returned.
 
 sub getLanguages {
     my ($self) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my ($lang, @languages);
     #my $authorized_locales_txt = $Config{'general'}{'locale'};

--- a/lib/pf/Portal/Session.pm
+++ b/lib/pf/Portal/Session.pm
@@ -38,7 +38,6 @@ use pf::util;
 use pf::web::constants;
 use pf::web::util;
 use pf::web::constants;
-use pf::log;
 use pf::activation qw(view_by_code);
 
 =head1 CONSTANTS

--- a/lib/pf/SearchBuilder.pm
+++ b/lib/pf/SearchBuilder.pm
@@ -43,6 +43,7 @@ pf::SearchBuilder
 
 use Moose;
 use namespace::autoclean;
+use pf::log;
 use pf::db qw(get_db_handle);
 use Scalar::Util qw(looks_like_number);
 BEGIN {
@@ -219,7 +220,7 @@ sub _where_clause {
 
 sub _add_implict_and {
     my ($self) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     if($self->has_where_clause_elements) {
         my $last_elem = $self->last_where_clause_element;
         if($last_elem eq ')' || ! exists $WHERE_SINGLE_OPS{$last_elem} ) {
@@ -517,7 +518,7 @@ sub format_from_on {
 sub _format_from_on {
     my ($self, $arg) = @_;
     my $clause = '';
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my $type = ref($arg);
     if ($type eq 'HASH') {
         $clause = $self->format_column($arg);

--- a/lib/pf/Switch.pm
+++ b/lib/pf/Switch.pm
@@ -18,7 +18,7 @@ use warnings;
 use Carp;
 use Data::Dumper;
 use Net::SNMP;
-use Log::Log4perl;
+use pf::log;
 use Try::Tiny;
 
 our $VERSION = 2.10;
@@ -53,7 +53,7 @@ Returns 1 if switch type supports floating network devices
 
 sub supportsFloatingDevice {
     my ( $this ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     $logger->error("Floating devices are not supported on switch type " . ref($this));
     return $FALSE;
@@ -67,7 +67,7 @@ Returns 1 if switch type supports external captive portal
 
 sub supportsExternalPortal {
     my ( $this ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     $logger->debug("External captive portal is not supported on switch type " . ref($this));
     return $FALSE;
@@ -81,7 +81,7 @@ Returns 1 if switch type supports web form registration (for release of the exte
 
 sub supportsWebFormRegistration {
     my ( $this ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     $logger->debug("Web form registration is not supported on switch type " . ref($this));
     return $FALSE;
@@ -95,7 +95,7 @@ Returns 1 if switch type supports Wired MAC Authentication (Wired Access Authori
 
 sub supportsWiredMacAuth {
     my ( $this ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     $logger->error(
         "Wired MAC Authentication (Wired Access Authorization through RADIUS) "
@@ -110,7 +110,7 @@ sub supportsWiredMacAuth {
 
 sub supportsWiredDot1x {
     my ( $this ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     $logger->error(
         "Wired 802.1X is not supported on switch type " . ref($this) . ". "
@@ -127,7 +127,7 @@ Returns 1 if switch type supports Wireless MAC Authentication (RADIUS Authentica
 
 sub supportsWirelessMacAuth {
     my ( $this ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     $logger->error(
         "Wireless MAC Authentication is not supported on switch type " . ref($this) . ". "
@@ -142,7 +142,7 @@ sub supportsWirelessMacAuth {
 
 sub supportsWirelessDot1x {
     my ( $this ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     $logger->error(
         "Wireless 802.1X (WPA-Enterprise) is not supported on switch type " . ref($this) . ". "
@@ -157,7 +157,7 @@ sub supportsWirelessDot1x {
 
 sub supportsRadiusVoip {
     my ( $this ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     $logger->warn(
         "RADIUS Authentication of IP Phones is not supported on switch type " . ref($this) . ". "
@@ -172,7 +172,7 @@ sub supportsRadiusVoip {
 
 sub supportsRoleBasedEnforcement {
     my ( $this ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if (defined($this->{'_roles'}) && %{$this->{'_roles'}}) {
         $logger->warn(
@@ -184,7 +184,7 @@ sub supportsRoleBasedEnforcement {
 
 sub supportsAccessListBasedEnforcement {
     my ( $this ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->info("Access list based enforcement is not supported on network device type " . ref($this) . ". ");
     return $FALSE;
 }
@@ -195,7 +195,7 @@ sub supportsAccessListBasedEnforcement {
 
 sub supportsRoamingAccounting {
     my ( $this ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->info("Update of the locationlog based on accounting data is not supported on network device type " . ref($this) . ". ");
     return $FALSE;
 }
@@ -206,7 +206,7 @@ sub supportsRoamingAccounting {
 
 sub supportsSaveConfig {
     my ( $this ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     return $FALSE;
 }
 
@@ -218,7 +218,7 @@ Does the network device supports Cisco Discovery Protocol (CDP)
 
 sub supportsCdp {
     my ( $this ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     return $FALSE;
 }
 
@@ -230,7 +230,7 @@ Does the network device supports Link-Layer Discovery Protocol (LLDP)
 
 sub supportsLldp {
     my ( $this ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     return $FALSE;
 }
 
@@ -249,7 +249,7 @@ sub inlineCapabilities { return; }
 
 sub supportsMABFloatingDevices {
     my ( $this ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     return $FALSE;
 }
 
@@ -328,7 +328,7 @@ sub isUpLink {
 
 sub connectRead {
     my $this   = shift;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( defined( $this->{_sessionRead} ) ) {
         return 1;
     }
@@ -389,7 +389,7 @@ sub connectRead {
 
 sub disconnectRead {
     my $this   = shift;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !defined( $this->{_sessionRead} ) ) {
         return 1;
     }
@@ -407,7 +407,7 @@ It performs a write test to make sure that the write actually works.
 
 sub connectWriteTo {
     my ($this, $ip, $sessionKey,$port) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     # if connection already exists, no need to connect again
     return 1 if ( defined( $this->{$sessionKey} ) );
@@ -512,7 +512,7 @@ Closes an SNMP Write connection. Requires sessionKey stored in object (as when c
 
 sub disconnectWriteTo {
     my ($this, $sessionKey) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     return 1 if ( !defined( $this->{$sessionKey} ) );
 
@@ -557,7 +557,7 @@ Set a port to a VLAN validating some rules first then calling the switch's _setV
 
 sub setVlan {
     my ($this, $ifIndex, $newVlan, $switch_locker_ref, $presentPCMac) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->isProductionMode() ) {
         $logger->warn(
@@ -636,7 +636,7 @@ TODO: not implemented, currently only a nameholder
 
 sub setVlanWithName {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->warn("not implemented!");
     return;
 }
@@ -647,7 +647,7 @@ sub setVlanWithName {
 
 sub _setVlanByOnlyModifyingPvid {
     my ( $this, $ifIndex, $newVlan, $oldVlan, $switch_locker_ref ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectRead() ) {
         return 0;
     }
@@ -680,7 +680,7 @@ Get the switch-specific role of a given global role in switches.conf
 
 sub getRoleByName {
     my ($this, $roleName) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     # skip if not defined or empty
     return if (!defined($this->{'_roles'}) || !%{$this->{'_roles'}});
@@ -701,7 +701,7 @@ Input: VLAN name (as in switches.conf)
 
 sub getVlanByName {
     my ($this, $vlanName) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     if (!defined($this->{'_vlans'}) || !defined($this->{'_vlans'}->{$vlanName})) {
         # VLAN name doesn't exist
@@ -727,7 +727,7 @@ sub getVlanByName {
 
 sub getAccessListByName {
     my ($this, $access_list_name) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     # skip if not defined or empty
     return if (!defined($this->{'_access_lists'}) || !%{$this->{'_access_lists'}});
@@ -749,7 +749,7 @@ Input: ifIndex, VLAN name (as in switches.conf), switch lock
 
 sub setVlanByName {
     my ($this, $ifIndex, $vlanName, $switch_locker_ref) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     if (!exists($this->{"_".$vlanName})) {
         # VLAN name doesn't exist
@@ -771,7 +771,7 @@ sub setVlanByName {
 
 sub getIfOperStatus {
     my ( $this, $ifIndex ) = @_;
-    my $logger           = Log::Log4perl::get_logger( ref($this) );
+    my $logger           = $this->logger;
     my $oid_ifOperStatus = '1.3.6.1.2.1.2.2.1.8';
     if ( !$this->connectRead() ) {
         return 0;
@@ -801,7 +801,7 @@ sub setMacDetectionVlan {
 
 sub getAlias {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectRead() ) {
         return '';
     }
@@ -818,7 +818,7 @@ sub getAlias {
 
 sub getSwitchLocation {
     my ( $this ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     return if ( !$this->connectRead() );
 
     my $OID_sysLocation = '1.3.6.1.2.1.1.6.0';
@@ -840,7 +840,7 @@ sub getSwitchLocation {
 
 sub setAlias {
     my ( $this, $ifIndex, $alias ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->info( "setting "
             . $this->{_id}
             . " ifIndex $ifIndex ifAlias from "
@@ -868,7 +868,7 @@ sub setAlias {
 
 sub getManagedIfIndexes {
     my $this   = shift;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my @managedIfIndexes;
     my @tmp_managedIfIndexes;
     my $ifTypeHashRef;
@@ -1025,7 +1025,7 @@ configured it's switches.conf to do VoIP.
 
 sub isVoIPEnabled {
     my ($self) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger();
 
     # if user set VoIPEnabled to true and we don't support it log a warning
     $logger->warn("VoIP is not supported on this network module") if ($self->{_VoIPEnabled} == $TRUE);
@@ -1042,7 +1042,7 @@ sub setVlanAllPort {
     my $oid_ifType = '1.3.6.1.2.1.2.2.1.3';    # MIB: ifTypes
     my @ports;
 
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->info("setting all ports of switch $this->{_id} to VLAN $vlan");
     if ( !$this->isProductionMode() ) {
         $logger->info(
@@ -1074,7 +1074,7 @@ sub setVlanAllPort {
 
 sub getMacAtIfIndex {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $i      = 0;
     my $start  = time;
     my @macArray;
@@ -1110,7 +1110,7 @@ fully-qualified domain name
 
 sub getSysName {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $OID_sysName = '1.3.6.1.2.1.1.5';                     # mib-2
     if ( !$this->connectRead() ) {
         return '';
@@ -1131,7 +1131,7 @@ sub getSysName {
 
 sub getIfDesc {
     my ( $this, $ifIndex ) = @_;
-    my $logger     = Log::Log4perl::get_logger( ref($this) );
+    my $logger     = $this->logger;
     my $OID_ifDesc = '1.3.6.1.2.1.2.2.1.2';                     # IF-MIB
     my $oid        = $OID_ifDesc . "." . $ifIndex;
     if ( !$this->connectRead() ) {
@@ -1153,7 +1153,7 @@ sub getIfDesc {
 
 sub getIfName {
     my ( $this, $ifIndex ) = @_;
-    my $logger     = Log::Log4perl::get_logger( ref($this) );
+    my $logger     = $this->logger;
     my $OID_ifName = '1.3.6.1.2.1.31.1.1.1.1';                  # IF-MIB
     my $oid        = $OID_ifName . "." . $ifIndex;
     if ( !$this->connectRead() ) {
@@ -1175,7 +1175,7 @@ sub getIfName {
 
 sub getIfNameIfIndexHash {
     my ($this)     = @_;
-    my $logger     = Log::Log4perl::get_logger( ref($this) );
+    my $logger     = $this->logger;
     my $OID_ifName = '1.3.6.1.2.1.31.1.1.1.1';                  # IF-MIB
     my %ifNameIfIndexHash;
     if ( !$this->connectRead() ) {
@@ -1196,7 +1196,7 @@ sub getIfNameIfIndexHash {
 
 sub setAdminStatus {
     my ( $this, $ifIndex, $status ) = @_;
-    my $logger            = Log::Log4perl::get_logger( ref($this) );
+    my $logger            = $this->logger;
     my $OID_ifAdminStatus = '1.3.6.1.2.1.2.2.1.7';
 
     if ( !$this->isProductionMode() ) {
@@ -1257,7 +1257,7 @@ This version here is a fallback stub, provide your implementation in a switch mo
 
 sub setPortSecurityEnableByIfIndex {
     my ( $this, $ifIndex, $trueFalse ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     $logger->error("Function not implemented for switch type " . ref($this));
     return ( 0 == 1 );
@@ -1265,7 +1265,7 @@ sub setPortSecurityEnableByIfIndex {
 
 sub setPortSecurityMaxSecureMacAddrByIfIndex {
     my ( $this, $ifIndex, $maxSecureMac ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     $logger->error("Function not implemented for switch type " . ref($this));
     return ( 0 == 1 );
@@ -1273,7 +1273,7 @@ sub setPortSecurityMaxSecureMacAddrByIfIndex {
 
 sub setPortSecurityViolationActionByIfIndex {
     my ( $this, $ifIndex, $action ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     $logger->error("Function not implemented for switch type " . ref($this));
     return ( 0 == 1 );
@@ -1305,7 +1305,7 @@ sub disablePortSecurityByIfIndex {
 
 sub setModeTrunk {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     $logger->error("Function not implemented for switch type " . ref($this));
     return ( 0 == 1 );
@@ -1313,7 +1313,7 @@ sub setModeTrunk {
 
 sub setTaggedVlans {
     my ( $this, $ifIndex, $taggedVlans ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     $logger->error("Function not implemented for switch type " . ref($this));
     return ( 0 == 1 );
@@ -1321,7 +1321,7 @@ sub setTaggedVlans {
 
 sub removeAllTaggedVlans {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     $logger->error("Function not implemented for switch type " . ref($this));
     return ( 0 == 1 );
@@ -1329,7 +1329,7 @@ sub removeAllTaggedVlans {
 
 sub isTrunkPort {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     $logger->debug("Unimplemented. Are you sure you are using the right switch module? Switch type: " . ref($this));
     return ( 0 == 1 );
@@ -1353,7 +1353,7 @@ Connects to the switch and configures the specified port to be RADIUS floating d
 
 sub enableMABFloatingDevice {
     my ($this, $ifIndex) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->warn("Cannot enable floating device on $this->{ip} on $ifIndex because this function is not implemented");
 }
 
@@ -1365,7 +1365,7 @@ Connects to the switch and removes the RADIUS floating device configuration
 
 sub disableMABFloatingDevice {
     my ($this, $ifIndex) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->warn("Cannot disable floating device on $this->{ip} on $ifIndex because this function is not implemented");
 }
 
@@ -1381,7 +1381,7 @@ Polls from all supported sources and will filter out duplicates.
 # implementations of getPhonesCDPAtIfIndex / getPhonesLLDPAtIfIndex
 sub getPhonesDPAtIfIndex {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->isVoIPEnabled() ) {
         $logger->debug( "VoIP not enabled on network device $this->{_id}: no phones returned" );
@@ -1419,7 +1419,7 @@ Is there at least one IP Phone on the given ifIndex.
 
 sub hasPhoneAtIfIndex {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->isVoIPEnabled() ) {
         $logger->debug( "VoIP not enabled on switch " . $this->{_id} );
@@ -1443,7 +1443,7 @@ sub hasPhoneAtIfIndex {
 
 sub isPhoneAtIfIndex {
     my ( $this, $mac, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->isVoIPEnabled() ) {
         $logger->debug( "VoIP not enabled on switch " . $this->{_id} );
         return 0;
@@ -1487,14 +1487,14 @@ sub isPhoneAtIfIndex {
 
 sub getMinOSVersion {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->error("function is NOT implemented");
     return -1;
 }
 
 sub getMaxMacAddresses {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->error("function is NOT implemented");
     return -1;
 }
@@ -1502,27 +1502,27 @@ sub getMaxMacAddresses {
 sub getSecureMacAddresses {
     my ( $this, $ifIndex ) = @_;
     my $secureMacAddrHashRef = {};
-    my $logger               = Log::Log4perl::get_logger( ref($this) );
+    my $logger               = $this->logger;
     return $secureMacAddrHashRef;
 }
 
 sub getAllSecureMacAddresses {
     my ($this)               = @_;
-    my $logger               = Log::Log4perl::get_logger( ref($this) );
+    my $logger               = $this->logger;
     my $secureMacAddrHashRef = {};
     return $secureMacAddrHashRef;
 }
 
 sub authorizeMAC {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->error("function is NOT implemented");
     return 1;
 }
 
 sub _authorizeMAC {
     my ( $this, $ifIndex, $mac, $authorize, $vlan ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->error("function is NOT implemented");
     return 1;
 }
@@ -1592,7 +1592,7 @@ sub _authorizeCurrentMacWithNewVlan {
 
 sub getRegExpFromList {
     my ( $this, @list ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     my %decompHash;
     foreach my $item (@list) {
@@ -1733,7 +1733,7 @@ sub reverseBitmask {
 
 sub getSysUptime {
     my ($this)        = @_;
-    my $logger        = Log::Log4perl::get_logger( ref($this) );
+    my $logger        = $this->logger;
     my $oid_sysUptime = '1.3.6.1.2.1.1.3.0';
     if ( !$this->connectRead() ) {
         return '';
@@ -1750,7 +1750,7 @@ sub getSysUptime {
 
 sub getIfType {
     my ( $this, $ifIndex ) = @_;
-    my $logger     = Log::Log4perl::get_logger( ref($this) );
+    my $logger     = $this->logger;
     my $OID_ifType = '1.3.6.1.2.1.2.2.1.3';                     #IF-MIB
     if ( !$this->connectRead() ) {
         return 0;
@@ -1767,7 +1767,7 @@ sub getIfType {
 
 sub _getMacAtIfIndex {
     my ( $this, $ifIndex, $vlan ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my @macArray;
     if ( !$this->connectRead() ) {
         return @macArray;
@@ -1789,7 +1789,7 @@ sub _getMacAtIfIndex {
 
 sub getAllDot1dBasePorts {
     my ( $this, @ifIndexes ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !@ifIndexes ) {
         @ifIndexes = $this->getManagedIfIndexes();
     }
@@ -1823,7 +1823,7 @@ sub getAllDot1dBasePorts {
 
 sub getDot1dBasePortForThisIfIndex {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $OID_dot1dBasePortIfIndex = '1.3.6.1.2.1.17.1.4.1.2';    #BRIDGE-MIB
     my $dot1dBasePort            = undef;
     if ( !$this->connectRead() ) {
@@ -1847,7 +1847,7 @@ sub getDot1dBasePortForThisIfIndex {
 
 sub getAllIfDesc {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $ifDescHashRef;
     my $OID_ifDesc = '1.3.6.1.2.1.2.2.1.2';    # IF-MIB
 
@@ -1868,7 +1868,7 @@ sub getAllIfDesc {
 
 sub getAllIfType {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $ifTypeHashRef;
     my $OID_ifType = '1.3.6.1.2.1.2.2.1.3';
 
@@ -1889,7 +1889,7 @@ sub getAllIfType {
 
 sub getAllVlans {
     my ( $this, @ifIndexes ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $vlanHashRef;
     if ( !@ifIndexes ) {
         @ifIndexes = $this->getManagedIfIndexes();
@@ -1921,7 +1921,7 @@ sub getAllVlans {
 
 sub getVoiceVlan {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( $this->isVoIPEnabled() ) {
         $logger->error("function is NOT implemented");
         return -1;
@@ -1935,7 +1935,7 @@ sub getVoiceVlan {
 
 sub getVlan {
     my ( $this, $ifIndex ) = @_;
-    my $logger        = Log::Log4perl::get_logger( ref($this) );
+    my $logger        = $this->logger;
     my $OID_dot1qPvid = '1.3.6.1.2.1.17.7.1.4.5.1.1';           # Q-BRIDGE-MIB
     if ( !$this->connectRead() ) {
         return 0;
@@ -1958,7 +1958,7 @@ sub getVlan {
 
 sub getVlans {
     my $this   = shift;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $OID_dot1qVlanStaticName = '1.3.6.1.2.1.17.7.1.4.3.1.1';  #Q-BRIDGE-MIB
     my $vlans                   = {};
     if ( !$this->connectRead() ) {
@@ -1986,7 +1986,7 @@ sub getVlans {
 
 sub isDefinedVlan {
     my ( $this, $vlan ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $OID_dot1qVlanStaticName = '1.3.6.1.2.1.17.7.1.4.3.1.1';  #Q-BRIDGE-MIB
     if ( !$this->connectRead() ) {
         return 0;
@@ -2009,7 +2009,7 @@ sub isDefinedVlan {
 sub getMacBridgePortHash {
     my $this   = shift;
     my $vlan   = shift || '';
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $OID_dot1qTpFdbPort = '1.3.6.1.2.1.17.7.1.2.2.1.2';    #Q-BRIDGE-MIB
     my %macBridgePortHash  = ();
     if ( !$this->connectRead() ) {
@@ -2044,7 +2044,7 @@ sub getMacBridgePortHash {
 
 sub getHubs {
     my $this              = shift;
-    my $logger            = Log::Log4perl::get_logger( ref($this) );
+    my $logger            = $this->logger;
     my @upLinks           = $this->getUpLinks();
     my $hubPorts          = {};
     my %macBridgePortHash = $this->getMacBridgePortHash();
@@ -2078,7 +2078,7 @@ sub getHubs {
 
 sub getIfIndexForThisMac {
     my ( $this, $mac ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $oid_mac = mac2oid($mac);
 
     if (!defined($oid_mac)) {
@@ -2120,7 +2120,7 @@ sub getMacAddrVlan {
     my @upLinks = $this->getUpLinks();
     my %ifIndexMac;
     my %macVlan;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     my $OID_dot1qTpFdbPort = '1.3.6.1.2.1.17.7.1.2.2.1.2';    #Q-BRIDGE-MIB
     if ( !$this->connectRead() ) {
@@ -2167,7 +2167,7 @@ sub getMacAddrVlan {
 
 sub getAllMacs {
     my ( $this, @ifIndexes ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !@ifIndexes ) {
         @ifIndexes = $this->getManagedIfIndexes();
     }
@@ -2211,7 +2211,7 @@ sub getAllMacs {
 
 sub getAllIfOctets {
     my ( $this, @ifIndexes ) = @_;
-    my $logger          = Log::Log4perl::get_logger( ref($this) );
+    my $logger          = $this->logger;
     my $oid_ifInOctets  = '1.3.6.1.2.1.2.2.1.10';
     my $oid_ifOutOctets = '1.3.6.1.2.1.2.2.1.16';
     my $ifOctetsHashRef;
@@ -2269,7 +2269,7 @@ sub isNewerVersionThan {
 # TODO move out to a util package
 sub generateFakeMac {
     my ($this, $is_voice_vlan, $ifIndex) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     # generating a fixed 6 digit string with ifIndex (zero filled)
     my $zero_filled_ifIndex = sprintf('%06d', $ifIndex);
@@ -2308,7 +2308,7 @@ Returns an array of port ifIndex or -1 on failure
 sub getUpLinks {
     my ($this) = @_;
     my @upLinks;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( lc(@{ $this->{_uplink} }[0]) eq 'dynamic' ) {
         $logger->warn( "Warning: for switch "
@@ -2326,14 +2326,14 @@ sub getUpLinks {
 sub getVlanFdbId {
     my ( $this, $vlan ) = @_;
     my $OID_dot1qVlanFdbId = '1.3.6.1.2.1.17.7.1.4.2.1.3.0';    #Q-BRIDGE-MIB
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     return $vlan;
 }
 
 sub isIfLinkUpDownTrapEnable {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectRead() ) {
         return 0;
     }
@@ -2347,7 +2347,7 @@ sub isIfLinkUpDownTrapEnable {
 
 sub setIfLinkUpDownTrapEnable {
     my ( $this, $ifIndex, $enable ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->isProductionMode() ) {
         $logger->info("not in production mode ... we won't change this port ifLinkUpDownTrapEnable");
@@ -2403,7 +2403,7 @@ is_dot1x - set to 1 if special dot1x de-authentication is required
 
 sub deauthenticateMac {
     my ($this, $mac, $is_dot1x) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
     my ($switchdeauthMethod, $deauthTechniques) = $this->deauthTechniques($this->{_deauthMethod});
     $this->$deauthTechniques($mac);
 }
@@ -2431,7 +2431,7 @@ Allows callers to refer to this implementation even though someone along the way
 
 sub _dot1xPortReauthenticate {
     my ($this, $ifIndex) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     $logger->info("Trying generic MIB to force 802.1x port re-authentication. Your mileage may vary. "
         . "If it doesn't work open a bug report with your hardware type.");
@@ -2464,7 +2464,7 @@ Default fallback implementation: we just return the NAS-Port as ifIndex.
 
 sub NasPortToIfIndex {
     my ($this, $nas_port) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     $logger->trace("Fallback implementation. Returning NAS-Port as ifIndex: $nas_port");
     return $nas_port;
@@ -2480,7 +2480,7 @@ Default behavior is to bounce the port
 
 sub handleReAssignVlanTrapForWiredMacAuth {
     my ($this, $ifIndex, $mac) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     # TODO extract that behavior in a method call in pf::vlan so it can be overridden easily
 
@@ -2511,7 +2511,7 @@ We support also:
 
 sub extractSsid {
     my ($this, $radius_request) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     # it's put in Called-Station-Id
     # ie: Called-Station-Id = "aa-bb-cc-dd-ee-ff:Secure SSID" or "aa:bb:cc:dd:ee:ff:Secure SSID"
@@ -2543,7 +2543,7 @@ Get Voice over IP RADIUS Vendor Specific Attribute (VSA).
 
 sub getVoipVsa {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     $logger->warn(
         "No RADIUS Vendor Specific Attributes (VSA) for module " . ref($this) . ". "
@@ -2560,7 +2560,7 @@ sub getVoipVsa {
 
 sub enablePortConfigAsTrunk {
     my ($this, $mac, $switch_port, $switch_locker_ref, $taggedVlans)  = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     # switchport mode trunk
     $logger->info("Setting port $switch_port as trunk.");
@@ -2583,7 +2583,7 @@ sub enablePortConfigAsTrunk {
 
 sub disablePortConfigAsTrunk {
     my ($this, $switch_port, $switch_locker_ref) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     # switchport mode access
     $logger->info("Setting port $switch_port as non trunk.");
@@ -2614,7 +2614,7 @@ See L<pf::Switch::Dlink::DWS_3026> for a usage example.
 
 sub getDeauthSnmpConnectionKey {
     my $this = shift;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if (defined($this->{_controllerIp}) && $this->{_controllerIp} ne '') {
 
@@ -2642,7 +2642,7 @@ Uses L<pf::util::radius> for the low-level RADIUS stuff.
 # TODO consider whether we should handle retries or not?
 sub radiusDisconnect {
     my ($self, $mac, $add_attributes_ref) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger();
 
     # initialize
     $add_attributes_ref = {} if (!defined($add_attributes_ref));
@@ -2722,7 +2722,7 @@ Default implementation.
 
 sub returnRadiusAccessAccept {
     my ($self, $vlan, $mac, $port, $connection_type, $user_name, $ssid, $wasInline, $user_role) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger();
 
     # Inline Vs. VLAN enforcement
     my $radius_reply_ref = {};
@@ -2763,7 +2763,7 @@ Return the reference to the deauth technique or the default deauth technique.
 
 sub deauthTechniques {
     my ($this, $method) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $default = $SNMP::SNMP;
     my %tech = (
         $SNMP::SNMP => 'deauthenticateMacDefault',
@@ -2798,7 +2798,7 @@ return Default Deauthentication Default technique
 
 sub deauthenticateMacDefault {
     my ( $this ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     $logger->warn("Unimplemented! First, make sure your configuration is ok. "
         . "If it is then we don't support your hardware. Open a bug report with your hardware type.");
@@ -2824,7 +2824,7 @@ Return the reference to the deauth technique or the default deauth technique.
 
 sub wiredeauthTechniques {
     my ($this, $method, $connection_type) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ($connection_type == $WIRED_802_1X) {
         my $default = $SNMP::SNMP;
         my %tech = (
@@ -2863,7 +2863,7 @@ Extract VLAN from the radius attributes.
 
 sub extractVLAN {
     my ($self, $radius_request) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger();
     $logger->warn("Not implemented");
     return;
 }
@@ -2903,7 +2903,7 @@ Extract all the param from the url.
 
 sub parseUrl {
     my ($self,$req) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger();
     $logger->warn("Not implemented");
     return;
 }
@@ -2916,7 +2916,7 @@ Get the accept form that will trigger the device registration on the switch
 
 sub getAcceptForm {
     my ( $self, $mac , $destination_url) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger();
     $logger->error("This function is not implemented.");
     return;
 }
@@ -2930,7 +2930,7 @@ The object isn't created at that point
 
 sub parseSwitchIdFromRequest {
     my ( $class, $req) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($class) );
+    my $logger = $class->logger;
     $logger->error("This function is not implemented.");
     return;
 }
@@ -2943,7 +2943,7 @@ Unimplemented base method meant to be overriden in switches that support SNMP tr
 
 sub parseTrap {
     my $self   = shift;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger();
     $logger->warn("SNMP trap handling not implemented for this type of switch.");
     my $trapHashRef;
     $trapHashRef->{'trapType'} = 'unknown';
@@ -2958,7 +2958,7 @@ Used to override L<pf::Connection::identifyType> behavior if needed on a per swi
 
 sub identifyConnectionType {
     my ( $self, $connection ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     return;
 }
@@ -2971,7 +2971,7 @@ Disables mac authentication bypass on the specified port
 
 sub disableMABByIfIndex {
     my ($self, $ifIndex) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger();
     $logger->error("This function is unimplemented.");
     return 0;
 }
@@ -2984,7 +2984,7 @@ Enables mac authentication bypass on the specified port
 
 sub enableMABByIfIndex {
     my ($self, $ifIndex) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger();
     $logger->error("This function is unimplemented.");
     return 0;
 }
@@ -3007,6 +3007,16 @@ sub deauth_source_ip {
     }
 }
 
+=item logger
+
+Return the current logger for the switch
+
+=cut
+
+sub logger {
+    my ($proto) = @_;
+    return get_logger( ref($proto) || $proto );
+}
 
 =back
 

--- a/lib/pf/Switch/Accton.pm
+++ b/lib/pf/Switch/Accton.pm
@@ -15,13 +15,13 @@ use strict;
 use warnings;
 
 use base ('pf::Switch');
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 sub getVersion {
     my ($this)          = @_;
     my $oid_swOpCodeVer = '1.3.6.1.4.1.259.6.10.74.1.1.3.1.6.1';
-    my $logger          = Log::Log4perl::get_logger( ref($this) );
+    my $logger          = $this->logger;
     if ( !$this->connectRead() ) {
         return '';
     }
@@ -39,7 +39,7 @@ sub getVersion {
 sub parseTrap {
     my ( $this, $trapString ) = @_;
     my $trapHashRef;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( $trapString
         =~ /^BEGIN TYPE ([23]) END TYPE BEGIN SUBTYPE 0 END SUBTYPE BEGIN VARIABLEBINDINGS \.1\.3\.6\.1\.2\.1\.2\.2\.1\.1\.(\d+) = INTEGER: \d+ END VARIABLEBINDINGS$/
         )
@@ -75,7 +75,7 @@ sub getTrunkPorts {
     my ($this) = @_;
     my $OID_vlanPortMode = '1.3.6.1.4.1.259.6.10.74.1.12.2.1.2';
     my @trunkPorts;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->connectRead() ) {
         return -1;
@@ -101,7 +101,7 @@ sub getTrunkPorts {
 
 sub getUpLinks {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my @upLinks;
 
     if ( lc(@{ $this->{_uplink} }[0]) eq 'dynamic' ) {
@@ -114,7 +114,7 @@ sub getUpLinks {
 
 sub _setVlan {
     my ( $this, $ifIndex, $newVlan, $oldVlan, $switch_locker_ref ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectRead() ) {
         return 0;
     }

--- a/lib/pf/Switch/Accton.pm
+++ b/lib/pf/Switch/Accton.pm
@@ -15,7 +15,6 @@ use strict;
 use warnings;
 
 use base ('pf::Switch');
-use pf::log;
 use Net::SNMP;
 
 sub getVersion {

--- a/lib/pf/Switch/Accton/ES3526XA.pm
+++ b/lib/pf/Switch/Accton/ES3526XA.pm
@@ -19,7 +19,7 @@ F<conf/switches.conf>
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 use base ('pf::Switch::Accton');
 
@@ -27,7 +27,7 @@ sub description { 'Accton ES3526XA' }
 
 sub getMinOSVersion {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     return '2.3.3.5';
 }
 

--- a/lib/pf/Switch/Accton/ES3526XA.pm
+++ b/lib/pf/Switch/Accton/ES3526XA.pm
@@ -19,7 +19,6 @@ F<conf/switches.conf>
 
 use strict;
 use warnings;
-use pf::log;
 use Net::SNMP;
 use base ('pf::Switch::Accton');
 

--- a/lib/pf/Switch/Accton/ES3528M.pm
+++ b/lib/pf/Switch/Accton/ES3528M.pm
@@ -13,7 +13,6 @@ to access SNMP enabled Accton::ES3528M switches.
 
 use strict;
 use warnings;
-use pf::log;
 use Net::SNMP;
 use base ('pf::Switch::Accton');
 

--- a/lib/pf/Switch/Accton/ES3528M.pm
+++ b/lib/pf/Switch/Accton/ES3528M.pm
@@ -13,7 +13,7 @@ to access SNMP enabled Accton::ES3528M switches.
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 use base ('pf::Switch::Accton');
 

--- a/lib/pf/Switch/AeroHIVE.pm
+++ b/lib/pf/Switch/AeroHIVE.pm
@@ -230,7 +230,7 @@ assigning VLANs and Roles at the same time.
 
 sub returnRadiusAccessAccept {
     my ($this, $vlan, $mac, $port, $connection_type, $user_name, $ssid, $wasInline, $user_role) = @_;
-    my $logger = $self->logger;
+    my $logger = $this->logger;
 
     my $radius_reply_ref = {};
 

--- a/lib/pf/Switch/AeroHIVE.pm
+++ b/lib/pf/Switch/AeroHIVE.pm
@@ -37,7 +37,7 @@ Nothing documented at this point.
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::Appliance::Session;
 use Try::Tiny;
 
@@ -77,7 +77,7 @@ obtain image version information from switch
 sub getVersion {
     my ($this) = @_;
     my $oid_AeroHiveSoftwareVersion = '1.3.6.1.2.1.1.1.0'; #
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectRead() ) {
         return '';
     }
@@ -102,7 +102,7 @@ Old roaming snmp support has been commented if you need to activate it then unco
 sub parseTrap {
     my ( $this, $trapString ) = @_;
     my $trapHashRef;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
 #    if ($trapString =~ /\.1\.3\.6\.1\.6\.3\.1\.1\.4\.1\.0 = OID: $AEROHIVE::ahConnectionChangeEvent/ ) {
 #        $trapHashRef->{'trapType'} = 'roaming';
@@ -145,7 +145,7 @@ New implementation using RADIUS Disconnect-Request.
 
 sub deauthenticateMacDefault {
     my ( $self, $mac, $is_dot1x ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
 
     if ( !$self->isProductionMode() ) {
         $logger->info("[$mac] (".$self->{'_id'}.") not in production mode... we won't perform deauthentication");
@@ -170,7 +170,7 @@ Warning: this code doesn't support elevating to privileged mode. See #900 and #1
 
 sub _deauthenticateMacTelnet {
     my ( $this, $mac ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->isProductionMode() ) {
         $logger->info("[$mac] (".$this->{'_id'}.") not in production mode ... we won't deauthenticate");
@@ -231,7 +231,7 @@ assigning VLANs and Roles at the same time.
 
 sub returnRadiusAccessAccept {
     my ($this, $vlan, $mac, $port, $connection_type, $user_name, $ssid, $wasInline, $user_role) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $self->logger;
 
     my $radius_reply_ref = {};
 
@@ -287,7 +287,7 @@ Return the reference to the deauth technique or the default deauth technique.
 
 sub deauthTechniques {
     my ($this, $method) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $default = $SNMP::RADIUS;
     my %tech = (
         $SNMP::RADIUS => 'deauthenticateMacDefault',

--- a/lib/pf/Switch/AeroHIVE.pm
+++ b/lib/pf/Switch/AeroHIVE.pm
@@ -37,7 +37,6 @@ Nothing documented at this point.
 use strict;
 use warnings;
 
-use pf::log;
 use Net::Appliance::Session;
 use Try::Tiny;
 

--- a/lib/pf/Switch/AeroHIVE/AP.pm
+++ b/lib/pf/Switch/AeroHIVE/AP.pm
@@ -17,7 +17,7 @@ This module is currently only a placeholder, see pf::Switch::AeroHIVE
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 
 use base ('pf::Switch::AeroHIVE');
 

--- a/lib/pf/Switch/AeroHIVE/AP.pm
+++ b/lib/pf/Switch/AeroHIVE/AP.pm
@@ -17,7 +17,6 @@ This module is currently only a placeholder, see pf::Switch::AeroHIVE
 
 use strict;
 use warnings;
-use pf::log;
 
 use base ('pf::Switch::AeroHIVE');
 

--- a/lib/pf/Switch/AeroHIVE/AP_http.pm
+++ b/lib/pf/Switch/AeroHIVE/AP_http.pm
@@ -25,7 +25,7 @@ Using the default success page of AeroHIVE works.
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 use pf::constants;
 use pf::config;
 use pf::node;
@@ -46,7 +46,7 @@ sub supportsWebFormRegistration { return $TRUE }
 
 sub parseUrl {
     my($self, $req) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
     # need to synchronize the locationlog event if we'll reject
     $self->synchronize_locationlog("0", "0", clean_mac($$req->param('Calling-Station-Id')),
         0, $WIRELESS_MAC_AUTH, clean_mac($$req->param('Calling-Station-Id')), $$req->param('ssid')
@@ -64,7 +64,7 @@ Overriding the default implementation for the external captive portal
 
 sub returnRadiusAccessAccept {
     my ($self, $vlan, $mac, $port, $connection_type, $user_name, $ssid, $wasInline, $user_role) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
 
     my $radius_reply_ref = {};
 
@@ -91,7 +91,7 @@ sub returnRadiusAccessAccept {
 
 sub getAcceptForm {
     my ( $self, $mac , $destination_url) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
     $logger->debug("[$mac] Creating web release form");
 
     my $node = node_view($mac);

--- a/lib/pf/Switch/AeroHIVE/AP_http.pm
+++ b/lib/pf/Switch/AeroHIVE/AP_http.pm
@@ -25,7 +25,6 @@ Using the default success page of AeroHIVE works.
 
 use strict;
 use warnings;
-use pf::log;
 use pf::constants;
 use pf::config;
 use pf::node;

--- a/lib/pf/Switch/Alcatel.pm
+++ b/lib/pf/Switch/Alcatel.pm
@@ -30,7 +30,7 @@ F<conf/switches.conf>
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 use Try::Tiny;
 use base ('pf::Switch');
@@ -69,7 +69,7 @@ For now it returns the voiceRole untagged since Alcatel supports multiple untagg
 
 sub getVoipVsa{
     my ($this) = @_; 
-    my $logger = Log::Log4perl::get_logger( ref($this) ); 
+    my $logger = $this->logger; 
     my $voiceRole = $this->getRoleByName('voice');
     $logger->info("Accepting phone with untagged Access-Accept on role $voiceRole");
     
@@ -88,7 +88,7 @@ Method to deauth a wired node with CoA.
 
 sub deauthenticateMacRadius {
     my ($this, $ifIndex,$mac) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
 
     # perform CoA
@@ -115,7 +115,7 @@ Return the reference to the deauth technique or the default deauth technique.
 
 sub wiredeauthTechniques { 
    my ($this, $method, $connection_type) = @_;
-   my $logger = Log::Log4perl::get_logger( ref($this) );
+   my $logger = $this->logger;
 
     if ($connection_type == $WIRED_802_1X) {
         my $default = $SNMP::RADIUS;
@@ -158,7 +158,7 @@ Uses L<pf::util::radius> for the low-level RADIUS stuff.
 
 sub radiusDisconnect {
     my ($self, $mac, $add_attributes_ref) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
 
     # initialize
     $add_attributes_ref = {} if (!defined($add_attributes_ref));

--- a/lib/pf/Switch/Alcatel.pm
+++ b/lib/pf/Switch/Alcatel.pm
@@ -30,7 +30,6 @@ F<conf/switches.conf>
 
 use strict;
 use warnings;
-use pf::log;
 use Net::SNMP;
 use Try::Tiny;
 use base ('pf::Switch');

--- a/lib/pf/Switch/AlliedTelesis.pm
+++ b/lib/pf/Switch/AlliedTelesis.pm
@@ -41,7 +41,7 @@ F<conf/switches.conf>
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 use base ('pf::Switch');
 
@@ -71,7 +71,7 @@ sub inlineCapabilities { return ($MAC,$PORT); }
 sub getVersion {
     my ($this) = @_;
     my $oid_alliedFirmwareVersion = '.1.3.6.1.4.1.89.2.4.0';
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectRead() ) {
         return '';
     }

--- a/lib/pf/Switch/AlliedTelesis.pm
+++ b/lib/pf/Switch/AlliedTelesis.pm
@@ -41,7 +41,6 @@ F<conf/switches.conf>
 
 use strict;
 use warnings;
-use pf::log;
 use Net::SNMP;
 use base ('pf::Switch');
 

--- a/lib/pf/Switch/AlliedTelesis/AT8000GS.pm
+++ b/lib/pf/Switch/AlliedTelesis/AT8000GS.pm
@@ -21,7 +21,6 @@ F<conf/switches.conf>
 
 use strict;
 use warnings;
-use pf::log;
 use Net::SNMP;
 use base ('pf::Switch::AlliedTelesis');
 

--- a/lib/pf/Switch/AlliedTelesis/AT8000GS.pm
+++ b/lib/pf/Switch/AlliedTelesis/AT8000GS.pm
@@ -21,7 +21,7 @@ F<conf/switches.conf>
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 use base ('pf::Switch::AlliedTelesis');
 

--- a/lib/pf/Switch/Amer.pm
+++ b/lib/pf/Switch/Amer.pm
@@ -21,13 +21,13 @@ use strict;
 use warnings;
 
 use base ('pf::Switch');
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 sub getVersion {
     my ($this)          = @_;
     my $oid_swOpCodeVer = '1.3.6.1.4.1.5929.11.48.1.1.1.1.1.1.0';
-    my $logger          = Log::Log4perl::get_logger( ref($this) );
+    my $logger          = $this->logger;
     if ( !$this->connectRead() ) {
         return '';
     }
@@ -45,7 +45,7 @@ sub getVersion {
 sub parseTrap {
     my ( $this, $trapString ) = @_;
     my $trapHashRef;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     
     #this trap is identical to Accton's 'newest' firmware release trap
     if ( $trapString =~ /BEGIN VARIABLEBINDINGS .+\|\.1\.3\.6\.1\.6\.3\.1\.1\.4\.1\.0 = OID: \.1\.3\.6\.1\.6\.3\.1\.1\.5\.([34])\|\.1\.3\.6\.1\.2\.1\.2\.2\.1\.1\.(\d+) =/ )
@@ -61,7 +61,7 @@ sub parseTrap {
 
 sub _setVlan {
     my ( $this, $ifIndex, $newVlan, $oldVlan, $switch_locker_ref ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->connectRead() ) {
         return 0;

--- a/lib/pf/Switch/Amer.pm
+++ b/lib/pf/Switch/Amer.pm
@@ -21,7 +21,6 @@ use strict;
 use warnings;
 
 use base ('pf::Switch');
-use pf::log;
 use Net::SNMP;
 
 sub getVersion {

--- a/lib/pf/Switch/Amer/SS2R24i.pm
+++ b/lib/pf/Switch/Amer/SS2R24i.pm
@@ -21,7 +21,7 @@ Developed and tested on SS2R24i running on firmware version 4.02-B15
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 use base ('pf::Switch::Amer');
 

--- a/lib/pf/Switch/Amer/SS2R24i.pm
+++ b/lib/pf/Switch/Amer/SS2R24i.pm
@@ -21,7 +21,6 @@ Developed and tested on SS2R24i running on firmware version 4.02-B15
 
 use strict;
 use warnings;
-use pf::log;
 use Net::SNMP;
 use base ('pf::Switch::Amer');
 

--- a/lib/pf/Switch/Anyfi.pm
+++ b/lib/pf/Switch/Anyfi.pm
@@ -19,7 +19,7 @@ use strict;
 use warnings;
 
 use base ('pf::Switch');
-use Log::Log4perl;
+use pf::log;
 
 use pf::constants;
 use pf::config;
@@ -46,7 +46,7 @@ This is called when we receive an SNMP-Trap for this device
 sub parseTrap {
     my ( $this, $trapString ) = @_;
     my $trapHashRef;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     $logger->debug("trap currently not handled");
     $trapHashRef->{'trapType'} = 'unknown';
@@ -60,7 +60,7 @@ sub parseTrap {
 
 sub getVersion {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->info("we don't know how to determine the version through SNMP !");
     return '1.4.6';
 }
@@ -76,7 +76,7 @@ New implementation using RADIUS Disconnect-Request.
 
 sub deauthenticateMacDefault {
     my ( $self, $mac, $is_dot1x ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
 
     if ( !$self->isProductionMode() ) {
         $logger->info("not in production mode... we won't perform deauthentication");

--- a/lib/pf/Switch/Anyfi.pm
+++ b/lib/pf/Switch/Anyfi.pm
@@ -19,7 +19,6 @@ use strict;
 use warnings;
 
 use base ('pf::Switch');
-use pf::log;
 
 use pf::constants;
 use pf::config;

--- a/lib/pf/Switch/Aruba.pm
+++ b/lib/pf/Switch/Aruba.pm
@@ -59,7 +59,6 @@ use warnings;
 use base ('pf::Switch');
 
 use POSIX;
-use pf::log;
 use Net::Telnet;
 use Try::Tiny;
 

--- a/lib/pf/Switch/Aruba.pm
+++ b/lib/pf/Switch/Aruba.pm
@@ -59,7 +59,7 @@ use warnings;
 use base ('pf::Switch');
 
 use POSIX;
-use Log::Log4perl;
+use pf::log;
 use Net::Telnet;
 use Try::Tiny;
 
@@ -100,7 +100,7 @@ sub inlineCapabilities { return ($MAC,$SSID); }
 sub getVersion {
     my ($this)       = @_;
     my $oid_sysDescr = '1.3.6.1.2.1.1.1.0';
-    my $logger       = Log::Log4perl::get_logger( ref($this) );
+    my $logger       = $this->logger;
     if ( !$this->connectRead() ) {
         return '';
     }
@@ -119,7 +119,7 @@ sub getVersion {
 sub parseTrap {
     my ( $this, $trapString ) = @_;
     my $trapHashRef;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     # wlsxNUserEntryDeAuthenticated: 1.3.6.1.4.1.14823.2.3.1.11.1.2.1017
 
@@ -147,7 +147,7 @@ New implementation using RADIUS Disconnect-Request.
 
 sub deauthenticateMacDefault {
     my ( $self, $mac, $is_dot1x ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
 
     if ( !$self->isProductionMode() ) {
         $logger->info("[$mac] (".$self->{'_id'}.") not in production mode... we won't perform deauthentication");
@@ -170,7 +170,7 @@ Here, we find out what submodule to call _dot1xDeauthenticateMAC or _deauthentic
 
 sub _deauthenticateMacWithTelnet {
     my ( $this, $mac, $is_dot1x ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->isProductionMode() ) {
         $logger->info("[$mac] (".$this->{'_id'}.") not in production mode ... we won't write to the bnsMobileStationTable");
@@ -201,7 +201,7 @@ sub _deauthenticateMacWithTelnet {
 #use constant AUTH_DOT1X => 4;
 #sub deauthenticateMac {
 #    my ($this, $mac) = @_;
-#    my $logger = Log::Log4perl::get_logger( ref($this) );
+#    my $logger = $this->logger;
 #    my $OID_nUserAuthenticationMethod = '1.3.6.1.4.1.14823.2.2.1.4.1.2.1.6'; # from WLSX-USER-MIB
 #    ...
 #    # Query the controller to get the type of authentication the user is using
@@ -251,7 +251,7 @@ De-authenticate a MAC from controller when user is in 802.1x mode using Telnet.
 
 sub _dot1xDeauthenticateMAC {
     my ($this, $mac) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     my $session = $this->getTelnetSession;
     if (!$session) {
@@ -289,7 +289,7 @@ and without an IP in the table.
 
 sub _deauthenticateMAC {
     my ($this, $mac) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
     my $OID_nUserApBSSID = '1.3.6.1.4.1.14823.2.2.1.4.1.2.1.11'; # from WLSX-USER-MIB
 
     # Query the controller to get the MAC address of the AP to which the client is associated
@@ -340,7 +340,7 @@ sub _deauthenticateMAC {
 # TODO: extract in a more generic place?
 sub getTelnetSession {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     # use telnet to deauthenticate the client
     # FIXME: we do not honor the $this->{_cliTransport} parameter
@@ -380,7 +380,7 @@ Aruba specific parser. See pf::Switch for base implementation.
 
 sub extractSsid {
     my ($this, $radius_request) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     # Aruba-Essid-Name VSA
     if (defined($radius_request->{'Aruba-Essid-Name'})) {
@@ -403,7 +403,7 @@ assigning VLANs and Roles at the same time.
 
 sub returnRadiusAccessAccept {
     my ($this, $vlan, $mac, $port, $connection_type, $user_name, $ssid, $wasInline, $user_role) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     my $radius_reply_ref = {};
 
@@ -455,7 +455,7 @@ Return the reference to the deauth technique or the default deauth technique.
 
 sub deauthTechniques {
     my ($this, $method) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $default = $SNMP::RADIUS;
     my %tech = (
         $SNMP::RADIUS => 'deauthenticateMacDefault',
@@ -482,7 +482,7 @@ Uses L<pf::util::radius> for the low-level RADIUS stuff.
 
 sub radiusDisconnect {
     my ($self, $mac, $add_attributes_ref) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
 
     # initialize
     $add_attributes_ref = {} if (!defined($add_attributes_ref));
@@ -575,7 +575,7 @@ Extract VLAN from the radius attributes.
 
 sub extractVLAN {
     my ($self, $radius_request) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
     return ($radius_request->{'Aruba-User-Vlan'});
 }
 
@@ -594,7 +594,7 @@ status code
 
 sub parseUrl {
     my($this, $req) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     return ($$req->param('mac'),$$req->param('essid'),$$req->param('ip'),$$req->param('url'),undef,undef);
 }
 

--- a/lib/pf/Switch/Aruba/Controller_200.pm
+++ b/lib/pf/Switch/Aruba/Controller_200.pm
@@ -13,7 +13,7 @@ to access SNMP enabled Aruba Controller 200
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 
 use base ('pf::Switch::Aruba');
 

--- a/lib/pf/Switch/Aruba/Controller_200.pm
+++ b/lib/pf/Switch/Aruba/Controller_200.pm
@@ -13,7 +13,6 @@ to access SNMP enabled Aruba Controller 200
 
 use strict;
 use warnings;
-use pf::log;
 
 use base ('pf::Switch::Aruba');
 

--- a/lib/pf/Switch/ArubaSwitch.pm
+++ b/lib/pf/Switch/ArubaSwitch.pm
@@ -27,7 +27,6 @@ F<conf/switches.conf>
 
 use strict;
 use warnings;
-use pf::log;
 use Net::SNMP;
 use Try::Tiny;
 use base ('pf::Switch');

--- a/lib/pf/Switch/ArubaSwitch.pm
+++ b/lib/pf/Switch/ArubaSwitch.pm
@@ -27,7 +27,7 @@ F<conf/switches.conf>
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 use Try::Tiny;
 use base ('pf::Switch');
@@ -62,7 +62,7 @@ sub inlineCapabilities { return ($MAC,$PORT); }
 sub getVersion {
     my ($this)       = @_;
     my $oid_sysDescr = '1.3.6.1.2.1.1.1.0';
-    my $logger       = Log::Log4perl::get_logger( ref($this) );
+    my $logger       = $this->logger;
     if ( !$this->connectRead() ) {
         return '';
     }
@@ -88,7 +88,7 @@ Allows callers to refer to this implementation even though someone along the way
 
 sub dot1xPortReauthenticate {
     my ($this, $ifIndex) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     return;
 }
@@ -103,7 +103,7 @@ All traps ignored
 sub parseTrap {
     my ( $this, $trapString ) = @_;
     my $trapHashRef;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     $logger->debug("trap ignored, not useful for switch");
     $trapHashRef->{'trapType'} = 'unknown';
@@ -144,7 +144,7 @@ Method to deauth a wired node with CoA.
 
 sub deauthenticateMacRadius {
     my ($this, $ifIndex,$mac) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
 
     # perform CoA
@@ -171,7 +171,7 @@ Return the reference to the deauth technique or the default deauth technique.
 
 sub wiredeauthTechniques {
     my ($this, $method, $connection_type) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ($connection_type == $WIRED_802_1X) {
         my $default = $SNMP::SNMP;
         my %tech = (
@@ -212,7 +212,7 @@ Uses L<pf::util::radius> for the low-level RADIUS stuff.
 
 sub radiusDisconnect {
     my ($self, $mac, $add_attributes_ref) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
 
     # initialize
     $add_attributes_ref = {} if (!defined($add_attributes_ref));

--- a/lib/pf/Switch/Avaya.pm
+++ b/lib/pf/Switch/Avaya.pm
@@ -30,7 +30,7 @@ Be aware of that if you start to see MAC authorization failures and report the p
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Nortel');
@@ -57,7 +57,7 @@ TODO: This list is incomplete
 sub parseTrap {
     my ( $this, $trapString ) = @_;
     my $trapHashRef;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( $trapString
         =~ /^BEGIN TYPE ([23]) END TYPE BEGIN SUBTYPE 0 END SUBTYPE BEGIN VARIABLEBINDINGS \.1\.3\.6\.1\.2\.1\.2\.2\.1\.1\.(\d+) = INTEGER: \d+\|\.1\.3\.6\.1\.2\.1\.2\.2\.1\.7\.\d+ = INTEGER: [^|]+\|\.1\.3\.6\.1\.2\.1\.2\.2\.1\.8\.\d+ = INTEGER: [^)]+\)/
         )
@@ -111,7 +111,7 @@ sub getIfIndex {
 
 sub getBoardPortFromIfIndex {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectRead() ) {
         return 0;
     }
@@ -141,7 +141,7 @@ sub getBoardPortFromIfIndexForSecurityStatus {
 
 sub getAllSecureMacAddresses {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $OID_s5SbsAuthCfgAccessCtrlType = '1.3.6.1.4.1.45.1.6.5.3.10.1.2.0';
 
     my $secureMacAddrHashRef = {};
@@ -170,7 +170,7 @@ sub getAllSecureMacAddresses {
 
 sub getSecureMacAddresses {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $OID_s5SbsAuthCfgAccessCtrlType = '1.3.6.1.4.1.45.1.6.5.3.10.1.2';
     my $secureMacAddrHashRef = {};
 
@@ -208,7 +208,7 @@ sub _authorizeMAC {
     my ( $this, $ifIndex, $mac, $authorize ) = @_;
     my $OID_s5SbsAuthCfgAccessCtrlType = '1.3.6.1.4.1.45.1.6.5.3.10.1.4';
     my $OID_s5SbsAuthCfgStatus         = '1.3.6.1.4.1.45.1.6.5.3.10.1.5';
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->isProductionMode() ) {
         $logger->info( "not in production mode ... we won't delete an entry from the SecureMacAddrTable" );
@@ -273,7 +273,7 @@ sub _authorizeMAC {
 
 sub getPhonesLLDPAtIfIndex {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my @phones;
     if ( !$this->isVoIPEnabled() ) {
         $logger->debug( "VoIP not enabled on switch "
@@ -354,7 +354,7 @@ Allows callers to refer to this implementation even though someone along the way
 
 sub deauthenticateMac {
     my ($this, $IfIndex, $mac) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
 
     my $oid_bseePortConfigMultiHostClearNeap = "1.3.6.1.4.1.45.5.3.3.1.19";
@@ -384,7 +384,7 @@ Return the reference to the deauth technique or the default deauth technique.
 
 sub wiredeauthTechniques {
     my ($this, $method, $connection_type) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ($connection_type == $WIRED_802_1X) {
         my $default = $SNMP::SNMP;
         my %tech = (
@@ -418,7 +418,7 @@ Method to deauth a wired node with CoA.
 
 sub deauthenticateMacRadius {
     my ($this, $ifIndex,$mac) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
 
     # perform CoA
@@ -439,7 +439,7 @@ Uses L<pf::util::radius> for the low-level RADIUS stuff.
 
 sub radiusDisconnect {
     my ($self, $mac, $add_attributes_ref) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
 
     # initialize
     $add_attributes_ref = {} if (!defined($add_attributes_ref));

--- a/lib/pf/Switch/Avaya.pm
+++ b/lib/pf/Switch/Avaya.pm
@@ -30,7 +30,6 @@ Be aware of that if you start to see MAC authorization failures and report the p
 use strict;
 use warnings;
 
-use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Nortel');

--- a/lib/pf/Switch/Avaya/ERS2500.pm
+++ b/lib/pf/Switch/Avaya/ERS2500.pm
@@ -33,7 +33,7 @@ Firmware series 4.3 is apparently fine.
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Avaya');

--- a/lib/pf/Switch/Avaya/ERS2500.pm
+++ b/lib/pf/Switch/Avaya/ERS2500.pm
@@ -33,7 +33,6 @@ Firmware series 4.3 is apparently fine.
 use strict;
 use warnings;
 
-use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Avaya');

--- a/lib/pf/Switch/Avaya/ERS4000.pm
+++ b/lib/pf/Switch/Avaya/ERS4000.pm
@@ -19,7 +19,6 @@ use strict;
 use warnings;
 
 use pf::Switch::constants;
-use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Avaya');

--- a/lib/pf/Switch/Avaya/ERS4000.pm
+++ b/lib/pf/Switch/Avaya/ERS4000.pm
@@ -19,7 +19,7 @@ use strict;
 use warnings;
 
 use pf::Switch::constants;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Avaya');

--- a/lib/pf/Switch/Avaya/ERS5000.pm
+++ b/lib/pf/Switch/Avaya/ERS5000.pm
@@ -18,7 +18,7 @@ This module is currently only a placeholder, see pf::SNMP::Avaya.
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Avaya');

--- a/lib/pf/Switch/Avaya/ERS5000.pm
+++ b/lib/pf/Switch/Avaya/ERS5000.pm
@@ -18,7 +18,6 @@ This module is currently only a placeholder, see pf::SNMP::Avaya.
 use strict;
 use warnings;
 
-use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Avaya');

--- a/lib/pf/Switch/Avaya/ERS5000_6x.pm
+++ b/lib/pf/Switch/Avaya/ERS5000_6x.pm
@@ -24,7 +24,7 @@ If the switch is stacked, the trap will come with the wrong ifIndex number.
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Avaya');

--- a/lib/pf/Switch/Avaya/ERS5000_6x.pm
+++ b/lib/pf/Switch/Avaya/ERS5000_6x.pm
@@ -24,7 +24,6 @@ If the switch is stacked, the trap will come with the wrong ifIndex number.
 use strict;
 use warnings;
 
-use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Avaya');

--- a/lib/pf/Switch/Avaya/WC.pm
+++ b/lib/pf/Switch/Avaya/WC.pm
@@ -35,7 +35,6 @@ use strict;
 use warnings;
 
 use base ('pf::Switch');
-use pf::log;
 
 use pf::constants;
 use pf::config;

--- a/lib/pf/Switch/Avaya/WC.pm
+++ b/lib/pf/Switch/Avaya/WC.pm
@@ -35,7 +35,7 @@ use strict;
 use warnings;
 
 use base ('pf::Switch');
-use Log::Log4perl;
+use pf::log;
 
 use pf::constants;
 use pf::config;
@@ -67,7 +67,7 @@ obtain image version information from switch
 sub getVersion {
     my ($this)        = @_;
     my $oid_s5ChasVer = '1.3.6.1.4.1.45.1.6.3.1.5.0';
-    my $logger        = Log::Log4perl::get_logger( ref($this) );
+    my $logger        = $this->logger;
 
     if ( !$this->connectRead() ) {
         return '';
@@ -90,7 +90,7 @@ All traps ignored
 sub parseTrap {
     my ( $this, $trapString ) = @_;
     my $trapHashRef;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     # example disassociate trap on MAC 00 1B B1 8B 82 13
     # BEGIN TYPE 0 END TYPE BEGIN SUBTYPE 0 END SUBTYPE BEGIN VARIABLEBINDINGS .1.3.6.1.2.1.1.3.0 = Timeticks: (865381) 2:24:13.81|.1.3.6.1.6.3.1.1.4.1.0 = OID: .1.3.6.1.4.1.388.14.5.1.7.1.6|.1.3.6.1.4.1.388.14.5.1.7.1.1 = Hex-STRING: 00 1B B1 8B 82 13 |.1.3.6.1.4.1.388.14.3.3.1.2.2.1.1 = Counter32: 1|.1.3.6.1.4.1.388.14.4.1.4.1.1.1 = INTEGER: 31|.1.3.6.1.4.1.388.14.4.1.4.1.1.2 = INTEGER: 4|.1.3.6.1.4.1.388.14.4.1.4.1.1.4 = STRING: "disassociated"|.1.3.6.1.4.1.388.14.4.1.4.1.1.5 = Hex-STRING: 07 DA 09 1B 09 25 0F 00 |.1.3.6.1.4.1.388.14.4.1.4.1.1.8 = INTEGER: 2 END VARIABLEBINDINGS
@@ -112,7 +112,7 @@ deauthenticateMacDefault a MAC address from wireless network (including 802.1x)
 
 sub deauthenticateMacDefault {
     my ($this, $mac) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
     my $oid_avWlanAssociatedClientDisassociateAction = '1.3.6.1.4.1.45.7.9.1.1.1.10';
 
     if ( !$this->isProductionMode() ) {
@@ -150,7 +150,7 @@ Return the reference to the deauth technique or the default deauth technique.
 
 sub deauthTechniques {
     my ($this, $method) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $default = $SNMP::SNMP;
     my %tech = (
         $SNMP::SNMP => 'deauthenticateMacDefault',

--- a/lib/pf/Switch/Belair.pm
+++ b/lib/pf/Switch/Belair.pm
@@ -39,7 +39,6 @@ use strict;
 use warnings;
 
 use base ('pf::Switch');
-use pf::log;
 
 use pf::constants;
 use pf::config;

--- a/lib/pf/Switch/Belair.pm
+++ b/lib/pf/Switch/Belair.pm
@@ -39,7 +39,7 @@ use strict;
 use warnings;
 
 use base ('pf::Switch');
-use Log::Log4perl;
+use pf::log;
 
 use pf::constants;
 use pf::config;
@@ -69,7 +69,7 @@ obtain image version information from switch
 sub getVersion {
     my ($this)       = @_;
     my $oid_beActiveBank = '.1.3.6.1.4.1.15768.3.1.1.3.1';
-    my $logger       = Log::Log4perl::get_logger( ref($this) );
+    my $logger       = $this->logger;
     if ( !$this->connectRead() ) {
         return '';
     }
@@ -99,7 +99,7 @@ All traps ignored
 sub parseTrap {
     my ( $this, $trapString ) = @_;
     my $trapHashRef;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     $logger->debug("trap currently not handled.  TrapString was: $trapString");
     $trapHashRef->{'trapType'} = 'unknown';
@@ -117,7 +117,7 @@ New implementation using RADIUS Disconnect-Request.
 
 sub deauthenticateMacDefault {
     my ( $self, $mac, $is_dot1x ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
 
     if ( !$self->isProductionMode() ) {
         $logger->info("not in production mode... we won't perform deauthentication");
@@ -136,7 +136,7 @@ Return the reference to the deauth technique or the default deauth technique.
 
 sub deauthTechniques {
     my ($this, $method) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $default = $SNMP::RADIUS;
     my %tech = (
         $SNMP::RADIUS => 'deauthenticateMacDefault',

--- a/lib/pf/Switch/Brocade.pm
+++ b/lib/pf/Switch/Brocade.pm
@@ -60,7 +60,7 @@ F<conf/switches.conf>
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 use base ('pf::Switch');
 
@@ -95,7 +95,7 @@ sub inlineCapabilities { return ($MAC,$PORT); }
 sub getVersion {
     my ($this) = @_;
     my $oid_snAgImgVer = '.1.3.6.1.4.1.1991.1.1.2.1.11';          #Proprietary Brocade MIB 1.3.6.1.4.1.1991 -> brcdIp
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectRead() ) {
         return '';
     }
@@ -124,7 +124,7 @@ Allows callers to refer to this implementation even though someone along the way
 
 sub dot1xPortReauthenticate {
     my ($this, $ifIndex, $mac) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
 
     my $oid_brcdDot1xAuthPortConfigPortControl = "1.3.6.1.4.1.1991.1.1.3.38.3.1.1.1"; # from brcdlp
@@ -163,7 +163,7 @@ All traps ignored
 sub parseTrap {
     my ( $this, $trapString ) = @_;
     my $trapHashRef;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     $logger->debug("trap ignored, not useful for switch");
     $trapHashRef->{'trapType'} = 'unknown';
@@ -179,7 +179,7 @@ Get Voice over IP RADIUS Vendor Specific Attribute (VSA).
 
 sub getVoipVsa {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
     return (
         'Foundry-MAC-Authent-needs-802.1x' => $FALSE,
         'Tunnel-Type'               => $RADIUS::VLAN,
@@ -210,7 +210,7 @@ Disabled by default.
 
 sub returnRadiusAccessAccept {
     my ($self, $vlan, $mac, $port, $connection_type, $user_name, $ssid, $wasInline, $user_role) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
 
     # VLAN enforcement
     my $radius_reply_ref = {

--- a/lib/pf/Switch/Brocade.pm
+++ b/lib/pf/Switch/Brocade.pm
@@ -60,7 +60,6 @@ F<conf/switches.conf>
 
 use strict;
 use warnings;
-use pf::log;
 use Net::SNMP;
 use base ('pf::Switch');
 

--- a/lib/pf/Switch/Cisco.pm
+++ b/lib/pf/Switch/Cisco.pm
@@ -15,7 +15,7 @@ use warnings;
 
 use Data::Dumper;
 use base ('pf::Switch');
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 use Net::Appliance::Session;
 use Try::Tiny;
@@ -43,7 +43,7 @@ TODO: This list is incomplete
 sub getVersion {
     my ($this)       = @_;
     my $oid_sysDescr = '1.3.6.1.2.1.1.1.0';
-    my $logger       = Log::Log4perl::get_logger( ref($this) );
+    my $logger       = $this->logger;
     if ( !$this->connectRead() ) {
         return '';
     }
@@ -133,7 +133,7 @@ sub isNewerVersionThan {
 sub parseTrap {
     my ( $this, $trapString ) = @_;
     my $trapHashRef;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     #link up/down
     if ( $trapString
@@ -311,7 +311,7 @@ sub parseTrap {
 
 sub getAllVlans {
     my ( $this, @ifIndexes ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $vlanHashRef;
     if ( !@ifIndexes ) {
         @ifIndexes = $this->getManagedIfIndexes();
@@ -360,7 +360,7 @@ sub getAllVlans {
 
 sub getVoiceVlan {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectRead() ) {
         return 0;
     }
@@ -383,7 +383,7 @@ sub getVoiceVlan {
 # to reproduce: bin/pfcmd_vlan -getVlan -ifIndex 999 -switch <ip>
 sub getVlan {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectRead() ) {
         return 0;
     }
@@ -409,7 +409,7 @@ sub getVlan {
 
 sub isLearntTrapsEnabled {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectRead() ) {
         return 0;
     }
@@ -431,7 +431,7 @@ sub setLearntTrapsEnabled {
 
     #1 means 'enabled', 2 means 'disabled'
     my ( $this, $ifIndex, $trueFalse ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectWrite() ) {
         return 0;
     }
@@ -450,7 +450,7 @@ sub setLearntTrapsEnabled {
 
 sub isRemovedTrapsEnabled {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectRead() ) {
         return 0;
     }
@@ -472,7 +472,7 @@ sub setRemovedTrapsEnabled {
 
     #1 means 'enabled', 2 means 'disabled'
     my ( $this, $ifIndex, $trueFalse ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectWrite() ) {
         return 0;
     }
@@ -491,7 +491,7 @@ sub setRemovedTrapsEnabled {
 
 sub isPortSecurityEnabled {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     #CISCO-PORT-SECURITY-MIB
     my $OID_cpsIfPortSecurityEnable = '1.3.6.1.4.1.9.9.315.1.2.1.1.1';
@@ -518,7 +518,7 @@ sub isPortSecurityEnabled {
 
 sub _setVlan {
     my ( $this, $ifIndex, $newVlan, $oldVlan, $switch_locker_ref ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->connectWrite() ) {
         return 0;
@@ -560,7 +560,7 @@ sub _setVlan {
 
 sub setTrunkPortNativeVlan {
     my ( $this, $ifIndex, $newVlan ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->connectWrite() ) {
         return 0;
@@ -583,7 +583,7 @@ sub setTrunkPortNativeVlan {
 # 4 => trunk
 sub getVmVlanType {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectRead() ) {
         return 0;
     }
@@ -606,7 +606,7 @@ sub getVmVlanType {
 
 sub setVmVlanType {
     my ( $this, $ifIndex, $type ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->info( "setting port $ifIndex vmVlanType from "
             . $this->getVmVlanType($ifIndex)
             . " to $type" );
@@ -639,7 +639,7 @@ sub getMacBridgePortHash {
     my $this              = shift;
     my $vlan              = shift || '';
     my %macBridgePortHash = ();
-    my $logger            = Log::Log4perl::get_logger( ref($this) );
+    my $logger            = $this->logger;
     my $OID_dot1dTpFdbPort       = '1.3.6.1.2.1.17.4.3.1.2';    #BRIDGE-MIB
     my $OID_dot1dBasePortIfIndex = '1.3.6.1.2.1.17.1.4.1.2';    #BRIDGE-MIB
 
@@ -744,7 +744,7 @@ sub getMacBridgePortHash {
 
 sub getIfIndexForThisMac {
     my ( $this, $mac ) = @_;
-    my $logger   = Log::Log4perl::get_logger( ref($this) );
+    my $logger   = $this->logger;
     my @macParts = split( ':', $mac );
     my @uplinks  = $this->getUpLinks();
     my $OID_dot1dTpFdbPort       = '1.3.6.1.2.1.17.4.3.1.2';    #BRIDGE-MIB
@@ -828,7 +828,7 @@ sub getIfIndexForThisMac {
 
 sub isMacInAddressTableAtIfIndex {
     my ( $this, $mac, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my @macParts = split( ':', $mac );
     my $OID_dot1dTpFdbPort       = '1.3.6.1.2.1.17.4.3.1.2';    #BRIDGE-MIB
     my $OID_dot1dBasePortIfIndex = '1.3.6.1.2.1.17.1.4.1.2';    #BRIDGE-MIB
@@ -914,7 +914,7 @@ sub isMacInAddressTableAtIfIndex {
 
 sub isTrunkPort {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $OID_vlanTrunkPortDynamicState
         = "1.3.6.1.4.1.9.9.46.1.6.1.1.13";    #CISCO-VTP-MIB
     if ( !$this->connectRead() ) {
@@ -939,7 +939,7 @@ sub isTrunkPort {
 
 sub setModeTrunk {
     my ( $this, $ifIndex, $enable ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $OID_vlanTrunkPortDynamicState = "1.3.6.1.4.1.9.9.46.1.6.1.1.13";    #CISCO-VTP-MIB
 
     # $mode = 1 -> switchport mode trunk
@@ -964,7 +964,7 @@ sub getVlans {
     my ($this)          = @_;
     my $vlans           = {};
     my $oid_vtpVlanName = '1.3.6.1.4.1.9.9.46.1.3.1.1.4.1';    #CISCO-VTP-MIB
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->connectRead() ) {
         return $vlans;
@@ -986,7 +986,7 @@ sub getVlans {
 sub isDefinedVlan {
     my ( $this, $vlan ) = @_;
     my $oid_vtpVlanName = '1.3.6.1.4.1.9.9.46.1.3.1.1.4.1';    #CISCO-VTP-MIB
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->connectRead() ) {
         return 0;
@@ -1012,7 +1012,7 @@ sub isNotUpLink {
 # traps causing concerns.
 sub getUpLinks {
     my ( $this ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     # not dynamic, return uplink list
     return @{ $this->{_uplink} } if ( lc(@{ $this->{_uplink} }[0]) ne 'dynamic' );
@@ -1083,7 +1083,7 @@ sub getMacAddr {
     my $command;
     my $session;
     my @macAddressTable;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     eval {
         $session = Net::Appliance::Session->new(
@@ -1125,7 +1125,7 @@ sub getMacAddr {
 
 sub getManagedIfIndexes {
     my $this   = shift;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my @managedIfIndexes;
     my @tmp_managedIfIndexes = $this->SUPER::getManagedIfIndexes();
     foreach my $ifIndex (@tmp_managedIfIndexes) {
@@ -1146,7 +1146,7 @@ sub getMacAddrVlan {
     my %macVlan;
     my @managedPorts = $this->getManagedPorts();
     my @macAddr;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     @macAddr = $this->getMacAddr(@managedPorts);
 
@@ -1184,7 +1184,7 @@ sub getMacAddrVlan {
 
 sub getAllMacs {
     my ( $this, @ifIndexes ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !@ifIndexes ) {
         @ifIndexes = $this->getManagedIfIndexes();
     }
@@ -1323,7 +1323,7 @@ sub getHubs {
     my $hubPorts;
     my @macAddr;
     my @managedPorts = $this->getManagedPorts();
-    my $logger       = Log::Log4perl::get_logger( ref($this) );
+    my $logger       = $this->logger;
 
     if (@managedPorts) {
 
@@ -1344,7 +1344,7 @@ sub getHubs {
 
 sub getPhonesCDPAtIfIndex {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my @phones;
     if ( !$this->isVoIPEnabled() ) {
         $logger->debug( "VoIP not enabled on switch "
@@ -1407,7 +1407,7 @@ Inspired by: http://www.notarus.net/networking/cisco_snmp_config.html#wrmem
 
 sub copyConfig {
     my ( $this, $src_type, $dest_type, $uri ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     # Validation
     die("Can't connect in SNMP Read to switch " . $this->{_ip}) if (!$this->connectRead());
@@ -1519,7 +1519,7 @@ At proof of concept stage. For now using SNMP is still preferred way to bounce a
 
 sub _radiusBounceMac {
     my ( $self, $mac ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
 
     if ( !$self->isProductionMode() ) {
         $logger->info("not in production mode... we won't perform port bounce");

--- a/lib/pf/Switch/Cisco/Aironet.pm
+++ b/lib/pf/Switch/Cisco/Aironet.pm
@@ -48,7 +48,7 @@ use strict;
 use warnings;
 
 use Carp;
-use Log::Log4perl;
+use pf::log;
 use Net::Appliance::Session;
 use Net::SNMP;
 
@@ -88,7 +88,7 @@ L<http://www.cpanforum.com/threads/6909/>
 
 sub deauthenticateMacDefault {
     my ( $this, $mac ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     $mac = format_mac_as_cisco($mac);
     if ( !defined($mac) ) {
@@ -134,7 +134,7 @@ sub isLearntTrapsEnabled {
 
 sub setLearntTrapsEnabled {
     my ( $this, $ifIndex, $trueFalse ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->error("function is NOT implemented");
     return -1;
 }
@@ -146,28 +146,28 @@ sub isRemovedTrapsEnabled {
 
 sub setRemovedTrapsEnabled {
     my ( $this, $ifIndex, $trueFalse ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->error("function is NOT implemented");
     return -1;
 }
 
 sub getVmVlanType {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->error("function is NOT implemented");
     return -1;
 }
 
 sub setVmVlanType {
     my ( $this, $ifIndex, $type ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->error("function is NOT implemented");
     return -1;
 }
 
 sub isTrunkPort {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->error("function is NOT implemented");
     return -1;
 }
@@ -175,14 +175,14 @@ sub isTrunkPort {
 sub getVlans {
     my ($this) = @_;
     my $vlans  = {};
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->error("function is NOT implemented");
     return $vlans;
 }
 
 sub isDefinedVlan {
     my ( $this, $vlan ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->error("function is NOT implemented");
     return 0;
 }
@@ -201,7 +201,7 @@ Overriding default extractSsid because on Aironet AP SSID is in the Cisco-AVPair
 # Same as in pf::Switch::Cisco::Aironet_WDS. Please keep both in sync. Once Moose push in a role.
 sub extractSsid {
     my ($this, $radius_request) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     if (defined($radius_request->{'Cisco-AVPair'})) {
         if (ref($radius_request->{'Cisco-AVPair'}) eq 'ARRAY') {
@@ -239,7 +239,7 @@ Return the reference to the deauth technique or the default deauth technique.
 
 sub deauthTechniques {
     my ($this, $method) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $default = $SNMP::TELNET;
     my %tech = (
         $SNMP::TELNET => 'deauthenticateMacDefault',

--- a/lib/pf/Switch/Cisco/Aironet.pm
+++ b/lib/pf/Switch/Cisco/Aironet.pm
@@ -48,7 +48,6 @@ use strict;
 use warnings;
 
 use Carp;
-use pf::log;
 use Net::Appliance::Session;
 use Net::SNMP;
 

--- a/lib/pf/Switch/Cisco/Aironet_1130.pm
+++ b/lib/pf/Switch/Cisco/Aironet_1130.pm
@@ -15,7 +15,6 @@ This modules extends pf::Switch::Cisco::Aironet
 
 use strict;
 use warnings;
-use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Cisco::Aironet');

--- a/lib/pf/Switch/Cisco/Aironet_1130.pm
+++ b/lib/pf/Switch/Cisco/Aironet_1130.pm
@@ -15,7 +15,7 @@ This modules extends pf::Switch::Cisco::Aironet
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Cisco::Aironet');

--- a/lib/pf/Switch/Cisco/Aironet_1242.pm
+++ b/lib/pf/Switch/Cisco/Aironet_1242.pm
@@ -15,7 +15,6 @@ This modules extends pf::Switch::Cisco::Aironet
 
 use strict;
 use warnings;
-use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Cisco::Aironet');

--- a/lib/pf/Switch/Cisco/Aironet_1242.pm
+++ b/lib/pf/Switch/Cisco/Aironet_1242.pm
@@ -15,7 +15,7 @@ This modules extends pf::Switch::Cisco::Aironet
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Cisco::Aironet');

--- a/lib/pf/Switch/Cisco/Aironet_1250.pm
+++ b/lib/pf/Switch/Cisco/Aironet_1250.pm
@@ -15,7 +15,6 @@ This modules extends pf::Switch::Cisco::Aironet
 
 use strict;
 use warnings;
-use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Cisco::Aironet');

--- a/lib/pf/Switch/Cisco/Aironet_1250.pm
+++ b/lib/pf/Switch/Cisco/Aironet_1250.pm
@@ -15,7 +15,7 @@ This modules extends pf::Switch::Cisco::Aironet
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Cisco::Aironet');

--- a/lib/pf/Switch/Cisco/Aironet_1600.pm
+++ b/lib/pf/Switch/Cisco/Aironet_1600.pm
@@ -15,7 +15,6 @@ This modules extends pf::Switch::Cisco::Aironet
 
 use strict;
 use warnings;
-use pf::log;
 use Net::SNMP;
 
 use pf::config;

--- a/lib/pf/Switch/Cisco/Aironet_1600.pm
+++ b/lib/pf/Switch/Cisco/Aironet_1600.pm
@@ -15,7 +15,7 @@ This modules extends pf::Switch::Cisco::Aironet
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use pf::config;
@@ -35,7 +35,7 @@ Specifices the type of deauth
 
 sub deauthTechniques {
     my ($this, $method) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $default = $SNMP::RADIUS;
     my %tech = (
         $SNMP::RADIUS => 'deauthenticateMacRadius',
@@ -55,7 +55,7 @@ Method to deauth a wired node with CoA.
 
 sub deauthenticateMacRadius {
     my ($this, $mac) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
     $mac = format_mac_as_cisco($mac);
 
     # perform CoA
@@ -70,7 +70,7 @@ Send a CoA to disconnect a mac
 
 sub radiusDisconnect {
     my ($self, $mac, $add_attributes_ref) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
 
     # initialize
     $add_attributes_ref = {} if (!defined($add_attributes_ref));

--- a/lib/pf/Switch/Cisco/Aironet_WDS.pm
+++ b/lib/pf/Switch/Cisco/Aironet_WDS.pm
@@ -48,7 +48,7 @@ For more information see: https://supportforums.cisco.com/thread/2148888
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::Appliance::Session;
 use Net::SNMP;
 use Try::Tiny;
@@ -86,7 +86,7 @@ Diverges from L<pf::Switch::Cisco::WLC> in the following aspects:
 # The Service-Type entry was causing the WDS enabled Aironet to crash (IOS 12.3.8JEC3)
 sub deauthenticateMacDefault {
     my ( $self, $mac, $is_dot1x ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     if ( !$self->isProductionMode() ) {
         $logger->info("not in production mode... we won't perform deauthentication");
@@ -120,7 +120,7 @@ Warning: this code doesn't support elevating to privileged mode. See #900 and #1
 
 sub getCurrentApFromMac {
     my ( $self, $mac ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my $session;
     try {
@@ -200,7 +200,7 @@ Overriding default extractSsid because on Aironet AP SSID is in the Cisco-AVPair
 # Same as in pf::Switch::Cisco::Aironet. Please keep both in sync. Once Moose push in a role.
 sub extractSsid {
     my ($this, $radius_request) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     if (defined($radius_request->{'Cisco-AVPair'})) {
         if (ref($radius_request->{'Cisco-AVPair'}) eq 'ARRAY') {
@@ -238,7 +238,7 @@ Return the reference to the deauth technique or the default deauth technique.
 
 sub deauthTechniques {
     my ($this, $method) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $default = $SNMP::RADIUS;
     my %tech = (
         $SNMP::RADIUS => 'deauthenticateMacDefault',

--- a/lib/pf/Switch/Cisco/Catalyst_2900XL.pm
+++ b/lib/pf/Switch/Cisco/Catalyst_2900XL.pm
@@ -15,7 +15,7 @@ This modules extends pf::Switch::Cisco::Catalyst_3500XL
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Cisco::Catalyst_3500XL');

--- a/lib/pf/Switch/Cisco/Catalyst_2900XL.pm
+++ b/lib/pf/Switch/Cisco/Catalyst_2900XL.pm
@@ -15,7 +15,6 @@ This modules extends pf::Switch::Cisco::Catalyst_3500XL
 
 use strict;
 use warnings;
-use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Cisco::Catalyst_3500XL');

--- a/lib/pf/Switch/Cisco/Catalyst_2950.pm
+++ b/lib/pf/Switch/Cisco/Catalyst_2950.pm
@@ -86,7 +86,7 @@ use strict;
 use warnings;
 
 use base ('pf::Switch::Cisco');
-use Log::Log4perl;
+use pf::log;
 use Carp;
 use Net::Appliance::Session;
 use Net::SNMP;
@@ -124,13 +124,13 @@ sub inlineCapabilities { return ($MAC,$PORT); }
 
 sub getMinOSVersion {
     my $this   = shift;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     return '12.1(22)EA10';
 }
 
 sub getManagedPorts {
     my $this       = shift;
-    my $logger     = Log::Log4perl::get_logger( ref($this) );
+    my $logger     = $this->logger;
     my $oid_ifType = '1.3.6.1.2.1.2.2.1.3';                     # MIB: ifTypes
     my $oid_ifName = '1.3.6.1.2.1.31.1.1.1.1';
     my @nonUpLinks;
@@ -220,7 +220,7 @@ sub clearMacAddressTable {
     my $command;
     my $session;
     my $oid_ifName = '1.3.6.1.2.1.31.1.1.1.1';
-    my $logger     = Log::Log4perl::get_logger( ref($this) );
+    my $logger     = $this->logger;
 
     eval {
         $session = Net::Appliance::Session->new(
@@ -269,7 +269,7 @@ sub clearMacAddressTable {
 
 sub getAllSecureMacAddresses {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $oid_cpsSecureMacAddrRowStatus = '1.3.6.1.4.1.9.9.315.1.2.2.1.4';
 
     my $secureMacAddrHashRef = {};
@@ -299,7 +299,7 @@ sub getAllSecureMacAddresses {
 
 sub isDynamicPortSecurityEnabled {
     my ( $this, $ifIndex ) = @_;
-    my $logger                   = Log::Log4perl::get_logger( ref($this) );
+    my $logger                   = $this->logger;
     my $oid_cpsSecureMacAddrType = '1.3.6.1.4.1.9.9.315.1.2.2.1.2';
 
     if ( !$this->connectRead() ) {
@@ -325,7 +325,7 @@ sub isDynamicPortSecurityEnabled {
 
 sub isStaticPortSecurityEnabled {
     my ( $this, $ifIndex ) = @_;
-    my $logger                   = Log::Log4perl::get_logger( ref($this) );
+    my $logger                   = $this->logger;
     my $oid_cpsSecureMacAddrType = '1.3.6.1.4.1.9.9.315.1.2.2.1.2';
 
     if ( !$this->connectRead() ) {
@@ -351,7 +351,7 @@ sub isStaticPortSecurityEnabled {
 
 sub getSecureMacAddresses {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $oid_cpsSecureMacAddrRowStatus = '1.3.6.1.4.1.9.9.315.1.2.2.1.4';
 
     my $secureMacAddrHashRef = {};
@@ -380,7 +380,7 @@ sub getSecureMacAddresses {
 
 sub authorizeMAC {
     my ( $this, $ifIndex, $deauthMac, $authMac, $deauthVlan, $authVlan ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $oid_cpsSecureMacAddrRowStatus = '1.3.6.1.4.1.9.9.315.1.2.2.1.4';
 
     if ( !$this->isProductionMode() ) {
@@ -430,7 +430,7 @@ sub authorizeMAC {
 
 sub getMaxMacAddresses {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     #CISCO-PORT-SECURITY-MIB
     my $OID_cpsIfPortSecurityEnable = '1.3.6.1.4.1.9.9.315.1.2.1.1.1';
@@ -491,7 +491,7 @@ Warning: this code doesn't support elevating to privileged mode. See #900 and #1
 sub ping {
     my ( $this, $ip ) = @_;
     my $session;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     eval {
         $session = Net::Appliance::Session->new(
@@ -545,7 +545,7 @@ With VoIP
 
 sub enablePortSecurityByIfIndex {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     my $maxSecureMacTotal;
     my $maxSecureMacVlanAccess = 1;
@@ -590,7 +590,7 @@ sub enablePortSecurityByIfIndex {
 
 sub disablePortSecurityByIfIndex {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     # no switchport port-security
     if (! $this->setPortSecurityEnableByIfIndex($ifIndex, $FALSE)) {
         $logger->error("An error occured while disablling port-security on ifIndex $ifIndex");
@@ -626,7 +626,7 @@ sub disablePortSecurityByIfIndex {
 
 sub setPortSecurityEnableByIfIndex {
     my ( $this, $ifIndex, $enable ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->isProductionMode() ) {
         $logger->warn("Should set IfPortSecurityEnable on $ifIndex to $enable but the switch is not in production -> Do nothing");
@@ -653,7 +653,7 @@ Sets the global (data + voice) maximum number of MAC addresses for port-security
 
 sub setPortSecurityMaxSecureMacAddrByIfIndex {
     my ( $this, $ifIndex, $maxSecureMac ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->isProductionMode() ) {
         $logger->warn("Should set IfMaxSecureMacAddr on $ifIndex to $maxSecureMac but the switch is not in production -> Do nothing");
@@ -681,7 +681,7 @@ floating network devices with VoIP through SSH transport
 
 sub setPortSecurityMaxSecureMacAddrVlanAccessByIfIndex {
     my ( $this, $ifIndex, $maxSecureMac ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     # we spawn a shell to workaround a thread safety bug in Net::Appliance::Session when using SSH transport
     # http://www.cpanforum.com/threads/6909
@@ -710,7 +710,7 @@ Warning: this code doesn't support elevating to privileged mode. See #900 and #1
 
 sub _setPortSecurityMaxSecureMacAddrVlanAccessByIfIndex {
     my ( $this, $ifIndex, $maxSecureMac ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->isProductionMode() ) {
         $logger->warn("Should set IfMaxSecureMacAddrPerVlan on $ifIndex to $maxSecureMac but the switch is not in production -> Do nothing");
@@ -779,7 +779,7 @@ Tells the switch what to do when the number of MAC addresses on the port has exc
 
 sub setPortSecurityViolationActionByIfIndex {
     my ( $this, $ifIndex, $action ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->isProductionMode() ) {
         $logger->warn("Should set IfViolationAction on $ifIndex to $action but the switch is not in production -> Do nothing");
@@ -806,7 +806,7 @@ Allows all the tagged Vlans on a multi-Vlan port. Used for floating network devi
 
 sub setTaggedVlans {
     my ( $this, $ifIndex, $switch_locker, @vlans ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     
     if ( !$this->isProductionMode() ) {
         $logger->info("not in production mode ... we won't change this port vlanTrunkPortVlansEnabled");
@@ -857,7 +857,7 @@ Removes all the tagged Vlans on a multi-Vlan port. Used for floating network dev
 
 sub removeAllTaggedVlans {
     my ( $this, $ifIndex, $switch_locker) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->isProductionMode() ) {
         $logger->info("not in production mode ... we won't change this port OID_vlanTrunkPortVlansEnabled");
@@ -910,7 +910,7 @@ Overriding default enablePortConfigAsTrunk to fix a race issue with Cisco
 
 sub enablePortConfigAsTrunk {
     my ($this, $mac, $switch_port, $switch_locker, $taggedVlans)  = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     # switchport mode trunk
     $logger->info("Setting port $switch_port as trunk.");
@@ -944,7 +944,7 @@ Translate RADIUS NAS-Port into switch's ifIndex.
 
 sub NasPortToIfIndex {
     my ($this, $NAS_port) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this)); 
+    my $logger = $this->logger; 
 
     # 50017 is ifIndex 17
     if ($NAS_port =~ s/^500//) {
@@ -964,7 +964,7 @@ Get Voice over IP RADIUS Vendor Specific Attribute (VSA).
 
 sub getVoipVsa {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     return ('Cisco-AVPair' => "device-traffic-class=voice");
 }
@@ -979,7 +979,7 @@ or set the VLAN and log if there is a VoIP device.
 
 sub dot1xPortReauthenticate {
     my ($this, $ifIndex, $mac) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     $logger->info(
         "802.1X renegociation on this switch is not compatible with PacketFence. "
@@ -1067,7 +1067,7 @@ In that case, create a generic ifIndexToLldpLocalPort also.
 
 sub getPhonesLLDPAtIfIndex {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     # if can't SNMP read abort
     return if ( !$this->connectRead() );
@@ -1133,7 +1133,7 @@ We use ifDescr to lookup the lldpRemLocalPortNum in the lldpLocPortDesc table.
 
 sub ifIndexToLldpLocalPort {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     # if can't SNMP read abort
     return if ( !$this->connectRead() );

--- a/lib/pf/Switch/Cisco/Catalyst_2950.pm
+++ b/lib/pf/Switch/Cisco/Catalyst_2950.pm
@@ -86,7 +86,6 @@ use strict;
 use warnings;
 
 use base ('pf::Switch::Cisco');
-use pf::log;
 use Carp;
 use Net::Appliance::Session;
 use Net::SNMP;

--- a/lib/pf/Switch/Cisco/Catalyst_2960.pm
+++ b/lib/pf/Switch/Cisco/Catalyst_2960.pm
@@ -105,7 +105,7 @@ F<conf/switches.conf>
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 use Try::Tiny;
 
@@ -140,13 +140,13 @@ TODO: This list is incomplete
 
 sub getMinOSVersion {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     return '12.2(25)SEE2';
 }
 
 sub getAllSecureMacAddresses {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $oid_cpsIfVlanSecureMacAddrRowStatus = '1.3.6.1.4.1.9.9.315.1.2.3.1.5';
 
     my $secureMacAddrHashRef = {};
@@ -176,7 +176,7 @@ sub getAllSecureMacAddresses {
 
 sub isDynamicPortSecurityEnabled {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $oid_cpsIfVlanSecureMacAddrType = '1.3.6.1.4.1.9.9.315.1.2.3.1.3';
 
     if ( !$this->connectRead() ) {
@@ -205,7 +205,7 @@ sub isDynamicPortSecurityEnabled {
 
 sub isStaticPortSecurityEnabled {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $oid_cpsIfVlanSecureMacAddrType = '1.3.6.1.4.1.9.9.315.1.2.3.1.3';
 
     if ( !$this->connectRead() ) {
@@ -234,7 +234,7 @@ sub isStaticPortSecurityEnabled {
 
 sub getSecureMacAddresses {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $oid_cpsIfVlanSecureMacAddrRowStatus = '1.3.6.1.4.1.9.9.315.1.2.3.1.5';
 
     my $secureMacAddrHashRef = {};
@@ -263,7 +263,7 @@ sub getSecureMacAddresses {
 
 sub authorizeMAC {
     my ( $this, $ifIndex, $deauthMac, $authMac, $deauthVlan, $authVlan ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $oid_cpsIfVlanSecureMacAddrRowStatus = '1.3.6.1.4.1.9.9.315.1.2.3.1.5';
 
     if ( !$this->isProductionMode() ) {
@@ -323,7 +323,7 @@ Translate RADIUS NAS-Port into switch's ifIndex.
 
 sub NasPortToIfIndex {
     my ($this, $NAS_port) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     # ex: 50023 is ifIndex 10023
     if ($NAS_port =~ s/^5/1/) {
@@ -343,7 +343,7 @@ Get Voice over IP RADIUS Vendor Specific Attribute (VSA).
 
 sub getVoipVsa {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     return ('Cisco-AVPair' => "device-traffic-class=voice");
 }
@@ -356,7 +356,7 @@ Method to deauth a wired node with CoA.
 
 sub deauthenticateMacRadius {
     my ($this, $ifIndex,$mac) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
 
     # perform CoA
@@ -372,7 +372,7 @@ Send a CoA to disconnect a mac
 
 sub radiusDisconnect {
     my ($self, $mac, $add_attributes_ref) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
 
     # initialize
     $add_attributes_ref = {} if (!defined($add_attributes_ref));
@@ -451,7 +451,7 @@ Return the reference to the deauth technique or the default deauth technique.
 
 sub wiredeauthTechniques {
     my ($this, $method, $connection_type) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ($connection_type == $WIRED_802_1X) {
         my $default = $SNMP::SNMP;
         my %tech = (
@@ -488,7 +488,7 @@ Overrides the default implementation to add the dynamic acls
 
 sub returnRadiusAccessAccept {
     my ($self, $vlan, $mac, $port, $connection_type, $user_name, $ssid, $wasInline, $user_role) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
 
     # Inline Vs. VLAN enforcement
     my $radius_reply_ref = {};
@@ -547,7 +547,7 @@ sub returnAccessListAttribute {
 
 sub disableMABByIfIndex {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     if ( !$this->isProductionMode() ) {
         $logger->warn("Should set cafPortAuthorizeControl on $ifIndex to 3:forceAuthorized but the s");
@@ -568,7 +568,7 @@ sub disableMABByIfIndex {
 
 sub enableMABByIfIndex {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     if ( !$this->isProductionMode() ) {
         $logger->warn("Should set cafPortAuthorizeControl on $ifIndex to 2:auto but the switch is no");

--- a/lib/pf/Switch/Cisco/Catalyst_2960G.pm
+++ b/lib/pf/Switch/Cisco/Catalyst_2960G.pm
@@ -23,7 +23,7 @@ LIMITATIONS section of L<pf::Switch::Cisco::Catalyst_2960>.
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use pf::config;
@@ -47,7 +47,7 @@ Translate RADIUS NAS-Port into switch's ifIndex.
 
 sub NasPortToIfIndex {
     my ($this, $NAS_port) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     # ex: 50023 is ifIndex 10123
     if ($NAS_port =~ s/^500/101/) {

--- a/lib/pf/Switch/Cisco/Catalyst_2960_http.pm
+++ b/lib/pf/Switch/Cisco/Catalyst_2960_http.pm
@@ -23,7 +23,7 @@ Developped and tested on IOS 15.0(2)SE5
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 use Net::Telnet;
 use Try::Tiny;
@@ -68,7 +68,7 @@ Called when a ReAssignVlan trap is received for a switch-port in Wired MAC Authe
 
 sub handleReAssignVlanTrapForWiredMacAuth {
     my ($this, $ifIndex, $mac) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     $this->radiusDisconnect($mac);
 }
@@ -88,7 +88,7 @@ status code
 
 sub parseUrl {
     my($this, $req) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     return ($$req->param('client_mac'),$$req->param('wlan'),$$req->param('client_ip'),$$req->param('redirect'),$$req->param('switch_url'),$$req->param('statusCode'));
 }
 
@@ -112,7 +112,7 @@ Overide to support the captive portal special RADIUS accept
 
 sub returnRadiusAccessAccept {
     my ($this, $vlan, $mac, $port, $connection_type, $user_name, $ssid, $wasInline, $user_role) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     my $radius_reply_ref = {};
 
@@ -202,7 +202,7 @@ Uses L<pf::util::radius> for the low-level RADIUS stuff.
 
 sub radiusDisconnect {
     my ($self, $mac, $add_attributes_ref) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
 
     # initialize
     $add_attributes_ref = {} if (!defined($add_attributes_ref));

--- a/lib/pf/Switch/Cisco/Catalyst_2960_http.pm
+++ b/lib/pf/Switch/Cisco/Catalyst_2960_http.pm
@@ -23,7 +23,6 @@ Developped and tested on IOS 15.0(2)SE5
 use strict;
 use warnings;
 
-use pf::log;
 use Net::SNMP;
 use Net::Telnet;
 use Try::Tiny;

--- a/lib/pf/Switch/Cisco/Catalyst_2970.pm
+++ b/lib/pf/Switch/Cisco/Catalyst_2970.pm
@@ -17,7 +17,6 @@ L<pf::Switch::Cisco::Catalyst_2960> also.
 
 use strict;
 use warnings;
-use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Cisco::Catalyst_2960');

--- a/lib/pf/Switch/Cisco/Catalyst_2970.pm
+++ b/lib/pf/Switch/Cisco/Catalyst_2970.pm
@@ -17,7 +17,7 @@ L<pf::Switch::Cisco::Catalyst_2960> also.
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Cisco::Catalyst_2960');

--- a/lib/pf/Switch/Cisco/Catalyst_3500XL.pm
+++ b/lib/pf/Switch/Cisco/Catalyst_3500XL.pm
@@ -21,7 +21,6 @@ use strict;
 use warnings;
 
 use base ('pf::Switch::Cisco');
-use pf::log;
 use Carp;
 use Net::Appliance::Session;
 use Net::SNMP;

--- a/lib/pf/Switch/Cisco/Catalyst_3500XL.pm
+++ b/lib/pf/Switch/Cisco/Catalyst_3500XL.pm
@@ -21,7 +21,7 @@ use strict;
 use warnings;
 
 use base ('pf::Switch::Cisco');
-use Log::Log4perl;
+use pf::log;
 use Carp;
 use Net::Appliance::Session;
 use Net::SNMP;
@@ -33,7 +33,7 @@ sub description { 'Cisco Catalyst 3500XL Series' }
 
 sub getMinOSVersion {
     my $this   = shift;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     return '12.0(5)WC15';
 }
 
@@ -48,7 +48,7 @@ TODO: This list is incomplete
 # return the list of managed ports
 sub getManagedPorts {
     my $this        = shift;
-    my $logger      = Log::Log4perl::get_logger( ref($this) );
+    my $logger      = $this->logger;
     my $oid_ifType  = '1.3.6.1.2.1.2.2.1.3';                    # MIB: ifTypes
     my $oid_ifDescr = '1.3.6.1.2.1.2.2.1.2';
     my @nonUpLinks;
@@ -138,7 +138,7 @@ sub clearMacAddressTable {
     my $command;
     my $session;
     my $oid_ifDescr = '1.3.6.1.2.1.2.2.1.2';
-    my $logger      = Log::Log4perl::get_logger( ref($this) );
+    my $logger      = $this->logger;
 
     eval {
         $session = Net::Appliance::Session->new(
@@ -187,7 +187,7 @@ sub clearMacAddressTable {
 
 sub getMaxMacAddresses {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     #CISCO-C2900-MIB
     my $OID_c2900PortUsageApplication       = '1.3.6.1.4.1.9.9.87.1.4.1.1.3';
@@ -290,7 +290,7 @@ sub getMaxMacAddresses {
 
 sub ping {
     my ( $this, $ip ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $result;
     my $random;
 

--- a/lib/pf/Switch/Cisco/Catalyst_3550.pm
+++ b/lib/pf/Switch/Cisco/Catalyst_3550.pm
@@ -37,7 +37,6 @@ IfIndex on this platform is not the same as port # or dot1d port.
 
 use strict;
 use warnings;
-use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Cisco::Catalyst_2960');

--- a/lib/pf/Switch/Cisco/Catalyst_3550.pm
+++ b/lib/pf/Switch/Cisco/Catalyst_3550.pm
@@ -37,7 +37,7 @@ IfIndex on this platform is not the same as port # or dot1d port.
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Cisco::Catalyst_2960');
@@ -63,7 +63,7 @@ method do per-IOS translations.
 
 sub NasPortToIfIndex {
     my ($this, $NAS_port) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     # 50017 is ifIndex 17
     if ($NAS_port =~ s/^500//) {

--- a/lib/pf/Switch/Cisco/Catalyst_3560.pm
+++ b/lib/pf/Switch/Cisco/Catalyst_3560.pm
@@ -63,7 +63,7 @@ This is a Cisco bug, nothing much we can do. Don't use this IOS for VoIP.
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use pf::config;
@@ -77,7 +77,7 @@ sub description { 'Cisco Catalyst 3560' }
 
 sub setModeTrunk {
     my ( $this, $ifIndex, $enable ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $OID_vlanTrunkPortDynamicState = "1.3.6.1.4.1.9.9.46.1.6.1.1.13";    #CISCO-VTP-MIB
     my $OID_vlanTrunkEncapsulation = "1.3.6.1.4.1.9.9.46.1.6.1.1.3";
 

--- a/lib/pf/Switch/Cisco/Catalyst_3560.pm
+++ b/lib/pf/Switch/Cisco/Catalyst_3560.pm
@@ -63,7 +63,6 @@ This is a Cisco bug, nothing much we can do. Don't use this IOS for VoIP.
 use strict;
 use warnings;
 
-use pf::log;
 use Net::SNMP;
 
 use pf::config;

--- a/lib/pf/Switch/Cisco/Catalyst_3560G.pm
+++ b/lib/pf/Switch/Cisco/Catalyst_3560G.pm
@@ -61,7 +61,6 @@ This is a Cisco bug, nothing much we can do. Don't use this IOS for VoIP.
 use strict;
 use warnings;
 
-use pf::log;
 use Net::SNMP;
 
 use pf::config;

--- a/lib/pf/Switch/Cisco/Catalyst_3560G.pm
+++ b/lib/pf/Switch/Cisco/Catalyst_3560G.pm
@@ -61,7 +61,7 @@ This is a Cisco bug, nothing much we can do. Don't use this IOS for VoIP.
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use pf::config;
@@ -81,7 +81,7 @@ Translate RADIUS NAS-Port into switch's ifIndex.
 
 sub NasPortToIfIndex {
     my ($this, $NAS_port) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     # ex: 50023 is ifIndex 10023
     if ($NAS_port =~ s/^500/101/) {

--- a/lib/pf/Switch/Cisco/Catalyst_3750.pm
+++ b/lib/pf/Switch/Cisco/Catalyst_3750.pm
@@ -36,7 +36,6 @@ F<conf/switches.conf>
 use strict;
 use warnings;
 
-use pf::log;
 use Net::SNMP;
 
 use pf::config;

--- a/lib/pf/Switch/Cisco/Catalyst_3750.pm
+++ b/lib/pf/Switch/Cisco/Catalyst_3750.pm
@@ -36,7 +36,7 @@ F<conf/switches.conf>
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use pf::config;
@@ -61,7 +61,7 @@ Translate RADIUS NAS-Port into switch's ifIndex.
 
 sub NasPortToIfIndex {
     my ($this, $NAS_port) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     # NAS-Port bumps by +100 between stacks while ifIndex bumps by +500
     # some examples values for stacked switches are available in t/network-devices/cisco.t

--- a/lib/pf/Switch/Cisco/Catalyst_3750G.pm
+++ b/lib/pf/Switch/Cisco/Catalyst_3750G.pm
@@ -36,7 +36,6 @@ F<conf/switches.conf>
 use strict;
 use warnings;
 
-use pf::log;
 use Net::SNMP;
 
 use pf::config;

--- a/lib/pf/Switch/Cisco/Catalyst_3750G.pm
+++ b/lib/pf/Switch/Cisco/Catalyst_3750G.pm
@@ -36,7 +36,7 @@ F<conf/switches.conf>
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use pf::config;
@@ -61,7 +61,7 @@ Translate RADIUS NAS-Port into switch's ifIndex.
 
 sub NasPortToIfIndex {
     my ($this, $NAS_port) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     # NAS-Port bumps by +100 between stacks while ifIndex bumps by +500
     # some examples values for stacked switches are available in t/network-devices/cisco.t

--- a/lib/pf/Switch/Cisco/Catalyst_4500.pm
+++ b/lib/pf/Switch/Cisco/Catalyst_4500.pm
@@ -23,7 +23,6 @@ F<conf/switches.conf>
 
 use strict;
 use warnings;
-use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Cisco::Catalyst_2960');

--- a/lib/pf/Switch/Cisco/Catalyst_4500.pm
+++ b/lib/pf/Switch/Cisco/Catalyst_4500.pm
@@ -23,7 +23,7 @@ F<conf/switches.conf>
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Cisco::Catalyst_2960');

--- a/lib/pf/Switch/Cisco/Catalyst_6500.pm
+++ b/lib/pf/Switch/Cisco/Catalyst_6500.pm
@@ -29,7 +29,6 @@ F<conf/switches.conf>
 use strict;
 use warnings;
 
-use pf::log;
 use Net::SNMP;
 
 use pf::Switch::constants;

--- a/lib/pf/Switch/Cisco/Catalyst_6500.pm
+++ b/lib/pf/Switch/Cisco/Catalyst_6500.pm
@@ -29,7 +29,7 @@ F<conf/switches.conf>
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use pf::Switch::constants;
@@ -52,7 +52,7 @@ The 6500's security table is per port per Vlan as opposed to per port (as most o
 
 sub _setVlan {
     my ( $this, $ifIndex, $newVlan, $oldVlan, $switch_locker_ref ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->connectWrite() ) {
         return 0;
@@ -99,7 +99,7 @@ Changed authVlan's deauthVlan to authVlan.
 
 sub authorizeMAC {
     my ( $this, $ifIndex, $deauthMac, $authMac, $deauthVlan, $authVlan ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $oid_cpsIfVlanSecureMacAddrRowStatus = '1.3.6.1.4.1.9.9.315.1.2.3.1.5';
 
     if ( !$this->isProductionMode() ) {

--- a/lib/pf/Switch/Cisco/ISR_1800.pm
+++ b/lib/pf/Switch/Cisco/ISR_1800.pm
@@ -42,7 +42,6 @@ use strict;
 use warnings;
 
 use base ('pf::Switch::Cisco');
-use pf::log;
 use Carp;
 use Net::SNMP;
 use Net::Appliance::Session;

--- a/lib/pf/Switch/Cisco/ISR_1800.pm
+++ b/lib/pf/Switch/Cisco/ISR_1800.pm
@@ -42,7 +42,7 @@ use strict;
 use warnings;
 
 use base ('pf::Switch::Cisco');
-use Log::Log4perl;
+use pf::log;
 use Carp;
 use Net::SNMP;
 use Net::Appliance::Session;
@@ -51,7 +51,7 @@ sub description { 'Cisco ISR 1800 Series' }
 
 #sub getMinOSVersion {
 #    my $this   = shift;
-#    my $logger = Log::Log4perl::get_logger( ref($this) );
+#    my $logger = $this->logger;
 #    return '';
 #}
 
@@ -71,7 +71,7 @@ sub description { 'Cisco ISR 1800 Series' }
 
 sub isDefinedVlan {
     my ($this, $vlan) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     # port assigned to VLAN (VLAN membership)
     my $oid_vmMembershipSummaryMemberPorts = "1.3.6.1.4.1.9.9.68.1.2.1.1.2"; #from CISCO-VLAN-MEMBERSHIP-MIB
@@ -93,7 +93,7 @@ sub isDefinedVlan {
 
 sub getVlan {
     my ($this, $ifIndex) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     if (!$this->connectRead()) {
         return 0;
@@ -126,7 +126,7 @@ Warning: this code doesn't support elevating to privileged mode. See #900 and #1
 sub getMacBridgePortHash {
     my $this   = shift;
     my $vlan   = shift || '';
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
     my %macBridgePortHash  = ();
 
     if ($vlan eq '') {
@@ -216,7 +216,7 @@ Returns a list of all IfIndex part of a given VLAN
 
 sub _getAllIfIndexForThisVlan {
     my ($this, $vlan) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     if (!$this->connectRead()) {
         return 0;

--- a/lib/pf/Switch/Cisco/SG300.pm
+++ b/lib/pf/Switch/Cisco/SG300.pm
@@ -6,7 +6,7 @@ pf::Switch::Cisco::SG300
 
 =head1 SYNOPSIS
 
-The pf::Switch::Cisco::SG300 module implements an object oriented interface to 
+The pf::Switch::Cisco::SG300 module implements an object oriented interface to
 manage Cisco SG300 switches
 
 =head1 STATUS
@@ -23,19 +23,21 @@ Developed and tested on SG300 running 1.1.2.0
 
 =item VoIP with MAC authentication
 
+=back
+
+=back
+
 =cut
 
 use strict;
 use warnings;
 
 use base ('pf::Switch::Cisco::Catalyst_2960');
-use Log::Log4perl;
+use pf::log;
 
 sub description { 'Cisco SG300' }
 
 =head1 SUBROUTINES
-
-=over
 
 =cut
 
@@ -53,7 +55,7 @@ For now it returns the voiceVlan untagged since Cisco supports multiple untagged
 
 sub getVoipVsa {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     return (
         'Tunnel-Medium-Type' => $RADIUS::ETHERNET,
@@ -82,14 +84,12 @@ Just returns the NAS-Port
 
 sub NasPortToIfIndex {
     my ($this, $NAS_port) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this)); 
+    my $logger = $this->logger;
 
     $logger->debug("Found $NAS_port for ifindex");
 
     return $NAS_port;
 }
-
-=back
 
 =head1 AUTHOR
 

--- a/lib/pf/Switch/Cisco/WLC.pm
+++ b/lib/pf/Switch/Cisco/WLC.pm
@@ -102,7 +102,7 @@ Caveat CSCty44701
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 use Net::Telnet;
 
@@ -143,7 +143,7 @@ New implementation using RADIUS Disconnect-Request.
 
 sub deauthenticateMacDefault {
     my ( $self, $mac, $is_dot1x ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
 
     if ( !$self->isProductionMode() ) {
         $logger->info("not in production mode... we won't perform deauthentication");
@@ -168,7 +168,7 @@ See L<BUGS AND LIMITATIONS> for details.
 
 sub _deauthenticateMacSNMP {
     my ( $this, $mac ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $OID_bsnMobileStationDeleteAction = '1.3.6.1.4.1.14179.2.1.4.1.22';
 
     if ( !$this->isProductionMode() ) {
@@ -207,7 +207,7 @@ sub _deauthenticateMacSNMP {
 
 sub blacklistMac {
     my ( $this, $mac, $description ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( length($mac) == 17 ) {
 
@@ -247,7 +247,7 @@ sub isLearntTrapsEnabled {
 
 sub setLearntTrapsEnabled {
     my ( $this, $ifIndex, $trueFalse ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->error("function is NOT implemented");
     return -1;
 }
@@ -259,28 +259,28 @@ sub isRemovedTrapsEnabled {
 
 sub setRemovedTrapsEnabled {
     my ( $this, $ifIndex, $trueFalse ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->error("function is NOT implemented");
     return -1;
 }
 
 sub getVmVlanType {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->error("function is NOT implemented");
     return -1;
 }
 
 sub setVmVlanType {
     my ( $this, $ifIndex, $type ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->error("function is NOT implemented");
     return -1;
 }
 
 sub isTrunkPort {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->error("function is NOT implemented");
     return -1;
 }
@@ -288,14 +288,14 @@ sub isTrunkPort {
 sub getVlans {
     my ($this) = @_;
     my $vlans  = {};
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->error("function is NOT implemented");
     return $vlans;
 }
 
 sub isDefinedVlan {
     my ( $this, $vlan ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->error("function is NOT implemented");
     return 0;
 }
@@ -325,7 +325,7 @@ Return the reference to the deauth technique or the default deauth technique.
 
 sub deauthTechniques {
     my ($this, $method) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $default = $SNMP::RADIUS;
     my %tech = (
         $SNMP::RADIUS => 'deauthenticateMacDefault',
@@ -353,7 +353,7 @@ status code
 
 sub parseUrl {
     my($this, $req) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     return ($$req->param('client_mac'),$$req->param('wlan'),$$req->param('client_ip'),$$req->param('redirect'),$$req->param('switch_url'),$$req->param('statusCode'));
 }
 

--- a/lib/pf/Switch/Cisco/WLC.pm
+++ b/lib/pf/Switch/Cisco/WLC.pm
@@ -102,7 +102,6 @@ Caveat CSCty44701
 use strict;
 use warnings;
 
-use pf::log;
 use Net::SNMP;
 use Net::Telnet;
 

--- a/lib/pf/Switch/Cisco/WLC_2100.pm
+++ b/lib/pf/Switch/Cisco/WLC_2100.pm
@@ -37,7 +37,6 @@ Requires IOS 5 or later.
 use strict;
 use warnings;
 
-use pf::log;
 use Net::Appliance::Session;
 use Net::SNMP;
 

--- a/lib/pf/Switch/Cisco/WLC_2100.pm
+++ b/lib/pf/Switch/Cisco/WLC_2100.pm
@@ -37,7 +37,7 @@ Requires IOS 5 or later.
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::Appliance::Session;
 use Net::SNMP;
 
@@ -82,7 +82,7 @@ Warning: this code doesn't support elevating to privileged mode. See #900 and #1
 
 sub _deauthenticateMacSNMP {
     my ( $this, $mac ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     $mac = format_mac_as_cisco($mac);
     if ( !defined($mac) ) {

--- a/lib/pf/Switch/Cisco/WLC_2106.pm
+++ b/lib/pf/Switch/Cisco/WLC_2106.pm
@@ -13,7 +13,7 @@ This module is currently only a placeholder, see L<pf::Switch::Cisco::WLC_2100> 
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Cisco::WLC_2100');

--- a/lib/pf/Switch/Cisco/WLC_2106.pm
+++ b/lib/pf/Switch/Cisco/WLC_2106.pm
@@ -13,7 +13,6 @@ This module is currently only a placeholder, see L<pf::Switch::Cisco::WLC_2100> 
 use strict;
 use warnings;
 
-use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Cisco::WLC_2100');

--- a/lib/pf/Switch/Cisco/WLC_2500.pm
+++ b/lib/pf/Switch/Cisco/WLC_2500.pm
@@ -14,7 +14,6 @@ This module is currently only a placeholder, see L<pf::Switch::Cisco::WLC> for r
 use strict;
 use warnings;
 
-use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Cisco::WLC');

--- a/lib/pf/Switch/Cisco/WLC_2500.pm
+++ b/lib/pf/Switch/Cisco/WLC_2500.pm
@@ -14,7 +14,7 @@ This module is currently only a placeholder, see L<pf::Switch::Cisco::WLC> for r
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Cisco::WLC');

--- a/lib/pf/Switch/Cisco/WLC_4400.pm
+++ b/lib/pf/Switch/Cisco/WLC_4400.pm
@@ -13,7 +13,6 @@ This module is currently only a placeholder, see L<pf::Switch::Cisco::WLC> for r
 use strict;
 use warnings;
 
-use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Cisco::WLC');

--- a/lib/pf/Switch/Cisco/WLC_4400.pm
+++ b/lib/pf/Switch/Cisco/WLC_4400.pm
@@ -13,7 +13,7 @@ This module is currently only a placeholder, see L<pf::Switch::Cisco::WLC> for r
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Cisco::WLC');

--- a/lib/pf/Switch/Cisco/WLC_5500.pm
+++ b/lib/pf/Switch/Cisco/WLC_5500.pm
@@ -14,7 +14,6 @@ This module is currently only a placeholder, see L<pf::Switch::Cisco::WLC> for r
 use strict;
 use warnings;
 
-use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Cisco::WLC');

--- a/lib/pf/Switch/Cisco/WLC_5500.pm
+++ b/lib/pf/Switch/Cisco/WLC_5500.pm
@@ -14,7 +14,7 @@ This module is currently only a placeholder, see L<pf::Switch::Cisco::WLC> for r
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Cisco::WLC');

--- a/lib/pf/Switch/Cisco/WLC_http.pm
+++ b/lib/pf/Switch/Cisco/WLC_http.pm
@@ -24,7 +24,7 @@ With CWA mode (not available for LWA)
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 use Net::Telnet;
 use Try::Tiny;
@@ -74,7 +74,7 @@ Need to implement the CoA to remove the ACL and the redirect URL.
 
 sub deauthenticateMacDefault {
     my ( $self, $mac, $is_dot1x ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
 
     if ( !$self->isProductionMode() ) {
         $logger->info("not in production mode... we won't perform deauthentication");
@@ -96,7 +96,7 @@ Return the reference to the deauth technique or the default deauth technique.
 
 sub deauthTechniques {
     my ($this, $method) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $default = $SNMP::RADIUS;
     my %tech = (
         $SNMP::RADIUS => 'deauthenticateMacDefault',
@@ -123,7 +123,7 @@ status code
 
 sub parseUrl {
     my($this, $req) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     return ($$req->param('client_mac'),$$req->param('wlan'),$$req->param('client_ip'),$$req->param('redirect'),$$req->param('switch_url'),$$req->param('statusCode'));
 }
 
@@ -136,7 +136,7 @@ assigning VLANs and Roles at the same time.
 
 sub returnRadiusAccessAccept {
     my ($this, $vlan, $mac, $port, $connection_type, $user_name, $ssid, $wasInline, $user_role) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     my $radius_reply_ref = {};
 
@@ -203,7 +203,7 @@ Uses L<pf::util::radius> for the low-level RADIUS stuff.
 
 sub radiusDisconnect {
     my ($self, $mac, $add_attributes_ref) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
 
     # initialize
     $add_attributes_ref = {} if (!defined($add_attributes_ref));

--- a/lib/pf/Switch/Cisco/WLC_http.pm
+++ b/lib/pf/Switch/Cisco/WLC_http.pm
@@ -24,7 +24,6 @@ With CWA mode (not available for LWA)
 use strict;
 use warnings;
 
-use pf::log;
 use Net::SNMP;
 use Net::Telnet;
 use Try::Tiny;

--- a/lib/pf/Switch/Cisco/WiSM.pm
+++ b/lib/pf/Switch/Cisco/WiSM.pm
@@ -15,7 +15,6 @@ It should work on all 6500 WiSM modules and maybe 7500.
 use strict;
 use warnings;
 
-use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Cisco::WLC');

--- a/lib/pf/Switch/Cisco/WiSM.pm
+++ b/lib/pf/Switch/Cisco/WiSM.pm
@@ -15,7 +15,7 @@ It should work on all 6500 WiSM modules and maybe 7500.
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Cisco::WLC');

--- a/lib/pf/Switch/Cisco/WiSM2.pm
+++ b/lib/pf/Switch/Cisco/WiSM2.pm
@@ -15,7 +15,6 @@ It should work on all 6500 WiSM2 modules and maybe 7500.
 use strict;
 use warnings;
 
-use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Cisco::WLC');

--- a/lib/pf/Switch/Cisco/WiSM2.pm
+++ b/lib/pf/Switch/Cisco/WiSM2.pm
@@ -15,7 +15,7 @@ It should work on all 6500 WiSM2 modules and maybe 7500.
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Cisco::WLC');

--- a/lib/pf/Switch/Dell.pm
+++ b/lib/pf/Switch/Dell.pm
@@ -15,7 +15,6 @@ use strict;
 use warnings;
 
 use base ('pf::Switch');
-use pf::log;
 
 sub getVersion {
     my ($this) = @_;

--- a/lib/pf/Switch/Dell.pm
+++ b/lib/pf/Switch/Dell.pm
@@ -15,13 +15,13 @@ use strict;
 use warnings;
 
 use base ('pf::Switch');
-use Log::Log4perl;
+use pf::log;
 
 sub getVersion {
     my ($this) = @_;
     my $oid_productIdentificationBuildNumber
         = '1.3.6.1.4.1.674.10895.3000.1.2.100.5.0';    # Dell-Vendor-MIB
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectRead() ) {
         return '';
     }
@@ -36,7 +36,7 @@ sub getVersion {
 sub parseTrap {
     my ( $this, $trapString ) = @_;
     my $trapHashRef;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( $trapString
         =~ /OID: \.1\.3\.6\.1\.6\.3\.1\.1\.5\.([34])\|\.1\.3\.6\.1\.2\.1\.2\.2\.1\.1\.(\d+) = INTEGER/
         )
@@ -59,7 +59,7 @@ sub parseTrap {
 # 2 => dynamic
 sub getVmVlanType {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectRead() ) {
         return 0;
     }

--- a/lib/pf/Switch/Dell/Force10.pm
+++ b/lib/pf/Switch/Dell/Force10.pm
@@ -18,7 +18,7 @@ F<conf/switches.conf>
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 use pf::constants;
 use pf::config;
 use base ('pf::Switch::Dell');
@@ -36,7 +36,7 @@ sub supportsRadiusDynamicVlanAssignment { return $TRUE; }
 
 sub getMinOSVersion {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     return '112';
 }
 
@@ -48,7 +48,7 @@ Fetch the ifindex on the switch by NAS-Port-Id radius attribute
 
 sub getIfIndexByNasPortId {
     my ($this, $ifDesc_param) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
     if ( !$this->connectRead() ) {
         return 0;
     }

--- a/lib/pf/Switch/Dell/Force10.pm
+++ b/lib/pf/Switch/Dell/Force10.pm
@@ -18,7 +18,6 @@ F<conf/switches.conf>
 
 use strict;
 use warnings;
-use pf::log;
 use pf::constants;
 use pf::config;
 use base ('pf::Switch::Dell');

--- a/lib/pf/Switch/Dell/PowerConnect3424.pm
+++ b/lib/pf/Switch/Dell/PowerConnect3424.pm
@@ -19,7 +19,6 @@ F<conf/switches.conf>
 use strict;
 use warnings;
 use Data::Dumper;
-use pf::log;
 use Net::Telnet;
 
 use base ('pf::Switch::Dell');

--- a/lib/pf/Switch/Dell/PowerConnect3424.pm
+++ b/lib/pf/Switch/Dell/PowerConnect3424.pm
@@ -19,7 +19,7 @@ F<conf/switches.conf>
 use strict;
 use warnings;
 use Data::Dumper;
-use Log::Log4perl;
+use pf::log;
 use Net::Telnet;
 
 use base ('pf::Switch::Dell');
@@ -28,13 +28,13 @@ sub description { 'Dell PowerConnect 3424' }
 
 sub getMinOSVersion {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     return '112';
 }
 
 sub _setVlan {
     my ( $this, $ifIndex, $newVlan, $oldVlan, $switch_locker_ref ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $session;
 
     eval {

--- a/lib/pf/Switch/Dlink.pm
+++ b/lib/pf/Switch/Dlink.pm
@@ -16,7 +16,6 @@ use warnings;
 
 use base ('pf::Switch');
 use Net::SNMP;
-use pf::log;
 
 use pf::Switch::constants;
 use pf::util;

--- a/lib/pf/Switch/Dlink.pm
+++ b/lib/pf/Switch/Dlink.pm
@@ -16,7 +16,7 @@ use warnings;
 
 use base ('pf::Switch');
 use Net::SNMP;
-use Log::Log4perl;
+use pf::log;
 
 use pf::Switch::constants;
 use pf::util;
@@ -25,7 +25,7 @@ sub getVersion {
     my ($this) = @_;
     my $oid_swDlinkEquipmentCapacitySwVersion
         = '1.3.6.1.4.1.171.12.11.1.9.4.1.8.1';
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectRead() ) {
         return '';
     }
@@ -43,7 +43,7 @@ sub getVersion {
 sub parseTrap {
     my ( $this, $trapString ) = @_;
     my $trapHashRef;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( $trapString
         =~ /BEGIN VARIABLEBINDINGS [^|]+[|]\.1\.3\.6\.1\.6\.3\.1\.1\.4\.1\.0 = OID: \.1\.3\.6\.1\.6\.3\.1\.1\.5\.([34])\|.1.3.6.1.2.1.2.2.1.1.([0-9]+)/
@@ -88,7 +88,7 @@ sub parseTrap {
 
 sub _setVlan {
     my ( $this, $ifIndex, $newVlan, $oldVlan, $switch_locker_ref ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectRead() ) {
         return 0;
     }
@@ -185,7 +185,7 @@ sub _setVlan {
 
 sub isLearntTrapsEnabled {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     return 1;
 }
 

--- a/lib/pf/Switch/Dlink/DES_3028.pm
+++ b/lib/pf/Switch/Dlink/DES_3028.pm
@@ -13,7 +13,6 @@ to access SNMP enabled Dlink DES 3526 switches.
 
 use strict;
 use warnings;
-use pf::log;
 use Net::SNMP;
 use base ('pf::Switch::Dlink');
 

--- a/lib/pf/Switch/Dlink/DES_3028.pm
+++ b/lib/pf/Switch/Dlink/DES_3028.pm
@@ -13,7 +13,7 @@ to access SNMP enabled Dlink DES 3526 switches.
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 use base ('pf::Switch::Dlink');
 
@@ -22,7 +22,7 @@ sub description { 'D-Link DES 3028' }
 sub parseTrap {
     my ( $this, $trapString ) = @_;
     my $trapHashRef;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     my @fields = split '\|', $trapString;
 

--- a/lib/pf/Switch/Dlink/DES_3526.pm
+++ b/lib/pf/Switch/Dlink/DES_3526.pm
@@ -17,7 +17,7 @@ No port security support, no RADIUS.
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 use base ('pf::Switch::Dlink');
 
@@ -26,7 +26,7 @@ sub description {'D-Link DES 3526'}
 sub parseTrap {
     my ( $this, $trapString ) = @_;
     my $trapHashRef;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     my @fields = split '\|', $trapString;
 

--- a/lib/pf/Switch/Dlink/DES_3526.pm
+++ b/lib/pf/Switch/Dlink/DES_3526.pm
@@ -17,7 +17,6 @@ No port security support, no RADIUS.
 
 use strict;
 use warnings;
-use pf::log;
 use Net::SNMP;
 use base ('pf::Switch::Dlink');
 

--- a/lib/pf/Switch/Dlink/DES_3550.pm
+++ b/lib/pf/Switch/Dlink/DES_3550.pm
@@ -23,7 +23,6 @@ Tested by the community on the 5.01.B65 firmware.
 use strict;
 use warnings;
 
-use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Nortel');

--- a/lib/pf/Switch/Dlink/DES_3550.pm
+++ b/lib/pf/Switch/Dlink/DES_3550.pm
@@ -23,7 +23,7 @@ Tested by the community on the 5.01.B65 firmware.
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Nortel');

--- a/lib/pf/Switch/Dlink/DGS_3100.pm
+++ b/lib/pf/Switch/Dlink/DGS_3100.pm
@@ -38,7 +38,7 @@ F<conf/switches.conf>
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 use base ('pf::Switch::Dlink');
 
@@ -70,7 +70,7 @@ sub inlineCapabilities { return ($MAC,$PORT); }
 sub getVersion {
     my ($this) = @_;
     my $oid_dlinkFirmwareVersion = '1.3.6.1.4.1.171.10.94.89.89.2.4.0';
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectRead() ) {
         return '';
     }
@@ -91,7 +91,7 @@ Translate RADIUS NAS-Port into the physical port ifIndex
 
 sub NasPortToIfIndex {
     my ($this, $NAS_port) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
     
     #NAS-Port is ifIndex (Stacked switch not tested!!)
     return $NAS_port;

--- a/lib/pf/Switch/Dlink/DGS_3100.pm
+++ b/lib/pf/Switch/Dlink/DGS_3100.pm
@@ -38,7 +38,6 @@ F<conf/switches.conf>
 
 use strict;
 use warnings;
-use pf::log;
 use Net::SNMP;
 use base ('pf::Switch::Dlink');
 

--- a/lib/pf/Switch/Dlink/DGS_3200.pm
+++ b/lib/pf/Switch/Dlink/DGS_3200.pm
@@ -35,7 +35,6 @@ F<conf/switches.conf>
 
 use strict;
 use warnings;
-use pf::log;
 use Net::SNMP;
 use base ('pf::Switch::Dlink');
 

--- a/lib/pf/Switch/Dlink/DGS_3200.pm
+++ b/lib/pf/Switch/Dlink/DGS_3200.pm
@@ -35,7 +35,7 @@ F<conf/switches.conf>
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 use base ('pf::Switch::Dlink');
 
@@ -67,7 +67,7 @@ sub inlineCapabilities { return ($MAC,$PORT); }
 sub getVersion {
     my ($this) = @_;
     my $oid_dlinkFirmwareVersion = '1.3.6.1.4.1.171.10.94.89.89.2.4.0';
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectRead() ) {
         return '';
     }
@@ -88,7 +88,7 @@ Translate RADIUS NAS-Port into the physical port ifIndex
 
 sub NasPortToIfIndex {
     my ($this, $NAS_port) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
     
     #NAS-Port is ifIndex (Stacked switch not tested!!)
     return $NAS_port;

--- a/lib/pf/Switch/Dlink/DWL.pm
+++ b/lib/pf/Switch/Dlink/DWL.pm
@@ -21,7 +21,6 @@ This module is currently only a placeholder, see L<pf::Switch::Dlink::DWS_3026> 
 use strict;
 use warnings;
 
-use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Dlink::DWS_3026');

--- a/lib/pf/Switch/Dlink/DWL.pm
+++ b/lib/pf/Switch/Dlink/DWL.pm
@@ -21,7 +21,7 @@ This module is currently only a placeholder, see L<pf::Switch::Dlink::DWS_3026> 
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Dlink::DWS_3026');

--- a/lib/pf/Switch/Dlink/DWS_3026.pm
+++ b/lib/pf/Switch/Dlink/DWS_3026.pm
@@ -44,7 +44,6 @@ Firmware 3.0.0.13 and 3.0.0.16 are known to be affected.
 use strict;
 use warnings;
 
-use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Dlink');

--- a/lib/pf/Switch/Dlink/DWS_3026.pm
+++ b/lib/pf/Switch/Dlink/DWS_3026.pm
@@ -44,7 +44,7 @@ Firmware 3.0.0.13 and 3.0.0.16 are known to be affected.
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Dlink');
@@ -64,7 +64,7 @@ sub inlineCapabilities { return ($MAC,$SSID); }
 
 sub deauthenticateMacDefault {
     my ( $this, $mac ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $OID_wsAssociatedClientDisassociateAction = '1.3.6.1.4.1.171.10.73.30.9.1.1.9';
 
     if ( !$this->isProductionMode() ) {
@@ -98,7 +98,7 @@ sub isLearntTrapsEnabled {
 
 sub setLearntTrapsEnabled {
     my ( $this, $ifIndex, $trueFalse ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->error("function is NOT implemented");
     return -1;
 }
@@ -110,28 +110,28 @@ sub isRemovedTrapsEnabled {
 
 sub setRemovedTrapsEnabled {
     my ( $this, $ifIndex, $trueFalse ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->error("function is NOT implemented");
     return -1;
 }
 
 sub getVmVlanType {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->error("function is NOT implemented");
     return -1;
 }
 
 sub setVmVlanType {
     my ( $this, $ifIndex, $type ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->error("function is NOT implemented");
     return -1;
 }
 
 sub isTrunkPort {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->error("function is NOT implemented");
     return -1;
 }
@@ -139,14 +139,14 @@ sub isTrunkPort {
 sub getVlans {
     my ($this) = @_;
     my $vlans  = {};
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->error("function is NOT implemented");
     return $vlans;
 }
 
 sub isDefinedVlan {
     my ( $this, $vlan ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->error("function is NOT implemented");
     return 0;
 }
@@ -158,7 +158,7 @@ sub isVoIPEnabled {
 
 sub deauthTechniques {
     my ($this, $method) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $default = $SNMP::SNMP;
     my %tech = (
         $SNMP::SNMP => 'deauthenticateMacDefault',

--- a/lib/pf/Switch/EdgeCore.pm
+++ b/lib/pf/Switch/EdgeCore.pm
@@ -18,7 +18,7 @@ Tested on EdgeCore 4510 running v1.3.2.0
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use POSIX;
 
 use base ('pf::Switch');

--- a/lib/pf/Switch/EdgeCore.pm
+++ b/lib/pf/Switch/EdgeCore.pm
@@ -18,7 +18,6 @@ Tested on EdgeCore 4510 running v1.3.2.0
 use strict;
 use warnings;
 
-use pf::log;
 use POSIX;
 
 use base ('pf::Switch');

--- a/lib/pf/Switch/Enterasys.pm
+++ b/lib/pf/Switch/Enterasys.pm
@@ -17,7 +17,6 @@ use warnings;
 
 use base ('pf::Switch');
 use POSIX;
-use pf::log;
 use Net::SNMP;
 
 use pf::Switch::constants;

--- a/lib/pf/Switch/Enterasys.pm
+++ b/lib/pf/Switch/Enterasys.pm
@@ -17,7 +17,7 @@ use warnings;
 
 use base ('pf::Switch');
 use POSIX;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use pf::Switch::constants;
@@ -26,7 +26,7 @@ use pf::util;
 sub parseTrap {
     my ( $this, $trapString ) = @_;
     my $trapHashRef;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( $trapString
         =~ /\.1\.3\.6\.1\.6\.3\.1\.1\.4\.1\.0 = OID: \.1\.3\.6\.1\.6\.3\.1\.1\.5\.([34])\|\.1\.3\.6\.1\.2\.1\.2\.2\.1\.1\.(\d+) =/
         )
@@ -63,20 +63,20 @@ sub parseTrap {
 
 sub _setVlan {
     my ( $this, $ifIndex, $newVlan, $oldVlan, $switch_locker_ref ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     return $this->_setVlanByOnlyModifyingPvid( $ifIndex, $newVlan, $oldVlan,
         $switch_locker_ref );
 }
 
 sub isLearntTrapsEnabled {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     return 0;
 }
 
 sub isPortSecurityEnabled {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     #ENTERASYS-MAC_LOCKING-MIB
     my $OID_etsysMACLockingSystemEnable = '1.3.6.1.4.1.5624.1.2.21.1.1.1';
@@ -126,7 +126,7 @@ sub isPortSecurityEnabled {
 
 sub getMaxMacAddresses {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->connectRead() ) {
         return -1;
@@ -163,7 +163,7 @@ sub getMaxMacAddresses {
 
 sub authorizeMAC {
     my ( $this, $ifIndex, $deauthMac, $authMac, $deauthVlan, $authVlan ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     my $OID_etsysMACLockingStaticEntryRowStatus
         = '1.3.6.1.4.1.5624.1.2.21.1.3.1.1.2';
@@ -210,7 +210,7 @@ sub authorizeMAC {
 
 sub getAllSecureMacAddresses {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $OID_etsysMACLockingStaticEntryRowStatus
         = '1.3.6.1.4.1.5624.1.2.21.1.3.1.1.2';
 
@@ -240,7 +240,7 @@ sub getAllSecureMacAddresses {
 
 sub getSecureMacAddresses {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $OID_etsysMACLockingStaticEntryRowStatus
         = '1.3.6.1.4.1.5624.1.2.21.1.3.1.1.2';
 

--- a/lib/pf/Switch/Enterasys/D2.pm
+++ b/lib/pf/Switch/Enterasys/D2.pm
@@ -15,7 +15,7 @@ It should work on all D2 switches and maybe more.
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 use Net::Telnet;
 use pf::Switch::constants;
@@ -42,7 +42,7 @@ sub supportsWiredMacAuth { return $SNMP::TRUE; }
 # maybe the Matrix N3's telnet code would be a safer bet?
 sub _setVlan {
     my ( $this, $ifIndex, $newVlan, $oldVlan, $switch_locker_ref ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if (!$this->connectRead()) {
         return 0;
     }

--- a/lib/pf/Switch/Enterasys/D2.pm
+++ b/lib/pf/Switch/Enterasys/D2.pm
@@ -15,7 +15,6 @@ It should work on all D2 switches and maybe more.
 
 use strict;
 use warnings;
-use pf::log;
 use Net::SNMP;
 use Net::Telnet;
 use pf::Switch::constants;

--- a/lib/pf/Switch/Enterasys/Matrix_N3.pm
+++ b/lib/pf/Switch/Enterasys/Matrix_N3.pm
@@ -15,7 +15,6 @@ It should work on all Matrix chassis.
 
 use strict;
 use warnings;
-use pf::log;
 use Net::SNMP;
 use Net::Telnet;
 use base ('pf::Switch::Enterasys');

--- a/lib/pf/Switch/Enterasys/Matrix_N3.pm
+++ b/lib/pf/Switch/Enterasys/Matrix_N3.pm
@@ -15,7 +15,7 @@ It should work on all Matrix chassis.
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 use Net::Telnet;
 use base ('pf::Switch::Enterasys');
@@ -36,7 +36,7 @@ What we do here is the parent method and then translate dot1dBasePort to ifIndex
 
 sub getMacBridgePortHash {
     my $this   = shift;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
     my %macBridgePortHash = ();
 
     # call our parent method fill the hash with mac -> dot1dBasePort
@@ -75,7 +75,7 @@ sub getMacBridgePortHash {
 # see http://www.packetfence.org/mantis/view.php?id=803 for details
 sub _setVlan {
     my ( $this, $ifIndex, $newVlan, $oldVlan, $switch_locker_ref ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if (!$this->connectRead()) {
         return 0;
     }
@@ -181,7 +181,7 @@ sub _setVlan {
 # LIMITATION: only works with gigabit ports (ge.x.y)
 #sub _setVlan {
 #    my ($this, $ifIndex, $newVlan, $oldVlan, $switch_locker_ref) = @_;
-#    my $logger = Log::Log4perl::get_logger(ref($this));
+#    my $logger = $this->logger;
 #
 #    # use telnet to set the new VLAN
 #    my $session;

--- a/lib/pf/Switch/Enterasys/SecureStack_C2.pm
+++ b/lib/pf/Switch/Enterasys/SecureStack_C2.pm
@@ -13,7 +13,6 @@ oriented interface to access SNMP enabled Enterasys SecureStack C2 switches.
 
 use strict;
 use warnings;
-use pf::log;
 use Net::SNMP;
 use base ('pf::Switch::Enterasys');
 

--- a/lib/pf/Switch/Enterasys/SecureStack_C2.pm
+++ b/lib/pf/Switch/Enterasys/SecureStack_C2.pm
@@ -13,7 +13,7 @@ oriented interface to access SNMP enabled Enterasys SecureStack C2 switches.
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 use base ('pf::Switch::Enterasys');
 

--- a/lib/pf/Switch/Enterasys/SecureStack_C3.pm
+++ b/lib/pf/Switch/Enterasys/SecureStack_C3.pm
@@ -16,7 +16,6 @@ It should work on all C3 switches and maybe more.
 
 use strict;
 use warnings;
-use pf::log;
 use Net::SNMP;
 use base ('pf::Switch::Enterasys');
 

--- a/lib/pf/Switch/Enterasys/SecureStack_C3.pm
+++ b/lib/pf/Switch/Enterasys/SecureStack_C3.pm
@@ -16,7 +16,7 @@ It should work on all C3 switches and maybe more.
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 use base ('pf::Switch::Enterasys');
 

--- a/lib/pf/Switch/Enterasys/V2110.pm
+++ b/lib/pf/Switch/Enterasys/V2110.pm
@@ -18,7 +18,6 @@ Should work on the hostapd version started 2.0
 use strict;
 use warnings;
 
-use pf::log;
 use POSIX;
 use Try::Tiny;
 

--- a/lib/pf/Switch/Enterasys/V2110.pm
+++ b/lib/pf/Switch/Enterasys/V2110.pm
@@ -18,7 +18,7 @@ Should work on the hostapd version started 2.0
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use POSIX;
 use Try::Tiny;
 
@@ -55,7 +55,7 @@ This is called when we receive an SNMP-Trap for this device
 sub parseTrap {
     my ( $this, $trapString ) = @_;
     my $trapHashRef;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     $logger->debug("trap currently not handled");
     $trapHashRef->{'trapType'} = 'unknown';
@@ -69,7 +69,7 @@ sub parseTrap {
 
 sub getVersion {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->info("we don't know how to determine the version through SNMP !");
     return '2.0.13';
 }
@@ -82,7 +82,7 @@ Return the reference to the deauth technique or the default deauth technique.
 
 sub deauthTechniques {
     my ($this, $method) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $default = $SNMP::RADIUS;
     my %tech = (
         $SNMP::RADIUS => 'deauthenticateMacRadius',
@@ -104,7 +104,7 @@ New implementation using RADIUS Disconnect-Request.
 
 sub deauthenticateMacRadius {
     my ( $self, $mac, $is_dot1x ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
 
     if ( !$self->isProductionMode() ) {
         $logger->info("not in production mode... we won't perform deauthentication");
@@ -128,7 +128,7 @@ Uses L<pf::util::radius> for the low-level RADIUS stuff.
 # TODO consider whether we should handle retries or not?
 sub radiusDisconnect {
     my ($self, $mac, $add_attributes_ref) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
 
     # initialize
     $add_attributes_ref = {} if (!defined($add_attributes_ref));
@@ -205,7 +205,7 @@ Enterasys specific parser. See pf::SNMP for base implementation.
 
 sub extractSsid {
     my ($this, $radius_request) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     if (defined($radius_request->{'Siemens-SSID'})) {
         return $radius_request->{'Siemens-SSID'};

--- a/lib/pf/Switch/Extreme.pm
+++ b/lib/pf/Switch/Extreme.pm
@@ -60,7 +60,7 @@ use strict;
 use warnings;
 
 use base ('pf::Switch');
-use Log::Log4perl;
+use pf::log;
 use Net::Appliance::Session;
 use Net::SNMP;
 use SOAP::Lite;
@@ -91,7 +91,7 @@ sub getVersion {
     my ($this) = @_;
     # current image description
     my $oid_extremeImageDescription = '1.3.6.1.4.1.1916.1.1.1.34.1.10.3'; # from EXTREME-SYSTEM-MIB
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
     if (!$this->connectRead()) {
         return '';
     }
@@ -111,7 +111,7 @@ sub getVersion {
 
 sub getVlan {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
     # a binary map of all the ports 0 = not in vlan, 1 = in vlan
     my $oid_extremeVlanOpaqueUntaggedPorts = '1.3.6.1.4.1.1916.1.2.6.1.1.2'; #from EXTREME-VLAN-MIB
 
@@ -157,7 +157,7 @@ sub getVlan {
 
 sub getVlans {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
     # vlanIfIndex to vlan number (vlan tag)
     my $oid_extremeVlanIfVlanId = "1.3.6.1.4.1.1916.1.2.1.2.1.10"; #from EXTREME-VLAN-MIB
     # vlanIfIndex to vlan name
@@ -200,7 +200,7 @@ sub getVlans {
 
 sub isDefinedVlan {
     my ($this, $vlan) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
     # vlanIfIndex to vlan number (vlan tag)
     my $oid_extremeVlanIfVlanId = "1.3.6.1.4.1.1916.1.2.1.2.1.10"; #from EXTREME-VLAN-MIB
     
@@ -230,7 +230,7 @@ It uses the new MIB available in Extreme XOS 12.2+: extremeFdbMacExosFdbTable.
 
 sub _getMacAtIfIndex {
     my ( $this, $ifIndex, $vlan ) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
     my @macArray;
 
     if ( !$this->connectRead() ) {
@@ -287,7 +287,7 @@ A auto-detection layer and code re-routing could be written if there is some inc
 
 sub _getMacAtIfIndexPreXOS {
     my ( $this, $ifIndex, $vlan ) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
     my @macArray;
 
     if ( !$this->connectRead() ) {
@@ -338,7 +338,7 @@ key: mac address / value: ifIndex of port where mac address is
 sub getMacBridgePortHash {
     my $this   = shift;
     my $vlan   = shift || '';
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
     my %macBridgePortHash  = ();
 
     if ( !$this->connectRead() ) {
@@ -379,7 +379,7 @@ These switches uses a vlan ifIndex everywhere instead of using directly the vlan
 
 sub _getVlanTagFromVlanIfIndex {
     my ($this, $vlanIfIndex) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
     # vlanIfIndex to vlan number (vlan tag)
     my $oid_extremeVlanIfVlanId = "1.3.6.1.4.1.1916.1.2.1.2.1.10.".$vlanIfIndex; #from EXTREME-VLAN-MIB
 
@@ -410,7 +410,7 @@ Useful to avoid multiple lookups in a tight loop.
 
 sub _getVlanTagLookupTable {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     # vlanIfIndex to vlan number (vlan tag)
     my $oid_extremeVlanIfVlanId = "1.3.6.1.4.1.1916.1.2.1.2.1.10"; #from EXTREME-VLAN-MIB
@@ -445,7 +445,7 @@ number like most of the other makers do.
 
 sub _getVlanIfIndexFromVlanTag {
     my ($this, $vlan) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
     # vlanIfIndex to vlan number (vlan tag)
     my $oid_extremeVlanIfVlanId = "1.3.6.1.4.1.1916.1.2.1.2.1.10"; #from EXTREME-VLAN-MIB
     
@@ -475,7 +475,7 @@ These switches uses VLAN ifDescr for Fdb operations over Web Services. Helper me
 
 sub _getVlanIfDescrFromVlanTag {
     my ($this, $vlan) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     # vlanIfIndex to vlanIfDescr
     my $oid_extremeVlanIfDescr = "1.3.6.1.4.1.1916.1.2.1.2.1.2"; #from EXTREME-VLAN-MIB
@@ -506,7 +506,7 @@ sub _getVlanIfDescrFromVlanTag {
 
 sub _getVlanTagFromVlanIfDescr {
     my ($this, $vlanIfDescr) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     # vlanIfIndex to vlanIfDescr
     my $oid_extremeVlanIfDescr = "1.3.6.1.4.1.1916.1.2.1.2.1.2"; #from EXTREME-VLAN-MIB
@@ -545,7 +545,7 @@ sub _getVlanTagFromVlanIfDescr {
 
 sub _getDot1dPortFromIfIndex {
     my ($this, $ifIndex) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     my $ifName = $this->_getIfNameFromIfIndex($ifIndex);
     if ($ifName =~ /(\d+):(\d+)/) {
@@ -563,7 +563,7 @@ ifName format is: <switch stack id>:<dot1d port number> (ex: 1:12)
 
 sub _getIfNameFromIfIndex {
     my ($this, $ifIndex) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
     # get interface name which is stack:port on extreme switches
     my $oid_ifName = "1.3.6.1.2.1.31.1.1.1.1.".$ifIndex; # from IF-MIB
 
@@ -588,7 +588,7 @@ ifName format is: <switch stack id>:<dot1d port number> (ex: 1:12)
 
 sub _getIfIndexLookupTable {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
     # get interface name which is stack:port on extreme switches
     my $oid_ifName = "1.3.6.1.2.1.31.1.1.1.1"; # from IF-MIB
 
@@ -622,7 +622,7 @@ sub _getIfIndexLookupTable {
 sub parseTrap {
     my ( $this, $trapString ) = @_;
     my $trapHashRef;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     
     # linkUp / linkDown trap
     if ($trapString =~ /BEGIN TYPE 0 END TYPE BEGIN SUBTYPE 0 END SUBTYPE BEGIN VARIABLEBINDINGS .+\|\.1\.3\.6\.1\.6\.3\.1\.1\.4\.1\.0 = OID: \.1\.3\.6\.1\.6\.3\.1\.1\.5\.([34])\|\.1\.3\.6\.1\.2\.1\.2\.2\.1\.1 = INTEGER: (\d+)\|/) {
@@ -649,7 +649,7 @@ sub parseTrap {
 
 sub _setVlan {
     my ( $this, $ifIndex, $newVlan, $oldVlan, $switch_locker_ref ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $result;
 
     if ( !$this->connectRead() ) {
@@ -772,7 +772,7 @@ Returns an hashref with MAC => ifIndex => Array(VLANs)
 
 sub _getAllSecureMacAddressesWithSNMP {
     my ( $this ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     # from EXTREME-FDB-MIB
     my $oid_extremeFdbMacExosFdbPortIfIndex = '1.3.6.1.4.1.1916.1.16.4.1.3';
@@ -830,7 +830,7 @@ Returns an hashref with MAC => ifIndex => Array(VLANs)
 # and we should have the SNMP interface back (hopefully)
 sub _getAllSecureMacAddressesWithWS {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     my $secureMacAddrHashRef = {};
 
@@ -908,7 +908,7 @@ Returns an hashref with MAC => Array(VLANs)
 # and we should have the SNMP interface back (hopefully)
 sub _getSecureMacAddressesWithWS {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     my $secureMacAddrHashRef = {};
 
@@ -967,7 +967,7 @@ Returns an hashref with MAC => Array(VLANs)
 
 sub _getSecureMacAddressesWithSNMP {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     # from EXTREME-FDB-MIB
     my $oid_extremeFdbMacExosFdbPortIfIndex = '1.3.6.1.4.1.1916.1.16.4.1.3';
@@ -1021,7 +1021,7 @@ Requires ExtremeXOS 12.4.3
 
 sub isPortSecurityEnabled {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     my $oid_extremePortVlanInfoMacLockDownEnabled = '1.3.6.1.4.1.1916.1.4.17.1.4'; # from EXTREME-PORT-MIB
 
@@ -1077,7 +1077,7 @@ capabilities of the Extreme OS (can't know if maclock is activated or not)
 
 sub _isPortSecurityEnabledOld {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     my $oid_extremeFdbPermFdbPortList = '1.3.6.1.4.1.1916.1.16.3.1.4'; # from EXTREME-FDB-MIB
 
@@ -1128,7 +1128,7 @@ sub _isPortSecurityEnabledOld {
 
 sub authorizeMAC {
     my ( $this, $ifIndex, $deauthMac, $authMac, $deauthVlan, $authVlan ) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     if ( !$this->isProductionMode() ) {
         $logger->info("not in production mode ... we won't add an entry to the SecureMacAddrTable");
@@ -1154,7 +1154,7 @@ sub authorizeMAC {
 
 sub _authorizeMAC {
     my ($this, $ifIndex, $mac, $vlan) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     my $ws_client = $this->_getSOAPHandle();
 
@@ -1199,7 +1199,7 @@ For compatibility we won't change subroutine signature, we will just throw out t
 
 sub _deauthorizeMAC {
     my ($this, $ifIndex, $mac, $vlan) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     my $ws_client = $this->_getSOAPHandle();
 
@@ -1301,7 +1301,7 @@ sub _translateStackDot1dToPortListPosition {
 
 sub _getPortsPerSlot {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     $logger->debug("unimplemented");
     # TODO: unimplemented but would be relatively easy to do so since all required hooks are there
@@ -1318,7 +1318,7 @@ sub _getPortsPerSlot {
 #TODO test self-signed certs from the server (disabled by default)
 sub _getSOAPHandle {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     my $proxy_url = 
         $this->{_wsTransport} . "://" # transport (http, https)
@@ -1349,7 +1349,7 @@ On this switch, the lock-learning is a per-vlan attribute so it performs it on t
 
 sub enablePortSecurityByIfIndex {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     my $result = $this->_setPortSecurityByIfIndex($ifIndex, $TRUE);
     if (!defined($result)) {
@@ -1367,7 +1367,7 @@ On this switch, the lock-learning is a per-vlan attribute so it performs it on t
 
 sub disablePortSecurityByIfIndex {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     my $result = $this->_setPortSecurityByIfIndex($ifIndex, $FALSE);
     if (!defined($result)) {
@@ -1387,7 +1387,7 @@ On this switch, the lock-learning is a per-vlan attribute so it performs it on t
 
 sub _setPortSecurityByIfIndex {
     my ( $this, $ifIndex, $enable ) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     my $oid_extremePortVlanInfoMacLockDownEnabled = '1.3.6.1.4.1.1916.1.4.17.1.4'; # from EXTREME-PORT-MIB
 
@@ -1437,7 +1437,7 @@ Warning: this code doesn't support elevating to privileged mode. See #900 and #1
 
 sub _setPortSecurityByIfIndexCLI {
     my ( $this, $ifIndex, $enable ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     my $session;
     eval {
@@ -1501,7 +1501,7 @@ sub isVoIPEnabled {
 
 sub getVoiceVlan {
     my ($this, $ifIndex) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     my $voiceVlan = $this->getVlanByName('voice');
     if (defined($voiceVlan)) {

--- a/lib/pf/Switch/Extreme.pm
+++ b/lib/pf/Switch/Extreme.pm
@@ -60,7 +60,6 @@ use strict;
 use warnings;
 
 use base ('pf::Switch');
-use pf::log;
 use Net::Appliance::Session;
 use Net::SNMP;
 use SOAP::Lite;

--- a/lib/pf/Switch/Extreme/Summit.pm
+++ b/lib/pf/Switch/Extreme/Summit.pm
@@ -13,7 +13,6 @@ This module is currently only a placeholder, see pf::Switch::Extreme.
 
 use strict;
 use warnings;
-use pf::log;
 use Net::SNMP;
 use base ('pf::Switch::Extreme');
 

--- a/lib/pf/Switch/Extreme/Summit.pm
+++ b/lib/pf/Switch/Extreme/Summit.pm
@@ -13,7 +13,7 @@ This module is currently only a placeholder, see pf::Switch::Extreme.
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 use base ('pf::Switch::Extreme');
 

--- a/lib/pf/Switch/Extreme/Summit_X250e.pm
+++ b/lib/pf/Switch/Extreme/Summit_X250e.pm
@@ -13,7 +13,7 @@ This module is currently only a placeholder, see pf::Switch::Extreme.
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 use base ('pf::Switch::Extreme::Summit');
 

--- a/lib/pf/Switch/Extreme/Summit_X250e.pm
+++ b/lib/pf/Switch/Extreme/Summit_X250e.pm
@@ -13,7 +13,6 @@ This module is currently only a placeholder, see pf::Switch::Extreme.
 
 use strict;
 use warnings;
-use pf::log;
 use Net::SNMP;
 use base ('pf::Switch::Extreme::Summit');
 

--- a/lib/pf/Switch/Extricom.pm
+++ b/lib/pf/Switch/Extricom.pm
@@ -24,7 +24,7 @@ use strict;
 use warnings;
 
 use Carp;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch');
@@ -57,7 +57,7 @@ obtain image version information from switch
 sub getVersion {
     my ($this) = @_;
     my $oid_inventoryswver = '1.3.6.1.4.1.23937.6.11.0'; # EXTRICOM-SNMP-MIB::inventoryswver
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->connectRead() ) {
         return '';
@@ -82,7 +82,7 @@ sub getVersion {
 sub parseTrap {
     my ( $this, $trapString ) = @_;
     my $trapHashRef;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     # EXTRICOM-SNMP-MIB::clientDisassociate: .1.3.6.1.4.1.23937.2.1
     if ( $trapString =~ /\.1\.3\.6\.1\.4\.1\.23937\.2\.1 = STRING: "[0-9]+:Client ([0-9A-Z]{2}:[0-9A-Z]{2}:[0-9A-Z]{2}:[0-9A-Z]{2}:[0-9A-Z]{2}:[0-9A-Z]{2})/ ) {
@@ -105,7 +105,7 @@ Writing to the read community instead (then putting back appropriate in place)
 
 sub connectWrite {
     my $this   = shift;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( defined( $this->{_sessionWrite} ) ) {
         return 1;
     }
@@ -188,7 +188,7 @@ sub connectWrite {
 
 sub deauthenticateMacDefault {
     my ( $this, $mac ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $OID_clearDot11Client = '1.3.6.1.4.1.23937.9.12.0'; # EXTRICOM-SNMP-MIB::clearDot11Client
 
     if ( !$this->isProductionMode() ) {
@@ -230,7 +230,7 @@ Return the reference to the deauth technique or the default deauth technique.
 
 sub deauthTechniques {
     my ($this, $method) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $default = $SNMP::SNMP;
     my %tech = (
         $SNMP::SNMP => 'deauthenticateMacDefault',

--- a/lib/pf/Switch/Extricom.pm
+++ b/lib/pf/Switch/Extricom.pm
@@ -24,7 +24,6 @@ use strict;
 use warnings;
 
 use Carp;
-use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch');

--- a/lib/pf/Switch/Extricom/EXSW.pm
+++ b/lib/pf/Switch/Extricom/EXSW.pm
@@ -12,7 +12,7 @@ This module is currently only a placeholder, see pf::Switch::Extricom
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 
 use base ('pf::Switch::Extricom');
 

--- a/lib/pf/Switch/Extricom/EXSW.pm
+++ b/lib/pf/Switch/Extricom/EXSW.pm
@@ -12,7 +12,6 @@ This module is currently only a placeholder, see pf::Switch::Extricom
 
 use strict;
 use warnings;
-use pf::log;
 
 use base ('pf::Switch::Extricom');
 

--- a/lib/pf/Switch/Foundry.pm
+++ b/lib/pf/Switch/Foundry.pm
@@ -50,7 +50,6 @@ use warnings;
 
 use base ('pf::Switch');
 use POSIX;
-use pf::log;
 use Net::SNMP;
 
 use pf::util;

--- a/lib/pf/Switch/Foundry.pm
+++ b/lib/pf/Switch/Foundry.pm
@@ -50,7 +50,7 @@ use warnings;
 
 use base ('pf::Switch');
 use POSIX;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use pf::util;
@@ -64,7 +64,7 @@ use constant DUAL_MODE => 3;
 sub getVersion {
     my ($this)         = @_;
     my $oid_snAgImgVer = '1.3.6.1.4.1.1991.1.1.2.1.11.0';
-    my $logger         = Log::Log4perl::get_logger( ref($this) );
+    my $logger         = $this->logger;
 
     if ( !$this->connectRead() ) {
         return '';
@@ -78,7 +78,7 @@ sub getVersion {
 sub parseTrap {
     my ( $this, $trapString ) = @_;
     my $trapHashRef;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( $trapString
         =~ /\.1\.3\.6\.1\.6\.3\.1\.1\.4\.1\.0 = OID: \.1\.3\.6\.1\.6\.3\.1\.1\.5\.([34])\|\.1\.3\.6\.1\.2\.1\.2\.2\.1\.1\.(\d+) =/
         )
@@ -120,7 +120,7 @@ sub parseTrap {
 
 sub isDefinedVlan {
     my ($this, $vlan) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
     # vlanIfIndex to vlan number (vlan tag)
     my $oid_snVLanByPortVLanId = '1.3.6.1.4.1.1991.1.1.3.2.1.1.2'; #from FOUNDRY-SN-SWITCH-GROUP-MIB
 
@@ -147,7 +147,7 @@ sub getVlans {
     my $vlans                    = {};
     my $oid_snVLanByPortVLanName = '1.3.6.1.4.1.1991.1.1.3.2.1.1.25';
 
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->connectRead() ) {
         return $vlans;
@@ -174,7 +174,7 @@ sub getVlans {
 
 sub _setVlan {
     my ( $this, $ifIndex, $newVlan, $oldVlan, $switch_locker_ref ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->connectWrite() ) {
         return 0;
@@ -229,13 +229,13 @@ sub _setVlan {
 
 sub isLearntTrapsEnabled {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     return 0;
 }
 
 sub isPortSecurityEnabled {
     my ($this, $ifIndex) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     if (!$this->connectRead()) {
         return 0;
@@ -274,7 +274,7 @@ Returns an hashref with MAC => Array(VLANs)
 
 sub getSecureMacAddresses {
     my ($this, $ifIndex) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     # from FOUNDRY-SN-SWITCH-GROUP-MIB
     my $oid_snPortMacSecurityIntfMacVlanId = '1.3.6.1.4.1.1991.1.1.3.24.1.1.4.1.3';
@@ -313,7 +313,7 @@ Returns an hashref with MAC => ifIndex => Array(VLANs)
 
 sub getAllSecureMacAddresses {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     # from FOUNDRY-SN-SWITCH-GROUP-MIB
     my $oid_snPortMacSecurityIntfMacVlanId = '1.3.6.1.4.1.1991.1.1.3.24.1.1.4.1.3';
@@ -352,7 +352,7 @@ sub getAllSecureMacAddresses {
 
 sub authorizeMAC {
     my ($this, $ifIndex, $deauthMac, $authMac, $deauthVlan, $authVlan) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     # TODO consider pushing this up to caller (especially if we do it in every authorizeMAC)
     if (!$this->isProductionMode()) {
@@ -423,7 +423,7 @@ sub authorizeMAC {
 
 sub getMaxMacAddresses {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->connectRead() ) {
         return -1;
@@ -452,7 +452,7 @@ Dual-mode allows an ifIndex to support an untagged vlan along with a tagged one 
 
 sub _setDualModeVlan {
     my ($this, $ifIndex, $vlan) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->connectWrite() ) {
         return 0;
@@ -490,7 +490,7 @@ sub _setDualModeVlan {
 
 sub getVoiceVlan {
     my ($this, $ifIndex) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     my $voiceVlan = $this->getVlanByName('voice');
     if (defined($voiceVlan)) {

--- a/lib/pf/Switch/Foundry/FastIron_4802.pm
+++ b/lib/pf/Switch/Foundry/FastIron_4802.pm
@@ -14,7 +14,7 @@ oriented interface to access SNMP enabled Foundry FastIron 4802 switches.
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 use base ('pf::Switch::Foundry');
 

--- a/lib/pf/Switch/Foundry/FastIron_4802.pm
+++ b/lib/pf/Switch/Foundry/FastIron_4802.pm
@@ -14,7 +14,6 @@ oriented interface to access SNMP enabled Foundry FastIron 4802 switches.
 
 use strict;
 use warnings;
-use pf::log;
 use Net::SNMP;
 use base ('pf::Switch::Foundry');
 

--- a/lib/pf/Switch/Foundry/MC.pm
+++ b/lib/pf/Switch/Foundry/MC.pm
@@ -20,7 +20,7 @@ Please let us know if you have access to such hardware and can validate our clai
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 
 use base ('pf::Switch::Meru');
 

--- a/lib/pf/Switch/Foundry/MC.pm
+++ b/lib/pf/Switch/Foundry/MC.pm
@@ -20,7 +20,6 @@ Please let us know if you have access to such hardware and can validate our clai
 
 use strict;
 use warnings;
-use pf::log;
 
 use base ('pf::Switch::Meru');
 

--- a/lib/pf/Switch/H3C.pm
+++ b/lib/pf/Switch/H3C.pm
@@ -19,7 +19,7 @@ pf::Switch::H3C - Object oriented module to access and configure enabled H3C swi
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 use POSIX;
 
@@ -84,7 +84,7 @@ Same as pf::Switch::ThreeCom::SS4500
 #TODO consider subclassing ThreeCom to avoid code duplication
 sub getIfIndexForThisDot1dBasePort {
     my ( $this, $dot1dBasePort ) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
     # port number into ifIndex
     my $OID_dot1dBasePortIfIndex = '.1.3.6.1.2.1.17.1.4.1.2.'.$dot1dBasePort; # from BRIDGE-MIB
 
@@ -110,7 +110,7 @@ Returns the software version of the slot.
 
 sub getVersion {
     my ( $this ) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     my $OID_hh3cLswSysVersion = '1.3.6.1.4.1.25506.8.35.18.1.4';    # from HH3C-LSW-DEV-ADM-MIB
     my $slotNumber = '0';
@@ -150,7 +150,7 @@ Returns RADIUS attributes for voip phone devices.
 
 sub getVoipVsa {
     my ( $this ) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     return (
         'Tunnel-Type'               => $RADIUS::VLAN,
@@ -179,7 +179,7 @@ Same as pf::Switch::ThreeCom::Switch_4200G
 #TODO consider subclassing ThreeCom to avoid code duplication
 sub NasPortToIfIndex {
     my ($this, $nas_port) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     # 4096 NAS-Port slots are reserved per physical ports, 
     # I'm assuming that each client will get a +1 so I translate all of them into the same ifIndex
@@ -210,7 +210,7 @@ All traps ignored
 
 sub parseTrap {
     my ( $this, $trapString ) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     my $trapHashRef;
 

--- a/lib/pf/Switch/H3C.pm
+++ b/lib/pf/Switch/H3C.pm
@@ -19,7 +19,6 @@ pf::Switch::H3C - Object oriented module to access and configure enabled H3C swi
 use strict;
 use warnings;
 
-use pf::log;
 use Net::SNMP;
 use POSIX;
 

--- a/lib/pf/Switch/HP.pm
+++ b/lib/pf/Switch/HP.pm
@@ -29,7 +29,7 @@ use strict;
 use warnings;
 
 use base ('pf::Switch');
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use pf::Switch::constants;
@@ -46,7 +46,7 @@ TODO: This list is incomplete
 sub getVersion {
     my ($this)                = @_;
     my $oid_hpSwitchOsVersion = '1.3.6.1.4.1.11.2.14.11.5.1.1.3.0';
-    my $logger                = Log::Log4perl::get_logger( ref($this) );
+    my $logger                = $this->logger;
     if ( !$this->connectRead() ) {
         return '';
     }
@@ -65,7 +65,7 @@ sub getVersion {
 sub parseTrap {
     my ( $this, $trapString ) = @_;
     my $trapHashRef;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     #-- secureMacAddrViolation SNMP v1 & v2c
     if ( $trapString
@@ -101,7 +101,7 @@ sub parseTrap {
 
 sub _setVlan {
     my ( $this, $ifIndex, $newVlan, $oldVlan, $switch_locker_ref ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectRead() ) {
         return 0;
     }
@@ -193,7 +193,7 @@ sub _setVlan {
 
 sub getAllSecureMacAddresses {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $OID_hpSecCfgStatus
         = '1.3.6.1.4.1.11.2.14.2.10.4.1.4';    #HP-ICF-GENERIC-RPTR
     my $hpSecCfgAddrGroupIndex = 1;
@@ -228,7 +228,7 @@ sub getAllSecureMacAddresses {
 
 sub getSecureMacAddresses {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $OID_hpSecCfgStatus
         = '1.3.6.1.4.1.11.2.14.2.10.4.1.4';    #HP-ICF-GENERIC-RPTR
     my $hpSecCfgAddrGroupIndex = 1;
@@ -263,7 +263,7 @@ sub getSecureMacAddresses {
 
 sub getMaxMacAddresses {
     my ( $this, $ifIndex ) = @_;
-    my $logger                  = Log::Log4perl::get_logger( ref($this) );
+    my $logger                  = $this->logger;
     my $OID_hpSecPtAddressLimit = '1.3.6.1.4.1.11.2.14.2.10.3.1.3';
     my $OID_hpSecPtLearnMode    = '1.3.6.1.4.1.11.2.14.2.10.3.1.4';
     my $hpSecCfgAddrGroupIndex  = 1;
@@ -325,7 +325,7 @@ sub getMaxMacAddresses {
 
 sub authorizeMAC {
     my ( $this, $ifIndex, $deauthMac, $authMac, $deauthVlan, $authVlan ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( ($deauthMac) && ( !$this->isFakeMac($deauthMac) ) ) {
         $this->_authorizeMAC( $ifIndex, $deauthMac, 0 );
@@ -341,7 +341,7 @@ sub authorizeMAC {
 # In both case, resets IntrusionFlag
 sub _authorizeMAC {
     my ( $this, $ifIndex, $MACHexString, $authorize ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $OID_hpSecCfgStatus
         = '1.3.6.1.4.1.11.2.14.2.10.4.1.4';    #HP-ICF-GENERIC-RPTR
     my $OID_hpSecPtIntrusionFlag
@@ -397,7 +397,7 @@ sub isStaticPortSecurityEnabled {
 
 sub setPortSecurityEnableByIfIndex {
     my ( $this, $ifIndex, $trueFalse ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     $logger->info("function not implemented yet");
     return 1;
@@ -405,7 +405,7 @@ sub setPortSecurityEnableByIfIndex {
 
 sub isPortSecurityEnabled {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     my $OID_hpSecPtLearnMode   = '1.3.6.1.4.1.11.2.14.2.10.3.1.4';
     my $OID_hpSecPtAlarmEnable = '1.3.6.1.4.1.11.2.14.2.10.3.1.6';
@@ -447,7 +447,7 @@ sub isPortSecurityEnabled {
 sub getVlanFdbId {
     my ( $this, $vlan ) = @_;
     my $OID_dot1qVlanFdbId = '1.3.6.1.2.1.17.7.1.4.2.1.3.0';    #Q-BRIDGE-MIB
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->connectRead() ) {
         return 0;
@@ -484,7 +484,7 @@ In what VLAN should a VoIP device be.
 
 sub getVoiceVlan {
     my ($this, $ifIndex) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     my $voiceVlan = $this->getVlanByName('voice');
     if (defined($voiceVlan)) {

--- a/lib/pf/Switch/HP.pm
+++ b/lib/pf/Switch/HP.pm
@@ -29,7 +29,6 @@ use strict;
 use warnings;
 
 use base ('pf::Switch');
-use pf::log;
 use Net::SNMP;
 
 use pf::Switch::constants;

--- a/lib/pf/Switch/HP/Controller_MSM710.pm
+++ b/lib/pf/Switch/HP/Controller_MSM710.pm
@@ -25,7 +25,6 @@ presents some issues, the SNMP deauthentication is not working.
 use strict;
 use warnings;
 
-use pf::log;
 use POSIX;
 
 use base ('pf::Switch');

--- a/lib/pf/Switch/HP/Controller_MSM710.pm
+++ b/lib/pf/Switch/HP/Controller_MSM710.pm
@@ -25,7 +25,7 @@ presents some issues, the SNMP deauthentication is not working.
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use POSIX;
 
 use base ('pf::Switch');
@@ -59,7 +59,7 @@ sub inlineCapabilities { return ($MAC,$SSID); }
 sub getVersion {
     my ($this)       = @_;
     my $oid_sysDescr = '1.3.6.1.2.1.1.1.0'; #SNMPv2-MIB
-    my $logger       = Log::Log4perl::get_logger( ref($this) );
+    my $logger       = $this->logger;
     if ( !$this->connectRead() ) {
         return '';
     }
@@ -82,7 +82,7 @@ sub getVersion {
 sub parseTrap {
     my ( $this, $trapString ) = @_;
     my $trapHashRef;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     # COLUBRIS-DEVICE-EVENT-MIB :: coDeviceEventSuccessfulDeAuthentication :: 1.3.6.1.4.1.8744.5.26.2.0.9
     # COLUBRIS-DEVICE-EVENT-MIB :: coDevEvDetMacAddress ::                    1.3.6.1.4.1.8744.5.26.1.2.2.1.2
@@ -105,7 +105,7 @@ sub parseTrap {
 
 sub deauthenticateMacDefault {
     my ($this, $mac) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
     my $OID_coDevWirCliStaMACAddress = '1.3.6.1.4.1.8744.5.25.1.7.1.1.2'; # from COLUBRIS-DEVICE-WIRELESS-MIB
     my $OID_coDevWirCliDisassociate = '1.3.6.1.4.1.8744.5.25.1.7.1.1.27'; # from COLUBRIS-DEVICE-WIRELESS-MIB
 
@@ -156,7 +156,7 @@ HP / Colubris specific parser. See pf::Switch for base implementation.
 
 sub extractSsid {
     my ($this, $radius_request) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     if (defined($radius_request->{'Colubris-AVPair'})) {
         # With HP Procurve AP Ccontroller, we receive an array of settings in Colubris-AVPair:
@@ -184,7 +184,7 @@ Method to deauthenticate a node with SSH
 
 sub _deauthenticateMacWithSSH {
     my ( $this, $mac ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $session;
     my @addition_ops;
     if (defined $this->{_controllerPort} && $this->{_cliTransport} eq 'SSH' ) {
@@ -229,7 +229,7 @@ Return the reference to the deauth technique or the default deauth technique.
 
 sub deauthTechniques {
     my ($this, $method) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $default = $SNMP::SNMP;
     my %tech = (
         $SNMP::SNMP => 'deauthenticateMacDefault',

--- a/lib/pf/Switch/HP/E4800G.pm
+++ b/lib/pf/Switch/HP/E4800G.pm
@@ -82,7 +82,6 @@ It's really a matter of choice.
 use strict;
 use warnings;
 
-use pf::log;
 use Net::SNMP;
 use POSIX;
 

--- a/lib/pf/Switch/HP/E4800G.pm
+++ b/lib/pf/Switch/HP/E4800G.pm
@@ -82,7 +82,7 @@ It's really a matter of choice.
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 use POSIX;
 

--- a/lib/pf/Switch/HP/E5500G.pm
+++ b/lib/pf/Switch/HP/E5500G.pm
@@ -89,7 +89,7 @@ It's really a matter of choice.
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 use POSIX;
 

--- a/lib/pf/Switch/HP/E5500G.pm
+++ b/lib/pf/Switch/HP/E5500G.pm
@@ -89,7 +89,6 @@ It's really a matter of choice.
 use strict;
 use warnings;
 
-use pf::log;
 use Net::SNMP;
 use POSIX;
 

--- a/lib/pf/Switch/HP/MSM.pm
+++ b/lib/pf/Switch/HP/MSM.pm
@@ -17,7 +17,7 @@ Should work on all HP Wireless Access Point
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use POSIX;
 
 use base ('pf::Switch::HP::Controller_MSM710');
@@ -44,7 +44,7 @@ Method to deauthenticate a node with SSH
 
 sub _deauthenticateMacWithSSH {
     my ( $this, $mac ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $session;
     my @addition_ops;
     if (defined $this->{_controllerPort} && $this->{_cliTransport} eq 'SSH' ) {
@@ -89,7 +89,7 @@ Return the reference to the deauth technique or the default deauth technique.
 
 sub deauthTechniques {
     my ($this, $method) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $default = $SNMP::SSH;
     my %tech = (
         $SNMP::SSH  => '_deauthenticateMacWithSSH',

--- a/lib/pf/Switch/HP/MSM.pm
+++ b/lib/pf/Switch/HP/MSM.pm
@@ -17,7 +17,6 @@ Should work on all HP Wireless Access Point
 use strict;
 use warnings;
 
-use pf::log;
 use POSIX;
 
 use base ('pf::Switch::HP::Controller_MSM710');

--- a/lib/pf/Switch/HP/Procurve_2500.pm
+++ b/lib/pf/Switch/HP/Procurve_2500.pm
@@ -20,7 +20,7 @@ We are also not sure about the VoIP using 802.1X/Mac Auth.
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 use base ('pf::Switch::HP');
 
@@ -41,7 +41,7 @@ sub inlineCapabilities { return ($MAC,$PORT); }
 
 sub getMaxMacAddresses {
     my ( $this, $ifIndex ) = @_;
-    my $logger                  = Log::Log4perl::get_logger( ref($this) );
+    my $logger                  = $this->logger;
     my $OID_hpSecPtAddressLimit = '1.3.6.1.4.1.11.2.14.2.10.3.1.3';
     my $OID_hpSecPtLearnMode    = '1.3.6.1.4.1.11.2.14.2.10.3.1.4';
     my $hpSecCfgAddrGroupIndex  = 1;
@@ -103,7 +103,7 @@ sub getMaxMacAddresses {
 
 sub isPortSecurityEnabled {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     my $OID_hpSecPtLearnMode   = '1.3.6.1.4.1.11.2.14.2.10.3.1.4';
     my $OID_hpSecPtAlarmEnable = '1.3.6.1.4.1.11.2.14.2.10.3.1.6';
@@ -144,7 +144,7 @@ sub isPortSecurityEnabled {
 
 sub authorizeMAC {
     my ( $this, $ifIndex, $deauthMac, $authMac, $deauthVlan, $authVlan ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     my $OID_hpSecCfgStatus
         = '1.3.6.1.4.1.11.2.14.2.10.4.1.4';    #HP-ICF-GENERIC-RPTR

--- a/lib/pf/Switch/HP/Procurve_2500.pm
+++ b/lib/pf/Switch/HP/Procurve_2500.pm
@@ -20,7 +20,6 @@ We are also not sure about the VoIP using 802.1X/Mac Auth.
 
 use strict;
 use warnings;
-use pf::log;
 use Net::SNMP;
 use base ('pf::Switch::HP');
 

--- a/lib/pf/Switch/HP/Procurve_2600.pm
+++ b/lib/pf/Switch/HP/Procurve_2600.pm
@@ -17,7 +17,7 @@ VoIP not tested using MAC Authentication/802.1X
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 use base ('pf::Switch::HP');
 

--- a/lib/pf/Switch/HP/Procurve_2600.pm
+++ b/lib/pf/Switch/HP/Procurve_2600.pm
@@ -17,7 +17,6 @@ VoIP not tested using MAC Authentication/802.1X
 
 use strict;
 use warnings;
-use pf::log;
 use Net::SNMP;
 use base ('pf::Switch::HP');
 

--- a/lib/pf/Switch/HP/Procurve_2920.pm
+++ b/lib/pf/Switch/HP/Procurve_2920.pm
@@ -17,7 +17,7 @@ VoIP not tested using MAC Authentication/802.1X
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 use base ('pf::Switch::HP');
 
@@ -47,7 +47,7 @@ Get Voice over IP RADIUS Vendor Specific Attribute (VSA).
 
 sub getVoipVsa {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $vlanid = sprintf( "%03x\n", $this->getVlanByName('voice') );
     my $hexvlan = hex( "31000" . $vlanid );
     return ( 'Egress-VLANID' => $hexvlan, );
@@ -61,7 +61,7 @@ Using SNMP and LLDP we determine if there is VoIP connected on the switch port
 
 sub getPhonesLLDPAtIfIndex {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my @phones;
     if ( !$this->isVoIPEnabled() ) {
         $logger->debug( "VoIP not enabled on switch "

--- a/lib/pf/Switch/HP/Procurve_2920.pm
+++ b/lib/pf/Switch/HP/Procurve_2920.pm
@@ -17,7 +17,6 @@ VoIP not tested using MAC Authentication/802.1X
 
 use strict;
 use warnings;
-use pf::log;
 use Net::SNMP;
 use base ('pf::Switch::HP');
 

--- a/lib/pf/Switch/HP/Procurve_3400cl.pm
+++ b/lib/pf/Switch/HP/Procurve_3400cl.pm
@@ -12,7 +12,6 @@ This switch was reported to work by the community with the Procurve 2600 module.
 
 use strict;
 use warnings;
-use pf::log;
 use Net::SNMP;
 use base ('pf::Switch::HP');
 

--- a/lib/pf/Switch/HP/Procurve_3400cl.pm
+++ b/lib/pf/Switch/HP/Procurve_3400cl.pm
@@ -12,7 +12,7 @@ This switch was reported to work by the community with the Procurve 2600 module.
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 use base ('pf::Switch::HP');
 

--- a/lib/pf/Switch/HP/Procurve_4100.pm
+++ b/lib/pf/Switch/HP/Procurve_4100.pm
@@ -13,7 +13,6 @@ oriented interface to access SNMP enabled HP Procurve 4100 switches.
 
 use strict;
 use warnings;
-use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::HP::Procurve_2500');

--- a/lib/pf/Switch/HP/Procurve_4100.pm
+++ b/lib/pf/Switch/HP/Procurve_4100.pm
@@ -13,7 +13,7 @@ oriented interface to access SNMP enabled HP Procurve 4100 switches.
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::HP::Procurve_2500');

--- a/lib/pf/Switch/HP/Procurve_5300.pm
+++ b/lib/pf/Switch/HP/Procurve_5300.pm
@@ -15,7 +15,7 @@ This module is currently only a placeholder, see L<pf::Switch::HP::Procurve_5400
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::HP::Procurve_5400');

--- a/lib/pf/Switch/HP/Procurve_5300.pm
+++ b/lib/pf/Switch/HP/Procurve_5300.pm
@@ -15,7 +15,6 @@ This module is currently only a placeholder, see L<pf::Switch::HP::Procurve_5400
 use strict;
 use warnings;
 
-use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::HP::Procurve_5400');

--- a/lib/pf/Switch/HP/Procurve_5400.pm
+++ b/lib/pf/Switch/HP/Procurve_5400.pm
@@ -40,7 +40,7 @@ Recommanded Firmware is K.15.06.0008
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::HP::Procurve_2500');
@@ -76,7 +76,7 @@ TODO: Use Egress-VLANID instead. See: http://wiki.freeradius.org/HP#RFC+4675+%28
 
 sub getVoipVsa {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     return ('Egress-VLAN-Name' => "1".$VOICEVLANAME);
 }

--- a/lib/pf/Switch/HP/Procurve_5400.pm
+++ b/lib/pf/Switch/HP/Procurve_5400.pm
@@ -40,7 +40,6 @@ Recommanded Firmware is K.15.06.0008
 
 use strict;
 use warnings;
-use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::HP::Procurve_2500');

--- a/lib/pf/Switch/Hostapd.pm
+++ b/lib/pf/Switch/Hostapd.pm
@@ -18,7 +18,6 @@ Should work on the hostapd version started 2.0
 use strict;
 use warnings;
 
-use pf::log;
 use POSIX;
 use Try::Tiny;
 

--- a/lib/pf/Switch/Hostapd.pm
+++ b/lib/pf/Switch/Hostapd.pm
@@ -18,7 +18,7 @@ Should work on the hostapd version started 2.0
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use POSIX;
 use Try::Tiny;
 
@@ -56,7 +56,7 @@ This is called when we receive an SNMP-Trap for this device
 sub parseTrap {
     my ( $this, $trapString ) = @_;
     my $trapHashRef;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     $logger->debug("trap currently not handled");
     $trapHashRef->{'trapType'} = 'unknown';
@@ -70,7 +70,7 @@ sub parseTrap {
 
 sub getVersion {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->info("we don't know how to determine the version through SNMP !");
     return '2.0.13';
 }
@@ -83,7 +83,7 @@ Return the reference to the deauth technique or the default deauth technique.
 
 sub deauthTechniques {
     my ($this, $method) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $default = $SNMP::RADIUS;
     my %tech = (
         $SNMP::RADIUS => 'deauthenticateMacRadius',
@@ -105,7 +105,7 @@ New implementation using RADIUS Disconnect-Request.
 
 sub deauthenticateMacRadius {
     my ( $self, $mac, $is_dot1x ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
 
     if ( !$self->isProductionMode() ) {
         $logger->info("not in production mode... we won't perform deauthentication");
@@ -129,7 +129,7 @@ Uses L<pf::util::radius> for the low-level RADIUS stuff.
 # TODO consider whether we should handle retries or not?
 sub radiusDisconnect {
     my ($self, $mac, $add_attributes_ref) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
 
     # initialize
     $add_attributes_ref = {} if (!defined($add_attributes_ref));

--- a/lib/pf/Switch/Huawei.pm
+++ b/lib/pf/Switch/Huawei.pm
@@ -18,7 +18,7 @@ Should work on the Huawei version started 2.0
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use POSIX;
 use Try::Tiny;
 
@@ -57,7 +57,7 @@ This is called when we receive an SNMP-Trap for this device
 sub parseTrap {
     my ( $this, $trapString ) = @_;
     my $trapHashRef;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     $logger->debug("trap currently not handled");
     $trapHashRef->{'trapType'} = 'unknown';
@@ -71,7 +71,7 @@ sub parseTrap {
 
 sub getVersion {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->info("we don't know how to determine the version through SNMP !");
     return '2.0.13';
 }
@@ -84,7 +84,7 @@ Return the reference to the deauth technique or the default deauth technique.
 
 sub deauthTechniques {
     my ($this, $method) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $default = $SNMP::RADIUS;
     my %tech = (
         $SNMP::RADIUS => 'deauthenticateMacRadius',
@@ -106,7 +106,7 @@ New implementation using RADIUS Disconnect-Request.
 
 sub deauthenticateMacRadius {
     my ( $self, $mac, $is_dot1x ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
 
     if ( !$self->isProductionMode() ) {
         $logger->info("not in production mode... we won't perform deauthentication");
@@ -131,7 +131,7 @@ Uses L<pf::util::radius> for the low-level RADIUS stuff.
 # TODO consider whether we should handle retries or not?
 sub radiusDisconnect {
     my ($self, $mac, $add_attributes_ref) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
 
     # initialize
     $add_attributes_ref = {} if (!defined($add_attributes_ref));
@@ -203,7 +203,7 @@ Find RADIUS SSID parameter on the Huawei AC6605 controller
 
 sub extractSsid {
     my ($this, $radius_request) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     if (defined($radius_request->{'Called-Station-Id'})) {
         return $radius_request->{'Called-Station-Id'};

--- a/lib/pf/Switch/Huawei.pm
+++ b/lib/pf/Switch/Huawei.pm
@@ -18,7 +18,6 @@ Should work on the Huawei version started 2.0
 use strict;
 use warnings;
 
-use pf::log;
 use POSIX;
 use Try::Tiny;
 

--- a/lib/pf/Switch/Huawei/S5710.pm
+++ b/lib/pf/Switch/Huawei/S5710.pm
@@ -20,7 +20,7 @@ Bumping a port doesn't reevaluate the access.
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use POSIX;
 use Try::Tiny;
 
@@ -53,7 +53,7 @@ Called when a ReAssignVlan trap is received for a switch-port in Wired MAC Authe
 
 sub handleReAssignVlanTrapForWiredMacAuth {
     my ($this, $ifIndex, $mac) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     $this->deauthenticateMacRadius($mac);
 }

--- a/lib/pf/Switch/IBM/IBM_RackSwitch_G8052.pm
+++ b/lib/pf/Switch/IBM/IBM_RackSwitch_G8052.pm
@@ -46,7 +46,7 @@ Return the reference to the deauth technique or the default deauth technique.
 
 sub wiredeauthTechniques {
     my ($this, $method, $connection_type) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ($connection_type == $WIRED_802_1X) {
         my $default = $SNMP::SNMP;
         my %tech = (
@@ -66,7 +66,7 @@ sub wiredeauthTechniques {
 
 sub _dot1xPortReauthenticate {
     my ($this, $ifIndex) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     $logger->info("Trying to do IBM 802.1x port re-authentication.");
 

--- a/lib/pf/Switch/Intel.pm
+++ b/lib/pf/Switch/Intel.pm
@@ -15,12 +15,12 @@ use strict;
 use warnings;
 
 use base ('pf::Switch');
-use Log::Log4perl;
+use pf::log;
 
 sub parseTrap {
     my ( $this, $trapString ) = @_;
     my $trapHashRef;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( $trapString
         =~ /^BEGIN TYPE ([23]) END TYPE BEGIN SUBTYPE 0 END SUBTYPE BEGIN VARIABLEBINDINGS \.1\.3\.6\.1\.2\.1\.2\.2\.1\.1\.(\d+) = INTEGER: \d+ END VARIABLEBINDINGS$/
         )

--- a/lib/pf/Switch/Intel.pm
+++ b/lib/pf/Switch/Intel.pm
@@ -15,7 +15,6 @@ use strict;
 use warnings;
 
 use base ('pf::Switch');
-use pf::log;
 
 sub parseTrap {
     my ( $this, $trapString ) = @_;

--- a/lib/pf/Switch/Intel/Express_460.pm
+++ b/lib/pf/Switch/Intel/Express_460.pm
@@ -19,7 +19,6 @@ F<conf/switches.conf>
 
 use strict;
 use warnings;
-use pf::log;
 use Net::SNMP;
 use base ('pf::Switch::Intel');
 

--- a/lib/pf/Switch/Intel/Express_460.pm
+++ b/lib/pf/Switch/Intel/Express_460.pm
@@ -19,7 +19,7 @@ F<conf/switches.conf>
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 use base ('pf::Switch::Intel');
 
@@ -27,14 +27,14 @@ sub description { 'Intel Express 460' }
 
 sub getMinOSVersion {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     return '4.60.89';
 }
 
 sub getVersion {
     my ($this) = @_;
     my $oid_es400AgentRuntimeSwVersion = '1.3.6.1.4.1.343.6.17.1.1.1.0';
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectRead() ) {
         return '';
     }
@@ -54,7 +54,7 @@ sub getVersion {
 
 sub getAllVlans {
     my ( $this, @ifIndexes ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $vlanHashRef;
     if ( !@ifIndexes ) {
         @ifIndexes = $this->getManagedIfIndexes();
@@ -78,7 +78,7 @@ sub getAllVlans {
 
 sub getVlan {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectRead() ) {
         return 0;
     }
@@ -91,7 +91,7 @@ sub getVlan {
 
 sub _setVlan {
     my ( $this, $ifIndex, $newVlan, $oldVlan, $switch_locker_ref ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectRead() ) {
         return 0;
     }
@@ -194,7 +194,7 @@ sub _setVlan {
 
 sub setAdminStatus {
     my ( $this, $ifIndex, $enabled ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $OID_es400PortConfigAdminState = '1.3.6.1.4.1.343.6.17.3.2.1.2';
     if ( !$this->connectWrite() ) {
         return 0;

--- a/lib/pf/Switch/Intel/Express_530.pm
+++ b/lib/pf/Switch/Intel/Express_530.pm
@@ -20,7 +20,6 @@ F<conf/switches.conf>
 use strict;
 use warnings;
 use Data::Dumper;
-use pf::log;
 use Net::SNMP;
 use base ('pf::Switch::Intel');
 

--- a/lib/pf/Switch/Intel/Express_530.pm
+++ b/lib/pf/Switch/Intel/Express_530.pm
@@ -20,7 +20,7 @@ F<conf/switches.conf>
 use strict;
 use warnings;
 use Data::Dumper;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 use base ('pf::Switch::Intel');
 
@@ -28,14 +28,14 @@ sub description { 'Intel Express 530' }
 
 sub getMinOSVersion {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     return '1.00.23';
 }
 
 sub getVersion {
     my ($this) = @_;
     my $oid_es530AgentRuntimeSwVersion = '1.3.6.1.4.1.343.6.63.1.1.1.0';
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectRead() ) {
         return '';
     }
@@ -55,7 +55,7 @@ sub getVersion {
 
 sub _setVlan {
     my ( $this, $ifIndex, $newVlan, $oldVlan, $switch_locker_ref ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectRead() ) {
         return 0;
     }
@@ -154,7 +154,7 @@ sub _setVlan {
 
 sub setAdminStatus {
     my ( $this, $ifIndex, $enabled ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     #obtain unit and module from unique ifIndex
     my $OID_es530HwPortEncodingFactor = '1.3.6.1.4.1.343.6.63.2.1.3.0';

--- a/lib/pf/Switch/Juniper.pm
+++ b/lib/pf/Switch/Juniper.pm
@@ -33,7 +33,6 @@ use strict;
 use warnings;
 
 use base ('pf::Switch');
-use pf::log;
 use Net::Appliance::Session;
 
 use pf::constants;

--- a/lib/pf/Switch/Juniper.pm
+++ b/lib/pf/Switch/Juniper.pm
@@ -33,7 +33,7 @@ use strict;
 use warnings;
 
 use base ('pf::Switch');
-use Log::Log4perl;
+use pf::log;
 use Net::Appliance::Session;
 
 use pf::constants;
@@ -68,7 +68,7 @@ Ex: NAS-Port 115 is the 115th ifIndex entry  which is ifIndex 598.
 
 sub NasPortToIfIndex {
     my ($this, $NAS_port) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     # grab ifName -> ifIndex hash
     my %ifNameIfIndexHash = $this->getIfNameIfIndexHash();
@@ -118,7 +118,7 @@ Warning: This is really slow! About 6 second for the link change.
 
 sub setAdminStatus {
     my ($this, $ifIndex, $enable) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     
     if ( !$this->isProductionMode() ) {
         $logger->info("not in production mode ... we won't set the admin status for ifIndex $ifIndex");
@@ -185,7 +185,7 @@ Called when a ReAssignVlan trap is received for a switch-port in Wired MAC Authe
 
 sub handleReAssignVlanTrapForWiredMacAuth {
     my ($this, $ifIndex, $mac) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     my $switch_ip = $this->{_ip};
 

--- a/lib/pf/Switch/Juniper/EX.pm
+++ b/lib/pf/Switch/Juniper/EX.pm
@@ -14,7 +14,6 @@ use strict;
 use warnings;
 
 use base ('pf::Switch::Juniper');
-use pf::log;
 use Net::Appliance::Session;
 
 use pf::config;

--- a/lib/pf/Switch/Juniper/EX.pm
+++ b/lib/pf/Switch/Juniper/EX.pm
@@ -14,7 +14,7 @@ use strict;
 use warnings;
 
 use base ('pf::Switch::Juniper');
-use Log::Log4perl;
+use pf::log;
 use Net::Appliance::Session;
 
 use pf::config;

--- a/lib/pf/Switch/Juniper/EX2200.pm
+++ b/lib/pf/Switch/Juniper/EX2200.pm
@@ -30,7 +30,7 @@ use strict;
 use warnings;
 
 use base ('pf::Switch::Juniper');
-use Log::Log4perl;
+use pf::log;
 use Net::Appliance::Session;
 
 use pf::constants;
@@ -68,7 +68,7 @@ For now it returns the voiceVlan untagged since Juniper supports multiple untagg
 
 sub getVoipVsa{
     my ($this) = @_; 
-    my $logger = Log::Log4perl::get_logger( ref($this) ); 
+    my $logger = $this->logger; 
     my $voiceVlan = $this->{'_voiceVlan'};
     $logger->info("Accepting phone with untagged Access-Accept on voiceVlan $voiceVlan");
     
@@ -90,7 +90,7 @@ Method to deauth a wired node with RADIUS Disconnect.
 
 sub deauthenticateMacRadius {
     my ($this, $ifIndex,$mac) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     $this->radiusDisconnect($mac );
 }
@@ -103,7 +103,7 @@ Send a Disconnect request to disconnect a mac
 
 sub radiusDisconnect {
     my ($self, $mac, $add_attributes_ref) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
 
     # initialize
     $add_attributes_ref = {} if (!defined($add_attributes_ref));
@@ -167,7 +167,7 @@ Return the reference to the deauth technique or the default deauth technique.
 
 sub wiredeauthTechniques { 
    my ($this, $method, $connection_type) = @_;
-   my $logger = Log::Log4perl::get_logger( ref($this) );
+   my $logger = $this->logger;
 
     if ($connection_type == $WIRED_802_1X) {
         my $default = $SNMP::RADIUS;
@@ -204,7 +204,7 @@ Connects to the switch and configures the specified port to be RADIUS floating d
 
 sub enableMABFloatingDevice{
     my ($this, $ifIndex) = @_; 
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     
     my $session;
     eval {
@@ -263,7 +263,7 @@ Connects to the switch and removes the RADIUS floating device configuration
 
 sub disableMABFloatingDevice{
     my ($this, $ifIndex) = @_; 
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     
     my $session;
     eval {
@@ -320,7 +320,7 @@ sub disableMABFloatingDevice{
 #sub supportsLldp { return $TRUE; }
 #sub getPhonesLLDPAtIfIndex {
 #    my ( $this, $ifIndex ) = @_;
-#    my $logger = Log::Log4perl::get_logger( ref($this) );
+#    my $logger = $this->logger;
 #
 #    # if can't SNMP read abort
 #    return if ( !$this->connectRead() );

--- a/lib/pf/Switch/Juniper/EX2200.pm
+++ b/lib/pf/Switch/Juniper/EX2200.pm
@@ -30,7 +30,6 @@ use strict;
 use warnings;
 
 use base ('pf::Switch::Juniper');
-use pf::log;
 use Net::Appliance::Session;
 
 use pf::constants;

--- a/lib/pf/Switch/LG.pm
+++ b/lib/pf/Switch/LG.pm
@@ -54,7 +54,6 @@ use warnings;
 use base ('pf::Switch');
 
 use POSIX;
-use pf::log;
 use Net::SNMP;
 
 use pf::constants;

--- a/lib/pf/Switch/LG.pm
+++ b/lib/pf/Switch/LG.pm
@@ -54,7 +54,7 @@ use warnings;
 use base ('pf::Switch');
 
 use POSIX;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use pf::constants;
@@ -82,7 +82,7 @@ This list is incomplete.
 sub parseTrap {
     my ( $this, $trapString ) = @_;
     my $trapHashRef;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     # link up/down
     if ( $trapString =~ 
@@ -123,7 +123,7 @@ sub parseTrap {
 
 sub getVersion {
     my ( $this ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     my $OID_swProdVersion = '1.3.6.1.4.1.572.17389.14500.1.1.5.4.0';    # iPECS_ES-4500G MIB
 
@@ -143,7 +143,7 @@ sub getVersion {
 
 sub isPortSecurityEnabled {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     my $OID_portSecPortStatus = '1.3.6.1.4.1.572.17389.14500.1.17.2.1.1.2';    # iPECS_ES-4500G MIB
 
@@ -163,7 +163,7 @@ sub isPortSecurityEnabled {
 
 sub authorizeMAC {
     my ( $this, $ifIndex, $deauthMac, $authMac, $deauthVlan, $authVlan ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     my $OID_dot1qStaticUnicastStatus = '1.3.6.1.2.1.17.7.1.3.1.1.4';           # Q-BRIDGE MIB
     my $OID_dot1qStaticUnicastAllowedToGoTo = '1.3.6.1.2.1.17.7.1.3.1.1.3';    # Q-BRIDGE MIB
@@ -235,7 +235,7 @@ sub authorizeMAC {
 
 sub _setVlan {
     my ( $this, $ifIndex, $newVlan, $oldVlan, $switch_locker_ref ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     my $OID_dot1qPvid = '1.3.6.1.2.1.17.7.1.4.5.1.1';                       # Q-BRIDGE-MIB
     my $OID_dot1qVlanStaticUntaggedPorts = '1.3.6.1.2.1.17.7.1.4.3.1.4';    # Q-BRIDGE-MIB
@@ -379,7 +379,7 @@ Returns an hashref with MAC => Array(VLANs)
 
 sub getSecureMacAddresses {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     my $OID_dot1qStaticUnicastAllowedToGoTo = '1.3.6.1.2.1.17.7.1.3.1.1.3';    # Q-BRIDGE MIB
 
@@ -424,7 +424,7 @@ Returns an hashref with MAC => ifIndex => Array(VLANs)
 
 sub getAllSecureMacAddresses {
     my ( $this ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     my $OID_dot1qStaticUnicastAllowedToGoTo = '1.3.6.1.2.1.17.7.1.3.1.1.3';    # Q-BRIDGE MIB
 
@@ -480,7 +480,7 @@ sub getAllSecureMacAddresses {
 
 sub getDot1dBasePortForThisIfIndex {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     my $OID_dot1dBaseNumPort = '1.3.6.1.2.1.17.1.2.0';    # BRIDGE MIB 
 

--- a/lib/pf/Switch/LG/ES4500G.pm
+++ b/lib/pf/Switch/LG/ES4500G.pm
@@ -14,7 +14,7 @@ use strict;
 use warnings;
 
 use POSIX;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use pf::Switch::constants;

--- a/lib/pf/Switch/LG/ES4500G.pm
+++ b/lib/pf/Switch/LG/ES4500G.pm
@@ -14,7 +14,6 @@ use strict;
 use warnings;
 
 use POSIX;
-use pf::log;
 use Net::SNMP;
 
 use pf::Switch::constants;

--- a/lib/pf/Switch/Linksys.pm
+++ b/lib/pf/Switch/Linksys.pm
@@ -16,7 +16,6 @@ use strict;
 use warnings;
 
 use base ('pf::Switch');
-use pf::log;
 use Net::SNMP;
 # disabling port-security since its known not to work
 #use Net::Telnet;

--- a/lib/pf/Switch/Linksys.pm
+++ b/lib/pf/Switch/Linksys.pm
@@ -16,7 +16,7 @@ use strict;
 use warnings;
 
 use base ('pf::Switch');
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 # disabling port-security since its known not to work
 #use Net::Telnet;
@@ -25,7 +25,7 @@ sub getVersion {
     my ($this) = @_;
     my $oid_rlPhdUnitGenParamSoftwareVersion
         = '1.3.6.1.4.1.89.53.14.1.2.1';    #RADLAN-Physicaldescription-MIB
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectRead() ) {
         return '';
     }
@@ -47,7 +47,7 @@ sub getVersion {
 sub parseTrap {
     my ( $this, $trapString ) = @_;
     my $trapHashRef;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->trace("matching trap string");
     if ( $trapString
         =~ /BEGIN VARIABLEBINDINGS \.1\.3\.6\.1\.2\.1\.2\.2\.1\.1\.(\d+) = INTEGER: \d+\|\.1\.3\.6\.1\.2\.1\.2\.2\.1\.7\.\d+ = INTEGER: [^|]+\|\.1\.3\.6\.1\.2\.1\.2\.2\.1\.8\.\d+ = INTEGER: [^(]+\((\d)\) END VARIABLEBINDINGS/
@@ -81,7 +81,7 @@ sub parseTrap {
 
 sub isDefinedVlan {
     my ( $this, $vlan ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->trace("isDefinedVlan vlan: $vlan ?");
     if ( $vlan == 1 ) {
         return 1;
@@ -93,7 +93,7 @@ sub getTrunkPorts {
     my ($this) = @_;
     my $OID_vlanPortModeState = '1.3.6.1.4.1.89.48.22.1.1';    #RADLAN-vlan-MIB
     my @trunkPorts;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->connectRead() ) {
         return -1;
@@ -133,7 +133,7 @@ sub getUpLinks {
 
 sub _setVlan {
     my ( $this, $ifIndex, $newVlan, $oldVlan, $switch_locker_ref ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectRead() ) {
         return 0;
     }
@@ -305,7 +305,7 @@ sub _setVlan {
 # See other telnet consuming switches for correct implementation.
 #sub connectTelnet {
 #    my ($this)       = @_;
-#    my $logger       = Log::Log4perl::get_logger( ref($this) );
+#    my $logger       = $this->logger;
 #    my $maxTries     = 50;
 #    my $tryNb        = 1;
 #    my $cliAvailable = 0;
@@ -360,7 +360,7 @@ sub _setVlan {
 # disabling port-security since its known not to work
 #sub isPortSecurityEnabled {
 #    my ( $this, $ifIndex ) = @_;
-#    my $logger = Log::Log4perl::get_logger( ref($this) );
+#    my $logger = $this->logger;
 #    my $OID_swIfHostMode
 #        = '1.3.6.1.4.1.89.43.1.1.30';    #RADLAN-rlInterfaces MIB
 #
@@ -381,7 +381,7 @@ sub _setVlan {
 # disabling port-security since its known not to work
 #sub setPortSecurityDisabled {
 #    my ( $this, $ifIndex ) = @_;
-#    my $logger = Log::Log4perl::get_logger( ref($this) );
+#    my $logger = $this->logger;
 #
 #    $logger->info("function not implemented yet !");
 #    return 1;
@@ -390,7 +390,7 @@ sub _setVlan {
 # disabling port-security since its known not to work
 #sub isDynamicPortSecurityEnabled {
 #    my ( $this, $ifIndex ) = @_;
-#    my $logger = Log::Log4perl::get_logger( ref($this) );
+#    my $logger = $this->logger;
 #    return ( $this->isPortSecurityEnabled($ifIndex)
 #            && ( !$this->isStaticPortSecurityEnabled($ifIndex) ) );
 #}
@@ -398,7 +398,7 @@ sub _setVlan {
 # disabling port-security since its known not to work
 #sub isStaticPortSecurityEnabled {
 #    my ( $this, $ifIndex ) = @_;
-#    my $logger                  = Log::Log4perl::get_logger( ref($this) );
+#    my $logger                  = $this->logger;
 #    my $OID_swIfLockAdminStatus = '1.3.6.1.4.1.89.43.1.1.8';
 #
 #    if ( !$this->connectRead() ) {
@@ -430,7 +430,7 @@ sub _setVlan {
 
 sub getMaxMacAddresses {
     my ( $this, $ifIndex ) = @_;
-    my $logger                      = Log::Log4perl::get_logger( ref($this) );
+    my $logger                      = $this->logger;
     my $OID_swIfLockMaxMacAddresses = '1.3.6.1.4.1.89.43.1.1.38';
 
     if ( !$this->connectRead() ) {
@@ -463,7 +463,7 @@ sub getMaxMacAddresses {
 # disabling port-security since its known not to work
 #sub getSecureMacAddresses {
 #    my ( $this, $ifIndex ) = @_;
-#    my $logger               = Log::Log4perl::get_logger( ref($this) );
+#    my $logger               = $this->logger;
 #    my $secureMacAddrHashRef = {};
 #    my $ifName               = $this->getIfName($ifIndex);
 #    if ( $ifName eq '' ) {
@@ -494,7 +494,7 @@ sub getMaxMacAddresses {
 # disabling port-security since its known not to work
 #sub getAllSecureMacAddresses {
 #    my ($this)               = @_;
-#    my $logger               = Log::Log4perl::get_logger( ref($this) );
+#    my $logger               = $this->logger;
 #    my $secureMacAddrHashRef = {};
 #    my %ifNameIfIndexHash    = $this->getIfNameIfIndexHash();
 #    my $telnetConnection     = $this->connectTelnet();
@@ -522,7 +522,7 @@ sub getMaxMacAddresses {
 # disabling port-security since its known not to work
 #sub authorizeMAC {
 #    my ( $this, $ifIndex, $deauthMac, $authMac, $deauthVlan, $authVlan ) = @_;
-#    my $logger = Log::Log4perl::get_logger( ref($this) );
+#    my $logger = $this->logger;
 #    my $oid_cpsSecureMacAddrRowStatus = '1.3.6.1.4.1.9.9.315.1.2.2.1.4';
 #
 #    if ( !$this->isProductionMode() ) {

--- a/lib/pf/Switch/Linksys/SRW224G4.pm
+++ b/lib/pf/Switch/Linksys/SRW224G4.pm
@@ -13,7 +13,7 @@ oriented interface to access SNMP enabled Linksys SRW224G4 switches.
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 use base ('pf::Switch::Linksys');
 

--- a/lib/pf/Switch/Linksys/SRW224G4.pm
+++ b/lib/pf/Switch/Linksys/SRW224G4.pm
@@ -13,7 +13,6 @@ oriented interface to access SNMP enabled Linksys SRW224G4 switches.
 
 use strict;
 use warnings;
-use pf::log;
 use Net::SNMP;
 use base ('pf::Switch::Linksys');
 

--- a/lib/pf/Switch/Meraki/AP_http.pm
+++ b/lib/pf/Switch/Meraki/AP_http.pm
@@ -31,7 +31,6 @@ use strict;
 use warnings;
 
 use base ('pf::Switch');
-use pf::log;
 
 use pf::constants;
 use pf::config;
@@ -49,7 +48,7 @@ sub supportsWirelessMacAuth { return $TRUE; }
 sub supportsExternalPortal { return $TRUE; }
 sub supportsWebFormRegistration { return $TRUE }
 
-=item getVersion - obtain image version information from switch
+=head2 getVersion - obtain image version information from switch
 
 =cut
 

--- a/lib/pf/Switch/Meraki/AP_http.pm
+++ b/lib/pf/Switch/Meraki/AP_http.pm
@@ -6,7 +6,7 @@ pf::Switch::Meraki::AP_http
 
 =head1 SYNOPSIS
 
-The pf::Switch::Meraki::AP_http module implements an object oriented interface to 
+The pf::Switch::Meraki::AP_http module implements an object oriented interface to
 manage the external captive portal on Meraki access points
 
 =head1 STATUS
@@ -31,7 +31,7 @@ use strict;
 use warnings;
 
 use base ('pf::Switch');
-use Log::Log4perl;
+use pf::log;
 
 use pf::constants;
 use pf::config;
@@ -55,7 +55,7 @@ sub supportsWebFormRegistration { return $TRUE }
 
 sub getVersion {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->info("we don't know how to determine the version through SNMP !");
     return '1';
 }
@@ -75,7 +75,7 @@ status code
 
 sub parseUrl {
     my($this, $req, $r) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $connection = $r->connection;
     $this->synchronize_locationlog("0", "0", clean_mac($$req->param('client_mac')),
         0, $WIRELESS_MAC_AUTH, clean_mac($$req->param('client_mac')), "Unknown"
@@ -86,8 +86,7 @@ sub parseUrl {
 
 sub parseSwitchIdFromRequest {
     my($class, $req) = @_;
-    my $logger = Log::Log4perl::get_logger( $class );
-    return $$req->param('ap_mac'); 
+    return $$req->param('ap_mac');
 }
 
 =head2 returnRadiusAccessAccept
@@ -100,22 +99,22 @@ Overriding the default implementation for the external captive portal
 
 sub returnRadiusAccessAccept {
     my ($self, $vlan, $mac, $port, $connection_type, $user_name, $ssid, $wasInline, $user_role) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
 
     my $radius_reply_ref = {};
 
     my $node = node_view($mac);
 
     my $violation = pf::violation::violation_view_top($mac);
-    # if user is unregistered or is in violation then we reject him to show him the captive portal 
+    # if user is unregistered or is in violation then we reject him to show him the captive portal
     if ( $node->{status} eq $pf::node::STATUS_UNREGISTERED || defined($violation) ){
         $logger->info("[$mac] is unregistered. Refusing access to force the eCWP");
         my $radius_reply_ref = {
             'Tunnel-Medium-Type' => $RADIUS::ETHERNET,
             'Tunnel-Type' => $RADIUS::VLAN,
             'Tunnel-Private-Group-ID' => -1,
-        }; 
-        return [$RADIUS::RLM_MODULE_OK, %$radius_reply_ref]; 
+        };
+        return [$RADIUS::RLM_MODULE_OK, %$radius_reply_ref];
 
     }
     else{
@@ -127,7 +126,7 @@ sub returnRadiusAccessAccept {
 
 sub getAcceptForm {
     my ( $self, $mac , $destination_url, $cgi_session) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
     $logger->debug("[$mac] Creating web release form");
 
     my $login_url = $cgi_session->param("ecwp-original-param-login_url");

--- a/lib/pf/Switch/Meru.pm
+++ b/lib/pf/Switch/Meru.pm
@@ -68,7 +68,7 @@ ethernet interface.
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::Appliance::Session;
 
 use base ('pf::Switch');
@@ -102,7 +102,7 @@ obtain image version information from switch
 sub getVersion {
     my ($this) = @_;
     my $oid_mwWncVarsSoftwareVersion = '1.3.6.1.4.1.15983.1.1.4.1.1.27'; # from meru-wlan
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectRead() ) {
         return '';
     }
@@ -137,7 +137,7 @@ This is called when we receive an SNMP-Trap for this device
 sub parseTrap {
     my ( $this, $trapString ) = @_;
     my $trapHashRef;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     $logger->debug("trap currently not handled");
     $trapHashRef->{'trapType'} = 'unknown';
@@ -157,7 +157,7 @@ Warning: this code doesn't support elevating to privileged mode. See #900 and #1
 
 sub deauthenticateMacDefault {
     my ( $this, $mac ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->isProductionMode() ) {
         $logger->info("not in production mode ... we won't deauthenticate $mac");
@@ -241,7 +241,7 @@ Return the reference to the deauth technique or the default deauth technique.
 
 sub deauthTechniques {
     my ($this, $method) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $default = $SNMP::TELNET;
     my %tech = (
         $SNMP::TELNET => 'deauthenticateMacDefault',

--- a/lib/pf/Switch/Meru.pm
+++ b/lib/pf/Switch/Meru.pm
@@ -68,7 +68,6 @@ ethernet interface.
 use strict;
 use warnings;
 
-use pf::log;
 use Net::Appliance::Session;
 
 use base ('pf::Switch');

--- a/lib/pf/Switch/Meru/MC.pm
+++ b/lib/pf/Switch/Meru/MC.pm
@@ -17,7 +17,6 @@ This module is currently only a placeholder, see pf::Switch::Meru
 
 use strict;
 use warnings;
-use pf::log;
 
 use base ('pf::Switch::Meru');
 

--- a/lib/pf/Switch/Meru/MC.pm
+++ b/lib/pf/Switch/Meru/MC.pm
@@ -17,7 +17,7 @@ This module is currently only a placeholder, see pf::Switch::Meru
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 
 use base ('pf::Switch::Meru');
 

--- a/lib/pf/Switch/Mikrotik.pm
+++ b/lib/pf/Switch/Mikrotik.pm
@@ -18,7 +18,6 @@ Should work on CAPsMAN enabled APs, tested on v6.18
 use strict;
 use warnings;
 
-use pf::log;
 use Net::SSH2;
 use POSIX;
 use Try::Tiny;

--- a/lib/pf/Switch/Mikrotik.pm
+++ b/lib/pf/Switch/Mikrotik.pm
@@ -18,7 +18,7 @@ Should work on CAPsMAN enabled APs, tested on v6.18
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::SSH2;
 use POSIX;
 use Try::Tiny;
@@ -54,7 +54,7 @@ sub inlineCapabilities { return ($MAC,$SSID); }
 sub getVersion {
     my ($this)       = @_;
     my $oid_sysDescr = '1.3.6.1.4.1.14988.1.1.4.4.0';
-    my $logger       = Log::Log4perl::get_logger( ref($this) );
+    my $logger       = $this->logger;
     if ( !$this->connectRead() ) {
         return '';
     }
@@ -72,7 +72,7 @@ Return the reference to the deauth technique or the default deauth technique.
 
 sub deauthTechniques {
     my ($this, $method) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $default = $SNMP::SSH;
     my %tech = (
         $SNMP::SSH    => 'deauthenticateMacSSH',
@@ -96,7 +96,7 @@ This method has been kept since we will probably use this deauth method in the f
 
 sub deauthenticateMacRadius {
     my ( $self, $mac, $is_dot1x ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
 
     if ( !$self->isProductionMode() ) {
         $logger->info("not in production mode... we won't perform deauthentication");
@@ -121,7 +121,7 @@ Uses L<pf::util::radius> for the low-level RADIUS stuff.
 
 sub radiusDisconnect {
     my ($self, $mac, $add_attributes_ref) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
 
     # initialize
     $add_attributes_ref = {} if (!defined($add_attributes_ref));
@@ -198,7 +198,7 @@ ATTRIBUTE       Mikrotik-Wireless-VlanIDType            27      integer
 
 sub returnRadiusAccessAccept {
     my ($self, $vlan, $mac, $port, $connection_type, $user_name, $ssid, $wasInline, $user_role) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
 
     # Inline Vs. VLAN enforcement
     my $radius_reply_ref = {};
@@ -240,7 +240,7 @@ Right now the only way to do it is from the CLI (through SSH).
 
 sub deauthenticateMacSSH {
     my ( $self, $mac ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
 
     if ( !$self->isProductionMode() ) {
         $logger->info("not in production mode ... we won't deauthenticate $mac");

--- a/lib/pf/Switch/MockedSwitch.pm
+++ b/lib/pf/Switch/MockedSwitch.pm
@@ -37,7 +37,7 @@ use strict;
 use warnings;
 use Carp;
 use Data::Dumper;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 use Test::MockObject::Extends;
 use Time::HiRes qw( usleep );
@@ -110,7 +110,7 @@ sub inlineCapabilities { return ($MAC,$PORT,$SSID); }
 
 sub connectRead {
     my $this   = shift;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( defined( $this->{_sessionRead} ) ) {
         return 1;
     }
@@ -205,7 +205,7 @@ sub connectRead {
 
 sub disconnectRead {
     my $this   = shift;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !defined( $this->{_sessionRead} ) ) {
         return 1;
     }
@@ -225,7 +225,7 @@ It performs a write test to make sure that the write actually works.
 
 sub connectWriteTo {
     my ($this, $ip, $sessionKey) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     # if connection already exists, no need to connect again
     return 1 if ( defined( $this->{$sessionKey} ) );
@@ -286,7 +286,7 @@ Closes an SNMP Write connection. Requires sessionKey stored in object (as when c
 
 sub disconnectWriteTo {
     my ($this, $sessionKey) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     return 1 if ( !defined( $this->{$sessionKey} ) );
 
@@ -302,7 +302,7 @@ sub disconnectWriteTo {
 
 sub _setVlanByOnlyModifyingPvid {
     my ( $this, $ifIndex, $newVlan, $oldVlan, $switch_locker_ref ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectRead() ) {
         return 0;
     }
@@ -333,7 +333,7 @@ sub _setVlanByOnlyModifyingPvid {
 
 sub getIfOperStatus {
     my ( $this, $ifIndex ) = @_;
-    my $logger           = Log::Log4perl::get_logger( ref($this) );
+    my $logger           = $this->logger;
     my $oid_ifOperStatus = '1.3.6.1.2.1.2.2.1.8';
     if ( !$this->connectRead() ) {
         return 0;
@@ -352,7 +352,7 @@ sub getIfOperStatus {
 
 sub getAlias {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectRead() ) {
         return '';
     }
@@ -370,7 +370,7 @@ sub getAlias {
 
 sub getSwitchLocation {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectRead() ) {
         return '';
     }
@@ -387,7 +387,7 @@ sub getSwitchLocation {
 
 sub setAlias {
     my ( $this, $ifIndex, $alias ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->info( "setting "
             . $this->{_id}
             . " ifIndex $ifIndex ifAlias from "
@@ -415,7 +415,7 @@ fully-qualified domain name
 
 sub getSysName {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $OID_sysName = '1.3.6.1.2.1.1.5';                     # mib-2
     if ( !$this->connectRead() ) {
         return '';
@@ -436,7 +436,7 @@ sub getSysName {
 
 sub getIfDesc {
     my ( $this, $ifIndex ) = @_;
-    my $logger     = Log::Log4perl::get_logger( ref($this) );
+    my $logger     = $this->logger;
     my $OID_ifDesc = '1.3.6.1.2.1.2.2.1.2';                     # IF-MIB
     my $oid        = $OID_ifDesc . "." . $ifIndex;
     if ( !$this->connectRead() ) {
@@ -458,7 +458,7 @@ sub getIfDesc {
 
 sub getIfName {
     my ( $this, $ifIndex ) = @_;
-    my $logger     = Log::Log4perl::get_logger( ref($this) );
+    my $logger     = $this->logger;
     my $OID_ifName = '1.3.6.1.2.1.31.1.1.1.1';                  # IF-MIB
     my $oid        = $OID_ifName . "." . $ifIndex;
     if ( !$this->connectRead() ) {
@@ -481,7 +481,7 @@ sub getIfName {
 # FIXME this one doesn't work
 sub getIfNameIfIndexHash {
     my ($this)     = @_;
-    my $logger     = Log::Log4perl::get_logger( ref($this) );
+    my $logger     = $this->logger;
     my $OID_ifName = '1.3.6.1.2.1.31.1.1.1.1';                  # IF-MIB
     my %ifNameIfIndexHash;
     if ( !$this->connectRead() ) {
@@ -502,7 +502,7 @@ sub getIfNameIfIndexHash {
 
 sub setAdminStatus {
     my ( $this, $ifIndex, $status ) = @_;
-    my $logger            = Log::Log4perl::get_logger( ref($this) );
+    my $logger            = $this->logger;
     my $OID_ifAdminStatus = '1.3.6.1.2.1.2.2.1.7';
 
     if ( !$this->isProductionMode() ) {
@@ -545,7 +545,7 @@ sub bouncePort {
 
 sub getSysUptime {
     my ($this)        = @_;
-    my $logger        = Log::Log4perl::get_logger( ref($this) );
+    my $logger        = $this->logger;
     my $oid_sysUptime = '1.3.6.1.2.1.1.3.0';
     if ( !$this->connectRead() ) {
         return '';
@@ -562,7 +562,7 @@ sub getSysUptime {
 
 sub getIfType {
     my ( $this, $ifIndex ) = @_;
-    my $logger     = Log::Log4perl::get_logger( ref($this) );
+    my $logger     = $this->logger;
     my $OID_ifType = '1.3.6.1.2.1.2.2.1.3';                     #IF-MIB
     if ( !$this->connectRead() ) {
         return 0;
@@ -577,7 +577,7 @@ sub getIfType {
 
 sub getAllDot1dBasePorts {
     my ( $this, @ifIndexes ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !@ifIndexes ) {
         @ifIndexes = $this->getManagedIfIndexes();
     }
@@ -611,7 +611,7 @@ sub getAllDot1dBasePorts {
 
 sub getDot1dBasePortForThisIfIndex {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $OID_dot1dBasePortIfIndex = '1.3.6.1.2.1.17.1.4.1.2';    #BRIDGE-MIB
     my $dot1dBasePort            = undef;
     if ( !$this->connectRead() ) {
@@ -635,7 +635,7 @@ sub getDot1dBasePortForThisIfIndex {
 # FIXME not properly mocked
 sub getAllIfDesc {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $ifDescHashRef;
     my $OID_ifDesc = '1.3.6.1.2.1.2.2.1.2';    # IF-MIB
 
@@ -657,7 +657,7 @@ sub getAllIfDesc {
 # FIXME not properly mocked
 sub getAllIfType {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $ifTypeHashRef;
     my $OID_ifType = '1.3.6.1.2.1.2.2.1.3';
 
@@ -679,7 +679,7 @@ sub getAllIfType {
 # FIXME not properly mocked
 sub getAllIfOctets {
     my ( $this, @ifIndexes ) = @_;
-    my $logger          = Log::Log4perl::get_logger( ref($this) );
+    my $logger          = $this->logger;
     my $oid_ifInOctets  = '1.3.6.1.2.1.2.2.1.10';
     my $oid_ifOutOctets = '1.3.6.1.2.1.2.2.1.16';
     my $ifOctetsHashRef;
@@ -722,7 +722,7 @@ sub getAllIfOctets {
 # FIXME not properly mocked
 sub isIfLinkUpDownTrapEnable {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectRead() ) {
         return 0;
     }
@@ -737,7 +737,7 @@ sub isIfLinkUpDownTrapEnable {
 # FIXME not properly mocked
 sub setIfLinkUpDownTrapEnable {
     my ( $this, $ifIndex, $enable ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->isProductionMode() ) {
         $logger->info("not in production mode ... we won't change this port ifLinkUpDownTrapEnable");
@@ -760,7 +760,7 @@ sub setIfLinkUpDownTrapEnable {
 sub getVersion {
     my ($this)       = @_;
     my $oid_sysDescr = '1.3.6.1.2.1.1.1.0';
-    my $logger       = Log::Log4perl::get_logger( ref($this) );
+    my $logger       = $this->logger;
     if ( !$this->connectRead() ) {
         return '';
     }
@@ -851,7 +851,7 @@ sub isNewerVersionThan {
 sub parseTrap {
     my ( $this, $trapString ) = @_;
     my $trapHashRef;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     #link up/down
     if ( $trapString
@@ -1021,7 +1021,7 @@ sub parseTrap {
 # FIXME not properly mocked
 sub getAllVlans {
     my ( $this, @ifIndexes ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $vlanHashRef;
     if ( !@ifIndexes ) {
         @ifIndexes = $this->getManagedIfIndexes();
@@ -1071,7 +1071,7 @@ sub getAllVlans {
 # FIXME not properly mocked
 sub getVoiceVlan {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectRead() ) {
         return 0;
     }
@@ -1095,7 +1095,7 @@ sub getVoiceVlan {
 # to reproduce: bin/pfcmd_vlan -getVlan -ifIndex 999 -switch <ip>
 sub getVlan {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectRead() ) {
         return 0;
     }
@@ -1125,7 +1125,7 @@ sub getVlan {
 # FIXME not properly mocked
 sub isLearntTrapsEnabled {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectRead() ) {
         return 0;
     }
@@ -1148,7 +1148,7 @@ sub setLearntTrapsEnabled {
 
     #1 means 'enabled', 2 means 'disabled'
     my ( $this, $ifIndex, $trueFalse ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectWrite() ) {
         return 0;
     }
@@ -1168,7 +1168,7 @@ sub setLearntTrapsEnabled {
 # FIXME not properly mocked
 sub isRemovedTrapsEnabled {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectRead() ) {
         return 0;
     }
@@ -1194,7 +1194,7 @@ sub setRemovedTrapsEnabled {
 
     #1 means 'enabled', 2 means 'disabled'
     my ( $this, $ifIndex, $trueFalse ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectWrite() ) {
         return 0;
     }
@@ -1214,7 +1214,7 @@ sub setRemovedTrapsEnabled {
 # FIXME not properly mocked
 sub isPortSecurityEnabled {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     #CISCO-PORT-SECURITY-MIB
     my $OID_cpsIfPortSecurityEnable = '1.3.6.1.4.1.9.9.315.1.2.1.1.1';
@@ -1242,7 +1242,7 @@ sub isPortSecurityEnabled {
 # FIXME not properly mocked
 sub _setVlan {
     my ( $this, $ifIndex, $newVlan, $oldVlan, $switch_locker_ref ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->connectWrite() ) {
         return 0;
@@ -1285,7 +1285,7 @@ sub _setVlan {
 # FIXME not properly mocked
 sub setTrunkPortNativeVlan {
     my ( $this, $ifIndex, $newVlan ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->connectWrite() ) {
         return 0;
@@ -1309,7 +1309,7 @@ sub setTrunkPortNativeVlan {
 # FIXME not properly mocked
 sub getVmVlanType {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectRead() ) {
         return 0;
     }
@@ -1333,7 +1333,7 @@ sub getVmVlanType {
 # FIXME not properly mocked
 sub setVmVlanType {
     my ( $this, $ifIndex, $type ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->info( "setting port $ifIndex vmVlanType from "
             . $this->getVmVlanType($ifIndex)
             . " to $type" );
@@ -1367,7 +1367,7 @@ sub getMacBridgePortHash {
     my $this              = shift;
     my $vlan              = shift || '';
     my %macBridgePortHash = ();
-    my $logger            = Log::Log4perl::get_logger( ref($this) );
+    my $logger            = $this->logger;
     my $OID_dot1dTpFdbPort       = '1.3.6.1.2.1.17.4.3.1.2';    #BRIDGE-MIB
     my $OID_dot1dBasePortIfIndex = '1.3.6.1.2.1.17.1.4.1.2';    #BRIDGE-MIB
 
@@ -1460,7 +1460,7 @@ sub getMacBridgePortHash {
 # FIXME not properly mocked
 sub getIfIndexForThisMac {
     my ( $this, $mac ) = @_;
-    my $logger   = Log::Log4perl::get_logger( ref($this) );
+    my $logger   = $this->logger;
     my @macParts = split( ':', $mac );
     my @uplinks  = $this->getUpLinks();
     my $OID_dot1dTpFdbPort       = '1.3.6.1.2.1.17.4.3.1.2';    #BRIDGE-MIB
@@ -1533,7 +1533,7 @@ sub getIfIndexForThisMac {
 # FIXME not properly mocked
 sub isMacInAddressTableAtIfIndex {
     my ( $this, $mac, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my @macParts = split( ':', $mac );
     my $OID_dot1dTpFdbPort       = '1.3.6.1.2.1.17.4.3.1.2';    #BRIDGE-MIB
     my $OID_dot1dBasePortIfIndex = '1.3.6.1.2.1.17.1.4.1.2';    #BRIDGE-MIB
@@ -1609,7 +1609,7 @@ sub isMacInAddressTableAtIfIndex {
 # FIXME not properly mocked
 sub isTrunkPort {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $OID_vlanTrunkPortDynamicState
         = "1.3.6.1.4.1.9.9.46.1.6.1.1.13";    #CISCO-VTP-MIB
     if ( !$this->connectRead() ) {
@@ -1636,7 +1636,7 @@ sub isTrunkPort {
 # FIXME not properly mocked
 sub setModeTrunk {
     my ( $this, $ifIndex, $enable ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $OID_vlanTrunkPortDynamicState = "1.3.6.1.4.1.9.9.46.1.6.1.1.13";    #CISCO-VTP-MIB
 
     # $mode = 1 -> switchport mode trunk
@@ -1662,7 +1662,7 @@ sub getVlans {
     my ($this)          = @_;
     my $vlans           = {};
     my $oid_vtpVlanName = '1.3.6.1.4.1.9.9.46.1.3.1.1.4.1';    #CISCO-VTP-MIB
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->connectRead() ) {
         return $vlans;
@@ -1685,7 +1685,7 @@ sub getVlans {
 sub isDefinedVlan {
     my ( $this, $vlan ) = @_;
     my $oid_vtpVlanName = '1.3.6.1.4.1.9.9.46.1.3.1.1.4.1';    #CISCO-VTP-MIB
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->connectRead() ) {
         return 0;
@@ -1704,7 +1704,7 @@ sub getUpLinks {
     my @ifIndex;
     my @upLinks;
     my $result;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( lc(@{ $this->{_uplink} }[0]) eq 'dynamic' ) {
 
@@ -1770,7 +1770,7 @@ sub getUpLinks {
 
 sub getManagedIfIndexes {
     my $this   = shift;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->debug("fake getManagedIfIndexes");
     my @managedIfIndexes;
     my @tmp_managedIfIndexes = $this->SUPER::getManagedIfIndexes();
@@ -1790,7 +1790,7 @@ sub getManagedIfIndexes {
 # FIXME not properly mocked
 sub getAllMacs {
     my ( $this, @ifIndexes ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !@ifIndexes ) {
         @ifIndexes = $this->getManagedIfIndexes();
     }
@@ -1905,7 +1905,7 @@ sub getAllMacs {
 
 sub getPhonesDPAtIfIndex {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->isVoIPEnabled() ) {
         $logger->debug( "VoIP not enabled on network device $this->{_id}: no phones returned" );
@@ -1938,7 +1938,7 @@ sub getPhonesDPAtIfIndex {
 # FIXME not properly mocked
 sub getPhonesCDPAtIfIndex {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->debug("fake getPhonesCDPAtIfIndex ifIndex: $ifIndex");
     my @phones;
     if ( !$this->isVoIPEnabled() ) {
@@ -1988,7 +1988,7 @@ sub isVoIPEnabled {
 # FIXME not properly mocked
 sub getManagedPorts {
     my $this       = shift;
-    my $logger     = Log::Log4perl::get_logger( ref($this) );
+    my $logger     = $this->logger;
     my $oid_ifType = '1.3.6.1.2.1.2.2.1.3';                     # MIB: ifTypes
     my $oid_ifName = '1.3.6.1.2.1.31.1.1.1.1';
     my @nonUpLinks;
@@ -2071,7 +2071,7 @@ sub clearMacAddressTable {
     my $command;
     my $session;
     my $oid_ifName = '1.3.6.1.2.1.31.1.1.1.1';
-    my $logger     = Log::Log4perl::get_logger( ref($this) );
+    my $logger     = $this->logger;
     $logger->info("clearMacAddressTable called.");
 
     $logger->info("Connect through Telnet and get enabled rights if required.");
@@ -2097,7 +2097,7 @@ sub clearMacAddressTable {
 # FIXME not properly mocked
 sub getMaxMacAddresses {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     #CISCO-PORT-SECURITY-MIB
     my $OID_cpsIfPortSecurityEnable = '1.3.6.1.4.1.9.9.315.1.2.1.1.1';
@@ -2159,7 +2159,7 @@ With VoIP
 
 sub enablePortSecurityByIfIndex {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->debug("called with ifIndex: $ifIndex");
 
     my $maxSecureMacTotal;
@@ -2205,7 +2205,7 @@ sub enablePortSecurityByIfIndex {
 
 sub disablePortSecurityByIfIndex {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->debug("called with ifIndex: $ifIndex");
 
     # no switchport port-security
@@ -2243,7 +2243,7 @@ sub disablePortSecurityByIfIndex {
 # FIXME not properly mocked
 sub setPortSecurityEnableByIfIndex {
     my ( $this, $ifIndex, $enable ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->debug("called with ifIndex: $ifIndex");
 
     if ( !$this->isProductionMode() ) {
@@ -2272,7 +2272,7 @@ Sets the global (data + voice) maximum number of MAC addresses for port-security
 # FIXME not properly mocked
 sub setPortSecurityMaxSecureMacAddrByIfIndex {
     my ( $this, $ifIndex, $maxSecureMac ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->isProductionMode() ) {
         $logger->warn("Should set IfMaxSecureMacAddr on $ifIndex to $maxSecureMac but the switch is not in production -> Do nothing");
@@ -2298,7 +2298,7 @@ Sets the maximum number of MAC addresses on the data vlan for port-security on a
 
 sub setPortSecurityMaxSecureMacAddrVlanAccessByIfIndex {
     my ( $this, $ifIndex, $maxSecureMac ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->isProductionMode() ) {
         $logger->warn("Should set IfMaxSecureMacAddrPerVlan on $ifIndex to $maxSecureMac but the switch is not in production -> Do nothing");
@@ -2343,7 +2343,7 @@ Tells the switch what to do when the number of MAC addresses on the port has exc
 # FIXME not properly mocked
 sub setPortSecurityViolationActionByIfIndex {
     my ( $this, $ifIndex, $action ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->isProductionMode() ) {
         $logger->warn("Should set IfViolationAction on $ifIndex to $action but the switch is not in production -> Do nothing");
@@ -2371,7 +2371,7 @@ Allows all the tagged Vlans on a multi-Vlan port. Used for floating network devi
 # FIXME not properly mocked
 sub setTaggedVlans {
     my ( $this, $ifIndex, @vlans ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->isProductionMode() ) {
         $logger->info("not in production mode ... we won't change this port vlanTrunkPortVlansEnabled");
@@ -2423,7 +2423,7 @@ Removes all the tagged Vlans on a multi-Vlan port. Used for floating network dev
 # FIXME not properly mocked
 sub removeAllTaggedVlans {
     my ( $this, $ifIndex) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->isProductionMode() ) {
         $logger->info("not in production mode ... we won't change this port OID_vlanTrunkPortVlansEnabled");
@@ -2474,7 +2474,7 @@ sub removeAllTaggedVlans {
 
 sub enablePortConfigAsTrunk {
     my ($this, $mac, $switch_port, $taggedVlans)  = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     # switchport mode trunk
     $logger->info("Setting port $switch_port as trunk.");
@@ -2507,7 +2507,7 @@ sub enablePortConfigAsTrunk {
 
 sub disablePortConfigAsTrunk {
     my ($this, $switch_port) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     # switchport mode access
     $logger->info("Setting port $switch_port as non trunk.");
@@ -2551,7 +2551,7 @@ Allows callers to refer to this implementation even though someone along the way
 
 sub _dot1xPortReauthenticate {
     my ($this, $ifIndex) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     $logger->info("Trying generic MIB to force 802.1x port re-authentication. Your mileage may vary. "
         . "If it doesn't work open a bug report with your hardware type.");
@@ -2576,14 +2576,14 @@ sub _dot1xPortReauthenticate {
 
 sub getMinOSVersion {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     return '12.2(25)SEE2';
 }
 
 # FIXME not properly mocked
 sub getAllSecureMacAddresses {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $oid_cpsIfVlanSecureMacAddrRowStatus = '1.3.6.1.4.1.9.9.315.1.2.3.1.5';
 
     my $secureMacAddrHashRef = {};
@@ -2614,7 +2614,7 @@ sub getAllSecureMacAddresses {
 # FIXME not properly mocked
 sub isDynamicPortSecurityEnabled {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $oid_cpsIfVlanSecureMacAddrType = '1.3.6.1.4.1.9.9.315.1.2.3.1.3';
 
     if ( !$this->connectRead() ) {
@@ -2642,7 +2642,7 @@ sub isDynamicPortSecurityEnabled {
 # FIXME not properly mocked
 sub isStaticPortSecurityEnabled {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $oid_cpsIfVlanSecureMacAddrType = '1.3.6.1.4.1.9.9.315.1.2.3.1.3';
 
     if ( !$this->connectRead() ) {
@@ -2670,7 +2670,7 @@ sub isStaticPortSecurityEnabled {
 # FIXME not properly mocked
 sub getSecureMacAddresses {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $oid_cpsIfVlanSecureMacAddrRowStatus = '1.3.6.1.4.1.9.9.315.1.2.3.1.5';
 
     my $secureMacAddrHashRef = {};
@@ -2698,7 +2698,7 @@ sub getSecureMacAddresses {
 # FIXME not properly mocked
 sub authorizeMAC {
     my ( $this, $ifIndex, $deauthMac, $authMac, $deauthVlan, $authVlan ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $oid_cpsIfVlanSecureMacAddrRowStatus = '1.3.6.1.4.1.9.9.315.1.2.3.1.5';
 
     if ( !$this->isProductionMode() ) {
@@ -2753,7 +2753,7 @@ sub authorizeMAC {
 
 sub NasPortToIfIndex {
     my ($this, $NAS_port) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     if ($NAS_port =~ s/^5/1/) {
         return $NAS_port;
@@ -2770,7 +2770,7 @@ sub NasPortToIfIndex {
 
 sub handleReAssignVlanTrapForWiredMacAuth {
     my ($this, $ifIndex, $mac) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     my $switch_ip = $this->{'_ip'};
     my @locationlog = locationlog_view_open_switchport_no_VoIP( $switch_ip, $ifIndex );
@@ -2837,7 +2837,7 @@ Get Voice over IP RADIUS Vendor Specific Attribute (VSA).
 
 sub getVoipVsa {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     return ('Cisco-AVPair' => "device-traffic-class=voice");
 }
@@ -2850,7 +2850,7 @@ Return the reference to the deauth technique or the default deauth technique.
 
 sub deauthTechniques {
     my ($this, $method) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     return $TRUE;
 }
 
@@ -2874,7 +2874,7 @@ return Default Deauthentication Default technique
 
 sub deauthenticateMacDefault {
     my ( $this ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     $logger->warn("Unimplemented! First, make sure your configuration is ok. "
         . "If it is then we don't support your hardware. Open a bug report with your hardware type.");
@@ -2899,7 +2899,7 @@ Extract VLAN from the radius attributes.
 
 sub extractVLAN {
     my ($self, $radius_request) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
     $logger->warn("Not implemented");
     return;
 }
@@ -2912,7 +2912,7 @@ Return the reference to the deauth technique or the default deauth technique.
 
 sub wiredeauthTechniques {
     my ($this, $method, $connection_type) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     return $TRUE;
 }
 
@@ -2953,7 +2953,7 @@ Extract all the param from the url.
 
 sub parseUrl {
     my ($self,$req) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
     $logger->warn("Not implemented");
     return;
 }

--- a/lib/pf/Switch/MockedSwitch.pm
+++ b/lib/pf/Switch/MockedSwitch.pm
@@ -37,7 +37,6 @@ use strict;
 use warnings;
 use Carp;
 use Data::Dumper;
-use pf::log;
 use Net::SNMP;
 use Test::MockObject::Extends;
 use Time::HiRes qw( usleep );

--- a/lib/pf/Switch/Motorola.pm
+++ b/lib/pf/Switch/Motorola.pm
@@ -54,7 +54,6 @@ use strict;
 use warnings;
 
 use base ('pf::Switch');
-use pf::log;
 
 use pf::accounting qw(node_accounting_current_sessionid);
 use pf::constants;

--- a/lib/pf/Switch/Motorola.pm
+++ b/lib/pf/Switch/Motorola.pm
@@ -54,7 +54,7 @@ use strict;
 use warnings;
 
 use base ('pf::Switch');
-use Log::Log4perl;
+use pf::log;
 
 use pf::accounting qw(node_accounting_current_sessionid);
 use pf::constants;
@@ -84,7 +84,7 @@ obtain image version information from switch
 sub getVersion {
     my ($this)       = @_;
     my $oid_sysDescr = '1.3.6.1.2.1.1.1.0';
-    my $logger       = Log::Log4perl::get_logger( ref($this) );
+    my $logger       = $this->logger;
     if ( !$this->connectRead() ) {
         return '';
     }
@@ -113,7 +113,7 @@ Parsing SNMP Traps - WIDS stuff only, other types are discarded
 sub parseTrap {
     my ( $this, $trapString ) = @_;
     my $trapHashRef;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     # Handle WIPS Trap
     if ( $trapString =~ /BEGIN VARIABLEBINDINGS.*\.1\.3\.6\.1\.4\.1\.388\.50\.1\.2\.1\.4 = STRING: "Unsanctioned AP ([A-F0-9]{2}-[A-F0-9]{2}-[A-F0-9]{2}-[A-F0-9]{2}-[A-F0-9]{2}-[A-F0-9]{2})/){
@@ -136,7 +136,7 @@ New implementation using RADIUS Disconnect-Request.
 
 sub deauthenticateMacDefault {
     my ( $self, $mac, $is_dot1x ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
 
     if ( !$self->isProductionMode() ) {
         $logger->info("not in production mode... we won't perform deauthentication");
@@ -163,7 +163,7 @@ deauthenticate a MAC address from wireless network (including 802.1x)
 
 sub _deauthenticateMacSNMP {
     my ($this, $mac) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
     my $oid_wsCcRfMuDisassociateNow = '1.3.6.1.4.1.388.14.3.2.1.12.3.1.19'; # from WS-CC-RF-MIB
 
     if ( !$this->isProductionMode() ) {
@@ -215,7 +215,7 @@ Return the reference to the deauth technique or the default deauth technique.
 
 sub deauthTechniques {
     my ($this, $method) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $default = $SNMP::SNMP;
     my %tech = (
         $SNMP::SNMP => 'deauthenticateMacDefault',

--- a/lib/pf/Switch/Motorola/RFS.pm
+++ b/lib/pf/Switch/Motorola/RFS.pm
@@ -16,7 +16,6 @@ This module is currently only a placeholder, see pf::Switch::Motorola
 
 use strict;
 use warnings;
-use pf::log;
 
 use base ('pf::Switch::Motorola');
 

--- a/lib/pf/Switch/Motorola/RFS.pm
+++ b/lib/pf/Switch/Motorola/RFS.pm
@@ -16,7 +16,7 @@ This module is currently only a placeholder, see pf::Switch::Motorola
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 
 use base ('pf::Switch::Motorola');
 

--- a/lib/pf/Switch/Netgear.pm
+++ b/lib/pf/Switch/Netgear.pm
@@ -9,7 +9,6 @@ pf::Switch::Netgear - Object oriented module to access and configure enabled Net
 use strict;
 use warnings;
 
-use pf::log;
 use Net::SNMP;
 
 use pf::Switch::constants;

--- a/lib/pf/Switch/Netgear.pm
+++ b/lib/pf/Switch/Netgear.pm
@@ -9,7 +9,7 @@ pf::Switch::Netgear - Object oriented module to access and configure enabled Net
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use pf::Switch::constants;

--- a/lib/pf/Switch/Netgear/FSM726v1.pm
+++ b/lib/pf/Switch/Netgear/FSM726v1.pm
@@ -43,7 +43,7 @@ use strict;
 use warnings;
 
 use POSIX;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use pf::Switch::constants;
@@ -65,7 +65,7 @@ sub description { 'Netgear FSM726v1' }
 
 sub authorizeMAC {
     my ( $this, $ifIndex, $deauthMac, $authMac, $deauthVlan, $authVlan ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     my $OID_trustedMacStatus = '1.3.6.1.4.1.4526.1.1.15.1.1.3';    # NETGEAR-MIB
 
@@ -141,7 +141,7 @@ See bugs and limitations.
 
 sub forceDeauthOnLinkDown {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     # here we actively ignore uplinks because this is called from the parsing threads which don't
     # check for uplinks (yet). 
@@ -168,7 +168,7 @@ sub forceDeauthOnLinkDown {
 
 sub getAllSecureMacAddresses {
     my ( $this ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     
     my $OID_trustedMacAddress = '1.3.6.1.4.1.4526.1.1.15.1.1.2';
     my $secureMacAddrHashRef = {};
@@ -206,7 +206,7 @@ sub getAllSecureMacAddresses {
 
 sub getSecureMacAddresses {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     
     my $OID_trustedMacAddress = '1.3.6.1.4.1.4526.1.1.15.1.1.2';
     my $secureMacAddrHashRef = {};
@@ -243,7 +243,7 @@ sub getSecureMacAddresses {
 
 sub getVlan {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     
     my $OID_configPortDefaultVlanId = '1.3.6.1.4.1.4526.1.1.11.6.1.12';    # NETGEAR-MIB
     
@@ -289,7 +289,7 @@ sub isPortSecurityEnabled { return $TRUE; }
 
 sub parseTrap {
     my ( $this, $trapString ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my $trapHashRef;
 
@@ -333,7 +333,7 @@ See bugs and limitations.
 
 sub setAdminStatus {
     my ( $this, $ifIndex, $status ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     my $OID_configPortAutoNegotiation = '1.3.6.1.4.1.4526.1.1.11.6.1.14';    # NETGEAR-MIB
 
@@ -378,7 +378,7 @@ sub setAdminStatus {
 
 sub _setVlan {
     my ( $this, $ifIndex, $newVlan, $oldVlan, $switch_locker_ref ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     
     my $OID_vlanPortStatus = '1.3.6.1.4.1.4526.1.1.13.2.1.3';            # NETGEAR-MIB
     my $OID_configPortDefaultVlanId = '1.3.6.1.4.1.4526.1.1.11.6.1.12';  # NETGEAR-MIB

--- a/lib/pf/Switch/Netgear/FSM7328S.pm
+++ b/lib/pf/Switch/Netgear/FSM7328S.pm
@@ -29,7 +29,7 @@ use strict;
 use warnings;
 
 use POSIX;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use pf::Switch::constants;
@@ -52,7 +52,7 @@ Returns 1 on success 0 on failure.
 
 sub authorizeMAC {
     my ( $this, $ifIndex, $deauthMac, $authMac, $deauthVlan, $authVlan ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->debug("Args to authorizeMAC: $ifIndex, $deauthMac, $authMac, $deauthVlan, $authVlan");
 
 
@@ -134,7 +134,7 @@ See bugs and limitations.
 
 sub forceDeauthOnLinkDown {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     # here we actively ignore uplinks because this is called from the parsing threads which don't
     # check for uplinks (yet).
@@ -170,7 +170,7 @@ This is to maintain backwards compatibility with existing implementations of thi
 
 sub getAllSecureMacAddresses {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     my $OID_agentPortSecurityTable      = '1.3.6.1.4.1.4526.10.20.1.2';
     my $OID_agentPortSecurityMode       = '1.3.6.1.4.1.4526.10.20.1.2.1.1'; # NETGEAR-PORTSECURITY-PRIVATE-MIB
@@ -218,7 +218,7 @@ This is to maintain backwards compatibility with existing implementations of thi
 
 sub getSecureMacAddresses {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     my $OID_agentPortSecurityStaticMACs = '1.3.6.1.4.1.4526.10.20.1.2.1.6'; # NETGEAR-PORTSECURITY-PRIVATE-MIB
     my $secureMacAddrHashRef            = {};
@@ -256,7 +256,7 @@ sub getSecureMacAddresses {
 
 sub isPortSecurityEnabled {
     my $this   = shift;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     my $OID_agentGlobalPortSecurityMode = '1.3.6.1.4.1.4526.10.20.1.1.0';   # NETGEAR-PORTSECURITY-PRIVATE-MIB
     my %PortSecurityMode = ( 1 => "enabled", 2 => "disabled" );
@@ -294,7 +294,7 @@ sub isPortSecurityEnabled {
 
 sub parseTrap {
     my ( $this, $trapString ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my $trapHashRef;
 
@@ -347,7 +347,7 @@ sub parseTrap {
 
 sub _setVlan {
     my ( $this, $ifIndex, $newVlan, $oldVlan, $switch_locker_ref ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     my $OID_configPortDefaultVlanId = '1.3.6.1.2.1.17.7.1.4.5.1.1';    # Q-BRIDGE-MIB
 

--- a/lib/pf/Switch/Netgear/GS110.pm
+++ b/lib/pf/Switch/Netgear/GS110.pm
@@ -31,7 +31,7 @@ and voice VLANs).
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use pf::Switch::constants;
@@ -50,7 +50,7 @@ sub description { 'Netgear GS110' }
 
 sub getVersion {
     my ( $this ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my $OID_version = "1.3.6.1.2.1.47.1.1.1.1.10.1";    # Provided by snmpbulkwalk the switch
 
@@ -87,7 +87,7 @@ sub getVersion {
 
 sub parseTrap {
     my ( $this, $trapString ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my $trapHashRef;
 
@@ -117,7 +117,7 @@ sub parseTrap {
 
 sub _setVlan {
     my ( $this, $ifIndex, $newVlan, $oldVlan, $switch_locker_ref ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     if ( !$this->isProductionMode() ) {
         $logger->info("The switch isn't in production mode (Do nothing): Should set ifIndex $ifIndex to VLAN $newVlan");

--- a/lib/pf/Switch/Netgear/MSeries.pm
+++ b/lib/pf/Switch/Netgear/MSeries.pm
@@ -13,7 +13,7 @@ Tested on a Netgear M4100 on firmware 10.0.1.27
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 use pf::constants;
 use pf::config;

--- a/lib/pf/Switch/Netgear/MSeries.pm
+++ b/lib/pf/Switch/Netgear/MSeries.pm
@@ -13,7 +13,6 @@ Tested on a Netgear M4100 on firmware 10.0.1.27
 use strict;
 use warnings;
 
-use pf::log;
 use Net::SNMP;
 use pf::constants;
 use pf::config;

--- a/lib/pf/Switch/Nortel.pm
+++ b/lib/pf/Switch/Nortel.pm
@@ -34,7 +34,7 @@ Be aware of that if you start to see MAC authorization failures and report the p
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch');
@@ -70,7 +70,7 @@ TODO: This list is incomplete
 sub getVersion {
     my ($this) = @_;
     my $oid_s5ChasVer = '1.3.6.1.4.1.45.1.6.3.1.5.0';
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->connectRead() ) {
         return '';
@@ -88,7 +88,7 @@ sub getVersion {
 sub parseTrap {
     my ( $this, $trapString ) = @_;
     my $trapHashRef;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( $trapString
         =~ /^BEGIN TYPE ([23]) END TYPE BEGIN SUBTYPE 0 END SUBTYPE BEGIN VARIABLEBINDINGS \.1\.3\.6\.1\.2\.1\.2\.2\.1\.1\.(\d+) = INTEGER: \d+\|\.1\.3\.6\.1\.2\.1\.2\.2\.1\.7\.\d+ = INTEGER: [^|]+\|\.1\.3\.6\.1\.2\.1\.2\.2\.1\.8\.\d+ = INTEGER: [^)]+\)/
         )
@@ -130,7 +130,7 @@ Warning: MIB says 1 is access, 2 is trunk but we've encountered other values.
 
 sub isTrunkPort {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->connectRead() ) {
         return;
@@ -168,7 +168,7 @@ sub getTrunkPorts {
     my ($this) = @_;
     my $OID_rcVlanPortType = '1.3.6.1.4.1.2272.1.3.3.1.4'; #RC-VLAN-MIB
     my @trunkPorts;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->connectRead() ) {
         return -1;
@@ -210,7 +210,7 @@ Set a port as mode access or mode trunk based on ifIndex given.
 
 sub setModeTrunk {
     my ( $this, $ifIndex, $setTrunk ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->isProductionMode() ) {
         $logger->info("not in production mode ... we won't change this port's trunk mode");
@@ -246,7 +246,7 @@ In what VLAN should a VoIP device be?
 
 sub getVoiceVlan {
     my ($this, $ifIndex) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     my $voiceVlan = $this->getVlanByName('voice');
     if (defined($voiceVlan)) {
@@ -260,7 +260,7 @@ sub getVoiceVlan {
 
 sub getVlans {
     my $this = shift;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $OID_rcVlanName = '1.3.6.1.4.1.2272.1.3.2.1.2'; #RC-VLAN-MIB
     my $vlans = {};
     if ( !$this->connectRead() ) {
@@ -283,7 +283,7 @@ sub getVlans {
 
 sub isDefinedVlan {
     my ( $this, $vlan ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $OID_rcVlanName = '1.3.6.1.4.1.2272.1.3.2.1.2'; #RC-VLAN-MIB
     if ( !$this->connectRead() ) {
         return 0;
@@ -300,7 +300,7 @@ sub isDefinedVlan {
 
 sub getAllVlans {
     my ( $this, @ifIndexes ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $vlanHashRef;
     if ( !@ifIndexes ) {
         @ifIndexes = $this->getManagedIfIndexes();
@@ -331,7 +331,7 @@ sub getVlan {
     my ( $this, $ifIndex ) = @_;
     my $OID_rcVlanPortDefaultVlanId
         = '1.3.6.1.4.1.2272.1.3.3.1.7'; # RC-VLAN-MIB
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectRead() ) {
         return 0;
     }
@@ -347,7 +347,7 @@ sub _setVlan {
     my ( $this, $ifIndex, $newVlan, $oldVlan, $switch_locker_ref ) = @_;
     my $OID_rcVlanPortMembers = '1.3.6.1.4.1.2272.1.3.2.1.11'; #RC-VLAN-MIB
     my $OID_rcVlanPortDefaultVlanId = '1.3.6.1.4.1.2272.1.3.3.1.7'; #RC-VLAN-MIB
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $result;
 
     if ( !$this->connectRead() ) {
@@ -419,7 +419,7 @@ Should return either 0 or 1
 
 sub getFirstBoardIndex {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
   
     if ( !$this->connectRead() ) {
         return 1;
@@ -484,7 +484,7 @@ sub getIfIndexFromBoardPort {
 
 sub getAllSecureMacAddresses {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $OID_s5SbsAuthCfgAccessCtrlType = '1.3.6.1.4.1.45.1.6.5.3.10.1.4'; #S5-SWITCH-BAYSECURE-MIB
 
     my $secureMacAddrHashRef = {};
@@ -513,7 +513,7 @@ $/x) && ( $ctrlType == 1 )) {
 
 sub getSecureMacAddresses {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $OID_s5SbsAuthCfgAccessCtrlType = '1.3.6.1.4.1.45.1.6.5.3.10.1.4'; #S5-SWITCH-BAYSECURE-MIB
     my $secureMacAddrHashRef = {};
 
@@ -546,7 +546,7 @@ $/x ) && ( $ctrlType == 1 )) {
 
 sub getMaxMacAddresses {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     #so that everything runs like on a Cisco
     return 2;
@@ -554,7 +554,7 @@ sub getMaxMacAddresses {
 
 sub authorizeMAC {
     my ( $this, $ifIndex, $deauthMac, $authMac, $deauthVlan, $authVlan ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( ($deauthMac) && ( !$this->isFakeMac($deauthMac) ) ) {
         $this->_authorizeMAC( $ifIndex, $deauthMac, 0 );
@@ -571,7 +571,7 @@ sub _authorizeMAC {
     my ( $this, $ifIndex, $mac, $authorize ) = @_;
     my $OID_s5SbsAuthCfgAccessCtrlType = '1.3.6.1.4.1.45.1.6.5.3.10.1.4';
     my $OID_s5SbsAuthCfgStatus = '1.3.6.1.4.1.45.1.6.5.3.10.1.5';
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->isProductionMode() ) {
         $logger->info( "not in production mode ... we won't delete an entry from the SecureMacAddrTable" );
@@ -627,7 +627,7 @@ sub isStaticPortSecurityEnabled {
 # This function has not been tested on stacked switches !
 sub setPortSecurityEnableByIfIndex {
     my ( $this, $ifIndex, $enable ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     my $OID_s5SbsPortSecurityStatus = "1.3.6.1.4.1.45.1.6.5.3.15.0";
 
@@ -662,7 +662,7 @@ sub setPortSecurityEnableByIfIndex {
 
 sub isPortSecurityEnabled {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     my $oid_s5SbsSecurityStatus = '1.3.6.1.4.1.45.1.6.5.3.3';
     my $oid_s5SbsSecurityAction = '1.3.6.1.4.1.45.1.6.5.3.5';
@@ -732,7 +732,7 @@ sub isPortSecurityEnabled {
 
 sub getPhonesLLDPAtIfIndex {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my @phones;
     if ( !$this->isVoIPEnabled() ) {
         $logger->debug( "VoIP not enabled on switch "
@@ -797,7 +797,7 @@ Takes an ifIndex, a TRUE/FALSE value (tag or untag), the switch locker to avoid 
 
 sub setTagVlansByIfIndex {
     my ( $this, $ifIndex, $setTo, $switch_locker_ref, @vlans ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $OID_rcVlanPortMembers = '1.3.6.1.4.1.2272.1.3.2.1.11'; #RC-VLAN-MIB
 
     if ( !$this->connectRead() ) {

--- a/lib/pf/Switch/Nortel.pm
+++ b/lib/pf/Switch/Nortel.pm
@@ -34,7 +34,6 @@ Be aware of that if you start to see MAC authorization failures and report the p
 use strict;
 use warnings;
 
-use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch');

--- a/lib/pf/Switch/Nortel/BPS2000.pm
+++ b/lib/pf/Switch/Nortel/BPS2000.pm
@@ -19,7 +19,7 @@ Otherwise this module is identical to pf::Switch::Nortel.
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Nortel');

--- a/lib/pf/Switch/Nortel/BPS2000.pm
+++ b/lib/pf/Switch/Nortel/BPS2000.pm
@@ -19,7 +19,6 @@ Otherwise this module is identical to pf::Switch::Nortel.
 
 use strict;
 use warnings;
-use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Nortel');

--- a/lib/pf/Switch/Nortel/BayStack4550.pm
+++ b/lib/pf/Switch/Nortel/BayStack4550.pm
@@ -18,7 +18,7 @@ This module is currently only a placeholder, see pf::Switch::Nortel.
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Nortel');

--- a/lib/pf/Switch/Nortel/BayStack4550.pm
+++ b/lib/pf/Switch/Nortel/BayStack4550.pm
@@ -18,7 +18,6 @@ This module is currently only a placeholder, see pf::Switch::Nortel.
 use strict;
 use warnings;
 
-use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Nortel');

--- a/lib/pf/Switch/Nortel/BayStack470.pm
+++ b/lib/pf/Switch/Nortel/BayStack470.pm
@@ -18,7 +18,7 @@ This module is currently only a placeholder, see pf::Switch::Nortel.
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Nortel');

--- a/lib/pf/Switch/Nortel/BayStack470.pm
+++ b/lib/pf/Switch/Nortel/BayStack470.pm
@@ -18,7 +18,6 @@ This module is currently only a placeholder, see pf::Switch::Nortel.
 use strict;
 use warnings;
 
-use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Nortel');

--- a/lib/pf/Switch/Nortel/BayStack5500.pm
+++ b/lib/pf/Switch/Nortel/BayStack5500.pm
@@ -18,7 +18,7 @@ This module is currently only a placeholder, see pf::Switch::Nortel.
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Nortel');

--- a/lib/pf/Switch/Nortel/BayStack5500.pm
+++ b/lib/pf/Switch/Nortel/BayStack5500.pm
@@ -18,7 +18,6 @@ This module is currently only a placeholder, see pf::Switch::Nortel.
 use strict;
 use warnings;
 
-use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Nortel');

--- a/lib/pf/Switch/Nortel/BayStack5500_6x.pm
+++ b/lib/pf/Switch/Nortel/BayStack5500_6x.pm
@@ -19,7 +19,6 @@ Aside from ifIndex handling this module is identical to pf::Switch::Nortel.
 use strict;
 use warnings;
 
-use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Nortel');

--- a/lib/pf/Switch/Nortel/BayStack5500_6x.pm
+++ b/lib/pf/Switch/Nortel/BayStack5500_6x.pm
@@ -19,7 +19,7 @@ Aside from ifIndex handling this module is identical to pf::Switch::Nortel.
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Nortel');

--- a/lib/pf/Switch/Nortel/ERS2500.pm
+++ b/lib/pf/Switch/Nortel/ERS2500.pm
@@ -33,7 +33,7 @@ Firmware series 4.3 is apparently fine.
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Nortel');

--- a/lib/pf/Switch/Nortel/ERS2500.pm
+++ b/lib/pf/Switch/Nortel/ERS2500.pm
@@ -33,7 +33,6 @@ Firmware series 4.3 is apparently fine.
 use strict;
 use warnings;
 
-use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Nortel');

--- a/lib/pf/Switch/Nortel/ERS4000.pm
+++ b/lib/pf/Switch/Nortel/ERS4000.pm
@@ -19,7 +19,6 @@ use strict;
 use warnings;
 
 use pf::Switch::constants;
-use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Nortel');

--- a/lib/pf/Switch/Nortel/ERS4000.pm
+++ b/lib/pf/Switch/Nortel/ERS4000.pm
@@ -19,7 +19,7 @@ use strict;
 use warnings;
 
 use pf::Switch::constants;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Nortel');

--- a/lib/pf/Switch/Nortel/ERS5000.pm
+++ b/lib/pf/Switch/Nortel/ERS5000.pm
@@ -18,7 +18,7 @@ This module is currently only a placeholder, see pf::Switch::Nortel.
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Nortel');

--- a/lib/pf/Switch/Nortel/ERS5000.pm
+++ b/lib/pf/Switch/Nortel/ERS5000.pm
@@ -18,7 +18,6 @@ This module is currently only a placeholder, see pf::Switch::Nortel.
 use strict;
 use warnings;
 
-use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Nortel');

--- a/lib/pf/Switch/Nortel/ERS5000_6x.pm
+++ b/lib/pf/Switch/Nortel/ERS5000_6x.pm
@@ -24,7 +24,7 @@ If the switch is stacked, the trap will come with the wrong ifIndex number.
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Nortel');

--- a/lib/pf/Switch/Nortel/ERS5000_6x.pm
+++ b/lib/pf/Switch/Nortel/ERS5000_6x.pm
@@ -24,7 +24,6 @@ If the switch is stacked, the trap will come with the wrong ifIndex number.
 use strict;
 use warnings;
 
-use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Nortel');

--- a/lib/pf/Switch/Nortel/ES325.pm
+++ b/lib/pf/Switch/Nortel/ES325.pm
@@ -18,7 +18,7 @@ This module is currently only a placeholder, see pf::Switch::Nortel.
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Nortel');

--- a/lib/pf/Switch/Nortel/ES325.pm
+++ b/lib/pf/Switch/Nortel/ES325.pm
@@ -18,7 +18,6 @@ This module is currently only a placeholder, see pf::Switch::Nortel.
 use strict;
 use warnings;
 
-use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::Nortel');

--- a/lib/pf/Switch/PacketFence.pm
+++ b/lib/pf/Switch/PacketFence.pm
@@ -19,7 +19,6 @@ use strict;
 use warnings;
 
 use base ('pf::Switch');
-use pf::log;
 use Net::SNMP;
 
 sub description { 'PacketFence' }

--- a/lib/pf/Switch/PacketFence.pm
+++ b/lib/pf/Switch/PacketFence.pm
@@ -19,14 +19,14 @@ use strict;
 use warnings;
 
 use base ('pf::Switch');
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 sub description { 'PacketFence' }
 
 sub connectWrite {
     my $this   = shift;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( defined( $this->{_sessionWrite} ) ) {
         return 1;
     }
@@ -50,7 +50,7 @@ sub sendLocalReAssignVlanTrap {
     my ($this, $switch, $ifIndex, $connection_type, $mac) = @_;
     my $switch_ip = $switch->{_ip};
     my $switch_id = $switch->{_id};
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectWrite() ) {
         return 0;
     }
@@ -90,7 +90,7 @@ sub sendLocalDesAssociateTrap {
     my ($this, $switch, $mac, $connection_type) = @_;
     my $switch_ip = $switch->{_ip};
     my $switch_id = $switch->{_id};
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectWrite() ) {
         return 0;
     }
@@ -121,7 +121,7 @@ sub sendLocalFirewallRequestTrap {
     my ($this, $switch, $mac) = @_;
     my $switch_ip = $switch->{_ip};
     my $switch_id = $switch->{_id};
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectWrite() ) {
         return 0;
     }

--- a/lib/pf/Switch/Ruckus.pm
+++ b/lib/pf/Switch/Ruckus.pm
@@ -39,7 +39,7 @@ use strict;
 use warnings;
 
 use base ('pf::Switch');
-use Log::Log4perl;
+use pf::log;
 
 use pf::accounting qw(node_accounting_dynauth_attr);
 use pf::constants;
@@ -82,7 +82,7 @@ obtain image version information from switch
 sub getVersion {
     my ($this)       = @_;
     my $oid_ruckusVer = '1.3.6.1.4.1.25053.1.2.1.1.1.1.18';
-    my $logger       = Log::Log4perl::get_logger( ref($this) );
+    my $logger       = $this->logger;
     if ( !$this->connectRead() ) {
         return '';
     }
@@ -109,7 +109,7 @@ All traps ignored
 sub parseTrap {
     my ( $this, $trapString ) = @_;
     my $trapHashRef;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     # Handle WIPS Trap
     if ( $trapString =~ /\.1\.3\.6\.1\.4\.1\.25053\.2\.2\.2\.20 = STRING: \"([a-f0-9]{2}:[a-f0-9]{2}:[a-f0-9]{2}:[a-f0-9]{2}:[a-f0-9]{2}:[a-f0-9]{2})/ ) {
@@ -132,7 +132,7 @@ New implementation using RADIUS Disconnect-Request.
 
 sub deauthenticateMacDefault {
     my ( $self, $mac, $is_dot1x ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
 
     if ( !$self->isProductionMode() ) {
         $logger->info("not in production mode... we won't perform deauthentication");
@@ -156,7 +156,7 @@ Return the reference to the deauth technique or the default deauth technique.
 
 sub deauthTechniques {
     my ($this, $method) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $default = $SNMP::RADIUS;
     my %tech = (
         $SNMP::RADIUS => 'deauthenticateMacDefault',
@@ -183,7 +183,7 @@ status code
 
 sub parseUrl {
     my($this, $req) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     return (clean_mac($$req->param('client_mac')),$$req->param('ssid'),$$req->param('uip'),$$req->param('url'),undef,undef);
 }
 
@@ -195,7 +195,7 @@ Creates the form that should be given to the client device to trigger a reauthen
 
 sub getAcceptForm {
     my ( $self, $mac , $destination_url, $cgi_session) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
     $logger->debug("[$mac] Creating web release form");
 
     my $client_ip = $cgi_session->param("ecwp-original-param-uip");

--- a/lib/pf/Switch/Ruckus.pm
+++ b/lib/pf/Switch/Ruckus.pm
@@ -39,7 +39,6 @@ use strict;
 use warnings;
 
 use base ('pf::Switch');
-use pf::log;
 
 use pf::accounting qw(node_accounting_dynauth_attr);
 use pf::constants;

--- a/lib/pf/Switch/SMC.pm
+++ b/lib/pf/Switch/SMC.pm
@@ -20,7 +20,7 @@ use strict;
 use warnings;
 
 use POSIX;
-use Log::Log4perl;
+use pf::log;
 
 use base ('pf::Switch');
 
@@ -39,7 +39,7 @@ use pf::util;
 sub parseTrap {
     my ( $this, $trapString ) = @_;
     my $trapHashRef;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     #link up/down
     if ( $trapString =~ /BEGIN VARIABLEBINDINGS [^|]+[|]\.1\.3\.6\.1\.6\.3\.1\.1\.4\.1\.0 = OID: \.1\.3\.6\.1\.6\.3\.1\.1\.5\.([34])\|.1.3.6.1.2.1.2.2.1.1.([0-9]+)/) {
@@ -67,7 +67,7 @@ sub parseTrap {
 
 sub _setVlan {
     my ( $this, $ifIndex, $newVlan, $oldVlan, $switch_locker_ref ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectRead() ) {
         return 0;
     }
@@ -153,7 +153,7 @@ sub _setVlan {
 
 sub getDot1dBasePortForThisIfIndex {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->connectRead() ) {
         return 0;
@@ -190,7 +190,7 @@ Returns an hashref with MAC => ifIndex => Array(VLANs)
 
 sub getAllSecureMacAddresses {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     # from Q-BRIDGE MIB
     my $OID_dot1qStaticUnicastAllowedToGoTo = '1.3.6.1.2.1.17.7.1.3.1.1.3';
@@ -247,7 +247,7 @@ Have that in mind when doing maintenance.
 
 sub getSecureMacAddresses {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $OID_dot1qStaticUnicastAllowedToGoTo = '1.3.6.1.2.1.17.7.1.3.1.1.3';
 
     my $secureMacAddrHashRef = {};
@@ -281,7 +281,7 @@ sub getSecureMacAddresses {
 
 sub authorizeMAC {
     my ( $this, $ifIndex, $deauthMac, $authMac, $deauthVlan, $authVlan ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     # from Q-BRIDGE-MIB (RFC4363)
     my $OID_dot1qStaticUnicastStatus = '1.3.6.1.2.1.17.7.1.3.1.1.4';

--- a/lib/pf/Switch/SMC.pm
+++ b/lib/pf/Switch/SMC.pm
@@ -20,7 +20,6 @@ use strict;
 use warnings;
 
 use POSIX;
-use pf::log;
 
 use base ('pf::Switch');
 

--- a/lib/pf/Switch/SMC/TS6128L2.pm
+++ b/lib/pf/Switch/SMC/TS6128L2.pm
@@ -31,7 +31,6 @@ SNMPv3 support was not tested.
 use strict;
 use warnings;
 
-use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::SMC');

--- a/lib/pf/Switch/SMC/TS6128L2.pm
+++ b/lib/pf/Switch/SMC/TS6128L2.pm
@@ -31,7 +31,7 @@ SNMPv3 support was not tested.
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::SMC');
@@ -54,7 +54,7 @@ TODO: This list is incomplete
 sub getVersion {
     my ($this) = @_;
     my $OID_swProdVersion = '1.3.6.1.4.1.202.20.'.MODEL_OID_ID.'.1.1.5.4.0';    #swProdVersion
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectRead() ) {
         return '';
     }
@@ -66,7 +66,7 @@ sub getVersion {
 
 sub isPortSecurityEnabled {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     # portSecPortStatus
     # by looking at other SMC MIBS, I noticed that portSecPortStatus is always like .1.3.6.1.4.1.202.20.yy.1.17.2.1.1.2

--- a/lib/pf/Switch/SMC/TS6224M.pm
+++ b/lib/pf/Switch/SMC/TS6224M.pm
@@ -16,7 +16,6 @@ This module was not developed by Inverse. Unknown firmware revision used for dev
 use strict;
 use warnings;
 
-use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::SMC');

--- a/lib/pf/Switch/SMC/TS6224M.pm
+++ b/lib/pf/Switch/SMC/TS6224M.pm
@@ -16,7 +16,7 @@ This module was not developed by Inverse. Unknown firmware revision used for dev
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::SMC');
@@ -29,7 +29,7 @@ use pf::Switch::constants;
 sub getVersion {
     my ($this) = @_;
     my $OID_swProdVersion = '1.3.6.1.4.1.202.20.43.1.1.5.4.0';    #swProdVersion
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectRead() ) {
         return '';
     }
@@ -41,7 +41,7 @@ sub getVersion {
 
 sub isPortSecurityEnabled {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     # portSecPortStatus
     # by looking at other SMC MIBS, I noticed that portSecPortStatus is always like .1.3.6.1.4.1.202.20.yy.1.17.2.1.1.2

--- a/lib/pf/Switch/SMC/TS8800M.pm
+++ b/lib/pf/Switch/SMC/TS8800M.pm
@@ -34,7 +34,6 @@ SNMPv3 support was not tested.
 
 use strict;
 use warnings;
-use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::SMC');

--- a/lib/pf/Switch/SMC/TS8800M.pm
+++ b/lib/pf/Switch/SMC/TS8800M.pm
@@ -34,7 +34,7 @@ SNMPv3 support was not tested.
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::SMC');
@@ -57,7 +57,7 @@ TODO: This list is incomplete
 sub getVersion {
     my ($this) = @_;
     my $OID_swProdVersion = '1.3.6.1.4.1.202.20.'.MODEL_OID_ID.'.1.1.5.4.0';    #swProdVersion
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectRead() ) {
         return '';
     }
@@ -75,7 +75,7 @@ sub getVersion {
 
 sub isPortSecurityEnabled {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     # portSecPortStatus
     # by looking at other SMC MIBS, I noticed that portSecPortStatus is always like .1.3.6.1.4.1.202.20.yy.1.17.2.1.1.2

--- a/lib/pf/Switch/ThreeCom.pm
+++ b/lib/pf/Switch/ThreeCom.pm
@@ -16,7 +16,6 @@ use strict;
 use warnings;
 
 use base ('pf::Switch');
-use pf::log;
 use Net::SNMP;
 
 use pf::Switch::constants;

--- a/lib/pf/Switch/ThreeCom.pm
+++ b/lib/pf/Switch/ThreeCom.pm
@@ -90,7 +90,7 @@ sub _getMacAtIfIndex {
 
 sub getIfIndexByNasPortId {
     my ($this, $ifDesc_param) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->connectRead() ) {
         return 0;

--- a/lib/pf/Switch/ThreeCom.pm
+++ b/lib/pf/Switch/ThreeCom.pm
@@ -16,7 +16,7 @@ use strict;
 use warnings;
 
 use base ('pf::Switch');
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use pf::Switch::constants;
@@ -25,7 +25,7 @@ use pf::util;
 sub parseTrap {
     my ( $this, $trapString ) = @_;
     my $trapHashRef;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( $trapString
         =~ /BEGIN TYPE ([23]) END TYPE BEGIN SUBTYPE 0 END SUBTYPE BEGIN VARIABLEBINDINGS \.1\.3\.6\.1\.2\.1\.2\.2\.1\.2\.(\d+) = /
         )
@@ -55,7 +55,7 @@ sub parseTrap {
 
 sub getDot1dBasePortForThisIfIndex {
     my ( $this, $ifIndex ) = @_;
-    my $logger                   = Log::Log4perl::get_logger( ref($this) );
+    my $logger                   = $this->logger;
     my $ifIndexDot1dBasePortHash = {
         102 => 1,
         103 => 2,
@@ -68,13 +68,13 @@ sub getDot1dBasePortForThisIfIndex {
 
 sub _setVlan {
     my ( $this, $ifIndex, $newVlan, $oldVlan, $switch_locker_ref ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     return $this->_setVlanByOnlyModifyingPvid( $ifIndex, $newVlan, $oldVlan, $switch_locker_ref );
 }
 
 sub _getMacAtIfIndex {
     my ( $this, $ifIndex, $vlan ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my @macArray;
     if ( !$this->connectRead() ) {
         return @macArray;

--- a/lib/pf/Switch/ThreeCom/E4800G.pm
+++ b/lib/pf/Switch/ThreeCom/E4800G.pm
@@ -82,7 +82,6 @@ It's really a matter of choice.
 use strict;
 use warnings;
 
-use pf::log;
 use Net::SNMP;
 use POSIX;
 

--- a/lib/pf/Switch/ThreeCom/E4800G.pm
+++ b/lib/pf/Switch/ThreeCom/E4800G.pm
@@ -82,7 +82,7 @@ It's really a matter of choice.
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 use POSIX;
 

--- a/lib/pf/Switch/ThreeCom/E5500G.pm
+++ b/lib/pf/Switch/ThreeCom/E5500G.pm
@@ -89,7 +89,7 @@ It's really a matter of choice.
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 use POSIX;
 

--- a/lib/pf/Switch/ThreeCom/E5500G.pm
+++ b/lib/pf/Switch/ThreeCom/E5500G.pm
@@ -89,7 +89,6 @@ It's really a matter of choice.
 use strict;
 use warnings;
 
-use pf::log;
 use Net::SNMP;
 use POSIX;
 

--- a/lib/pf/Switch/ThreeCom/NJ220.pm
+++ b/lib/pf/Switch/ThreeCom/NJ220.pm
@@ -19,7 +19,6 @@ F<conf/switches.conf>
 
 use strict;
 use warnings;
-use pf::log;
 use Net::SNMP;
 use base ('pf::Switch::ThreeCom');
 

--- a/lib/pf/Switch/ThreeCom/NJ220.pm
+++ b/lib/pf/Switch/ThreeCom/NJ220.pm
@@ -19,7 +19,7 @@ F<conf/switches.conf>
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 use base ('pf::Switch::ThreeCom');
 
@@ -27,13 +27,13 @@ sub description { '3COM NJ220' }
 
 sub getMinOSVersion {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     return '2.0.23';
 }
 
 sub getVersion {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     $logger->info("we don't know how to determine the version through SNMP !");
     return '2.0.13';
 }

--- a/lib/pf/Switch/ThreeCom/SS4200.pm
+++ b/lib/pf/Switch/ThreeCom/SS4200.pm
@@ -14,7 +14,7 @@ oriented interface to access SNMP enabled
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::ThreeCom');
@@ -23,7 +23,7 @@ sub description { '3COM SS4200' }
 
 sub getVersion {
     my ($this) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     my $OID_StackUnitSWVersion
         = '1.3.6.1.4.1.43.10.27.1.1.1.12.1';    #from A3COM-0352-STACK-CONFIG
@@ -47,7 +47,7 @@ sub getVersion {
 
 sub getDot1dBasePortForThisIfIndex {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->connectRead() ) {
         return 0;
@@ -114,7 +114,7 @@ sub getDot1dBasePortForThisIfIndex {
 
 sub getVlan {
     my ( $this, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     my $OID_dot1qPvid = '1.3.6.1.2.1.17.7.1.4.5.1.1';    # Q-BRIDGE-MIB
     if ( !$this->connectRead() ) {
@@ -136,7 +136,7 @@ sub getVlan {
 
 sub _setVlan {
     my ( $this, $ifIndex, $newVlan, $oldVlan, $switch_locker_ref ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->connectRead() ) {
         return 0;

--- a/lib/pf/Switch/ThreeCom/SS4200.pm
+++ b/lib/pf/Switch/ThreeCom/SS4200.pm
@@ -14,7 +14,6 @@ oriented interface to access SNMP enabled
 
 use strict;
 use warnings;
-use pf::log;
 use Net::SNMP;
 
 use base ('pf::Switch::ThreeCom');

--- a/lib/pf/Switch/ThreeCom/SS4500.pm
+++ b/lib/pf/Switch/ThreeCom/SS4500.pm
@@ -61,7 +61,6 @@ Maybe we can switch to use autolearn with forced 02:00... addresses to fill the 
 
 use strict;
 use warnings;
-use pf::log;
 use Net::SNMP;
 use Net::Telnet;
 

--- a/lib/pf/Switch/ThreeCom/Switch_4200G.pm
+++ b/lib/pf/Switch/ThreeCom/Switch_4200G.pm
@@ -84,7 +84,6 @@ It's really a matter of choice.
 use strict;
 use warnings;
 
-use pf::log;
 use Net::SNMP;
 use POSIX;
 

--- a/lib/pf/Switch/ThreeCom/Switch_4200G.pm
+++ b/lib/pf/Switch/ThreeCom/Switch_4200G.pm
@@ -84,7 +84,7 @@ It's really a matter of choice.
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::SNMP;
 use POSIX;
 
@@ -120,7 +120,7 @@ Translate RADIUS NAS-Port into switch's ifIndex.
 
 sub NasPortToIfIndex {
     my ($this, $nas_port) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     # 4096 NAS-Port slots are reserved per physical ports, 
     # I'm assuming that each client will get a +1 so I translate all of them into the same ifIndex
@@ -152,7 +152,7 @@ See in L</"BUGS AND LIMITATIONS">.
 
 sub dot1xPortReauthenticate {
     my ($this, $ifIndex, $mac) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
 
     $logger->warn(
         "Bouncing the port instead of performing 802.1x port re-authentication because of a 4200G bug. "

--- a/lib/pf/Switch/Trapeze.pm
+++ b/lib/pf/Switch/Trapeze.pm
@@ -13,7 +13,7 @@ Module to manage Trapeze controllers
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Net::Appliance::Session;
 use POSIX;
 
@@ -62,7 +62,7 @@ obtain image version information from switch
 sub getVersion {
     my ($this) = @_;
     my $oid_ntwsVersionString = '1.3.6.1.4.1.45.6.1.4.2.1.4';
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     if ( !$this->connectRead() ) {
         return '';
     }
@@ -97,7 +97,7 @@ This is called when we receive an SNMP-Trap for this device
 sub parseTrap {
     my ( $this, $trapString ) = @_;
     my $trapHashRef;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     $logger->debug("trap currently not handled");
     $trapHashRef->{'trapType'} = 'unknown';
@@ -115,7 +115,7 @@ Right now te only way to do it is from the CLi (through Telnet or SSH).
 
 sub deauthenticateMacDefault {
     my ( $this, $mac ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     if ( !$this->isProductionMode() ) {
         $logger->info("not in production mode ... we won't deauthenticate $mac");
@@ -183,7 +183,7 @@ Return the reference to the deauth technique or the default deauth technique.
 
 sub deauthTechniques {
     my ($this, $method) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $default = $SNMP::TELNET;
     my %tech = (
         $SNMP::TELNET => 'deauthenticateMacDefault',

--- a/lib/pf/Switch/Trapeze.pm
+++ b/lib/pf/Switch/Trapeze.pm
@@ -13,7 +13,6 @@ Module to manage Trapeze controllers
 use strict;
 use warnings;
 
-use pf::log;
 use Net::Appliance::Session;
 use POSIX;
 

--- a/lib/pf/Switch/WirelessModuleTemplate.pm
+++ b/lib/pf/Switch/WirelessModuleTemplate.pm
@@ -43,7 +43,7 @@ use strict;
 use warnings;
 
 use base ('pf::Switch');
-use Log::Log4perl;
+use pf::log;
 
 use pf::constants;
 use pf::config;
@@ -79,7 +79,7 @@ sub parseTrap {
     # Optional for Wireless devices
     my ( $this, $trapString ) = @_;
     my $trapHashRef;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     
     $logger->debug("trap currently not handled");
     $trapHashRef->{'trapType'} = 'unknown';

--- a/lib/pf/Switch/WirelessModuleTemplate.pm
+++ b/lib/pf/Switch/WirelessModuleTemplate.pm
@@ -43,7 +43,6 @@ use strict;
 use warnings;
 
 use base ('pf::Switch');
-use pf::log;
 
 use pf::constants;
 use pf::config;

--- a/lib/pf/Switch/Xirrus.pm
+++ b/lib/pf/Switch/Xirrus.pm
@@ -23,7 +23,6 @@ SNMPv3 support is untested.
 use strict;
 use warnings;
 
-use pf::log;
 use POSIX;
 
 use base ('pf::Switch');

--- a/lib/pf/Switch/Xirrus.pm
+++ b/lib/pf/Switch/Xirrus.pm
@@ -23,7 +23,7 @@ SNMPv3 support is untested.
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use POSIX;
 
 use base ('pf::Switch');
@@ -61,7 +61,7 @@ obtain image version information from switch
 sub getVersion {
     my ($this)       = @_;
     my $oid_sysDescr = '1.3.6.1.2.1.1.1.0';
-    my $logger       = Log::Log4perl::get_logger( ref($this) );
+    my $logger       = $this->logger;
     if ( !$this->connectRead() ) {
         return '';
     }
@@ -84,7 +84,7 @@ sub getVersion {
 sub parseTrap {
     my ( $this, $trapString ) = @_;
     my $trapHashRef;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
 
     # wlsxNUserEntryDeAuthenticated: 1.3.6.1.4.1.14823.2.3.1.11.1.2.1017
 
@@ -107,7 +107,7 @@ deauthenticate a MAC address from wireless network (including 802.1x)
 
 sub deauthenticateMacDefault {
     my ($this, $mac) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = $this->logger;
     my $OID_stationDeauthMacAddress = '1.3.6.1.4.1.21013.1.2.22.3.0'; # from XIRRUS-MIB
 
     if ( !$this->isProductionMode() ) {
@@ -143,7 +143,7 @@ New implementation using RADIUS Disconnect-Request.
 
 sub deauthenticateMacRadius {
     my ( $self, $mac, $is_dot1x ) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
 
     if ( !$self->isProductionMode() ) {
         $logger->info("not in production mode... we won't perform deauthentication");
@@ -170,7 +170,7 @@ Uses L<pf::util::radius> for the low-level RADIUS stuff.
 
 sub radiusDisconnect {
     my ($self, $mac, $add_attributes_ref) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
 
     # initialize
     $add_attributes_ref = {} if (!defined($add_attributes_ref));
@@ -245,7 +245,7 @@ Return the reference to the deauth technique or the default deauth technique.
 
 sub deauthTechniques {
     my ($this, $method) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $default = $SNMP::SNMP;
     my %tech = (
         $SNMP::SNMP => 'deauthenticateMacDefault',

--- a/lib/pf/Switch/Xirrus/AP_http.pm
+++ b/lib/pf/Switch/Xirrus/AP_http.pm
@@ -27,7 +27,6 @@ use strict;
 use warnings;
 
 use base ('pf::Switch::Xirrus');
-use pf::log;
 
 use pf::constants;
 use pf::config;

--- a/lib/pf/Switch/Xirrus/AP_http.pm
+++ b/lib/pf/Switch/Xirrus/AP_http.pm
@@ -6,7 +6,7 @@ pf::Switch::Xirrus::AP_http
 
 =head1 SYNOPSIS
 
-The pf::Switch::Xirrus::AP_http module implements an object oriented interface to 
+The pf::Switch::Xirrus::AP_http module implements an object oriented interface to
 manage the external captive portal on Xirrus access points
 
 =head1 STATUS
@@ -27,7 +27,7 @@ use strict;
 use warnings;
 
 use base ('pf::Switch::Xirrus');
-use Log::Log4perl;
+use pf::log;
 
 use pf::constants;
 use pf::config;
@@ -61,7 +61,7 @@ status code
 
 sub parseUrl {
     my($this, $req, $r) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($this) );
+    my $logger = $this->logger;
     my $connection = $r->connection;
     $this->synchronize_locationlog("0", "0", clean_mac($$req->param('mac')),
         0, $WIRELESS_MAC_AUTH, clean_mac($$req->param('mac')), $$req->param('ssid')
@@ -73,8 +73,7 @@ sub parseUrl {
 
 sub parseSwitchIdFromRequest {
     my($class, $req) = @_;
-    my $logger = Log::Log4perl::get_logger( $class );
-    return $$req->param('nasid'); 
+    return $$req->param('nasid');
 }
 
 =head2 returnRadiusAccessAccept
@@ -87,22 +86,22 @@ Overriding the default implementation for the external captive portal
 
 sub returnRadiusAccessAccept {
     my ($self, $vlan, $mac, $port, $connection_type, $user_name, $ssid, $wasInline, $user_role) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
 
     my $radius_reply_ref = {};
 
     my $node = node_view($mac);
 
     my $violation = pf::violation::violation_view_top($mac);
-    # if user is unregistered or is in violation then we reject him to show him the captive portal 
+    # if user is unregistered or is in violation then we reject him to show him the captive portal
     if ( $node->{status} eq $pf::node::STATUS_UNREGISTERED || defined($violation) ){
         $logger->info("[$mac] is unregistered. Refusing access to force the eCWP");
         my $radius_reply_ref = {
             'Tunnel-Medium-Type' => $RADIUS::ETHERNET,
             'Tunnel-Type' => $RADIUS::VLAN,
             'Tunnel-Private-Group-ID' => -1,
-        }; 
-        return [$RADIUS::RLM_MODULE_OK, %$radius_reply_ref]; 
+        };
+        return [$RADIUS::RLM_MODULE_OK, %$radius_reply_ref];
 
     }
     else{
@@ -114,7 +113,7 @@ sub returnRadiusAccessAccept {
 
 sub getAcceptForm {
     my ( $self, $mac , $destination_url, $cgi_session) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
     $logger->debug("[$mac] Creating web release form");
 
     my $uamip = $cgi_session->param("ecwp-original-param-uamip");

--- a/lib/pf/WebAPI.pm
+++ b/lib/pf/WebAPI.pm
@@ -49,7 +49,7 @@ my $server_jsonrpc = pf::WebAPI::JSONRPC->new({dispatch_to => 'pf::api'});
 sub handler {
     my ($r) = @_;
     pf::client::setClient("pf::api::local");
-    my $logger = get_logger;
+    my $logger = get_logger();
     if (defined($r->headers_in->{Request})) {
         $r->user($r->headers_in->{Request});
     }
@@ -65,7 +65,7 @@ sub handler {
 }
 
 sub log_faults {
-    my $logger = get_logger;
+    my $logger = get_logger();
     $logger->info(@_);
 }
 

--- a/lib/pf/WebAPI.pm
+++ b/lib/pf/WebAPI.pm
@@ -17,7 +17,6 @@ use ModPerl::Util;
 use pf::config;
 use pf::api;
 use pf::client;
-use pf::log;
 pf::client::setClient("pf::api::local");
 
 #uncomment for more debug information

--- a/lib/pf/WebAPI.pm
+++ b/lib/pf/WebAPI.pm
@@ -11,7 +11,7 @@ use warnings;
 
 use Apache2::MPM ();
 use Apache2::RequestRec;
-use Log::Log4perl;
+use pf::log;
 use ModPerl::Util;
 
 use pf::config;

--- a/lib/pf/WebAPI/JSONRPC.pm
+++ b/lib/pf/WebAPI/JSONRPC.pm
@@ -42,7 +42,7 @@ our $RPC_VERSION  = "2.0";
 sub allowed {return exists $ALLOW_CONTENT_TYPE{$_[0]}}
 
 sub handler {
-    my $logger = get_logger;
+    my $logger = get_logger();
     use bytes;
     my ($self, $r) = @_;
     my $content = $self->get_all_content($r);

--- a/lib/pf/WebAPI/MsgPack.pm
+++ b/lib/pf/WebAPI/MsgPack.pm
@@ -28,7 +28,7 @@ our $MSGPACKRPC_RESPONSE = 1;
 our $MSGPACKRPC_NOTIFICATION = 2;
 
 sub handler {
-    my $logger = get_logger;
+    my $logger = get_logger();
     use bytes;
     my ($self,$r) = @_;
     my $content_type = $r->headers_in->{'Content-Type'};

--- a/lib/pf/accounting.pm
+++ b/lib/pf/accounting.pm
@@ -15,7 +15,7 @@ pf::accounting is a module to add the RADIUS accounting fonctionnalities and ena
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Readonly;
 
 use constant ACCOUNTING => 'accounting';
@@ -84,7 +84,7 @@ Initialize database prepared statements
 =cut
 
 sub accounting_db_prepare {
-    my $logger = Log::Log4perl::get_logger('pf::accounting');
+    my $logger = get_logger();
     $logger->debug("Preparing pf::accounting database queries");
 
     $accounting_statements->{'acct_current_sessionid_sql'} = get_db_handle()->prepare(qq[
@@ -357,7 +357,7 @@ Check in the accounting tables for potential bandwidth abuse
 =cut
 
 sub acct_maintenance {
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     $logger->info("getting violations triggers for accounting cleanup");
 
     foreach my $info (@ACCOUNTING_TRIGGERS) {

--- a/lib/pf/action.pm
+++ b/lib/pf/action.pm
@@ -87,7 +87,7 @@ our $action_db_prepared = 0;
 our $action_statements = {};
 
 sub action_db_prepare {
-    my $logger = get_logger;
+    my $logger = get_logger();
     $logger->debug("Preparing pf::action database queries");
 
     $action_statements->{'action_add_sql'} = get_db_handle()->prepare(qq[ insert into action(vid,action) values(?,?) ]);
@@ -118,7 +118,7 @@ sub action_exist {
 
 sub action_add {
     my ($vid, $action) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
     if ( action_exist( $vid, $action ) ) {
         $logger->warn("attempt to add existing action $action to class $vid");
         return (2);
@@ -149,7 +149,7 @@ sub action_view_all {
 
 sub action_delete {
     my ($vid, $action) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
     db_query_execute(ACTION, $action_statements, 'action_delete_sql', $vid, $action) || return (0);
     $logger->debug("action $action deleted from class $vid");
 
@@ -158,7 +158,7 @@ sub action_delete {
 
 sub action_delete_all {
     my ($vid) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
     db_query_execute(ACTION, $action_statements, 'action_delete_all_sql', $vid) || return (0);
     $logger->debug("all actions for class $vid deleted");
 
@@ -168,7 +168,7 @@ sub action_delete_all {
 # TODO what is that? Isn't it dangerous?
 sub action_api {
     my ($mac, $vid) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
     my $class_info = class_view($vid);
     my @params = split(' ', $class_info->{'external_command'});
     my $return;
@@ -190,7 +190,7 @@ sub action_api {
 
 sub action_execute {
     my ($mac, $vid, $notes) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
     my $leave_open = 0;
     my @actions = class_view_actions($vid);
     # Sort the actions in reverse order in order to always finish with the autoreg action
@@ -316,7 +316,7 @@ sub action_email_user {
 
 sub action_log {
     my ($mac, $vid) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
     require pf::iplog;
     my $ip = pf::iplog::mac2ip($mac) || 0;
 
@@ -345,7 +345,7 @@ sub action_reevaluate_access {
 
 sub action_autoregister {
     my ($mac, $vid) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
 
     if(pf::node::is_node_registered($mac)){
         $logger->debug("Calling autoreg on already registered node. Doing nothing.");
@@ -364,7 +364,7 @@ sub action_autoregister {
 
 sub action_close {
    my ($mac, $vid) = @_;
-   my $logger = get_logger;
+   my $logger = get_logger();
 
    #We need to fetch which violation id to close
    my $class = class_view($vid);

--- a/lib/pf/action.pm
+++ b/lib/pf/action.pm
@@ -23,7 +23,6 @@ use warnings;
 use pf::log;
 use Readonly;
 use pf::node;
-use pf::log;
 use pf::person;
 use pf::util;
 use pf::violation_config;
@@ -79,7 +78,6 @@ use pf::config::util;
 use pf::class qw(class_view class_view_actions);
 use pf::violation qw(violation_force_close);
 use pf::Portal::ProfileFactory;
-use pf::log;
 use pf::constants::scan qw($POST_SCAN_VID $PRE_SCAN_VID);
 
 # The next two variables and the _prepare sub are required for database handling magic (see pf::db)

--- a/lib/pf/activation.pm
+++ b/lib/pf/activation.pm
@@ -123,7 +123,7 @@ TODO: This list is incomplete
 =cut
 
 sub activation_db_prepare {
-    my $logger = get_logger;
+    my $logger = get_logger();
     $logger->debug("Preparing pf::activation database queries");
 
     $activation_statements->{'activation_view_sql'} = get_db_handle()->prepare(qq[
@@ -301,7 +301,7 @@ invalidate all unverified activation codes for a given mac and contact_info
 
 sub invalidate_codes {
     my ($mac, $pid, $contact_info) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
 
     if ($mac) {
         # Invalidate previous activation codes matching MAC, pid (user or sponsor email) and contact_info
@@ -347,7 +347,7 @@ Returns the activation code
 
 sub create {
     my ($mac, $pid, $pending_addr, $type, $portal, $provider_id) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
 
     # invalidate older codes for the same MAC / contact_info
     invalidate_codes($mac, $pid, $pending_addr);
@@ -387,7 +387,7 @@ generate proper activation code. Created to encapsulate flexible hash types.
 
 sub _generate_activation_code {
     my (%data) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
 
     if ($HASH_FORMAT == $SIMPLE_MD5) {
         my $code;
@@ -441,7 +441,7 @@ Send an email with the activation code
 
 sub send_email {
     my ($activation_code, $template, %info) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
 
     my $smtpserver = $Config{'alerting'}{'smtpserver'};
     $info{'from'} = $Config{'alerting'}{'fromaddr'} || 'root@' . $fqdn;
@@ -514,7 +514,7 @@ sub create_and_send_activation_code {
 # returns the validated activation record hashref or undef
 sub validate_code {
     my ($activation_code) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
 
     my $activation_record = find_unverified_code($activation_code);
     if (!defined($activation_record) || ref($activation_record eq 'HASH')) {
@@ -543,7 +543,7 @@ Change the status of a given pending activation code to VERIFIED which means it 
 
 sub set_status_verified {
     my ($activation_code) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
 
     my $activation_record = find_code($activation_code);
     modify_status($activation_record->{'code_id'}, $VERIFIED);

--- a/lib/pf/authentication.pm
+++ b/lib/pf/authentication.pm
@@ -13,7 +13,7 @@ pf::authentication
 use strict;
 use warnings;
 
-use Log::Log4perl qw(get_logger);
+use pf::log;
 
 use pf::constants;
 use pf::config;

--- a/lib/pf/billing.pm
+++ b/lib/pf/billing.pm
@@ -16,7 +16,7 @@ All of the methods of this module can be redefined using pf:billing:custom in li
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use POSIX;
 use Try::Tiny;
 
@@ -90,7 +90,7 @@ This will allow methods redefinition.
 
 sub new {
     my ( $class, %argv ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     $logger->debug("Instanciating a new pf:billing object");
 
@@ -107,7 +107,7 @@ TODO: Add some verification that all the information is there and in a good form
 
 sub createNewTransaction {
     my ( $self, $transaction_infos_ref ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     # Preparing the transaction attributes
     # slicing hashref on the right assigning proper values to the left
@@ -144,7 +144,7 @@ TODO: Put theses configuration in database and be able to modify them using the 
 
 sub getAvailableTiers {
     my ($self) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my %tiers = (
             tier1 => {
@@ -169,7 +169,7 @@ Instantiate a new transaction using the payment gateway configured.
 
 sub instantiateNewTransaction {
     my ( $self, $type, $transaction_infos_ref ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my $transaction = 'pf::billing::gateway::' . $type;
     try {
@@ -191,7 +191,7 @@ sub instantiateNewTransaction {
 
 sub processTransaction {
     my ( $self, $transaction_infos_ref ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     # Create the new transaction
     my $transaction = $self->createNewTransaction($transaction_infos_ref);
@@ -217,7 +217,7 @@ Update the status of a transaction in the database
 
 sub updateTransactionStatus {
     my ( $self, $id, $status ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     $logger->debug("Updating the transaction: $id with status: $status");
 
@@ -235,7 +235,7 @@ This is meant to be overridden in L<pf::billing::custom>.
 
 sub prepareConfirmationInfo {
     my ( $self, $transaction_infos_ref, $confirmationInfo ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my %info = ( pf::web::constants::to_hash() );
     my %tiers = $self->getAvailableTiers();

--- a/lib/pf/billing/custom.pm
+++ b/lib/pf/billing/custom.pm
@@ -16,7 +16,7 @@ This module extends pf::billing
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 
 use base ('pf::billing');
 
@@ -29,7 +29,7 @@ our $VERSION = 1.00;
 =cut
 
 #sub getAvailableTiers {
-#    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+#    my $logger = get_logger();
 #
 #    my %tiers = (
 #            tier1 => {

--- a/lib/pf/billing/gateway/authorize_net.pm
+++ b/lib/pf/billing/gateway/authorize_net.pm
@@ -17,7 +17,7 @@ use strict;
 use warnings;
 
 use HTTP::Request::Common qw(POST);
-use Log::Log4perl;
+use pf::log;
 use LWP::UserAgent;
 use Readonly;
 
@@ -44,7 +44,7 @@ Create a new object for transactions using Authorize.net payment gateway
 
 sub new {
     my ( $class, $transaction_infos_ref ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     $logger->debug("Instanciating a new " . __PACKAGE__ . " object");
 
@@ -85,7 +85,7 @@ sub new {
 
 sub processPayment {
     my ( $this ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my $post_values = {
             x_login           => $this->{'_authorizenet_login'},

--- a/lib/pf/class.pm
+++ b/lib/pf/class.pm
@@ -14,7 +14,7 @@ pf::class contains the functions necessary to manage the violation classes.
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 
 use constant CLASS => 'class';
 
@@ -43,7 +43,7 @@ our $class_db_prepared = 0;
 our $class_statements = {};
 
 sub class_db_prepare {
-    my $logger = Log::Log4perl::get_logger('pf::class');
+    my $logger = get_logger();
     $logger->debug("Preparing pf::class database queries");
 
     $class_statements->{'class_view_sql'} = get_db_handle()->prepare(
@@ -107,7 +107,7 @@ sub class_view_actions {
 
 sub class_add {
     my $id = $_[0];
-    my $logger = Log::Log4perl::get_logger('pf::class');
+    my $logger = get_logger();
     if ( class_exist($id) ) {
         $logger->warn("attempt to add existing class $id");
         return (2);
@@ -119,14 +119,14 @@ sub class_add {
 
 sub class_delete {
     my ($id) = @_;
-    my $logger = Log::Log4perl::get_logger('pf::class');
+    my $logger = get_logger();
     db_query_execute(CLASS, $class_statements, 'class_delete_sql', $id) || return (0);
     $logger->debug("class $id deleted");
     return (1);
 }
 
 sub class_cleanup {
-    my $logger = Log::Log4perl::get_logger('pf::class');
+    my $logger = get_logger();
     db_query_execute(CLASS, $class_statements, 'class_cleanup_sql') || return (0);
     $logger->debug("class cleanup completed");
     return (1);
@@ -134,7 +134,7 @@ sub class_cleanup {
 
 sub class_modify {
     my $id = shift(@_);
-    my $logger = Log::Log4perl::get_logger('pf::class');
+    my $logger = get_logger();
     push( @_, $id );
     if ( class_exist($id) ) {
         $logger->debug("modify existing existing class $id");
@@ -148,7 +148,7 @@ sub class_merge {
     my $id = $_[0];
     my $actions = pop(@_);
     my $whitelisted_roles = pop(@_);
-    my $logger = Log::Log4perl::get_logger('pf::class');
+    my $logger = get_logger();
 
     # delete existing violation actions
     if ( !pf::action::action_delete_all($id) ) {

--- a/lib/pf/cluster.pm
+++ b/lib/pf/cluster.pm
@@ -55,7 +55,7 @@ Returns 1 if this node is the management node (i.e. owning the management ip)
 =cut
 
 sub is_management {
-    my $logger = get_logger;
+    my $logger = get_logger();
     unless($cluster_enabled){
         $logger->info("Clustering is not enabled. Cannot be management node.");
         return 0;
@@ -146,7 +146,7 @@ sub is_dhcpd_primary {
 
 =head2 should_offer_dhcp
 
-Get whether or not this node should offer DHCP 
+Get whether or not this node should offer DHCP
 
 =cut
 
@@ -162,7 +162,7 @@ Get the IP address of the DHCP peer for an interface
 
 sub dhcpd_peer {
     my ($interface) = @_;
-    
+
     unless(defined($cluster_servers[1])){
         return undef;
     }
@@ -202,7 +202,7 @@ Get all the members IP for an interface
 
 sub members_ips {
     my ($interface) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
     unless(exists($ConfigCluster{$host_id}->{"interface $interface"}->{ip})){
         $logger->warn("requesting member ips for an undefined interface...");
         return {};
@@ -262,7 +262,7 @@ sub sync_storages {
             my $config_file = $cs->configFile;
             my %data = (
                 namespace => $pfconfig_namespace,
-                conf_file => $config_file,          
+                conf_file => $config_file,
             );
             my ($result) = $apiclient->call( 'expire_cluster', %data );
         };

--- a/lib/pf/config.pm
+++ b/lib/pf/config.pm
@@ -245,7 +245,7 @@ use pf::util::apache qw(url_parser);
 
 $thread = 0;
 
-my $logger = Log::Log4perl->get_logger('pf::config');
+my $logger = get_logger();
 
 
 # Accounting trigger policies
@@ -441,7 +441,7 @@ our $BANDWIDTH_UNITS_RE = qr/B|KB|MB|GB|TB/;
 =cut
 
 sub os_detection {
-    my $logger = Log::Log4perl::get_logger('pf::config');
+    my $logger = get_logger();
     if (-e '/etc/debian_version') {
         return "debian";
     }elsif (-e '/etc/redhat-release') {

--- a/lib/pf/config/ui.pm
+++ b/lib/pf/config/ui.pm
@@ -21,7 +21,7 @@ conf/ui.conf
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 
 our $VERSION = 1.00;
 
@@ -59,7 +59,7 @@ pf::config::ui::custom subclass instead.
 
 sub new {
     my ( $class, %argv ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     $logger->debug("instantiating new " . __PACKAGE__ . " object");
     my $self = bless {}, $class;
     return $self;
@@ -83,7 +83,7 @@ Load ui.conf into a Config::IniFiles tied hashref
 
 sub _ui_conf {
     my ($self) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     unless (defined $_ui_conf_tie) {
         my %conf;
@@ -115,7 +115,7 @@ Ex resources:
 #      hard-coded names
 sub field_order {
     my ($self, $resource) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my $uiconfig = $self->_ui_conf();
     my @fields;

--- a/lib/pf/configfile.pm
+++ b/lib/pf/configfile.pm
@@ -2,18 +2,18 @@ package pf::configfile;
 
 =head1 NAME
 
-pf::configfile - module to store the configuration files in the 
+pf::configfile - module to store the configuration files in the
 database.
 
 =cut
 
 =head1 DESCRIPTION
 
-pf::configfile contains the functions necessary to store/read a 
-configuration file to the database. PacketFence stores the 
+pf::configfile contains the functions necessary to store/read a
+configuration file to the database. PacketFence stores the
 configuration files in the database after every configuration change
-through the web interface or a C<pfcmd> call. In a redundancy setup, in 
-case of a failover, you need to manually pull the configuration files 
+through the web interface or a C<pfcmd> call. In a redundancy setup, in
+case of a failover, you need to manually pull the configuration files
 out of the database in order to be up-to-date.
 
 =head1 CONFIGURATION AND ENVIRONMENT
@@ -25,7 +25,7 @@ Read the F<pf.conf> configuration file.
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use File::Copy;
 
 use constant CONFIGFILE => 'configfile';
@@ -58,7 +58,7 @@ our $configfile_db_prepared = 0;
 our $configfile_statements = {};
 
 sub configfile_db_prepare {
-    my $logger = Log::Log4perl::get_logger('pf::configfile');
+    my $logger = get_logger();
     $logger->debug("Preparing pf::configfile database queries");
 
     $configfile_statements->{'configfile_update_sql'} = get_db_handle()->prepare(
@@ -84,7 +84,7 @@ sub configfile_db_prepare {
 
 sub configfile_import {
     my ($filename) = @_;
-    my $logger = Log::Log4perl::get_logger('pf::configfile');
+    my $logger = get_logger();
     if ( !configfile_exist($filename) ) {
         $logger->info(
             "config file $filename does not exist in database; addind new database entry"
@@ -102,7 +102,7 @@ sub configfile_import {
 
 sub configfile_export {
     my ($filename) = @_;
-    my $logger = Log::Log4perl::get_logger('pf::configfile');
+    my $logger = get_logger();
     if ( !configfile_exist($filename) ) {
         $logger->info(
             "config file $filename does not exist in database; unable to export"
@@ -180,7 +180,7 @@ sub configfile_update {
 sub configfile_view {
     my ($filename) = @_;
 
-    my $query = db_query_execute(CONFIGFILE, $configfile_statements, 'configfile_view_sql', $filename) 
+    my $query = db_query_execute(CONFIGFILE, $configfile_statements, 'configfile_view_sql', $filename)
         || return (0);
     my $ref = $query->fetchrow_hashref();
 

--- a/lib/pf/enforcement.pm
+++ b/lib/pf/enforcement.pm
@@ -25,7 +25,7 @@ use strict;
 use warnings;
 
 use List::MoreUtils qw(none);
-use Log::Log4perl;
+use pf::log;
 
 BEGIN {
     use Exporter ();
@@ -64,7 +64,7 @@ Triggered by pfcmd.
 
 sub reevaluate_access {
     my ( $mac, $function, %opts ) = @_;
-    my $logger = Log::Log4perl::get_logger('pf::enforcement');
+    my $logger = get_logger();
 
     # Untaint MAC
     $mac = clean_mac($mac);
@@ -115,7 +115,7 @@ Sends local SNMP traps to pfsetvlan if we should reevaluate the VLAN of a node.
 
 sub _vlan_reevaluation {
     my ( $mac, $locationlog_entry, %opts ) = @_;
-    my $logger = Log::Log4perl::get_logger('pf::enforcement');
+    my $logger = get_logger();
 
     if ( _should_we_reassign_vlan( $mac, $locationlog_entry, %opts ) ) {
 
@@ -168,7 +168,7 @@ Evaluates node's VLAN through L<pf::vlan>'s fetchVlanForNode (which can be redef
 
 sub _should_we_reassign_vlan {
     my ( $mac, $locationlog_entry, %opts ) = @_;
-    my $logger = Log::Log4perl::get_logger('pf::enforcement');
+    my $logger = get_logger();
     if ( $opts{'force'} ) {
         $logger->info("[$mac] VLAN reassignment is forced.");
         return $TRUE;

--- a/lib/pf/firewallsso/Checkpoint.pm
+++ b/lib/pf/firewallsso/Checkpoint.pm
@@ -14,7 +14,7 @@ to update the Checkpoint user table.
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use POSIX;
 
 use base ('pf::firewallsso');
@@ -37,7 +37,7 @@ Perform a radius accounting request based on the registered status of the node a
 
 sub action {
     my ($self, $firewall_conf, $method, $mac, $ip, $timeout) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($self));
+    my $logger = $self->logger;
 
     my $node_info = node_view($mac);
 
@@ -78,6 +78,17 @@ sub action {
     } else {
         return $FALSE;
     }
+}
+
+=head2 logger
+
+Return the current logger for the switch
+
+=cut
+
+sub logger {
+    my ($proto) = @_;
+    return get_logger( ref($proto) || $proto );
 }
 
 =head1 AUTHOR

--- a/lib/pf/firewallsso/FortiGate.pm
+++ b/lib/pf/firewallsso/FortiGate.pm
@@ -18,7 +18,7 @@ use warnings;
 use base ('pf::firewallsso');
 
 use POSIX;
-use Log::Log4perl;
+use pf::log;
 
 use pf::config;
 sub description { 'FortiGate Firewall' }
@@ -36,7 +36,7 @@ Perform a radius accounting request based on the registered status of the node a
 
 sub action {
     my ($self,$firewall_conf,$method,$mac,$ip,$timeout) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($self));
+    my $logger = $self->logger;
 
     my $node_info = node_view($mac);
 
@@ -77,6 +77,17 @@ sub action {
     } else {
         return 0;
     }
+}
+
+=head2 logger
+
+Return the current logger for the switch
+
+=cut
+
+sub logger {
+    my ($proto) = @_;
+    return get_logger( ref($proto) || $proto );
 }
 
 =head1 AUTHOR

--- a/lib/pf/firewallsso/PaloAlto.pm
+++ b/lib/pf/firewallsso/PaloAlto.pm
@@ -18,7 +18,7 @@ use warnings;
 use base ('pf::firewallsso');
 
 use POSIX;
-use Log::Log4perl;
+use pf::log;
 
 use pf::config;
 sub description { 'PaloAlto Firewall' }
@@ -39,7 +39,7 @@ Perform a xml api request based on the registered status of the node and his rol
 
 sub action {
     my ($self,$firewall_conf,$method,$mac,$ip,$timeout) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($self));
+    my $logger = $self->logger;
 
     if ($method eq 'Start') {
         my $node_info = node_view($mac);
@@ -116,6 +116,17 @@ XML
         }
     }
     return 0;
+}
+
+=head2 logger
+
+Return the current logger for the switch
+
+=cut
+
+sub logger {
+    my ($proto) = @_;
+    return get_logger( ref($proto) || $proto );
 }
 
 =head1 AUTHOR

--- a/lib/pf/floatingdevice.pm
+++ b/lib/pf/floatingdevice.pm
@@ -92,7 +92,7 @@ Get an instance of the pf::floatingdevice object
 =cut
 
 sub new {
-    my $logger = get_logger;
+    my $logger = get_logger();
     $logger->debug("instantiating new pf::floatingdevice object");
     my ($class, %argv) = @_;
     my $this = bless {}, $class;
@@ -113,7 +113,7 @@ sub enablePortConfig {
 
 
     my ($this, $mac, $switch, $switch_port, $switch_locker_ref, $radius_triggered) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
 
     # Since PF only manages floating network devices plugged in ports configured with port-security
     # all the switches with no port-security won't work here.
@@ -172,7 +172,7 @@ sub disablePortConfig {
 # cause in this case there would be any traps enabled anymore...
 
     my ($this, $mac, $switch, $switch_port, $switch_locker_ref) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
 
     if (! $switch->supportsFloatingDevice()) {
         $logger->error("Floating devices are not supported on switch type " . ref($switch));
@@ -245,7 +245,7 @@ Puts the switchport in MAB floating device mode
 
 sub enableMABFloating{
     my ( $this, $mac, $switch, $ifIndex ) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
 
     my $result;
     if($switch->supportsFloatingDevice && !$switch->supportsMABFloatingDevices){
@@ -268,7 +268,7 @@ Verifies if there is a floating device plugged into the switchport in the locati
 
 sub portHasFloatingDevice {
     my ($this, $switch, $switch_port) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
 
     $logger->debug("Determining if there is a floating device on $switch port $switch_port");
     my @locationlog_switchport = pf::locationlog::locationlog_view_open_switchport_no_VoIP($switch, $switch_port);
@@ -291,7 +291,7 @@ Disconnects the active locationlog macs on the port so they reauthenticate to be
 
 sub _disconnectCurrentDevices{
     my ( $this, $switch, $switch_port ) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
 
     my @locationlog_switchport = pf::locationlog::locationlog_view_open_switchport_no_VoIP($switch->{_ip}, $switch_port);
 

--- a/lib/pf/floatingdevice.pm
+++ b/lib/pf/floatingdevice.pm
@@ -11,7 +11,7 @@ pf::floatingdevice - module to manage the floating network devices.
 pf::floatingdevice contains the functions necessary to manage the floating network devices.
 A floating network device is a device that PacketFence does not manage as a regular device.
 
-This code was originally added to support mobile Access Points. 
+This code was originally added to support mobile Access Points.
 When an AP is plugged, PacketFence should:
 
 =over
@@ -24,7 +24,7 @@ When an AP is plugged, PacketFence should:
 
 When an AP is unplugged, PacketFence should reconfigure the port like before the AP was plugged
 
-In order to simplify things at first, we decided that 
+In order to simplify things at first, we decided that
 FLOATING NETWORK DEVICES SHOULD ONLY BE PLUGGED IN PORT CONFIGURED WITH PORT_SECURITY!
 
 Here is how it works:
@@ -35,10 +35,10 @@ Here is how it works:
 
 =item - linkup/linkdown traps are not enabled on the switches, only port-security traps are.
 
-=item - when PF receives a port-security violation trap, it checks if the device is a floating network device. if so, 
+=item - when PF receives a port-security violation trap, it checks if the device is a floating network device. if so,
 PF changes the port configuration so that:
 
-=over 
+=over
 
 =item - it disables port-security
 
@@ -51,7 +51,7 @@ PF changes the port configuration so that:
 =back
 
 =item - when PF receives a linkdown trap, it checks if the last device plugged is a floating network device. If so,
- PF changes the port configuration so that: 
+ PF changes the port configuration so that:
 
 =over
 
@@ -72,7 +72,7 @@ Read F<pf.conf> and F<floating_network_device.conf> configuration files.
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Readonly;
 
 use pf::constants;
@@ -82,24 +82,24 @@ use pf::util;
 use pf::config::util;
 
 =head1 SUBROUTINES
-            
-=over   
-            
-=item new 
+
+=over
+
+=item new
 
 Get an instance of the pf::floatingdevice object
 
 =cut
 
 sub new {
-    my $logger = Log::Log4perl::get_logger("pf::floatingdevice");
+    my $logger = get_logger;
     $logger->debug("instantiating new pf::floatingdevice object");
     my ($class, %argv) = @_;
     my $this = bless {}, $class;
     return $this;
 }
 
-=item enablePortConfig 
+=item enablePortConfig
 
 Change port configuration to disable port-security, set PVID and set port as multi-vlan if necessary
 
@@ -109,14 +109,14 @@ sub enablePortConfig {
 
 # FIXME
 # we have to change the error handling in case we leave the function before we enable Linkup/down traps
-# cause in this case there would be any traps enabled anymore... 
+# cause in this case there would be any traps enabled anymore...
 
 
     my ($this, $mac, $switch, $switch_port, $switch_locker_ref, $radius_triggered) = @_;
-    my $logger = Log::Log4perl::get_logger('pf::floatingdevice');
+    my $logger = get_logger;
 
     # Since PF only manages floating network devices plugged in ports configured with port-security
-    # all the switches with no port-security won't work here. 
+    # all the switches with no port-security won't work here.
     if (! $switch->supportsFloatingDevice()) {
         $logger->error("Floating devices are not supported on switch type " . ref($switch));
         return 0;
@@ -134,13 +134,13 @@ sub enablePortConfig {
 
     # if port should be trunk
     if ( $ConfigFloatingDevices{$mac}{'trunkPort'}) {
-        if (! $switch->enablePortConfigAsTrunk($mac, $switch_port, $switch_locker_ref, 
+        if (! $switch->enablePortConfigAsTrunk($mac, $switch_port, $switch_locker_ref,
             $ConfigFloatingDevices{$mac}{'taggedVlan'})) {
             return 0;
         }
     }
 
-    # switchport trunk native vlan x 
+    # switchport trunk native vlan x
     # OR switchport access vlan x
     my $vlan = $ConfigFloatingDevices{$mac}{'pvid'};
     $logger->info("Setting PVID as $vlan on port $switch_port.");
@@ -159,7 +159,7 @@ sub enablePortConfig {
     return 1;
 }
 
-=item disablePortConfig 
+=item disablePortConfig
 
 Reset port configuration to enable port-security and remove multi-vlan settings (if there are some)
 
@@ -169,10 +169,10 @@ sub disablePortConfig {
 
 # FIXME
 # we have to change the error handling in case we leave the function before we enable port-security traps
-# cause in this case there would be any traps enabled anymore... 
+# cause in this case there would be any traps enabled anymore...
 
     my ($this, $mac, $switch, $switch_port, $switch_locker_ref) = @_;
-    my $logger = Log::Log4perl::get_logger('pf::floatingdevice');
+    my $logger = get_logger;
 
     if (! $switch->supportsFloatingDevice()) {
         $logger->error("Floating devices are not supported on switch type " . ref($switch));
@@ -187,7 +187,7 @@ sub disablePortConfig {
     }
 
     # we check the actual port configuration rather than reading $ConfigFloatingDevices{$mac}{'trunkPort'} in the flat
-    # file, just in case the flat file has changed 
+    # file, just in case the flat file has changed
     if ($switch->isTrunkPort($switch_port)) {
         if (! $switch->disablePortConfigAsTrunk($switch_port, $switch_locker_ref)) {
             return 0;
@@ -200,7 +200,7 @@ sub disablePortConfig {
                       "but the port should work.");
     }
 
-    my @locationlog = pf::locationlog::locationlog_view_open_switchport_no_VoIP($switch->{_ip}, $switch_port); 
+    my @locationlog = pf::locationlog::locationlog_view_open_switchport_no_VoIP($switch->{_ip}, $switch_port);
     my $radius_triggered;
     if(scalar(@locationlog) > 0){
         $radius_triggered = (str_to_connection_type($locationlog[0]->{connection_type}) eq $WIRED_MAC_AUTH);
@@ -231,7 +231,7 @@ Removes the MAB floating device mode on the switchport
 
 sub disableMABFloating {
     my ( $this, $switch, $ifIndex ) = @_;
-    
+
     if($switch->supportsMABFloatingDevices){
         $switch->disableMABFloatingDevice($ifIndex);
     }
@@ -245,9 +245,9 @@ Puts the switchport in MAB floating device mode
 
 sub enableMABFloating{
     my ( $this, $mac, $switch, $ifIndex ) = @_;
-    my $logger = Log::Log4perl::get_logger('pf::floatingdevice');
-     
-    my $result;         
+    my $logger = get_logger;
+
+    my $result;
     if($switch->supportsFloatingDevice && !$switch->supportsMABFloatingDevices){
         $this->enablePortConfig($mac, $switch, $ifIndex, undef, $TRUE);
     }
@@ -255,9 +255,9 @@ sub enableMABFloating{
         $switch->enableMABFloatingDevice($ifIndex);
         # disconnect and close additionnal entries that could have been opened (a device was authentified before the floating)
         $this->_disconnectCurrentDevices($switch, $ifIndex);
-        pf::locationlog::locationlog_update_end_switchport_no_VoIP($switch->{_ip}, $ifIndex); 
+        pf::locationlog::locationlog_update_end_switchport_no_VoIP($switch->{_ip}, $ifIndex);
     }
-    
+
 }
 
 =item portHasFloatingDevice
@@ -268,12 +268,12 @@ Verifies if there is a floating device plugged into the switchport in the locati
 
 sub portHasFloatingDevice {
     my ($this, $switch, $switch_port) = @_;
-    my $logger = Log::Log4perl::get_logger('pf::floatingdevice');
+    my $logger = get_logger;
 
     $logger->debug("Determining if there is a floating device on $switch port $switch_port");
     my @locationlog_switchport = pf::locationlog::locationlog_view_open_switchport_no_VoIP($switch, $switch_port);
-    if (@locationlog_switchport && scalar(@locationlog_switchport) > 0){ 
-        my $mac = $locationlog_switchport[0]->{'mac'}; 
+    if (@locationlog_switchport && scalar(@locationlog_switchport) > 0){
+        my $mac = $locationlog_switchport[0]->{'mac'};
         if( exists($ConfigFloatingDevices{$mac}) ){
             $logger->info("There is a floating device on $switch port $switch_port");
             return $mac;
@@ -291,7 +291,7 @@ Disconnects the active locationlog macs on the port so they reauthenticate to be
 
 sub _disconnectCurrentDevices{
     my ( $this, $switch, $switch_port ) = @_;
-    my $logger = Log::Log4perl::get_logger('pf::floatingdevice');
+    my $logger = get_logger;
 
     my @locationlog_switchport = pf::locationlog::locationlog_view_open_switchport_no_VoIP($switch->{_ip}, $switch_port);
 

--- a/lib/pf/floatingdevice/custom.pm
+++ b/lib/pf/floatingdevice/custom.pm
@@ -17,7 +17,6 @@ to customize behavior here.
 
 use strict;
 use warnings;
-use Log::Log4perl;
 
 use base ('pf::floatingdevice');
 

--- a/lib/pf/freeradius.pm
+++ b/lib/pf/freeradius.pm
@@ -23,7 +23,7 @@ use strict;
 use warnings;
 
 use Carp;
-use Log::Log4perl;
+use pf::log;
 use Readonly;
 use List::MoreUtils qw(natatime);
 use Time::HiRes qw(time);
@@ -67,7 +67,7 @@ Prepares all the SQL statements related to this module
 =cut
 
 sub freeradius_db_prepare {
-    my $logger = Log::Log4perl::get_logger('pf::freeradius');
+    my $logger = get_logger();
     $logger->debug("Preparing pf::freeradius database queries");
     my $dbh = get_db_handle();
     if($dbh) {
@@ -99,7 +99,7 @@ Empties the radius_nas table
 =cut
 
 sub _delete_all_nas {
-    my $logger = Log::Log4perl::get_logger('pf::freeradius');
+    my $logger = get_logger();
     $logger->debug("emptying radius_nas table");
 
     db_query_execute(FREERADIUS, $freeradius_statements, 'freeradius_delete_all_sql')
@@ -109,7 +109,7 @@ sub _delete_all_nas {
 
 sub _delete_expired {
     my ($timestamp) = @_;
-    my $logger = Log::Log4perl::get_logger('pf::freeradius');
+    my $logger = get_logger();
     $logger->debug("emptying radius_nas table");
 
     db_query_execute(FREERADIUS, $freeradius_statements, 'freeradius_delete_expired_sql', $timestamp)
@@ -125,7 +125,7 @@ Add a new NAS (FreeRADIUS client) record
 
 sub _insert_nas_bulk {
     my (@rows) = @_;
-    my $logger = Log::Log4perl::get_logger('pf::freeradius');
+    my $logger = get_logger();
     return 0 unless @rows;
     my $row_count = @rows;
     my $sql = "REPLACE INTO radius_nas ( nasname, shortname, secret, description, config_timestamp, start_ip, end_ip, range_length) VALUES ( ?, ?, ?, ?, ?, ?, ?, ?)" . ",( ?, ?, ?, ?, ?, ?, ?, ?)" x ($row_count -1)    ;
@@ -145,7 +145,7 @@ Add a new NAS (FreeRADIUS client) record
 
 sub _insert_nas {
     my ($nasname, $shortname, $secret, $description) = @_;
-    my $logger = Log::Log4perl::get_logger('pf::freeradius');
+    my $logger = get_logger();
 
     db_query_execute(
         FREERADIUS, $freeradius_statements, 'freeradius_insert_nas', $nasname, $shortname, $secret, $description
@@ -161,7 +161,7 @@ Populates the radius_nas table with switches in switches.conf.
 
 # First, we aim at reduced complexity. I prefer to dump and reload than to deal with merging config vs db changes.
 sub freeradius_populate_nas_config {
-    my $logger = Log::Log4perl::get_logger('pf::freeradius');
+    my $logger = get_logger();
     return unless db_ping;
     my ($switch_config,$timestamp) = @_;
     my %skip = (default => undef, '127.0.0.1' => undef );

--- a/lib/pf/ifoctetslog.pm
+++ b/lib/pf/ifoctetslog.pm
@@ -20,7 +20,7 @@ Read the F<pf.conf> configuration file.
 use strict;
 use warnings;
 use Date::Parse;
-use Log::Log4perl;
+use pf::log;
 
 use constant IFOCTETSLOG => 'ifoctetslog';
 
@@ -54,7 +54,7 @@ our $ifoctetslog_db_prepared = 0;
 our $ifoctetslog_statements = {};
 
 sub ifoctetslog_db_prepare {
-    my $logger = Log::Log4perl::get_logger('pf::ifoctetslog');
+    my $logger = get_logger();
     $logger->debug("Preparing pf::ifoctetslog database queries");
 
     $ifoctetslog_statements->{'ifoctetslog_history_mac_sql'} = get_db_handle()->prepare(

--- a/lib/pf/import.pm
+++ b/lib/pf/import.pm
@@ -26,7 +26,7 @@ Remove this note when it will be no longer relevant. ;)
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Text::CSV;
 use POSIX;
 
@@ -60,7 +60,7 @@ Supported: One MAC address per line.
 #      this would allow callers to determine where the output should go. pfcmd -> STDOUT, SOAP -> Apache
 sub nodes {
     my ($filename) = @_;
-    my $logger = Log::Log4perl::get_logger('pf::import');
+    my $logger = get_logger();
 
     my $csv = Text::CSV->new({ binary => 1 });
     open my $io, "<", $filename

--- a/lib/pf/inline.pm
+++ b/lib/pf/inline.pm
@@ -14,7 +14,7 @@ All the behavior contained here can be overridden in lib/pf/inline/custom.pm.
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 
 use pf::constants;
 use pf::config;
@@ -36,7 +36,7 @@ Usually you don't want to call this constructor but use the pf::inline::custom s
 =cut
 
 sub new {
-    my $logger = Log::Log4perl::get_logger("pf::inline");
+    my $logger = get_logger();
     $logger->debug("instantiating new pf::inline object");
     my ( $class, %argv ) = @_;
     my $this = bless {}, $class;
@@ -51,7 +51,7 @@ Instantiate the correct iptables modification method between iptables and ipset
 =cut
 
 sub get_technique {
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my $type;
     $type = "pf::ipset";
 
@@ -76,7 +76,7 @@ sub get_technique {
 
 sub performInlineEnforcement {
     my ($this, $mac) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = get_logger(ref($this));
 
     # What is the MAC's current state?
     my $current_mark = $this->{_technique}->get_mangle_mark_for_mac($mac);
@@ -115,7 +115,7 @@ sub isInlineEnforcementRequired {
 
 sub fetchMarkForNode {
     my ($this, $mac) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($this));
+    my $logger = get_logger(ref($this));
 
     # Violation first
     my $open_violation_count = violation_count_reevaluate_access($mac);

--- a/lib/pf/inline/accounting.pm
+++ b/lib/pf/inline/accounting.pm
@@ -27,7 +27,7 @@ use strict;
 use warnings;
 
 use Carp;
-use Log::Log4perl;
+use pf::log;
 use Readonly;
 
 my $accounting_table = 'inline_accounting';
@@ -73,7 +73,7 @@ Prepares all the SQL statements related to this module
 =cut
 
 sub accounting_db_prepare {
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     $logger->debug("Preparing" . __PACKAGE__ . "database queries");
 
     $accounting_statements->{'accounting_update_session_for_ip'} =
@@ -155,7 +155,7 @@ sub accounting_db_prepare {
 
 sub inline_accounting_update_session_for_ip {
     my ($ip, $inbytes, $outbytes, $firstseen, $lastmodified) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my $active_session_query =  db_query_execute("inline::accounting",
                                                  $accounting_statements,
@@ -179,7 +179,7 @@ sub inline_accounting_update_session_for_ip {
 
 sub inline_accounting_maintenance {
     my $accounting_session_timeout = shift;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my $result = 0;
 
     # Check if there's at least a violation using an accounting

--- a/lib/pf/inline/custom.pm
+++ b/lib/pf/inline/custom.pm
@@ -15,7 +15,6 @@ This module extends pf::inline
 use strict;
 use warnings;
 
-use Log::Log4perl;
 
 use base ('pf::inline');
 use pf::config;

--- a/lib/pf/iplog.pm
+++ b/lib/pf/iplog.pm
@@ -40,7 +40,6 @@ use pf::node qw(node_add_simple node_exist);
 use pf::util;
 use pf::CHI;
 use pf::OMAPI;
-use pf::log;
 
 # The next two variables and the _prepare sub are required for database handling magic (see pf::db)
 our $iplog_db_prepared = 0;

--- a/lib/pf/iplog.pm
+++ b/lib/pf/iplog.pm
@@ -17,8 +17,7 @@ use strict;
 use warnings;
 
 use Date::Parse;
-use Log::Log4perl;
-use Log::Log4perl::Level;
+use pf::log;
 
 use constant IPLOG => 'iplog';
 use constant IPLOG_CACHE_EXPIRE => 60;
@@ -50,7 +49,7 @@ our $iplog_db_prepared = 0;
 our $iplog_statements = {};
 
 sub iplog_db_prepare {
-    my $logger = Log::Log4perl::get_logger('pf::iplog');
+    my $logger = get_logger();
     $logger->debug("Preparing pf::iplog database queries");
 
     # We could have used the iplog_list_open_by_ip_sql statement but for performances, we enforce the LIMIT 1
@@ -646,7 +645,7 @@ sub close {
 
 sub cleanup {
     my ($expire_seconds, $batch, $time_limit) = @_;
-    my $logger = Log::Log4perl::get_logger('pf::iplog');
+    my $logger = get_logger();
     $logger->debug("calling iplog_cleanup with time=$expire_seconds batch=$batch timelimit=$time_limit");
     my $now = db_now();
     my $start_time = time;

--- a/lib/pf/ipset.pm
+++ b/lib/pf/ipset.pm
@@ -17,7 +17,7 @@ use strict;
 use warnings;
 
 use base ('pf::iptables');
-use Log::Log4perl;
+use pf::log;
 use Readonly;
 use NetAddr::IP;
 
@@ -51,7 +51,7 @@ TODO: This list is incomplete
 
 sub iptables_generate {
     my ($self) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     # init ipset tables
     $logger->warn("We are using IPSET");
     #Flush mangle table to permit ipset destroy
@@ -107,7 +107,7 @@ The last mark will be the one having an effect.
 
 sub generate_mangle_rules {
     my ($self) =@_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my $mangle_rules = '';
     my @ops = ();
 
@@ -210,7 +210,7 @@ TODO: This should goes in the 'generate_mangle_rules' method but that last one s
 
 sub generate_mangle_postrouting_rules {
     my ( $self ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my $rules = '';
 
@@ -234,7 +234,7 @@ sub generate_mangle_postrouting_rules {
 
 sub iptables_mark_node {
     my ( $self, $mac, $mark, $newip ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     foreach my $network ( keys %ConfigNetworks ) {
 
@@ -280,7 +280,7 @@ sub iptables_mark_node {
 
 sub iptables_unmark_node {
     my ( $self, $mac, $mark ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my $ipset = $self->get_ip_from_ipset_by_mac($mac, $mark);
 
@@ -323,7 +323,7 @@ Returns IPTABLES MARK constant ($IPTABLES_MARK_...) or undef on failure.
 sub get_mangle_mark_for_mac {
     my ( $self, $mac ) = @_;
 
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my $_EXIT_CODE_EXISTS = 1;
 
     my $iplog = pf::iplog::mac2ip($mac);
@@ -367,7 +367,7 @@ Remove ip from ipset session
 
 sub ipset_remove_ip {
     my ( $self, $ip, $mark, $network) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my ($cmd, $out);
     $cmd = "LANG=C sudo ipset --list pfsession_$mark_type_to_str{$mark}\_$network 2>&1";
     $out  = pf_run($cmd);
@@ -410,7 +410,7 @@ Fetches all the ip address from ipset by mac address
 
 sub get_ip_from_ipset_by_mac {
     my ( $self, $mac, $mark) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my $session = {};
     my ($cmd, $out);
     foreach my $network ( keys %ConfigNetworks ) {
@@ -461,7 +461,7 @@ Update session when the ip address change
 
 sub update_node {
     my ( $self, $oldip, $srcip, $srcmac ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my $view_mac = node_view($srcmac);
     my $src_ip = new NetAddr::IP::Lite clean_ip($srcip);
     my $old_ip = new NetAddr::IP::Lite clean_ip($oldip);
@@ -526,7 +526,7 @@ Flush mangle table
 
 sub iptables_flush_mangle {
     my ($self, $restore_file) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     $logger->info( "flushing iptables" );
     pf_run("/sbin/iptables -t mangle -F");
 }

--- a/lib/pf/locationlog.pm
+++ b/lib/pf/locationlog.pm
@@ -16,7 +16,6 @@ MAC-Switch-Port-VLAN history.
 use strict;
 use warnings;
 use pf::log;
-use pf::log;
 use pf::floatingdevice::custom;
 
 use constant LOCATIONLOG => 'locationlog';

--- a/lib/pf/locationlog.pm
+++ b/lib/pf/locationlog.pm
@@ -15,8 +15,8 @@ MAC-Switch-Port-VLAN history.
 
 use strict;
 use warnings;
-use Log::Log4perl;
-use Log::Log4perl::Level;
+use pf::log;
+use pf::log;
 use pf::floatingdevice::custom;
 
 use constant LOCATIONLOG => 'locationlog';
@@ -98,7 +98,7 @@ TODO: list incomplete
 =cut
 
 sub locationlog_db_prepare {
-    my $logger = Log::Log4perl::get_logger('pf::locationlog');
+    my $logger = get_logger();
     $logger->debug("Preparing pf::locationlog database queries");
 
     $locationlog_statements->{'locationlog_history_mac_sql'} = get_db_handle()->prepare(qq[
@@ -369,7 +369,7 @@ sub locationlog_view_open_mac {
 
 sub locationlog_insert_start {
     my ( $switch, $switch_ip, $switch_mac, $ifIndex, $vlan, $mac, $connection_type, $connection_sub_type, $user_name, $ssid, $stripped_user_name, $realm, $locationlog_mac ) = @_;
-    my $logger = Log::Log4perl::get_logger('pf::locationlog');
+    my $logger = get_logger();
 
     my $conn_type = connection_type_to_str($connection_type)
         or $logger->info("Asked to insert a locationlog entry with connection type unknown.");
@@ -396,7 +396,7 @@ sub locationlog_insert_start {
 
 sub locationlog_insert_closed {
     my ( $switch, $switch_ip, $switch_mac, $ifIndex, $vlan, $mac, $connection_type, $connection_sub_type, $user_name, $ssid, $stripped_user_name, $realm ) = @_;
-    my $logger = Log::Log4perl::get_logger('pf::locationlog');
+    my $logger = get_logger();
 
     my $conn_type = connection_type_to_str($connection_type)
         or $logger->info("Asked to insert a locationlog entry with connection type unknown.");
@@ -410,7 +410,7 @@ sub locationlog_insert_closed {
 sub locationlog_update_end {
     my ( $switch, $ifIndex, $mac ) = @_;
 
-    my $logger = Log::Log4perl::get_logger('pf::locationlog');
+    my $logger = get_logger();
     if ( defined($mac) ) {
         $logger->info("locationlog_update_end called with mac=$mac");
         locationlog_update_end_mac($mac);
@@ -459,7 +459,7 @@ synchronize locationlog to current values if necessary
 
 sub locationlog_synchronize {
     my ( $switch, $switch_ip, $switch_mac, $ifIndex, $vlan, $mac, $voip_status, $connection_type, $connection_sub_type, $user_name, $ssid, $stripped_user_name, $realm) = @_;
-    my $logger = Log::Log4perl::get_logger('pf::locationlog');
+    my $logger = get_logger();
     $logger->trace("locationlog_synchronize called");
 
     # flag to determine if we must insert a new record or not
@@ -538,7 +538,7 @@ sub locationlog_close_all {
 
 sub locationlog_cleanup {
     my ($expire_seconds, $batch, $time_limit) = @_;
-    my $logger = Log::Log4perl::get_logger('pf::locationlog');
+    my $logger = get_logger();
     $logger->debug("calling locationlog_cleanup with time=$expire_seconds batch=$batch timelimit=$time_limit");
     my $now = db_now();
     my $start_time = time;
@@ -567,7 +567,7 @@ return 1 if locationlog entry is accurate, 0 otherwise
 # Note: voip_status was removed from the accuracy check, feel free to revisit this assumption if we face VoIP problems
 sub _is_locationlog_accurate {
     my ( $locationlog_mac, $switch, $ifIndex, $vlan, $mac, $connection_type, $connection_sub_type, $user_name, $ssid ) = @_;
-    my $logger = Log::Log4perl::get_logger('pf::locationlog');
+    my $logger = get_logger();
     $logger->trace("verifying if locationlog is accurate called");
 
     # avoid undef warnings during tests by setting undef values to empty string

--- a/lib/pf/lookup/person.pm
+++ b/lib/pf/lookup/person.pm
@@ -6,7 +6,7 @@ pf::lookup::person - lookup person information
 
 =head1 SYNOPSYS
 
-The lookup_person function is called via 
+The lookup_person function is called via
 "pfcmd lookup person E<lt>pidE<gt>"
 through the administrative GUI,
 or as the content of a violation action
@@ -19,18 +19,19 @@ use strict;
 use warnings;
 use Net::LDAP;
 
+use pf::log;
 use pf::person;
 use pf::util;
 use pf::authentication;
 
 sub lookup_person {
     my ($pid,$source_id) = @_;
-    my $logger = Log::Log4perl::get_logger('pf::lookup::person');
+    my $logger = get_logger();
     my $source = pf::authentication::getAuthenticationSource($source_id);
     if (!$source) {
        $logger->info("Unable to locate the source $source_id");
        return "Unable to locate the source $source_id!\n";
-    } 
+    }
 
     unless (person_exist($pid)) {
         return "Person $pid is not a registered user!\n";
@@ -39,8 +40,8 @@ sub lookup_person {
     if (!$person) {
        $logger->info("Cannot search attributes for user '$pid'");
        return "Cannot search attributes for user '$pid'!\n";
-    } 
-   
+    }
+
     person_modify($pid, %$person);
 }
 

--- a/lib/pf/node.pm
+++ b/lib/pf/node.pm
@@ -19,8 +19,7 @@ Read the F<pf.conf> configuration file.
 
 use strict;
 use warnings;
-use Log::Log4perl qw(get_logger);
-use Log::Log4perl::Level;
+use pf::log;
 use Readonly;
 use pf::StatsD;
 use pf::util::statsd qw(called);
@@ -103,7 +102,7 @@ TODO: This list is incomlete
 =cut
 
 sub node_db_prepare {
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     $logger->debug("Preparing pf::node database queries");
 
     $node_statements->{'node_exist_sql'} = get_db_handle()->prepare(qq[ select mac from node where mac=? ]);
@@ -415,7 +414,7 @@ sub node_view_reg_pid {
 #
 sub node_delete {
     my ($mac) = @_;
-    my $logger = Log::Log4perl::get_logger('pf::node');
+    my $logger = get_logger();
 
     $mac = clean_mac($mac);
 
@@ -460,7 +459,7 @@ our %DEFAULT_NODE_VALUES = (
 #
 sub node_add {
     my ( $mac, %data ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     $logger->trace("node add called");
 
     $mac = clean_mac($mac);
@@ -591,7 +590,7 @@ sub _node_view_old {
     $mac = clean_mac($mac);
 
     # Uncomment to log callers
-    #my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    #my $logger = get_logger();
     #my $caller = ( caller(1) )[3] || basename($0);
     #$logger->trace("node_view called from $caller");
 
@@ -616,7 +615,7 @@ sub node_view {
     my ($mac) = @_;
 
     # Uncomment to log callers
-    #my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    #my $logger = get_logger();
     #my $caller = ( caller(1) )[3] || basename($0);
     #$logger->trace("node_view called from $caller");
 
@@ -645,7 +644,7 @@ sub node_view {
 
 sub node_count_all {
     my ( $id, %params ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     # Hack! we prepare the statement here so that $node_count_all_sql is pre-filled
     node_db_prepare() if (!$node_db_prepared);
@@ -701,7 +700,7 @@ sub node_count_all {
 
 sub node_custom_search {
     my ($sql) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     $logger->debug($sql);
     $node_statements->{'node_custom_search_sql_customer'} = $sql;
     return db_data(NODE, $node_statements, 'node_custom_search_sql_customer');
@@ -715,7 +714,7 @@ Warning: The connection_type field is translated into its human form before retu
 
 sub node_view_all {
     my ( $id, %params ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     # Hack! we prepare the statement here so that $node_view_all_sql is pre-filled
     node_db_prepare() if (!$node_db_prepared);
@@ -776,7 +775,7 @@ node_attributes_with_fingerprint code.  This code will disappear in 2013.
 
 sub node_view_with_fingerprint {
     my ($mac) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     $logger->warn("DEPRECATED! You should migrate the caller to the faster node_attributes_with_fingerprint");
     my $query = db_query_execute(NODE, $node_statements, 'node_view_with_fingerprint_sql', $mac) || return (0);
@@ -789,7 +788,7 @@ sub node_view_with_fingerprint {
 
 sub node_modify {
     my ( $mac, %data ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     # validation
     $mac = clean_mac($mac);
@@ -895,7 +894,7 @@ sub node_modify {
 
 sub node_register {
     my ( $mac, $pid, %info ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     $mac = lc($mac);
     my $auto_registered = 0;
 
@@ -970,7 +969,7 @@ sub node_register {
 
 sub node_deregister {
     my ($mac, %info) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     $pf::StatsD::statsd->increment( called() . ".called" );
 
     $info{'status'}    = 'unreg';
@@ -1004,7 +1003,7 @@ called by pfmon daemon every 10 maintenance interval (usually each 10 minutes)
 =cut
 
 sub nodes_maintenance {
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     $logger->debug("nodes_maintenance called");
 
@@ -1067,7 +1066,7 @@ sub node_expire_lastdhcp {
 
 sub node_cleanup {
     my ($time) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     $logger->debug("calling node_cleanup with time=$time");
 
     foreach my $rowVlan ( node_expire_lastdhcp($time) ) {
@@ -1095,7 +1094,7 @@ Updates the bandwidth balance of a node and close the violations that use the ba
 
 sub node_update_bandwidth {
     my ($mac, $bytes) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     # Validate arguments
     $mac = clean_mac($mac);
@@ -1136,7 +1135,7 @@ in: mac address
 
 sub is_node_voip {
     my ($mac) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     $logger->trace("Asked whether node $mac is a VoIP Device or not");
     my $node_info = node_attributes($mac);
@@ -1157,7 +1156,7 @@ in: mac address
 
 sub is_node_registered {
     my ($mac) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     $logger->trace("Asked whether node $mac is registered or not");
     my $node_info = node_attributes($mac);
@@ -1178,7 +1177,7 @@ returns category_id, undef if no category was required or 0 if no category is fo
 
 sub _node_category_handling {
     my (%data) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     if (defined($data{'category_id'})) {
         # category_id has priority over category
@@ -1215,7 +1214,7 @@ The MAC address is currently not used.
 
 sub is_max_reg_nodes_reached {
     my ($mac, $pid, $category, $category_id) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     # default_pid is a special case: no limit for this user
     return $FALSE if ($pid eq $default_pid || $pid eq $admin_pid);

--- a/lib/pf/nodecategory.pm
+++ b/lib/pf/nodecategory.pm
@@ -20,7 +20,7 @@ Read the F<pf.conf> configuration file.
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 
 use constant NODECATEGORY => 'nodecategory';
 
@@ -60,7 +60,7 @@ our $nodecategory_statements = {};
 =cut
 
 sub nodecategory_db_prepare {
-    my $logger = Log::Log4perl::get_logger('pf::nodecategory');
+    my $logger = get_logger();
     $logger->debug("Preparing pf::nodecategory database queries");
 
     $nodecategory_statements->{'nodecategory_view_all_sql'} = get_db_handle()->prepare(

--- a/lib/pf/password.pm
+++ b/lib/pf/password.pm
@@ -34,7 +34,7 @@ use warnings;
 
 use Date::Parse;
 use Crypt::GeneratePassword qw(word);
-use Log::Log4perl;
+use pf::log;
 use POSIX;
 use Readonly;
 
@@ -102,7 +102,7 @@ Instantiate SQL statements to be prepared
 =cut
 
 sub password_db_prepare {
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     $logger->debug("Preparing pf::password database queries");
 
     $password_statements->{'password_view_sql'} = get_db_handle()->prepare(qq[
@@ -271,7 +271,7 @@ Defaults to 0 (no per user limit)
 
 sub generate {
     my ( $pid, $actions, $password ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my %data;
     $data{'pid'} = $pid;
@@ -365,7 +365,7 @@ Modify the password actions
 
 sub modify_actions {
     my ( $password, $actions ) = @_;
-    my $logger        = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger        = get_logger();
     my @ACTION_FIELDS = qw(
         valid_from expiration
         access_duration access_level category sponsor unregdate
@@ -400,7 +400,7 @@ Return values:
 sub validate_password {
     my ( $pid, $password ) = @_;
 
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my $query = db_query_execute(
         PASSWORD,
@@ -549,7 +549,7 @@ Reset (change) a password for a user in the password table.
 
 sub reset_password {
     my ( $pid, $password ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     # Making sure pid/password are "ok"
     if ( !defined($pid) || !defined($password) || (length($pid) == 0) || (length($password) == 0) ) {

--- a/lib/pf/person.pm
+++ b/lib/pf/person.pm
@@ -15,7 +15,7 @@ deletion, read info, ...
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 
 use constant PERSON => 'person';
 
@@ -78,7 +78,7 @@ our @FIELDS = qw(
 =cut
 
 sub person_db_prepare {
-    my $logger = Log::Log4perl::get_logger('pf::person');
+    my $logger = get_logger();
     $logger->debug("Preparing pf::person database queries");
 
     $person_statements->{'person_exist_sql'} = get_db_handle()->prepare(qq[ select count(*) from person where pid=? ]);
@@ -173,7 +173,7 @@ sub person_exist {
 sub person_delete {
     my ($pid) = @_;
 
-    my $logger = Log::Log4perl::get_logger('pf::person');
+    my $logger = get_logger();
     return (0) if ( $pid eq "admin" || $pid eq "default" );
 
     if ( !person_exist($pid) ) {
@@ -200,7 +200,7 @@ sub person_delete {
 #
 sub person_add {
     my ( $pid, %data ) = @_;
-    my $logger = Log::Log4perl::get_logger('pf::person');
+    my $logger = get_logger();
 
     if ( person_exist($pid) ) {
         $logger->error("attempt to add existing person $pid");
@@ -229,7 +229,7 @@ sub person_view {
 
 sub person_count_all {
     my ( %params ) = @_;
-    my $logger = Log::Log4perl::get_logger('pf::person');
+    my $logger = get_logger();
 
     # Hack! we prepare the statement here so that $person_count_all_sql is pre-filled
     person_db_prepare() if (!$person_db_prepared);
@@ -261,7 +261,7 @@ sub person_count_all {
 
 sub person_custom_search {
     my ($sql) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     $person_statements->{'person_custom_search'} = $sql;
     return db_data(PERSON, $person_statements, 'person_custom_search');
@@ -269,7 +269,7 @@ sub person_custom_search {
 
 sub person_view_all {
     my ( %params ) = @_;
-    my $logger = Log::Log4perl::get_logger('pf::person');
+    my $logger = get_logger();
 
     # Hack! we prepare the statement here so that $person_view_all_sql is pre-filled
     person_db_prepare() if (!$person_db_prepared);
@@ -307,7 +307,7 @@ sub person_view_all {
 sub person_modify {
     my ( $pid, %data ) = @_;
 
-    my $logger = Log::Log4perl::get_logger('pf::person');
+    my $logger = get_logger();
     if ( !person_exist($pid) ) {
         if ( person_add( $pid, %data ) ) {
             $logger->warn(

--- a/lib/pf/pfcmd.pm
+++ b/lib/pf/pfcmd.pm
@@ -16,7 +16,7 @@ F</usr/local/pf/bin/pfcmd> to parse the options.
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Readonly;
 use Regexp::Common qw(net);
 
@@ -39,7 +39,7 @@ my $pid_re = qr{(?:
 
 sub parseCommandLine {
     my ($commandLine) = @_;
-    my $logger = Log::Log4perl::get_logger("pf::pfcmd");
+    my $logger = get_logger();
     $logger->debug("starting to parse '$commandLine'");
 
     $commandLine =~ s/\s+$//;

--- a/lib/pf/pfcmd/dashboard.pm
+++ b/lib/pf/pfcmd/dashboard.pm
@@ -9,7 +9,7 @@ pf::pfcmd::dashboard - module feeding data to the dashboard nuggets
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 
 use constant DASHBOARD => 'pfcmd::dashboard';
 
@@ -44,7 +44,7 @@ our $dashboard_db_prepared = 0;
 our $dashboard_statements = {};
 
 sub dashboard_db_prepare {
-    my $logger = Log::Log4perl::get_logger('pf::pfcmd::dashboard');
+    my $logger = get_logger();
     $logger->debug("Preparing pf::pfcmd::dashboard database queries");
 
     $dashboard_statements->{'nugget_recent_violations_sql'} = get_db_handle()->prepare(

--- a/lib/pf/pfcmd/graph.pm
+++ b/lib/pf/pfcmd/graph.pm
@@ -9,7 +9,6 @@ pf::pfcmd::graph - module feeding data to generate the graphics
 
 use strict;
 use warnings;
-use Log::Log4perl;
 
 use constant GRAPH => 'pfcmd::graph';
 

--- a/lib/pf/pfcmd/help.pm
+++ b/lib/pf/pfcmd/help.pm
@@ -9,7 +9,6 @@ pf::pfcmd::help - usage messages
 use strict;
 use warnings;
 use File::Basename qw(basename);
-use Log::Log4perl;
 
 BEGIN {
     use Exporter ();

--- a/lib/pf/pfcmd/report.pm
+++ b/lib/pf/pfcmd/report.pm
@@ -18,7 +18,7 @@ Read the F<pf.conf> configuration file.
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 
 use constant REPORT => 'pfcmd::report';
 
@@ -92,7 +92,7 @@ TODO: list incomplete
 =cut
 
 sub report_db_prepare {
-    my $logger = Log::Log4perl::get_logger('pf::pfcmd::report');
+    my $logger = get_logger();
 
     $report_statements->{'report_inactive_all_sql'} = get_db_handle()->prepare(
         qq [ select n.mac,pid,detect_date,regdate,lastskip,status,user_agent,computername,notes,last_arp,last_dhcp,device_type as os from node n where n.mac not in (select i.mac from iplog i where i.end_time=0 or i.end_time > now()) ]);
@@ -168,16 +168,16 @@ sub report_db_prepare {
     $report_statements->{'report_unknownuseragents_all_sql'} = get_db_handle()->prepare(qq[
         SELECT n.user_agent, nu.browser, nu.os, n.computername, device_type as description, n.dhcp_fingerprint
         FROM node as n
-            JOIN node_useragent AS nu USING (mac) 
+            JOIN node_useragent AS nu USING (mac)
         WHERE (nu.browser IS NULL OR nu.os IS NULL) AND n.user_agent != ''
     ]);
 
     $report_statements->{'report_unknownuseragents_active_sql'} = get_db_handle()->prepare(qq[
         SELECT n.user_agent, nu.browser, nu.os, n.computername, device_type as description, n.dhcp_fingerprint
         FROM node as n
-            JOIN node_useragent AS nu USING (mac) 
+            JOIN node_useragent AS nu USING (mac)
             LEFT JOIN iplog USING (mac)
-        WHERE (nu.browser IS NULL OR nu.os IS NULL) AND n.user_agent != '' 
+        WHERE (nu.browser IS NULL OR nu.os IS NULL) AND n.user_agent != ''
             AND (iplog.end_time=0 OR iplog.end_time > now())
     ]);
 
@@ -201,8 +201,8 @@ sub report_db_prepare {
                     INNER JOIN node ON node.mac=locationlog.mac
                     WHERE locationlog.end_time IS NULL
                 )*100,1
-            ) AS percent 
-        FROM locationlog INNER JOIN node ON node.mac=locationlog.mac 
+            ) AS percent
+        FROM locationlog INNER JOIN node ON node.mac=locationlog.mac
         WHERE locationlog.end_time IS NULL
         GROUP BY connection_type
     ]);
@@ -210,39 +210,39 @@ sub report_db_prepare {
     $report_statements->{'report_connectiontype_active_sql'} = get_db_handle()->prepare(qq[
         SELECT connection_type,count(*) as connections,
             ROUND(COUNT(*)/
-                (SELECT COUNT(*) FROM locationlog INNER JOIN node ON node.mac=locationlog.mac 
-                    INNER JOIN iplog ON node.mac=iplog.mac 
+                (SELECT COUNT(*) FROM locationlog INNER JOIN node ON node.mac=locationlog.mac
+                    INNER JOIN iplog ON node.mac=iplog.mac
                     WHERE iplog.end_time = 0 OR iplog.end_time > now() AND locationlog.end_time IS NULL
                 )*100,1
             ) AS percent
-        FROM locationlog INNER JOIN node ON node.mac=locationlog.mac INNER JOIN iplog ON node.mac=iplog.mac 
-        WHERE iplog.end_time = 0 OR iplog.end_time > now() AND locationlog.end_time IS NULL 
+        FROM locationlog INNER JOIN node ON node.mac=locationlog.mac INNER JOIN iplog ON node.mac=iplog.mac
+        WHERE iplog.end_time = 0 OR iplog.end_time > now() AND locationlog.end_time IS NULL
         GROUP BY connection_type
     ]);
-   
+
     $report_statements->{'report_connectiontypereg_all_sql'} = get_db_handle()->prepare(qq[
         SELECT connection_type, count(*) as connections,
-            ROUND( COUNT(*) / 
-                (SELECT COUNT(*) FROM locationlog INNER JOIN node ON node.mac=locationlog.mac 
+            ROUND( COUNT(*) /
+                (SELECT COUNT(*) FROM locationlog INNER JOIN node ON node.mac=locationlog.mac
                     WHERE node.status = "reg" AND locationlog.end_time IS NULL
                 )*100,1
             ) AS percent
-        FROM locationlog INNER JOIN node ON node.mac=locationlog.mac 
-        WHERE node.status = "reg" AND locationlog.end_time IS NULL 
+        FROM locationlog INNER JOIN node ON node.mac=locationlog.mac
+        WHERE node.status = "reg" AND locationlog.end_time IS NULL
         GROUP BY connection_type
     ]);
 
     $report_statements->{'report_connectiontypereg_active_sql'} = get_db_handle()->prepare(qq[
         SELECT connection_type, count(*) as connections,
-            ROUND( COUNT(*) / 
+            ROUND( COUNT(*) /
                 (SELECT COUNT(*) FROM locationlog
-                    INNER JOIN node ON node.mac=locationlog.mac INNER JOIN iplog ON node.mac=iplog.mac 
-                    WHERE node.status = "reg" AND (iplog.end_time =0 OR iplog.end_time > now()) 
+                    INNER JOIN node ON node.mac=locationlog.mac INNER JOIN iplog ON node.mac=iplog.mac
+                    WHERE node.status = "reg" AND (iplog.end_time =0 OR iplog.end_time > now())
                         AND locationlog.end_time IS NULL
                 )*100,1
             ) AS percent
-        FROM locationlog INNER JOIN node ON node.mac=locationlog.mac INNER JOIN iplog ON node.mac=iplog.mac 
-        WHERE node.status = "reg" AND (iplog.end_time = 0 OR iplog.end_time > now()) AND locationlog.end_time IS NULL 
+        FROM locationlog INNER JOIN node ON node.mac=locationlog.mac INNER JOIN iplog ON node.mac=iplog.mac
+        WHERE node.status = "reg" AND (iplog.end_time = 0 OR iplog.end_time > now()) AND locationlog.end_time IS NULL
         GROUP BY connection_type
     ]);
 
@@ -264,31 +264,31 @@ sub report_db_prepare {
 
     $report_statements->{'report_ssid_all_sql'} = get_db_handle()->prepare(qq [
         SELECT ssid,count(*) as nodes, ROUND(COUNT(*)/
-            (SELECT COUNT(*) 
+            (SELECT COUNT(*)
                 FROM locationlog
                     INNER JOIN node ON node.mac=locationlog.mac AND locationlog.end_time IS NULL
                 WHERE ssid != "")
-            *100,1) as percent 
+            *100,1) as percent
         FROM locationlog
            INNER JOIN node ON node.mac=locationlog.mac AND locationlog.end_time IS NULL
         WHERE ssid != ""
-        GROUP BY ssid 
+        GROUP BY ssid
         ORDER BY nodes
     ]);
 
     $report_statements->{'report_ssid_active_sql'} = get_db_handle()->prepare(qq [
        SELECT ssid,count(*) as nodes, ROUND(COUNT(*)/
-           (SELECT COUNT(*) 
+           (SELECT COUNT(*)
                 FROM locationlog
                     INNER JOIN node ON node.mac=locationlog.mac AND locationlog.end_time IS NULL
-                    INNER JOIN iplog ON node.mac=iplog.mac 
+                    INNER JOIN iplog ON node.mac=iplog.mac
                 WHERE ssid != "" AND (iplog.end_time=0 OR iplog.end_time > now())
-           )*100,1) as percent 
+           )*100,1) as percent
        FROM locationlog
            INNER JOIN node ON node.mac=locationlog.mac AND locationlog.end_time IS NULL
-           INNER JOIN iplog ON node.mac=iplog.mac 
-       WHERE ssid != "" AND (iplog.end_time=0 OR iplog.end_time > now()) 
-       GROUP BY ssid 
+           INNER JOIN iplog ON node.mac=iplog.mac
+       WHERE ssid != "" AND (iplog.end_time=0 OR iplog.end_time > now())
+       GROUP BY ssid
        ORDER BY nodes
     ]);
 
@@ -329,7 +329,7 @@ sub report_db_prepare {
             SUM(radacct_log.acctinputoctets+radacct_log.acctoutputoctets) AS accttotaloctets,
             ROUND(
                 SUM(radacct_log.acctinputoctets+radacct_log.acctoutputoctets)/(
-                    SELECT SUM(radacct_log.acctinputoctets+radacct_log.acctoutputoctets) 
+                    SELECT SUM(radacct_log.acctinputoctets+radacct_log.acctoutputoctets)
                     FROM radacct_log RIGHT JOIN radacct ON radacct_log.acctsessionid = radacct.acctsessionid
                     INNER JOIN node n ON n.mac = LOWER(CONCAT(
                         SUBSTRING(radacct.callingstationid,1,2),':',
@@ -359,7 +359,7 @@ sub report_db_prepare {
             SUM(radacct_log.acctinputoctets+radacct_log.acctoutputoctets) AS accttotaloctets,
             ROUND(
                 SUM(radacct_log.acctinputoctets+radacct_log.acctoutputoctets)/(
-                    SELECT SUM(radacct_log.acctinputoctets+radacct_log.acctoutputoctets) 
+                    SELECT SUM(radacct_log.acctinputoctets+radacct_log.acctoutputoctets)
                     FROM radacct_log RIGHT JOIN radacct ON radacct_log.acctsessionid = radacct.acctsessionid
                     INNER JOIN node n ON n.mac = LOWER(CONCAT(
                         SUBSTRING(radacct.callingstationid,1,2),':',
@@ -496,7 +496,7 @@ sub report_os_all {
                     percent     => $static_percent,
                     count       => $statics
                     };
-                
+
             }
         }
         if ( $record->{'count'} > 0 ) {
@@ -1073,7 +1073,7 @@ sub translate_connection_type {
     my @data = @_;
 
     return unless (@data);
-    my $logger = Log::Log4perl::get_logger('pf::pfcmd::report');
+    my $logger = get_logger();
 
     # determine if we are translating connection_type or last_connection_type
     my $field;

--- a/lib/pf/pki_provider/packetfence_pki.pm
+++ b/lib/pf/pki_provider/packetfence_pki.pm
@@ -75,7 +75,7 @@ has profile => ( is => 'rw' );
 
 sub _post_curl {
     my ($self, $uri, $post_fields) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
 
     $uri = $self->proto."://".$self->host.":".$self->port.$uri;
 
@@ -157,7 +157,7 @@ Revoke the certificate for a user
 
 sub revoke {
     my ($self, $cn) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
     my $uri = "/pki/cert/rest/revoke/".$cn."/";
     my $post_fields =
       "CRLReason=" . uri_escape("superseded");

--- a/lib/pf/provisioner/ibm.pm
+++ b/lib/pf/provisioner/ibm.pm
@@ -22,7 +22,7 @@ use pf::util qw(valid_mac clean_mac);
 use Sub::Name;
     # SOAP global error handler (mostly transport or server errors)
     # here we only log, the or on soap method calls will take care of returning
-my $logger = get_logger;
+my $logger = get_logger();
 use SOAP::Lite
     on_fault => subname on_fault => sub {
         my($soap, $res) = @_;

--- a/lib/pf/provisioner/opswat.pm
+++ b/lib/pf/provisioner/opswat.pm
@@ -107,19 +107,19 @@ sub supportsPolling {return 1}
 
 sub get_refresh_token {
     my ($self) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
     return $self->{'refresh_token'}
 }
 
 sub get_access_token {
     my ($self) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
     return $self->{'access_token'};
 }
 
 sub refresh_access_token {
     my ($self) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
 
     my $refresh_token = $self->get_refresh_token();
     my $curl = WWW::Curl::Easy->new;
@@ -184,7 +184,7 @@ sub update_config {
 
 sub get_device_info {
     my ($self, $mac) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
 
     my $access_token = $self->get_access_token();
     my $curl = WWW::Curl::Easy->new;
@@ -207,7 +207,7 @@ sub get_device_info {
 
 sub validate_mac_in_opswat {
     my ($self, $mac) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
     my $info = $self->get_device_info($mac);
     if($info != $pf::provisioner::COMMUNICATION_FAILED){
         return $self->check_active($mac, $info);
@@ -219,7 +219,7 @@ sub validate_mac_in_opswat {
 
 sub check_active {
     my ($self, $mac, $json_response) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
 
     my $f = DateTime::Format::RFC3339->new();
     unless(defined($json_response->{last_seen})){
@@ -242,7 +242,7 @@ sub check_active {
 
 sub authorize {
     my ($self,$mac) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
 
     my $result = $self->validate_mac_in_opswat($mac);
     if( $result == $pf::provisioner::COMMUNICATION_FAILED){
@@ -265,7 +265,7 @@ sub authorize {
 
 sub verify_compliance {
     my ($self, $mac) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
     my $info = $self->get_device_info($mac);
     if($info != $pf::provisioner::COMMUNICATION_FAILED){
         if($self->{critical_issues_threshold} != 0 && defined($info->{total_critical_issue}) && $info->{total_critical_issue} >= $self->{critical_issues_threshold}){
@@ -280,7 +280,7 @@ sub verify_compliance {
 
 sub pollAndEnforce{
     my ($self, $timeframe) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
     my $result = $self->get_status_changed_devices($timeframe);
     if ( $result == $pf::provisioner::COMMUNICATION_FAILED ){
         $logger->info("OPSWAT Oauth access token is probably not valid anymore.");
@@ -302,7 +302,7 @@ sub pollAndEnforce{
 
 sub get_status_changed_devices {
     my ($self, $timeframe) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
 
     my $access_token = $self->get_access_token();
     my $curl = WWW::Curl::Easy->new;
@@ -328,7 +328,7 @@ sub get_status_changed_devices {
 
 sub decode_response {
     my ($self, $code, $response_body) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
     if ( $code == 401 ) {
         $logger->error("Unauthorized to contact OPSWAT");
         return $pf::provisioner::COMMUNICATION_FAILED;

--- a/lib/pf/provisioner/opswat.pm
+++ b/lib/pf/provisioner/opswat.pm
@@ -20,7 +20,7 @@ use pf::util qw(clean_mac);
 use WWW::Curl::Easy;
 use JSON qw( decode_json );
 use XML::Simple;
-use Log::Log4perl;
+use pf::log;
 use pf::iplog;
 use pf::ConfigStore::Provisioning;
 use DateTime::Format::RFC3339;
@@ -348,6 +348,17 @@ sub decode_response {
         return $json_response;
     }
 
+}
+
+=head2 logger
+
+Return the current logger for the switch
+
+=cut
+
+sub logger {
+    my ($proto) = @_;
+    return get_logger( ref($proto) || $proto );
 }
 
 =head1 AUTHOR

--- a/lib/pf/provisioner/opswat.pm
+++ b/lib/pf/provisioner/opswat.pm
@@ -25,7 +25,6 @@ use pf::iplog;
 use pf::ConfigStore::Provisioning;
 use DateTime::Format::RFC3339;
 use pf::violation;
-use pf::log;
 
 =head1 Atrributes
 

--- a/lib/pf/radius/custom.pm
+++ b/lib/pf/radius/custom.pm
@@ -18,7 +18,6 @@ behavior here.
 
 use strict;
 use warnings;
-use Log::Log4perl;
 
 use base ('pf::radius');
 use pf::config;

--- a/lib/pf/radius/soapclient.pm
+++ b/lib/pf/radius/soapclient.pm
@@ -16,7 +16,6 @@ use strict;
 use warnings;
 
 use HTML::Entities;
-use Log::Log4perl;
 use WWW::Curl::Easy;
 use XML::Simple;
 use Encode qw(decode);

--- a/lib/pf/roles.pm
+++ b/lib/pf/roles.pm
@@ -26,7 +26,7 @@ Singleton patterns means you should not keep state within this module.
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 
 use pf::config;
 use pf::node qw(node_attributes);
@@ -65,7 +65,7 @@ pf::roles::custom subclass instead.
 
 sub new {
     my ( $class, %argv ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     $logger->debug("instantiating new " . __PACKAGE__ . " object");
     my $self = bless {}, $class;
     return $self;
@@ -85,7 +85,7 @@ Returns the proper role for a given node.
 
 sub getRoleForNode {
     my ($self, $mac, $switch) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($self));
+    my $logger = $self->logger;
 
     # Violation first
     my $open_violation_count = violation_count_reevaluate_access($mac);
@@ -127,7 +127,7 @@ looked up based on global role.
 
 sub performRoleLookup {
     my ($self, $node_attributes, $switch) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($self));
+    my $logger = $self->logger;
 
     my $mac = $node_attributes->{'mac'};
 
@@ -150,12 +150,23 @@ Return node category if defined.
 
 sub _assignRoleFromCategory {
     my ($self, $node_attributes) = @_;
-    my $logger = Log::Log4perl::get_logger(ref($self));
+    my $logger = $self->logger;
 
     return $node_attributes->{'category'} if (defined($node_attributes->{'category'}));
 
     $logger->warn("MAC: $node_attributes->{mac} is not categorized; no role returned");
     return;
+}
+
+=item logger
+
+Return the current logger for the object
+
+=cut
+
+sub logger {
+    my ($proto) = @_;
+    return get_logger( ref($proto) || $proto );
 }
 
 =back

--- a/lib/pf/roles/custom.pm
+++ b/lib/pf/roles/custom.pm
@@ -23,7 +23,6 @@ You have been warned!
 use strict;
 use warnings;
 
-use Log::Log4perl;
 
 use base ('pf::roles');
 use pf::config;

--- a/lib/pf/savedsearch.pm
+++ b/lib/pf/savedsearch.pm
@@ -13,7 +13,7 @@ pf::savedsearch - module for savedsearch management
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 
 use constant USERPREF => 'savedsearch';
 
@@ -51,7 +51,7 @@ Instantiate SQL statements to be prepared
 =cut
 
 sub savedsearch_db_prepare {
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     $logger->debug("Preparing pf::savedsearch database queries");
     my $dbh = get_db_handle();
 
@@ -102,7 +102,7 @@ BEGIN {
         my $statement_name = "savedsearch_${name}_sql";
         *{$sub_name} = sub {
             my (@args) = @_;
-            my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+            my $logger = get_logger();
             $logger->debug("Executing $statement_name with " . join(" ",@args));
             return db_data(USERPREF, $savedsearch_statements, $statement_name, @args);
         }
@@ -113,7 +113,7 @@ BEGIN {
         my $statement_name = "savedsearch_${name}_sql";
         *{$sub_name} = sub {
             my (@args) = @_;
-            my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+            my $logger = get_logger();
             my $sth = db_query_execute(USERPREF, $savedsearch_statements, $statement_name, @args);
             if($sth) {
                 return $sth->rows;

--- a/lib/pf/scan.pm
+++ b/lib/pf/scan.pm
@@ -15,7 +15,7 @@ pf::scan contains the general functions required to lauch and complete a vulnera
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Parse::Nessus::NBE;
 use Readonly;
 use Try::Tiny;
@@ -49,7 +49,7 @@ our $scan_db_prepared   = 0;
 our $scan_statements    = {};
 
 sub scan_db_prepare {
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     $logger->debug("Preparing database statements.");
 
@@ -90,7 +90,7 @@ Instantiate the correct vulnerability scanning engine with attributes
 
 sub instantiate_scan_engine {
     my ( $type, %scan_attributes ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my $scan_engine = 'pf::scan::' . $type;
     $logger->info("Instantiate a new vulnerability scanning engine object of type $scan_engine.");
@@ -116,7 +116,7 @@ Parse a scan report from the scan object and trigger violations if needed
 
 sub parse_scan_report {
     my ( $scan, $scan_vid ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     $logger->debug("Scan report to analyze. Scan id: $scan"); 
 
@@ -184,7 +184,7 @@ Retrieve a scan object populated from the database using the scan id
 
 sub retrieve_scan {
     my ( $scan_id ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my $query = db_query_execute(SCAN, $scan_statements, 'scan_select_sql', $scan_id) || return 0;
     my $scan_infos = $query->fetchrow_hashref();
@@ -211,7 +211,7 @@ Prepare the scan attributes, call the engine instantiation and start the scan
 
 sub run_scan {
     my ( $host_ip, $mac ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
 
     $host_ip =~ s/\//\\/g;          # escape slashes
@@ -288,7 +288,7 @@ Update the status and reportId of the scan in the database.
 
 sub statusReportSyncToDb {
     my ( $self ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     db_query_execute(SCAN, $scan_statements, 'scan_update_sql', 
         $self->{'_status'}, $self->{'_reportId'}, $self->{'_id'}

--- a/lib/pf/scan/nessus.pm
+++ b/lib/pf/scan/nessus.pm
@@ -15,7 +15,7 @@ pf::scan::nessus is a module to add Nessus scanning option.
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Readonly;
 
 use base ('pf::scan');
@@ -42,7 +42,7 @@ Create a new Nessus scanning object with the required attributes
 
 sub new {
     my ( $class, %data ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     $logger->debug("Instantiating a new pf::scan::nessus scanning object");
 
@@ -75,7 +75,7 @@ sub new {
 # WARNING: A lot of extra single quoting has been done to fix perl taint mode issues: #1087
 sub startScan {
     my ( $this ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     # nessus scan setup
     my $id                  = $this->{_id};

--- a/lib/pf/scan/openvas.pm
+++ b/lib/pf/scan/openvas.pm
@@ -15,7 +15,7 @@ pf::scan::openvas is a module to add OpenVAS scanning option.
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use MIME::Base64;
 use Readonly;
 
@@ -44,7 +44,7 @@ Create an escalator which will trigger an action on the OpenVAS server once the 
 
 sub createEscalator {
     my ( $this ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my $name = $this->{_id};
     my $callback = $this->_generateCallback();
@@ -83,7 +83,7 @@ Create a target (a target is a host to scan)
 
 sub createTarget {
     my ( $this ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my $name = $this->{_id};
     my $target_host = $this->{_scanIp};
@@ -122,7 +122,7 @@ Create a task (a task is a scan) with the existing config id and previously crea
 
 sub createTask {
     my ( $this )  = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my $name = $this->{_id};
 
@@ -165,7 +165,7 @@ Report processing's duty is to ensure that the proper violation will be triggere
 
 sub processReport {
     my ( $this ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my $name                = $this->{_id};
     my $report_id           = $this->{_reportId};
@@ -215,7 +215,7 @@ Create a new Openvas scanning object with the required attributes
 
 sub new {
     my ( $class, %data ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     $logger->debug("Instantiating a new pf::scan::openvas scanning object");
 
@@ -253,7 +253,7 @@ That's where we use all of these method to run a scan
 
 sub startScan {
     my ( $this ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     $this->createTarget();
     $this->createEscalator();
@@ -269,7 +269,7 @@ Start a scanning task with the previously created target and escalator
 
 sub startTask {
     my ( $this ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my $name    = $this->{_id};
     my $task_id = $this->{_taskId};
@@ -314,7 +314,7 @@ Remote: HTTPS with fully qualified domain name on admin interface
 
 sub _generateCallback {
     my ( $this ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my $name = $this->{'_id'};
     my $callback = "<method>HTTP Get<data>";

--- a/lib/pf/scan/wmi.pm
+++ b/lib/pf/scan/wmi.pm
@@ -15,7 +15,7 @@ pf::scan::wmi is a module to add WMI scanning option.
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Readonly;
 
 use base ('pf::scan');
@@ -42,7 +42,7 @@ Create a new WMI scanning object with the required attributes
 
 sub new {
     my ( $class, %data ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     $logger->debug("Instantiating a new pf::scan::wmi scanning object");
 
@@ -73,7 +73,7 @@ sub new {
 # WARNING: A lot of extra single quoting has been done to fix perl taint mode issues: #1087
 sub startScan {
     my ( $this ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my $rule_tester = new pf::scan::wmi::rules;
     my $result = $rule_tester->test($this);

--- a/lib/pf/scan/wmi/rules.pm
+++ b/lib/pf/scan/wmi/rules.pm
@@ -16,7 +16,7 @@ use strict;
 use warnings;
 
 use pf::config;
-use Log::Log4perl;
+use pf::log;
 use Net::WMIClient qw(wmiclient);
 use Config::IniFiles;
 use pf::api::jsonrpcclient;
@@ -37,7 +37,7 @@ our %RULE_OPS = (
 =cut
 
 sub new {
-   my $logger = Log::Log4perl::get_logger("pf::scan::wmi::rules");
+   my $logger = get_logger();
    $logger->debug("instantiating new pf::scan::wmi::rules");
    my ( $class, %argv ) = @_;
    my $self = bless {}, $class;
@@ -52,7 +52,7 @@ Test all the rules
 
 sub test {
     my ($self, $rules) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
 
     my @rules = split("\n",$rules->{'_wmi_rules'});
     my $success = 0;
@@ -201,6 +201,17 @@ sub evalParam {
         $return = { %$return, @param_unit };
     }
     return \$return;
+}
+
+=item logger
+
+Return the current logger for the switch
+
+=cut
+
+sub logger {
+    my ($proto) = @_;
+    return get_logger( ref($proto) || $proto );
 }
 
 =back

--- a/lib/pf/schedule.pm
+++ b/lib/pf/schedule.pm
@@ -23,7 +23,6 @@ See http://packetfence.org/mantis/view.php?id=674
 
 use strict;
 use warnings;
-use Log::Log4perl;
 
 sub new {
     my ($class) = @_;

--- a/lib/pf/services/manager.pm
+++ b/lib/pf/services/manager.pm
@@ -473,7 +473,7 @@ get the pid from the pid file
 sub pidFromFile {
     my ($self) = @_;
     my $name = $self->name;
-    my $logger = Log::Log4perl::get_logger('pf::services');
+    my $logger = get_logger();
     my $pid;
     my $pid_file = $self->pidFile;
     if (-e $pid_file) {

--- a/lib/pf/services/manager.pm
+++ b/lib/pf/services/manager.pm
@@ -216,7 +216,7 @@ sub postStartCleanup {
             $timedout = 1 if $@ && $@ =~ /^alarm clock restart/;
         };
         alarm 0;
-        my $logger = get_logger;
+        my $logger = get_logger();
         $logger->warn($self->name . " timed out trying to start" ) if $timedout;
     }
     return -e $pidFile;
@@ -498,7 +498,7 @@ removes the stale PID file
 sub removeStalePid {
     my ($self,$quick) = @_;
     return if $quick;
-    my $logger = get_logger;
+    my $logger = get_logger();
     my $pid = $self->pidFromFile;
     my $pidFile = $self->pidFile;
     $pidFile = untaint_chain($pidFile);

--- a/lib/pf/services/manager/dhcpd.pm
+++ b/lib/pf/services/manager/dhcpd.pm
@@ -114,7 +114,7 @@ EOT
                     if ($members) {
                         if ($current_network->contains($ip)) {
                             $dns = $members;
-                        $active = defined($net{next_hop}) ? 
+                        $active = defined($net{next_hop}) ?
                                  NetAddr::IP::Lite->new($net{'next_hop'}, $cfg->{'mask'}) :
                                  NetAddr::IP::Lite->new($cfg->{'ip'}, $cfg->{'mask'});
                         }
@@ -243,7 +243,7 @@ sub stop {
 
 sub manageStaticRoute {
     my $add_Route = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
 
     foreach my $network ( keys %ConfigNetworks ) {
         # shorter, more convenient local accessor
@@ -264,7 +264,7 @@ sub manageStaticRoute {
 
 sub isManaged {
     my ($self) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
     if($cluster_enabled && !pf::cluster::should_offer_dhcp()){
         $logger->info("This server cannot offer dhcp according to pf::cluster");
         return 0;

--- a/lib/pf/services/manager/httpd.pm
+++ b/lib/pf/services/manager/httpd.pm
@@ -22,6 +22,7 @@ use pf::config::util;
 use pf::util::apache qw(url_parser);
 use pf::web::constants;
 use pf::authentication;
+use pf::log;
 extends 'pf::services::manager';
 
 has '+launcher' => ( builder => 1, lazy => 1 );
@@ -50,7 +51,7 @@ sub generateConfig {
     my ($self) = @_;
     return 1 if $WAS_GENERATED;
     $WAS_GENERATED = 1;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     # injecting Web constants first
     my %tags = pf::web::constants::to_hash();
@@ -137,7 +138,7 @@ See Apache's documentation for MaxClients.
 
 sub calculate_max_clients {
     my ($total_ram) = @_;
-    my $logger = Log::Log4perl::get_logger('pf::services::apache');
+    my $logger = get_logger();
 
     if (!defined($total_ram)) {
         $logger->warn("Unable to find total system memory, will use 2Gb to determine Apache's MaxClients");

--- a/lib/pf/services/manager/pfdhcplistener.pm
+++ b/lib/pf/services/manager/pfdhcplistener.pm
@@ -64,7 +64,7 @@ sub postStartCleanup {
     my $result = 0;
     my $inotify = $self->inotify;
     my @pidFiles = map { $_->pidFile } $self->managers;
-    my $logger = get_logger;
+    my $logger = get_logger();
     if ( @pidFiles && any { ! -e $_ } @pidFiles ) {
         my $timedout;
         eval {

--- a/lib/pf/services/manager/snmptrapd.pm
+++ b/lib/pf/services/manager/snmptrapd.pm
@@ -73,7 +73,7 @@ Returns a tuple of two hashref. One with SNMPv3 Trap Users Auth parameters and o
 =cut
 
 sub _fetch_trap_users_and_communities {
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my %switchConfig = %{ pf::SwitchFactory->config };
 

--- a/lib/pf/services/manager/snort.pm
+++ b/lib/pf/services/manager/snort.pm
@@ -17,6 +17,7 @@ use Moo;
 extends 'pf::services::manager';
 with 'pf::services::manager::roles::pf_conf_trapping_engine';
 use pf::file_paths;
+use pf::log;
 use pf::constants;
 use pf::config;
 use pf::violation_config;
@@ -34,7 +35,7 @@ has '+launcher' => (
 );
 
 sub generateConfig {
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my %tags;
     $tags{'template'}      = "$conf_dir/snort.conf";
     $tags{'trapping-range'} = $Config{'trapping'}{'range'};

--- a/lib/pf/services/manager/suricata.pm
+++ b/lib/pf/services/manager/suricata.pm
@@ -13,6 +13,7 @@ pf::services::manager::suricata
 
 use strict;
 use warnings;
+use pf::log;
 use pf::file_paths;
 use pf::constants;
 use pf::config;
@@ -32,7 +33,7 @@ has '+launcher' => (
 );
 
 sub generateConfig {
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my %tags;
     $tags{'template'}      = "$conf_dir/suricata.yaml";
     $tags{'trapping-range'} = $Config{'trapping'}{'range'};

--- a/lib/pf/services/manager/winbindd.pm
+++ b/lib/pf/services/manager/winbindd.pm
@@ -77,7 +77,7 @@ sub postStartCleanup {
     my $result = 0;
     my $inotify = $self->inotify;
     my @pidFiles = map { $_->pidFile } $self->managers;
-    my $logger = get_logger;
+    my $logger = get_logger();
     if ( @pidFiles && any { ! -e $_ } @pidFiles ) {
         my $timedout;
         eval {

--- a/lib/pf/services/util.pm
+++ b/lib/pf/services/util.pm
@@ -21,7 +21,6 @@ use Log::Log4perl::Level;
 use pf::log;
 use pf::log::trapper;
 use pf::file_paths;
-use pf::log;
 use File::Basename qw(basename);
 use Fcntl qw(:flock);
 

--- a/lib/pf/services/util.pm
+++ b/lib/pf/services/util.pm
@@ -17,10 +17,11 @@ use strict;
 use warnings;
 use base qw(Exporter);
 our @EXPORT = qw(daemonize createpid deletepid);
+use Log::Log4perl::Level;
 use pf::log;
 use pf::log::trapper;
 use pf::file_paths;
-use Log::Log4perl::Level;
+use pf::log;
 use File::Basename qw(basename);
 use Fcntl qw(:flock);
 

--- a/lib/pf/services/util.pm
+++ b/lib/pf/services/util.pm
@@ -61,7 +61,7 @@ creates the pid file for the service
 
 sub createpid {
     my ($pname) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
     $pname = basename($0) if ( !$pname );
     my $pid     = $$;
     my $pidfile = $var_dir . "/run/$pname.pid";

--- a/lib/pf/sms_carrier.pm
+++ b/lib/pf/sms_carrier.pm
@@ -39,7 +39,7 @@ our $sms_carrier_statements = {};
 =cut
 
 sub sms_carrier_db_prepare {
-    my $logger = Log::Log4perl::get_logger('pf::sms_carrier');
+    my $logger = get_logger();
     $logger->debug("Preparing pf::sms_carrier database queries");
 
     $sms_carrier_statements->{'sms_carrier_view_all_sql'} = get_db_handle()->prepare(qq[

--- a/lib/pf/soh.pm
+++ b/lib/pf/soh.pm
@@ -21,7 +21,7 @@ The methods in pf::soh can be overriden in pf::soh::custom.
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use Data::Dumper;
 use Try::Tiny;
 
@@ -119,7 +119,7 @@ sub new {
     my ($class) = @_;
 
     my $self = {
-        logger => Log::Log4perl->get_logger("soh")
+        logger => get_logger()
     };
 
     return bless $self, $class;

--- a/lib/pf/useragent.pm
+++ b/lib/pf/useragent.pm
@@ -16,7 +16,7 @@ use strict;
 use warnings;
 
 use HTTP::BrowserDetect;
-use Log::Log4perl;
+use pf::log;
 use Sort::Naturally;
 use List::Util qw(first);
 
@@ -66,7 +66,7 @@ Initialize database prepared statements
 =cut
 
 sub useragent_db_prepare {
-    my $logger = Log::Log4perl::get_logger('pf::useragent');
+    my $logger = get_logger();
     $logger->debug("Preparing pf::useragent database queries");
 
     $useragent_statements->{'node_useragent_exist_sql'} = get_db_handle()->prepare(qq[
@@ -119,7 +119,7 @@ sub node_useragent_exist {
 
 sub node_useragent_add {
     my ( $mac, $data ) = @_;
-    my $logger = Log::Log4perl::get_logger('pf::useragent');
+    my $logger = get_logger();
 
     if ( node_useragent_exist($mac) ) {
         $logger->error("rejected attempt to add existing node-useragent entry for $mac");
@@ -140,7 +140,7 @@ sub node_useragent_add {
 
 sub node_useragent_update {
     my ( $mac, $data ) = @_;
-    my $logger = Log::Log4perl::get_logger('pf::useragent');
+    my $logger = get_logger();
 
     db_query_execute(USERAGENT, $useragent_statements, 'node_useragent_update_sql',
         $data->{'os'}, $data->{'browser'}, $data->{'device'}, $data->{'device_name'}, $data->{'mobile'}, $mac
@@ -156,7 +156,7 @@ sub node_useragent_update {
 
 sub update_node_useragent_record {
     my ($mac, $browserDetect) = @_;
-    my $logger = Log::Log4perl::get_logger('pf::useragent');
+    my $logger = get_logger();
 
     my $record = {
         'os' => $browserDetect->os_string() || undef,
@@ -289,7 +289,7 @@ View all useragent triggers
 =cut
 
 sub view_all {
-    my $logger = Log::Log4perl::get_logger('pf::useragent');
+    my $logger = get_logger();
 
     _init() if (!@useragent_data);
 
@@ -303,7 +303,7 @@ View all useragent triggers
 =cut
 
 sub node_useragent_view_all_searchable {
-    my $logger = Log::Log4perl::get_logger('pf::useragent');
+    my $logger = get_logger();
     my ( %params ) = @_;
     _init() if (!@useragent_data);
     my $greper = _make_greper(\%params);
@@ -400,7 +400,7 @@ We don't want our users to keep updating their conf/violations.conf file to trac
 =cut
 
 sub _init {
-    my $logger = Log::Log4perl::get_logger('pf::useragent');
+    my $logger = get_logger();
 
     # TODO this is very strongly coupled to HTTP::BrowserDetect's internals, we should aim to add a feature upstream
     my %triggers = (
@@ -460,7 +460,7 @@ based on User-Agent properties.
 
 sub process_useragent {
     my ($mac, $useragent) = @_;
-    my $logger = Log::Log4perl::get_logger('pf::useragent');
+    my $logger = get_logger();
 
     my $browserDetect = HTTP::BrowserDetect->new($useragent);
 

--- a/lib/pf/util.pm
+++ b/lib/pf/util.pm
@@ -465,7 +465,7 @@ sub safe_file_update {
     $temp->flush;
     close $temp;
     unless( rename ($temp->filename, $file) ) {
-        my $logger = pf::log::get_logger;
+        my $logger = pf::log::get_logger();
         $logger->error("cannot save contents to $file '$!'");
         die "cannot save contents to $file";
     }
@@ -1099,11 +1099,11 @@ sub strip_username {
 
 sub send_email {
     my ($smtp_server, $from, $to, $subject, $template, %info) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
     my %options;
     $options{INCLUDE_PATH} = "$conf_dir/templates/";
     $options{ENCODING} = "utf8";
-    
+
     utf8::decode($subject);
     my $msg = MIME::Lite::TT->new(
         From        =>  $from,

--- a/lib/pf/version.pm
+++ b/lib/pf/version.pm
@@ -58,7 +58,7 @@ Checks the version of database schema
 =cut
 
 sub version_check_db {
-    my $logger = get_logger;
+    my $logger = get_logger();
 
     my $current_pf_minor_version = version_get_current();
     $current_pf_minor_version =~ s/(\.\d+).*$/$1/; # Keeping only the major/minor part (i.e: X.Y.Z -> X.Y)
@@ -86,7 +86,7 @@ Get the last schema version in the datbase
 =cut
 
 sub version_get_last_db_version {
-    my $logger = get_logger;
+    my $logger = get_logger();
 
     my $sth = db_query_execute(PF_VERSION, $version_statements, 'version_get_last_db_version_sql');
     unless ( $sth ) {

--- a/lib/pf/violation.pm
+++ b/lib/pf/violation.pm
@@ -29,7 +29,6 @@ use fingerbank::Model::Device;
 use fingerbank::Model::DHCP_Fingerprint;
 use fingerbank::Model::DHCP_Vendor;
 use fingerbank::Model::User_Agent;
-use pf::log;
 use pf::violation_config;
 use pf::node;
 
@@ -875,7 +874,7 @@ sub violation_run_delayed {
 
 sub _violation_run_delayed {
     my ($violation) = @_;
-    my $logger = pf::log::get_logger();
+    my $logger = get_logger();
     my $mac = $violation->{mac};
     my $vid = $violation->{vid};
     my %data = (status => 'open');

--- a/lib/pf/violation.pm
+++ b/lib/pf/violation.pm
@@ -597,7 +597,6 @@ Returns 1 if at least one violation is added, 0 otherwise.
 
 sub violation_trigger {
     my ( $mac, $tid, $type ) = @_;
-    my $logger = Log::Log4perl::get_logger('pf::violation');
     my $logger = get_logger();
     $logger->info("Triggering violation $type $tid for mac $mac");
     return (0) if ( !$tid );

--- a/lib/pf/violation.pm
+++ b/lib/pf/violation.pm
@@ -19,7 +19,7 @@ Read the F<pf.conf> configuration file.
 
 use strict;
 use warnings;
-use Log::Log4perl;
+use pf::log;
 use Readonly;
 use POSIX;
 use Time::HiRes qw(time);
@@ -123,7 +123,7 @@ This list is incomplete.
 =cut
 
 sub violation_db_prepare {
-    my $logger = Log::Log4perl::get_logger('pf::violation');
+    my $logger = get_logger();
     $logger->debug("Preparing pf::violation database queries");
 
     $violation_statements->{'violation_desc_sql'} = get_db_handle()->prepare(qq [ desc violation ]);
@@ -226,7 +226,7 @@ sub violation_desc {
 #
 sub violation_modify {
     my ( $id, %data ) = @_;
-    my $logger = Log::Log4perl::get_logger('pf::violation');
+    my $logger = get_logger();
 
     return (0) if ( !$id );
     my $existing = violation_exist_id($id);
@@ -348,7 +348,7 @@ sub violation_view {
 
 sub violation_count_all {
     my ( $id, %params ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     # Hack! we prepare the statement here so that $node_count_all_sql is pre-filled
     violation_db_prepare() if (!$violation_db_prepared);
@@ -424,7 +424,7 @@ sub violation_view_all_active {
 #
 sub violation_add {
     my ( $mac, $vid, %data ) = @_;
-    my $logger = Log::Log4perl::get_logger('pf::violation');
+    my $logger = get_logger();
     return (0) if ( !$vid );
     violation_clear_warnings();
     violation_clear_errors();
@@ -599,6 +599,7 @@ Returns 1 if at least one violation is added, 0 otherwise.
 sub violation_trigger {
     my ( $mac, $tid, $type ) = @_;
     my $logger = Log::Log4perl::get_logger('pf::violation');
+    my $logger = get_logger();
     $logger->info("Triggering violation $type $tid for mac $mac");
     return (0) if ( !$tid );
     $type = lc($type);
@@ -619,7 +620,7 @@ sub violation_trigger {
     }
 
     my $info = info_for_violation_engine($mac,$type,$tid);
-    
+
     $logger->debug(sub { use Data::Dumper; "Infos for violation engine : ".Dumper($info) });
     my @vids = $VIOLATION_FILTER_ENGINE->match_all($info);
 
@@ -711,7 +712,7 @@ sub violation_delete {
 #
 sub violation_close {
     my ( $mac, $vid ) = @_;
-    my $logger = Log::Log4perl::get_logger('pf::violation');
+    my $logger = get_logger();
     require pf::class;
     my $class_info = pf::class::class_view($vid);
 
@@ -740,7 +741,7 @@ sub violation_close {
 #
 sub violation_force_close {
     my ( $mac, $vid ) = @_;
-    my $logger = Log::Log4perl::get_logger('pf::violation');
+    my $logger = get_logger();
 
     db_query_execute(VIOLATION, $violation_statements, 'violation_close_sql', $mac, $vid)
         || return (0);
@@ -791,7 +792,7 @@ sub violation_view_last_closed {
 
 sub _is_node_category_whitelisted {
     my ($vid, $mac) = @_;
-    my $logger = Log::Log4perl::get_logger('pf::violation');
+    my $logger = get_logger();
 
     my $class = $pf::violation_config::Violation_Config{$vid};
 
@@ -828,7 +829,7 @@ Check if we should close violations based on release_date
 
 sub violation_maintenance {
     my ($batch,$timelimit) = @_;
-    my $logger = Log::Log4perl::get_logger('pf::violation');
+    my $logger = get_logger();
 
     $logger->debug("Looking at expired violations... batching $batch timelimit $timelimit");
     my $start_time = time;

--- a/lib/pf/violation_config.pm
+++ b/lib/pf/violation_config.pm
@@ -14,7 +14,7 @@ pf::violation_config
 
 use strict;
 use warnings;
-use Log::Log4perl qw(get_logger);
+use pf::log;
 use Try::Tiny;
 
 use pf::config;

--- a/lib/pf/vlan.pm
+++ b/lib/pf/vlan.pm
@@ -53,7 +53,7 @@ Usually you don't want to call this constructor but use the pf::vlan::custom sub
 
 sub new {
     my ( $class, %argv ) = @_;
-    my $logger = $class->get_logger;
+    my $logger = $class->get_logger();
     $logger->debug("instantiating new pf::vlan object");
     my $this = bless {}, $class;
     return $this;
@@ -741,7 +741,7 @@ sub isInlineTrigger {
 
 sub _check_bypass {
     my ( $mac, $node_info, $switch ) = @_;
-    my $logger = get_logger;
+    my $logger = get_logger();
 
     if ( @_ < 3 ) { return undef; }
 

--- a/lib/pf/vlan/custom.pm
+++ b/lib/pf/vlan/custom.pm
@@ -55,7 +55,7 @@ See pf::vlan::shouldAutoRegister for full original method.
 #    #$ssid is set to the wireless ssid (will be empty if radius and not wireless, undef if not radius)
 #    my ($this, $mac, $switch_in_autoreg_mode, $violation_autoreg, $isPhone, $conn_type, $user_name, $ssid, $eap_type, $switch, $port, $radius_request) = @_;
 #
-#    my $logger = get_logger;
+#    my $logger = get_logger();
 #    # CUSTOM: We want to auto-register 802.1x connections
 #    # Since they already have validated credentials through EAP to do 802.1X
 #    if (defined($conn_type) && (($conn_type & $EAP) == $EAP)) {

--- a/lib/pf/vlan/custom.pm
+++ b/lib/pf/vlan/custom.pm
@@ -17,7 +17,6 @@ use strict;
 use warnings;
 
 use pf::log;
-use pf::log;
 
 use base ('pf::vlan');
 

--- a/lib/pf/vlan/custom.pm
+++ b/lib/pf/vlan/custom.pm
@@ -16,7 +16,7 @@ This module extends pf::vlan
 use strict;
 use warnings;
 
-use Log::Log4perl;
+use pf::log;
 use pf::log;
 
 use base ('pf::vlan');

--- a/lib/pf/web.pm
+++ b/lib/pf/web.pm
@@ -32,7 +32,6 @@ use File::Basename;
 use HTML::Entities;
 use JSON;
 use Locale::gettext qw(gettext ngettext);
-use Log::Log4perl;
 use Readonly;
 use Template;
 use URI::Escape::XS qw(uri_escape uri_unescape);
@@ -48,6 +47,7 @@ BEGIN {
 }
 
 use pf::authentication;
+use pf::log;
 use pf::Authentication::constants;
 use pf::constants;
 use pf::config;
@@ -104,7 +104,7 @@ Cuts in the session cookies and template rendering boiler plate.
 
 sub render_template {
     my ($portalSession, $template, $r) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
     # so that we will get the calling sub in the logs instead of this utility sub
     local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1;
 
@@ -184,7 +184,7 @@ sub generate_release_page {
 
 sub generate_scan_start_page {
     my ( $portalSession, $r ) = @_;
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     $portalSession->stash({
         timer           => $Config{'scan'}{'duration'},
@@ -229,7 +229,7 @@ sub generate_error_page {
 
 sub web_user_authenticate {
     my ( $portalSession ,$username, $password) = @_;
-    my $logger = Log::Log4perl::get_logger('pf::web');
+    my $logger = get_logger();
     $logger->trace("authentication attempt");
 
     my $session = $portalSession->getSession();

--- a/lib/pf/web/admin.pm
+++ b/lib/pf/web/admin.pm
@@ -26,8 +26,8 @@ use Apache2::Connection;
 use Data::Dumper;
 
 use APR::URI;
-use Log::Log4perl;
 use List::MoreUtils qw(uniq);
+use pf::log;
 
 use pf::config;
 use pf::util;
@@ -85,7 +85,7 @@ Rewrite Location header and links to Packetfence captive portal.
 sub rewrite {
     my $f = shift;
     my $r = $f->r;
-    my $logger = Log::Log4perl->get_logger(__PACKAGE__);
+    my $logger = get_logger();
     if ($r->content_type =~ /(text\/xml|text\/html|application\/vnd.ogc.wms_xml|text\/css|application\/x-javascript)/) {
         unless ($f->ctx) {
             $f->r->headers_out->unset('Content-Length');
@@ -159,11 +159,11 @@ Proxy request to the captive portal
 
 sub proxy_portal {
     my ($self, $r) = @_;
-    my $logger = Log::Log4perl->get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my @interfaces = uniq (@internal_nets, @portal_ints );
     my $s = $r->server;
     if ($r->uri =~ /portal_preview\/(.*)/) {
-         $r->headers_in->{'X-Forwarded-For'} = $management_network->{'Tip'}; 
+         $r->headers_in->{'X-Forwarded-For'} = $management_network->{'Tip'};
          my $interface = $interfaces[0];
          $r->set_handlers(PerlResponseHandler => []);
          $r->add_output_filter(\&rewrite);
@@ -188,7 +188,7 @@ sub proxy_portal {
 
 =item replace
 
-Uncompress, search for links , replace and compress 
+Uncompress, search for links , replace and compress
 
 =cut
 

--- a/lib/pf/web/backend_modperl_require.pl
+++ b/lib/pf/web/backend_modperl_require.pl
@@ -16,7 +16,6 @@ use lib "/usr/local/pf/conf";
 use strict;
 use warnings;
 
-use Log::Log4perl;
 
 use pf::config;
 use pf::locationlog;

--- a/lib/pf/web/custom.pm
+++ b/lib/pf/web/custom.pm
@@ -8,7 +8,7 @@ pf::web::custom - custom code to override pf::web's behavior
 
 =head1 DESCRIPTION
 
-pf::web::custom allows you to redefine subs in pf::web. 
+pf::web::custom allows you to redefine subs in pf::web.
 It will never be overwritten when upgrading PacketFence.
 
 =cut
@@ -21,7 +21,7 @@ use POSIX;
 use JSON;
 use Template;
 use Locale::gettext;
-use Log::Log4perl;
+use pf::log;
 use Readonly;
 
 use pf::config;
@@ -33,7 +33,7 @@ use pf::web;
 
 =head1 WARNING
 
-What we are doing here is a little bit tricky: We are redefining subs in pf::web. 
+What we are doing here is a little bit tricky: We are redefining subs in pf::web.
 
 To do so, we are messing with typeglobs installing anonymous subs in the pf::web namespace
 replacing earlier implementations.
@@ -53,12 +53,12 @@ package pf::web;
 
 =item categorization sample
 
-WARNING: The technique described below is for demonstration purposes only. 
-Node categorization is better performed by the authentication modules under 
+WARNING: The technique described below is for demonstration purposes only.
+Node categorization is better performed by the authentication modules under
 conf/authentication now. See L<pf::web::auth> for more information.
 
 Here if a particular session variable was set, we categorize the node as a guest
-and we set it's expiration to now + $GUEST_SESSION_DURATION. 
+and we set it's expiration to now + $GUEST_SESSION_DURATION.
 Then the normal registration code is called.
 
 To set the particular session variable use the following:

--- a/lib/pf/web/dispatcher.pm
+++ b/lib/pf/web/dispatcher.pm
@@ -26,7 +26,7 @@ BEGIN {
     use pf::log service => 'httpd.portal';
 }
 
-use pf:log;
+use pf::log;
 use pf::config;
 use pf::util;
 use pf::web::constants;

--- a/lib/pf/web/dispatcher.pm
+++ b/lib/pf/web/dispatcher.pm
@@ -25,6 +25,8 @@ use URI::Escape::XS qw(uri_escape);
 BEGIN {
     use pf::log service => 'httpd.portal';
 }
+
+use pf:log;
 use pf::config;
 use pf::util;
 use pf::web::constants;
@@ -51,7 +53,7 @@ Reference: http://perl.apache.org/docs/2.0/user/handlers/http.html#PerlTransHand
 
 sub handler {
     my $r = Apache::SSLLookup->new(shift);
-    my $logger = Log::Log4perl->get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my $hostname = $r->hostname;
     my $uri = $r->uri;
@@ -82,7 +84,7 @@ sub handler {
         return proxy_redirect($r);
     }
     # Enforce HTTP instead of HTTPS when dealing with captive-portal detection mecanism and having a self-signed SSL certificate
-    elsif ( ($url =~ /$captive_portal_detection_mecanism_urls/o || $user_agent =~ /CaptiveNetworkSupport/s) 
+    elsif ( ($url =~ /$captive_portal_detection_mecanism_urls/o || $user_agent =~ /CaptiveNetworkSupport/s)
       && isenabled($Config{'captive_portal'}{'secure_redirect'}) && pf::web::util::is_certificate_self_signed ) {
         $logger->info("Dealing with a endpoint / browser with captive-portal detection capabilities while having a self-signed SSL certificate. Using HTTP instead of HTTPS");
         return html_redirect($r, { secure => $FALSE });
@@ -148,7 +150,7 @@ sub handler {
 
 sub html_redirect {
     my ($r, $params) = @_;
-    my $logger = Log::Log4perl->get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     $logger->debug("hitting html_redirect with URI '" . $r->uri . "' (URL: " . $r->construct_url . ")");
     $logger->debug(sub { "'html_redirect' called with the following parameters: " . join(", ", map { "$_ => $params->{$_}" } keys %$params) }) if defined($params);
@@ -177,7 +179,7 @@ sub html_redirect {
         $logger->debug("We set the destination URL to $destination_url for further usage");
         $r->pnotes(destination_url => $destination_url);
     }
-        
+
     # Configuring redirect URLs for both the portal and the WISPr(need to be part of the header in case of a WISPr client)
     my $portal_url = APR::URI->parse($r->pool,"$proto://".${captive_portal_domain}."/captive-portal");
     $portal_url->query("destination_url=$destination_url&".$r->args);
@@ -229,7 +231,7 @@ sub html_redirect {
 
 sub proxy_redirect {
     my ($r) = @_;
-    my $logger = Log::Log4perl->get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     $logger->debug("hitting proxy_redirect with URI '" . $r->uri . "' (URL: " . $r->construct_url . ")");
 

--- a/lib/pf/web/dispatcher/custom.pm
+++ b/lib/pf/web/dispatcher/custom.pm
@@ -22,7 +22,6 @@ use Apache2::ServerRec;
 
 use APR::Table;
 use APR::URI;
-use Log::Log4perl;
 use Template;
 use URI::Escape::XS qw(uri_escape);
 

--- a/lib/pf/web/externalportal.pm
+++ b/lib/pf/web/externalportal.pm
@@ -19,7 +19,7 @@ use Apache2::Const -compile => qw(:http);
 use Apache2::Request;
 use Apache2::RequestRec;
 use Apache2::Connection;
-use Log::Log4perl;
+use pf::log;
 use UNIVERSAL::require;
 
 use pf::config;
@@ -40,7 +40,7 @@ use pf::constants;
 =cut
 
 sub new {
-   my $logger = Log::Log4perl::get_logger("pf::web::externalportal");
+   my $logger = get_logger();
    $logger->debug("instantiating new pf::web::externalportal");
    my ( $class, %argv ) = @_;
    my $self = bless {}, $class;
@@ -55,7 +55,7 @@ Instantiate the switch module and use a specific captive portal
 
 sub external_captive_portal {
     my ($self, $switchId, $req, $r, $session) = @_;
-    my $logger = Log::Log4perl->get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my $switch;
     if (defined($switchId)) {
@@ -92,7 +92,7 @@ sub external_captive_portal {
 
 sub _setup_session {
     my ($req, $client_mac, $client_ip, $redirect_url, $grant_url) = @_;
-    my $logger = Log::Log4perl->get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my %info = (
         'client_mac' => $client_mac,
     );
@@ -120,7 +120,7 @@ handle the detection of the external portal
 sub handle {
     my ($self,$r) = @_;
     my $req = Apache2::Request->new($r);
-    my $logger = Log::Log4perl->get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my $is_external_portal;
     my $url = $r->uri;
 

--- a/lib/pf/web/filter.pm
+++ b/lib/pf/web/filter.pm
@@ -8,7 +8,7 @@ pf::web::filter - handle the authorization rules on the portal
 
 =head1 DESCRIPTION
 
-pf::web::filter allow, deny, redirect client based on rules. 
+pf::web::filter allow, deny, redirect client based on rules.
 
 =cut
 
@@ -18,7 +18,7 @@ use warnings;
 use Apache2::Const -compile => qw(:http);
 use Apache2::Request;
 use Apache2::Connection;
-use Log::Log4perl;
+use pf::log;
 use pf::config;
 use pfconfig::cached_hash;
 our (%ConfigApacheFilters);
@@ -33,7 +33,7 @@ tie %ConfigApacheFilters, 'pfconfig::cached_hash', 'config::ApacheFilters';
 =cut
 
 sub new {
-   my $logger = Log::Log4perl::get_logger("pf::web::filter");
+   my $logger = get_logger();
    $logger->debug("instantiating new pf::web::filter");
    my ( $class, %argv ) = @_;
    my $self = bless {}, $class;
@@ -49,7 +49,7 @@ Test all the rules
 
 sub test {
     my ($self, $r) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
 
     my $c = $r->connection();
     foreach my $rule  ( sort keys %ConfigApacheFilters ) {
@@ -75,7 +75,7 @@ Return the reference to the function that parses the rule.
 
 sub dispatch_rule {
     my ($self, $r, $rule, $name) = @_;
-    my $logger = Log::Log4perl::get_logger( ref($self) );
+    my $logger = $self->logger;
 
     if (!defined($rule)) {
         $logger->error("The rule $name you try to test doesn´t exist");
@@ -220,6 +220,17 @@ sub code {
     } else {
         return 1;
     }
+}
+
+=item logger
+
+Return the current logger for the switch
+
+=cut
+
+sub logger {
+    my ($proto) = @_;
+    return get_logger( ref($proto) || $proto );
 }
 
 

--- a/lib/pf/web/guest.pm
+++ b/lib/pf/web/guest.pm
@@ -28,7 +28,6 @@ use warnings;
 use Encode;
 use File::Basename;
 use HTML::Entities;
-use Log::Log4perl;
 use Net::LDAP;
 use POSIX;
 use Readonly;
@@ -44,6 +43,7 @@ BEGIN {
     @EXPORT = qw();
 }
 
+use pf::log;
 use pf::constants;
 use pf::config;
 use pf::password;
@@ -93,7 +93,7 @@ Return the Acceptable User Policy (AUP) defined in the template file
 =cut
 
 sub aup {
-    my $logger = Log::Log4perl::get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     my $html;
     my $template = Template->new({
@@ -110,7 +110,7 @@ sub aup {
 
 sub send_template_email {
     my ($template, $subject, $info) = @_;
-    my $logger = Log::Log4perl::get_logger('pf::web::guest');
+    my $logger = get_logger();
 
     my $smtpserver = $Config{'alerting'}{'smtpserver'};
     # local override (EMAIL_FROM) or pf.conf's value or root@domain

--- a/lib/pf/web/interceptproxy.pm
+++ b/lib/pf/web/interceptproxy.pm
@@ -16,7 +16,7 @@ use Apache2::Connection;
 use Apache2::URI;
 
 use APR::URI;
-use Log::Log4perl;
+use pf::log;
 use URI::Escape::XS qw(uri_escape);
 
 use pf::config;
@@ -37,7 +37,7 @@ Intercept proxy requests to forward them to the captive portal.
 
 sub translate {
     my ($r) = shift;
-    my $logger = Log::Log4perl->get_logger(__PACKAGE__);
+    my $logger = get_logger();
     $logger->warn("hitting interceptor with URL: " . $r->uri);
     #Fetch the captive portal URL
     my $proto = isenabled($Config{'captive_portal'}{'secure_redirect'}) ? $HTTPS : $HTTP;
@@ -122,7 +122,7 @@ Rewrite Location header to Packetfence captive portal.
 sub rewrite {
     my $f = shift;
     my $r = $f->r;
-    my $logger = Log::Log4perl->get_logger(__PACKAGE__);
+    my $logger = get_logger();
     if ($r->content_type =~ /text\/html(.*)/) {
         unless ($f->ctx) {
             my @valhead = $r->headers_out->get('Location');
@@ -163,7 +163,7 @@ Last Handler and last chance to do something in the request
 
 sub fixup {
     my $r = shift;
-    my $logger = Log::Log4perl->get_logger(__PACKAGE__);
+    my $logger = get_logger();
     if($r->pnotes('url_to_mod_proxy')){
         return proxy_redirect($r, $r->pnotes('url_to_mod_proxy'));
     }
@@ -177,7 +177,7 @@ Mod_proxy redirect
 
 sub proxy_redirect {
         my ($r, $url) = @_;
-        my $logger = Log::Log4perl->get_logger(__PACKAGE__);
+        my $logger = get_logger();
         $r->set_handlers(PerlResponseHandler => []);
         $r->filename("proxy:".$url);
         $r->proxyreq(2);
@@ -194,7 +194,7 @@ Reverse proxy TransHandler
 
 sub reverse {
     my $r = shift;
-    my $logger = Log::Log4perl->get_logger(__PACKAGE__);
+    my $logger = get_logger();
     $logger->trace("Reverse proxy :".$r->uri);
     my $parsed_request = APR::URI->parse($r->pool, $r->uri);
     my $proto = isenabled($Config{'captive_portal'}{'secure_redirect'}) ? $HTTPS : $HTTP;

--- a/lib/pf/web/release.pm
+++ b/lib/pf/web/release.pm
@@ -15,7 +15,7 @@ use Apache2::RequestRec ();
 use Apache2::RequestIO ();
 use Apache2::Const -compile => qw(OK REDIRECT);
 use Date::Parse;
-use Log::Log4perl;
+use pf::log;
 use URI::Escape::XS qw(uri_escape);
 
 use pf::class;

--- a/lib/pf/web/release.pm
+++ b/lib/pf/web/release.pm
@@ -27,7 +27,6 @@ use pf::constants::scan qw($SCAN_VID);
 use pf::util;
 use pf::violation;
 use pf::web;
-use pf::log;
 use pf::enforcement;
 # called last to allow redefinitions
 use pf::web::custom;
@@ -71,17 +70,17 @@ sub handler
       }
     }
   }
-  
-  my $violations = violation_view_top($mac); 
+
+  my $violations = violation_view_top($mac);
   # is violations valid
   if (!defined($violations) || ref($violations) ne 'HASH' || !defined($violations->{'vid'})) {
     # not valid, we should not be here then, lets tell the user to re-open his browser
     pf::web::generate_error_page($portalSession, i18n("release: reopen browser"), $r);
     return Apache2::Const::OK;
   }
-  
-  my $vid = $violations->{'vid'}; 
-  
+
+  my $vid = $violations->{'vid'};
+
   # is class valid? if so, let's grab some related info that we will need
   my ($class_redirect_url, $class_max_enable_url);
   my $class = class_view($vid);
@@ -99,30 +98,30 @@ sub handler
       pf::web::generate_scan_status_page($portalSession, $1, $r);
       return Apache2::Const::OK;
     }
-    
+
     # Start scan in cleanup phase to avoid browser to hang on connection
     my $cmd = $bin_dir."/pfcmd schedule now $ip 1>/dev/null 2>&1";
     $logger->info("scanning $ip by calling $cmd");
-    $r->pool->cleanup_register(\&scan, [$logger, $violations, $cmd]); 
- 
+    $r->pool->cleanup_register(\&scan, [$logger, $violations, $cmd]);
+
     $logger->trace("parent part, redirecting to scan started page");
     pf::web::generate_scan_start_page($portalSession, $r);
-  
+
     return Apache2::Const::OK;
   }
-  
+
   $logger->info("Will try to close violation $vid for $mac");
   my $grace = violation_close($mac,$vid);
   $logger->info("Closing of violation $vid for $mac returned $grace");
-  
+
   if ($grace != -1) {
-    my $count = violation_count($mac); 
-  
+    my $count = violation_count($mac);
+
     $logger->info("$mac enabled for $grace minutes");
     if ($count == 0) {
       # we reevaluate the access so the user is release from isolation if needed
       pf::enforcement::reevaluate_access( $mac, "manage_vclose" );
-  
+
       if ($class_redirect_url) {
         $destination_url = $class_redirect_url;
       }
@@ -161,11 +160,11 @@ sub scan {
   # HACK: add a start date in the violation's ticket_ref to track the fact that the scan is in progress
   my $currentScanViolationId = $violations->{'id'};
   violation_modify($currentScanViolationId, (ticket_ref => "Scan in progress, started at: ".mysql_date()));
-  
+
   # requesting the scan
   $logger->trace("cleanup phase, forking $cmd");
   my $scan = qx/$cmd/;
-  
+
   return Apache2::Const::OK;
 } # sub scan
 
@@ -180,20 +179,20 @@ Inverse inc. <info@inverse.ca>
 Copyright (C) 2005-2015 Inverse inc.
 
 =head1 LICENSE
-    
+
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
 as published by the Free Software Foundation; either version 2
 of the License, or (at your option) any later version.
-    
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
-            
+
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
-USA.            
-                
+USA.
+
 =cut

--- a/lib/pf/web/util.pm
+++ b/lib/pf/web/util.pm
@@ -18,6 +18,7 @@ See F<pf::web::custom> for details.
 use strict;
 use warnings;
 
+use pf::log;
 use pf::constants;
 use pf::constants::config qw($TIME_MODIFIER_RE $DEADLINE_UNIT);
 use pf::config;
@@ -334,7 +335,7 @@ retreive packetfence cookie
 
 sub getcookie {
     my ($cookies) =@_;
-    my $logger = Log::Log4perl->get_logger(__PACKAGE__);
+    my $logger = get_logger();
     my $cleaned_cookies = '';
     if ( defined($cookies) ) {
         foreach (split(';', $cookies)) {

--- a/lib/pf/web/util.pm
+++ b/lib/pf/web/util.pm
@@ -374,7 +374,7 @@ sub build_captive_portal_detection_mecanisms_regex {
         return qr/ ^(?: $captive_portal_detection_mecanism_urls ) /x; # eXtended pattern
     } else {
         return '';
-    }    
+    }
 }
 
 =item is_certificate_self_signed
@@ -384,7 +384,7 @@ Check if configured SSL certificate is self-signed
 =cut
 
 sub is_certificate_self_signed {
-    my $logger = Log::Log4perl->get_logger(__PACKAGE__);
+    my $logger = get_logger();
 
     unless ( -e $ssl_configuration_file ) {
         $logger->warn("Unable to read the SSL certificate file '$ssl_configuration_file', assuming self-signed");

--- a/lib/pf/web/wispr.pm
+++ b/lib/pf/web/wispr.pm
@@ -21,7 +21,7 @@ use Apache2::Request;
 use Apache2::Access;
 use Apache2::Connection;
 use Apache2::Const;
-use Log::Log4perl;
+use pf::log;
 use Template;
 
 use pf::authentication;
@@ -50,7 +50,7 @@ sub handler {
 
     my $r = (shift);
     my $req = Apache2::Request->new($r);
-    my $logger = Log::Log4perl->get_logger('auth_handler');
+    my $logger = get_logger();
 
     $logger->trace("hitting wispr");
 

--- a/sbin/pfbandwidthd
+++ b/sbin/pfbandwidthd
@@ -45,7 +45,7 @@ use pf::ConfigStore::Interface;
 # assign process name (see #1464)
 our $PROGRAM_NAME = $0 = "pfbandwidthd";
 
-my $logger = Log::Log4perl->get_logger( basename($PROGRAM_NAME) );
+my $logger = get_logger( basename($PROGRAM_NAME) );
 
 # init signal handlers
 POSIX::sigaction(

--- a/sbin/pfdetect
+++ b/sbin/pfdetect
@@ -28,6 +28,7 @@ BEGIN {
     use pf::log(service => 'pfdetect');
 }
 
+use pf::log;
 use pf::action;
 use pf::class;
 use pf::config;
@@ -51,7 +52,7 @@ use pfconfig::cached_hash;
 # assign process name (see #1464)
 our $PROGRAM_NAME = $0 = "pfdetect";
 
-my $logger = Log::Log4perl->get_logger( $PROGRAM_NAME );
+my $logger = get_logger( $PROGRAM_NAME );
 
 # init signal handlers
 POSIX::sigaction(

--- a/sbin/pfdetect
+++ b/sbin/pfdetect
@@ -28,7 +28,6 @@ BEGIN {
     use pf::log(service => 'pfdetect');
 }
 
-use pf::log;
 use pf::action;
 use pf::class;
 use pf::config;

--- a/sbin/pfdhcplistener
+++ b/sbin/pfdhcplistener
@@ -56,7 +56,7 @@ pf::SwitchFactory::preLoadModules();
 # assign process name (see #1464)
 our $PROGRAM_NAME = "pfdhcplistener";
 
-my $logger = Log::Log4perl->get_logger( basename($PROGRAM_NAME) );
+my $logger = get_logger( $PROGRAM_NAME );
 
 # init signal handlers
 POSIX::sigaction(

--- a/sbin/pfdns
+++ b/sbin/pfdns
@@ -53,7 +53,7 @@ pf::SwitchFactory::preLoadModules();
 # init signal handlers
 our $PROGRAM_NAME = $0 = "pfdns";
 
-my $logger = Log::Log4perl->get_logger( basename($PROGRAM_NAME) );
+my $logger = get_logger( $PROGRAM_NAME );
 
 POSIX::sigaction(
     &POSIX::SIGHUP,

--- a/sbin/pfmon
+++ b/sbin/pfmon
@@ -62,7 +62,7 @@ our %CHILDREN;
 our @TASKS_RUN;
 our $ALARM_RECV = 0;
 
-my $logger = Log::Log4perl->get_logger( $PROGRAM_NAME );
+my $logger = get_logger( $PROGRAM_NAME );
 my $old_child_sigaction = POSIX::SigAction->new;
 
 POSIX::sigaction(

--- a/sbin/pfsetvlan
+++ b/sbin/pfsetvlan
@@ -85,7 +85,7 @@ $thread = 1;
 # assign process name (see #1464)
 our $PROGRAM_NAME = $0 = "pfsetvlan";
 
-my $logger = Log::Log4perl->get_logger( $PROGRAM_NAME );
+my $logger = get_logger( $PROGRAM_NAME );
 
 # Initialize a new cache for the traps sent from switches IfIndex
 our $traps_switchIfIndex_cache = new Cache::FileCache( {'namespace'=>'pfSetVlan_TrapsLimitSwitchIfIndex'} );
@@ -236,8 +236,8 @@ while ( defined( $currentTrapLine = $fh->read ) ) {
 # sub addTrapLineToQueue($trapLine) - cond_signal(@trapList_queued){{{1
 sub addTrapLineToQueue {
     my ($trapLine) = @_;
-    my $logger     = Log::Log4perl->get_logger('pfsetvlan::parsing');
-    my $lockLogger = Log::Log4perl->get_logger('pfsetvlan::locking');
+    my $logger     = get_logger('pfsetvlan::parsing');
+    my $lockLogger = get_logger('pfsetvlan::locking');
     Log::Log4perl::MDC->put( 'tid', threads->self->tid() );
     $lockLogger->trace("locking - trying to lock trapList_queued");
     {
@@ -255,8 +255,8 @@ sub addTrapLineToQueue {
 # sub signalHandlerTrapListQueued - cond_wait(@trapList_queued), parseTrap($trapLineToParse) {{{1
 sub signalHandlerTrapListQueued {
     use pf::log(service => 'pfsetvlan', reinit => 1);
-    my $logger     = Log::Log4perl->get_logger('pfsetvlan::parsing');
-    my $lockLogger = Log::Log4perl->get_logger('pfsetvlan::locking');
+    my $logger     = get_logger('pfsetvlan::parsing');
+    my $lockLogger = get_logger('pfsetvlan::locking');
     Log::Log4perl::MDC->put( 'tid', threads->self->tid() );
 
     while (1) {
@@ -518,8 +518,8 @@ sub signalHandlerTrapListQueued {
 # sub parseTrap {{{1
 sub parseTrap {
     my ($trapLine) = @_;
-    my $logger     = Log::Log4perl->get_logger('pfsetvlan::parsing');
-    my $lockLogger = Log::Log4perl->get_logger('pfsetvlan::locking');
+    my $logger     = get_logger('pfsetvlan::parsing');
+    my $lockLogger = get_logger('pfsetvlan::locking');
     Log::Log4perl::MDC->put( 'tid', threads->self->tid() );
 
     $logger->debug("parsing trap $trapLine");
@@ -751,8 +751,8 @@ sub parseTrap {
 # sub signalHandlerThreadListQueued {{{1
 sub signalHandlerThreadListQueued {
     use pf::log(service => 'pfsetvlan', reinit => 1);
-    my $logger     = Log::Log4perl->get_logger('pfsetvlan::parsing');
-    my $lockLogger = Log::Log4perl->get_logger('pfsetvlan::locking');
+    my $logger     = get_logger('pfsetvlan::parsing');
+    my $lockLogger = get_logger('pfsetvlan::locking');
 
     Log::Log4perl::MDC->put( 'tid', threads->self->tid() );
 
@@ -791,8 +791,8 @@ sub signalHandlerThreadListQueued {
 
 # sub startTrapHandlers {{{1
 sub startTrapHandlers {
-    my $logger     = Log::Log4perl->get_logger('pfsetvlan::handling');
-    my $lockLogger = Log::Log4perl->get_logger('pfsetvlan::locking');
+    my $logger     = get_logger('pfsetvlan::handling');
+    my $lockLogger = get_logger('pfsetvlan::locking');
     Log::Log4perl::MDC->put( 'tid', threads->self->tid() );
 
     my $mustDoSomeThing = 0;
@@ -927,8 +927,8 @@ sub handleTrap {
 
     # initialize {{{2
     my ( $switch_id, $switch_port, $trapType, $trapVlan, $trapOperation, $trapMac, $trapSSID , $trapClientUserName, $trapIfIndex, $trapConnectionType) = @_;
-    my $logger     = Log::Log4perl->get_logger('pfsetvlan::handling');
-    my $lockLogger = Log::Log4perl->get_logger('pfsetvlan::locking');
+    my $logger     = get_logger('pfsetvlan::handling');
+    my $lockLogger = get_logger('pfsetvlan::locking');
     Log::Log4perl::MDC->put( 'tid', threads->self->tid() );
     my $vlan_obj = new pf::vlan::custom();
 
@@ -1721,8 +1721,8 @@ sub handleTrap {
 
 # sub cleanupAfterThread {{{1
 sub cleanupAfterThread {
-    my $logger     = Log::Log4perl->get_logger('pfsetvlan::cleanup');
-    my $lockLogger = Log::Log4perl->get_logger('pfsetvlan::locking');
+    my $logger     = get_logger('pfsetvlan::cleanup');
+    my $lockLogger = get_logger('pfsetvlan::locking');
     Log::Log4perl::MDC->put( 'tid', threads->self->tid() );
     my ( $switch_id, $switch_port ) = @_;
     $lockLogger->trace(
@@ -1767,8 +1767,8 @@ sub cleanupAfterThread {
 
 # sub normal_sighandler {{{1
 sub normal_sighandler {
-    my $logger     = Log::Log4perl->get_logger('pfsetvlan');
-    my $lockLogger = Log::Log4perl->get_logger('pfsetvlan::locking');
+    my $logger     = get_logger('pfsetvlan');
+    my $lockLogger = get_logger('pfsetvlan::locking');
     Log::Log4perl::MDC->put( 'tid', threads->self->tid() );
     if (   ( isenabled( $Config{'vlan'}{'closelocationlogonstop'} ) )
         && ( threads->self->tid() == 0 ) )
@@ -1784,7 +1784,7 @@ sub normal_sighandler {
 # ref: http://rt.perl.org/rt3/Public/Bug/Display.html?id=16807
 # bug: http://www.packetfence.org/mantis/view.php?id=907
 sub ignore_sighandler {
-    my $logger     = Log::Log4perl->get_logger('pfsetvlan');
+    my $logger     = get_logger('pfsetvlan');
 
     $logger->error("caught SIG" . $_[0] . ". This is probably a telnet or ssh management attempt that timed out. "
         ."THIS WILL HANG A PACKETFENCE THREAD FOR SEVERAL MINUTES! Doublecheck your config or the network between "
@@ -1796,7 +1796,7 @@ sub ignore_sighandler {
 # sub node_update_PF {{{1
 sub node_update_PF {
     my ($switch, $switch_port, $mac, $vlan, $isPhone, $registrationMode) = @_;
-    my $logger = Log::Log4perl->get_logger('pfsetvlan');
+    my $logger = get_logger('pfsetvlan');
     Log::Log4perl::MDC->put( 'tid', threads->self->tid() );
     my $vlan_obj = new pf::vlan::custom();
 
@@ -1835,7 +1835,7 @@ sub node_update_PF {
 sub node_determine_and_set_into_VLAN {
     my ( $mac, $switch, $ifIndex, $connection_type ) = @_;
 
-    my $logger = Log::Log4perl->get_logger('pfsetvlan::handling');
+    my $logger = get_logger('pfsetvlan::handling');
     Log::Log4perl::MDC->put( 'tid', threads->self->tid() );
 
     my $vlan_obj = new pf::vlan::custom();
@@ -1855,7 +1855,7 @@ sub node_determine_and_set_into_VLAN {
 # sub perform_trap_limiting {{{1
 sub perform_trap_limiting {
     my ( $switch, $switchIfIndex ) = @_;
-    my $logger = Log::Log4perl->get_logger(__PACKAGE__);
+    my $logger = get_logger('pfsetvlan');
 
     # skipping if feature is disabled
     return $FALSE if (isdisabled($Config{'vlan'}{'trap_limit'}));
@@ -1920,8 +1920,8 @@ sub perform_trap_limiting {
 # sub do_port_security {{{1
 sub do_port_security {
     my ( $mac, $switch, $switch_port, $trapType ) = @_;
-    my $logger     = Log::Log4perl->get_logger('pfsetvlan::handling');
-    my $lockLogger = Log::Log4perl->get_logger('pfsetvlan::locking');
+    my $logger     = get_logger('pfsetvlan::handling');
+    my $lockLogger = get_logger('pfsetvlan::locking');
     Log::Log4perl::MDC->put( 'tid', threads->self->tid() );
 
     #determine if $mac is authorized elsewhere
@@ -2056,7 +2056,7 @@ sub getSwitch {
     my ($switch_id) = @_;
     local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1;
     my $switch;
-    my $lockLogger = Log::Log4perl->get_logger('pfsetvlan::locking');
+    my $lockLogger = get_logger('pfsetvlan::locking');
     {
         lock $switchFactory_locker;
     #    $pf::ConfigStore::SwitchOverlay::switches_overlay_cached_config->ReadConfig();

--- a/t/hardware-snmp-objects.t
+++ b/t/hardware-snmp-objects.t
@@ -54,9 +54,9 @@ my @whitelist = (
     'disableIfLinkUpDownTraps', 'enableIfLinkUpDownTraps', 'connectWrite', 'connectWriteToController',
     'disconnectWrite', 'disconnectWriteToController', 'getDeauthSnmpConnectionKey', '_NasPortToIfIndex',
     'radiusDisconnect', 'supportsRoleBasedEnforcement', 'getRoleByName', 'returnRadiusAccessAccept',
-    'synchronize_locationlog', 'extractVLAN', 
+    'synchronize_locationlog', 'extractVLAN',
     'supportsMABFloatingDevices', 'disableMABFloatingDevice', 'enableMABFloatingDevice', 'disableMABByIfIndex', 'enableMABByIfIndex',
-    'identifyConnectionType'
+    'identifyConnectionType', 'logger'
 );
 
 my @missing_subs;


### PR DESCRIPTION
## Description

Refactor all the logging to use pf::log instead of Log::Log4perl directly
## Impacts

Should be none
## NEWS file entries

New Features
++++++++++++

Enhancements
++++++++++++
- Refactoring and code cleanup

Bug Fixes
+++++++++
## Fixes

Fixes #754
## Delete branch after merge

NO
