### PR TITLE
Fix/851 omapi config is bogus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ conf/ssl/server.crt:
 	-nodes -config /usr/local/pf/conf/openssl.cnf
 
 conf/pf_omapi_key:
-	echo $$(date) $$HOSTNAME | base64 > /usr/local/pf/conf/pf_omapi_key
+	/usr/bin/openssl rand -base64 -out /usr/local/pf/conf/pf_omapi_key 32
 
 bin/pfcmd: src/pfcmd.c
 	$(CC) -O2 -g -std=c99  -Wall $< -o $@

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,9 @@ conf/ssl/server.crt:
 	-keyout /usr/local/pf/conf/ssl/server.key \
 	-nodes -config /usr/local/pf/conf/openssl.cnf
 
+conf/pf_omapi_key:
+	echo $$(date) $$HOSTNAME | base64 > /usr/local/pf/conf/pf_omapi_key
+
 bin/pfcmd: src/pfcmd.c
 	$(CC) -O2 -g -std=c99  -Wall $< -o $@
 
@@ -137,4 +140,4 @@ fingerbank:
 	rm -f /usr/local/pf/lib/fingerbank
 	ln -s /usr/local/fingerbank/lib/fingerbank /usr/local/pf/lib/fingerbank \
 
-devel: configurations conf/ssl/server.crt bin/pfcmd raddb/certs/dh sudo lib/pf/pfcmd/pfcmd_pregrammar.pm translation mysql-schema raddb/sites-enabled fingerbank chown_pf permissions
+devel: configurations conf/ssl/server.crt conf/pf_omapi_key bin/pfcmd raddb/certs/dh sudo lib/pf/pfcmd/pfcmd_pregrammar.pm translation mysql-schema raddb/sites-enabled fingerbank chown_pf permissions

--- a/addons/packages/packetfence.spec
+++ b/addons/packages/packetfence.spec
@@ -585,7 +585,7 @@ fi
 
 # Create OMAPI key
 if [ ! -f /usr/local/pf/conf/pf_omapi_key ]; then
-    echo $(date) $HOSTNAME | base64 > /usr/local/pf/conf/pf_omapi_key
+    /usr/bin/openssl rand -base64 -out /usr/local/pf/conf/pf_omapi_key 32
 fi
 
 for service in snortd httpd snmptrapd memcached portreserve

--- a/addons/packages/packetfence.spec
+++ b/addons/packages/packetfence.spec
@@ -583,6 +583,10 @@ if [ ! -f /usr/local/pf/conf/ssl/server.crt ]; then
     cat /usr/local/pf/conf/ssl/server.crt /usr/local/pf/conf/ssl/server.key > /usr/local/pf/conf/ssl/server.pem
 fi
 
+# Create OMAPI key
+if [ ! -f /usr/local/pf/conf/pf_omapi_key ]; then
+    echo $(date) $HOSTNAME | base64 > /usr/local/pf/conf/pf_omapi_key
+fi
 
 for service in snortd httpd snmptrapd memcached portreserve
 do

--- a/debian/packetfence.postinst
+++ b/debian/packetfence.postinst
@@ -81,7 +81,7 @@ case "$1" in
 
         # Create OMAPI key
         if [ ! -f /usr/local/pf/conf/pf_omapi_key ]; then
-            echo $(date) $HOSTNAME | base64 > /usr/local/pf/conf/pf_omapi_key
+            /usr/bin/openssl rand -base64 -out /usr/local/pf/conf/pf_omapi_key 32
         fi
 
 	if [ ! -f /usr/local/pf/raddb/certs/dh ]; then

--- a/debian/packetfence.postinst
+++ b/debian/packetfence.postinst
@@ -79,6 +79,11 @@ case "$1" in
             cat /usr/local/pf/conf/ssl/server.crt /usr/local/pf/conf/ssl/server.key > /usr/local/pf/conf/ssl/server.pem
         fi
 
+        # Create OMAPI key
+        if [ ! -f /usr/local/pf/conf/pf_omapi_key ]; then
+            echo $(date) $HOSTNAME | base64 > /usr/local/pf/conf/pf_omapi_key
+        fi
+
 	if [ ! -f /usr/local/pf/raddb/certs/dh ]; then
 	    echo "Building default RADIUS certificates..."
 	    cd /usr/local/pf/raddb/certs

--- a/lib/pf/config.pm
+++ b/lib/pf/config.pm
@@ -830,6 +830,23 @@ sub is_omapi_enabled {
     return $FALSE;
 }
 
+=item is_omapi_configured
+
+Check if required OMAPI configuration parameters (omapi.key_name & omapi.key_base64) are present before configuring it
+
+=cut
+
+sub is_omapi_configured {
+    return $FALSE unless is_omapi_enabled;
+
+    if ( ($Config{'omapi'}{'key_name'} && $Config{'omapi'}{'key_name'} ne '') && ($Config{'omapi'}{'key_base64'} && $Config{'omapi'}{'key_base64'} ne '') ) {
+        return $TRUE;
+    }
+
+    $logger->warn("OMAPI is enabled but missing required configuration parameters 'key_name' and/or 'key_base64'");
+    return $FALSE;
+}
+
 =item configreload
 
 Reload the config

--- a/lib/pf/config.pm
+++ b/lib/pf/config.pm
@@ -837,13 +837,13 @@ Check if required OMAPI configuration parameters (omapi.key_name & omapi.key_bas
 =cut
 
 sub is_omapi_configured {
-    return $FALSE unless is_omapi_enabled;
+    return $FALSE unless $Config{'omapi'}{'host'} eq "localhost";
 
     if ( ($Config{'omapi'}{'key_name'} && $Config{'omapi'}{'key_name'} ne '') && ($Config{'omapi'}{'key_base64'} && $Config{'omapi'}{'key_base64'} ne '') ) {
         return $TRUE;
     }
 
-    $logger->warn("OMAPI is enabled but missing required configuration parameters 'key_name' and/or 'key_base64'");
+    $logger->warn("OMAPI lookup is locally enabled but missing required configuration parameters 'key_name' and/or 'key_base64'");
     return $FALSE;
 }
 

--- a/lib/pf/config.pm
+++ b/lib/pf/config.pm
@@ -816,13 +816,13 @@ sub is_in_list {
     return $FALSE;
 }
 
-=item is_omapi_enabled
+=item is_omapi_lookup_enabled
 
 Check whether pf::iplog::ip2mac or pf::iplog::mac2ip are configured to use OMAPI based on configuration parameters.
 
 =cut
 
-sub is_omapi_enabled {
+sub is_omapi_lookup_enabled {
     if ( isenabled($Config{'omapi'}{'ip2mac_lookup'}) || isenabled($Config{'omapi'}{'mac2ip_lookup'}) ) {
         return $TRUE;
     }

--- a/lib/pf/iplog.pm
+++ b/lib/pf/iplog.pm
@@ -676,7 +676,7 @@ return undef if omapi is disabled
 
 sub _get_omapi_client {
     my ($self) = @_;
-    return unless pf::config::is_omapi_enabled;
+    return unless pf::config::is_omapi_lookup_enabled;
 
     return pf::OMAPI->new( $Config{omapi} );
 }

--- a/lib/pf/pfcmd/checkup.pm
+++ b/lib/pf/pfcmd/checkup.pm
@@ -124,6 +124,7 @@ sub sanity_check {
     billing() if ( isenabled($Config{'registration'}{'billing_engine'}) );
 
     database();
+    omapi();
     network();
     fingerbank();
     inline() if (is_inline_enforcement_enabled());
@@ -363,6 +364,18 @@ sub scan_openvas {
     if ( !$Config{'scan'}{'openvas_reportformatid'} ) {
         add_problem( $WARN, "SCAN: The use of OpenVas as a scanning engine require to fill the " .
                 "scan.openvas_reportformatid field in pf.conf");
+    }
+}
+
+=item omapi
+
+Validation related to the OMAPI configuration
+
+=cut
+
+sub omapi {
+    if ( pf::config::is_omapi_enabled && !pf::config::is_omapi_configured ) {
+        add_problem( $WARN, "OMAPI is enabled but missing required configuration parameters 'key_name' and/or 'key_base64'" );
     }
 }
 

--- a/lib/pf/pfcmd/checkup.pm
+++ b/lib/pf/pfcmd/checkup.pm
@@ -374,7 +374,7 @@ Validation related to the OMAPI configuration
 =cut
 
 sub omapi {
-    if ( pf::config::is_omapi_enabled && !pf::config::is_omapi_configured ) {
+    if ( pf::config::is_omapi_lookup_enabled && !pf::config::is_omapi_configured ) {
         add_problem( $WARN, "OMAPI is enabled but missing required configuration parameters 'key_name' and/or 'key_base64'" );
     }
 }

--- a/lib/pf/pfcmd/checkup.pm
+++ b/lib/pf/pfcmd/checkup.pm
@@ -374,8 +374,8 @@ Validation related to the OMAPI configuration
 =cut
 
 sub omapi {
-    if ( pf::config::is_omapi_lookup_enabled && !pf::config::is_omapi_configured ) {
-        add_problem( $WARN, "OMAPI is enabled but missing required configuration parameters 'key_name' and/or 'key_base64'" );
+    if ( (pf::config::is_omapi_lookup_enabled) && ($Config{'omapi'}{'host'} eq "localhost") && (!pf::config::is_omapi_configured) ) {
+        add_problem( $WARN, "OMAPI lookup is locally enabled but missing required configuration parameters 'key_name' and/or 'key_base64'" );
     }
 }
 

--- a/lib/pf/services/manager/dhcpd.pm
+++ b/lib/pf/services/manager/dhcpd.pm
@@ -180,7 +180,7 @@ Generate the omapi section if it is defined
 
 sub omapi_section {
     my $omapi_section = $Config{omapi};
-    return '"# OMAPI is not enabled on this server' unless pf::config::is_omapi_enabled;
+    return '# OMAPI is not enabled on this server' unless pf::config::is_omapi_enabled;
     my $section = "omapi-port $omapi_section->{port};\n";
     my $keyname = $omapi_section->{key_name};
     my $key_base64 = $omapi_section->{key_base64};

--- a/lib/pf/services/manager/dhcpd.pm
+++ b/lib/pf/services/manager/dhcpd.pm
@@ -179,14 +179,12 @@ Generate the omapi section if it is defined
 =cut
 
 sub omapi_section {
-    my $omapi_section = $Config{omapi};
-
     return '# OMAPI is not enabled on this server' unless pf::config::is_omapi_enabled;
     return '# OMAPI is enabled on this server but no key configured' unless pf::config::is_omapi_configured;
 
-    my $port        = $omapi_section->{port};
-    my $key_name    = $omapi_section->{key_name};
-    my $key_base64  = $omapi_section->{key_base64};
+    my $port        = $Config{'omapi'}{'port'};
+    my $key_name    = $Config{'omapi'}{'key_name'};
+    my $key_base64  = $Config{'omapi'}{'key_base64'};
 
     my $section = <<EOT;
 # OMAPI for IP <-> MAC lookup

--- a/lib/pf/services/manager/dhcpd.pm
+++ b/lib/pf/services/manager/dhcpd.pm
@@ -180,19 +180,23 @@ Generate the omapi section if it is defined
 
 sub omapi_section {
     my $omapi_section = $Config{omapi};
+
     return '# OMAPI is not enabled on this server' unless pf::config::is_omapi_enabled;
-    my $section = "omapi-port $omapi_section->{port};\n";
-    my $keyname = $omapi_section->{key_name};
-    my $key_base64 = $omapi_section->{key_base64};
-    if ( $keyname && $key_base64 ) {
-        $section .=<<EOT;
-key $keyname {
-        algorithm HMAC-MD5;
-        secret "$key_base64";
+    return '# OMAPI is enabled on this server but no key configured' unless pf::config::is_omapi_configured;
+
+    my $port        = $omapi_section->{port};
+    my $key_name    = $omapi_section->{key_name};
+    my $key_base64  = $omapi_section->{key_base64};
+
+    my $section = <<EOT;
+# OMAPI for IP <-> MAC lookup
+omapi-port $port;
+key $key_name {
+    algorithm HMAC-MD5;
+    secret "$key_base64";
 };
-omapi-key $keyname;
+omapi-key $key_name;
 EOT
-    }
 
     return $section;
 }

--- a/lib/pf/services/manager/dhcpd.pm
+++ b/lib/pf/services/manager/dhcpd.pm
@@ -179,8 +179,8 @@ Generate the omapi section if it is defined
 =cut
 
 sub omapi_section {
-    return '# OMAPI is not enabled on this server' unless pf::config::is_omapi_enabled;
-    return '# OMAPI is enabled on this server but no key configured' unless pf::config::is_omapi_configured;
+    return '# OMAPI is not enabled on this server' unless $Config{'omapi'}{'host'} eq "localhost";
+    return '# OMAPI is enabled on this server but missing configuration parameter(s)' unless pf::config::is_omapi_configured;
 
     my $port        = $Config{'omapi'}{'port'};
     my $key_name    = $Config{'omapi'}{'key_name'};

--- a/lib/pfconfig/namespaces/config/Pf.pm
+++ b/lib/pfconfig/namespaces/config/Pf.pm
@@ -126,6 +126,13 @@ sub build_child {
     $Config{network}{dhcp_filter_by_message_types}
         = [ split( /\s*,\s*/, $Config{network}{dhcp_filter_by_message_types} || '' ) ];
 
+    # Fetch default OMAPI key_base64 (conf/pf_omapi_key file) if none is provided
+    if ( $Config{omapi}{key_base64} eq '' ) {
+        open FILE, "<" . $conf_dir . "/pf_omapi_key";
+        $Config{omapi}{key_base64} = do { local $/; <FILE> };
+        $Config{omapi}{key_base64}=~ s/\R//g;
+    }
+
     return \%Config;
 
 }


### PR DESCRIPTION
# Description

Do not configure OMAPI dhcpd side if no key is provided, even if the feature is enabled
# Impacts

iplog (ip2mac, mac2ip)
# Issue

fixes #851 
# Delete branch after merge

YES
# NEWS file entries
## Enhancements
- Now generates default OMAPI key on install time
## Bug Fixes
- Issue with dhcpd side OMAPI configuration being unsecure (#851)
