### PR TITLE
Instantiate the correct portal based on the current connection attributes

### DIFF
--- a/lib/pf/vlan.pm
+++ b/lib/pf/vlan.pm
@@ -387,7 +387,7 @@ sub getNormalVlan {
     my $logger = Log::Log4perl->get_logger(__PACKAGE__);
     my $start = Time::HiRes::gettimeofday();
 
-    my $options;
+    my $options = {};
     $options->{'last_connection_type'} = connection_type_to_str($connection_type) if (defined( $connection_type));
     $options->{'last_switch'}          = $switch->{_id} if (defined($switch->{_id}));
     $options->{'last_port'}            = $ifIndex if (defined($ifIndex));
@@ -568,7 +568,7 @@ sub getNodeInfoForAutoReg {
     my $start = Time::HiRes::gettimeofday();
 
     #define the current connection value to instantiate the correct portal
-    my $options;
+    my $options = {};
     $options->{'last_connection_type'} = connection_type_to_str($conn_type) if (defined($conn_type));
     $options->{'last_switch'}          = $switch->{_id} if (defined($switch->{_id}));
     $options->{'last_port'}            = $switch_port if (defined($switch_port));

--- a/lib/pf/vlan.pm
+++ b/lib/pf/vlan.pm
@@ -386,7 +386,16 @@ sub getNormalVlan {
     my ($this, $switch, $ifIndex, $mac, $node_info, $connection_type, $user_name, $ssid, $radius_request, $realm, $stripped_user_name, $autoreg) = @_;
     my $logger = Log::Log4perl->get_logger(__PACKAGE__);
     my $start = Time::HiRes::gettimeofday();
-    my $profile = pf::Portal::ProfileFactory->instantiate($mac);
+
+    my $options;
+    $options->{'last_connection_type'} = connection_type_to_str($connection_type) if (defined( $connection_type));
+    $options->{'last_switch'}          = $switch->{_id} if (defined($switch->{_id}));
+    $options->{'last_port'}            = $ifIndex if (defined($ifIndex));
+    $options->{'last_ssid'}            = $ssid if (defined($ssid));
+    $options->{'last_dot1x_username'}  = $user_name if (defined($user_name));
+    $options->{'realm'}                = $realm if (defined($realm));
+
+    my $profile = pf::Portal::ProfileFactory->instantiate($mac,$options);
 
     my ($vlan, $role, $result);
 


### PR DESCRIPTION
# Description

Location is updated after we try to compute the vlan so a portal profile based on the node will not be instantiate on the first connection.
# Impacts

No
# Delete branch after merge

YES
# NEWS file entries
## Bug Fixes
- Fix wrong portal profile instantiate based on the first connection.
