### PR TITLE
add update action and caching to firewallsso to reduce duplicate requests

### DIFF
--- a/html/pfappserver/lib/pfappserver/Form/Config/Firewall_SSO.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Firewall_SSO.pm
@@ -68,6 +68,23 @@ has_field 'uid' =>
    options_method => \&uid_type,
   );
 
+has_field 'cache_updates' =>
+  (
+   type => 'Checkbox',
+   label => 'Cache updates',
+   checkbox_value => 'enabled',
+   tags => { after_element => \&help,
+             help => 'Enable this to debounce updates to the Firewall.<br/>By default, PacketFence will send a SSO on every DHCP request for every device. Enabling this enables "sleep" periods during which the update is not sent if the informations stay the same.' },
+  );
+
+has_field 'cache_timeout' =>
+  (
+   type => 'PosInteger',
+   label => 'Cache timeout',
+   checkbox_value => 'enabled',
+   tags => { after_element => \&help,
+             help => 'Adjust the "Cache timeout" to half the expiration delay in your firewall.<br/>Your DHCP renewal interval should match this value.' },
+  );
 
 =head2 Methods
 

--- a/html/pfappserver/lib/pfappserver/Form/Config/Firewall_SSO/BarracudaNG.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Firewall_SSO/BarracudaNG.pm
@@ -69,7 +69,7 @@ has_field 'categories' =>
 
 has_block definition =>
   (
-   render_list => [ qw(id type username password port categories) ],
+   render_list => [ qw(id type username password port categories cache_updates cache_timeout) ],
   );
 
 has_field 'uid' =>

--- a/html/pfappserver/lib/pfappserver/Form/Config/Firewall_SSO/Checkpoint.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Firewall_SSO/Checkpoint.pm
@@ -69,7 +69,7 @@ has_field 'uid' =>
 
 has_block 'definition' =>
   (
-   render_list => [ qw(id type password port uid categories) ],
+   render_list => [ qw(id type password port uid categories cache_updates cache_timeout) ],
   );
 
 =head2 Methods

--- a/html/pfappserver/lib/pfappserver/Form/Config/Firewall_SSO/FortiGate.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Firewall_SSO/FortiGate.pm
@@ -68,7 +68,7 @@ has_field 'uid' =>
 
 has_block definition =>
   (
-   render_list => [ qw(id type password port uid categories) ],
+   render_list => [ qw(id type password port uid categories cache_updates cache_timeout) ],
   );
 
 has_field 'uid' =>

--- a/html/pfappserver/lib/pfappserver/Form/Config/Firewall_SSO/Iboss.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Firewall_SSO/Iboss.pm
@@ -78,7 +78,7 @@ has_field 'uid' =>
 
 has_block definition =>
   (
-   render_list => [ qw(id type password port nac_name categories) ],
+   render_list => [ qw(id type password port nac_name categories cache_updates cache_timeout) ],
   );
 
 has_field 'uid' =>

--- a/html/pfappserver/lib/pfappserver/Form/Config/Firewall_SSO/PaloAlto.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Firewall_SSO/PaloAlto.pm
@@ -69,7 +69,7 @@ has_field 'uid' =>
 
 has_block definition =>
   (
-   render_list => [ qw(id type password port categories) ],
+   render_list => [ qw(id type password port categories cache_updates cache_timeout) ],
   );
 
 has_field 'uid' =>

--- a/lib/pf/CHI.pm
+++ b/lib/pf/CHI.pm
@@ -62,7 +62,7 @@ Hash::Merge::specify_behavior(
     'PF_CHI_MERGE'
 );
 
-our @CACHE_NAMESPACES = qw(configfilesdata configfiles httpd.admin httpd.portal pfdns switch.overlay ldap_auth omapi fingerbank);
+our @CACHE_NAMESPACES = qw(configfilesdata configfiles httpd.admin httpd.portal pfdns switch.overlay ldap_auth omapi fingerbank firewall_sso);
 
 our $chi_config = pf::IniFiles->new( -file => $chi_config_file, -allowempty => 1) or die;
 our %DEFAULT_CONFIG = (

--- a/lib/pf/api.pm
+++ b/lib/pf/api.pm
@@ -40,6 +40,7 @@ use pf::cluster;
 use JSON;
 use File::Slurp;
 use pf::file_paths;
+use pf::CHI;
 
 use List::MoreUtils qw(uniq);
 use NetAddr::IP;
@@ -222,9 +223,29 @@ sub firewallsso : Public {
 
     my $logger = pf::log::get_logger();
 
-    foreach my $firewall_conf ( sort keys %pf::config::ConfigFirewallSSO ) {
-        my $firewall = pf::factory::firewallsso->new($firewall_conf);
-        $firewall->action($firewall_conf,$postdata{'method'},$postdata{'mac'},$postdata{'ip'},$postdata{'timeout'});
+    foreach my $firewall_id ( sort keys %pf::config::ConfigFirewallSSO ) {
+        my $firewall = pf::factory::firewallsso->new($firewall_id);
+
+        if($postdata{method} eq "Update"){
+            if( pf::util::isenabled($pf::config::ConfigFirewallSSO{$firewall_id}{cache_updates}) ){
+                my $cache = pf::CHI->new( namespace => 'firewall_sso' );
+                my $cache_timeout = $pf::config::ConfigFirewallSSO{$firewall_id}{cache_timeout} || $postdata{timeout} / 2;
+                my $cache_key = "$firewall_id - $postdata{ip}";
+                return $cache->compute($cache_key, { expires_in => $cache_timeout },
+                    sub {
+                        $logger->debug("Doing cached firewall SSO for '$cache_key' with expiration of $cache_timeout");
+                        $firewall->action($firewall_id,'Start',$postdata{'mac'},$postdata{'ip'},$postdata{'timeout'});
+                    }
+                );
+            }
+            else {
+                $firewall->action($firewall_id,'Start',$postdata{'mac'},$postdata{'ip'},$postdata{'timeout'});
+            }
+        }
+        else {
+            $firewall->action($firewall_id,$postdata{'method'},$postdata{'mac'},$postdata{'ip'},$postdata{'timeout'});
+        }
+
     }
     return $pf::config::TRUE;
 }

--- a/lib/pf/constants/dhcp.pm
+++ b/lib/pf/constants/dhcp.pm
@@ -1,0 +1,52 @@
+package pf::constants::dhcp;
+
+=head1 NAME
+
+pf::constants::dhcp - constants for dhcp
+
+=cut
+
+=head1 DESCRIPTION
+
+pf::constants::dhcp
+
+=cut
+
+use strict;
+use warnings;
+use base qw(Exporter);
+use Readonly;
+
+our @EXPORT_OK = qw($DEFAULT_LEASE_LENGTH);
+
+Readonly our $DEFAULT_LEASE_LENGTH => 86400;
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2015 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and::or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;
+

--- a/sbin/pfdhcplistener
+++ b/sbin/pfdhcplistener
@@ -31,6 +31,7 @@ BEGIN {
 }
 
 use pf::constants;
+use pf::constants::dhcp qw($DEFAULT_LEASE_LENGTH);
 use pf::clustermgmt;
 use pf::config;
 use pf::config::cached;
@@ -375,10 +376,8 @@ sub parse_dhcp_request {
         );
         $apiclient->notify('trigger_scan', %data );
 
-        if(defined($lease_length)) {
-            my $firewallsso = pf::firewallsso->new;
-            $firewallsso->do_sso('Start',$dhcp->{'chaddr'}, $client_ip,$lease_length);
-        }
+        my $firewallsso = pf::firewallsso->new;
+        $firewallsso->do_sso('Update', $dhcp->{'chaddr'}, $client_ip, $lease_length || $DEFAULT_LEASE_LENGTH);
     }
 
     # As per RFC2131 in a DHCPREQUEST if ciaddr is set and we broadcast, we are in re-binding state
@@ -568,6 +567,8 @@ sub update_iplog {
         my $view_mac = node_view($srcmac);
         my $firewallsso = pf::firewallsso->new;
         $firewallsso->do_sso('Stop',$oldmac,$oldip,undef);
+        $firewallsso->do_sso('Start', $srcmac, $srcip, $lease_length || $DEFAULT_LEASE_LENGTH);
+
         if ($view_mac->{'last_connection_type'} eq $connection_type_to_str{$INLINE}) {
             $apiclient->notify('ipset_node_update',$oldip, $srcip, $srcmac);
         }


### PR DESCRIPTION
# Description

Add caching to firewall SSO update calls to reduce duplicate calls when a device renews DHCP often due to roaming
# Impacts

pfdhcplistener, firewall SSO
# Delete branch after merge

YES
# NEWS file entries
## New Features
- Added option to cache firewall SSO requests to reduce duplicate calls to the firewall
