### PR TITLE
Fix issue where the status code set by pf::WebAPI::JSONRPC did not match

### DIFF
--- a/lib/pf/WebAPI/JSONRPC.pm
+++ b/lib/pf/WebAPI/JSONRPC.pm
@@ -19,7 +19,6 @@ use pf::log;
 use Apache2::RequestIO;
 use Apache2::RequestRec;
 use Apache2::Response;
-use Apache2::Log;
 use Apache2::Const -compile =>
   qw(DONE OK DECLINED HTTP_UNAUTHORIZED HTTP_NOT_IMPLEMENTED HTTP_UNSUPPORTED_MEDIA_TYPE HTTP_PRECONDITION_FAILED HTTP_NO_CONTENT HTTP_NOT_FOUND SERVER_ERROR HTTP_OK HTTP_INTERNAL_SERVER_ERROR);
 use List::MoreUtils qw(any);

--- a/lib/pf/WebAPI/JSONRPC.pm
+++ b/lib/pf/WebAPI/JSONRPC.pm
@@ -1,4 +1,5 @@
 package pf::WebAPI::JSONRPC;
+
 =head1 NAME
 
 pf::WebAPI::JSONRPC - jsonrpc apache handler
@@ -15,99 +16,142 @@ use strict;
 use warnings;
 use JSON::XS;
 use pf::log;
-use Apache2::RequestIO();
-use Apache2::RequestRec();
-use Apache2::Response ();
-use Apache2::Const -compile => qw(OK DECLINED HTTP_UNAUTHORIZED HTTP_NOT_IMPLEMENTED HTTP_UNSUPPORTED_MEDIA_TYPE HTTP_PRECONDITION_FAILED HTTP_NO_CONTENT HTTP_NOT_FOUND SERVER_ERROR HTTP_OK HTTP_INTERNAL_SERVER_ERROR);
+use Apache2::RequestIO;
+use Apache2::RequestRec;
+use Apache2::Response;
+use Apache2::Log;
+use Apache2::Const -compile =>
+  qw(DONE OK DECLINED HTTP_UNAUTHORIZED HTTP_NOT_IMPLEMENTED HTTP_UNSUPPORTED_MEDIA_TYPE HTTP_PRECONDITION_FAILED HTTP_NO_CONTENT HTTP_NOT_FOUND SERVER_ERROR HTTP_OK HTTP_INTERNAL_SERVER_ERROR);
 use List::MoreUtils qw(any);
 use base qw(Class::Accessor);
 __PACKAGE__->mk_accessors(qw(dispatch_to));
 
-our $JSONRPC_ERROR_CODE_NOT_FOUND     = -32601;
-our $JSONRPC_ERROR_CODE_GENERIC_ERROR = -32000;
+our $JSONRPC_ERROR_CODE_GENERIC_ERROR   = -32000;
+our $JSONRPC_ERROR_CODE_INVALID_REQUEST = -32600;
+our $JSONRPC_ERROR_CODE_NOT_FOUND       = -32601;
+our $JSONRPC_ERROR_CODE_PARSE_ERROR     = -32700;
 
 our %ALLOW_CONTENT_TYPE = (
-    'application/json-rpc' => undef,
-    'application/json' => undef,
+    'application/json-rpc'    => undef,
+    'application/json'        => undef,
     'application/jsonrequest' => undef,
 );
 
-sub allowed { return exists $ALLOW_CONTENT_TYPE{$_[0]} }
+our $CONTENT_TYPE = 'application/json-rpc';
+our $RPC_VERSION  = "2.0";
+
+sub allowed {return exists $ALLOW_CONTENT_TYPE{$_[0]}}
 
 sub handler {
     my $logger = get_logger;
     use bytes;
-    my ($self,$r) = @_;
-    my $content_type = $r->headers_in->{'Content-Type'};
-    return Apache2::Const::HTTP_UNSUPPORTED_MEDIA_TYPE unless allowed($content_type);
-    my $content = '';
-    my $offset = 0;
-    my $cnt = 0;
-    do {
-        $cnt = $r->read($content,8192,$offset);
-        $offset += $cnt;
-    } while($cnt == 8192);
-    my $data = decode_json $content;
-    my $ref_type = ref($data);
-    return Apache2::Const::HTTP_UNSUPPORTED_MEDIA_TYPE unless $ref_type;
-    #for now not supporting batch
-    return Apache2::Const::HTTP_NOT_IMPLEMENTED if $ref_type eq 'ARRAY';
-    my ($method,$id,$jsonrpc) = @{$data}{qw(method id jsonrpc)};
-    return Apache2::Const::HTTP_NOT_IMPLEMENTED  unless defined $method;
-    my ($response, $status_code, $method_sub, @args);
+    my ($self, $r) = @_;
+    my $content = $self->get_all_the_content($r);
+    my $data = eval {decode_json $content };
+    if ($@) {
+        get_logger->error($@);
+        return $self->send_request(
+            $r,
+            Apache2::Const::HTTP_UNSUPPORTED_MEDIA_TYPE,
+            $self->make_error_object(undef, $JSONRPC_ERROR_CODE_PARSE_ERROR, "Cannot parse request\n", $@),
+        );
+    }
+    my $ref_type = ref $data;
+    unless ($ref_type && $ref_type eq 'HASH') {
+        get_logger->error("Invalid request");
+        return $self->send_request(
+            $r,
+            Apache2::Const::HTTP_UNSUPPORTED_MEDIA_TYPE,
+            $self->make_error_object(undef, $JSONRPC_ERROR_CODE_INVALID_REQUEST, "Invalid request\n"),
+        );
+    }
+
+    my ($method, $id, $jsonrpc) = @{$data}{qw(method id jsonrpc)};
+    unless (defined $method) {
+        get_logger->error("Invalid request no method defined");
+        return $self->send_request(
+            $r,
+            Apache2::Const::HTTP_UNSUPPORTED_MEDIA_TYPE,
+            $self->make_error_object(undef, $JSONRPC_ERROR_CODE_INVALID_REQUEST, "Invalid request no method defined\n"),
+        );
+    }
     my $dispatch_to = $self->dispatch_to;
-    if(exists $data->{'params'} ) {
+    my $response_content = '';
+    my $method_sub;
+    unless ( $method_sub = $dispatch_to->isPublic($method)) {
+        get_logger->error("Invalid request no method defined");
+        return $self->send_request(
+            $r,
+            Apache2::Const::HTTP_NOT_FOUND,
+            $self->make_error_object(undef, $JSONRPC_ERROR_CODE_NOT_FOUND, "Method '$method' not found\n"),
+        );
+    }
+    my @args;
+    if (exists $data->{'params'}) {
         my $params = $data->{'params'};
-        if (ref ($params) eq 'ARRAY' ) {
+        if (ref($params) eq 'ARRAY') {
             @args = @$params;
         } else {
             @args = ($params);
         }
     }
-    unless ($method_sub = $dispatch_to->isPublic($method)) {
-        $r->print(
-            encode_json({
-                (defined $jsonrpc ? (jsonrpc => $jsonrpc) : ()),
-                (defined $id      ? (id      => $id)      : ()),
-                error => {code => $JSONRPC_ERROR_CODE_NOT_FOUND, message => "Method not found"},
-            })
-        );
-        $status_code = Apache2::Const::HTTP_NOT_FOUND;
-    } elsif (defined $id) {
-        my $response_content = '';
+    if (defined $id) {
+        my $object;
         eval {
-            $response_content = encode_json ({
-                ( defined $jsonrpc ?  (jsonrpc => $jsonrpc) : () ),
-                result => [$dispatch_to->$method_sub(@args)],
-                id => $id,
-            });
-        };
-        if($@) {
-            $response_content = encode_json({
+            $object = {
                 (defined $jsonrpc ? (jsonrpc => $jsonrpc) : ()),
-                id => $id,
-                error => {code => $JSONRPC_ERROR_CODE_GENERIC_ERROR, message => "$@"},
-            });
-            $logger->error($@);
-            $status_code = Apache2::Const::HTTP_INTERNAL_SERVER_ERROR;
-        } else {
-            $status_code = Apache2::Const::HTTP_OK;
+                result => [$dispatch_to->$method_sub(@args)],
+                id     => $id,
+            }
+        };
+        if ($@) {
+            get_logger->error($@);
+            return $self->send_request(
+                $r,
+                Apache2::Const::HTTP_INTERNAL_SERVER_ERROR,
+                $self->make_error_object($id, $JSONRPC_ERROR_CODE_GENERIC_ERROR, $@)
+            );
         }
-        $r->print($response_content);
-    } else {
-        $r->push_handlers(PerlCleanupHandler => sub {
-            eval {
-                $dispatch_to->$method(@args);
-            };
-            $logger->error($@) if $@;
-        });
-        $status_code = Apache2::Const::HTTP_NO_CONTENT;
+        return $self->send_request($r, Apache2::Const::HTTP_OK, $object);
     }
-    $r->content_type($content_type);
-    $r->status($status_code);
+    # Notify message defer until later
+    $r->push_handlers(
+        PerlCleanupHandler => sub {
+            eval {$dispatch_to->$method(@args);};
+            $logger->error($@) if $@;
+        }
+    );
+    $r->content_type($CONTENT_TYPE);
+    return Apache2::Const::HTTP_NO_CONTENT;
+}
+
+sub send_request {
+    my ($self, $r, $status, $object) = @_;
+    $r->custom_response($status, '');
+    $r->content_type($CONTENT_TYPE);
+    $r->status($status);
+    my $response_content = encode_json($object);
+    $r->print($response_content);
+    $r->rflush;
     return Apache2::Const::OK;
 }
 
+sub get_all_the_content {
+    my ($self, $r) = @_;
+    my $content = '';
+    my $offset  = 0;
+    my $cnt     = 0;
+    do {
+        $cnt = $r->read($content, 8192, $offset);
+        $offset += $cnt;
+    } while ($cnt == 8192);
+    return $content;
+}
+
+sub make_error_object {
+    my ($self, $id, $code, $message, $data) = @_;
+    return {jsonrpc => "2.0", id => $id, error => {code => $code, message => $message}, data => $data};
+}
 
 =head1 AUTHOR
 
@@ -137,4 +181,3 @@ USA.
 =cut
 
 1;
-

--- a/lib/pf/api.pm
+++ b/lib/pf/api.pm
@@ -933,6 +933,17 @@ sub fingerbank_submit_unmatched : Public {
     pf::config::util::pfmailer(( subject => 'Fingerbank - Submit unknown/unmatched fingerprints status', message => $status_msg ));
 }
 
+=head2 throw
+
+TODO: documention
+
+=cut
+
+sub throw : Public {
+    die "This will always die\n";
+}
+
+
 =head1 AUTHOR
 
 Inverse inc. <info@inverse.ca>

--- a/lib/pf/api.pm
+++ b/lib/pf/api.pm
@@ -935,7 +935,7 @@ sub fingerbank_submit_unmatched : Public {
 
 =head2 throw
 
-TODO: documention
+Method throw for testing purposes
 
 =cut
 


### PR DESCRIPTION
Fixes #929
## Description

If an exception happened when handling the rpc request the error sent by apache did match the one set by pf::WebAPI::JSONRPC
## Impacts

The pf::api::jsonrpcclient response handlin
## NEWS file entries

Bug Fixes
+++++++++
- Fix improper httpd status code being set
## Delete branch after merge

NO
