### PR TITLE
Safely update the contents of a file using rename in the pf::api

### DIFF
--- a/lib/pf/api.pm
+++ b/lib/pf/api.pm
@@ -38,6 +38,7 @@ use pfconfig::manager;
 use pf::api::jsonrpcclient;
 use pf::cluster;
 use JSON;
+use File::Slurp;
 use pf::file_paths;
 
 use List::MoreUtils qw(uniq);
@@ -409,7 +410,7 @@ sub release_all_violations : Public {
         else {
             $logger->error("Cannot close violation $violation->{vid} for $mac");
         }
-    } 
+    }
     return $closed_violation;
 }
 
@@ -506,13 +507,9 @@ sub notify_configfile_changed : Public {
     my $apiclient = pf::api::jsonrpcclient->new(proto => 'https', host => $master_server->{management_ip});
 
     eval {
-        pf::util::pf_run("sudo /usr/local/pf/bin/pfcmd fixpermissions file $postdata{conf_file}");
-        open(my $fh, '>', $postdata{conf_file}) or die "Cannot open file $postdata{conf_file} for writing.'";
         my %data = ( conf_file => $postdata{conf_file} );
         my ($result) = $apiclient->call( 'download_configfile', %data );
-        print $fh $result;
-        close($fh);
-        use pf::config::cached;
+        _safe_file_update($postdata{conf_file}, $result);
         pf::config::cached::updateCacheControl();
         pf::config::cached::ReloadConfigs(1);
 
@@ -532,7 +529,6 @@ sub download_configfile : Public {
     my @found = grep {exists $postdata{$_}} @require;
     return unless validate_argv(\@require, \@found);
 
-    use File::Slurp;
     die "Config file $postdata{conf_file} doesn't exist" unless(-e $postdata{conf_file});
     my $config = read_file($postdata{conf_file});
 
@@ -549,13 +545,32 @@ sub distant_download_configfile : Public {
     my %data = ( conf_file => $file );
     my $apiclient = pf::api::jsonrpcclient->new(host => $postdata{from}, proto => 'https');
     my ($result) = $apiclient->call( 'download_configfile', %data );
-    open(my $fh, '>', $file);
-    print $fh $result;
-    close($fh);
-    `chown pf.pf $file`;
-
+    _safe_file_update($file, $result);
     return 1;
+}
 
+=head2 _safe_file_update
+
+This safely modifies the contents of a file using a rename
+
+=cut
+
+sub _safe_file_update {
+    my ($file, $contents) = @_;
+    my ($volume, $dir, $filename) = File::Spec->splitpath($file);
+    $dir = '.' if $dir eq '';
+    # Creates a new file in the same directory to ensure it is on the same filesystem
+    my $temp = File::Temp->new(DIR => $dir) or die "cannot create temp file in $dir";
+    syswrite $temp, $contents;
+    $temp->flush;
+    close $temp;
+    unless( rename ($temp->filename, $file) ) {
+        my $logger = pf::log::get_logger;
+        $logger->error("cannot save contents to $file '$!'");
+        die "cannot save contents to $file";
+    }
+    $temp->unlink_on_destroy(0);
+    `chown pf.pf $file`;
 }
 
 sub expire_cluster : Public {
@@ -602,7 +617,7 @@ sub expire_cluster : Public {
             next;
         }
     }
-    
+
     if(@failed){
         die "Failed to sync configuration on server(s) ".join(',',@failed);
     }

--- a/lib/pf/cmd/pf/fixpermissions.pm
+++ b/lib/pf/cmd/pf/fixpermissions.pm
@@ -6,8 +6,8 @@ pf::cmd::pf::fixpermissions add documentation
 =head1 SYNOPSIS
 
  pfcmd fixpermissions <command>
- 
- Commands : 
+
+ Commands :
   all                             | executes a fix on the permissions on all PF files
   file file1 [file2, file3, ...]  | executes a fix on the permissions on a list of files (absolute paths)
     (File(s) must exist and located in /usr/local/pf or /usr/local/fingerbank)
@@ -87,7 +87,7 @@ sub action_file {
 
     foreach my $file (@files){
         $file = untaint_chain($file);
-        
+
         my $user;
         if($file =~ /\/usr\/local\/pf\//){
             $user = 'pf';
@@ -99,10 +99,11 @@ sub action_file {
             print STDERR "Cannot compute user from directory \n";
             return $EXIT_FAILURE;
         }
-        _changeFilesToOwner('fingerbank',$file);
+        _changeFilesToOwner($user,$file);
+        chmod 0660, $file;
         print "Fixed permissions on file $file \n";
     }
-  
+
     return $EXIT_SUCCESS;
 }
 

--- a/lib/pf/util.pm
+++ b/lib/pf/util.pm
@@ -29,6 +29,7 @@ use List::MoreUtils qw(all);
 use Try::Tiny;
 use pf::file_paths;
 use NetAddr::IP;
+use File::Temp;
 use Date::Parse;
 use Crypt::OpenSSL::X509;
 
@@ -475,8 +476,8 @@ fix the file permissions of the files
 =cut
 
 sub fix_file_permissions {
-    my (@files) = @_;
-    qx(chown pf.pf @files);
+    my ($file) = @_;
+    pf_run('sudo /usr/local/pf/bin/pfcmd fixpermissions file "' . $file . '"');
 }
 
 sub parse_template {

--- a/lib/pf/util.pm
+++ b/lib/pf/util.pm
@@ -62,6 +62,8 @@ BEGIN {
         is_prod_interface
         valid_ip_range
         cert_has_expired
+        safe_file_update
+        fix_file_permissions
     );
 }
 
@@ -442,6 +444,41 @@ sub readpid {
     }
 }
 
+=item safe_file_update($file, $content)
+
+This safely modifies the contents of a file using a rename
+
+=cut
+
+sub safe_file_update {
+    my ($file, $contents) = @_;
+    my ($volume, $dir, $filename) = File::Spec->splitpath($file);
+    $dir = '.' if $dir eq '';
+    # Creates a new file in the same directory to ensure it is on the same filesystem
+    my $temp = File::Temp->new(DIR => $dir) or die "cannot create temp file in $dir";
+    syswrite $temp, $contents;
+    $temp->flush;
+    close $temp;
+    unless( rename ($temp->filename, $file) ) {
+        my $logger = pf::log::get_logger;
+        $logger->error("cannot save contents to $file '$!'");
+        die "cannot save contents to $file";
+    }
+    $temp->unlink_on_destroy(0);
+    fix_file_permissions($file);
+}
+
+=item fix_file_permissions(@files)
+
+fix the file permissions of the files
+
+=cut
+
+sub fix_file_permissions {
+    my (@files) = @_;
+    qx(chown pf.pf @files);
+}
+
 sub parse_template {
     my ( $tags, $template, $destination, $comment_char ) = @_;
     my $logger = get_logger();
@@ -718,7 +755,7 @@ with code 1, 2 or 3 without reporting it as an error.
 sub pf_run {
     my ($command, %options) = @_;
     my $logger = get_logger();
-    
+
     # REVIEW AND DISCUSS THIS ! IS IT OK TO DO THIS ?
     # IMO yes.
     # Also this comment needs to be removed before the merge
@@ -753,7 +790,7 @@ sub pf_run {
 
     my $loggable_command = $command;
     if(defined($options{log_strip})){
-        $loggable_command =~ s/$options{log_strip}/*obfuscated-information*/g; 
+        $loggable_command =~ s/$options{log_strip}/*obfuscated-information*/g;
     }
     # died with an OS problem
     if ($CHILD_ERROR == -1) {
@@ -966,7 +1003,7 @@ sub normalize_time {
 
 Used to search for an element in a hash that has a specific value in one of it's field
 
-Ex : 
+Ex :
 my %h = {
   'test' => {'result' => '2'},
   'test2' => {'result' => 'success'}


### PR DESCRIPTION
## Description

To avoid file corruption when updating configuration files through the api.
Use file rename instead of writing directly to the file.
## Impacts
## NEWS file entries

New Features
++++++++++++

Enhancements
++++++++++++

Bug Fixes
+++++++++
- Avoid the possibility of file corruption when updating configuration files through the api 
## Delete branch after merge

NO
