### PR TITLE
Move from Cache::Memcached to Cache::Memcached::libmemcached

### DIFF
--- a/addons/packages/packetfence.spec
+++ b/addons/packages/packetfence.spec
@@ -237,8 +237,7 @@ Requires: perl(Data::Serializer)
 Requires: perl(Data::Structure::Util)
 Requires: perl(Data::Swap)
 Requires: perl(HTML::FormHandler) = 0.40013
-Requires: perl(Cache::Memcached)
-Requires: perl(Cache::Memcached::GetParserXS)
+Requires: perl(Cache::Memcached::libmemcached)
 Requires: perl(CHI::Driver::Memcached)
 Requires: perl(File::Flock)
 Requires: perl(Perl::Version)
@@ -321,7 +320,7 @@ server.
 
 %package -n %{real_name}-remote-arp-sensor
 Group: System Environment/Daemons
-Requires: perl >= %{perl_version}, perl(Config::IniFiles), perl(IO::Socket::SSL), perl(XML::Parser), perl(Crypt::SSLeay), perl(LWP::Protocol::https), perl(Net::Pcap) >= 0.16, memcached, perl(Cache::Memcached)
+Requires: perl >= %{perl_version}, perl(Config::IniFiles), perl(IO::Socket::SSL), perl(XML::Parser), perl(Crypt::SSLeay), perl(LWP::Protocol::https), perl(Net::Pcap) >= 0.16, memcached, perl(Cache::Memcached::libmemcached)
 Requires: perl(Moo), perl(Data::MessagePack), perl(WWW::Curl)
 Conflicts: %{real_name}
 AutoReqProv: 0

--- a/addons/pfarp_remote/sbin/pfarp_remote
+++ b/addons/pfarp_remote/sbin/pfarp_remote
@@ -25,7 +25,7 @@ use Pod::Usage;
 use strict;
 use warnings;
 use Net::Pcap 0.16;
-use Cache::Memcached;
+use Cache::Memcached::libmemcached;
 
 POSIX::sigaction(&POSIX::SIGHUP,
   POSIX::SigAction->new(
@@ -141,7 +141,7 @@ However it has been kept around since we might introduce ARP surveillance in the
 sub listen_arp {
     my ( $type, $srcmac, $srcip, $destmac, $destip ) = &decode(@_);
     if ( $type == 2 ) {
-        
+
         soap_send(clean_mac($srcmac),$srcip);
         #syslog("warning","ARP $srcip is-at $srcmac $srcmac $srcip $destmac $destip");
     }
@@ -254,7 +254,7 @@ get information stored in memcached
 sub get_memcached {
     my ( $key, $mc ) = @_;
     my $memd;
-    $memd = Cache::Memcached->new(
+    $memd = Cache::Memcached::libmemcached->new(
         servers => [$mc],
         debug => 0,
         compress_threshold => 10_000,
@@ -270,7 +270,7 @@ set information into memcached
 sub set_memcached {
     my ( $key, $value, $exptime, $mc ) = @_;
     my $memd;
-    $memd = Cache::Memcached->new(
+    $memd = Cache::Memcached::libmemcached->new(
         servers => [$mc],
         debug => 0,
         compress_threshold => 10_000,
@@ -287,7 +287,7 @@ sub set_memcached {
 
 sub daemonize {
   chdir '/'               or die "Can't chdir to /: $!";
-  open STDIN, '<', '/dev/null' or die "Can't read /dev/null: $!";  
+  open STDIN, '<', '/dev/null' or die "Can't read /dev/null: $!";
   open STDOUT, '>', '/dev/null' or die "Can't write to /dev/null: $!";
 
   defined(my $pid = fork) or die "pfarp_remote: could not fork: $!";

--- a/conf/chi.conf.example
+++ b/conf/chi.conf.example
@@ -23,10 +23,10 @@ expires_in=10m
 expires_on_backend=1
 
 [storage memcached]
-driver=Memcached
-servers=127.0.0.1:11211
-global=1
-compress_threshold=10000
+driver = Memcached::libmemcached
+servers = 127.0.0.1:11211
+compress_threshold = 10000
+behavior_binary_protocol = 1
 
 [storage file]
 driver=File

--- a/debian/control
+++ b/debian/control
@@ -87,7 +87,7 @@ Depends: ${misc:Depends}, vlan, make,
  libcatalyst-authentication-store-htpasswd-perl, libcatalyst-plugin-unicode-encoding-perl,
  libcatalyst-view-tt-perl (>= 0.37), libhtml-formfu-perl, libjson-perl, libjson-xs-perl,
  libsort-naturally-perl, libhtml-formhandler-perl (=0.40013-2), libchi-perl (>=0.59),
- libchi-driver-memcached-perl,libcache-memcached-perl, libcache-memcached-getparserxs-perl, libdata-serializer-perl,
+ libchi-driver-memcached-perl,libcache-memcached-libmemcached-perl, libdata-serializer-perl,
  libcache-fastmmap-perl, libmoo-perl (=1.004002-1), libterm-size-any-perl,
 # packaging workaround (we don't require it but something in catalyst seem to do)
  libmodule-install-perl,
@@ -164,7 +164,7 @@ Package: packetfence-remote-arp-sensor
 Architecture: all
 Depends: ${misc:Depends}, libfile-tail-perl, libconfig-inifiles-perl (>= 2.4.0),
  libio-socket-ssl-perl, libxml-parser-perl, libcrypt-ssleay-perl,
- libnet-pcap-perl, libcache-memcached-perl, memcached,
+ libnet-pcap-perl, libcache-memcached-libmemcached-perl, memcached,
 # FIXME track what requires the conveyor stuff and identify it. If we can, get rid of it.
  libsoap-lite-perl, libthread-conveyor-monitored-perl, libthread-conveyor-perl
 Conflicts: packetfence

--- a/lib/pf/WebAPI/InitHandler.pm
+++ b/lib/pf/WebAPI/InitHandler.pm
@@ -19,7 +19,7 @@ use pf::config::cached;
 use pf::StatsD;
 use pf::db;
 use pf::CHI;
-use Cache::Memcached;
+use Cache::Memcached::libmemcached;
 use pf::SwitchFactory();
 
 use Apache2::Const -compile => 'OK';
@@ -59,7 +59,7 @@ sub post_config {
     pf::StatsD->closeStatsd;
     db_disconnect();
     pf::CHI->clear_memoized_cache_objects;
-    Cache::Memcached->disconnect_all;
+    Cache::Memcached::libmemcached->disconnect_all;
     pf::SwitchFactory::preLoadModules();
     return Apache2::Const::OK;
 }

--- a/lib/pf/web/util.pm
+++ b/lib/pf/web/util.pm
@@ -26,7 +26,7 @@ use pf::config::util;
 use pf::web;
 use Apache::Session::Generate::MD5;
 use Apache::Session::Flex;
-use Cache::Memcached;
+use Cache::Memcached::libmemcached;
 
 BEGIN {
     use Exporter ();
@@ -233,7 +233,7 @@ get memcached object
 sub get_memcached_connection {
     my ( $mc ) = @_;
     my $memd;
-    $memd = Cache::Memcached->new(
+    $memd = Cache::Memcached::libmemcached->new(
         servers => $mc,
         debug => 0,
         compress_threshold => 10_000,
@@ -250,7 +250,7 @@ get information stored in memcached
 sub get_memcached {
     my ( $key, $mc ) = @_;
     my $memd;
-    $memd = Cache::Memcached->new(
+    $memd = Cache::Memcached::libmemcached->new(
         servers => $mc,
         debug => 0,
         compress_threshold => 10_000,
@@ -267,7 +267,7 @@ set information into memcached
 sub set_memcached {
     my ( $key, $value, $exptime, $mc ) = @_;
     my $memd;
-    $memd = Cache::Memcached->new(
+    $memd = Cache::Memcached::libmemcached->new(
         servers => $mc,
         debug => 0,
         compress_threshold => 10_000,
@@ -291,7 +291,7 @@ get information stored in memcached
 sub del_memcached {
     my ( $key, $mc ) = @_;
     my $memd;
-    $memd = Cache::Memcached->new(
+    $memd = Cache::Memcached::libmemcached->new(
         servers => $mc,
         debug => 0,
         compress_threshold => 10_000,

--- a/lib/pfconfig/backend/memcached.pm
+++ b/lib/pfconfig/backend/memcached.pm
@@ -18,14 +18,12 @@ use strict;
 use warnings;
 
 use base 'pfconfig::backend';
-use Cache::Memcached;
+use Cache::Memcached::libmemcached;
 
 sub init {
     my ($self) = @_;
-    $self->{cache} = new Cache::Memcached { 'servers' => ['127.0.0.1:11211'] };
+    $self->{cache} = new Cache::Memcached::libmemcached { 'servers' => ['127.0.0.1:11211'] };
 }
-
-=back
 
 =head1 AUTHOR
 

--- a/lib/pfconfig/manager.pm
+++ b/lib/pfconfig/manager.pm
@@ -32,7 +32,7 @@ use strict;
 use warnings;
 
 #use Cache::BDB;
-use Cache::Memcached;
+use Cache::Memcached::libmemcached;
 use Config::IniFiles;
 use List::MoreUtils qw(any firstval uniq);
 use Scalar::Util qw(refaddr reftype tainted blessed);
@@ -405,7 +405,7 @@ sub list_top_namespaces {
     foreach my $namespace (@$static_namespaces){
         push @top_level_namespaces, $namespace unless any { $_ eq $namespace } @children;
     }
-    
+
     return @top_level_namespaces;
 }
 


### PR DESCRIPTION
## Description

Currently all our code uses the memecached text based protocol.
How this can create some security issues https://hackmag.com/security/a-small-injection-for-memcached/
By moving to the binary protocol we eliminate any possibility of this attack vector
Fixes #432
## Impacts

pf::CHI, pfarp_remote, pfconfig::backend::memcached
## NEWS file entries

New Features
++++++++++++

Enhancements
++++++++++++

Bug Fixes
+++++++++
- Move to the memcached binary protocol to avoid memcached injection exploit
## Delete branch after merge

NO
## UPDATE NOTES

If your conf/chi.conf was modified then ensure that for the 'storage memcached' section change the following parameters

[storage memcached]
driver = Memcached::libmemcached
servers = 127.0.0.1:11211
compress_threshold = 10000
behavior_binary_protocol = 1
