### PR TITLE
Feature/show role instead of vlan

### DIFF
--- a/html/pfappserver/root/node/view.tt
+++ b/html/pfappserver/root/node/view.tt
@@ -81,11 +81,11 @@
                     <span class="badge badge-info"><i class="icon-signal"></i> [% item.ssid | html %]</span>
                   [% ELSE %]
                     [% IF item.port.length %]<span class="badge badge-info">[% l('port') %] [% item.port | html %]</span> [% END %]
-                    [% IF item.vlan.length %]<span class="badge badge-info">vlan [% item.vlan | html %]</span>[% END %]
+                    [% IF item.role.length %]<span class="badge badge-info">role [% item.role | html %]</span>[% END %]
                   [% END %]
                 </span>
                   [%- IF node.last_port.length && !node.last_ssid %] <span class="badge badge-info">port [% node.last_port | html %]</span>[% END %]
-                  [%- IF node.last_vlan.length %] <span class="badge badge-info">vlan [% node.last_vlan | html %]</span>[% END %]
+                  [%- IF node.last_role.length %] <span class="badge badge-info">role [% node.last_role | html %]</span>[% END %]
                   <span class="label">On [% node.last_start_time | html %]</span></div>
             </div>
             [%- END %]
@@ -184,7 +184,7 @@
                         <span class="badge badge-info"><i class="icon-signal"></i> [% item.ssid | html %]</span>
                       [% ELSE %]
                         [% IF item.port.length %]<span class="badge badge-info">[% l('port') %] [% item.port | html %]</span> [% END %]
-                        [% IF item.vlan.length %]<span class="badge badge-info">vlan [% item.vlan | html %]</span>[% END %]
+                        [% IF item.role.length %]<span class="badge badge-info">role [% item.role | html %]</span>[% END %]
                       [% END %]
                     </td>
                     <td>[% l(item.connection_type) %]</td>

--- a/lib/pf/node.pm
+++ b/lib/pf/node.pm
@@ -187,6 +187,7 @@ sub node_db_prepare {
             IF(ISNULL(locationlog.connection_type), '', locationlog.connection_type) as last_connection_type,
             locationlog.dot1x_username as last_dot1x_username, locationlog.ssid as last_ssid,
             locationlog.stripped_user_name as stripped_user_name, locationlog.realm as realm,
+            locationlog.role as last_role,
             COUNT(DISTINCT violation.id) as nbopenviolations,
             node.notes
         FROM node
@@ -228,7 +229,7 @@ sub node_db_prepare {
            IF(ISNULL(locationlog.connection_sub_type), '', locationlog.connection_sub_type) as last_connection_sub_type,
            locationlog.dot1x_username as last_dot1x_username, locationlog.ssid as last_ssid,
            locationlog.stripped_user_name as stripped_user_name, locationlog.realm as realm,
-           locationlog.start_time as last_start_time,
+           locationlog.start_time as last_start_time, locationlog.role as last_role,
            UNIX_TIMESTAMP(locationlog.start_time) as last_start_timestamp
        FROM locationlog
        WHERE mac = ? AND end_time = 0
@@ -247,6 +248,7 @@ sub node_db_prepare {
             IF(ISNULL(locationlog.connection_type), '', locationlog.connection_type) as last_connection_type,
             locationlog.dot1x_username as last_dot1x_username, locationlog.ssid as last_ssid,
             locationlog.stripped_user_name as stripped_user_name, locationlog.realm as realm,
+            locationlog.role as last_role,
             COUNT(DISTINCT violation.id) as nbopenviolations,
             node.notes
         FROM node

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -231,7 +231,8 @@ sub authorize {
 
     # Fetch VLAN depending on node status
     my $role = $role_obj->fetchRoleForNode($args);
-    my $vlan = $role->{vlan} || $switch->getVlanByName($role->{role}) if (isenabled($switch->{_VlanMap})) || 0;
+    my $vlan = $switch->getVlanByName($role->{role}) if (isenabled($switch->{_VlanMap}));
+    $vlan = $role->{vlan} || $vlan || 0;
 
     $args->{'node_info'}{'source'} = $role->{'source'} if (defined($role->{'source'}) && $role->{'source'} ne '');
     $args->{'node_info'}{'portal'} = $role->{'portal'} if (defined($role->{'portal'}) && $role->{'portal'} ne '');

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -231,7 +231,7 @@ sub authorize {
 
     # Fetch VLAN depending on node status
     my $role = $role_obj->fetchRoleForNode($args);
-    my $vlan = $role->{vlan} || $switch->getVlanByName($role->{role}) || 0;
+    my $vlan = $role->{vlan} || $switch->getVlanByName($role->{role}) if (isenabled($switch->{_VlanMap})) || 0;
 
     $args->{'node_info'}{'source'} = $role->{'source'} if (defined($role->{'source'}) && $role->{'source'} ne '');
     $args->{'node_info'}{'portal'} = $role->{'portal'} if (defined($role->{'portal'}) && $role->{'portal'} ne '');


### PR DESCRIPTION
# Description

In node location let see the role instead of the vlan id (not revelant when we use acl or role by role)
# Impacts

View of the location history of the node show the role instead of the vlan id
# Delete branch after merge

YES
# NEWS file entries
## Enhancements
- Location history of a node show the role instead of the vlan id
