### PR TITLE
Speed up the creation of switches

### DIFF
--- a/lib/pf/Switch.pm
+++ b/lib/pf/Switch.pm
@@ -254,7 +254,7 @@ sub supportsMABFloatingDevices {
 }
 
 sub new {
-    my ( $class, %argv ) = @_;
+    my ($class, $argv) = @_;
     my $this = bless {
         '_error'                    => undef,
         '_id'                       => undef,
@@ -307,114 +307,8 @@ sub new {
         '_switchMac'                => undef,
         '_VlanMap'                  => 'enabled',
         '_RoleMap'                  => 'enabled',
+        map { "_".$_ => $argv->{$_} } keys %$argv,
     }, $class;
-
-    foreach ( keys %argv ) {
-        if (/^-?SNMPCommunityRead$/i) {
-            $this->{_SNMPCommunityRead} = $argv{$_};
-        } elsif (/^-?SNMPCommunityTrap$/i) {
-            $this->{_SNMPCommunityTrap} = $argv{$_};
-        } elsif (/^-?SNMPCommunityWrite$/i) {
-            $this->{_SNMPCommunityWrite} = $argv{$_};
-        } elsif (/^-?id$/i) {
-            $this->{_id} = $argv{$_};
-        } elsif (/^-?macSearchesMaxNb$/i) {
-            $this->{_macSearchesMaxNb} = $argv{$_};
-        } elsif (/^-?macSearchesSleepInterval$/i) {
-            $this->{_macSearchesSleepInterval} = $argv{$_};
-        } elsif (/^-?mode$/i) {
-            $this->{_mode} = $argv{$_};
-        } elsif (/^-?SNMPAuthPasswordRead$/i) {
-            $this->{_SNMPAuthPasswordRead} = $argv{$_};
-        } elsif (/^-?SNMPAuthPasswordTrap$/i) {
-            $this->{_SNMPAuthPasswordTrap} = $argv{$_};
-        } elsif (/^-?SNMPAuthPasswordWrite$/i) {
-            $this->{_SNMPAuthPasswordWrite} = $argv{$_};
-        } elsif (/^-?SNMPAuthProtocolRead$/i) {
-            $this->{_SNMPAuthProtocolRead} = $argv{$_};
-        } elsif (/^-?SNMPAuthProtocolTrap$/i) {
-            $this->{_SNMPAuthProtocolTrap} = $argv{$_};
-        } elsif (/^-?SNMPAuthProtocolWrite$/i) {
-            $this->{_SNMPAuthProtocolWrite} = $argv{$_};
-        } elsif (/^-?SNMPPrivPasswordRead$/i) {
-            $this->{_SNMPPrivPasswordRead} = $argv{$_};
-        } elsif (/^-?SNMPPrivPasswordTrap$/i) {
-            $this->{_SNMPPrivPasswordTrap} = $argv{$_};
-        } elsif (/^-?SNMPPrivPasswordWrite$/i) {
-            $this->{_SNMPPrivPasswordWrite} = $argv{$_};
-        } elsif (/^-?SNMPPrivProtocolRead$/i) {
-            $this->{_SNMPPrivProtocolRead} = $argv{$_};
-        } elsif (/^-?SNMPPrivProtocolTrap$/i) {
-            $this->{_SNMPPrivProtocolTrap} = $argv{$_};
-        } elsif (/^-?SNMPPrivProtocolWrite$/i) {
-            $this->{_SNMPPrivProtocolWrite} = $argv{$_};
-        } elsif (/^-?SNMPUserNameRead$/i) {
-            $this->{_SNMPUserNameRead} = $argv{$_};
-        } elsif (/^-?SNMPUserNameTrap$/i) {
-            $this->{_SNMPUserNameTrap} = $argv{$_};
-        } elsif (/^-?SNMPUserNameWrite$/i) {
-            $this->{_SNMPUserNameWrite} = $argv{$_};
-        } elsif (/^-?cliEnablePwd$/i) {
-            $this->{_cliEnablePwd} = $argv{$_};
-        } elsif (/^-?cliPwd$/i) {
-            $this->{_cliPwd} = $argv{$_};
-        } elsif (/^-?cliUser$/i) {
-            $this->{_cliUser} = $argv{$_};
-        } elsif (/^-?cliTransport$/i) {
-            $this->{_cliTransport} = $argv{$_};
-        } elsif (/^-?wsPwd$/i) {
-            $this->{_wsPwd} = $argv{$_};
-        } elsif (/^-?wsUser$/i) {
-            $this->{_wsUser} = $argv{$_};
-        } elsif (/^-?wsTransport$/i) {
-            $this->{_wsTransport} = lc($argv{$_});
-        } elsif (/^-?radiusSecret$/i) {
-            $this->{_radiusSecret} = $argv{$_};
-        } elsif (/^-?controllerIp$/i) {
-            $this->{_controllerIp} = $argv{$_}? lc($argv{$_}) : undef;
-        } elsif (/^-?controllerPort$/i) {
-            $this->{_controllerPort} = $argv{$_};
-        } elsif (/^-?uplink$/i) {
-            $this->{_uplink} = $argv{$_};
-        } elsif (/^-?SNMPEngineID$/i) {
-            $this->{_SNMPEngineID} = $argv{$_};
-        } elsif (/^-?SNMPVersion$/i) {
-            $this->{_SNMPVersion} = $argv{$_};
-        } elsif (/^-?SNMPVersionTrap$/i) {
-            $this->{_SNMPVersionTrap} = $argv{$_};
-        } elsif (/^-?vlans$/i) {
-            $this->{_vlans} = $argv{$_};
-        } elsif (/^-?VoIPEnabled$/i) {
-            $this->{_VoIPEnabled} = $argv{$_};
-        } elsif (/^-?roles$/i) {
-            $this->{_roles} = $argv{$_};
-        } elsif (/^-?inlineTrigger$/i) {
-            $this->{_inlineTrigger} = $argv{$_};
-        } elsif (/^-?deauthMethod$/i) {
-            $this->{_deauthMethod} = $argv{$_};
-        } elsif (/^-?(ip)$/i) {
-            $this->{_ip} = $argv{$_};
-        } elsif (/^-?(switchIp)$/i) {
-            $this->{_switchIp} = $argv{$_};
-        } elsif (/^-?switchMac$/i) {
-            $this->{_switchMac} = $argv{$_};
-        } elsif (/^-?portalURL$/i) {
-            $this->{_portalURL} = $argv{$_};
-        } elsif (/^-?VlanMap$/i) {
-            $this->{_VlanMap} = $argv{$_};
-        } elsif (/^-?RoleMap$/i) {
-            $this->{_RoleMap} = $argv{$_};
-        } elsif (/^-?AccessListMap$/i) {
-            $this->{_AccessListMap} = $argv{$_};
-        } elsif (/^-?access_lists$/i) {
-            $this->{_access_lists} = $argv{$_};
-        }
-        # customVlan members are now dynamically generated. 0 to 99 supported.
-        elsif (/^-?(\w+)Vlan$/i) {
-            $this->{'_'.$1.'Vlan'} = $argv{$_};
-        }
-
-    }
     return $this;
 }
 
@@ -687,14 +581,14 @@ sub setVlan {
     # VLAN -1 handling
     # TODO at some point we should create a new blackhole / blacklist API
     # it would take advantage of per-switch features
-    if ($newVlan == -1) {
+    if (looks_like_number($newVlan) &&  $newVlan == -1) {
         $logger->warn("VLAN -1 is not supported in SNMP-Traps mode. Returning the switch's mac-detection VLAN.");
         $newVlan = $macDetectionVlan;
     }
 
     # VLAN are not defined on the switch
     if ( !$this->isDefinedVlan($newVlan) ) {
-        if ( $newVlan == $macDetectionVlan ) {
+        if ( $newVlan eq $macDetectionVlan ) {
             $logger->warn(
                 "MAC detection VLAN " . $macDetectionVlan
                 . " is not defined on switch " . $this->{_id}

--- a/lib/pf/Switch.pm
+++ b/lib/pf/Switch.pm
@@ -581,7 +581,7 @@ sub setVlan {
     # VLAN -1 handling
     # TODO at some point we should create a new blackhole / blacklist API
     # it would take advantage of per-switch features
-    if (looks_like_number($newVlan) &&  $newVlan == -1) {
+    if ( $newVlan eq "-1") {
         $logger->warn("VLAN -1 is not supported in SNMP-Traps mode. Returning the switch's mac-detection VLAN.");
         $newVlan = $macDetectionVlan;
     }

--- a/lib/pf/SwitchFactory.pm
+++ b/lib/pf/SwitchFactory.pm
@@ -162,14 +162,14 @@ sub instantiate {
     my $result;
     pfconfig::timeme::timeme('creating', sub {
     $logger->debug("creating new $module object");
-    $result = $module->new(
+    $result = $module->new({
          id => $requestedSwitch,
          ip => $switch_ip,
          switchIp => $switch_ip,
          switchMac => $switch_mac,
          %$switch_data,
          %$switchOverlay,
-    );
+    });
     });
     return $result;
 }

--- a/t/SNMP.t
+++ b/t/SNMP.t
@@ -109,7 +109,7 @@ my $switch = pf::SwitchFactory->instantiate('127.0.0.1');
 ok(!defined($switch->setVlanByName(1001, 'inexistantVlan', {})),
     "call setVlanByName with a vlan that doesn't exist in switches.conf");
 
-ok(!defined($switch->setVlanByName(1001, 'customVlan1', {})),
+ok(defined($switch->setVlanByName(1001, 'customVlan1', {})),
     "call setVlanByName with a vlan that exists but with a non-numeric value");
 
 ok(!defined($switch->setVlanByName(1001, 'customVlan2', {})),

--- a/t/SNMP.t
+++ b/t/SNMP.t
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use diagnostics;
 
-use Test::More tests => 30;
+use Test::More tests => 31;
 use Test::NoWarnings;
 
 use lib '/usr/local/pf/lib';
@@ -110,6 +110,9 @@ ok(!defined($switch->setVlanByName(1001, 'inexistantVlan', {})),
     "call setVlanByName with a vlan that doesn't exist in switches.conf");
 
 ok(defined($switch->setVlanByName(1001, 'customVlan1', {})),
+    "call setVlanByName with a vlan that exists but with a non-numeric value");
+
+ok(defined($switch->setVlanByName(1001, 'custom1Vlan', {})),
     "call setVlanByName with a vlan that exists but with a non-numeric value");
 
 ok(!defined($switch->setVlanByName(1001, 'customVlan2', {})),

--- a/t/data/switches.conf
+++ b/t/data/switches.conf
@@ -18,6 +18,7 @@ customVlan2=
 customVlan3=
 customVlan4=
 customVlan5=
+custom1Vlan=patate
 
 macSearchesMaxNb=30
 macSearchesSleepInterval=2

--- a/t/network-devices/wireless.t
+++ b/t/network-devices/wireless.t
@@ -66,12 +66,12 @@ foreach my $wireless_object (@wireless_devices) {
 
 # regression test for #1426: RADIUS CoA Broken on WLC 5500
 # http://www.packetfence.org/bugs/view.php?id=1426
-my $networkdevice_object = pf::Switch::Cisco::WiSM2->new(
-    '-mode' => 'production',
-    '-radiusSecret' => 'fake',
-    '-ip' => '127.0.0.1',
-    '-id' => '127.0.0.1',
-);
+my $networkdevice_object = pf::Switch::Cisco::WiSM2->new({
+    'mode' => 'production',
+    'radiusSecret' => 'fake',
+    'ip' => '127.0.0.1',
+    'id' => '127.0.0.1',
+});
 # bogusly calling methods trying to generate warnings
 $networkdevice_object->deauthenticateMacDefault("aa:bb:cc:dd:ee:ff");
 
@@ -85,12 +85,12 @@ local $SIG{__DIE__} = sub {
     my $str = join("\n", @_);
     warn(@_) if ($str !~ /No answer from 127\.0\.0\.1 on port 3799/m);
 };
-$networkdevice_object = pf::Switch::Aruba->new(
-    '-mode' => 'production',
-    '-radiusSecret' => 'fake',
-    '-ip' => '127.0.0.1',
-    '-id' => '127.0.0.1',
-);
+$networkdevice_object = pf::Switch::Aruba->new({
+    'mode' => 'production',
+    'radiusSecret' => 'fake',
+    'ip' => '127.0.0.1',
+    'id' => '127.0.0.1',
+});
 # bogusly calling methods trying to generate warnings
 $networkdevice_object->deauthenticateMacDefault("aa:bb:cc:dd:ee:ff");
 # putting back old die handler


### PR DESCRIPTION
## Description

During a benchmark session switch creation was shown to be slow.
One of the factors was the fact we passed the hash by value not by reference

Below is the benchmark of the speed difference by passing by value vs reference

```
Benchmark: running by value, by ref for at least 3 CPU seconds...
by value:  4 wallclock secs ( 3.37 usr +  0.00 sys =  3.37 CPU) @ 100499.70/s (n=338684)
by ref:    4 wallclock secs ( 3.17 usr +  0.00 sys =  3.17 CPU) @ 2260450.79/s (n=7165629)

```

| Benchmark | Rate | by value | by ref |
| --- | --- | --- | --- |
| **by value** | 100500/s | -- | -96% |
| **by ref** | 2260451/s | 2149% | -- |
## Impacts

Switch creation
## NEWS file entries

Enhancements
++++++++++++
- Speed up switch creation
## Delete branch after merge

NO
