### PR TITLE
Feature/pfconfig sync pp

### DIFF
--- a/bin/cluster/sync
+++ b/bin/cluster/sync
@@ -90,7 +90,7 @@ if($as_master){
             my ($result) = $apiclient->call( 'expire_cluster', %data );
         };
         if($@){
-            print STDERR "Failed to sync store : $store \n";
+            print STDERR "ERROR !!! Failed to sync store : $store ($@) \n";
         }
     }
 

--- a/lib/pf/WebAPI/JSONRPC.pm
+++ b/lib/pf/WebAPI/JSONRPC.pm
@@ -90,7 +90,6 @@ sub handler {
             });
             $logger->error($@);
             $status_code = Apache2::Const::HTTP_INTERNAL_SERVER_ERROR;
-            $r->print($response_content);
         } else {
             $status_code = Apache2::Const::HTTP_OK;
         }

--- a/lib/pf/api.pm
+++ b/lib/pf/api.pm
@@ -480,7 +480,8 @@ sub notify_configfile_changed : Public {
 
     my $apiclient = pf::api::jsonrpcclient->new(proto => 'https', host => $master_server->{management_ip});
 
-    open(my $fh, '>', $postdata{conf_file}) or die "Cannot open file $postdata{conf_file} for writing. This is excessively bad. Run '/usr/local/pf/bin/pfcmd fixpermissions'";
+    pf::util::pf_run("sudo /usr/local/pf/bin/pfcmd fixpermissions file $postdata{conf_file}");
+    open(my $fh, '>', $postdata{conf_file}) or die "Cannot open file $postdata{conf_file} for writing.'";
     eval {
         my %data = ( conf_file => $postdata{conf_file} );
         my ($result) = $apiclient->call( 'download_configfile', %data );

--- a/lib/pf/api.pm
+++ b/lib/pf/api.pm
@@ -480,9 +480,9 @@ sub notify_configfile_changed : Public {
 
     my $apiclient = pf::api::jsonrpcclient->new(proto => 'https', host => $master_server->{management_ip});
 
-    pf::util::pf_run("sudo /usr/local/pf/bin/pfcmd fixpermissions file $postdata{conf_file}");
-    open(my $fh, '>', $postdata{conf_file}) or die "Cannot open file $postdata{conf_file} for writing.'";
     eval {
+        pf::util::pf_run("sudo /usr/local/pf/bin/pfcmd fixpermissions file $postdata{conf_file}");
+        open(my $fh, '>', $postdata{conf_file}) or die "Cannot open file $postdata{conf_file} for writing.'";
         my %data = ( conf_file => $postdata{conf_file} );
         my ($result) = $apiclient->call( 'download_configfile', %data );
         print $fh $result;
@@ -495,6 +495,7 @@ sub notify_configfile_changed : Public {
     };
     if($@){
         $logger->error("Couldn't download configuration file $postdata{conf_file} from $postdata{server}. $@");
+        die $@;
     }
 
     return 1;

--- a/lib/pf/base/cmd/action_cmd.pm
+++ b/lib/pf/base/cmd/action_cmd.pm
@@ -15,9 +15,19 @@ use strict;
 use warnings;
 use base qw(pf::cmd);
 
+=head2 default_action
+
+The default action to make when none is specified
+Defaults to no action
+
+=cut
+
+sub default_action { undef }
+
 sub parseArgs {
     my ($self) = @_;
     my ($action,@args) = $self->args;
+    $action = $self->default_action if(!defined($action) && defined($self->default_action));
     if($self->is_valid_action($action)) {
         $self->{action} = $action;
         return $self->_parseArgs(@args);
@@ -53,6 +63,7 @@ sub action_args {
     my ($self) = @_;
     return @{ $self->{action_args} || []  }
 }
+
 
 =head1 AUTHOR
 

--- a/lib/pf/cmd/pf/configreload.pm
+++ b/lib/pf/cmd/pf/configreload.pm
@@ -26,16 +26,7 @@ use pf::constants::exit_code qw($EXIT_SUCCESS);
 
 use base qw(pf::base::cmd::action_cmd);
 
-sub parseArgs {
-    my ($self) = @_;
-    my ($action,@args) = $self->args;
-    $action = 'soft' unless defined $action;
-    if($self->is_valid_action($action)) {
-        $self->{action} = $action;
-        return $self->_parseArgs(@args);
-    }
-    return 0;
-}
+sub default_action { 'soft' }
 
 sub action_soft {
     my ($self) = @_;

--- a/lib/pf/cmd/pf/fixpermissions.pm
+++ b/lib/pf/cmd/pf/fixpermissions.pm
@@ -34,6 +34,12 @@ use File::Spec::Functions qw(catfile);
 
 sub default_action { 'all' }
 
+=head2 action_all
+
+Fix the permissions on pf and fingerbank files
+
+=cut
+
 sub action_all {
     my $pfcmd = "${bin_dir}/pfcmd";
     my @extra_var_dirs = map { catfile($var_dir,$_) } qw(run cache conf sessions);
@@ -61,6 +67,14 @@ sub parse_file {
     }
     return 1;
 }
+
+=head2 action_file
+
+Apply the permission fix on specific(s) file(s)
+Will determine the user to set rights to depending on the destination directory
+Doesn't work outside /usr/local/pf and /usr/local/fingerbank
+
+=cut
 
 sub action_file {
     my ($self) = @_;

--- a/lib/pf/cmd/pf/fixpermissions.pm
+++ b/lib/pf/cmd/pf/fixpermissions.pm
@@ -18,19 +18,20 @@ pf::cmd::pf::fixpermissions
 use strict;
 use warnings;
 
-use base qw(pf::cmd);
+use base qw(pf::base::cmd::action_cmd);
 
 use pf::file_paths;
 use pf::log;
 use pf::constants::exit_code qw($EXIT_SUCCESS);
+use pf::util;
 
 use fingerbank::FilePath;
 
 use File::Spec::Functions qw(catfile);
 
-sub parseArgs { 1 }
+sub default_action { 'all' }
 
-sub _run {
+sub action_all {
     my $pfcmd = "${bin_dir}/pfcmd";
     my @extra_var_dirs = map { catfile($var_dir,$_) } qw(run cache conf sessions);
     _changeFilesToOwner('pf',@log_files, @stored_config_files, $install_dir, $bin_dir, $conf_dir, $var_dir, $lib_dir, $log_dir, $generated_conf_dir, $tt_compile_cache_dir, $pfconfig_cache_dir, @extra_var_dirs);
@@ -39,6 +40,16 @@ sub _run {
     chmod(0664, @stored_config_files);
     chmod(02775, $conf_dir, $var_dir, $log_dir);
     _fingerbank();
+    print "Fixed permissions.\n";
+    return $EXIT_SUCCESS;
+}
+
+sub action_file {
+    my ($self) = @_;
+    my ($file) = $self->action_args;
+    $file = untaint_chain($file);
+    _changeFilesToOwner('pf',$file);
+    print "Fixed permissions on file $file \n";
     return $EXIT_SUCCESS;
 }
 


### PR DESCRIPTION
# Description

Adds better error propagation on sync failure in bin/cluster/sync
Admin will show a failure when saving and the cluster fails to sync completely
Adds an option to fix permissions of specific files in `pfcmd fixpermissions`
Fix the permissions of a file before synching so pf can write to it
# Impacts

Active/active sync
# Delete branch after merge

YES
# NEWS file entries
## Enhancements
- Added better error message propagation during a cluster synchronization
- pfcmd fixpermissions can not be used on specific files
## Bug Fixes
- Fix bad permissions before synching a file in a cluster
