### PR TITLE
added not equals to ldap auth rule

### DIFF
--- a/lib/pf/Authentication/Source/LDAPSource.pm
+++ b/lib/pf/Authentication/Source/LDAPSource.pm
@@ -421,7 +421,9 @@ sub ldap_filter_for_conditions {
           my $attribute = $condition->{'attribute'};
 
           if ($operator eq $Conditions::EQUALS) {
-              $str = "${attribute}=${value}";
+              $str = "(${attribute}=${value})";
+          }elsif ($operator eq $Conditions::NOT_EQUALS) {
+              $str = "!(${attribute}=${value})";
           } elsif ($operator eq $Conditions::CONTAINS) {
               $str = "${attribute}=*${value}*";
           } elsif ($operator eq $Conditions::STARTS) {

--- a/lib/pf/Authentication/constants.pm
+++ b/lib/pf/Authentication/constants.pm
@@ -62,6 +62,7 @@ Constants related to conditions rules.
 package Conditions;
 
 Readonly::Scalar our $EQUALS => 'equals';
+Readonly::Scalar our $NOT_EQUALS => 'not equals';
 Readonly::Scalar our $CONTAINS => 'contains';
 Readonly::Scalar our $STARTS => 'starts';
 Readonly::Scalar our $ENDS => 'ends';
@@ -102,7 +103,7 @@ Readonly::Hash our %OPERATORS =>
    $DATE => [$IS_BEFORE, $IS, $IS_AFTER],
    $TIME => [$IS_BEFORE, $IS_AFTER],
    $CONNECTION => [$IS, $IS_NOT],
-   $LDAP_ATTRIBUTE => [$STARTS, $EQUALS, $CONTAINS, $ENDS, $MATCHES, $IS_MEMBER],
+   $LDAP_ATTRIBUTE => [$STARTS, $EQUALS, $NOT_EQUALS, $CONTAINS, $ENDS, $MATCHES, $IS_MEMBER],
   );
 
 =back


### PR DESCRIPTION
# Description

Adds a 'not equal' operator to LDAP sources conditions
# Impacts

LDAP authentication and authorization
# Delete branch after merge

YES
# NEWS file entries
## New Features
- Added the ability to create 'not equal' conditions in LDAP sources
