### PR TITLE
pfdetect trigger src and dst ip

### DIFF
--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -132,7 +132,7 @@ detection_engine=snort
 #
 # Comma-delimited list of address ranges/CIDR blocks that Snort/Suricata will monitor/detect/trap on.  Gateway, network, and 
 # broadcast addresses are ignored.
-range=192.168.0.0/24
+range=
 
 #
 # trapping.wireless_ips

--- a/conf/pfqueue.conf.example
+++ b/conf/pfqueue.conf.example
@@ -12,3 +12,6 @@ delayed_queue_workers=1
 
 [queue pfdhcplistener]
 workers=8
+
+[queue pfdetect]
+workers=4

--- a/conf/pfqueue.conf.example
+++ b/conf/pfqueue.conf.example
@@ -14,4 +14,4 @@ delayed_queue_workers=1
 workers=8
 
 [queue pfdetect]
-workers=4
+workers=1

--- a/lib/pf/api.pm
+++ b/lib/pf/api.pm
@@ -23,6 +23,7 @@ use pf::Authentication::constants;
 use pf::config();
 use pf::config::util();
 use pf::config::cached;
+use pf::config::trapping_range;
 use pf::ConfigStore::Interface();
 use pf::ConfigStore::Pf();
 use pf::iplog();
@@ -65,10 +66,9 @@ sub event_add : Public {
     my $logger = pf::log::get_logger();
 
     my ($type, $id) = each %{$postdata{'events'}};
-    $logger->info("violation: $id - IP $postdata{'srcip'}") if (defined($postdata{'srcip'}));
+    $logger->info("violation: $id - IP SRC $postdata{'srcip'} - IP DST $postdata{'dstip'}") if (defined($postdata{'srcip'}) && defined($postdata{'dst'}));
     if (defined ($pf::config::Config{'trapping'}{'range'}) && $pf::config::Config{'trapping'}{'range'} ne '') {
-        foreach my $network (split(',',$pf::config::Config{'trapping'}{'range'})) {
-            my $net_addr = NetAddr::IP->new($network);
+        foreach my $net_addr (@TRAPPING_RANGE) {
             if (defined $postdata{'srcip'}) {
                 my $ip = new NetAddr::IP::Lite pf::util::clean_ip($postdata{'srcip'});
                 if ($net_addr->contains($ip)) {
@@ -99,14 +99,14 @@ sub event_add : Public {
         # fetch IP associated to MAC
         my $srcmac = pf::iplog::ip2mac($postdata{'srcip'});
         if ($srcmac) {
+
             # trigger a violation
             pf::violation::violation_trigger( { 'mac' => $srcmac, 'tid' => $id, 'type' => $type } );
-
+            return(1);
         } else {
             $logger->info("violation on IP $postdata{'srcip'} with trigger ${type}::${id}: violation not added, can't resolve IP to mac !");
             return(0);
         }
-        return(1);
     }
 }
 

--- a/lib/pf/config/trapping_range.pm
+++ b/lib/pf/config/trapping_range.pm
@@ -1,0 +1,58 @@
+package pf::config::trapping_range;
+
+=head1 NAME
+
+pf::config::trapping_range -
+
+=cut
+
+=head1 DESCRIPTION
+
+pf::config::trapping_range
+
+=cut
+
+use strict;
+use warnings;
+use pfconfig::cached_array;
+
+tie our @TRAPPING_RANGE, 'pfconfig::cached_array' => 'resource::trapping_range';
+
+BEGIN {
+    use Exporter ();
+    our ( @ISA, @EXPORT );
+    @ISA = qw(Exporter);
+    @EXPORT = qw(
+        @TRAPPING_RANGE
+    );
+}
+
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2016 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;

--- a/lib/pf/detect/parser/security_onion.pm
+++ b/lib/pf/detect/parser/security_onion.pm
@@ -32,10 +32,11 @@ sub parse {
         date    => $split1[1],
         descr   => $split1[3],
         srcip   => $split2[0],
+        dstip   => $split2[1],
         sid     => $split2[6],
     };
 
-    return { date => $data->{date}, srcip => $data->{srcip}, events => { detect => $data->{sid}, suricata_event => $data->{descr} } };
+    return { date => $data->{date}, srcip => $data->{srcip}, dstip => $data->{dstip}, events => { detect => $data->{sid}, suricata_event => $data->{descr} } };
 }
 
 =head1 AUTHOR

--- a/lib/pf/detect/parser/snort.pm
+++ b/lib/pf/detect/parser/snort.pm
@@ -33,7 +33,7 @@ sub parse {
             srcip => $4,
             dstip => $6,
         };
-        return { srcip => $data->{srcip}, date => $data->{date}, events => { detect => $data->{sid}, suricata_event => $data->{descr} } };
+        return { srcip => $data->{srcip}, date => $data->{date}, dstip => $data->{dstip}, events => { detect => $data->{sid}, suricata_event => $data->{descr} } };
     } elsif ( $line
         =~ /^(.+?)\s+\[\*\*\]\s+\[\d+:(\d+):\d+\]\s+Portscan\s+detected\s+from\s+(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})/
         )

--- a/lib/pfconfig/namespaces/config/Pf.pm
+++ b/lib/pfconfig/namespaces/config/Pf.pm
@@ -62,7 +62,7 @@ sub init {
     $self->{doc_config}      = $self->{cache}->get_cache('config::Documentation');
     $self->{cluster_config}  = $self->{cache}->get_cache('config::Cluster');
 
-    $self->{child_resources} = [ 'resource::CaptivePortal', 'resource::Database', 'resource::fqdn', 'config::Pfdetect' ];
+    $self->{child_resources} = [ 'resource::CaptivePortal', 'resource::Database', 'resource::fqdn', 'config::Pfdetect', 'resource::trapping_range' ];
     if(defined($host_id)){
         push @{$self->{child_resources}}, "interfaces($host_id)";
     }

--- a/lib/pfconfig/namespaces/resource/trapping_range.pm
+++ b/lib/pfconfig/namespaces/resource/trapping_range.pm
@@ -1,0 +1,70 @@
+package pfconfig::namespaces::resource::trapping_range;
+
+=head1 NAME
+
+pfconfig::namespaces::resource::trapping_range
+
+=cut
+
+=head1 DESCRIPTION
+
+pfconfig::namespaces::resource::trapping_range
+
+This module creates the configuration hash of all the trapping range
+
+=cut
+
+use strict;
+use warnings;
+
+use base 'pfconfig::namespaces::resource';
+
+use NetAddr::IP;
+
+sub init {
+    my ($self) = @_;
+    $self->{config} = $self->{cache}->get_cache('config::Pf');
+}
+
+sub build {
+    my ($self) = @_;
+    my @ranges;
+    foreach my $range (split(',',$self->{config}{'trapping'}{'range'})) {
+        my $network = NetAddr::IP->new($range);
+        push @ranges,$network;
+    }
+    return \@ranges;
+}
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2016 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;
+
+# vim: set shiftwidth=4:
+# vim: set expandtab:
+# vim: set backspace=indent,eol,start:

--- a/sbin/pfdetect
+++ b/sbin/pfdetect
@@ -148,7 +148,7 @@ sub _run_detector {
 
     my $parser = pf::factory::detect::parser->new($parser_type);
 
-    my $client = pf::client->getClient();
+    my $client = pf::api::queue->new(queue => 'pfdetect');
 
     while (<$alert_pipe_fh>) {
         last unless $running;
@@ -162,7 +162,7 @@ sub _run_detector {
         }
         next if $data eq "0";   # Getting '0' from the parser indicates "job's done" which mean, nothing more to do for that line
         while (my ($type, $value) = each %{$data->{events}}) {
-            $client->notify( event_add => ( $data->{date}, $data->{srcip}, $type, $value ));
+            $client->notify( 'event_add', %{$data} );
         }
 
         #Stop running if parent is no longer alive


### PR DESCRIPTION
# Description

Allow PacketFence to trigger a violation on the src ip or dst ip address based on trapping range configuration parameter from snort/suricata/security_onion.
Use pfqueue to trigger violation instead of httpd.webservices
# Impacts

pfdetect
# Delete branch after merge

YES
## Enhancements
- Trigger violation on source ip or destination ip addess if they are in the trapping range networks
