### PR TITLE
Fix/accounting uniqueid

### DIFF
--- a/db/pf-schema-X.Y.Z.sql
+++ b/db/pf-schema-X.Y.Z.sql
@@ -563,7 +563,6 @@ CREATE TABLE radacct_log (
 ) ENGINE=InnoDB;
 
 -- Adding RADIUS Updates Stored Procedure
-
 DROP PROCEDURE IF EXISTS acct_update;
 DELIMITER /
 CREATE PROCEDURE acct_update(
@@ -588,7 +587,8 @@ BEGIN
     FROM radacct
     WHERE acctsessionid = p_acctsessionid
     AND username = p_username
-    AND nasipaddress = p_nasipaddress;
+    AND nasipaddress = p_nasipaddress
+    AND (acctstoptime IS NULL OR acctstoptime = 0);
 
   # Set values to 0 when no previous records
   IF (Previous_Session_Time IS NULL) THEN
@@ -618,6 +618,7 @@ BEGIN
     (p_acctsessiontime - Previous_Session_Time));
 END /
 DELIMITER ;
+
 
 -- Adding RADIUS Start Stored Procedure
 
@@ -709,7 +710,8 @@ BEGIN
     FROM radacct
     WHERE acctsessionid = p_acctsessionid
     AND username = p_username
-    AND nasipaddress = p_nasipaddress;
+    AND nasipaddress = p_nasipaddress
+    AND (acctstoptime IS NULL OR acctstoptime = 0);
 
   # Set values to 0 when no previous records
   IF (Previous_Session_Time IS NULL) THEN
@@ -741,7 +743,6 @@ BEGIN
     (p_acctsessiontime - Previous_Session_Time));
 END /
 DELIMITER ;
-
 --
 -- Statement of Health (SoH) related
 --

--- a/db/upgrade-X.X.X-X.Y.Z.sql
+++ b/db/upgrade-X.X.X-X.Y.Z.sql
@@ -1,3 +1,123 @@
 --
 -- PacketFence SQL schema upgrade from X.X.X to X.Y.Z
 --
+
+-- Adding RADIUS Updates Stored Procedure
+
+DROP PROCEDURE IF EXISTS acct_update;
+DELIMITER /
+CREATE PROCEDURE acct_update(
+  IN p_timestamp datetime,
+  IN p_acctsessiontime int(12),
+  IN p_acctinputoctets bigint(20),
+  IN p_acctoutputoctets bigint(20),
+  IN p_acctsessionid varchar(64),
+  IN p_username varchar(64),
+  IN p_nasipaddress varchar(15),
+  IN p_framedipaddress varchar(15),
+  IN p_acctstatustype varchar(25)
+)
+BEGIN
+  DECLARE Previous_Input_Octets bigint(20);
+  DECLARE Previous_Output_Octets bigint(20);
+  DECLARE Previous_Session_Time int(12);
+
+  # Collect traffic previous values in the update table
+  SELECT acctinputoctets, acctoutputoctets, acctsessiontime
+    INTO Previous_Input_Octets, Previous_Output_Octets, Previous_Session_Time
+    FROM radacct
+    WHERE acctsessionid = p_acctsessionid
+    AND username = p_username
+    AND nasipaddress = p_nasipaddress
+    AND (acctstoptime IS NULL OR acctstoptime = 0);
+
+  # Set values to 0 when no previous records
+  IF (Previous_Session_Time IS NULL) THEN
+    SET Previous_Session_Time = 0;
+    SET Previous_Input_Octets = 0;
+    SET Previous_Output_Octets = 0;
+  END IF;
+
+  # Update record with new traffic
+  UPDATE radacct SET
+    framedipaddress = p_framedipaddress,
+    acctsessiontime = p_acctsessiontime,
+    acctinputoctets = p_acctinputoctets,
+    acctoutputoctets = p_acctoutputoctets
+    WHERE acctsessionid = p_acctsessionid
+    AND username = p_username
+    AND nasipaddress = p_nasipaddress
+    AND (acctstoptime IS NULL OR acctstoptime = 0);
+
+  # Create new record in the log table
+  INSERT INTO radacct_log
+   (acctsessionid, username, nasipaddress,
+    timestamp, acctstatustype, acctinputoctets, acctoutputoctets, acctsessiontime)
+  VALUES
+   (p_acctsessionid, p_username, p_nasipaddress,
+    p_timestamp, p_acctstatustype, (p_acctinputoctets - Previous_Input_Octets), (p_acctoutputoctets - Previous_Output_Octets),
+    (p_acctsessiontime - Previous_Session_Time));
+END /
+DELIMITER ;
+
+-- Adding RADIUS Stop Stored Procedure
+
+DROP PROCEDURE IF EXISTS acct_stop;
+DELIMITER /
+CREATE PROCEDURE acct_stop(
+  IN p_timestamp datetime,
+  IN p_acctsessiontime int(12),
+  IN p_acctinputoctets bigint(20),
+  IN p_acctoutputoctets bigint(20),
+  IN p_acctterminatecause varchar(12),
+  IN p_acctdelaystop varchar(32),
+  IN p_connectinfo_stop varchar(50),
+  IN p_acctsessionid varchar(64),
+  IN p_username varchar(64),
+  IN p_nasipaddress varchar(15),
+  IN p_acctstatustype varchar(25)
+)
+BEGIN
+  DECLARE Previous_Input_Octets bigint(20);
+  DECLARE Previous_Output_Octets bigint(20);
+  DECLARE Previous_Session_Time int(12);
+
+  # Collect traffic previous values in the update table
+  SELECT acctinputoctets, acctoutputoctets, acctsessiontime
+    INTO Previous_Input_Octets, Previous_Output_Octets, Previous_Session_Time
+    FROM radacct
+    WHERE acctsessionid = p_acctsessionid
+    AND username = p_username
+    AND nasipaddress = p_nasipaddress
+    AND (acctstoptime IS NULL OR acctstoptime = 0);
+
+  # Set values to 0 when no previous records
+  IF (Previous_Session_Time IS NULL) THEN
+    SET Previous_Session_Time = 0;
+    SET Previous_Input_Octets = 0;
+    SET Previous_Output_Octets = 0;
+  END IF;
+
+  # Update record with new traffic
+  UPDATE radacct SET
+    acctstoptime = p_timestamp,
+    acctsessiontime = p_acctsessiontime,
+    acctinputoctets = p_acctinputoctets,
+    acctoutputoctets = p_acctoutputoctets,
+    acctterminatecause = p_acctterminatecause,
+    connectinfo_stop = p_connectinfo_stop
+    WHERE acctsessionid = p_acctsessionid
+    AND username = p_username
+    AND nasipaddress = p_nasipaddress
+    AND (acctstoptime IS NULL OR acctstoptime = 0);
+
+  # Create new record in the log table
+  INSERT INTO radacct_log
+   (acctsessionid, username, nasipaddress,
+    timestamp, acctstatustype, acctinputoctets, acctoutputoctets, acctsessiontime)
+  VALUES
+   (p_acctsessionid, p_username, p_nasipaddress,
+    p_timestamp, p_acctstatustype, (p_acctinputoctets - Previous_Input_Octets), (p_acctoutputoctets - Previous_Output_Octets),
+    (p_acctsessiontime - Previous_Session_Time));
+END /
+DELIMITER ;


### PR DESCRIPTION
# Description

Fixes possible errors in accounting update and accounting stop when accounting IDs are reused.
# Impacts

The select has been made more specific and should only match closed accounting sessions.
# Issue

Fixes #1169 
# Delete branch after merge

YES
# NEWS file entries
## Bug Fixes
- Fixes broken accounting when the controller reuses session ids (#1169)
