### PR TITLE
Enable / Disable captive-portal WISPr redirection

### DIFF
--- a/NEWS.asciidoc
+++ b/NEWS.asciidoc
@@ -31,6 +31,7 @@ Enhancements
 * Detecting when using a self-signed SSL certificate for device with captive-portal detection mecanisms
 * httpd.portal serves static content directly (without going through Catalyst engine)
 * Changed verbosity of, a bit to verbose, logging statements in ip <-> mac discovery
+* Introduction of a new configuration parameter (captive_portal.wispr_redirection) to allow enabling/disabling captive-portal WISPr redirection capabilities
 
 Bug Fixes
 +++++++++

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1073,6 +1073,13 @@ Comma-delimited list of URLs known to be used by devices to detect the presence
 of a captive portal and trigger their captive portal mecanism.
 EOT
 
+[captive_portal.wispr_redirection]
+type=toggle
+options=enabled|disabled
+description=<<EOT
+Enable or disable WISPr redirection capabilities on the captive-portal
+EOT
+
 [advanced.reevaluate_access_reasons]
 type=multi
 options=node_modify|manage_register|manage_deregister|manage_vclose|manage_vopen|violation_modify|violation_add|violation_delete|redir.cgi|pfcmd_vlan

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -828,6 +828,11 @@ detection_mecanism_bypass = disabled
 # Comma-delimited list of URLs known to be used by devices to detect the presence 
 # of a captive portal and trigger their captive portal mecanism.
 detection_mecanism_urls = http://www.gstatic.com/generate_204,http://clients3.google.com/generate_204,http://www.apple.com/library/test/success,http://connectivitycheck.android.com/generate_204
+#
+# captive_portal.wispr_redirection
+#
+# Enable or disable WISPr redirection capabilities on the captive-portal
+wispr_redirection = enabled
 
 [advanced]
 #

--- a/html/captive-portal/templates/redirect.tt
+++ b/html/captive-portal/templates/redirect.tt
@@ -5,6 +5,7 @@
     <body>
         <h1>Moved</h1>
         <p>The document has moved <a href="[% portal_url %]">here</a>.</p>
+        [% IF is_wispr_redirection_enabled %]
         <!--
         <?xml version="1.0" encoding="UTF-8"?>
         <WISPAccessGatewayParam
@@ -22,5 +23,6 @@
             </Redirect>
         </WISPAccessGatewayParam>
         -->
+        [% END %]
     </body>
 </html>

--- a/html/pfappserver/lib/pfappserver/I18N/i_default.po
+++ b/html/pfappserver/lib/pfappserver/I18N/i_default.po
@@ -6142,6 +6142,10 @@ msgstr "Secure redirect"
 msgid "captive_portal.status_only_on_production"
 msgstr "Status URI only on production network"
 
+# conf/documentation.conf
+msgid "captive_portal.wispr_redirection"
+msgstr "WISPr redirection capabilities"
+
 # html/pfappserver/root/admin/users.tt
 # pfappserver::Form::Config::ProfileCommon (mandatory fields)
 msgid "cell_phone"

--- a/lib/pf/web/dispatcher.pm
+++ b/lib/pf/web/dispatcher.pm
@@ -202,8 +202,9 @@ sub html_redirect {
     }
 
     my $stash = {
-        'portal_url' => $portal_url->unparse(),
-        'wispr_url' => $wispr_url->unparse(),
+        'portal_url'    => $portal_url->unparse(),
+        'wispr_url'     => $wispr_url->unparse(),
+        'is_wispr_redirection_enabled'  => isenabled($Config{'captive_portal'}{'wispr_redirection'}) ? $TRUE : $FALSE,
     };
 
     my $response = '';


### PR DESCRIPTION
# Description

Enable / Disable captive-portal WISPr redirection capabilities
# Impacts

302 that redirects to the captive-portal (with or without WISPr)
# Delete branch after merge

YES
# NEWS file entries
## Enhancements
- Introduction of a new configuration parameter (captive_portal.wispr_redirection) to allow enabling/disabling captive-portal WISPr redirection capabilities
