### PR TITLE
Return the VIP for DNS requests in clustered mode.

### DIFF
--- a/lib/pf/services/manager/dhcpd.pm
+++ b/lib/pf/services/manager/dhcpd.pm
@@ -105,7 +105,7 @@ EOT
                 my $members = join(',',@active_members);
                 if ($members) {
                     if ($current_network->contains($ip)) {
-                        $dns = $members;
+                        $dns = pf::cluster::cluster_ip($interface);
                         $active = defined($net{next_hop}) ? 
                                  NetAddr::IP::Lite->new($net{'next_hop'}, $cfg->{'mask'}) :
 				 NetAddr::IP::Lite->new($cfg->{'ip'}, $cfg->{'mask'});


### PR DESCRIPTION
# Description

Return the VIP as name-server in dhcp leases.
# Impacts

Changes the behavior of dhcpd in clustered mode.
With this change the dns returned will be the VIP.

The previous behaviour sometimes broke the passthroughs.
If we return both servers addresses then the dns request may not be
going to the server that is used to tunnel to the requested passthrough
URL. It would therefore not be added in the passthrough ipset by pfdns.
# Dependencies

Clustered mode only.
# Issue

fixes #820
# Delete branch after merge

YES 
# NEWS file entries
## Bug Fixes

If an issue exists on Github, please refer to it (name) along with it's number...
ie.: 
- Issue with passthroughs in clustered mode not working because they are not added on the correct server.
