### PR TITLE
Limit the maximum unregdate an admin can set

### DIFF
--- a/html/pfappserver/lib/pfappserver/Form/Config/AdminRoles.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/AdminRoles.pm
@@ -73,6 +73,14 @@ has_field 'allowed_access_levels' =>
              help => 'List of access levels available to the admin user. If none are provided then all access levels are available' },
   );
 
+has_field 'allowed_unreg_date' =>
+  (
+   type => 'DatePicker',
+   label => 'Maximum allowed unregistration date',
+   tags => { after_element => \&help,
+             help => 'The maximal unregistration date that can be set.' },
+  );
+
 has_field 'allowed_access_durations' =>
   (
    type => 'Text',

--- a/html/pfappserver/lib/pfappserver/Form/User/Create.pm
+++ b/html/pfappserver/lib/pfappserver/Form/User/Create.pm
@@ -95,9 +95,25 @@ sub validate {
     if (scalar @actions == 0) {
         $self->field('actions')->add_error("You must at least set a role, mark the user as a sponsor, or set an access level.");
     }
+    $self->_check_allowed_unreg_date("Unregistration date provided is after the maximum allowed.");
     $self->_check_allowed_options($Actions::SET_ACCESS_DURATION,'allowed_access_durations',"Access Duration provided is not an allowed access duration");
     $self->_check_allowed_options($Actions::SET_ACCESS_LEVEL,'allowed_access_levels',"Access Level provided is not an allowed access level");
     $self->_check_allowed_options($Actions::SET_ROLE,'allowed_roles',"Role provided is not an allowed role");
+}
+
+=head2 _check_allowed_unreg_date
+
+check to see the unregdate in the actions can be set according to the user role
+
+=cut
+
+sub _check_allowed_unreg_date {
+    my ($self, $error_msg) = @_;
+    if ( my $action = first { $_->{type} eq $Actions::SET_UNREG_DATE } @{$self->value->{actions}} ) {
+        unless(check_allowed_unreg_date([$self->ctx->user->roles], $action->{value})){
+            $self->field('actions')->add_error($error_msg);
+        }
+    }
 }
 
 

--- a/html/pfappserver/root/config/adminroles/view.tt
+++ b/html/pfappserver/root/config/adminroles/view.tt
@@ -22,6 +22,7 @@
         [% form.field('allowed_access_levels').render | none %]
         [% form.field('allowed_roles').render | none %]
         [% form.field('allowed_access_durations').render | none %]
+        [% form.field('allowed_unreg_date').render | none %]
   </div><!--modal-body-->
 
   <div class="modal-footer">

--- a/lib/pf/admin_roles.pm
+++ b/lib/pf/admin_roles.pm
@@ -123,7 +123,7 @@ sub check_allowed_unreg_date {
         
         #If no option is defined then any date is allowed
         # we got one that is unlimited so we're good
-        unless(defined($max_unreg_date_value)){
+        unless(defined($max_unreg_date_value) && $max_unreg_date_value){
             $result = $TRUE;
             last;
         }

--- a/lib/pf/admin_roles.pm
+++ b/lib/pf/admin_roles.pm
@@ -19,9 +19,11 @@ use base qw(Exporter);
 use pf::file_paths;
 use List::MoreUtils qw(any all uniq);
 use pfconfig::cached_hash;
+use pf::constants;
 use pf::constants::admin_roles qw(@ADMIN_ACTIONS);
+use DateTime::Format::Strptime;
 
-our @EXPORT = qw(admin_can admin_can_do_any admin_can_do_any_in_group %ADMIN_ROLES admin_allowed_options admin_allowed_options_all);
+our @EXPORT = qw(admin_can admin_can_do_any admin_can_do_any_in_group %ADMIN_ROLES admin_allowed_options admin_allowed_options_all check_allowed_unreg_date);
 our %ADMIN_ROLES;
 tie %ADMIN_ROLES, 'pfconfig::cached_hash', 'config::AdminRoles';
 
@@ -98,6 +100,44 @@ sub admin_allowed_options {
         push @options, split /\s*,\s*/, $allowed_options;
     }
     return uniq @options;
+}
+
+=head2 check_allowed_unreg_date
+
+Check if the unreg date can be assigned by the user
+
+=cut
+
+sub check_allowed_unreg_date {
+    my ($roles, $date) = @_;
+    my $parser = DateTime::Format::Strptime->new(
+        pattern => '%F',
+        on_error => 'croak',
+    );
+    my $result = $FALSE;
+    my $unreg_date = $parser->parse_datetime($date);
+    foreach my $role (@{$roles}){
+        next unless exists $ADMIN_ROLES{$role};
+
+        my $max_unreg_date_value = $ADMIN_ROLES{$role}->{allowed_unreg_date};
+        
+        #If no option is defined then any date is allowed
+        # we got one that is unlimited so we're good
+        unless(defined($max_unreg_date_value)){
+            $result = $TRUE;
+            last;
+        }
+        else {
+            my $compare = DateTime->compare($unreg_date, $parser->parse_datetime($max_unreg_date_value));
+            # it is before so we're good
+            if($compare == -1){
+                $result = $TRUE;
+                last;
+            }
+        }
+        
+    }
+    return $result;
 }
 
 


### PR DESCRIPTION
# Description

Limit the maximum unregdate an admin can set
# Impacts

Admin roles
User creation
# NEWS file entries

(REQUIRED)
## New Features
- Give the ability to limit the registration date an administrator can set while creating a user
