### PR TITLE
Feature/tcp fingerprints

### DIFF
--- a/addons/packages/packetfence.spec
+++ b/addons/packages/packetfence.spec
@@ -96,6 +96,7 @@ Requires: freeradius >= 2.2.8-34, freeradius-mysql, freeradius-perl, freeradius-
 Requires: make
 Requires: net-tools
 Requires: sscep
+Requires: p0f
 Requires: net-snmp >= 5.3.2.2
 Requires: mysql, mysql-server, perl(DBD::mysql)
 Requires: perl >= %{perl_version}

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -261,6 +261,13 @@ description=<<EOT
 Should radsniff be managed by PacketFence?
 EOT
 
+[services.p0f]
+type=toggle
+options=enabled|disabled
+description=<<EOT
+Should p0f be managed by PacketFence?
+EOT
+
 [services.statsd]
 type=toggle
 options=enabled|disabled
@@ -373,6 +380,12 @@ EOT
 type=text
 description=<<EOT
 Location of the radsniff binary.
+EOT
+
+[services.p0f_binary]
+type=text
+description=<<EOT
+Location of the p0f binary.
 EOT
 
 [services.statsd_binary]

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -625,9 +625,9 @@ collectd_binary=/usr/sbin/collectd
 # Location of the radsniff3 binary. Only necessary to change if you are not running the pre-packaged version.
 radsniff3_binary=/usr/bin/radsniff3
 # 
-# services.radsniff_binary
+# services.p0f_binary
 # 
-# Location of the radsniff3 binary. Only necessary to change if you are not running the pre-packaged version.
+# Location of the p0f binary. Only necessary to change if you are not running the pre-packaged version.
 p0f_binary=/usr/local/bin/p0f
 # 
 # services.iptables_binary

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -555,6 +555,11 @@ statsd=enabled
 # Should radsniff be started?
 radsniff3=enabled
 #
+# services.p0f
+#
+# Should p0f be started?
+p0f=enabled
+#
 # services.snort_binary
 #
 # Location of the snort binary. Only necessary to change if you are not running the RPMed version. 
@@ -619,6 +624,11 @@ collectd_binary=/usr/sbin/collectd
 # 
 # Location of the radsniff3 binary. Only necessary to change if you are not running the pre-packaged version.
 radsniff3_binary=/usr/bin/radsniff3
+# 
+# services.radsniff_binary
+# 
+# Location of the radsniff3 binary. Only necessary to change if you are not running the pre-packaged version.
+p0f_binary=/usr/local/bin/p0f
 # 
 # services.iptables_binary
 # 

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/CaptivePortal.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/CaptivePortal.pm
@@ -134,6 +134,7 @@ sub processFingerbank :Private {
         mac                 => $mac,
         dhcp_fingerprint    => $node_attributes->{'dhcp_fingerprint'},
         dhcp_vendor         => $node_attributes->{'dhcp_vendor'},
+        ip                  => $portalSession->clientIp,
     );
 
     pf::fingerbank::process(\%fingerbank_query_args);

--- a/html/pfappserver/lib/pfappserver/PacketFence/Controller/Config/Fingerbank/Settings.pm
+++ b/html/pfappserver/lib/pfappserver/PacketFence/Controller/Config/Fingerbank/Settings.pm
@@ -87,6 +87,7 @@ sub index :Path :Args(0) :AdminRole('FINGERBANK_READ') {
     my $logger = pf::log::get_logger;
 
     $c->forward('check_for_api_key');
+    $c->stash(fingerbank_configured => fingerbank::Config::is_api_key_configured);
 
     my ( $status, $status_msg ) = HTTP_OK;
     my $form = $c->form("Config::Fingerbank::Settings");
@@ -125,6 +126,17 @@ sub index :Path :Args(0) :AdminRole('FINGERBANK_READ') {
         );
     }
 
+    $c->response->status($status);
+}
+
+sub update_p0f_map :Local :Args(0) :AdminRole('FINGERBANK_UPDATE') {
+    my ( $self, $c ) = @_;
+
+    $c->stash->{current_view} = 'JSON';
+
+    my ( $status, $status_msg ) = fingerbank::Config::update_p0f_map();
+
+    $c->stash->{status_msg} = $status_msg;
     $c->response->status($status);
 }
 

--- a/html/pfappserver/root/config/fingerbank/combination/index.tt
+++ b/html/pfappserver/root/config/fingerbank/combination/index.tt
@@ -17,15 +17,6 @@
 
       <h2>[% l('Combination') %]</h2>
 
-      <div class="options">
-        [% IF fingerbank_configured %]
-          <a class="updates_section_status_msg" href="[%c.uri_for(c.controller('Config::Fingerbank::DB').action_for('submit') )%]" ><i class="icon-share"></i> [% l('Submit Unknown/Unmatched Fingerprints') %]</a>
-          [% IF can_access("FINGERPRINTS_UPDATE") %] 
-            | <a class="updates_section_status_msg" href="[%c.uri_for(c.controller('Config::Fingerbank::DB').action_for('update') )%]" ><i class="icon-refresh"></i> [% l('Update Fingerbank DB') %]</a>
-          [% END %]
-        [% ELSE %]
-          [% l('It looks like Fingerbank is not configured. Please proceed to the Fingerbank Settings section to follow the onboard procedure') %]
-        [% END %]
-      </div>
+      [% INCLUDE config/fingerbank/header.tt %]
 
       [% INCLUDE config/fingerbank/combination/list.tt %]

--- a/html/pfappserver/root/config/fingerbank/device/index.tt
+++ b/html/pfappserver/root/config/fingerbank/device/index.tt
@@ -17,15 +17,6 @@
 
       <h2>[% l('Device') %]</h2>
 
-      <div class="options">
-        [% IF fingerbank_configured %]
-          <a class="updates_section_status_msg" href="[%c.uri_for(c.controller('Config::Fingerbank::DB').action_for('submit') )%]" ><i class="icon-share"></i> [% l('Submit Unknown/Unmatched Fingerprints') %]</a>
-          [% IF can_access("FINGERPRINTS_UPDATE") %]
-             | <a class="updates_section_status_msg" href="[%c.uri_for(c.controller('Config::Fingerbank::DB').action_for('update') )%]" ><i class="icon-refresh"></i> [% l('Update Fingerbank DB') %]</a>
-          [% END %]
-        [% ELSE %]
-          [% l('It looks like Fingerbank is not configured. Please proceed to the Fingerbank Settings section to follow the onboard procedure') %]
-        [% END %]
-      </div>
+      [% INCLUDE config/fingerbank/header.tt %]
 
       [% INCLUDE config/fingerbank/device/list.tt %]

--- a/html/pfappserver/root/config/fingerbank/device/upstream/index.tt
+++ b/html/pfappserver/root/config/fingerbank/device/upstream/index.tt
@@ -17,16 +17,7 @@
 
       <h2>[% l('Device') %]</h2>
 
-      <div class="options">
-        [% IF fingerbank_configured %]
-          <a class="updates_section_status_msg" href="[%c.uri_for(c.controller('Config::Fingerbank::DB').action_for('submit') )%]" ><i class="icon-share"></i> [% l('Submit Unknown/Unmatched Fingerprints') %]</a>
-          [% IF can_access("FINGERPRINTS_UPDATE") %]
-             | <a class="updates_section_status_msg" href="[%c.uri_for(c.controller('Config::Fingerbank::DB').action_for('update') )%]" ><i class="icon-refresh"></i> [% l('Update Fingerbank DB') %]</a>
-          [% END %]
-        [% ELSE %]
-          [% l('It looks like Fingerbank is not configured. Please proceed to the Fingerbank Settings section to follow the onboard procedure') %]
-        [% END %]
-      </div>
+      [% INCLUDE config/fingerbank/header.tt %]
 
       [% INCLUDE config/fingerbank/device/upstream/list.tt %]
 

--- a/html/pfappserver/root/config/fingerbank/dhcp_fingerprint/index.tt
+++ b/html/pfappserver/root/config/fingerbank/dhcp_fingerprint/index.tt
@@ -17,15 +17,6 @@
 
       <h2>[% l('DHCP Fingerprint') %]</h2>
 
-      <div class="options">
-        [% IF fingerbank_configured %]
-          <a class="updates_section_status_msg" href="[%c.uri_for(c.controller('Config::Fingerbank::DB').action_for('submit') )%]" ><i class="icon-share"></i> [% l('Submit Unknown/Unmatched Fingerprints') %]</a>
-          [% IF can_access("FINGERPRINTS_UPDATE") %] 
-             | <a class="updates_section_status_msg" href="[%c.uri_for(c.controller('Config::Fingerbank::DB').action_for('update') )%]" ><i class="icon-refresh"></i> [% l('Update Fingerbank DB') %]</a>
-          [% END %]
-        [% ELSE %]
-          [% l('It looks like Fingerbank is not configured. Please proceed to the Fingerbank Settings section to follow the onboard procedure') %]
-        [% END %]
-      </div>
+      [% INCLUDE config/fingerbank/header.tt %]
 
       [% INCLUDE config/fingerbank/dhcp_fingerprint/list.tt %]

--- a/html/pfappserver/root/config/fingerbank/dhcp_vendor/index.tt
+++ b/html/pfappserver/root/config/fingerbank/dhcp_vendor/index.tt
@@ -17,15 +17,6 @@
 
       <h2>[% l('DHCP Vendor') %]</h2>
 
-      <div class="options">
-        [% IF fingerbank_configured %]
-          <a class="updates_section_status_msg" href="[%c.uri_for(c.controller('Config::Fingerbank::DB').action_for('submit') )%]" ><i class="icon-share"></i> [% l('Submit Unknown/Unmatched Fingerprints') %]</a>
-          [% IF can_access("FINGERPRINTS_UPDATE") %] 
-            | <a class="updates_section_status_msg" href="[%c.uri_for(c.controller('Config::Fingerbank::DB').action_for('update') )%]" ><i class="icon-refresh"></i> [% l('Update Fingerbank DB') %]</a>
-          [% END %]
-        [% ELSE %]
-          [% l('It looks like Fingerbank is not configured. Please proceed to the Fingerbank Settings section to follow the onboard procedure') %]
-        [% END %]
-      </div>
+      [% INCLUDE config/fingerbank/header.tt %]
 
       [% INCLUDE config/fingerbank/dhcp_vendor/list.tt %]

--- a/html/pfappserver/root/config/fingerbank/header.tt
+++ b/html/pfappserver/root/config/fingerbank/header.tt
@@ -1,0 +1,11 @@
+<div class="options">
+  [% IF fingerbank_configured %]
+    <a class="updates_section_status_msg" href="[%c.uri_for(c.controller('Config::Fingerbank::DB').action_for('submit') )%]" ><i class="icon-share"></i> [% l('Submit Unknown/Unmatched Fingerprints') %]</a>
+    [% IF can_access("FINGERPRINTS_UPDATE") %]
+       | <a class="updates_section_status_msg" href="[%c.uri_for(c.controller('Config::Fingerbank::DB').action_for('update') )%]" ><i class="icon-refresh"></i> [% l('Update Fingerbank DB') %]</a>
+       | <a class="updates_section_status_msg" href="[%c.uri_for(c.controller('Config::Fingerbank::Settings').action_for('update_p0f_map') )%]" ><i class="icon-refresh"></i> [% l('Update Fingebank p0f map') %]</a>
+    [% END %]
+  [% ELSE %]
+    [% l('It looks like Fingerbank is not configured. Please proceed to the Fingerbank Settings section to follow the onboard procedure') %]
+  [% END %]
+</div>

--- a/html/pfappserver/root/config/fingerbank/mac_vendor/index.tt
+++ b/html/pfappserver/root/config/fingerbank/mac_vendor/index.tt
@@ -17,15 +17,6 @@
 
       <h2>[% l('MAC Vendor') %]</h2>
 
-      <div class="options">
-        [% IF fingerbank_configured %]
-          <a class="updates_section_status_msg" href="[%c.uri_for(c.controller('Config::Fingerbank::DB').action_for('submit') )%]" ><i class="icon-share"></i> [% l('Submit Unknown/Unmatched Fingerprints') %]</a>
-          [% IF can_access("FINGERPRINTS_UPDATE") %] 
-             | <a class="updates_section_status_msg" href="[%c.uri_for(c.controller('Config::Fingerbank::DB').action_for('update') )%]" ><i class="icon-refresh"></i> [% l('Update Fingerbank DB') %]</a>
-          [% END %]
-        [% ELSE %]
-          [% l('It looks like Fingerbank is not configured. Please proceed to the Fingerbank Settings section to follow the onboard procedure') %]
-        [% END %]
-      </div>
+      [% INCLUDE config/fingerbank/header.tt %]
 
       [% INCLUDE config/fingerbank/mac_vendor/list.tt %]

--- a/html/pfappserver/root/config/fingerbank/settings/index.tt
+++ b/html/pfappserver/root/config/fingerbank/settings/index.tt
@@ -1,11 +1,6 @@
 <h2>[% l('Fingerbank Settings') %]</h2>
 
-<div class="options">
-  <a class="updates_section_status_msg" href="[%c.uri_for(c.controller('Config::Fingerbank::DB').action_for('submit') )%]" ><i class="icon-share"></i> [% l('Submit Unknown/Unmatched Fingerprints') %]</a>
-  [% IF can_access("FINGERPRINTS_UPDATE") %]
-    | <a class="updates_section_status_msg" href="[%c.uri_for(c.controller('Config::Fingerbank::DB').action_for('update') )%]" ><i class="icon-refresh"></i> [% l('Update Fingerbank DB') %]</a>
-  [% END %]
-</div>
+[% INCLUDE config/fingerbank/header.tt %]
 
 <br/>
 

--- a/html/pfappserver/root/config/fingerbank/user_agent/index.tt
+++ b/html/pfappserver/root/config/fingerbank/user_agent/index.tt
@@ -17,15 +17,6 @@
 
       <h2>[% l('User Agent') %]</h2>
 
-      <div class="options">
-        [% IF fingerbank_configured %]
-          <a class="updates_section_status_msg" href="[%c.uri_for(c.controller('Config::Fingerbank::DB').action_for('submit') )%]" ><i class="icon-share"></i> [% l('Submit Unknown/Unmatched Fingerprints') %]</a>
-          [% IF can_access("FINGERPRINTS_UPDATE") %] 
-             | <a class="updates_section_status_msg" href="[%c.uri_for(c.controller('Config::Fingerbank::DB').action_for('update') )%]" ><i class="icon-refresh"></i> [% l('Update Fingerbank DB') %]</a>
-          [% END %]
-        [% ELSE %]
-          [% l('It looks like Fingerbank is not configured. Please proceed to the Fingerbank Settings section to follow the onboard procedure') %]
-        [% END %]
-      </div>
+      [% INCLUDE config/fingerbank/header.tt %]
 
       [% INCLUDE config/fingerbank/user_agent/list.tt %]

--- a/lib/pf/fingerbank.pm
+++ b/lib/pf/fingerbank.pm
@@ -19,6 +19,7 @@ use fingerbank::Model::MAC_Vendor;
 use fingerbank::Model::User_Agent;
 use fingerbank::Query;
 use fingerbank::FilePath;
+use fingerbank::Model::Endpoint;
 use pf::cluster;
 use pf::constants;
 
@@ -210,15 +211,15 @@ sub is_a {
 
     $logger->debug("Trying to determine the kind of device for '$device_type' device type");
 
-    my $fingerbank = fingerbank::Query->new;
+    my $endpoint = fingerbank::Model::Endpoint->new(name => $device_type, version => undef, score => undef);
 
-    return "Windows" if ( $fingerbank->isWindows($device_type) );
+    return "Windows" if ( $endpoint->isWindows($device_type) );
     # Macintosh / Mac OS
-    return "Macintosh" if ( $fingerbank->isMacOS($device_type) );
+    return "Macintosh" if ( $endpoint->isMacOS($device_type) );
     # Android
-    return "Generic Android" if ( $fingerbank->isAndroid($device_type) );
+    return "Generic Android" if ( $endpoint->isAndroid($device_type) );
     # Apple IOS
-    return "Apple iPod, iPhone or iPad" if ( $fingerbank->isIOS($device_type) );
+    return "Apple iPod, iPhone or iPad" if ( $endpoint->isIOS($device_type) );
 
     # Unknown (we were not able to match)
     return "unknown";

--- a/lib/pf/services/manager/p0f.pm
+++ b/lib/pf/services/manager/p0f.pm
@@ -1,0 +1,66 @@
+package pf::services::manager::p0f;
+
+=head1 NAME
+
+pf::services::manager::p0f management module. 
+
+=cut
+
+=head1 DESCRIPTION
+
+pf::services::manager::p0f
+
+=cut
+
+use strict;
+use warnings;
+use pf::file_paths;
+use pf::util;
+use pf::config;
+use Moo;
+use pf::cluster;
+
+extends 'pf::services::manager';
+
+has '+name' => ( default => sub {'p0f'} );
+has '+optional' => ( default => sub {1} );
+
+has '+launcher' => (
+    default => sub {
+        my ($self) = @_;
+        my $pid_file = $self->pidFile;
+        my $name = $self->name;
+        my $p0f_map = "/usr/local/fingerbank/conf/fingerbank-p0f.fp";
+        my $p0f_sock = "/var/run/p0f.sock";
+        "sudo %1\$s -d -i any -p -f $p0f_map -s $p0f_sock > /dev/null && pidof $name > $pid_file";
+    }
+);
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2015 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;

--- a/lib/pf/services/manager/p0f.pm
+++ b/lib/pf/services/manager/p0f.pm
@@ -19,6 +19,7 @@ use pf::util;
 use pf::config;
 use Moo;
 use pf::cluster;
+use fingerbank::Config;
 
 extends 'pf::services::manager';
 
@@ -28,10 +29,11 @@ has '+optional' => ( default => sub {1} );
 has '+launcher' => (
     default => sub {
         my ($self) = @_;
+        my $FingerbankConfig = fingerbank::Config::get_config;
+        my $p0f_map = $FingerbankConfig->{tcp_fingerprinting}{p0f_map_path};
+        my $p0f_sock = $FingerbankConfig->{tcp_fingerprinting}{p0f_socket_path};
         my $pid_file = $self->pidFile;
         my $name = $self->name;
-        my $p0f_map = "/usr/local/fingerbank/conf/fingerbank-p0f.fp";
-        my $p0f_sock = "/var/run/p0f.sock";
         "sudo %1\$s -d -i any -p -f $p0f_map -s $p0f_sock > /dev/null && pidof $name > $pid_file";
     }
 );

--- a/packetfence.sudoers
+++ b/packetfence.sudoers
@@ -1,2 +1,2 @@
-pf ALL=NOPASSWD: /sbin/iptables, /usr/sbin/ipset, /sbin/ip, /sbin/vconfig, /sbin/route, /sbin/service, /usr/bin/tee, /usr/local/pf/sbin/pfdhcplistener, /bin/kill, /usr/sbin/dhcpd, /usr/sbin/radiusd, /usr/sbin/snort, /usr/bin/suricata, /usr/sbin/chroot, /usr/local/pf/bin/pfcmd, /usr/sbin/conntrack
+pf ALL=NOPASSWD: /sbin/iptables, /usr/sbin/ipset, /sbin/ip, /sbin/vconfig, /sbin/route, /sbin/service, /usr/bin/tee, /usr/local/pf/sbin/pfdhcplistener, /bin/kill, /usr/sbin/dhcpd, /usr/sbin/radiusd, /usr/sbin/snort, /usr/bin/suricata, /usr/sbin/chroot, /usr/local/pf/bin/pfcmd, /usr/sbin/conntrack, /usr/local/bin/p0f
 Defaults !requiretty

--- a/sbin/pfdhcplistener
+++ b/sbin/pfdhcplistener
@@ -310,7 +310,8 @@ sub listen_dhcp {
             dhcp_fingerprint    => $tmp{'dhcp_fingerprint'},
             dhcp_vendor         => $tmp{'dhcp_vendor'},
             mac                 => $dhcp->{'chaddr'},
-            ip                  => $dhcp->{'yiaddr'},
+            # When listening on the mgmt interface, we can't rely on yiaddr as we only see requests
+            ip                  => ($dhcp->{'yiaddr'} ne "0.0.0.0") ? $dhcp->{'yiaddr'} : $dhcp->{'options'}{'50'},
         );
         $apiclient->notify('fingerbank_process', \%fingerbank_query_args );
 

--- a/sbin/pfdhcplistener
+++ b/sbin/pfdhcplistener
@@ -310,6 +310,7 @@ sub listen_dhcp {
             dhcp_fingerprint    => $tmp{'dhcp_fingerprint'},
             dhcp_vendor         => $tmp{'dhcp_vendor'},
             mac                 => $dhcp->{'chaddr'},
+            ip                  => $dhcp->{'yiaddr'},
         );
         $apiclient->notify('fingerbank_process', \%fingerbank_query_args );
 


### PR DESCRIPTION
# Description

Adds TCP fingerprinting to PacketFence via the Fingerbank library and p0f
# Impacts

Device recognition
# Dependencies

Requires the TCP fingerprinting in the Fingerbank library (https://github.com/inverse-inc/fingerbank/pull/24)
# NEWS file entries

(REQUIRED)
## New Features
- Added device detection through TCP fingerprinting
