### PR TITLE
Fix/radius acctlog SUM

### DIFF
--- a/db/pf-schema-X.Y.Z.sql
+++ b/db/pf-schema-X.Y.Z.sql
@@ -536,7 +536,7 @@ CREATE TABLE radacct (
   PRIMARY KEY  (radacctid),
   KEY username (username),
   KEY framedipaddress (framedipaddress),
-  KEY acctsessionid_username_nasip (acctsessionid,username,nasipaddress),
+  KEY acctsessionid_username_nasip (acctsessionid),
   KEY acctsessiontime (acctsessiontime),
   KEY acctuniqueid (acctuniqueid),
   KEY acctstarttime (acctstarttime),

--- a/db/pf-schema-X.Y.Z.sql
+++ b/db/pf-schema-X.Y.Z.sql
@@ -536,7 +536,7 @@ CREATE TABLE radacct (
   PRIMARY KEY  (radacctid),
   KEY username (username),
   KEY framedipaddress (framedipaddress),
-  KEY acctsessionid_username_nasip (acctsessionid),
+  KEY acctsessionid (acctsessionid),
   KEY acctsessiontime (acctsessiontime),
   KEY acctuniqueid (acctuniqueid),
   KEY acctstarttime (acctstarttime),

--- a/db/pf-schema-X.Y.Z.sql
+++ b/db/pf-schema-X.Y.Z.sql
@@ -536,7 +536,7 @@ CREATE TABLE radacct (
   PRIMARY KEY  (radacctid),
   KEY username (username),
   KEY framedipaddress (framedipaddress),
-  KEY acctsessionid (acctsessionid),
+  KEY acctsessionid_username_nasip (acctsessionid,username,nasipaddress),
   KEY acctsessiontime (acctsessiontime),
   KEY acctuniqueid (acctuniqueid),
   KEY acctstarttime (acctstarttime),
@@ -583,9 +583,9 @@ BEGIN
   DECLARE Previous_Session_Time int(12);
 
   # Collect traffic previous values in the update table
-  SELECT SUM(acctinputoctets), SUM(acctoutputoctets), SUM(acctsessiontime)
+  SELECT acctinputoctets, acctoutputoctets, acctsessiontime
     INTO Previous_Input_Octets, Previous_Output_Octets, Previous_Session_Time
-    FROM radacct_log
+    FROM radacct
     WHERE acctsessionid = p_acctsessionid
     AND username = p_username
     AND nasipaddress = p_nasipaddress;
@@ -704,9 +704,9 @@ BEGIN
   DECLARE Previous_Session_Time int(12);
 
   # Collect traffic previous values in the update table
-  SELECT SUM(acctinputoctets), SUM(acctoutputoctets), SUM(acctsessiontime)
+  SELECT acctinputoctets, acctoutputoctets, acctsessiontime
     INTO Previous_Input_Octets, Previous_Output_Octets, Previous_Session_Time
-    FROM radacct_log
+    FROM radacct
     WHERE acctsessionid = p_acctsessionid
     AND username = p_username
     AND nasipaddress = p_nasipaddress;

--- a/db/upgrade-X.X.X-X.Y.Z.sql
+++ b/db/upgrade-X.X.X-X.Y.Z.sql
@@ -50,3 +50,174 @@ SET @VERSION_INT = @MAJOR_VERSION << 16 | @MINOR_VERSION << 8 | @SUBMINOR_VERSIO
 --
 
 INSERT INTO pf_version (id, version) VALUES (@VERSION_INT, CONCAT_WS('.', @MAJOR_VERSION, @MINOR_VERSION, @SUBMINOR_VERSION));
+
+-- Changing RADIUS Updates Stored Procedure
+
+DROP PROCEDURE IF EXISTS acct_update;
+DELIMITER /
+CREATE PROCEDURE acct_update(
+  IN p_timestamp datetime,
+  IN p_acctsessiontime int(12),
+  IN p_acctinputoctets bigint(20),
+  IN p_acctoutputoctets bigint(20),
+  IN p_acctsessionid varchar(64),
+  IN p_username varchar(64),
+  IN p_nasipaddress varchar(15),
+  IN p_framedipaddress varchar(15),
+  IN p_acctstatustype varchar(25)
+)
+BEGIN
+  DECLARE Previous_Input_Octets bigint(20);
+  DECLARE Previous_Output_Octets bigint(20);
+  DECLARE Previous_Session_Time int(12);
+
+  SELECT acctinputoctets, acctoutputoctets, acctsessiontime
+    INTO Previous_Input_Octets, Previous_Output_Octets, Previous_Session_Time
+    FROM radacct
+    WHERE acctsessionid = p_acctsessionid
+    AND username = p_username
+    AND nasipaddress = p_nasipaddress;
+
+  IF (Previous_Session_Time IS NULL) THEN
+    SET Previous_Session_Time = 0;
+    SET Previous_Input_Octets = 0;
+    SET Previous_Output_Octets = 0;
+  END IF;
+
+  UPDATE radacct SET
+    framedipaddress = p_framedipaddress,
+    acctsessiontime = p_acctsessiontime,
+    acctinputoctets = p_acctinputoctets,
+    acctoutputoctets = p_acctoutputoctets
+    WHERE acctsessionid = p_acctsessionid
+    AND username = p_username
+    AND nasipaddress = p_nasipaddress
+    AND (acctstoptime IS NULL OR acctstoptime = 0);
+
+  INSERT INTO radacct_log
+   (acctsessionid, username, nasipaddress,
+    timestamp, acctstatustype, acctinputoctets, acctoutputoctets, acctsessiontime)
+  VALUES
+   (p_acctsessionid, p_username, p_nasipaddress,
+    p_timestamp, p_acctstatustype, (p_acctinputoctets - Previous_Input_Octets), (p_acctoutputoctets - Previous_Output_Octets),
+    (p_acctsessiontime - Previous_Session_Time));
+END /
+DELIMITER ;
+
+-- Changing RADIUS Start Stored Procedure
+
+DROP PROCEDURE IF EXISTS acct_start;
+DELIMITER /
+CREATE PROCEDURE acct_start (
+  IN p_acctsessionid varchar(64),
+  IN p_acctuniqueid varchar(32),
+  IN p_username varchar(64),
+  IN p_realm varchar(64),
+  IN p_nasipaddress varchar(15),
+  IN p_nasportid varchar(15),
+  IN p_nasporttype varchar(32),
+  IN p_acctstarttime datetime,
+  IN p_acctstoptime datetime,
+  IN p_acctsessiontime int(12),
+  IN p_acctauthentic varchar(32),
+  IN p_connectioninfo_start varchar(50),
+  IN p_connectioninfo_stop varchar(50),
+  IN p_acctinputoctets bigint(20),
+  IN p_acctoutputoctets bigint(20),
+  IN p_calledstationid varchar(50),
+  IN p_callingstationid varchar(50),
+  IN p_acctterminatecause varchar(32),
+  IN p_servicetype varchar(32),
+  IN p_framedprotocol varchar(32),
+  IN p_framedipaddress varchar(15),
+  IN p_acctstartdelay varchar(12),
+  IN p_acctstopdelay varchar(12),
+  IN p_xascendsessionsvrkey varchar(10),
+  IN p_acctstatustype varchar(25)
+)
+BEGIN
+  INSERT INTO radacct
+    (acctsessionid, acctuniqueid, username,
+     realm, nasipaddress, nasportid,
+     nasporttype, acctstarttime, acctstoptime,
+     acctsessiontime, acctauthentic, connectinfo_start,
+     connectinfo_stop, acctinputoctets, acctoutputoctets,
+     calledstationid, callingstationid, acctterminatecause,
+     servicetype, framedprotocol, framedipaddress,
+     acctstartdelay, acctstopdelay, xascendsessionsvrkey)
+  VALUES
+    (p_acctsessionid, p_acctuniqueid, p_username,
+     p_realm, p_nasipaddress, p_nasportid,
+     p_nasporttype, p_acctstarttime, p_acctstoptime,
+     p_acctsessiontime, p_acctauthentic, p_connectioninfo_start,
+     p_connectioninfo_stop, p_acctinputoctets, p_acctoutputoctets,
+     p_calledstationid, p_callingstationid, p_acctterminatecause,
+     p_servicetype, p_framedprotocol, p_framedipaddress,
+     p_acctstartdelay, p_acctstopdelay, p_xascendsessionsvrkey);
+
+  INSERT INTO radacct_log
+   (acctsessionid, username, nasipaddress,
+    timestamp, acctstatustype, acctinputoctets, acctoutputoctets, acctsessiontime)
+  VALUES
+   (p_acctsessionid, p_username, p_nasipaddress,
+    p_acctstarttime, p_acctstatustype,p_acctinputoctets,p_acctoutputoctets,p_acctsessiontime);
+END /
+DELIMITER ;
+
+-- Changing RADIUS Stop Stored Procedure
+
+DROP PROCEDURE IF EXISTS acct_stop;
+DELIMITER /
+CREATE PROCEDURE acct_stop(
+  IN p_timestamp datetime,
+  IN p_acctsessiontime int(12),
+  IN p_acctinputoctets bigint(20),
+  IN p_acctoutputoctets bigint(20),
+  IN p_acctterminatecause varchar(12),
+  IN p_acctdelaystop varchar(32),
+  IN p_connectinfo_stop varchar(50),
+  IN p_acctsessionid varchar(64),
+  IN p_username varchar(64),
+  IN p_nasipaddress varchar(15),
+  IN p_acctstatustype varchar(25)
+)
+BEGIN
+  DECLARE Previous_Input_Octets bigint(20);
+  DECLARE Previous_Output_Octets bigint(20);
+  DECLARE Previous_Session_Time int(12);
+
+  SELECT acctinputoctets, acctoutputoctets, acctsessiontime
+    INTO Previous_Input_Octets, Previous_Output_Octets, Previous_Session_Time
+    FROM radacct
+    WHERE acctsessionid = p_acctsessionid
+    AND username = p_username
+    AND nasipaddress = p_nasipaddress;
+
+  IF (Previous_Session_Time IS NULL) THEN
+    SET Previous_Session_Time = 0;
+    SET Previous_Input_Octets = 0;
+    SET Previous_Output_Octets = 0;
+  END IF;
+
+  UPDATE radacct SET
+    acctstoptime = p_timestamp,
+    acctsessiontime = p_acctsessiontime,
+    acctinputoctets = p_acctinputoctets,
+    acctoutputoctets = p_acctoutputoctets,
+    acctterminatecause = p_acctterminatecause,
+    connectinfo_stop = p_connectinfo_stop
+    WHERE acctsessionid = p_acctsessionid
+    AND username = p_username
+    AND nasipaddress = p_nasipaddress
+    AND (acctstoptime IS NULL OR acctstoptime = 0);
+
+  INSERT INTO radacct_log
+   (acctsessionid, username, nasipaddress,
+    timestamp, acctstatustype, acctinputoctets, acctoutputoctets, acctsessiontime)
+  VALUES
+   (p_acctsessionid, p_username, p_nasipaddress,
+    p_timestamp, p_acctstatustype, (p_acctinputoctets - Previous_Input_Octets), (p_acctoutputoctets - Previous_Output_Octets),
+    (p_acctsessiontime - Previous_Session_Time));
+END /
+DELIMITER ;
+


### PR DESCRIPTION
# Description

Fixes unnecessary summing of previous data in radius accounting stored procedure.
We already have that information in the radacct table. There is no need to sum the radacct_log entries.
# Impacts

Should very significantly lower the CPU and I/O load related to RADIUS accounting.
# Delete branch after merge

YES 
# NEWS file entries
## Bug Fixes
- RADIUS accounting no longer requires to sum up all previous accounting requests for the same session, resulting in lower CPU and I/O load.
