### PR TITLE
Feature/auth routing

### DIFF
--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Authenticate.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Authenticate.pm
@@ -507,7 +507,7 @@ sub authenticationLogin : Private {
 
     my $username = _clean_username($request->param("username"));
     my $realm;
-    ($username, $realm) = $self->strip_username($c,$username);
+    ($username, $realm) = strip_username($c,$username);
     my $password = $request->param("password");
 
     my @sources = $self->getSources($c, $username, $realm);
@@ -543,16 +543,6 @@ sub authenticationLogin : Private {
             $c->error($message);
         }
     }
-}
-
-sub strip_username {
-    my ($self,$c,$username) = @_;
-    if($username && $username =~ /(.*)@(.*)/){
-        #(username, realm)
-        $c->log->info("Found username containing a realm ($username). Stripped username : $1, Realm : $2.");
-        return ($1, $2);
-    }
-    return ($username);
 }
 
 =head2 getSources

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Authenticate.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Authenticate.pm
@@ -591,8 +591,10 @@ sub getSources : Private {
         $c->log->info("Realm source is part of the portal profile sources. Using it as the only auth source.");
         return ($realm_source);
     }
-
-    return @sources;
+    else {
+        $c->log->info("Realm source ".$realm_source->id." is configured in the realm $realm but is not in the portal profile. Ignoring it and using the portal profile sources.");
+        return @sources;
+    }
 }
 
 sub showLogin : Private {

--- a/html/pfappserver/lib/pfappserver/Form/Config/Realm.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Realm.pm
@@ -15,9 +15,11 @@ extends 'pfappserver::Base::Form';
 with 'pfappserver::Base::Form::Role::Help';
 
 use pf::config;
+use pf::authentication;
 use pf::util;
 
 has domains => ( is => 'rw');
+has sources => ( is => 'rw');
 
 ## Definition
 has_field 'id' =>
@@ -50,6 +52,20 @@ has_field 'domain' =>
              help => 'The domain to use for the authentication in that realm' },
   );
 
+has_field 'source' =>
+  (
+   type => 'Select',
+   multiple => 0,
+   label => 'Source',
+   options_method => \&options_sources,
+   element_class => ['chzn-deselect'],
+   element_attr => {'data-placeholder' => 'Click to select a source'},
+   tags => { after_element => \&help,
+             help => 'The authentication source to use in that realm.<br/>(Must also be defined in the portal profile)' },
+  );
+
+
+
 =head2 options_roles
 
 =cut
@@ -58,6 +74,17 @@ sub options_domains {
     my $self = shift;
     my @domains = map { $_->{id} => $_->{id} } @{$self->form->domains} if ($self->form->domains);
     return @domains;
+}
+
+=head2 options_sources
+
+=cut
+
+sub options_sources {
+    my $self = shift;
+    my @sources = map { $_->id => $_->id } @{$self->form->sources} if ($self->form->sources);
+    unshift @sources, ("" => "");
+    return @sources;
 }
 
 =head2 ACCEPT_CONTEXT
@@ -69,7 +96,7 @@ To automatically add the context to the Form
 sub ACCEPT_CONTEXT {
     my ($self, $c, @args) = @_;
     my (undef, $domains) = $c->model('Config::Domain')->readAll();
-    return $self->SUPER::ACCEPT_CONTEXT($c, domains => $domains, @args);
+    return $self->SUPER::ACCEPT_CONTEXT($c, domains => $domains, sources => pf::authentication::getInternalAuthenticationSources(), @args);
 }
 
 

--- a/html/pfappserver/root/config/realm/index.tt
+++ b/html/pfappserver/root/config/realm/index.tt
@@ -16,7 +16,7 @@
       </div>
 
       <h2>[% l('Realm')  %]</h2>
-      <h4 class="alert alert-warning">Any change to the realms requires a restart of the radiusd service.</h4>
+      <h4 class="alert alert-warning">Adding or removing a realm requires to restart the radiusd service to be effective.</h4>
 
       [% INCLUDE config/realm/list.tt %]
 

--- a/html/pfappserver/root/config/realm/view.tt
+++ b/html/pfappserver/root/config/realm/view.tt
@@ -12,6 +12,7 @@
         [% form.field('id').render | none UNLESS item.id %]
         [% form.field('options').render | none %]
         [% form.field('domain').render | none %]
+        [% form.field('source').render | none %]
   </div><!--modal-body-->
 
   <div class="modal-footer">

--- a/lib/pf/api.pm
+++ b/lib/pf/api.pm
@@ -884,7 +884,8 @@ sub dynamic_register_node : Public {
     my $logger = pf::log::get_logger();
     my $profile = pf::Portal::ProfileFactory->instantiate($postdata{'mac'});
     my $node_info = pf::node::node_view($postdata{'mac'});
-    my @sources = ($profile->getInternalSources, $profile->getExclusiveSources );
+    # We try this although the realm is not mandatory in case it proves to be useful in the future
+    my @sources = get_user_sources($profile, $postdata{'username'}, $postdata{'realm'}); 
     my $stripped_user = '';
 
     my $params = {

--- a/lib/pf/config/util.pm
+++ b/lib/pf/config/util.pm
@@ -29,7 +29,7 @@ use Net::SMTP;
 use POSIX();
 use File::Spec::Functions;
 use File::Slurp qw(read_dir);
-use List::MoreUtils qw(all);
+use List::MoreUtils qw(all any);
 use Try::Tiny;
 use pf::file_paths;
 use pf::util;
@@ -393,11 +393,14 @@ sub get_user_sources {
     my @sources = ($profile->getInternalSources, $profile->getExclusiveSources );
 
     if( $realm_source && any { $_ eq $realm_source} @sources ){
-        get_logger->info("Realm source is part of the portal profile sources. Using it as the only auth source.");
+        get_logger->info("Realm source ".$realm_source->id." is part of the portal profile sources. Using it as the only auth source.");
         return ($realm_source);
     }
+    else {
+        get_logger->info("Realm source ".$realm_source->id." is configured in the realm $realm but is not in the portal profile. Ignoring it and using the portal profile sources.");
+        return @sources;
+    }
 
-    return @sources;
 
 }
 

--- a/lib/pf/config/util.pm
+++ b/lib/pf/config/util.pm
@@ -379,6 +379,13 @@ sub portal_hosts {
     return @hosts;
 }
 
+=head2 get_realm_source
+
+Get a source for a specific username and realm
+Will look it up in the realm configuration
+
+=cut
+
 sub get_realm_source {
     my ($username, $realm) = @_;
 
@@ -402,6 +409,12 @@ sub get_realm_source {
     return $realm_source;
 
 }
+
+=head2 get_user_sources
+
+Get internal and external sources for a username and realm
+
+=cut
 
 sub get_user_sources {
     my ($profile, $username, $realm) = @_;

--- a/lib/pf/config/util.pm
+++ b/lib/pf/config/util.pm
@@ -412,7 +412,7 @@ sub get_realm_source {
 
 =head2 get_user_sources
 
-Get internal and external sources for a username and realm
+Get internal and exclusive sources for a username and realm
 
 =cut
 

--- a/lib/pf/config/util.pm
+++ b/lib/pf/config/util.pm
@@ -51,6 +51,7 @@ BEGIN {
     get_translatable_time trappable_mac
     portal_hosts
     get_user_sources
+    get_realm_source
   );
 }
 
@@ -378,9 +379,11 @@ sub portal_hosts {
     return @hosts;
 }
 
+sub get_realm_source {
+    my ($username, $realm) = @_;
 
-sub get_user_sources {
-    my ($profile, $username, $realm) = @_;
+    $realm = "null" unless(defined($realm));
+    $realm = lc $realm;
 
     my $realm_source;
     if(exists $ConfigRealm{$realm}){
@@ -389,6 +392,21 @@ sub get_user_sources {
             $realm_source = pf::authentication::getAuthenticationSource($source);
         }
     }
+    elsif(exists $ConfigRealm{default} && $realm ne "null"){
+        if(my $source = $ConfigRealm{default}{source}){
+            get_logger->info("Found auth source $source for realm $realm through the default configuration.");
+            $realm_source = pf::authentication::getAuthenticationSource($source);
+        }
+    }
+
+    return $realm_source;
+
+}
+
+sub get_user_sources {
+    my ($profile, $username, $realm) = @_;
+
+    my $realm_source = get_realm_source($username, $realm);
 
     my @sources = ($profile->getInternalSources, $profile->getExclusiveSources );
 

--- a/lib/pf/role.pm
+++ b/lib/pf/role.pm
@@ -452,7 +452,7 @@ sub getRegisteredRole {
             $logger->info("Role has already been computed and we don't want to recompute it. Getting role from node_info" );
             $role = $args->{'node_info'}->{'category'};
         } else {
-            my @sources = ($profile->getInternalSources, $profile->getExclusiveSources );
+            my @sources = get_user_sources($profile, $stripped_user_name, $realm); 
             my $stripped_user = '';
             $stripped_user = $args->{'stripped_user_name'} if(defined($args->{'stripped_user_name'}));
             my $params = {
@@ -598,7 +598,7 @@ sub getNodeInfoForAutoReg {
     # under 802.1X EAP, we trust the username provided since it authenticated
     if (defined($args->{'connection_type'}) && (($args->{'connection_type'} & $EAP) == $EAP) && defined($args->{'user_name'})) {
         $logger->debug("EAP connection with a username \"$args->{'user_name'}\". Trying to match rules from authentication sources.");
-        my @sources = ($profile->getInternalSources, $profile->getExclusiveSources );
+        my @sources = get_user_sources($profile, $stripped_user_name, $realm); 
         my $stripped_user = '';
         $stripped_user = $args->{'stripped_user_name'} if(defined($args->{'stripped_user_name'}));
         my $params = {

--- a/lib/pf/role.pm
+++ b/lib/pf/role.pm
@@ -452,7 +452,7 @@ sub getRegisteredRole {
             $logger->info("Role has already been computed and we don't want to recompute it. Getting role from node_info" );
             $role = $args->{'node_info'}->{'category'};
         } else {
-            my @sources = get_user_sources($profile, $stripped_user_name, $realm); 
+            my @sources = get_user_sources($profile, $args->{'stripped_user_name'}, $args->{'realm'}); 
             my $stripped_user = '';
             $stripped_user = $args->{'stripped_user_name'} if(defined($args->{'stripped_user_name'}));
             my $params = {
@@ -598,7 +598,7 @@ sub getNodeInfoForAutoReg {
     # under 802.1X EAP, we trust the username provided since it authenticated
     if (defined($args->{'connection_type'}) && (($args->{'connection_type'} & $EAP) == $EAP) && defined($args->{'user_name'})) {
         $logger->debug("EAP connection with a username \"$args->{'user_name'}\". Trying to match rules from authentication sources.");
-        my @sources = get_user_sources($profile, $stripped_user_name, $realm); 
+        my @sources = get_user_sources($profile, $args->{'stripped_user_name'}, $args->{'realm'}); 
         my $stripped_user = '';
         $stripped_user = $args->{'stripped_user_name'} if(defined($args->{'stripped_user_name'}));
         my $params = {


### PR DESCRIPTION
# Description

Realm based authentication routing
Depending on the realm defined in the portal (using user@realm) or in the 802.1x connection, the source defined in the realm will be used instead of going though all the sources of the portal profile.
# Impacts

802.1x authentication, portal authentication
# Delete branch after merge

YES
# NEWS file entries
## New Features
- Allowed to specify the authentication source to use depending on the realm
