### PR TITLE
Merge back upstream changes to raddb/certs/Makefile.

### DIFF
--- a/raddb/certs/Makefile
+++ b/raddb/certs/Makefile
@@ -14,12 +14,7 @@ DH_KEY_SIZE	= 2048
 #
 #  Set the passwords
 #
-PASSWORD_SERVER	= `grep output_password server.cnf | sed 's/.*=//;s/^ *//'`
-PASSWORD_CA	= `grep output_password ca.cnf | sed 's/.*=//;s/^ *//'`
-PASSWORD_CLIENT	= `grep output_password client.cnf | sed 's/.*=//;s/^ *//'`
-
-USER_NAME	= `grep emailAddress client.cnf | grep '@' | sed 's/.*=//;s/^ *//'`
-CA_DEFAULT_DAYS = `grep default_days ca.cnf | sed 's/.*=//;s/^ *//'`
+-include passwords.mk
 
 ######################################################################
 #
@@ -38,13 +33,20 @@ ca: ca.der
 .PHONY: server
 server: server.pem server.vrfy
 
+passwords.mk: server.cnf ca.cnf client.cnf
+	@echo "PASSWORD_SERVER	= '$(shell grep output_password server.cnf | sed 's/.*=//;s/^ *//')'"		> $@
+	@echo "PASSWORD_CA	= '$(shell grep output_password ca.cnf | sed 's/.*=//;s/^ *//')'"		>> $@
+	@echo "PASSWORD_CLIENT	= '$(shell grep output_password client.cnf | sed 's/.*=//;s/^ *//')'"		>> $@
+	@echo "USER_NAME	= '$(shell grep emailAddress client.cnf | grep '@' | sed 's/.*=//;s/^ *//')'"	>> $@
+	@echo "CA_DEFAULT_DAYS  = '$(shell grep default_days ca.cnf | sed 's/.*=//;s/^ *//')'"			>> $@
+
 ######################################################################
 #
 #  Diffie-Hellman parameters
 #
 ######################################################################
 dh:
-	openssl dhparam -out dh $(DH_KEY_SIZE)
+	openssl gendh -out dh -2 $(DH_KEY_SIZE)
 
 ######################################################################
 #
@@ -52,6 +54,8 @@ dh:
 #
 ######################################################################
 ca.key ca.pem: ca.cnf
+	@[ -f index.txt ] || $(MAKE) index.txt
+	@[ -f serial ] || $(MAKE) serial
 	openssl req -new -x509 -keyout ca.key -out ca.pem \
 		-days $(CA_DEFAULT_DAYS) -config ./ca.cnf
 
@@ -81,8 +85,7 @@ server.vrfy: ca.pem
 
 ######################################################################
 #
-#  Create a new client certificate, signed by the the above server
-#  certificate.
+#  Create a new client certificate, signed by the the above CA
 #
 ######################################################################
 client.csr client.key: client.cnf
@@ -99,7 +102,7 @@ client.pem: client.p12
 	cp client.pem $(USER_NAME).pem
 
 .PHONY: client.vrfy
-client.vrfy: server.pem client.pem 
+client.vrfy: ca.pem client.pem 
 	c_rehash .
 	openssl verify -CApath . client.pem
 


### PR DESCRIPTION
# Description

Merges the changes made by upstream (i.e. FreeRADIUS) to the certs/Makefile.
Those support more modern openssl commands and larger dh parameters.
# Impacts

Affects default raddb/certs/dh file for FreeRADIUS. Increases dh params to 2048 bits as required by recent OSes.
# Delete branch after merge

YES 
# NEWS file entry

Already taken care of in a previous commit.
