### PR TITLE
Avoid database lookup when filtering for arguments that are never used.

### DIFF
--- a/addons/packages/packetfence.spec
+++ b/addons/packages/packetfence.spec
@@ -261,6 +261,7 @@ Requires: perl(Hash::Merge)
 Requires: perl(IO::Socket::INET6)
 Requires: perl(IO::Interface)
 Requires: perl(Time::Period)
+Requires: perl(Data::Thunk);
 Requires: iproute >= 3.0.0, samba < 4, krb5-workstation
 # configuration-wizard
 Requires: iproute, vconfig

--- a/debian/control
+++ b/debian/control
@@ -69,7 +69,7 @@ Depends: ${misc:Depends}, vlan, make,
  libcrypt-openssl-pkcs12-perl,libcrypt-openssl-x509-perl,libconst-fast-perl,
  libtime-period-perl, libsereal-encoder-perl, libsereal-decoder-perl, libdata-serializer-sereal-perl (>= 1.04), libphp-serialization-perl,
  libnet-ip-perl, libdigest-hmac-perl, libcrypt-openssl-pkcs10-perl, libcrypt-openssl-rsa-perl, libfile-tempdir-perl,
- liburi-escape-xs-perl,
+ liburi-escape-xs-perl, libdata-thunk-perl,
 # hard-coded to specific version because v3 broke the API and we haven't ported to it yet
 # see #1313: Port our Net-Appliance-Session to the version 3 API
 # http://packetfence.org/bugs/view.php?id=1313

--- a/lib/pf/Portal/ProfileFactory.pm
+++ b/lib/pf/Portal/ProfileFactory.pm
@@ -30,6 +30,7 @@ use List::Util qw(first);
 use Time::HiRes;
 use pf::util::statsd qw(called);
 use pf::StatsD;
+use Data::Thunk;
 
 =head1 SUBROUTINES
 
@@ -47,10 +48,7 @@ sub instantiate {
     if (defined($options->{'portal'})) {
         return $self->_from_profile($options->{'portal'});
     }
-
-    my $node_info = node_view($mac) || {};
-    $node_info = {%$node_info, %$options};
-
+    my $node_info = lazy { {node_view($mac) || {}, %$options } };
     my $profile_name = $PROFILE_FILTER_ENGINE->match_first($node_info);
     my $instance = $self->_from_profile($profile_name);
     return $instance;

--- a/lib/pf/access_filter/radius.pm
+++ b/lib/pf/access_filter/radius.pm
@@ -20,6 +20,7 @@ use pf::locationlog qw(locationlog_set_session);
 use pf::util qw(isenabled generate_session_id);
 use pf::CHI;
 use Scalar::Util qw(reftype);
+use Data::Thunk;
 
 use base qw(pf::access_filter);
 tie our %ConfigRadiusFilters, 'pfconfig::cached_hash', 'config::RadiusFilters';
@@ -38,7 +39,7 @@ sub test {
     my ($self, $scope, $args) = @_;
     my $engine = $self->getEngineForScope($scope);
     if ($engine) {
-        $args->{'violation'} = violation_view_top($args->{'mac'});
+        $args->{'violation'} = lazy {  violation_view_top($args->{'mac'}) };
         my $answer = $engine->match_first($args);
         $self->logger->info("Match rule $answer->{_rule}") if defined $answer;
         return $answer;

--- a/lib/pf/vlan.pm
+++ b/lib/pf/vlan.pm
@@ -36,6 +36,7 @@ use pf::lookup::person;
 use Time::HiRes;
 use pf::util::statsd qw(called);
 use pf::StatsD;
+use Data::Thunk;
 
 our $VERSION = 1.04;
 
@@ -250,7 +251,7 @@ sub getViolationVlan {
     my $vid = $top_violation->{'vid'};
 
     # Scan violation that must be done in the production vlan
-    if ($vid == $POST_SCAN_VID) { 
+    if ($vid == $POST_SCAN_VID) {
         $pf::StatsD::statsd->end(called() . ".timing" , $start);
         return $FALSE;
     }
@@ -788,7 +789,7 @@ sub filterVlan {
         connection_type => $connection_type,
         username       => $user_name,
         ssid            => $ssid,
-        owner           => person_view($node_info->{'pid'}),
+        owner           => lazy { person_view($node_info->{'pid'}) },
         radius_request  => $radius_request
     };
     my @results = $filter->filter($scope, $args);


### PR DESCRIPTION
## Description

Avoid database lookup when filtering for arguments that are never used.
## Impacts

The filter engine
## NEWS file entries

New Features
++++++++++++

Enhancements
++++++++++++
- Avoid unneccesary calls to the database when using vlan filtering
- Avoid unneccesary calls to the database when using radius filtering
- Avoid unneccesary calls to the database for the profile filters

Bug Fixes
+++++++++
## Delete branch after merge

NO
