### PR TITLE
complete removal of statsd config

### DIFF
--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1397,18 +1397,6 @@ description=<<EOT
 The virtual router id for keepalive. Leave untouched unless you have another keepalive cluster in this network.
 EOT
 
-[monitoring.statsd_host]
-type=text
-description=<<EOT
-Host to which StatsD metrics are sent.
-EOT
-
-[monitoring.statsd_port]
-type=numeric
-description=<<EOT
-Port on the StatsD host to which metrics are sent.
-EOT
-
 [monitoring.graphite_host]
 type=text
 description=<<EOT

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -1096,14 +1096,6 @@ virtual_router_id=50
 
 [monitoring]
 #
-# monitoring.statsd_host
-#
-statsd_host=localhost
-#
-# monitoring.statsd_port
-#
-statsd_port=8125
-#
 # monitoring.graphite_host
 #
 graphite_host=localhost

--- a/html/pfappserver/lib/pfappserver/I18N/en.po
+++ b/html/pfappserver/lib/pfappserver/I18N/en.po
@@ -5170,14 +5170,6 @@ msgstr "Username"
 msgid "monitoring"
 msgstr "Monitoring"
 
-# conf/documentation.conf
-msgid "monitoring.statsd_host"
-msgstr "StatsD host"
-
-# conf/documentation.conf
-msgid "monitoring.statsd_port"
-msgstr "StatsD port"
-
 # html/pfappserver/lib/pfappserver/Form/Field/Duration.pm
 msgid "weeks"
 msgstr ""

--- a/html/pfappserver/lib/pfappserver/I18N/fr.po
+++ b/html/pfappserver/lib/pfappserver/I18N/fr.po
@@ -2067,10 +2067,6 @@ msgid ""
 " be automagically created."
 msgstr "Hôte où est exécuté le moteur d'analyse. Pour des raisons de performance, nous vous recommandons d'exécuter le moteur d'analyse sur un autre serveur. Une règle d'autorisation de pare-feu sera automatiquement créé."
 
-# conf/documentation.conf (monitoring.statsd_host)
-msgid "Host to which StatsD metrics are sent."
-msgstr "Hôte auquel les paramètres StatsD sont envoyés."
-
 # conf/documentation.conf (monitoring.graphite_host)
 msgid "Host to which graphite metrics are sent."
 msgstr "Hôte auquel les métriques de graphite sont envoyées"
@@ -3660,10 +3656,6 @@ msgstr "Port du service"
 # conf/documentation.conf (ports.soap)
 msgid "Port of the soap webservice."
 msgstr "Port du service web SOAP."
-
-# conf/documentation.conf (monitoring.statsd_port)
-msgid "Port on the StatsD host to which metrics are sent."
-msgstr "Port sur l'hôte StatsD à laquelle les paramètres sont envoyés."
 
 # conf/documentation.conf (monitoring.graphite_port)
 msgid "Port on the graphite host to which metrics are sent."
@@ -7101,14 +7093,6 @@ msgstr "hôte graphite"
 # conf/documentation.conf
 msgid "monitoring.graphite_port"
 msgstr "port de connection de graphite"
-
-# conf/documentation.conf
-msgid "monitoring.statsd_host"
-msgstr "Hôte StatsD de Supervision "
-
-# conf/documentation.conf
-msgid "monitoring.statsd_port"
-msgstr "StatsD port de supervision"
 
 # html/pfappserver/lib/pfappserver/Form/Field/Duration.pm
 msgid "months"

--- a/html/pfappserver/lib/pfappserver/I18N/i_default.po
+++ b/html/pfappserver/lib/pfappserver/I18N/i_default.po
@@ -1973,10 +1973,6 @@ msgstr ""
 msgid "Host the scanning engine is running on.  For performance reasons, we recommend running the scanning engine on a remote server. A passthrough will be automagically created."
 msgstr ""
 
-# conf/documentation.conf (monitoring.statsd_host)
-msgid "Host to which StatsD metrics are sent."
-msgstr "Host to which StatsD metrics are sent."
-
 # conf/documentation.conf (monitoring.graphite_host)
 msgid "Host to which graphite metrics are sent."
 msgstr "Host to which graphite metrics are sent."
@@ -3528,10 +3524,6 @@ msgstr ""
 
 # conf/documentation.conf (ports.soap)
 msgid "Port of the soap webservice."
-msgstr ""
-
-# conf/documentation.conf (monitoring.statsd_port)
-msgid "Port on the StatsD host to which metrics are sent."
 msgstr ""
 
 # conf/documentation.conf (monitoring.graphite_port)
@@ -6919,14 +6911,6 @@ msgstr ""
 
 # conf/documentation.conf
 msgid "monitoring.graphite_port"
-msgstr ""
-
-# conf/documentation.conf
-msgid "monitoring.statsd_host"
-msgstr ""
-
-# conf/documentation.conf
-msgid "monitoring.statsd_port"
 msgstr ""
 
 # html/pfappserver/lib/pfappserver/Form/Field/Duration.pm

--- a/lib/pf/StatsD.pm
+++ b/lib/pf/StatsD.pm
@@ -39,8 +39,8 @@ initStatsd();
 # we override new to add a "hostname" attribute.
 sub new {
     my ( $class, $host, $port, $sample_rate ) = @_;
-    $host = 'localhost' unless defined $host;
-    $port = 8125        unless defined $port;
+    $host = $STATSD_HOST unless defined $host;
+    $port = $STATSD_PORT unless defined $port;
     my $hostname = hostname; 
     $hostname =~ s/\Q$GRAPHITE_DELIMITER\E/_/g; # replace dots with underscores 
 

--- a/lib/pf/services/manager/statsd.pm
+++ b/lib/pf/services/manager/statsd.pm
@@ -32,13 +32,6 @@ sub generateConfig {
     my %tags;
     $tags{'template'}      = "$conf_dir/monitoring/statsd_config.js";
     $tags{'pid_file'}      = "$install_dir/var/run/statsd.pid";
-    $tags{'graphite_host'} = "$Config{'monitoring'}{'graphite_host'}";
-    $tags{'graphite_port'} = "$Config{'monitoring'}{'graphite_port'}";
-    $tags{'statsd_port'}   = "$Config{'monitoring'}{'statsd_port'}";
-    $tags{'management_ip'}
-        = defined( $management_network->tag('vip') )
-        ? $management_network->tag('vip')
-        : $management_network->tag('ip');
 
     parse_template( \%tags, "$tags{'template'}", "$install_dir/var/conf/statsd_config.js", '//' );
 }


### PR DESCRIPTION
# Description

Complete removal of statsd host and port configuration in pf.conf as it shouldn't be used anymore
# Impacts

statsd
# Delete branch after merge

YES
# NEWS file entries
## Enhancements
- Moved statsd host and port configuration in a constants file instead of the configuration
# UPGRADE

`monitoring.statsd_host` and `monitoring.statsd_port` have been removed from pf.conf. If you have specified a specific host or port, remove them from your configuration and change them in `/usr/local/pf/lib/pf/StatsD.pm`
