### PR TITLE
add cluster option to switch dhcp roles

### DIFF
--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1397,6 +1397,13 @@ description=<<EOT
 The virtual router id for keepalive. Leave untouched unless you have another keepalive cluster in this network.
 EOT
 
+[active_active.switch_dhcpd_roles]
+type=toggle
+options=enabled|disabled
+description=<<EOT
+Switch dhcpd roles so that server #1 will be primary and server #2 secondary
+EOT
+
 [monitoring.graphite_host]
 type=text
 description=<<EOT

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -1093,6 +1093,11 @@ password=1234
 #
 # Shared KEY for vrrp protocol (Must be the same on all members).
 virtual_router_id=50
+#
+# active_active.switch_dhcpd_roles
+#
+# Switch dhcpd roles so that server #1 will be primary and server #2 secondary
+switch_dhcpd_roles=disabled
 
 [monitoring]
 #

--- a/html/pfappserver/lib/pfappserver/I18N/i_default.po
+++ b/html/pfappserver/lib/pfappserver/I18N/i_default.po
@@ -5887,7 +5887,7 @@ msgstr "Virtual Router ID"
 
 # conf/documentation.conf
 msgid "active_active.switch_dhcpd_roles"
-msgstr "Switch dhcpd roles"
+msgstr "Switch dhcpd rolesSwitch dhcpd roles"
 
 # html/pfappserver/lib/pfappserver/Form/Field/Duration.pm
 # pfappserver::Form::Field::Duration (Operators)

--- a/html/pfappserver/lib/pfappserver/I18N/i_default.po
+++ b/html/pfappserver/lib/pfappserver/I18N/i_default.po
@@ -5885,6 +5885,10 @@ msgstr "Shared KEY"
 msgid "active_active.virtual_router_id"
 msgstr "Virtual Router ID"
 
+# conf/documentation.conf
+msgid "active_active.switch_dhcpd_roles"
+msgstr "Switch dhcpd roles"
+
 # html/pfappserver/lib/pfappserver/Form/Field/Duration.pm
 # pfappserver::Form::Field::Duration (Operators)
 msgid "add"

--- a/lib/pf/cluster.pm
+++ b/lib/pf/cluster.pm
@@ -133,9 +133,17 @@ Compute whether or not this node is the primary DHCP server in the cluster
 =cut
 
 sub is_dhcpd_primary {
+    my $primary;
     if(scalar(@cluster_servers) > 1){
-        # the non-management node is the primary
-        return cluster_index() == 1 ? 1 : 0;
+        require pf::config;
+        if(isenabled($pf::config::Config{active_active}{switch_dhcpd_roles})){
+            # the management node is the primary
+            return cluster_index() == 0 ? 1 : 0;
+        }
+        else {
+            # the non-management node is the primary
+            return cluster_index() == 1 ? 1 : 0;
+        }
     }
     else {
         # the server is alone so it's the primary


### PR DESCRIPTION
# Description

add cluster option to switch dhcp roles
# Impacts

dhcpd in clustering
# Issue

ie: fixes #817 
# Delete branch after merge

YES
# NEWS file entries
## New Features
- Added an option to make the management node the primary DHCP server in an active/active cluster
