### PR TITLE
returning source error message instead of generic one

### DIFF
--- a/lib/pf/Authentication/Source/ADSource.pm
+++ b/lib/pf/Authentication/Source/ADSource.pm
@@ -9,6 +9,7 @@ pf::Authentication::Source::ADSource
 =cut
 
 use pf::Authentication::constants;
+use pf::constants::authentication::messages;
 use pf::Authentication::Source::LDAPSource;
 
 use Moose;

--- a/lib/pf/Authentication/Source/BlackholeSource.pm
+++ b/lib/pf/Authentication/Source/BlackholeSource.pm
@@ -17,6 +17,7 @@ use Moose;
 use pf::constants;
 use pf::config;
 use pf::Authentication::constants;
+use pf::constants::authentication::messages;
 use pf::util;
 
 extends 'pf::Authentication::Source';

--- a/lib/pf/Authentication/Source/ChainedSource.pm
+++ b/lib/pf/Authentication/Source/ChainedSource.pm
@@ -17,6 +17,7 @@ use Moose;
 use pf::constants;
 use pf::config;
 use pf::Authentication::constants;
+use pf::constants::authentication::messages;
 use pf::util;
 use pf::log;
 

--- a/lib/pf/Authentication/Source/EmailSource.pm
+++ b/lib/pf/Authentication/Source/EmailSource.pm
@@ -9,6 +9,7 @@ pf::Authentication::Source::EmailSource
 =cut
 
 use pf::Authentication::constants;
+use pf::constants::authentication::messages;
 
 use Moose;
 extends 'pf::Authentication::Source';

--- a/lib/pf/Authentication/Source/HtpasswdSource.pm
+++ b/lib/pf/Authentication/Source/HtpasswdSource.pm
@@ -59,7 +59,7 @@ sub authenticate {
         return ($FALSE, 'Invalid login or password');
     }
 
-    return ($TRUE, 'Successful authentication using htpasswd file.');
+    return ($TRUE, 'Authentication successful.');
 }
 
 =head2 match_in_subclass

--- a/lib/pf/Authentication/Source/HtpasswdSource.pm
+++ b/lib/pf/Authentication/Source/HtpasswdSource.pm
@@ -10,6 +10,7 @@ pf::Authentication::Source::HtpasswdSource
 
 use pf::constants qw($TRUE $FALSE);
 use pf::Authentication::constants;
+use pf::constants::authentication::messages;
 use pf::Authentication::Source;
 use pf::util;
 
@@ -49,17 +50,17 @@ sub authenticate {
 
     if (! -r $password_file) {
         $logger->error("unable to read password file '$password_file'");
-        return ($FALSE, 'Unable to validate credentials at the moment');
+        return ($FALSE, $COMMUNICATION_ERROR_MSG);
     }
 
     my $htpasswd = new Apache::Htpasswd({ passwdFile => $password_file, ReadOnly   => 1});
     if ( (!defined($htpasswd->htCheckPassword($username, $password)))
          or ($htpasswd->htCheckPassword($username, $password) == 0) ) {
 
-        return ($FALSE, 'Invalid login or password');
+        return ($FALSE, $AUTH_FAIL_MSG);
     }
 
-    return ($TRUE, 'Authentication successful.');
+    return ($TRUE, $AUTH_SUCCESS_MSG);
 }
 
 =head2 match_in_subclass

--- a/lib/pf/Authentication/Source/KerberosSource.pm
+++ b/lib/pf/Authentication/Source/KerberosSource.pm
@@ -10,6 +10,7 @@ pf::Authentication::Source::KerberosSource
 
 use pf::constants qw($TRUE $FALSE);
 use pf::Authentication::constants;
+use pf::constants::authentication::messages;
 use pf::Authentication::Source;
 
 use Authen::Krb5::Simple;
@@ -42,12 +43,12 @@ sub authenticate_using_kerberos {
   my $kerberos = Authen::Krb5::Simple->new( realm => $self->{'realm'} );
 
   if ($kerberos->authenticate($username, $password)) {
-    return ($TRUE, 'Authentication successful');
+    return ($TRUE, $AUTH_SUCCESS_MSG);
   } else {
-    return ($FALSE, 'Invalid login or password');
+    return ($FALSE, $AUTH_FAIL_MSG);
   }
 
-  return ($FALSE, 'Unable to connect to Kerberos server');
+  return ($FALSE, $COMMUNICATION_ERROR_MSG);
 }
 
 =head2 match_in_subclass

--- a/lib/pf/Authentication/Source/KerberosSource.pm
+++ b/lib/pf/Authentication/Source/KerberosSource.pm
@@ -42,7 +42,7 @@ sub authenticate_using_kerberos {
   my $kerberos = Authen::Krb5::Simple->new( realm => $self->{'realm'} );
 
   if ($kerberos->authenticate($username, $password)) {
-    return ($TRUE, 'Successful authentication using Kerberos.');
+    return ($TRUE, 'Authentication successful');
   } else {
     return ($FALSE, 'Invalid login or password');
   }

--- a/lib/pf/Authentication/Source/LDAPSource.pm
+++ b/lib/pf/Authentication/Source/LDAPSource.pm
@@ -9,6 +9,7 @@ pf::Authentication::Source::LDAPSource
 =cut
 
 use pf::constants qw($TRUE $FALSE);
+use pf::constants::authentication::messages;
 use pf::Authentication::constants;
 use pf::Authentication::Condition;
 use pf::CHI;
@@ -75,13 +76,13 @@ sub authenticate {
   my ($connection, $LDAPServer, $LDAPServerPort ) = $self->_connect();
 
   if (!defined($connection)) {
-    return ($FALSE, 'Unable to validate credentials at the moment');
+    return ($FALSE, $COMMUNICATION_ERROR_MSG);
   }
   my $result = $self->bind_with_credentials($connection);
 
   if ($result->is_error) {
     $logger->error("[$self->{'id'}] Unable to bind with $self->{'binddn'} on $LDAPServer:$LDAPServerPort");
-    return ($FALSE, 'Unable to validate credentials at the moment');
+    return ($FALSE, $COMMUNICATION_ERROR_MSG);
   }
 
   my $filter = "($self->{'usernameattribute'}=$username)";
@@ -93,15 +94,15 @@ sub authenticate {
   );
   if ($result->is_error) {
     $logger->error("[$self->{'id'}] Unable to execute search $filter from $self->{'basedn'} on $LDAPServer:$LDAPServerPort");
-    return ($FALSE, 'Unable to validate credentials at the moment');
+    return ($FALSE, $COMMUNICATION_ERROR_MSG);
   }
 
   if ($result->count == 0) {
     $logger->warn("[$self->{'id'}] No entries found (". $result->count .") with filter $filter from $self->{'basedn'} on $LDAPServer:$LDAPServerPort");
-    return ($FALSE, 'Invalid login or password');
+    return ($FALSE, $COMMUNICATION_ERROR_MSG);
   } elsif ($result->count > 1) {
     $logger->warn("[$self->{'id'}] Unexpected number of entries found (" . $result->count .") with filter $filter from $self->{'basedn'} on $LDAPServer:$LDAPServerPort for source $self->{'id'}");
-    return ($FALSE, 'Invalid login or password');
+    return ($FALSE, $AUTH_FAIL_MSG);
   }
 
   my $user = $result->entry(0);
@@ -110,11 +111,11 @@ sub authenticate {
 
   if ($result->is_error) {
     $logger->warn("[$self->{'id'}] User " . $user->dn . " cannot bind from $self->{'basedn'} on $LDAPServer:$LDAPServerPort");
-    return ($FALSE, 'Invalid login or password');
+    return ($FALSE, $AUTH_FAIL_MSG);
   }
 
   $logger->info("[$self->{'id'}] Authentication successful for $username");
-  return ($TRUE, 'Authentication successful');
+  return ($TRUE, $AUTH_SUCCESS_MSG);
 }
 
 
@@ -454,13 +455,13 @@ sub search_attributes {
     my $logger = Log::Log4perl->get_logger( __PACKAGE__ );
     my ($connection, $LDAPServer, $LDAPServerPort ) = $self->_connect();
     if (!defined($connection)) {
-      return ($FALSE, 'Unable to connect to the LDAP Server');
+      return ($FALSE, $COMMUNICATION_ERROR_MSG);
     }
     my $result = $self->bind_with_credentials($connection);
 
     if ($result->is_error) {
       $logger->error("[$self->{'id'}] Unable to bind with $self->{'binddn'} on $LDAPServer:$LDAPServerPort");
-      return ($FALSE, 'Unable to validate credentials at the moment');
+      return ($FALSE, $COMMUNICATION_ERROR_MSG);
     }
     my $searchresult = $connection->search(
                   base => $self->{'basedn'},

--- a/lib/pf/Authentication/Source/LDAPSource.pm
+++ b/lib/pf/Authentication/Source/LDAPSource.pm
@@ -114,7 +114,7 @@ sub authenticate {
   }
 
   $logger->info("[$self->{'id'}] Authentication successful for $username");
-  return ($TRUE, 'Authentication successful using LDAP');
+  return ($TRUE, 'Authentication successful');
 }
 
 

--- a/lib/pf/Authentication/Source/LDAPSource.pm
+++ b/lib/pf/Authentication/Source/LDAPSource.pm
@@ -99,7 +99,7 @@ sub authenticate {
 
   if ($result->count == 0) {
     $logger->warn("[$self->{'id'}] No entries found (". $result->count .") with filter $filter from $self->{'basedn'} on $LDAPServer:$LDAPServerPort");
-    return ($FALSE, $COMMUNICATION_ERROR_MSG);
+    return ($FALSE, $AUTH_FAIL_MSG);
   } elsif ($result->count > 1) {
     $logger->warn("[$self->{'id'}] Unexpected number of entries found (" . $result->count .") with filter $filter from $self->{'basedn'} on $LDAPServer:$LDAPServerPort for source $self->{'id'}");
     return ($FALSE, $AUTH_FAIL_MSG);

--- a/lib/pf/Authentication/Source/NullSource.pm
+++ b/lib/pf/Authentication/Source/NullSource.pm
@@ -15,6 +15,7 @@ use strict;
 use warnings;
 use Moose;
 use pf::constants;
+use pf::constants::authentication::messages;
 use pf::config;
 use Email::Valid;
 use pf::util;
@@ -86,9 +87,9 @@ sub match_in_subclass {
 sub authenticate {
     my ($self, $username, $password) = @_;
     if (isdisabled($self->email_required) || Email::Valid->address($username) ) {
-        return ($TRUE, 'Authentication successful.');
+        return ($TRUE, $AUTH_SUCCESS_MSG);
     }
-    return ($FALSE, 'Invalid email address provided.');
+    return ($FALSE, $INVALID_EMAIL_MSG);
 }
 
 =head1 AUTHOR

--- a/lib/pf/Authentication/Source/NullSource.pm
+++ b/lib/pf/Authentication/Source/NullSource.pm
@@ -86,7 +86,7 @@ sub match_in_subclass {
 sub authenticate {
     my ($self, $username, $password) = @_;
     if (isdisabled($self->email_required) || Email::Valid->address($username) ) {
-        return ($TRUE, 'Successful authentication using null source.');
+        return ($TRUE, 'Authentication successful.');
     }
     return ($FALSE, 'Invalid email address provided.');
 }

--- a/lib/pf/Authentication/Source/RADIUSSource.pm
+++ b/lib/pf/Authentication/Source/RADIUSSource.pm
@@ -10,6 +10,7 @@ pf::Authentication::Source::RADIUSSource
 
 use pf::constants qw($TRUE $FALSE);
 use pf::Authentication::constants;
+use pf::constants::authentication::messages;
 
 use Authen::Radius;
 
@@ -52,16 +53,16 @@ sub authenticate {
      if ($radius->get_error() eq 'ENONE') {
 
        if ($result) {
-        return ($TRUE, 'Authentication successful.');
+        return ($TRUE, $AUTH_SUCCESS_MSG);
       } else {
-        return ($FALSE, 'Invalid login or password');
+        return ($FALSE, $AUTH_FAIL_MSG);
        }
      }
    }
 
    $logger->error("Unable to perform RADIUS authentication on any server: " . Authen::Radius::get_error() );
 
-   return ($FALSE, 'Unable to authenticate successfully using RADIUS.');
+   return ($FALSE, $COMMUNICATION_ERROR_MSG);
  }
 
 =head2 match_in_subclass

--- a/lib/pf/Authentication/Source/RADIUSSource.pm
+++ b/lib/pf/Authentication/Source/RADIUSSource.pm
@@ -52,7 +52,7 @@ sub authenticate {
      if ($radius->get_error() eq 'ENONE') {
 
        if ($result) {
-        return ($TRUE, 'Successful authentication using RADIUS.');
+        return ($TRUE, 'Authentication successful.');
       } else {
         return ($FALSE, 'Invalid login or password');
        }

--- a/lib/pf/Authentication/Source/SQLSource.pm
+++ b/lib/pf/Authentication/Source/SQLSource.pm
@@ -11,6 +11,7 @@ pf::Authentication::Source::SQLSource
 use pf::constants qw($TRUE $FALSE);
 use pf::password;
 use pf::Authentication::constants;
+use pf::constants::authentication::messages;
 use pf::Authentication::Action;
 use pf::Authentication::Source;
 
@@ -44,10 +45,10 @@ sub authenticate {
    my $result = pf::password::validate_password($username, $password);
 
    if ($result == $pf::password::AUTH_SUCCESS) {
-     return ($TRUE, 'Authentication successful.');
+     return ($TRUE, $AUTH_SUCCESS_MSG);
    }
 
-   return ($FALSE, 'Invalid login or password');
+   return ($FALSE, $AUTH_FAIL_MSG);
  }
 
 =head2 match

--- a/lib/pf/Authentication/Source/SQLSource.pm
+++ b/lib/pf/Authentication/Source/SQLSource.pm
@@ -44,10 +44,10 @@ sub authenticate {
    my $result = pf::password::validate_password($username, $password);
 
    if ($result == $pf::password::AUTH_SUCCESS) {
-     return ($TRUE, 'Successful authentication using SQL');
+     return ($TRUE, 'Authentication successful.');
    }
 
-   return ($FALSE, 'Unable to authenticate successfully using SQL.');
+   return ($FALSE, 'Invalid login or password');
  }
 
 =head2 match

--- a/lib/pf/authentication.pm
+++ b/lib/pf/authentication.pm
@@ -244,7 +244,7 @@ sub authenticate {
 
     my $message;
     foreach my $current_source (@sources) {
-        my ($result, $message);
+        my $result;
         $logger->trace("Trying to authenticate '$username' with source '".$current_source->id."'");
         eval {
             ($result, $message) = $current_source->authenticate($username, $password);

--- a/lib/pf/authentication.pm
+++ b/lib/pf/authentication.pm
@@ -257,7 +257,7 @@ sub authenticate {
     }
 
     $logger->trace("Authentication failed for '$display_username' for all ".scalar(@sources)." sources");
-    return ($FALSE, $message ? $message : 'Wrong username or password.');
+    return ($FALSE, $message ? $message : $AUTH_FAIL_MSG);
 }
 
 =item match

--- a/lib/pf/authentication.pm
+++ b/lib/pf/authentication.pm
@@ -242,6 +242,7 @@ sub authenticate {
 
     $logger->debug(sub {"Authenticating '$username' from source(s) " . join( ', ', map { $_->id } @sources ) });
 
+    my $message;
     foreach my $current_source (@sources) {
         my ($result, $message);
         $logger->trace("Trying to authenticate '$username' with source '".$current_source->id."'");
@@ -255,8 +256,8 @@ sub authenticate {
         }
     }
 
-    $logger->trace("Authentication failed for '$username' for all ".scalar(@sources)." sources");
-    return ($FALSE, 'Wrong username or password.');
+    $logger->trace("Authentication failed for '$display_username' for all ".scalar(@sources)." sources");
+    return ($FALSE, $message ? $message : 'Wrong username or password.');
 }
 
 =item match

--- a/lib/pf/authentication.pm
+++ b/lib/pf/authentication.pm
@@ -256,7 +256,7 @@ sub authenticate {
         }
     }
 
-    $logger->trace("Authentication failed for '$display_username' for all ".scalar(@sources)." sources");
+    $logger->trace("Authentication failed for '$username' for all ".scalar(@sources)." sources");
     return ($FALSE, $message ? $message : $AUTH_FAIL_MSG);
 }
 

--- a/lib/pf/constants/authentication.pm
+++ b/lib/pf/constants/authentication.pm
@@ -25,6 +25,8 @@ our @SOURCES = __PACKAGE__->sources();
 
 our %TYPE_TO_SOURCE = map { lc($_->meta->get_attribute('type')->default) => $_ } @SOURCES;
 
+
+
 =head1 AUTHOR
 
 Inverse inc. <info@inverse.ca>

--- a/lib/pf/constants/authentication.pm
+++ b/lib/pf/constants/authentication.pm
@@ -26,6 +26,15 @@ our @SOURCES = __PACKAGE__->sources();
 our %TYPE_TO_SOURCE = map { lc($_->meta->get_attribute('type')->default) => $_ } @SOURCES;
 
 
+=head2 Messages
+
+Replies for authentication success/error
+
+=cut
+
+Readonly our $INVALID_CREDENTIALS => ;
+Readonly our $AUTH_SUCESS
+
 
 =head1 AUTHOR
 

--- a/lib/pf/constants/authentication/messages.pm
+++ b/lib/pf/constants/authentication/messages.pm
@@ -1,29 +1,29 @@
-package pf::constants::authentication;
+package pf::constants::authentication::messages;
 
 =head1 NAME
 
-pf::constants::authentication - constants for authentication object
+pf::constants::authentication::messages - constants for authentication object result messages
 
 =cut
 
 =head1 DESCRIPTION
 
-pf::constants::authentication
+pf::constants::authentication::messages
 
 =cut
 
 use strict;
 use warnings;
+use Readonly;
+use base qw(Exporter);
+our @EXPORT = qw(
+  $COMMUNICATION_ERROR_MSG $AUTH_FAIL_MSG $AUTH_SUCCESS_MSG $INVALID_EMAIL_MSG
+);
 
-use Module::Pluggable
-  'search_path' => [qw(pf::Authentication::Source)],
-  'sub_name'    => 'sources',
-  'require'     => 1,
-  ;
-
-our @SOURCES = __PACKAGE__->sources();
-
-our %TYPE_TO_SOURCE = map { lc($_->meta->get_attribute('type')->default) => $_ } @SOURCES;
+Readonly our $COMMUNICATION_ERROR_MSG => 'Unable to validate credentials at the moment';
+Readonly our $AUTH_FAIL_MSG => 'Invalid login or password';
+Readonly our $AUTH_SUCCESS_MSG => 'Authentication successful.';
+Readonly our $INVALID_EMAIL_MSG => 'Invalid e-mail address';
 
 =head1 AUTHOR
 


### PR DESCRIPTION
# Description

Return the error message from the auth source instead of a generic 'wrong username/password' if the source provides one
# Impacts

login on the portal
# Delete branch after merge

YES
# NEWS file entries
## Enhancements
- Allow precise error messages from the authentication source when providing invalid credentials on the captive portal
