### PR TITLE
Fix/pfconfig overlay

### DIFF
--- a/lib/pf/cmd/pf/pfconfig.pm
+++ b/lib/pf/cmd/pf/pfconfig.pm
@@ -113,6 +113,45 @@ sub action_list {
     return $EXIT_SUCCESS;
 }
 
+=head2 action_list_overlayed
+
+List all pfconfig overlayed namespaces
+
+=cut
+
+sub action_list_overlayed {
+    my ($self) = @_;
+    my $manager = pfconfig::manager->new;
+    my @namespaces = @{ $manager->all_overlayed_namespaces() };
+    foreach my $namespace (@namespaces){
+        print "$namespace\n";
+    }
+    return $EXIT_SUCCESS;
+}
+=head2 action_list_backend
+
+List pfconfig namespaces persisted in the backend
+
+=cut
+
+sub action_list_backend {
+    my ($self) = @_;
+    my ($matching) = $self->action_args;
+    my $manager = pfconfig::manager->new;
+    my @keys;
+    if($matching){
+        @keys = $manager->{cache}->list_matching($matching);
+    }
+    else {
+        @keys = $manager->{cache}->list();
+    }
+    print "Namespaces : \n";
+    foreach my $key (@keys){
+        print "$key\n";
+    }
+    return $EXIT_SUCCESS;
+}
+
 =head2 action_get
 
 Display a pfconfig namespace from pfconfig process

--- a/lib/pf/cmd/pf/pfconfig.pm
+++ b/lib/pf/cmd/pf/pfconfig.pm
@@ -12,6 +12,8 @@ pf::cmd::pf::pfconfig
    expire <namespace>  | expire a pfconfig namespace 
    reload              | reload all pfconfig namespaces
    list                | list all pfconfig namespaces
+   list_overlayed      | list overlayed namespaces
+   list_backend        | list namespaces persisted in the backend - can be passed a regex
    show <namespace>    | rebuild and display a pfconfig namespace
    get <namespace>     | display a pfconfig namespace from pfconfig process
    clear_backend       | clear the backend of pfconfig
@@ -128,6 +130,7 @@ sub action_list_overlayed {
     }
     return $EXIT_SUCCESS;
 }
+
 =head2 action_list_backend
 
 List pfconfig namespaces persisted in the backend

--- a/lib/pfconfig/backend.pm
+++ b/lib/pfconfig/backend.pm
@@ -100,6 +100,28 @@ sub clear {
     return $self->{cache}->clear();
 }
 
+=head2 list
+
+List all the keys in the backend
+
+=cut
+
+sub list {
+    my ( $self ) = @_;
+    return $self->{cache}->get_keys();
+}
+
+sub list_matching {
+    my ( $self, $expression ) = @_;
+    my @keys = $self->list();
+
+    my @valid_keys;
+    foreach my $key (@keys){
+        push @valid_keys, $key if($key =~ /$expression/);
+    }
+    return @valid_keys;
+}
+
 =back
 
 =head1 AUTHOR

--- a/lib/pfconfig/backend.pm
+++ b/lib/pfconfig/backend.pm
@@ -111,6 +111,12 @@ sub list {
     return $self->{cache}->get_keys();
 }
 
+=head2 list_matching
+
+List all the keys matching a regular expression
+
+=cut
+
 sub list_matching {
     my ( $self, $expression ) = @_;
     my @keys = $self->list();

--- a/lib/pfconfig/backend/bdb.pm
+++ b/lib/pfconfig/backend/bdb.pm
@@ -55,6 +55,17 @@ sub get {
     return $value;
 }
 
+=head2 list
+
+List all the keys in the backend
+
+=cut
+
+sub list {
+    my ( $self ) = @_;
+    return keys %{ $self->{cache}->get_bulk() };
+}
+
 =back
 
 =head1 AUTHOR

--- a/lib/pfconfig/backend/mysql.pm
+++ b/lib/pfconfig/backend/mysql.pm
@@ -157,6 +157,50 @@ sub clear {
     return $result;
 }
 
+sub list {
+    my ( $self ) = @_;
+    my $logger = pfconfig::log::get_logger;
+    my $db = $self->_get_db();
+    unless($db){
+        $self->_db_error();
+        return 0;
+    }
+    my $statement = $db->prepare( "SELECT id FROM keyed");
+    eval {
+        $statement->execute();
+    };
+    if($@){
+        $logger->error("Couldn't select from table. Error : $@");
+        return undef;
+    }
+    my @keys = @{$statement->fetchall_arrayref()};
+    @keys = map { $_->[0] } @keys;
+    $db->disconnect();
+    return @keys;
+}
+
+sub list_matching {
+    my ( $self, $expression ) = @_;
+    my $logger = pfconfig::log::get_logger;
+    my $db = $self->_get_db();
+    unless($db){
+        $self->_db_error();
+        return 0;
+    }
+    my $statement = $db->prepare( "SELECT id FROM keyed where id regexp ".$db->quote($expression) );
+    eval {
+        $statement->execute();
+    };
+    if($@){
+        $logger->error("Couldn't select from table. Error : $@");
+        return undef;
+    }
+    my @keys = @{$statement->fetchall_arrayref()};
+    @keys = map { $_->[0] } @keys;
+    $db->disconnect();
+    return @keys;
+}
+
 =back
 
 =head1 AUTHOR

--- a/lib/pfconfig/backend/mysql.pm
+++ b/lib/pfconfig/backend/mysql.pm
@@ -157,6 +157,12 @@ sub clear {
     return $result;
 }
 
+=head2 list
+
+List keys in the backend
+
+=cut
+
 sub list {
     my ( $self ) = @_;
     my $logger = pfconfig::log::get_logger;
@@ -178,6 +184,12 @@ sub list {
     $db->disconnect();
     return @keys;
 }
+
+=head2 list_matching
+
+List keys matching a regular expression
+
+=cut
 
 sub list_matching {
     my ( $self, $expression ) = @_;

--- a/lib/pfconfig/manager.pm
+++ b/lib/pfconfig/manager.pm
@@ -93,13 +93,28 @@ sub get_namespace {
     return $elem;
 }
 
+=head2 is_overlayed_namespace
+
+Returns 0 if the namespace is static, 1 if it is an overlayed namespace
+
+=cut
+
 sub is_overlayed_namespace {
     my ($self, $base_namespace) = @_;
-    if($base_namespace =~ /.*\(.+\)/){
+    if($base_namespace =~ /.*\(.+\)$/){
         return 1;
     }
     return 0;
 }
+
+=head2 overlayed_namespaces
+
+Returns the overlayed namespaces for a static namespace
+  ex : 
+    static namespace : "config::Pf"
+    overlayed namespaces : ("config::Pf(some-argument)", "config::Pf(another-argument)")
+
+=cut
 
 sub overlayed_namespaces {
     my ($self, $base_namespace) = @_;
@@ -108,7 +123,7 @@ sub overlayed_namespaces {
     return () if $self->is_overlayed_namespace($base_namespace);
 
     my $namespaces_ref = $self->all_overlayed_namespaces();
-    my @namespaces = defined($namespaces_ref) ? @$namespaces_ref : ();
+    my @namespaces = @$namespaces_ref;
     my @overlayed_namespaces;
     $base_namespace = quotemeta($base_namespace);
     foreach my $namespace (@namespaces){
@@ -119,9 +134,15 @@ sub overlayed_namespaces {
     return @overlayed_namespaces;
 }
 
+=head2 all_overlayed_namespaces
+
+Returns an Array ref of all the overlayed namespaces persisted in the backend
+
+=cut
+
 sub all_overlayed_namespaces {
     my ($self) = @_;
-    return [ $self->{cache}->list_matching('\(.*\)') ];
+    return [ $self->{cache}->list_matching('\(.*\)$') ];
 }
 
 =head2 new
@@ -379,7 +400,7 @@ sub list_namespaces {
     my ( $self, $what ) = @_;
 
     my $static_namespaces = $self->list_static_namespaces();
-    my $overlayed_namespaces = $self->all_overlayed_namespaces || [];
+    my $overlayed_namespaces = $self->all_overlayed_namespaces;
     return (@$static_namespaces, @$overlayed_namespaces);
 }
 

--- a/lib/pfconfig/manager.pm
+++ b/lib/pfconfig/manager.pm
@@ -122,8 +122,7 @@ sub overlayed_namespaces {
     # An overlayed namespace can't have overlayed namespaces
     return () if $self->is_overlayed_namespace($base_namespace);
 
-    my $namespaces_ref = $self->all_overlayed_namespaces();
-    my @namespaces = @$namespaces_ref;
+    my @namespaces = @{ $self->all_overlayed_namespaces() };
     my @overlayed_namespaces;
     $base_namespace = quotemeta($base_namespace);
     foreach my $namespace (@namespaces){


### PR DESCRIPTION
# Description

Rework pfconfig overlay so it is based on the backend key list instead of a self maintained list of the overlayed namespaces
Prevents a race condition in an active/active cluster when both servers are reloading at the same time which makes the _namespace_overlay miss a few overlays
# Impacts

pfconfig overlayed namespaces (active/active clustering config)
pfconfig backends will now always need to be able to list their keys
# Issue

fixes #1067 
# Delete branch after merge

YES
# NEWS file entries
## Enhancements
- Reworked the configuration backends to prevent a race condition of the configuration namespaces in active/active cluster
