### PR TITLE
Fix/ssidbroadcast agent

### DIFF
--- a/html/pfappserver/lib/pfappserver/Form/Config/Provisioning/mobileconfig.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Provisioning/mobileconfig.pm
@@ -28,9 +28,8 @@ has_field 'broadcast' =>
   (
    type => 'Checkbox',
    label => 'Broadcast network',
-   value => 'true',
-   default => 'yes',
-   checkbox_value => 'Y',
+   checkbox_value => 1,
+   input_without_param => 0,
    tags => { after_element => \&help,
              help => 'Uncheck this box if you are using a hidden SSID' },
   );

--- a/lib/pf/provisioner/mobileconfig.pm
+++ b/lib/pf/provisioner/mobileconfig.pm
@@ -31,7 +31,7 @@ The set the default OS to IOS
 # Will always ignore the oses parameter provided and use ['Apple iPod, iPhone or iPad']
 has 'oses' => (is => 'ro', default => sub { ['Apple iPod, iPhone or iPad', 'Mac OS X'] }, coerce => sub { ['Apple iPod, iPhone or iPad', 'Mac OS X'] });
 
-=head2 hidden_ssid
+=head2 broadcast
 
 Is the ssid broadcasting
 

--- a/lib/pf/provisioner/mobileconfig.pm
+++ b/lib/pf/provisioner/mobileconfig.pm
@@ -31,6 +31,14 @@ The set the default OS to IOS
 # Will always ignore the oses parameter provided and use ['Apple iPod, iPhone or iPad']
 has 'oses' => (is => 'ro', default => sub { ['Apple iPod, iPhone or iPad', 'Mac OS X'] }, coerce => sub { ['Apple iPod, iPhone or iPad', 'Mac OS X'] });
 
+=head2 hidden_ssid
+
+Is the ssid broadcasting
+
+=cut
+
+has broadcast => (is => 'rw');
+
 =head2 ssid
 
 The ssid broadcast name


### PR DESCRIPTION
# Description

Allow the option "Broadcast ssid" (is the ssid visible) to be usable
# Impacts

provisionner workflow
# Dependencies

from https://github.com/inverse-inc/packetfence-windows-agent/pull/4
# Issue

MailingList issue raised by Hack, Daniel, November the 30
# Delete branch after merge

YES
## Bug Fixes

Resolve an issue raised in the mailing list, where no matter if the checkbox was tick or not, it stayed the same (provisionner configuration)
