### PR TITLE
Use client mac and ip in portal help instead of pregen messages

### DIFF
--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Root.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Root.pm
@@ -85,13 +85,6 @@ sub setupCommonStash : Private {
     my $portalSession   = $c->portalSession;
     my $destination_url = $portalSession->destinationUrl;
 
-    my @list_help_info;
-    push @list_help_info,
-      { name => i18n('IP'), value => $portalSession->clientIp }
-      if ( defined( $portalSession->clientIp ) );
-    push @list_help_info,
-      { name => i18n('MAC'), value => $portalSession->clientMac }
-      if ( defined( $portalSession->clientMac ) );
     if (defined( $portalSession->clientMac ) ) {
         my $node_info = node_view($portalSession->clientMac);
         if ( defined( $node_info ) ) {
@@ -106,8 +99,12 @@ sub setupCommonStash : Private {
         pf::web::constants::to_hash(),
         destination_url => encode_entities($destination_url),
         logo            => $c->profile->getLogo,
-        list_help_info  => \@list_help_info,
     );
+    $c->stash(
+        client_mac => $portalSession->clientMac,
+        client_ip => $portalSession->clientIp,
+    );
+
 }
 
 =head2 setupLanguage

--- a/html/captive-portal/templates/footer.html
+++ b/html/captive-portal/templates/footer.html
@@ -5,9 +5,8 @@
       <img src="/content/images/help.png" alt="Help" />
       <p>[% i18n("help: provide info") %]</p>
       <ul>
-        [%  FOREACH txt_help_info IN list_help_info %]
-          <li>[% txt_help_info.name %]: [% txt_help_info.value %]</li>
-        [%  END %]
+        <li>[% i18n("IP") %]: [% client_ip %]</li>
+        <li>[% i18n("MAC") %]: [% client_mac %]</li>
       </ul>
       [%- END %]
     </div>

--- a/html/pfappserver/lib/pfappserver/Base/Controller.pm
+++ b/html/pfappserver/lib/pfappserver/Base/Controller.pm
@@ -219,6 +219,8 @@ sub add_fake_profile_data {
     my ($self, $c) = @_;
     $c->stash(
         logo        => $Config{'general'}{'logo'},
+        client_mac  => '00:11:22:33:44:55',
+        client_ip   => '1.2.3.4',
         username    => 'mcrispin',
         last_port   => '4097',
         last_vlan   => '102',
@@ -226,8 +228,6 @@ sub add_fake_profile_data {
         last_switch => '10.0.0.4',
         dhcp_fingerprint      => '1,28,2,3,15,6,119,12,44,47,26,121,42',
         last_connection_type  => 'Wireless-802.11-EAP',
-        list_help_info        => [{ name => $c->loc('IP'), value => '10.0.0.123' },
-                               { name => $c->loc('MAC'), value => 'c8:bc:c8:ce:65:e1' }]
     );
 
 }


### PR DESCRIPTION
# Description

Refactored portal stash to make IP and MAC available in templates instead of using a pregenerated line to show them
# Impacts

Display on the portal
# Delete branch after merge

YES
# NEWS file entries
## Enhancements
- Client IP and MAC address are now available though direct variables in the captive portal templates
# UPDATE NOTES

The help message that contains the IP and MAC of the device on the captive portal has been reworked.
Make sure you adapt the changes in footer.html on each portal profile you have
