### PR TITLE
make local dhcp detection packet dependent

### DIFF
--- a/lib/pf/api.pm
+++ b/lib/pf/api.pm
@@ -1003,7 +1003,7 @@ The UDP payload must be base 64 encoded.
 
 sub process_dhcp : Public {
     my ($class, %postdata) = @_;
-    my @require = qw(src_mac src_ip dest_mac dest_ip running_w_dhcpd is_inline_vlan interface interface_ip interface_vlan net_type udp_payload_b64);
+    my @require = qw(src_mac src_ip dest_mac dest_ip is_inline_vlan interface interface_ip interface_vlan net_type udp_payload_b64);
     my @found = grep {exists $postdata{$_}} @require;
     return unless validate_argv(\@require,\@found);
     

--- a/sbin/pfdhcplistener
+++ b/sbin/pfdhcplistener
@@ -108,7 +108,6 @@ $PROGRAM_NAME = $0 = "${PROGRAM_NAME}_${interface}";
 daemonize($PROGRAM_NAME) if ($daemonize);
 
 my $net_addr = NetAddr::IP->new($Config{"interface $interface"}{'ip'},$Config{"interface $interface"}{'mask'});
-my $running_w_dhcpd = $FALSE;
 
 # start dhcp monitor
 if ( isenabled( $Config{'network'}{'dhcpdetector'} ) ) {
@@ -120,10 +119,6 @@ if ( isenabled( $Config{'network'}{'dhcpdetector'} ) ) {
         foreach my $network (keys %ConfigNetworks) {
             my %net = %{$ConfigNetworks{$network}};
             my $network_obj = NetAddr::IP->new($network,$ConfigNetworks{$network}{netmask});
-            if(isenabled($net{dhcpd}) && $network_obj->contains($net_addr)){
-                $running_w_dhcpd = $TRUE;
-                $logger->info("The listener process is on the same server as the DHCP server.");
-            }
 
             # are we listening on an inline interface ?
             next if (!pf::config::is_network_type_inline($network));
@@ -197,7 +192,6 @@ sub process_pkt {
                 dest_mac => clean_mac($l2->{'dest_mac'}),
                 src_ip => $l3->{'src_ip'},
                 dest_ip => $l3->{'dest_ip'},
-                running_w_dhcpd => $running_w_dhcpd,
                 is_inline_vlan => $is_inline_vlan,
                 interface => $interface,
                 interface_ip => $interface_ip,


### PR DESCRIPTION
# Description

Process requests properly when running a pfdhcplistener on an interface that has networks with and without dhcpd activated
# Impacts

pfdhcplistener
# Delete branch after merge

YES
# NEWS file entries
## Bug Fixes
- Process requests properly when running a pfdhcplistener on an interface that has networks with and without dhcpd activated
