### PR TITLE
dhcplistener ipv6 fix for filter out non-ip packets

### DIFF
--- a/sbin/pfdhcplistener
+++ b/sbin/pfdhcplistener
@@ -197,7 +197,6 @@ sub process_pkt {
             # a tagged frame and return the 'inner' ether_type of the frame.
             #
             # For this reason we chec to see if $l2->{tpid} is set
-            #
             if ( defined $l2->{tpid} ) {
                 $logger->trace("Skipping VLAN packets since it is probably addressed to another interface (offload decapsulated tagged packet).");
                 return;

--- a/sbin/pfdhcplistener
+++ b/sbin/pfdhcplistener
@@ -184,7 +184,7 @@ sub process_pkt {
         eval {
             my $l2 = NetPacket::Ethernet->decode($pkt);
 
-            # Skip frames that aren't ETH_TYPE_IP to avoid processing frames more than
+            # Skip frames that has a VLAN tag to avoid processing frames more than
             # once when pfdhcplistener listens on both a vlan interface and its parent
             #
             # On post-2008 kernels, with network devices supporting VLAN acceleration
@@ -196,9 +196,14 @@ sub process_pkt {
             # Also, NetPacket::Ethernet::decode will skip the VLAN header from
             # a tagged frame and return the 'inner' ether_type of the frame.
             #
-            # For these reasons, we must peek directly at the data.
-            # skip the first 12 bytes of the frame (src + dst eth addr)
-            # grab the ether_type field and discard the rest:
+            # For this reason we chec to see if $l2->{tpid} is set
+            #
+            if ( defined $l2->{tpid} ) {
+                $logger->trace("Skipping VLAN packets.");
+                return;
+            }
+
+            # Skip frames that aren't ETH_TYPE_IP/ETH_TYPE_IPv6
             if ( ($l2->{type} ne ETH_TYPE_IP) && ($l2->{type} ne ETH_TYPE_IPv6) ) {
                 $logger->trace("Skipping non ETH_TYPE_IP / ETH_TYPE_IPv6 frame since it is probably addressed to another interface (offload decapsulated tagged packet)");
                 return;

--- a/sbin/pfdhcplistener
+++ b/sbin/pfdhcplistener
@@ -213,7 +213,7 @@ sub process_pkt {
             # For these reasons, we must peek directly at the data.
             # skip the first 12 bytes of the frame (src + dst eth addr)
             # grab the ether_type field and discard the rest:
-            if ( ($l2->{type} ne ETH_TYPE_IP) || ($l2->{type} ne ETH_TYPE_IPv6) ) {
+            if ( ($l2->{type} ne ETH_TYPE_IP) && ($l2->{type} ne ETH_TYPE_IPv6) ) {
                 $logger->trace("Ignoring packet because we already listen on a VLAN interface");
                 return;
             }

--- a/sbin/pfdhcplistener
+++ b/sbin/pfdhcplistener
@@ -42,7 +42,7 @@ use List::MoreUtils qw(any);
 use NetAddr::IP;
 use pf::SwitchFactory;
 use MIME::Base64();
-use NetPacket::Ethernet qw(ETH_TYPE_IP);
+use NetPacket::Ethernet qw(ETH_TYPE_IP ETH_TYPE_IPv6);
 use NetPacket::IP;
 use NetPacket::IPv6;
 use NetPacket::UDP;
@@ -213,8 +213,7 @@ sub process_pkt {
             # For these reasons, we must peek directly at the data.
             # skip the first 12 bytes of the frame (src + dst eth addr)
             # grab the ether_type field and discard the rest:
-            my ($ether_type, undef) = unpack("x[12]nC*", $pkt);
-            if ($ether_type != NetPacket::Ethernet::ETH_TYPE_IP) {
+            if ( ($l2->{type} ne ETH_TYPE_IP) || ($l2->{type} ne ETH_TYPE_IPv6) ) {
                 $logger->trace("Ignoring packet because we already listen on a VLAN interface");
                 return;
             }
@@ -224,11 +223,11 @@ sub process_pkt {
             $pf::StatsD::statsd->increment("pfdhcplistener_$statsd_interface\::process_pkt.count" );
 
             # we send all IPv4 DHCPv4 codepath
-            if($l2->{type} eq ETH_TYPE_IP) {
+            if ( $l2->{type} eq ETH_TYPE_IP ) {
                 my $apiclient = pf::api::queue->new(queue => 'pfdhcplistener');
                 $apiclient->notify('process_dhcp', %args, udp_payload_b64 => $udp_payload_b64);
             }
-            else{
+            else {
                 my $apiclient = pf::api::queue->new;
                 $apiclient->notify('process_dhcpv6', $udp_payload_b64);
             }

--- a/sbin/pfdhcplistener
+++ b/sbin/pfdhcplistener
@@ -183,20 +183,6 @@ sub process_pkt {
     if ($process || !$pf::cluster::cluster_enabled){
         eval {
             my $l2 = NetPacket::Ethernet->decode($pkt);
-            my $l3 = $l2->{type} eq ETH_TYPE_IP ? NetPacket::IP->decode($l2->{'data'}) : NetPacket::IPv6->decode($l2->{'data'});
-            my $l4 = NetPacket::UDP->decode($l3->{'data'});
-            my $udp_payload_b64 = MIME::Base64::encode($l4->{data});
-            my %args = (
-                src_mac => clean_mac($l2->{'src_mac'}),
-                dest_mac => clean_mac($l2->{'dest_mac'}),
-                src_ip => $l3->{'src_ip'},
-                dest_ip => $l3->{'dest_ip'},
-                is_inline_vlan => $is_inline_vlan,
-                interface => $interface,
-                interface_ip => $interface_ip,
-                interface_vlan => $interface_vlan,
-                net_type => $net_type,
-            );
 
             # Skip frames that aren't ETH_TYPE_IP to avoid processing frames more than
             # once when pfdhcplistener listens on both a vlan interface and its parent
@@ -214,9 +200,24 @@ sub process_pkt {
             # skip the first 12 bytes of the frame (src + dst eth addr)
             # grab the ether_type field and discard the rest:
             if ( ($l2->{type} ne ETH_TYPE_IP) && ($l2->{type} ne ETH_TYPE_IPv6) ) {
-                $logger->trace("Ignoring packet because we already listen on a VLAN interface");
+                $logger->trace("Skipping non ETH_TYPE_IP / ETH_TYPE_IPv6 frame since it is probably addressed to another interface (offload decapsulated tagged packet)");
                 return;
             }
+
+            my $l3 = $l2->{type} eq ETH_TYPE_IP ? NetPacket::IP->decode($l2->{'data'}) : NetPacket::IPv6->decode($l2->{'data'});
+            my $l4 = NetPacket::UDP->decode($l3->{'data'});
+            my $udp_payload_b64 = MIME::Base64::encode($l4->{data});
+            my %args = (
+                src_mac => clean_mac($l2->{'src_mac'}),
+                dest_mac => clean_mac($l2->{'dest_mac'}),
+                src_ip => $l3->{'src_ip'},
+                dest_ip => $l3->{'dest_ip'},
+                is_inline_vlan => $is_inline_vlan,
+                interface => $interface,
+                interface_ip => $interface_ip,
+                interface_vlan => $interface_vlan,
+                net_type => $net_type,
+            );
 
             my $statsd_interface = $interface;
             $statsd_interface =~ s/\./_/g;

--- a/sbin/pfdhcplistener
+++ b/sbin/pfdhcplistener
@@ -199,13 +199,13 @@ sub process_pkt {
             # For this reason we chec to see if $l2->{tpid} is set
             #
             if ( defined $l2->{tpid} ) {
-                $logger->trace("Skipping VLAN packets.");
+                $logger->trace("Skipping VLAN packets since it is probably addressed to another interface (offload decapsulated tagged packet).");
                 return;
             }
 
             # Skip frames that aren't ETH_TYPE_IP/ETH_TYPE_IPv6
             if ( ($l2->{type} ne ETH_TYPE_IP) && ($l2->{type} ne ETH_TYPE_IPv6) ) {
-                $logger->trace("Skipping non ETH_TYPE_IP / ETH_TYPE_IPv6 frame since it is probably addressed to another interface (offload decapsulated tagged packet)");
+                $logger->trace("Skipping non ETH_TYPE_IP / ETH_TYPE_IPv6 frame");
                 return;
             }
 


### PR DESCRIPTION
# Description

Fixes bug introduced by myself that makes dhcplistener non-longer processing ipv6 packets
# Impacts

pfdhcplistener
# Delete branch after merge

YES
