### PR TITLE
pfconfig subcache amelioration

### DIFF
--- a/lib/pfconfig/cached.pm
+++ b/lib/pfconfig/cached.pm
@@ -145,6 +145,12 @@ sub set_in_subcache {
 
 }
 
+=head2 compute_from_subcache
+
+Get an element of the subcache or compute it's value and store it in the subcache
+
+=cut
+
 sub compute_from_subcache {
     my ($self, $key, $on_miss) = @_;
 

--- a/lib/pfconfig/cached.pm
+++ b/lib/pfconfig/cached.pm
@@ -34,9 +34,8 @@ use IO::Socket::UNIX qw( SOCK_STREAM );
 use JSON;
 use pfconfig::timeme;
 use pfconfig::log;
-use pfconfig::util;
+use pfconfig::util qw($undef_element);
 use pfconfig::constants;
-use pfconfig::undef_element;
 use Sereal::Encoder;
 use Sereal::Decoder;
 use Time::HiRes qw(stat time);
@@ -167,7 +166,7 @@ sub compute_from_subcache {
         $self->set_in_subcache($key,$result);
     }
     else {
-        $self->set_in_subcache($key, pfconfig::undef_element->new);
+        $self->set_in_subcache($key, $undef_element);
     }
 
     return $result;

--- a/lib/pfconfig/cached.pm
+++ b/lib/pfconfig/cached.pm
@@ -36,6 +36,7 @@ use pfconfig::timeme;
 use pfconfig::log;
 use pfconfig::util;
 use pfconfig::constants;
+use pfconfig::undef_element;
 use Sereal::Encoder;
 use Sereal::Decoder;
 use Time::HiRes qw(stat time);
@@ -142,6 +143,29 @@ sub set_in_subcache {
     $self->{_subcache}    = {}   unless $self->{_subcache};
     $self->{_subcache}{$key} = $result;
 
+}
+
+sub compute_from_subcache {
+    my ($self, $key, $on_miss) = @_;
+
+    my $subcache_value = $self->get_from_subcache($key);
+    if(defined($subcache_value) && ref($subcache_value) eq "pfconfig::undef_element"){
+        return undef;
+    }
+    elsif(defined($subcache_value)){
+        return $subcache_value;
+    }
+
+    my $result = $on_miss->();
+    if(defined($result)){
+        $self->set_in_subcache($key,$result);
+    }
+    else {
+        $self->set_in_subcache($key, pfconfig::undef_element->new);
+    }
+
+    return $result;
+    
 }
 
 =head2 _get_from_socket

--- a/lib/pfconfig/cached_hash.pm
+++ b/lib/pfconfig/cached_hash.pm
@@ -111,11 +111,11 @@ sub keys {
     my ($self) = @_;
     my $logger = pfconfig::log::get_logger;
 
-    my @keys = $self->compute_from_subcache("__PFCONFIG_HASH_KEYS__", sub {
-        return @{ $self->_get_from_socket( $self->{_namespace}, "keys" ) };
+    my $keys = $self->compute_from_subcache("__PFCONFIG_HASH_KEYS__", sub {
+        return $self->_get_from_socket( $self->{_namespace}, "keys" );
     });
 
-    return @keys;
+    return @$keys;
 }
 
 =head2 FIRSTKEY
@@ -219,9 +219,11 @@ Call it using tied(%hash)->search('result', 'success')
 
 sub search {
     my ($self, $field, $value ) = @_;
-    return $self->compute_from_subcache("__PFCONFIG_HASH_SEARCH_${field}_${value}__", sub {
-        return grep { exists $_->{$field} && defined $_->{$field} && $_->{$field} eq $value  } $self->values;
+    my $elements = $self->compute_from_subcache("__PFCONFIG_HASH_SEARCH_${field}_${value}__", sub {
+        my @elements = grep { exists $_->{$field} && defined $_->{$field} && $_->{$field} eq $value  } $self->values;
+        return \@elements;
     });
+    return @$elements;
 }
 
 =back

--- a/lib/pfconfig/cached_hash.pm
+++ b/lib/pfconfig/cached_hash.pm
@@ -89,17 +89,12 @@ sub FETCH {
         return undef;
     }
 
-    my $subcache_value;
-    $subcache_value = $self->get_from_subcache($key);
-    return $subcache_value if defined($subcache_value);
-
     return $self->{_internal_elements}{$key} if defined( $self->{_internal_elements}{$key} );
 
-    my $result;
-    my $reply = $self->_get_from_socket("$self->{_namespace};$key");
-    $result = defined($reply) ? $reply->{element} : undef;
-
-    $self->set_in_subcache( $key, $result );
+    my $result = $self->compute_from_subcache($key, sub {
+        my $reply = $self->_get_from_socket("$self->{_namespace};$key");
+        my $result = defined($reply) ? $reply->{element} : undef;
+    });
 
     return $result;
 }
@@ -116,7 +111,9 @@ sub keys {
     my ($self) = @_;
     my $logger = pfconfig::log::get_logger;
 
-    my @keys = @{ $self->_get_from_socket( $self->{_namespace}, "keys" ) };
+    my @keys = $self->compute_from_subcache("__PFCONFIG_HASH_KEYS__", sub {
+        return @{ $self->_get_from_socket( $self->{_namespace}, "keys" ) };
+    });
 
     return @keys;
 }
@@ -131,8 +128,11 @@ Proxies to pfconfig
 sub FIRSTKEY {
     my ($self) = @_;
     my $logger = pfconfig::log::get_logger;
-    my $first_key = $self->_get_from_socket( $self->{_namespace}, "next_key", ( last_key => undef ) );
-    return $first_key ? $first_key->{next_key} : undef;
+
+    return $self->compute_from_subcache("__PFCONFIG_FIRST_KEY__", sub {
+        my $first_key = $self->_get_from_socket( $self->{_namespace}, "next_key", ( last_key => undef ) );
+        return $first_key ? $first_key->{next_key} : undef;
+    });
 }
 
 =head2 FIRSTKEY
@@ -145,7 +145,10 @@ Proxies to pfconfig
 sub NEXTKEY {
     my ( $self, $last_key ) = @_;
     my $logger = pfconfig::log::get_logger;
-    return $self->_get_from_socket( $self->{_namespace}, "next_key", ( last_key => $last_key ) )->{next_key};
+
+    return $self->compute_from_subcache("__PFCONFIG_NEXT_KEY_${last_key}__", sub {
+        return $self->_get_from_socket( $self->{_namespace}, "next_key", ( last_key => $last_key ) )->{next_key};
+    });
 }
 
 =head2 STORE
@@ -174,7 +177,9 @@ Proxies to pfconfig
 sub EXISTS {
     my ( $self, $key ) = @_;
     my @keys = $self->keys;
-    return $self->_get_from_socket( $self->{_namespace}, "key_exists", ( search => $key ) )->{result};
+    return $self->compute_from_subcache("__PFCONFIG_KEY_EXISTS_${key}__", sub {
+        return $self->_get_from_socket( $self->{_namespace}, "key_exists", ( search => $key ) )->{result};
+    });
 }
 
 =head2 values
@@ -214,7 +219,9 @@ Call it using tied(%hash)->search('result', 'success')
 
 sub search {
     my ($self, $field, $value ) = @_;
-    return grep { exists $_->{$field} && defined $_->{$field} && $_->{$field} eq $value  } $self->values;
+    return $self->compute_from_subcache("__PFCONFIG_HASH_SEARCH_${field}_${value}__", sub {
+        return grep { exists $_->{$field} && defined $_->{$field} && $_->{$field} eq $value  } $self->values;
+    });
 }
 
 =back

--- a/lib/pfconfig/manager.pm
+++ b/lib/pfconfig/manager.pm
@@ -189,9 +189,8 @@ sub touch_cache {
         close($fh);
     }
     if ( -e $filename ) {
-        sysopen( my $fh, $filename, O_RDWR | O_CREAT );
-        POSIX::2008::futimens( fileno $fh );
-        close($fh);
+        my $command = 'touch --date=@'.time.' '.$filename;
+        `$command`;
     }
     my ( undef, undef, $uid, $gid ) = getpwnam('pf');
     chown( $uid, $gid, $filename );

--- a/lib/pfconfig/manager.pm
+++ b/lib/pfconfig/manager.pm
@@ -189,7 +189,7 @@ sub touch_cache {
         close($fh);
     }
     if ( -e $filename ) {
-        my $command = 'touch --date=@'.time.' '.$filename;
+        my $command = 'touch --date=@'.time.' '."'".$filename."'";
         `$command`;
     }
     my ( undef, undef, $uid, $gid ) = getpwnam('pf');

--- a/lib/pfconfig/undef_element.pm
+++ b/lib/pfconfig/undef_element.pm
@@ -1,0 +1,54 @@
+package pfconfig::undef_element;
+
+=head1 NAME
+
+pfconfig::empty_string
+
+=cut
+
+=head1 DESCRIPTION
+
+Used to represent an empty string in the BDB backend since Cache::BDB doesn't store empty strings
+
+=cut
+
+sub new {
+    my ($class) = @_;
+    my $self = bless {}, $class;
+    return $self;
+}
+
+=back
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2015 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;
+
+# vim: set shiftwidth=4:
+# vim: set expandtab:
+# vim: set backspace=indent,eol,start:

--- a/lib/pfconfig/util.pm
+++ b/lib/pfconfig/util.pm
@@ -30,6 +30,11 @@ our @EXPORT_OK = qw(
 
 sub fetch_socket {
     my ($socket, $payload) = @_;
+    
+    # The line below will log any request to pfconfig for debugging purposes
+    # As the logging cost even in trace is high, it's commented out
+    #pfconfig::log::get_logger->info("Doing request to pfconfig with payload : '$payload'");
+
     # we ask the cachemaster for our namespaced key
     print $socket "$payload\n";
 

--- a/lib/pfconfig/util.pm
+++ b/lib/pfconfig/util.pm
@@ -40,9 +40,6 @@ sub fetch_socket {
     # under some conditions we are receiving multiple lines.
     # this under here should now fix it
     use bytes;
-    # if the fix above doesn't fix it, then multi-line handling is done
-    # through the following lines
-    pfconfig::log::get_logger->trace("pfconfig has $count lines for us");
     my $line;
     my $line_read = 0;
     my $response  = '';

--- a/lib/pfconfig/util.pm
+++ b/lib/pfconfig/util.pm
@@ -19,14 +19,19 @@ use warnings;
 use base qw(Exporter);
 use pf::constants::config qw(%NET_INLINE_TYPES);
 use pfconfig::constants;
+use pfconfig::undef_element;
 use pfconfig::log;
 use pfconfig::constants;
 use IO::Socket::UNIX;
 use Sereal::Decoder;
+use Readonly;
 
 our @EXPORT_OK = qw(
     is_type_inline
+    $undef_element
 );
+
+Readonly our $undef_element => pfconfig::undef_element->new;
 
 sub fetch_socket {
     my ($socket, $payload) = @_;

--- a/t/unittest/pfconfig/cached.t
+++ b/t/unittest/pfconfig/cached.t
@@ -18,7 +18,7 @@ BEGIN {
     use PfFilePaths;
 }
 
-use Test::More tests => 7;                      # last test to print
+use Test::More tests => 21;                      # last test to print
 
 use Test::NoWarnings;
 

--- a/t/unittest/pfconfig/cached.t
+++ b/t/unittest/pfconfig/cached.t
@@ -1,0 +1,89 @@
+=head1 NAME
+
+pfconfig::cached
+
+=cut
+
+=head1 DESCRIPTION
+
+pfconfig::cached
+
+=cut
+
+use strict;
+use warnings;
+BEGIN {
+    use lib qw(/usr/local/pf/t /usr/local/pf/lib);
+    use PfFilePaths;
+}
+
+use Test::More tests => 7;                      # last test to print
+
+use Test::NoWarnings;
+
+use_ok("pfconfig::cached");
+use_ok("pfconfig::manager");
+
+my $cached_test = pfconfig::cached->new();
+$cached_test->{_namespace} = 'testing';
+
+my $manager = pfconfig::manager->new();
+$manager->touch_cache('testing');
+
+# test get_from_subcache
+is(undef, $cached_test->get_from_subcache('dinde'),
+    "subcache is empty and thus invalid so it shouldn't hit");
+
+$cached_test->set_in_subcache('dinde', 'turkey');
+
+is('turkey', $cached_test->get_from_subcache('dinde'), 
+    "Can get from subcache when it's set and valid");
+
+is(undef, $cached_test->get_from_subcache('dinde2'),
+    "Cannot get unset subcache key even when it exists");
+
+$manager->touch_cache('testing');
+
+is(undef, $cached_test->get_from_subcache('dinde'),
+    "Subcache is invalidated when cache is");
+
+$cached_test->set_in_subcache('dinde', 'turkey');
+
+is('turkey', $cached_test->get_from_subcache('dinde'),
+    "Subcache can be properly repopulated after expiration");
+
+$cached_test->set_in_subcache('dinde', 'dindo');
+
+is('dindo', $cached_test->get_from_subcache('dinde'),
+    "Subcache values can be changed");
+ 
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2015 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;
+
+


### PR DESCRIPTION
# Description

Use the subcache in all relevant pfconfig::cached subclasses calls
Also do not constantly call pfconfig on undef key
Use Time::HiRes for the control file timestamp instead of POSIX
Added tests for subcache + subcache computing
# Impacts

Configuration in the processes (pfconfig clients), doesn't change the pfconfig server part
# Delete branch after merge

YES
# NEWS file entries
## Enhancements
- Added additional in-process caching for pfconfig proxied configuration
