### PR TITLE
Windows agent - How we provide it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,4 +138,9 @@ fingerbank:
 	rm -f /usr/local/pf/lib/fingerbank
 	ln -s /usr/local/fingerbank/lib/fingerbank /usr/local/pf/lib/fingerbank \
 
+.PHONY: windows-agent
+
+windows-agent:
+	wget https://inverse.ca/downloads/packetfence-windows-agent.exe -P /usr/local/pf/html/captive-portal/content/
+
 devel: configurations conf/ssl/server.crt conf/pf_omapi_key bin/pfcmd raddb/certs/dh sudo lib/pf/pfcmd/pfcmd_pregrammar.pm translation mysql-schema raddb/sites-enabled fingerbank chown_pf permissions bin/ntlm_auth_wrapper

--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,6 @@ fingerbank:
 .PHONY: windows-agent
 
 windows-agent:
-	wget https://inverse.ca/downloads/packetfence-windows-agent.exe -P /usr/local/pf/html/captive-portal/content/
+	wget https://inverse.ca/downloads/addons/packetfence-windows-agent.exe -P /usr/local/pf/html/captive-portal/content/
 
 devel: configurations conf/ssl/server.crt conf/pf_omapi_key bin/pfcmd raddb/certs/dh sudo lib/pf/pfcmd/pfcmd_pregrammar.pm translation mysql-schema raddb/sites-enabled fingerbank chown_pf permissions bin/ntlm_auth_wrapper

--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,6 @@ fingerbank:
 .PHONY: windows-agent
 
 windows-agent:
-	wget https://inverse.ca/downloads/addons/packetfence-windows-agent.exe -P /usr/local/pf/html/captive-portal/content/
+	wget https://inverse.ca/downloads/PacketFence/addons/packetfence-windows-agent.exe -P /usr/local/pf/html/captive-portal/content/
 
 devel: configurations conf/ssl/server.crt conf/pf_omapi_key bin/pfcmd raddb/certs/dh sudo lib/pf/pfcmd/pfcmd_pregrammar.pm translation mysql-schema raddb/sites-enabled fingerbank chown_pf permissions bin/ntlm_auth_wrapper

--- a/addons/packages/packetfence.spec
+++ b/addons/packages/packetfence.spec
@@ -410,6 +410,8 @@ done
 gcc -g0 src/pfcmd.c -o bin/pfcmd
 # build ntlm_auth_wrapper
 make bin/ntlm_auth_wrapper
+# build window-agent
+make windows-agent
 # Define git_commit_id
 echo %{git_commit} > conf/git_commit_id
 

--- a/debian/control
+++ b/debian/control
@@ -21,7 +21,7 @@ Breaks: libdata-alias-perl
 Depends: ${misc:Depends}, vlan, make,
  openssl, openssl-blacklist, openssl-blacklist-extra,
  mysql-server|mariadb-server|mariadb-galera-server,
- snmp, snmptrapfmt, snmp-mibs-downloader, conntrack,
+ snmp, snmptrapfmt, snmp-mibs-downloader, conntrack, wget,
 # apache related
  apache2, apache2.2-common, apache2-utils, libapache2-mod-proxy-html,
  apache2-mpm-prefork, libapache2-mod-apreq2, libapache2-mod-perl2,

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: packetfence
 Section: net
 Priority: optional
 Maintainer: Durand fabrice <fdurand@inverse.ca>
-Build-Depends: debhelper (>= 7.0.50~), gettext, libparse-recdescent-perl, gcc
+Build-Depends: debhelper (>= 7.0.50~), gettext, libparse-recdescent-perl, gcc, wget,
 Standards-Version: 3.8.4
 Vcs-Git: git://github.com/inverse-inc/packetfence.git
 Vcs-browser: https://github.com/inverse-inc/packetfence/
@@ -21,7 +21,7 @@ Breaks: libdata-alias-perl
 Depends: ${misc:Depends}, vlan, make,
  openssl, openssl-blacklist, openssl-blacklist-extra,
  mysql-server|mariadb-server|mariadb-galera-server,
- snmp, snmptrapfmt, snmp-mibs-downloader, conntrack, wget,
+ snmp, snmptrapfmt, snmp-mibs-downloader, conntrack, 
 # apache related
  apache2, apache2.2-common, apache2-utils, libapache2-mod-proxy-html,
  apache2-mpm-prefork, libapache2-mod-apreq2, libapache2-mod-perl2,

--- a/debian/rules
+++ b/debian/rules
@@ -119,6 +119,8 @@ install: build
 	install -d -m0755 $(CURDIR)/debian/packetfence-ntlm-wrapper$(PREFIX)/$(NAME)/bin
 	make bin/ntlm_auth_wrapper
 	mv bin/ntlm_auth_wrapper $(CURDIR)/debian/packetfence-ntlm-wrapper$(PREFIX)/$(NAME)/bin
+	# packetfence-windows-agent
+	make windows-agent
 	# packetfence-config
 	install -d $(CURDIR)/debian/packetfence-config$(PREFIX)/$(NAME)/sbin
 	install -d -m0700 $(CURDIR)/debian/packetfence-config$(PREFIX)/$(NAME)/conf


### PR DESCRIPTION
# Description

Change the way we provide the packetfence-windows-agent (provisioning)
# Impacts
- Provisioning flow
- Installation 
# Delete branch after merge

YES
# NEWS file entries
## Enhancements
- packetfence-windows-agent is not in packetfence source code anymore. It will be download during the installation via inverse website.

This has been made because every time we update it, this add 15mb more the GitHub repo, where this could be managed differently. Also this will allow user to update their agent without update packetfence.
