### PR TITLE
add warning when user misconfigures configurator networks

### DIFF
--- a/html/pfappserver/lib/pfappserver/Model/Interface.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Interface.pm
@@ -746,6 +746,25 @@ sub getEnforcement {
     return $enforcement;
 }
 
+sub sort_interfaces_by_network {
+    my ($self, $interfaces) = @_;
+    my $seen_networks = {};
+    while(my ($int, $cfg) = each %$interfaces){
+        my $network = $cfg->{network};
+        next unless($network);
+        if(exists $seen_networks->{$network}){
+            push @{$seen_networks->{$network}}, $int;
+        }
+        else {
+            $seen_networks->{$network} = [$int];
+        }
+    }
+
+    return $seen_networks;
+}
+
+
+
 =head1 COPYRIGHT
 
 Copyright (C) 2005-2015 Inverse inc.

--- a/html/pfappserver/lib/pfappserver/Model/Interface.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Interface.pm
@@ -746,13 +746,13 @@ sub getEnforcement {
     return $enforcement;
 }
 
-=head2 sort_interfaces_by_network
+=head2 map_interface_to_networks
 
 Will create a hash that maps which interfaces are tied to which network
 
 =cut
 
-sub sort_interfaces_by_network {
+sub map_interface_to_networks {
     my ($self, $interfaces) = @_;
     my $seen_networks = {};
     while(my ($int, $cfg) = each %$interfaces){

--- a/html/pfappserver/lib/pfappserver/Model/Interface.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Interface.pm
@@ -746,6 +746,12 @@ sub getEnforcement {
     return $enforcement;
 }
 
+=head2 sort_interfaces_by_network
+
+Will create a hash that maps which interfaces are tied to which network
+
+=cut
+
 sub sort_interfaces_by_network {
     my ($self, $interfaces) = @_;
     my $seen_networks = {};

--- a/html/pfappserver/lib/pfappserver/PacketFence/Controller/Configurator.pm
+++ b/html/pfappserver/lib/pfappserver/PacketFence/Controller/Configurator.pm
@@ -242,7 +242,8 @@ sub networks :Chained('object') :PathPart('networks') :Args(0) {
         $c->session->{gateway} = $c->model('Config::System')->getDefaultGateway if (!defined($c->session->{gateway}));
 
         my $interfaces_ref = $c->model('Interface')->get('all');
-        $c->stash(interfaces => $interfaces_ref);
+        $c->stash->{interfaces} = $interfaces_ref;
+        $c->stash->{seen_networks} = $c->model('Interface')->sort_interfaces_by_network($c->stash->{interfaces});
     }
 }
 

--- a/html/pfappserver/lib/pfappserver/PacketFence/Controller/Configurator.pm
+++ b/html/pfappserver/lib/pfappserver/PacketFence/Controller/Configurator.pm
@@ -243,7 +243,7 @@ sub networks :Chained('object') :PathPart('networks') :Args(0) {
 
         my $interfaces_ref = $c->model('Interface')->get('all');
         $c->stash->{interfaces} = $interfaces_ref;
-        $c->stash->{seen_networks} = $c->model('Interface')->sort_interfaces_by_network($c->stash->{interfaces});
+        $c->stash->{seen_networks} = $c->model('Interface')->map_interface_to_networks($c->stash->{interfaces});
     }
 }
 

--- a/html/pfappserver/lib/pfappserver/PacketFence/Controller/Interface.pm
+++ b/html/pfappserver/lib/pfappserver/PacketFence/Controller/Interface.pm
@@ -78,7 +78,7 @@ sub list :Local :Args(0) :AdminRole('INTERFACES_READ') {
 
     $c->stash->{interfaces} = $c->model('Interface')->get('all');
 
-    $c->stash->{seen_networks} = $c->model('Interface')->sort_interfaces_by_network($c->stash->{interfaces});
+    $c->stash->{seen_networks} = $c->model('Interface')->map_interface_to_networks($c->stash->{interfaces});
 
 }
 

--- a/html/pfappserver/lib/pfappserver/PacketFence/Controller/Interface.pm
+++ b/html/pfappserver/lib/pfappserver/PacketFence/Controller/Interface.pm
@@ -77,6 +77,9 @@ sub list :Local :Args(0) :AdminRole('INTERFACES_READ') {
     my ( $self, $c ) = @_;
 
     $c->stash->{interfaces} = $c->model('Interface')->get('all');
+
+    $c->stash->{seen_networks} = $c->model('Interface')->sort_interfaces_by_network($c->stash->{interfaces});
+
 }
 
 

--- a/html/pfappserver/root/interface/list.tt
+++ b/html/pfappserver/root/interface/list.tt
@@ -1,3 +1,5 @@
+
+
       <div class="modal fade hide" id="modalEditInterface"></div>
       <form id="interfaces" name="interfaces" class="form">
         <table class="table">
@@ -12,6 +14,19 @@
             </tr>
           </thead>
           <tbody>
+
+          [% FOREACH network IN seen_networks.keys %]
+            [% IF seen_networks.$network.size > 1 %]
+              <tr>
+                <td colspan="6" class="alert alert-warning">
+                  WARNING : You have configured multiple interfaces ([% seen_networks.$network.join(", ") %]) in the same network. Their type was changed to be the same. <br/>
+                  Note that registration, isolation and management networks have to be in three distinct networks.
+                </td>
+              </tr>
+            [% END %]
+          [% END %]
+
+
            [% FOREACH i IN interfaces.keys.sort %]
             <tr>
               <td><div class="switch switch-mini"><input type="checkbox" id="[% i | html %]" name="[% i | html %]"[% IF interfaces.$i.is_running %] checked="checked"[% END %]/></div></td>


### PR DESCRIPTION
# Description

Warn the user when he is configuring multiple interfaces in the same network in the configurator as it seems to be a recurring issue
# Impacts

Less 'chair/keyboard' github issues and mailing list posts
# Issue

fixes #844 
# Delete branch after merge

YES
# NEWS file entries
## Enhancements
- Added a warning in the configurator when the user is configuring multiple interfaces in the same network
