### PR TITLE
stripped_username in LDAPSource without RADIUS attribute

### DIFF
--- a/lib/pf/Authentication/Source/LDAPSource.pm
+++ b/lib/pf/Authentication/Source/LDAPSource.pm
@@ -448,7 +448,15 @@ sub ldap_filter_for_conditions {
   my $timer = pf::StatsD::Timer->new({ 'stat' => "${timer_stat_prefix}", sample_rate => 0.1});
 
   my (@ldap_conditions, $expression);
-  $params->{'username'} = $params->{'stripped_user_name'} if (defined($params->{'stripped_user_name'} ) && $params->{'stripped_user_name'} ne '' && isenabled($self->{'stripped_user_name'}));
+
+  # Handling stripped_username condition
+  if ( isenabled($self->{'stripped_user_name'}) && defined($params->{'stripped_user_name'}) && $params->{'stripped_user_name'} ne '' ) {
+      $params->{'username'} = $params->{'stripped_user_name'};
+  } elsif ( isenabled($self->{'stripped_user_name'}) ) {
+      my ($username, $realm) = strip_username($params->{'username'});
+      $params->{'username'} = $username;
+  }
+
   if ($params->{'username'}) {
       $expression = '(' . $usernameattribute . '=' . $params->{'username'} . ')';
   } elsif ($params->{'email'}) {


### PR DESCRIPTION
# Description

Will strip the username / realm part if configured to do so and that no 'stripped_username' attribute is present in RADIUS request.
# Impacts

LDAP authentication source matching
# Delete branch after merge

YES
# NEWS file entries
## Enhancements
- Ability to strip a username in LDAP source even if not present in RADIUS request
