### PR TITLE
Don't enter multi-domain unless it's configured

### DIFF
--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1103,6 +1103,14 @@ The cost factor to apply to the password hashing if applicable.
 Currently only applies to bcrypt.
 EOT
 
+[advanced.disable_pf_domain_auth] 
+type=toggle
+options=enabled|disabled
+description=<<EOT
+Disables authentification on the domains defined in PacketFence.
+This will make it so the authentication only happens on the domain binded to the OS.
+EOT
+
 [omapi.ip2mac_lookup]
 type=toggle
 options=enabled|disabled

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1107,8 +1107,7 @@ EOT
 type=toggle
 options=enabled|disabled
 description=<<EOT
-Disables authentification on the domains defined in PacketFence.
-This will make it so the authentication only happens on the domain binded to the OS.
+Disable Active-Directory domain configuration from within PacketFence
 EOT
 
 [omapi.ip2mac_lookup]

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -851,6 +851,12 @@ hash_passwords=bcrypt
 # The cost factor to apply to the password hashing if applicable.
 # Currently only applies to bcrypt.
 hashing_cost=8
+#
+# advanced.disable_pf_domain_auth
+#
+# Disables authentification on the domains defined in PacketFence
+# This will make it so the authentication only happens on the domain binded to the OS.
+disable_pf_domain_auth=disabled
 
 [omapi]
 #

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -854,8 +854,7 @@ hashing_cost=8
 #
 # advanced.disable_pf_domain_auth
 #
-# Disables authentification on the domains defined in PacketFence
-# This will make it so the authentication only happens on the domain binded to the OS.
+# Disable Active-Directory domain configuration from within PacketFence
 disable_pf_domain_auth=disabled
 
 [omapi]

--- a/conf/radiusd/packetfence-tunnel.example
+++ b/conf/radiusd/packetfence-tunnel.example
@@ -3,7 +3,7 @@ server packetfence-tunnel {
 authorize {	
         suffix
         ntdomain
-        packetfence-multi-domain
+        %%multi_domain%%
         eap {
                 ok = return
         }

--- a/conf/radiusd/packetfence.example
+++ b/conf/radiusd/packetfence.example
@@ -4,7 +4,6 @@ server packetfence {
         suffix
         ntdomain
         preprocess
-        packetfence-multi-domain
         eap {
             ok = return
         }

--- a/html/pfappserver/lib/pfappserver/I18N/en.po
+++ b/html/pfappserver/lib/pfappserver/I18N/en.po
@@ -3828,6 +3828,10 @@ msgid "advanced.hashing_cost"
 msgstr "Database passwords hashing cost factor" 
 
 # conf/documentation.conf
+msgid "advanced.disable_pf_domain_auth"
+msgstr "Disable 802.1x authentication on PF domains" 
+
+# conf/documentation.conf
 msgid "alerting"
 msgstr "Alerting"
 

--- a/html/pfappserver/root/config/domain/index.tt
+++ b/html/pfappserver/root/config/domain/index.tt
@@ -25,6 +25,9 @@
       [% ELSE %]
         <h2>[% l('Domain')  %]</h2>
         <h4 class="alert alert-warning">Make sure you configure IPv4 forwarding on your server before continuing. Refer to the PacketFence administration guide for details.</h4>
+        [% UNLESS items.size %]
+        <h4 class="alert alert-warning">After configuring your first domain, you will need to restart the radiusd service to activate domain authentication.</h4>
+        [% END %]
 
         [% INCLUDE config/domain/list.tt %]
 

--- a/lib/pf/services/manager/radiusd.pm
+++ b/lib/pf/services/manager/radiusd.pm
@@ -49,7 +49,10 @@ sub generate_radiusd_sitesconf {
     parse_template( \%tags, "$conf_dir/radiusd/packetfence", "$install_dir/raddb/sites-enabled/packetfence" );
 
 
-    if(keys %ConfigDomain){
+    if(isenabled($Config{advanced}{disable_pf_domain_auth})){
+        $tags{'multi_domain'} = '# packetfence-multi-domain not activated because explicitly disabled in pf.conf';
+    }
+    elsif(keys %ConfigDomain){
         $tags{'multi_domain'} = 'packetfence-multi-domain';
     }
     else {

--- a/lib/pf/services/manager/radiusd.pm
+++ b/lib/pf/services/manager/radiusd.pm
@@ -49,6 +49,12 @@ sub generate_radiusd_sitesconf {
     parse_template( \%tags, "$conf_dir/radiusd/packetfence", "$install_dir/raddb/sites-enabled/packetfence" );
 
 
+    if(keys %ConfigDomain){
+        $tags{'multi_domain'} = 'packetfence-multi-domain';
+    }
+    else {
+        $tags{'multi_domain'} = '# packetfence-multi-domain not activated because no domains configured';
+    }
     $tags{'template'}    = "$conf_dir/raddb/sites-enabled/packetfence-tunnel";
     parse_template( \%tags, "$conf_dir/radiusd/packetfence-tunnel", "$install_dir/raddb/sites-enabled/packetfence-tunnel" );
 


### PR DESCRIPTION
# Description

Doesn't activate the multi domain FreeRADIUS module unless there are domains configured in PacketFence

Also adds the possibility to disable it even if there are domains configured so that when domains config in PacketFence will be used for something else than FreeRADIUS, it still won't do it

Remove the call to packetfence-multi-domain in the outer tunnel
# Impacts

FreeRADIUS domain authentication
# Issue

fixes #868 
# Delete branch after merge

YES
# NEWS file entries
## Enhancements
- Will not activate the packetfence multi-domain FreeRADIUS module unless there are domains configured in PacketFence
- Added option to disable the packetfence multi-domain FreeRADIUS module from the admin interface
