### PR TITLE
don't allow trace mode in Apache

### DIFF
--- a/conf/httpd.conf.d/httpd.aaa
+++ b/conf/httpd.conf.d/httpd.aaa
@@ -75,6 +75,8 @@
   </IfModule>
 </IfDefine>
 
+# We don't allow the TRACE HTTP method
+TraceEnable off
 
 PerlSwitches -I/usr/local/pf/lib
 PerlSwitches -I/usr/local/pf/html/pfappserver/lib

--- a/conf/httpd.conf.d/httpd.admin
+++ b/conf/httpd.conf.d/httpd.admin
@@ -62,6 +62,9 @@
   </IfModule>
 </IfDefine>
 
+# We don't allow the TRACE HTTP method
+TraceEnable off
+
 AcceptMutex posixsem
 
 PerlSwitches -I/usr/local/pf/lib

--- a/conf/httpd.conf.d/httpd.graphite
+++ b/conf/httpd.conf.d/httpd.graphite
@@ -62,6 +62,8 @@
   </IfModule>
 </IfDefine>
 
+# We don't allow the TRACE HTTP method
+TraceEnable off
 
 PerlSwitches -I/usr/local/pf/lib
 

--- a/conf/httpd.conf.d/httpd.portal
+++ b/conf/httpd.conf.d/httpd.portal
@@ -140,7 +140,8 @@ SetEnvIf User-Agent ".*MSIE.*" \
 
 TypesConfig /etc/mime.types
 
-
+# We don't allow the TRACE HTTP method
+TraceEnable off
 
 <Perl>
 BEGIN {

--- a/conf/httpd.conf.d/httpd.portal
+++ b/conf/httpd.conf.d/httpd.portal
@@ -103,6 +103,9 @@
   </IfModule>
 </IfDefine>
 
+# We don't allow the TRACE HTTP method
+TraceEnable off
+
 PerlSwitches -I/usr/local/pf/lib
 PerlSwitches -I/usr/local/pf/html/captive-portal/lib
 # mod_perl handlers are virtually assigned to /perl/
@@ -139,9 +142,6 @@ SetEnvIf User-Agent ".*MSIE.*" \
   downgrade-1.0 force-response-1.0
 
 TypesConfig /etc/mime.types
-
-# We don't allow the TRACE HTTP method
-TraceEnable off
 
 <Perl>
 BEGIN {

--- a/conf/httpd.conf.d/httpd.proxy
+++ b/conf/httpd.conf.d/httpd.proxy
@@ -86,6 +86,9 @@
   </IfModule>
 </IfDefine>
 
+# We don't allow the TRACE HTTP method
+TraceEnable off
+
 PerlSwitches -I/usr/local/pf/lib
 PerlPostConfigRequire /usr/local/pf/lib/pf/web/proxy_modperl_require.pl
 PerlModule APR::Table

--- a/conf/httpd.conf.d/httpd.webservices
+++ b/conf/httpd.conf.d/httpd.webservices
@@ -74,6 +74,8 @@
   </IfModule>
 </IfDefine>
 
+# We don't allow the TRACE HTTP method
+TraceEnable off
 
 PerlSwitches -I/usr/local/pf/lib
 PerlSwitches -I/usr/local/pf/html/pfappserver/lib


### PR DESCRIPTION
# Description

Don't allow the TRACE HTTP method to be used in the portal process
# Impacts

Portal HTTP requests
# Delete branch after merge

YES
# NEWS file entries
## Enhancements
- The HTTP TRACE method is not allowed anymore on the captive portal
