### PR TITLE
Added support for MAC auth and dot1x on Aruba controllers 

### DIFF
--- a/NEWS.asciidoc
+++ b/NEWS.asciidoc
@@ -24,6 +24,7 @@ Enhancements
 * Added merged_list configuration type which is the result of a configuration list merge between pf.conf.defaults and pf.conf (#598)
 * RADIUS Diffie-Hellman key size has been increased to 2048 bits to prevent attacks such as Logjam.
 * Improve error message in the profile managment page
+* Aruba Controllers now support RADIUS MAC authentication and dot1x.
 
 Bug Fixes
 +++++++++

--- a/lib/pf/Switch/Aruba.pm
+++ b/lib/pf/Switch/Aruba.pm
@@ -87,6 +87,8 @@ sub supportsRoleBasedEnforcement { return $TRUE; }
 sub supportsWirelessDot1x { return $TRUE; }
 sub supportsWirelessMacAuth { return $TRUE; }
 sub supportsExternalPortal { return $TRUE; }
+sub supportsWiredMacAuth { return $TRUE; }
+sub supportsWiredDot1x { return $TRUE; }
 
 # inline capabilities
 sub inlineCapabilities { return ($MAC,$SSID); }


### PR DESCRIPTION
# Description

Allows PacketFence to manage the wired ports on Aruba controllers with RADIUS.
# Impacts

Simply changes to supported methods in the controller class.
# Delete branch after merge

YES 
# NEWS file entries
## Enhancements
- Aruba Controllers now support RADIUS MAC authentication and dot1x.
