### PR TITLE
Portal preview inaccessible when no internal network is defined

### DIFF
--- a/lib/pf/web/admin.pm
+++ b/lib/pf/web/admin.pm
@@ -27,6 +27,7 @@ use Data::Dumper;
 
 use APR::URI;
 use Log::Log4perl;
+use List::MoreUtils qw(uniq);
 
 use pf::config;
 use pf::util;
@@ -159,10 +160,11 @@ Proxy request to the captive portal
 sub proxy_portal {
     my ($self, $r) = @_;
     my $logger = Log::Log4perl->get_logger(__PACKAGE__);
+    my @interfaces = uniq (@internal_nets, @portal_ints );
     my $s = $r->server;
     if ($r->uri =~ /portal_preview\/(.*)/) {
          $r->headers_in->{'X-Forwarded-For'} = $management_network->{'Tip'}; 
-         my $interface = $internal_nets[0];
+         my $interface = $interfaces[0];
          $r->set_handlers(PerlResponseHandler => []);
          $r->add_output_filter(\&rewrite);
          my $referef = APR::URI->parse($r->pool,$r->headers_in->{'Referer'});


### PR DESCRIPTION
# Description

Portal preview available even if there is no registration or isolation interface.
# Impacts

No
# Issue

Fixes #790  
# Delete branch after merge

YES
# NEWS file entries
## New Features
- 
## Enhancements
## Bug Fixes
- Fix portal preview inaccessible when no internal network is defined (#790)
