### PR TITLE
Remove old entry in ipset even if the category is undef

### DIFF
--- a/lib/pf/ipset.pm
+++ b/lib/pf/ipset.pm
@@ -552,11 +552,11 @@ sub iptables_update_set {
         my $ip = new NetAddr::IP::Lite clean_ip($ip);
         if ($net_addr->contains($ip)) {
             if ($ConfigNetworks{$network}{'type'} =~ /^$NET_TYPE_INLINE_L3$/i) {
-                pf_run("LANG=C sudo ipset del PF-iL3_ID$old\_$network $ip -exist 2>&1");
-                pf_run("LANG=C sudo ipset add PF-iL3_ID$new\_$network $ip -exist 2>&1");
+                pf_run("LANG=C sudo ipset del PF-iL3_ID$old\_$network $ip -exist 2>&1") if defined($old);
+                pf_run("LANG=C sudo ipset add PF-iL3_ID$new\_$network $ip -exist 2>&1") if defined($new);
             } else {
-                pf_run("LANG=C sudo ipset del PF-iL2_ID$old\_$network $ip -exist 2>&1");
-                pf_run("LANG=C sudo ipset add PF-iL2_ID$new\_$network $ip -exist 2>&1");
+                pf_run("LANG=C sudo ipset del PF-iL2_ID$old\_$network $ip -exist 2>&1") if defined($old);
+                pf_run("LANG=C sudo ipset add PF-iL2_ID$new\_$network $ip -exist 2>&1") if defined($new);
             }
         }
     }

--- a/lib/pf/node.pm
+++ b/lib/pf/node.pm
@@ -876,12 +876,13 @@ sub node_modify {
         } else {
             $new_role_id = $data{'category_id'};
         }
-        my $node_info = node_view($mac);
-        pf::ipset::iptables_update_set($mac, $old_role_id, $new_role_id) if ($node_info->{'last_connection_type'} eq $connection_type_to_str{$INLINE});
 
        # once the category conversion is complete, I delete the category entry to avoid complicating things
        delete $existing->{'category'} if defined($existing->{'category'});
     }
+    # If we are in inline mode then reevaluate the ipset session to clean old info
+    my $node_info = node_view($mac);
+    pf::ipset::iptables_update_set($mac, $old_role_id, $new_role_id) if ($node_info->{'last_connection_type'} eq $connection_type_to_str{$INLINE});
 
     # Autoregistration handling
     if (!defined($data{'autoreg'}) && (!defined($existing->{autoreg}) || $existing->{autoreg} ne 'yes' )) {


### PR DESCRIPTION
# Description

Test if the category is defined when we try to update ipset session
# Impacts

No
# Delete branch after merge

YES
# NEWS file entries
## Bug Fixes
- Remove old entries in ipset session
