### PR TITLE
Feature/campers parking

### DIFF
--- a/conf/dhcpd.conf
+++ b/conf/dhcpd.conf
@@ -10,3 +10,9 @@ log-facility local6;
 %%active%%
 
 %%networks%%
+
+group parking {
+  default-lease-time 3600;
+  max-lease-time 3600;
+}
+

--- a/conf/dhcpd.conf
+++ b/conf/dhcpd.conf
@@ -12,7 +12,7 @@ log-facility local6;
 %%networks%%
 
 group parking {
-  default-lease-time 3600;
-  max-lease-time 3600;
+  default-lease-time %%parking_lease_length%%;
+  max-lease-time %%parking_lease_length%%;
 }
 

--- a/conf/dhcpd.conf
+++ b/conf/dhcpd.conf
@@ -11,6 +11,7 @@ log-facility local6;
 
 %%networks%%
 
+# httpd.parking related
 group parking {
   default-lease-time %%parking_lease_length%%;
   max-lease-time %%parking_lease_length%%;

--- a/conf/dhcpd.conf
+++ b/conf/dhcpd.conf
@@ -11,9 +11,5 @@ log-facility local6;
 
 %%networks%%
 
-# httpd.parking related
-group parking {
-  default-lease-time %%parking_lease_length%%;
-  max-lease-time %%parking_lease_length%%;
-}
+%%parking%%
 

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -180,6 +180,13 @@ description=<<EOT
 Should httpd.portal be started ? Keep enabled unless you know what you're doing.
 EOT
 
+[services.httpd_parking]
+type=toggle
+options=enabled|disabled
+description=<<EOT
+Should httpd.parking be started ? Keep enabled unless you know what you're doing.
+EOT
+
 [services.httpd_webservices]
 type=toggle
 options=enabled|disabled
@@ -496,6 +503,13 @@ Lower order services start first and stop last.
 EOT
 
 [services.httpd_portal_order]
+type=numeric
+description=<<EOT
+Order in which the service should be started. 
+Lower order services start first and stop last.
+EOT
+
+[services.httpd_parking_order]
 type=numeric
 description=<<EOT
 Order in which the service should be started. 

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1791,3 +1791,10 @@ options=enabled|disabled
 description=<<EOT
 Place the device in the DHCP parking group when it is detected doing parking
 EOT
+
+[parking.show_parking_portal]
+type=toggle
+options=enabled|disabled
+description=<<EOT
+Show the parking portal to the device instead of the usual portal
+EOT

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1776,3 +1776,18 @@ type=numeric
 description=<<EOT
 Lease length (in seconds) when a device is in parking
 EOT
+
+[parking.threshold]
+type=numeric
+description=<<EOT
+The threshold (in seconds) after which a device will be placed in parking
+A value of 0 deactivates the parking detection.
+The detection works by looking at the time in seconds a device has been in the registration role and comparing it with this threshold
+EOT
+
+[parking.place_in_dhcp_parking_group]
+type=toggle
+options=enabled|disabled
+description=<<EOT
+Place the device in the DHCP parking group when it is detected doing parking
+EOT

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1770,3 +1770,9 @@ type=text
 description=<<EOT
 OPSWAT MetaScan Online Scanner URL for hash queries
 EOT
+
+[parking.lease_length]
+type=numeric
+description=<<EOT
+Lease length (in seconds) when a device is in parking
+EOT

--- a/conf/httpd.conf.d/httpd.parking
+++ b/conf/httpd.conf.d/httpd.parking
@@ -481,7 +481,7 @@ HostnameLookups Off
 # logged here.  If you *do* define an error logfile for a <VirtualHost>
 # container, that host's errors will be logged there and not here.
 #
-ErrorLog logs/error_log
+ErrorLog /usr/local/pf/logs/httpd.parking.error
 
 #
 # LogLevel: Control the number of messages logged to the error_log.
@@ -523,7 +523,7 @@ LogFormat "%{User-agent}i" agent
 # For a single logfile with access, agent, and referer information
 # (Combined Logfile Format), use the following directive:
 #
-CustomLog logs/access_log combined
+CustomLog /usr/local/pf/logs/httpd.parking.access combined
 
 #
 # Optionally add a line containing the server version and virtual host

--- a/conf/httpd.conf.d/httpd.parking
+++ b/conf/httpd.conf.d/httpd.parking
@@ -1,0 +1,1010 @@
+#
+# This is the main Apache server configuration file.  It contains the
+# configuration directives that give the server its instructions.
+# See <URL:http://httpd.apache.org/docs/2.2/> for detailed information.
+# In particular, see
+# <URL:http://httpd.apache.org/docs/2.2/mod/directives.html>
+# for a discussion of each configuration directive.
+#
+#
+# Do NOT simply read the instructions in here without understanding
+# what they do.  They're here only as hints or reminders.  If you are unsure
+# consult the online docs. You have been warned.  
+#
+# The configuration directives are grouped into three basic sections:
+#  1. Directives that control the operation of the Apache server process as a
+#     whole (the 'global environment').
+#  2. Directives that define the parameters of the 'main' or 'default' server,
+#     which responds to requests that aren't handled by a virtual host.
+#     These directives also provide default values for the settings
+#     of all virtual hosts.
+#  3. Settings for virtual hosts, which allow Web requests to be sent to
+#     different IP addresses or hostnames and have them handled by the
+#     same Apache server process.
+#
+# Configuration and logfile names: If the filenames you specify for many
+# of the server's control files begin with "/" (or "drive:/" for Win32), the
+# server will use that explicit path.  If the filenames do *not* begin
+# with "/", the value of ServerRoot is prepended -- so "logs/foo.log"
+# with ServerRoot set to "/etc/httpd" will be interpreted by the
+# server as "/etc/httpd/logs/foo.log".
+#
+
+### Section 1: Global Environment
+#
+# The directives in this section affect the overall operation of Apache,
+# such as the number of concurrent requests it can handle or where it
+# can find its configuration files.
+#
+
+#
+# Don't give away too much information about all the subcomponents
+# we are running.  Comment out this line if you don't mind remote sites
+# finding out what major optional modules you are running
+ServerTokens OS
+
+#
+# ServerRoot: The top of the directory tree under which the server's
+# configuration, error, and log files are kept.
+#
+# NOTE!  If you intend to place this on an NFS (or otherwise network)
+# mounted filesystem then please read the LockFile documentation
+# (available at <URL:http://httpd.apache.org/docs/2.2/mod/mpm_common.html#lockfile>);
+# you will save yourself a lot of trouble.
+#
+# Do NOT add a slash at the end of the directory path.
+#
+#ServerRoot "/opt/httpd"
+
+#
+# PidFile: The file in which the server should record its process
+# identification number when it starts.  Note the PIDFILE variable in
+# /etc/sysconfig/httpd must be set appropriately if this location is
+# changed.
+#
+PidFile run/httpd.pid
+
+#
+# Timeout: The number of seconds before receives and sends time out.
+#
+Timeout 60
+
+#
+# KeepAlive: Whether or not to allow persistent connections (more than
+# one request per connection). Set to "Off" to deactivate.
+#
+KeepAlive Off
+
+#
+# MaxKeepAliveRequests: The maximum number of requests to allow
+# during a persistent connection. Set to 0 to allow an unlimited amount.
+# We recommend you leave this number high, for maximum performance.
+#
+MaxKeepAliveRequests 100
+
+#
+# KeepAliveTimeout: Number of seconds to wait for the next request from the
+# same client on the same connection.
+#
+KeepAliveTimeout 3
+
+##
+## Server-Pool Size Regulation (MPM specific)
+## 
+
+# prefork MPM
+# StartServers: number of server processes to start
+# MinSpareServers: minimum number of server processes which are kept spare
+# MaxSpareServers: maximum number of server processes which are kept spare
+# ServerLimit: maximum value for MaxClients for the lifetime of the server
+# MaxClients: maximum number of server processes allowed to start
+# MaxRequestsPerChild: maximum number of requests a server process serves
+<IfModule prefork.c>
+StartServers       8
+MinSpareServers    5
+MaxSpareServers   20
+ServerLimit      256
+MaxClients       64
+MaxRequestsPerChild  4000
+</IfModule>
+
+# worker MPM
+# StartServers: initial number of server processes to start
+# MaxClients: maximum number of simultaneous client connections
+# MinSpareThreads: minimum number of worker threads which are kept spare
+# MaxSpareThreads: maximum number of worker threads which are kept spare
+# ThreadsPerChild: constant number of worker threads in each server process
+# MaxRequestsPerChild: maximum number of requests a server process serves
+<IfModule worker.c>
+StartServers         4
+MaxClients         300
+MinSpareThreads     25
+MaxSpareThreads     75 
+ThreadsPerChild     25
+MaxRequestsPerChild  0
+</IfModule>
+
+#
+# Listen: Allows you to bind Apache to specific IP addresses and/or
+# ports, in addition to the default. See also the <VirtualHost>
+# directive.
+#
+# Change this to Listen on specific IP addresses as shown below to 
+# prevent Apache from glomming onto all bound IP addresses (0.0.0.0)
+#
+#Listen 12.34.56.78:80
+Listen  0.0.0.0:5252
+
+#
+# Dynamic Shared Object (DSO) Support
+#
+# To be able to use the functionality of a module which was built as a DSO you
+# have to place corresponding `LoadModule' lines at this location so the
+# directives contained in it are actually available _before_ they are used.
+# Statically compiled modules (those listed by `httpd -l') do not need
+# to be loaded here.
+#
+# Example:
+# LoadModule foo_module modules/mod_foo.so
+#
+LoadModule auth_basic_module modules/mod_auth_basic.so
+LoadModule auth_digest_module modules/mod_auth_digest.so
+LoadModule authn_file_module modules/mod_authn_file.so
+LoadModule authn_alias_module modules/mod_authn_alias.so
+LoadModule authn_anon_module modules/mod_authn_anon.so
+LoadModule authn_dbm_module modules/mod_authn_dbm.so
+LoadModule authn_default_module modules/mod_authn_default.so
+LoadModule authz_host_module modules/mod_authz_host.so
+LoadModule authz_user_module modules/mod_authz_user.so
+LoadModule authz_owner_module modules/mod_authz_owner.so
+LoadModule authz_groupfile_module modules/mod_authz_groupfile.so
+LoadModule authz_dbm_module modules/mod_authz_dbm.so
+LoadModule authz_default_module modules/mod_authz_default.so
+LoadModule ldap_module modules/mod_ldap.so
+LoadModule authnz_ldap_module modules/mod_authnz_ldap.so
+LoadModule include_module modules/mod_include.so
+LoadModule log_config_module modules/mod_log_config.so
+LoadModule logio_module modules/mod_logio.so
+LoadModule env_module modules/mod_env.so
+LoadModule ext_filter_module modules/mod_ext_filter.so
+LoadModule mime_magic_module modules/mod_mime_magic.so
+LoadModule expires_module modules/mod_expires.so
+LoadModule deflate_module modules/mod_deflate.so
+LoadModule headers_module modules/mod_headers.so
+LoadModule usertrack_module modules/mod_usertrack.so
+LoadModule setenvif_module modules/mod_setenvif.so
+LoadModule mime_module modules/mod_mime.so
+LoadModule dav_module modules/mod_dav.so
+LoadModule status_module modules/mod_status.so
+LoadModule autoindex_module modules/mod_autoindex.so
+LoadModule info_module modules/mod_info.so
+LoadModule dav_fs_module modules/mod_dav_fs.so
+LoadModule vhost_alias_module modules/mod_vhost_alias.so
+LoadModule negotiation_module modules/mod_negotiation.so
+LoadModule dir_module modules/mod_dir.so
+LoadModule actions_module modules/mod_actions.so
+LoadModule speling_module modules/mod_speling.so
+LoadModule userdir_module modules/mod_userdir.so
+LoadModule alias_module modules/mod_alias.so
+LoadModule substitute_module modules/mod_substitute.so
+LoadModule rewrite_module modules/mod_rewrite.so
+LoadModule proxy_module modules/mod_proxy.so
+LoadModule proxy_balancer_module modules/mod_proxy_balancer.so
+LoadModule proxy_ftp_module modules/mod_proxy_ftp.so
+LoadModule proxy_http_module modules/mod_proxy_http.so
+LoadModule proxy_ajp_module modules/mod_proxy_ajp.so
+LoadModule proxy_connect_module modules/mod_proxy_connect.so
+LoadModule cache_module modules/mod_cache.so
+LoadModule suexec_module modules/mod_suexec.so
+LoadModule disk_cache_module modules/mod_disk_cache.so
+LoadModule cgi_module modules/mod_cgi.so
+LoadModule version_module modules/mod_version.so
+
+#
+# The following modules are not loaded by default:
+#
+#LoadModule asis_module modules/mod_asis.so
+#LoadModule authn_dbd_module modules/mod_authn_dbd.so
+#LoadModule cern_meta_module modules/mod_cern_meta.so
+#LoadModule cgid_module modules/mod_cgid.so
+#LoadModule dbd_module modules/mod_dbd.so
+#LoadModule dumpio_module modules/mod_dumpio.so
+#LoadModule filter_module modules/mod_filter.so
+#LoadModule ident_module modules/mod_ident.so
+#LoadModule log_forensic_module modules/mod_log_forensic.so
+#LoadModule unique_id_module modules/mod_unique_id.so
+#
+
+#
+# Load config files from the config directory "/etc/httpd/conf.d".
+#
+#Include /opt/httpd/conf.d/*.conf
+
+#
+# ExtendedStatus controls whether Apache will generate "full" status
+# information (ExtendedStatus On) or just basic information (ExtendedStatus
+# Off) when the "server-status" handler is called. The default is Off.
+#
+#ExtendedStatus On
+
+#
+# If you wish httpd to run as a different user or group, you must run
+# httpd as root initially and it will switch.  
+#
+# User/Group: The name (or #number) of the user/group to run httpd as.
+#  . On SCO (ODT 3) use "User nouser" and "Group nogroup".
+#  . On HPUX you may not be able to use shared memory as nobody, and the
+#    suggested workaround is to create a user www and use that user.
+#  NOTE that some kernels refuse to setgid(Group) or semctl(IPC_SET)
+#  when the value of (unsigned)Group is above 60000; 
+#  don't use Group #-1 on these systems!
+#
+User pf 
+Group pf
+
+### Section 2: 'Main' server configuration
+#
+# The directives in this section set up the values used by the 'main'
+# server, which responds to any requests that aren't handled by a
+# <VirtualHost> definition.  These values also provide defaults for
+# any <VirtualHost> containers you may define later in the file.
+#
+# All of these directives may appear inside <VirtualHost> containers,
+# in which case these default settings will be overridden for the
+# virtual host being defined.
+#
+
+#
+# ServerAdmin: Your address, where problems with the server should be
+# e-mailed.  This address appears on some server-generated pages, such
+# as error documents.  e.g. admin@your-domain.com
+#
+ServerAdmin root@localhost
+
+#
+# ServerName gives the name and port that the server uses to identify itself.
+# This can often be determined automatically, but we recommend you specify
+# it explicitly to prevent problems during startup.
+#
+# If this is not set to valid DNS name for your host, server-generated
+# redirections will not work.  See also the UseCanonicalName directive.
+#
+# If your host doesn't have a registered DNS name, enter its IP address here.
+# You will have to access it by its address anyway, and this will make 
+# redirections work in a sensible way.
+#
+#ServerName www.example.com:80
+
+#
+# UseCanonicalName: Determines how Apache constructs self-referencing 
+# URLs and the SERVER_NAME and SERVER_PORT variables.
+# When set "Off", Apache will use the Hostname and Port supplied
+# by the client.  When set "On", Apache will use the value of the
+# ServerName directive.
+#
+UseCanonicalName Off
+
+#
+# DocumentRoot: The directory out of which you will serve your
+# documents. By default, all requests are taken from this directory, but
+# symbolic links and aliases may be used to point to other locations.
+#
+DocumentRoot "/usr/local/pf/html/parking"
+
+#
+# Each directory to which Apache has access can be configured with respect
+# to which services and features are allowed and/or disabled in that
+# directory (and its subdirectories). 
+#
+# First, we configure the "default" to be a very restrictive set of 
+# features.  
+#
+<Directory />
+    Options FollowSymLinks
+    AllowOverride None
+</Directory>
+
+#
+# Note that from this point forward you must specifically allow
+# particular features to be enabled - so if something's not working as
+# you might expect, make sure that you have specifically enabled it
+# below.
+#
+
+#
+# This should be changed to whatever you set DocumentRoot to.
+#
+<Directory "/usr/local/pf/html/captive-portal/content/www">
+
+#
+# Possible values for the Options directive are "None", "All",
+# or any combination of:
+#   Indexes Includes FollowSymLinks SymLinksifOwnerMatch ExecCGI MultiViews
+#
+# Note that "MultiViews" must be named *explicitly* --- "Options All"
+# doesn't give it to you.
+#
+# The Options directive is both complicated and important.  Please see
+# http://httpd.apache.org/docs/2.2/mod/core.html#options
+# for more information.
+#
+    Options Indexes FollowSymLinks
+
+#
+# AllowOverride controls what directives may be placed in .htaccess files.
+# It can be "All", "None", or any combination of the keywords:
+#   Options FileInfo AuthConfig Limit
+#
+    AllowOverride None
+
+#
+# Controls who can get stuff from this server.
+#
+    Order allow,deny
+    Allow from all
+
+</Directory>
+
+#
+# UserDir: The name of the directory that is appended onto a user's home
+# directory if a ~user request is received.
+#
+# The path to the end user account 'public_html' directory must be
+# accessible to the webserver userid.  This usually means that ~userid
+# must have permissions of 711, ~userid/public_html must have permissions
+# of 755, and documents contained therein must be world-readable.
+# Otherwise, the client will only receive a "403 Forbidden" message.
+#
+# See also: http://httpd.apache.org/docs/misc/FAQ.html#forbidden
+#
+<IfModule mod_userdir.c>
+    #
+    # UserDir is disabled by default since it can confirm the presence
+    # of a username on the system (depending on home directory
+    # permissions).
+    #
+    UserDir disabled
+
+    #
+    # To enable requests to /~user/ to serve the user's public_html
+    # directory, remove the "UserDir disabled" line above, and uncomment
+    # the following line instead:
+    # 
+    #UserDir public_html
+
+</IfModule>
+
+#
+# Control access to UserDir directories.  The following is an example
+# for a site where these directories are restricted to read-only.
+#
+#<Directory /home/*/public_html>
+#    AllowOverride FileInfo AuthConfig Limit
+#    Options MultiViews Indexes SymLinksIfOwnerMatch IncludesNoExec
+#    <Limit GET POST OPTIONS>
+#        Order allow,deny
+#        Allow from all
+#    </Limit>
+#    <LimitExcept GET POST OPTIONS>
+#        Order deny,allow
+#        Deny from all
+#    </LimitExcept>
+#</Directory>
+
+#
+# DirectoryIndex: sets the file that Apache will serve if a directory
+# is requested.
+#
+# The index.html.var file (a type-map) is used to deliver content-
+# negotiated documents.  The MultiViews Option can be used for the 
+# same purpose, but it is much slower.
+#
+DirectoryIndex index.html index.html.var
+
+#
+# AccessFileName: The name of the file to look for in each directory
+# for additional configuration directives.  See also the AllowOverride
+# directive.
+#
+AccessFileName .htaccess
+
+#
+# The following lines prevent .htaccess and .htpasswd files from being 
+# viewed by Web clients. 
+#
+<Files ~ "^\.ht">
+    Order allow,deny
+    Deny from all
+    Satisfy All
+</Files>
+
+#
+# TypesConfig describes where the mime.types file (or equivalent) is
+# to be found.
+#
+TypesConfig /etc/mime.types
+
+#
+# DefaultType is the default MIME type the server will use for a document
+# if it cannot otherwise determine one, such as from filename extensions.
+# If your server contains mostly text or HTML documents, "text/plain" is
+# a good value.  If most of your content is binary, such as applications
+# or images, you may want to use "application/octet-stream" instead to
+# keep browsers from trying to display binary files as though they are
+# text.
+#
+DefaultType text/plain
+
+#
+# The mod_mime_magic module allows the server to use various hints from the
+# contents of the file itself to determine its type.  The MIMEMagicFile
+# directive tells the module where the hint definitions are located.
+#
+<IfModule mod_mime_magic.c>
+#   MIMEMagicFile /usr/share/magic.mime
+    MIMEMagicFile conf/magic
+</IfModule>
+
+#
+# HostnameLookups: Log the names of clients or just their IP addresses
+# e.g., www.apache.org (on) or 204.62.129.132 (off).
+# The default is off because it'd be overall better for the net if people
+# had to knowingly turn this feature on, since enabling it means that
+# each client request will result in AT LEAST one lookup request to the
+# nameserver.
+#
+HostnameLookups Off
+
+#
+# EnableMMAP: Control whether memory-mapping is used to deliver
+# files (assuming that the underlying OS supports it).
+# The default is on; turn this off if you serve from NFS-mounted 
+# filesystems.  On some systems, turning it off (regardless of
+# filesystem) can improve performance; for details, please see
+# http://httpd.apache.org/docs/2.2/mod/core.html#enablemmap
+#
+#EnableMMAP off
+
+#
+# EnableSendfile: Control whether the sendfile kernel support is 
+# used to deliver files (assuming that the OS supports it). 
+# The default is on; turn this off if you serve from NFS-mounted 
+# filesystems.  Please see
+# http://httpd.apache.org/docs/2.2/mod/core.html#enablesendfile
+#
+#EnableSendfile off
+
+#
+# ErrorLog: The location of the error log file.
+# If you do not specify an ErrorLog directive within a <VirtualHost>
+# container, error messages relating to that virtual host will be
+# logged here.  If you *do* define an error logfile for a <VirtualHost>
+# container, that host's errors will be logged there and not here.
+#
+ErrorLog logs/error_log
+
+#
+# LogLevel: Control the number of messages logged to the error_log.
+# Possible values include: debug, info, notice, warn, error, crit,
+# alert, emerg.
+#
+LogLevel warn
+
+#
+# The following directives define some format nicknames for use with
+# a CustomLog directive (see below).
+#
+LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+LogFormat "%h %l %u %t \"%r\" %>s %b" common
+LogFormat "%{Referer}i -> %U" referer
+LogFormat "%{User-agent}i" agent
+
+# "combinedio" includes actual counts of actual bytes received (%I) and sent (%O); this
+# requires the mod_logio module to be loaded.
+#LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" %I %O" combinedio
+
+#
+# The location and format of the access logfile (Common Logfile Format).
+# If you do not define any access logfiles within a <VirtualHost>
+# container, they will be logged here.  Contrariwise, if you *do*
+# define per-<VirtualHost> access logfiles, transactions will be
+# logged therein and *not* in this file.
+#
+#CustomLog logs/access_log common
+
+#
+# If you would like to have separate agent and referer logfiles, uncomment
+# the following directives.
+#
+#CustomLog logs/referer_log referer
+#CustomLog logs/agent_log agent
+
+#
+# For a single logfile with access, agent, and referer information
+# (Combined Logfile Format), use the following directive:
+#
+CustomLog logs/access_log combined
+
+#
+# Optionally add a line containing the server version and virtual host
+# name to server-generated pages (internal error documents, FTP directory
+# listings, mod_status and mod_info output etc., but not CGI generated
+# documents or custom error documents).
+# Set to "EMail" to also include a mailto: link to the ServerAdmin.
+# Set to one of:  On | Off | EMail
+#
+ServerSignature On
+
+#
+# Aliases: Add here as many aliases as you need (with no limit). The format is 
+# Alias fakename realname
+#
+# Note that if you include a trailing / on fakename then the server will
+# require it to be present in the URL.  So "/icons" isn't aliased in this
+# example, only "/icons/".  If the fakename is slash-terminated, then the 
+# realname must also be slash terminated, and if the fakename omits the 
+# trailing slash, the realname must also omit it.
+#
+# We include the /icons/ alias for FancyIndexed directory listings.  If you
+# do not use FancyIndexing, you may comment this out.
+#
+Alias /icons/ "/var/www/icons/"
+
+<Directory "/var/www/icons">
+    Options Indexes MultiViews FollowSymLinks
+    AllowOverride None
+    Order allow,deny
+    Allow from all
+</Directory>
+
+#
+# WebDAV module configuration section.
+# 
+<IfModule mod_dav_fs.c>
+    # Location of the WebDAV lock database.
+    DAVLockDB /var/lib/dav/lockdb
+</IfModule>
+
+#
+# ScriptAlias: This controls which directories contain server scripts.
+# ScriptAliases are essentially the same as Aliases, except that
+# documents in the realname directory are treated as applications and
+# run by the server when requested rather than as documents sent to the client.
+# The same rules about trailing "/" apply to ScriptAlias directives as to
+# Alias.
+#
+ScriptAlias /cgi-bin/ "/var/www/cgi-bin/"
+
+#
+# "/var/www/cgi-bin" should be changed to whatever your ScriptAliased
+# CGI directory exists, if you have that configured.
+#
+<Directory "/var/www/cgi-bin">
+    AllowOverride None
+    Options None
+    Order allow,deny
+    Allow from all
+</Directory>
+
+#
+# Redirect allows you to tell clients about documents which used to exist in
+# your server's namespace, but do not anymore. This allows you to tell the
+# clients where to look for the relocated document.
+# Example:
+# Redirect permanent /foo http://www.example.com/bar
+
+#
+# Directives controlling the display of server-generated directory listings.
+#
+
+#
+# IndexOptions: Controls the appearance of server-generated directory
+# listings.
+#
+IndexOptions FancyIndexing VersionSort NameWidth=* HTMLTable Charset=UTF-8
+
+#
+# AddIcon* directives tell the server which icon to show for different
+# files or filename extensions.  These are only displayed for
+# FancyIndexed directories.
+#
+AddIconByEncoding (CMP,/icons/compressed.gif) x-compress x-gzip
+
+AddIconByType (TXT,/icons/text.gif) text/*
+AddIconByType (IMG,/icons/image2.gif) image/*
+AddIconByType (SND,/icons/sound2.gif) audio/*
+AddIconByType (VID,/icons/movie.gif) video/*
+
+AddIcon /icons/binary.gif .bin .exe
+AddIcon /icons/binhex.gif .hqx
+AddIcon /icons/tar.gif .tar
+AddIcon /icons/world2.gif .wrl .wrl.gz .vrml .vrm .iv
+AddIcon /icons/compressed.gif .Z .z .tgz .gz .zip
+AddIcon /icons/a.gif .ps .ai .eps
+AddIcon /icons/layout.gif .html .shtml .htm .pdf
+AddIcon /icons/text.gif .txt
+AddIcon /icons/c.gif .c
+AddIcon /icons/p.gif .pl .py
+AddIcon /icons/f.gif .for
+AddIcon /icons/dvi.gif .dvi
+AddIcon /icons/uuencoded.gif .uu
+AddIcon /icons/script.gif .conf .sh .shar .csh .ksh .tcl
+AddIcon /icons/tex.gif .tex
+AddIcon /icons/bomb.gif core
+
+AddIcon /icons/back.gif ..
+AddIcon /icons/hand.right.gif README
+AddIcon /icons/folder.gif ^^DIRECTORY^^
+AddIcon /icons/blank.gif ^^BLANKICON^^
+
+#
+# DefaultIcon is which icon to show for files which do not have an icon
+# explicitly set.
+#
+DefaultIcon /icons/unknown.gif
+
+#
+# AddDescription allows you to place a short description after a file in
+# server-generated indexes.  These are only displayed for FancyIndexed
+# directories.
+# Format: AddDescription "description" filename
+#
+#AddDescription "GZIP compressed document" .gz
+#AddDescription "tar archive" .tar
+#AddDescription "GZIP compressed tar archive" .tgz
+
+#
+# ReadmeName is the name of the README file the server will look for by
+# default, and append to directory listings.
+#
+# HeaderName is the name of a file which should be prepended to
+# directory indexes. 
+ReadmeName README.html
+HeaderName HEADER.html
+
+#
+# IndexIgnore is a set of filenames which directory indexing should ignore
+# and not include in the listing.  Shell-style wildcarding is permitted.
+#
+IndexIgnore .??* *~ *# HEADER* README* RCS CVS *,v *,t
+
+#
+# DefaultLanguage and AddLanguage allows you to specify the language of 
+# a document. You can then use content negotiation to give a browser a 
+# file in a language the user can understand.
+#
+# Specify a default language. This means that all data
+# going out without a specific language tag (see below) will 
+# be marked with this one. You probably do NOT want to set
+# this unless you are sure it is correct for all cases.
+#
+# * It is generally better to not mark a page as 
+# * being a certain language than marking it with the wrong
+# * language!
+#
+# DefaultLanguage nl
+#
+# Note 1: The suffix does not have to be the same as the language
+# keyword --- those with documents in Polish (whose net-standard
+# language code is pl) may wish to use "AddLanguage pl .po" to
+# avoid the ambiguity with the common suffix for perl scripts.
+#
+# Note 2: The example entries below illustrate that in some cases 
+# the two character 'Language' abbreviation is not identical to 
+# the two character 'Country' code for its country,
+# E.g. 'Danmark/dk' versus 'Danish/da'.
+#
+# Note 3: In the case of 'ltz' we violate the RFC by using a three char
+# specifier. There is 'work in progress' to fix this and get
+# the reference data for rfc1766 cleaned up.
+#
+# Catalan (ca) - Croatian (hr) - Czech (cs) - Danish (da) - Dutch (nl)
+# English (en) - Esperanto (eo) - Estonian (et) - French (fr) - German (de)
+# Greek-Modern (el) - Hebrew (he) - Italian (it) - Japanese (ja)
+# Korean (ko) - Luxembourgeois* (ltz) - Norwegian Nynorsk (nn)
+# Norwegian (no) - Polish (pl) - Portugese (pt)
+# Brazilian Portuguese (pt-BR) - Russian (ru) - Swedish (sv)
+# Simplified Chinese (zh-CN) - Spanish (es) - Traditional Chinese (zh-TW)
+#
+AddLanguage ca .ca
+AddLanguage cs .cz .cs
+AddLanguage da .dk
+AddLanguage de .de
+AddLanguage el .el
+AddLanguage en .en
+AddLanguage eo .eo
+AddLanguage es .es
+AddLanguage et .et
+AddLanguage fr .fr
+AddLanguage he .he
+AddLanguage hr .hr
+AddLanguage it .it
+AddLanguage ja .ja
+AddLanguage ko .ko
+AddLanguage ltz .ltz
+AddLanguage nl .nl
+AddLanguage nn .nn
+AddLanguage no .no
+AddLanguage pl .po
+AddLanguage pt .pt
+AddLanguage pt-BR .pt-br
+AddLanguage ru .ru
+AddLanguage sv .sv
+AddLanguage zh-CN .zh-cn
+AddLanguage zh-TW .zh-tw
+
+#
+# LanguagePriority allows you to give precedence to some languages
+# in case of a tie during content negotiation.
+#
+# Just list the languages in decreasing order of preference. We have
+# more or less alphabetized them here. You probably want to change this.
+#
+LanguagePriority en ca cs da de el eo es et fr he hr it ja ko ltz nl nn no pl pt pt-BR ru sv zh-CN zh-TW
+
+#
+# ForceLanguagePriority allows you to serve a result page rather than
+# MULTIPLE CHOICES (Prefer) [in case of a tie] or NOT ACCEPTABLE (Fallback)
+# [in case no accepted languages matched the available variants]
+#
+ForceLanguagePriority Prefer Fallback
+
+#
+# Specify a default charset for all content served; this enables
+# interpretation of all content as UTF-8 by default.  To use the 
+# default browser choice (ISO-8859-1), or to allow the META tags
+# in HTML content to override this choice, comment out this
+# directive:
+#
+AddDefaultCharset UTF-8
+
+#
+# AddType allows you to add to or override the MIME configuration
+# file mime.types for specific file types.
+#
+#AddType application/x-tar .tgz
+
+#
+# AddEncoding allows you to have certain browsers uncompress
+# information on the fly. Note: Not all browsers support this.
+# Despite the name similarity, the following Add* directives have nothing
+# to do with the FancyIndexing customization directives above.
+#
+#AddEncoding x-compress .Z
+#AddEncoding x-gzip .gz .tgz
+
+# If the AddEncoding directives above are commented-out, then you
+# probably should define those extensions to indicate media types:
+#
+AddType application/x-compress .Z
+AddType application/x-gzip .gz .tgz
+
+#
+#   MIME-types for downloading Certificates and CRLs
+#
+AddType application/x-x509-ca-cert .crt
+AddType application/x-pkcs7-crl    .crl
+
+#
+# AddHandler allows you to map certain file extensions to "handlers":
+# actions unrelated to filetype. These can be either built into the server
+# or added with the Action directive (see below)
+#
+# To use CGI scripts outside of ScriptAliased directories:
+# (You will also need to add "ExecCGI" to the "Options" directive.)
+#
+#AddHandler cgi-script .cgi
+
+#
+# For files that include their own HTTP headers:
+#
+#AddHandler send-as-is asis
+
+#
+# For type maps (negotiated resources):
+# (This is enabled by default to allow the Apache "It Worked" page
+#  to be distributed in multiple languages.)
+#
+AddHandler type-map var
+
+#
+# Filters allow you to process content before it is sent to the client.
+#
+# To parse .shtml files for server-side includes (SSI):
+# (You will also need to add "Includes" to the "Options" directive.)
+#
+AddType text/html .shtml
+AddOutputFilter INCLUDES .shtml
+
+#
+# Action lets you define media types that will execute a script whenever
+# a matching file is called. This eliminates the need for repeated URL
+# pathnames for oft-used CGI file processors.
+# Format: Action media/type /cgi-script/location
+# Format: Action handler-name /cgi-script/location
+#
+
+#
+# Customizable error responses come in three flavors:
+# 1) plain text 2) local redirects 3) external redirects
+#
+# Some examples:
+#ErrorDocument 500 "The server made a boo boo."
+#ErrorDocument 404 /missing.html
+#ErrorDocument 404 "/cgi-bin/missing_handler.pl"
+#ErrorDocument 402 http://www.example.com/subscription_info.html
+#
+
+ErrorDocument 404 /index.html
+#
+# Putting this all together, we can internationalize error responses.
+#
+# We use Alias to redirect any /error/HTTP_<error>.html.var response to
+# our collection of by-error message multi-language collections.  We use 
+# includes to substitute the appropriate text.
+#
+# You can modify the messages' appearance without changing any of the
+# default HTTP_<error>.html.var files by adding the line:
+#
+#   Alias /error/include/ "/your/include/path/"
+#
+# which allows you to create your own set of files by starting with the
+# /var/www/error/include/ files and
+# copying them to /your/include/path/, even on a per-VirtualHost basis.
+#
+
+#Alias /error/ "/var/www/error/"
+#
+#<IfModule mod_negotiation.c>
+#<IfModule mod_include.c>
+#    <Directory "/var/www/error">
+#        AllowOverride None
+#        Options IncludesNoExec
+#        AddOutputFilter Includes html
+#        AddHandler type-map var
+#        Order allow,deny
+#        Allow from all
+#        LanguagePriority en es de fr
+#        ForceLanguagePriority Prefer Fallback
+#    </Directory>
+#
+##    ErrorDocument 400 /error/HTTP_BAD_REQUEST.html.var
+##    ErrorDocument 401 /error/HTTP_UNAUTHORIZED.html.var
+##    ErrorDocument 403 /error/HTTP_FORBIDDEN.html.var
+##    ErrorDocument 404 /error/HTTP_NOT_FOUND.html.var
+##    ErrorDocument 405 /error/HTTP_METHOD_NOT_ALLOWED.html.var
+##    ErrorDocument 408 /error/HTTP_REQUEST_TIME_OUT.html.var
+##    ErrorDocument 410 /error/HTTP_GONE.html.var
+##    ErrorDocument 411 /error/HTTP_LENGTH_REQUIRED.html.var
+##    ErrorDocument 412 /error/HTTP_PRECONDITION_FAILED.html.var
+##    ErrorDocument 413 /error/HTTP_REQUEST_ENTITY_TOO_LARGE.html.var
+##    ErrorDocument 414 /error/HTTP_REQUEST_URI_TOO_LARGE.html.var
+##    ErrorDocument 415 /error/HTTP_UNSUPPORTED_MEDIA_TYPE.html.var
+##    ErrorDocument 500 /error/HTTP_INTERNAL_SERVER_ERROR.html.var
+##    ErrorDocument 501 /error/HTTP_NOT_IMPLEMENTED.html.var
+##    ErrorDocument 502 /error/HTTP_BAD_GATEWAY.html.var
+##    ErrorDocument 503 /error/HTTP_SERVICE_UNAVAILABLE.html.var
+##    ErrorDocument 506 /error/HTTP_VARIANT_ALSO_VARIES.html.var
+#
+#</IfModule>
+#</IfModule>
+
+#
+# The following directives modify normal HTTP response behavior to
+# handle known problems with browser implementations.
+#
+BrowserMatch "Mozilla/2" nokeepalive
+BrowserMatch "MSIE 4\.0b2;" nokeepalive downgrade-1.0 force-response-1.0
+BrowserMatch "RealPlayer 4\.0" force-response-1.0
+BrowserMatch "Java/1\.0" force-response-1.0
+BrowserMatch "JDK/1\.0" force-response-1.0
+
+#
+# The following directive disables redirects on non-GET requests for
+# a directory that does not include the trailing slash.  This fixes a 
+# problem with Microsoft WebFolders which does not appropriately handle 
+# redirects for folders with DAV methods.
+# Same deal with Apple's DAV filesystem and Gnome VFS support for DAV.
+#
+BrowserMatch "Microsoft Data Access Internet Publishing Provider" redirect-carefully
+BrowserMatch "MS FrontPage" redirect-carefully
+BrowserMatch "^WebDrive" redirect-carefully
+BrowserMatch "^WebDAVFS/1.[0123]" redirect-carefully
+BrowserMatch "^gnome-vfs/1.0" redirect-carefully
+BrowserMatch "^XML Spy" redirect-carefully
+BrowserMatch "^Dreamweaver-WebDAV-SCM1" redirect-carefully
+
+#
+# Allow server status reports generated by mod_status,
+# with the URL of http://servername/server-status
+# Change the ".example.com" to match your domain to enable.
+#
+#<Location /server-status>
+#    SetHandler server-status
+#    Order deny,allow
+#    Deny from all
+#    Allow from .example.com
+#</Location>
+
+#
+# Allow remote server configuration reports, with the URL of
+#  http://servername/server-info (requires that mod_info.c be loaded).
+# Change the ".example.com" to match your domain to enable.
+#
+#<Location /server-info>
+#    SetHandler server-info
+#    Order deny,allow
+#    Deny from all
+#    Allow from .example.com
+#</Location>
+
+#
+# Proxy Server directives. Uncomment the following lines to
+# enable the proxy server:
+#
+#<IfModule mod_proxy.c>
+#ProxyRequests On
+#
+#<Proxy *>
+#    Order deny,allow
+#    Deny from all
+#    Allow from .example.com
+#</Proxy>
+
+#
+# Enable/disable the handling of HTTP/1.1 "Via:" headers.
+# ("Full" adds the server version; "Block" removes all outgoing Via: headers)
+# Set to one of: Off | On | Full | Block
+#
+#ProxyVia On
+
+#
+# To enable a cache of proxied content, uncomment the following lines.
+# See http://httpd.apache.org/docs/2.2/mod/mod_cache.html for more details.
+#
+#<IfModule mod_disk_cache.c>
+#   CacheEnable disk /
+#   CacheRoot "/var/cache/mod_proxy"
+#</IfModule>
+#
+
+#</IfModule>
+# End of proxy directives.
+
+### Section 3: Virtual Hosts
+#
+# VirtualHost: If you want to maintain multiple domains/hostnames on your
+# machine you can setup VirtualHost containers for them. Most configurations
+# use only name-based virtual hosts so the server doesn't need to worry about
+# IP addresses. This is indicated by the asterisks in the directives below.
+#
+# Please see the documentation at 
+# <URL:http://httpd.apache.org/docs/2.2/vhosts/>
+# for further details before you try to setup virtual hosts.
+#
+# You may use the command line option '-S' to verify your virtual host
+# configuration.
+
+#
+# Use name-based virtual hosting.
+#
+#NameVirtualHost *:80
+#
+# NOTE: NameVirtualHost cannot be used without a port specifier 
+# (e.g. :80) if mod_ssl is being used, due to the nature of the
+# SSL protocol.
+#
+
+#
+# VirtualHost example:
+# Almost any Apache directive may go into a VirtualHost container.
+# The first VirtualHost section is used for requests without a known
+# server name.
+#
+#<VirtualHost *:80>
+#    ServerAdmin webmaster@dummy-host.example.com
+#    DocumentRoot /www/docs/dummy-host.example.com
+#    ServerName dummy-host.example.com
+#    ErrorLog logs/dummy-host.example.com-error_log
+#    CustomLog logs/dummy-host.example.com-access_log common
+#</VirtualHost>

--- a/conf/httpd.conf.d/httpd.parking
+++ b/conf/httpd.conf.d/httpd.parking
@@ -62,7 +62,7 @@ ServerTokens OS
 # /etc/sysconfig/httpd must be set appropriately if this location is
 # changed.
 #
-PidFile run/httpd.pid
+PidFile /usr/local/pf/var/run/httpd.parking.pid
 
 #
 # Timeout: The number of seconds before receives and sends time out.
@@ -573,13 +573,13 @@ Alias /icons/ "/var/www/icons/"
 # The same rules about trailing "/" apply to ScriptAlias directives as to
 # Alias.
 #
-ScriptAlias /cgi-bin/ "/var/www/cgi-bin/"
+ScriptAlias /cgi-bin/ "/usr/local/pf/html/parking/cgi-bin/"
 
 #
 # "/var/www/cgi-bin" should be changed to whatever your ScriptAliased
 # CGI directory exists, if you have that configured.
 #
-<Directory "/var/www/cgi-bin">
+<Directory "/usr/local/pf/html/parking/cgi-bin">
     AllowOverride None
     Options None
     Order allow,deny
@@ -1001,10 +1001,3 @@ BrowserMatch "^Dreamweaver-WebDAV-SCM1" redirect-carefully
 # The first VirtualHost section is used for requests without a known
 # server name.
 #
-#<VirtualHost *:80>
-#    ServerAdmin webmaster@dummy-host.example.com
-#    DocumentRoot /www/docs/dummy-host.example.com
-#    ServerName dummy-host.example.com
-#    ErrorLog logs/dummy-host.example.com-error_log
-#    CustomLog logs/dummy-host.example.com-access_log common
-#</VirtualHost>

--- a/conf/iptables.conf.example
+++ b/conf/iptables.conf.example
@@ -78,6 +78,8 @@
 -A input-internal-vlan-if --protocol tcp --match tcp --dport 80  --jump ACCEPT
 -A input-internal-vlan-if --protocol tcp --match tcp --dport 443 --jump ACCEPT
 -A input-internal-vlan-if --protocol tcp --match tcp --dport 647 --jump ACCEPT
+# HTTP (parking portal)
+-A input-internal-vlan-if --protocol tcp --match tcp --dport 5252 --jump ACCEPT
 %%input_inter_vlan_if%%
 
 :input-internal-inline-if - [0:0]

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -519,6 +519,16 @@ httpd_portal=enabled
 # Order in which to start this service 
 httpd_portal_order=20
 #
+# services.httpd_parking
+#
+# Should httpd.parking be started?
+httpd_parking=enabled
+#
+# services.httpd_portal_order
+#
+# Order in which to start this service 
+httpd_parking_order=20
+#
 # services.httpd_webservices
 #
 # Should httpd.webservices be started?

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -1409,4 +1409,8 @@ threshold=0
 #
 # Place the device in the DHCP parking group when it is detected doing parking
 place_in_dhcp_parking_group=enabled
-
+#
+# parking.show_parking_portal
+#
+# Show the parking portal to the device instead of the usual portal
+show_parking_portal=enabled

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -1397,3 +1397,16 @@ query_url_hash=https://hashlookup.metascan-online.com/v2/hash/
 #
 # Lease length (in seconds) when a device is in parking
 lease_length=3600
+#
+# parking.lease_length
+#
+# The threshold (in seconds) after which a device will be placed in parking
+# A value of 0 deactivates the parking detection.
+# The detection works by looking at the time in seconds a device has been in the registration role and comparing it with this threshold
+threshold=0
+#
+# parking.place_in_dhcp_parking_group
+#
+# Place the device in the DHCP parking group when it is detected doing parking
+place_in_dhcp_parking_group=enabled
+

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -1390,3 +1390,10 @@ api_key=
 #
 # OPSWAT MetaScan Online Scanner URL for hash queries
 query_url_hash=https://hashlookup.metascan-online.com/v2/hash/
+
+[parking]
+#
+# parking.lease_length
+#
+# Lease length (in seconds) when a device is in parking
+lease_length=3600

--- a/conf/violations.conf.example
+++ b/conf/violations.conf.example
@@ -246,6 +246,8 @@ actions=log,reevaluate_access
 enabled=Y
 auto_enable=Y
 vlan=registration
+trigger=Internal::parking_detected
+
 
 #
 # 1400000 - 1499999 Reserved for local violations

--- a/conf/violations.conf.example
+++ b/conf/violations.conf.example
@@ -237,6 +237,16 @@ enabled=Y
 grace=0s
 delay_by=2m
 
+[1300003]
+priority=1
+desc=Parking violation
+max_enable=3
+grace=10m
+actions=log,reevaluate_access
+enabled=Y
+auto_enable=Y
+vlan=registration
+
 #
 # 1400000 - 1499999 Reserved for local violations
 #

--- a/html/parking/back-on-network.html
+++ b/html/parking/back-on-network.html
@@ -1,0 +1,3 @@
+<h1>Restrictions have been removed.</h1>
+
+<p>Please close and re-open your browser to continue</p>

--- a/html/parking/back-on-network.html
+++ b/html/parking/back-on-network.html
@@ -1,3 +1,4 @@
 <h1>Restrictions have been removed.</h1>
 
-<p>Please close and re-open your browser to continue</p>
+<a href="http://www.packetfence.org">Please click here to access the captive portal</a>
+

--- a/html/parking/cgi-bin/release.pl
+++ b/html/parking/cgi-bin/release.pl
@@ -1,4 +1,18 @@
 #!/usr/bin/perl
+
+=head1 NAME
+
+release.pl
+
+=cut
+
+=head1 DESCRIPTION
+
+Tries to release the user from the parking state.
+Notifies of the result through back-on-network.html and max-attempts.html
+
+=cut
+
 use strict;
 use warnings;
 use lib '/usr/local/pf/lib';
@@ -17,4 +31,34 @@ else {
     print redirect("/max-attempts.html");
 }
 
+=back
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2016 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
+USA.
+
+=cut
+
+1;
  

--- a/html/parking/cgi-bin/release.pl
+++ b/html/parking/cgi-bin/release.pl
@@ -1,0 +1,20 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use lib '/usr/local/pf/lib';
+
+use CGI qw(:standard);
+
+use pf::parking;
+
+my $ip = $ENV{REMOTE_ADDR};
+my $mac = pf::iplog::ip2mac($ip);
+
+if(pf::parking::unpark($mac, $ip)){
+    print redirect("/back-on-network.html");
+}
+else {
+    print redirect("/max-attempts.html");
+}
+
+ 

--- a/html/parking/index.html
+++ b/html/parking/index.html
@@ -1,0 +1,3 @@
+<h1>Parking</h1>
+
+<p>You're in parking bro...</p>

--- a/html/parking/index.html
+++ b/html/parking/index.html
@@ -1,4 +1,10 @@
+<script>
+function release(target){
+  target.parentElement.innerHTML = "One moment please"
+}
+</script>
+
 <h1>Parking</h1>
 
-<p>Please note that the period to register your device has been exceeded. In order to access the registration portal, <a href="/cgi-bin/release.pl">please click here.</a></p>
+<p>Please note that the period to register your device has been exceeded. In order to access the registration portal, <a href="/cgi-bin/release.pl" onclick="release(this)">please click here.</a></p>
 

--- a/html/parking/index.html
+++ b/html/parking/index.html
@@ -1,3 +1,4 @@
 <h1>Parking</h1>
 
-<p>You're in parking bro...</p>
+<p>Please note that the period to register your device has been exceeded. In order to access the registration portal, <a href="/cgi-bin/release.pl">please click here.</a></p>
+

--- a/html/parking/max-attempts.html
+++ b/html/parking/max-attempts.html
@@ -1,0 +1,3 @@
+<h1>Maximum attempts reached.</h1>
+
+<p>Couldn't release you back to the registration network. Please contact your local support staff</p>

--- a/lib/pf/OMAPI.pm
+++ b/lib/pf/OMAPI.pm
@@ -29,6 +29,7 @@ use IO::Socket::INET;
 use Socket qw(MSG_WAITALL);
 use Time::HiRes qw(alarm);
 use pf::log;
+use pf::config;
 
 our $VERSION = '0.01';
 
@@ -313,7 +314,7 @@ sub create_host {
     $self->connect();
     my $previous_entry = $self->lookup({"type" => "host"}, {"hardware-address" => $mac, "hardware-type" => 1});
     if($previous_entry->{op} == 3){
-        get_logger->warn("Entry for $mac already exists. Cannot create it...");
+        get_logger->info("Entry for $mac already exists. Cannot create it...");
     }
     else {
         my $result = $self->send_msg($OPEN, { "type" => "host", "create" => 1, exclusive => 1 }, { "name" => "dynhost-$mac", "hardware-address" => $mac, "hardware-type" => 1, %{$assignments}});
@@ -602,6 +603,17 @@ sub _sign {
     my $buffer = $self->buffer;
     my $digest = hmac_md5(substr($$buffer,4), $self->key);
     $$buffer .= $digest;
+}
+
+=head2 get_omapi_client
+
+Get the default OMAPI client based on the configuration
+
+=cut
+
+sub get_client {
+    my ($class) = @_;
+    return $class->new($Config{omapi});
 }
 
 =head1 AUTHOR

--- a/lib/pf/OMAPI.pm
+++ b/lib/pf/OMAPI.pm
@@ -305,6 +305,8 @@ sub lookup {
 
 =head2 create_host
 
+Create a host entry using the OMAPI
+
 =cut
 
 sub create_host {
@@ -326,6 +328,12 @@ sub create_host {
         }
     }
 }
+
+=head2 delete_host
+
+Remove a host entry using the OMAPI
+
+=cut
 
 sub delete_host {
     my ($self, $mac) = @_;

--- a/lib/pf/OMAPI.pm
+++ b/lib/pf/OMAPI.pm
@@ -312,7 +312,6 @@ Create a host entry using the OMAPI
 sub create_host {
     my ($self, $mac, $assignments) = @_;
     $assignments //= {};
-    use Data::Dumper;
     $self->connect();
     my $previous_entry = $self->lookup({"type" => "host"}, {"hardware-address" => $mac, "hardware-type" => 1});
     if($previous_entry->{op} == 3){

--- a/lib/pf/constants/parking.pm
+++ b/lib/pf/constants/parking.pm
@@ -1,0 +1,54 @@
+package pf::constants::parking;
+
+=head1 NAME
+
+pf::constants::parking - constants for parking object
+
+=cut
+
+=head1 DESCRIPTION
+
+pf::constants::parking
+
+=cut
+
+use strict;
+use warnings;
+use base qw(Exporter);
+use Readonly;
+
+our @EXPORT_OK = qw($PARKING_GROUP_NAME $PARKING_VID);
+
+Readonly our $PARKING_GROUP_NAME => "parking";
+
+Readonly our $PARKING_VID => 1300003;
+ 
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2016 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and::or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;
+

--- a/lib/pf/constants/parking.pm
+++ b/lib/pf/constants/parking.pm
@@ -17,9 +17,11 @@ use warnings;
 use base qw(Exporter);
 use Readonly;
 
-our @EXPORT_OK = qw($PARKING_GROUP_NAME $PARKING_VID);
+our @EXPORT_OK = qw($PARKING_DHCP_GROUP_NAME $PARKING_IPSET_NAME $PARKING_VID);
 
-Readonly our $PARKING_GROUP_NAME => "parking";
+Readonly our $PARKING_DHCP_GROUP_NAME => "parking";
+
+Readonly our $PARKING_IPSET_NAME => "parking";
 
 Readonly our $PARKING_VID => 1300003;
  

--- a/lib/pf/constants/trigger.pm
+++ b/lib/pf/constants/trigger.pm
@@ -55,6 +55,7 @@ Readonly::Scalar our $TRIGGER_MAP => {
     "1100010" => "Rogue DHCP detection",
     "new_dhcp_info" => "DHCP packet received",
     "hostname_change" => "Hostname changed",
+    "parking_detected" => "Parking detected",
   },
   $TRIGGER_TYPE_PROVISIONER => {
     $TRIGGER_ID_PROVISIONER => "Check status",

--- a/lib/pf/dhcp/processor.pm
+++ b/lib/pf/dhcp/processor.pm
@@ -647,11 +647,9 @@ sub update_iplog {
         return;
     }
 
-    # we have to check directly in the DB since the OMAPI already contains the
-    # current lease info
+    # we have to check directly in the DB since the OMAPI already contains the current lease info
     my $oldip  = pf::iplog::_mac2ip_sql($srcmac);
     my $oldmac = pf::iplog::_ip2mac_sql($srcip);
-    $logger->debug("Computed old IP $oldip and old MAC $oldmac");
     if ( $oldip && $oldip ne $srcip ) {
         my $view_mac = node_view($srcmac);
         my $firewallsso = pf::firewallsso->new;

--- a/lib/pf/dhcp/processor.pm
+++ b/lib/pf/dhcp/processor.pm
@@ -663,7 +663,7 @@ sub update_iplog {
     }
     elsif ($oldmac && $oldmac ne $srcmac) {
         # Remove the actions that were for the previous MAC address
-        pf::parking::unpark_actions($oldmac,$srcip);
+        pf::parking::remove_parking_actions($oldmac,$srcip);
     }
     my %data = (
         'mac' => $srcmac,

--- a/lib/pf/iplog.pm
+++ b/lib/pf/iplog.pm
@@ -674,7 +674,7 @@ sub _get_omapi_client {
     my ($self) = @_;
     return unless pf::config::is_omapi_lookup_enabled;
 
-    return pf::OMAPI->new( $Config{omapi} );
+    return pf::OMAPI->get_client();
 }
 
 =head2 _lookup_cached_omapi

--- a/lib/pf/ipset.pm
+++ b/lib/pf/ipset.pm
@@ -64,7 +64,7 @@ sub iptables_generate {
     $cmd = "sudo ipset --create portal_deny hash:ip timeout 300 2>&1";
     @lines  = pf_run($cmd);
     
-    $cmd = "LANG=C sudo ipset --create $PARKING_IPSET_NAME hash:ip 2>&1";
+    $cmd = "sudo ipset --create $PARKING_IPSET_NAME hash:ip 2>&1";
     @lines  = pf_run($cmd);
 
     foreach my $network ( keys %ConfigNetworks ) {

--- a/lib/pf/ipset.pm
+++ b/lib/pf/ipset.pm
@@ -62,6 +62,9 @@ sub iptables_generate {
 
     $cmd = "sudo ipset --create portal_deny hash:ip timeout 300 2>&1";
     @lines  = pf_run($cmd);
+    
+    $cmd = "LANG=C sudo ipset --create parking hash:ip 2>&1";
+    @lines  = pf_run($cmd);
 
     foreach my $network ( keys %ConfigNetworks ) {
         next if ( !pf::config::is_network_type_inline($network) );

--- a/lib/pf/ipset.pm
+++ b/lib/pf/ipset.pm
@@ -29,6 +29,7 @@ use pf::util;
 use pf::violation qw(violation_view_open_uniq violation_count);
 use pf::iplog;
 use pf::authentication;
+use pf::constants::parking qw($PARKING_IPSET_NAME);
 
 Readonly my $FW_TABLE_FILTER => 'filter';
 Readonly my $FW_TABLE_MANGLE => 'mangle';
@@ -63,7 +64,7 @@ sub iptables_generate {
     $cmd = "sudo ipset --create portal_deny hash:ip timeout 300 2>&1";
     @lines  = pf_run($cmd);
     
-    $cmd = "LANG=C sudo ipset --create parking hash:ip 2>&1";
+    $cmd = "LANG=C sudo ipset --create $PARKING_IPSET_NAME hash:ip 2>&1";
     @lines  = pf_run($cmd);
 
     foreach my $network ( keys %ConfigNetworks ) {

--- a/lib/pf/iptables.pm
+++ b/lib/pf/iptables.pm
@@ -146,6 +146,10 @@ sub iptables_generate {
 
     generate_domain_rules(\$tags{'filter_forward_domain'}, \$tags{'domain_postrouting'});
 
+    # HTTP parking related rule
+    $tags{'nat_prerouting_vlan'} .= "-A PREROUTING -p tcp --dport 80 -m set --match-set $pf::constants::parking::PARKING_IPSET_NAME src -j REDIRECT --to-port 5252\n";
+    $tags{'nat_prerouting_vlan'} .= "-A PREROUTING -p tcp --dport 443 -m set --match-set $pf::constants::parking::PARKING_IPSET_NAME src -j REDIRECT --to-port 5252\n";
+
     parse_template( \%tags, "$conf_dir/iptables.conf", "$generated_conf_dir/iptables.conf" );
     $self->iptables_restore("$generated_conf_dir/iptables.conf");
 }

--- a/lib/pf/parking.pm
+++ b/lib/pf/parking.pm
@@ -23,12 +23,26 @@ use pf::constants;
 use pf::config;
 use pf::util;
 
+=head2 trigger_parking
+
+Trigger the parking actions for a device if needed
+Will check if there is already a parking violation opened, if not, will open one
+Will make sure the proper parking actions are applied
+
+=cut
+
 sub trigger_parking {
     my ($mac,$ip) = @_;
     if(violation_count_open_vid($mac, $PARKING_VID) || violation_trigger( { mac => $mac, tid => 'parking_detected', type => 'INTERNAL' } )){
         park($mac,$ip);
     }
 }
+
+=head2 park
+
+Park a device by making its lease higher and by pointing it to another portal
+
+=cut
 
 sub park {
     my ($mac,$ip) = @_;
@@ -45,6 +59,12 @@ sub park {
     }
 }
 
+=head2 unpark
+
+Attempt to unpark a device. The parking violation needs to be successfully closed for the actions to be removed.
+
+=cut
+
 sub unpark {
     my ($mac,$ip) = @_;
     if(violation_close($mac, $PARKING_VID) != -1){
@@ -56,6 +76,12 @@ sub unpark {
         return $FALSE;
     }
 }
+
+=head2 remove_parking_actions
+
+Remove the parking actions that were taken against an IP + MAC
+
+=cut
 
 sub remove_parking_actions {
     my ($mac, $ip) = @_;

--- a/lib/pf/parking.pm
+++ b/lib/pf/parking.pm
@@ -26,7 +26,8 @@ sub park {
         $omapi->create_host($mac, {group => $PARKING_DHCP_GROUP_NAME});
     }
     if(isenabled($Config{parking}{show_parking_portal})){
-        my $cmd = "LANG=C sudo ipset --add $PARKING_IPSET_NAME $ip 2>&1";
+        my $cmd = "LANG=C sudo ipset add $PARKING_IPSET_NAME $ip 2>&1";
+        get_logger->debug("Adding device to parking ipset using $cmd");
         my $_EXIT_CODE_EXISTS = "1";
         my @lines = pf_run($cmd, accepted_exit_status => [$_EXIT_CODE_EXISTS]);
     }
@@ -50,7 +51,8 @@ sub unpark_actions {
     get_logger->info("Removing parking actions for $mac - $ip");
     my $omapi = pf::OMAPI->get_client();
     $omapi->delete_host($mac);
-    # remove from ipset
+
+    pf_run("LANG=C sudo ipset del $PARKING_IPSET_NAME $ip -exist 2>&1");
 }
 
 1;

--- a/lib/pf/parking.pm
+++ b/lib/pf/parking.pm
@@ -6,39 +6,51 @@ use warnings;
 use pf::log;
 use pf::OMAPI;
 use pf::violation;
-use pf::constants::parking qw($PARKING_VID $PARKING_GROUP_NAME);
+use pf::constants::parking qw($PARKING_VID $PARKING_DHCP_GROUP_NAME $PARKING_IPSET_NAME);
 use pf::constants;
 use pf::config;
 use pf::util;
 
 sub trigger_parking {
-    my ($mac) = @_;
+    my ($mac,$ip) = @_;
     if(violation_count_open_vid($mac, $PARKING_VID) || violation_trigger( { mac => $mac, tid => 'parking_detected', type => 'INTERNAL' } )){
-        park($mac);
+        park($mac,$ip);
     }
 }
 
 sub park {
-    my ($mac) = @_;
+    my ($mac,$ip) = @_;
     get_logger->debug("Setting client in parking");
     if(isenabled($Config{parking}{place_in_dhcp_parking_group})){
         my $omapi = pf::OMAPI->get_client();
-        $omapi->create_host($mac, {group => $PARKING_GROUP_NAME});
+        $omapi->create_host($mac, {group => $PARKING_DHCP_GROUP_NAME});
+    }
+    if(isenabled($Config{parking}{show_parking_portal})){
+        my $cmd = "LANG=C sudo ipset --add $PARKING_IPSET_NAME $ip 2>&1";
+        my $_EXIT_CODE_EXISTS = "1";
+        my @lines = pf_run($cmd, accepted_exit_status => [$_EXIT_CODE_EXISTS]);
     }
 }
 
 sub unpark {
-    my ($mac) = @_;
-    my $omapi = pf::OMAPI->get_client();
+    my ($mac,$ip) = @_;
     if(violation_close($mac, $PARKING_VID) != -1){
-        get_logger->info("Unparking device $mac");
-        $omapi->delete_host($mac);
+        unpark_actions($mac,$ip);
         return $TRUE;
     }
     else {
         get_logger->info("Device $mac cannot be unparked since the violation cannot be closed");
         return $FALSE;
     }
+}
+
+#rename to remove_parking_actions
+sub unpark_actions {
+    my ($mac, $ip) = @_;
+    get_logger->info("Removing parking actions for $mac - $ip");
+    my $omapi = pf::OMAPI->get_client();
+    $omapi->delete_host($mac);
+    # remove from ipset
 }
 
 1;

--- a/lib/pf/parking.pm
+++ b/lib/pf/parking.pm
@@ -1,0 +1,44 @@
+package pf::parking;
+
+use strict;
+use warnings;
+
+use pf::log;
+use pf::OMAPI;
+use pf::violation;
+use pf::constants::parking qw($PARKING_VID $PARKING_GROUP_NAME);
+use pf::constants;
+use pf::config;
+use pf::util;
+
+sub trigger_parking {
+    my ($mac) = @_;
+    if(violation_count_open_vid($mac, $PARKING_VID) || violation_trigger( { mac => $mac, tid => 'parking_detected', type => 'INTERNAL' } )){
+        park($mac);
+    }
+}
+
+sub park {
+    my ($mac) = @_;
+    get_logger->debug("Setting client in parking");
+    if(isenabled($Config{parking}{place_in_dhcp_parking_group})){
+        my $omapi = pf::OMAPI->get_client();
+        $omapi->create_host($mac, {group => $PARKING_GROUP_NAME});
+    }
+}
+
+sub unpark {
+    my ($mac) = @_;
+    my $omapi = pf::OMAPI->get_client();
+    if(violation_close($mac, $PARKING_VID) != -1){
+        get_logger->info("Unparking device $mac");
+        $omapi->delete_host($mac);
+        return $TRUE;
+    }
+    else {
+        get_logger->info("Device $mac cannot be unparked since the violation cannot be closed");
+        return $FALSE;
+    }
+}
+
+1;

--- a/lib/pf/parking.pm
+++ b/lib/pf/parking.pm
@@ -36,7 +36,7 @@ sub park {
 sub unpark {
     my ($mac,$ip) = @_;
     if(violation_close($mac, $PARKING_VID) != -1){
-        unpark_actions($mac,$ip);
+        remove_parking_actions($mac,$ip);
         return $TRUE;
     }
     else {
@@ -45,8 +45,7 @@ sub unpark {
     }
 }
 
-#rename to remove_parking_actions
-sub unpark_actions {
+sub remove_parking_actions {
     my ($mac, $ip) = @_;
     get_logger->info("Removing parking actions for $mac - $ip");
     my $omapi = pf::OMAPI->get_client();

--- a/lib/pf/parking.pm
+++ b/lib/pf/parking.pm
@@ -1,5 +1,17 @@
 package pf::parking;
 
+=head1 NAME
+
+pf::parking - module to manage parked device.
+
+=cut
+
+=head1 DESCRIPTION
+
+Contains the necessary methods to manage parked devices
+
+=cut
+
 use strict;
 use warnings;
 
@@ -53,5 +65,34 @@ sub remove_parking_actions {
 
     pf_run("LANG=C sudo ipset del $PARKING_IPSET_NAME $ip -exist 2>&1");
 }
+
+=back
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2016 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
+USA.
+
+=cut
 
 1;

--- a/lib/pf/parking.pm
+++ b/lib/pf/parking.pm
@@ -52,7 +52,7 @@ sub park {
         $omapi->create_host($mac, {group => $PARKING_DHCP_GROUP_NAME});
     }
     if(isenabled($Config{parking}{show_parking_portal})){
-        my $cmd = "LANG=C sudo ipset add $PARKING_IPSET_NAME $ip 2>&1";
+        my $cmd = "sudo ipset add $PARKING_IPSET_NAME $ip 2>&1";
         get_logger->debug("Adding device to parking ipset using $cmd");
         my $_EXIT_CODE_EXISTS = "1";
         my @lines = pf_run($cmd, accepted_exit_status => [$_EXIT_CODE_EXISTS]);
@@ -89,7 +89,7 @@ sub remove_parking_actions {
     my $omapi = pf::OMAPI->get_client();
     $omapi->delete_host($mac);
 
-    pf_run("LANG=C sudo ipset del $PARKING_IPSET_NAME $ip -exist 2>&1");
+    pf_run("sudo ipset del $PARKING_IPSET_NAME $ip -exist 2>&1");
 }
 
 =back

--- a/lib/pf/services/manager/dhcpd.pm
+++ b/lib/pf/services/manager/dhcpd.pm
@@ -175,6 +175,8 @@ $network {
 EOT
     }
 
+    $tags{parking_lease_length} = $Config{parking}{lease_length};
+
     parse_template( \%tags, "$conf_dir/dhcpd.conf", "$generated_conf_dir/dhcpd.conf" );
     return 1;
 }

--- a/lib/pf/services/manager/dhcpd.pm
+++ b/lib/pf/services/manager/dhcpd.pm
@@ -175,12 +175,33 @@ $network {
 EOT
     }
 
-    $tags{parking_lease_length} = $Config{parking}{lease_length};
+    $tags{'parking'} = parking_section();
 
     parse_template( \%tags, "$conf_dir/dhcpd.conf", "$generated_conf_dir/dhcpd.conf" );
     return 1;
 }
 
+
+=head2 parking_section
+
+Generate the parking section if it is defined
+
+=cut
+
+sub parking_section {
+    my $group_name = $pf::constants::parking::PARKING_DHCP_GROUP_NAME;
+    my $lease_length = $Config{'parking'}{'lease_length'};
+
+    my $section = <<EOT;
+# parking feature
+group $group_name {
+    default-lease-time $lease_length;
+    max-lease-time $lease_length;
+}
+EOT
+
+    return $section;
+}
 
 =head2 omapi_section
 

--- a/lib/pf/services/manager/httpd_parking.pm
+++ b/lib/pf/services/manager/httpd_parking.pm
@@ -1,0 +1,53 @@
+package pf::services::manager::httpd_parking;
+=head1 NAME
+
+pf::services::manager::httpd_parking
+
+=cut
+
+=head1 DESCRIPTION
+
+pf::services::manager::httpd_parking
+
+=cut
+
+use strict;
+use warnings;
+use Moo;
+
+extends 'pf::services::manager::httpd';
+
+has '+name' => (default => sub { 'httpd.parking' } );
+
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2016 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;
+
+


### PR DESCRIPTION
# Description

Fear not, this is not a place where you bring your mobile home and where low hygiene standards are mixed with alcohol and drugs abuse.
This here, allows to make devices that 'camp' the registration VLAN use a different portal and have a longer lease length in order to reduce the load on the server.
# Impacts

Registration network
# Code / PR Dependencies

(OPTIONAL. REMOVE IF NOT NEEDED)
List the PRs or other factors on which this PR depends
# NEW Package(s) required

NONE ! YAY !
# Delete branch after merge

YES
# NEWS file entries
## New Features
- Added ability to 'park' a device that stays in the registration network for too long without registering
