### PR TITLE
Feature/chi compute with undef

### DIFF
--- a/lib/pf/Authentication/Source/LDAPSource.pm
+++ b/lib/pf/Authentication/Source/LDAPSource.pm
@@ -229,7 +229,7 @@ sub match {
     my ($self, $params) = @_;
     my $start = Time::HiRes::gettimeofday();
     if($self->is_match_cacheable) {
-        my $result = $self->cache->compute([$self->id, $params], sub {
+        my $result = $self->cache->compute_with_undef([$self->id, $params], sub {
                 $pf::StatsD::statsd->increment(called() . "." . $self->id. ".cache_miss.count" );
                 my $result =   $self->SUPER::match($params);
                 return $result;

--- a/lib/pf/CHI.pm
+++ b/lib/pf/CHI.pm
@@ -27,7 +27,6 @@ use DBI;
 use Scalar::Util qw(tainted reftype);
 use pf::log;
 use Log::Any::Adapter;
-use pfconfig::util qw($undef_element);
 Log::Any::Adapter->set('Log4perl');
 
 my @PRELOADED_CHI_DRIVERS;
@@ -120,6 +119,7 @@ sub chiConfigFromIniFile {
             my $value =  listify($storage->{$param});
             $storage->{$param} = [ map { split /\s*,\s*/, $_ } @$value ];
         }
+        push @{$storage->{traits}}, '+pf::Role::CHI::Driver::ComputeWithUndef';
     }
     setDefaultStorage($args{storage});
     setRawL1CacheAsLast($args{storage}{configfiles});
@@ -200,27 +200,6 @@ sub preload_chi_drivers {
     unless (@PRELOADED_CHI_DRIVERS) {
         @PRELOADED_CHI_DRIVERS = __PACKAGE__->_preload_chi_drivers;
     }
-}
-
-sub compute_with_undef {
-    my ($cache, $key, $on_miss) = @_;
-    my $return = $cache->get($key);
-    if(defined($return) && ref($return) eq "pfconfig::undef_element"){
-        return undef;
-    }
-    elsif(defined($return)){
-        return $return;
-    }
-
-    my $result = $on_miss->();
-    if(defined($result)){
-        $cache->set($key,$result);
-    }
-    else {
-        $cache->set($key, $undef_element);
-    }
-
-    return $result;
 }
 
 

--- a/lib/pf/CHI.pm
+++ b/lib/pf/CHI.pm
@@ -27,6 +27,7 @@ use DBI;
 use Scalar::Util qw(tainted reftype);
 use pf::log;
 use Log::Any::Adapter;
+use pfconfig::util qw($undef_element);
 Log::Any::Adapter->set('Log4perl');
 
 my @PRELOADED_CHI_DRIVERS;
@@ -199,6 +200,27 @@ sub preload_chi_drivers {
     unless (@PRELOADED_CHI_DRIVERS) {
         @PRELOADED_CHI_DRIVERS = __PACKAGE__->_preload_chi_drivers;
     }
+}
+
+sub compute_with_undef {
+    my ($cache, $key, $on_miss) = @_;
+    my $return = $cache->get($key);
+    if(defined($return) && ref($return) eq "pfconfig::undef_element"){
+        return undef;
+    }
+    elsif(defined($return)){
+        return $return;
+    }
+
+    my $result = $on_miss->();
+    if(defined($result)){
+        $cache->set($key,$result);
+    }
+    else {
+        $cache->set($key, $undef_element);
+    }
+
+    return $result;
 }
 
 

--- a/lib/pf/Role/CHI/Driver/ComputeWithUndef.pm
+++ b/lib/pf/Role/CHI/Driver/ComputeWithUndef.pm
@@ -1,0 +1,70 @@
+package pf::Role::CHI::Driver::ComputeWithUndef;
+
+=head1 NAME
+
+pf::Role::CHI::Driver::ComputeWithUndef
+
+=cut
+
+=head1 DESCRIPTION
+
+Adds a method that caches undef results in compute
+
+=cut
+
+use strict;
+use warnings;
+use Moo::Role;
+use pfconfig::util qw($undef_element);
+
+sub compute_with_undef {
+    my ($self, $key, $on_miss) = @_;
+    my $return = $self->get($key);
+    if(defined($return) && ref($return) eq "pfconfig::undef_element"){
+        return undef;
+    }
+    elsif(defined($return)){
+        return $return;
+    }
+
+    my $result = $on_miss->();
+    if(defined($result)){
+        $self->set($key,$result);
+    }
+    else {
+        $self->set($key, $undef_element);
+    }
+
+    return $result;
+}
+
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2015 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;
+

--- a/t/data/chi.conf
+++ b/t/data/chi.conf
@@ -22,3 +22,9 @@ driver=Null
 [storage file]
 driver=File
 root_dir=/tmp/chi
+
+[namespace t]
+storage=t
+
+[storage t]
+storage=file

--- a/t/unittest/CHI.t
+++ b/t/unittest/CHI.t
@@ -1,0 +1,106 @@
+#!/usr/bin/perl
+
+=head1 NAME
+
+condition_parser
+
+=cut
+
+=head1 DESCRIPTION
+
+unit test for condition_parser
+
+=cut
+
+use strict;
+use warnings;
+#
+use lib '/usr/local/pf/lib';
+
+BEGIN {
+    #include test libs
+    use lib qw(/usr/local/pf/t);
+
+    #Module for overriding configuration paths
+    use PfFilePaths;
+
+}
+
+use pf::CHI;
+
+use Test::More tests => 9;
+use Test::Exception;
+
+#This test will running last
+use Test::NoWarnings;
+
+my $cache_miss = 0;
+
+my $cache = pf::CHI->new( namespace => 't');
+
+# Test computing with undef values
+
+my $result = pf::CHI::compute_with_undef($cache, 'undef_value', sub { $cache_miss++ ; undef });
+
+is(undef, $result,
+    "Computing undef returns undef in a cache miss");
+
+is(1, $cache_miss,
+    "Computing an uncomputed undef value increments the hits");
+
+$result = pf::CHI::compute_with_undef($cache, 'undef_value', sub { $cache_miss++ ; undef });
+
+is(undef, $result,
+    "Computing undef returns undef in a cache hit");
+
+is(1, $cache_miss,
+    "Computing a computed undef value does not increment the hits");
+
+# Test computing with non-undef values
+
+$cache_miss = 0;
+$result = pf::CHI::compute_with_undef($cache, 'defined_value', sub { $cache_miss++ ; "turkey" });
+
+is("turkey", $result,
+    "Computing a defined value returns the value in a cache miss");
+
+is(1, $cache_miss,
+    "Computing an uncomputed defined value increments the hits");
+
+$result = pf::CHI::compute_with_undef($cache, 'defined_value', sub { $cache_miss++ ; "turkey" });
+
+is("turkey", $result,
+    "Computing a defined value returns the value in a cache hit");
+
+is(1, $cache_miss,
+    "Computing a computed defined value does not increment the hits");
+ 
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2015 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;
+

--- a/t/unittest/CHI.t
+++ b/t/unittest/CHI.t
@@ -40,7 +40,7 @@ my $cache = pf::CHI->new( namespace => 't');
 
 # Test computing with undef values
 
-my $result = pf::CHI::compute_with_undef($cache, 'undef_value', sub { $cache_miss++ ; undef });
+my $result = $cache->compute_with_undef('undef_value', sub { $cache_miss++ ; undef });
 
 is(undef, $result,
     "Computing undef returns undef in a cache miss");
@@ -48,7 +48,7 @@ is(undef, $result,
 is(1, $cache_miss,
     "Computing an uncomputed undef value increments the hits");
 
-$result = pf::CHI::compute_with_undef($cache, 'undef_value', sub { $cache_miss++ ; undef });
+$result = $cache->compute_with_undef('undef_value', sub { $cache_miss++ ; undef });
 
 is(undef, $result,
     "Computing undef returns undef in a cache hit");
@@ -59,7 +59,7 @@ is(1, $cache_miss,
 # Test computing with non-undef values
 
 $cache_miss = 0;
-$result = pf::CHI::compute_with_undef($cache, 'defined_value', sub { $cache_miss++ ; "turkey" });
+$result = $cache->compute_with_undef('defined_value', sub { $cache_miss++ ; "turkey" });
 
 is("turkey", $result,
     "Computing a defined value returns the value in a cache miss");
@@ -67,7 +67,7 @@ is("turkey", $result,
 is(1, $cache_miss,
     "Computing an uncomputed defined value increments the hits");
 
-$result = pf::CHI::compute_with_undef($cache, 'defined_value', sub { $cache_miss++ ; "turkey" });
+$result = $cache->compute_with_undef('defined_value', sub { $cache_miss++ ; "turkey" });
 
 is("turkey", $result,
     "Computing a defined value returns the value in a cache hit");

--- a/t/unittest/CHI.t
+++ b/t/unittest/CHI.t
@@ -2,13 +2,13 @@
 
 =head1 NAME
 
-condition_parser
+CHI
 
 =cut
 
 =head1 DESCRIPTION
 
-unit test for condition_parser
+unit test for pf::CHI
 
 =cut
 


### PR DESCRIPTION
# Description

Add the ability to cache undef values when using cache computing
# Impacts

LDAP caching as its the only one which uses it
# Issue
#978
# Delete branch after merge

YES
# NEWS file entries
## Bug Fixes
- Non-found users will now be cached when using the caching in an LDAP source (#978)
