### PR TITLE
Update locationlog with the last connection_type and sub_type

### DIFF
--- a/lib/pf/locationlog.pm
+++ b/lib/pf/locationlog.pm
@@ -56,6 +56,7 @@ BEGIN {
         locationlog_set_session
         locationlog_get_session
         locationlog_online_nodes_count
+        locationlog_last_entry_mac
     );
 }
 
@@ -258,6 +259,12 @@ sub locationlog_db_prepare {
 
     $locationlog_statements->{'locationlog_online_nodes_count_sql'} = get_db_handle()->prepare(
         qq [ SELECT count(*) nb from locationlog WHERE end_time = 0]);
+
+    $locationlog_statements->{'locationlog_last_entry_mac_sql'} = get_db_handle()->prepare(qq [
+        SELECT mac, switch, switch_ip, switch_mac, port, vlan, role, connection_type, connection_sub_type, dot1x_username, ssid, start_time, end_time, stripped_user_name, realm
+        FROM locationlog
+        WHERE mac = ?
+        ORDER BY start_time DESC LIMIT 1 ]);
 
     $locationlog_db_prepared = 1;
 }
@@ -653,6 +660,23 @@ sub locationlog_online_nodes_count {
         return undef;
     }
     return $row->[0];
+}
+
+=item locationlog_last_entry_mac
+
+Return the last locationlog entry for a mac even if it's open or close.
+
+=cut
+
+sub locationlog_last_entry_mac {
+    my ($mac) = @_;
+    $mac = clean_mac($mac);
+    my $query =  db_query_execute(LOCATIONLOG, $locationlog_statements, 'locationlog_last_entry_mac_sql', $mac) || return (0);
+    my $ref = $query->fetchrow_hashref();
+
+    # just get one row and finish
+    $query->finish();
+    return ($ref);
 }
 
 =back

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -381,7 +381,7 @@ sub update_locationlog_accounting {
             return [ $RADIUS::RLM_MODULE_OK, ('Reply-Message' => "Update locationlog from accounting ok") ];
         }
     }
-    return [ $RADIUS::RLM_MODULE_OK, ('Reply-Message' => "Not updated locationlog from accounting ok") ];
+    return [ $RADIUS::RLM_MODULE_OK, ('Reply-Message' => "Did not update locationlog from the accounting") ];
 }
 
 =item * _parseRequest

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -365,44 +365,46 @@ sub update_locationlog_accounting {
 
     if ($switch->supportsRoamingAccounting()) {
         my ($nas_port_type, $eap_type, $mac, $port, $user_name, $nas_port_id, $session_id) = $switch->parseRequest($radius_request);
-        my $connection = pf::Connection->new;
-        $connection->identifyType($nas_port_type, $eap_type, $mac, $user_name, $switch);
-        my $connection_type = $connection->attributesToBackwardCompatible;
-        my $connection_sub_type = $connection->subType;
-        my $ssid;
-        if (($connection_type & $WIRELESS) == $WIRELESS) {
-            $ssid = $switch->extractSsid($radius_request);
-            $logger->debug("SSID resolved to: $ssid") if (defined($ssid));
+        my $locationlog_mac = locationlog_last_entry_mac($mac);
+        if (defined($locationlog_mac) && ref($locationlog_mac) eq 'HASH') {
+            my $connection_type = str_to_connection_type($locationlog_mac->{connection_type});
+            my $connection_sub_type = $locationlog_mac->{connection_sub_type};
+            my $ssid;
+            if (($connection_type & $WIRELESS) == $WIRELESS) {
+                $ssid = $switch->extractSsid($radius_request);
+                $logger->debug("SSID resolved to: $ssid") if (defined($ssid));
+            }
+            my $vlan;
+            $vlan = $radius_request->{'Tunnel-Private-Group-ID'} if ( (defined( $radius_request->{'Tunnel-Type'}) && $radius_request->{'Tunnel-Type'} eq '13') && (defined($radius_request->{'Tunnel-Medium-Type'}) && $radius_request->{'Tunnel-Medium-Type'} eq '6') );
+            $port = $switch->getIfIndexByNasPortId($nas_port_id) || $self->_translateNasPortToIfIndex($connection_type, $switch, $port);
+            my $node_info = node_attributes($mac);
+            my $args = {
+                ssid => $ssid,
+                node_info => $node_info,
+                switch => $switch,
+                switch_mac => $switch_mac,
+                switch_ip => $switch_ip,
+                source_ip => $source_ip,
+                stripped_user_name => $stripped_user_name,
+                realm => $realm,
+                nas_port_type => $nas_port_type,
+                eap_type => $eap_type // '',
+                mac => $mac,
+                ifIndex => $port,
+                user_name => $user_name,
+                nas_port_id => $nas_port_type // '',
+                session_id => $session_id,
+                connection_type => $connection_type,
+                connection_sub_type => $connection_sub_type,
+                radius_request => $radius_request,
+            };
+            my $role_obj = new pf::role::custom();
+            my $role = $role_obj->fetchRoleForNode($args);
+            $switch->synchronize_locationlog($port, $vlan, $mac, undef, $connection_type, $connection_sub_type, $user_name, $ssid, $stripped_user_name, $realm, $role->{role});
+            return [ $RADIUS::RLM_MODULE_OK, ('Reply-Message' => "Update locationlog from accounting ok") ];
         }
-        my $vlan;
-        $vlan = $radius_request->{'Tunnel-Private-Group-ID'} if ( (defined( $radius_request->{'Tunnel-Type'}) && $radius_request->{'Tunnel-Type'} eq '13') && (defined($radius_request->{'Tunnel-Medium-Type'}) && $radius_request->{'Tunnel-Medium-Type'} eq '6') );
-        $port = $switch->getIfIndexByNasPortId($nas_port_id) || $self->_translateNasPortToIfIndex($connection_type, $switch, $port);
-        my $node_info = node_attributes($mac);
-        my $args = {
-            ssid => $ssid,
-            node_info => $node_info,
-            switch => $switch,
-            switch_mac => $switch_mac,
-            switch_ip => $switch_ip,
-            source_ip => $source_ip,
-            stripped_user_name => $stripped_user_name,
-            realm => $realm,
-            nas_port_type => $nas_port_type,
-            eap_type => $eap_type // '',
-            mac => $mac,
-            ifIndex => $port,
-            user_name => $user_name,
-            nas_port_id => $nas_port_type // '',
-            session_id => $session_id,
-            connection_type => $connection_type,
-            connection_sub_type => $connection_sub_type,
-            radius_request => $radius_request,
-        };
-        my $role_obj = new pf::role::custom();
-        my $role = $role_obj->fetchRoleForNode($args);
-        $switch->synchronize_locationlog($port, $vlan, $mac, undef, $connection_type, $connection_sub_type, $user_name, $ssid, $stripped_user_name, $realm, $role->{role});
     }
-    return [ $RADIUS::RLM_MODULE_OK, ('Reply-Message' => "Update locationlog from accounting ok") ];
+    return [ $RADIUS::RLM_MODULE_OK, ('Reply-Message' => "Not updated locationlog from accounting ok") ];
 }
 
 =item * _parseRequest

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -377,30 +377,7 @@ sub update_locationlog_accounting {
             my $vlan;
             $vlan = $radius_request->{'Tunnel-Private-Group-ID'} if ( (defined( $radius_request->{'Tunnel-Type'}) && $radius_request->{'Tunnel-Type'} eq '13') && (defined($radius_request->{'Tunnel-Medium-Type'}) && $radius_request->{'Tunnel-Medium-Type'} eq '6') );
             $port = $switch->getIfIndexByNasPortId($nas_port_id) || $self->_translateNasPortToIfIndex($connection_type, $switch, $port);
-            my $node_info = node_attributes($mac);
-            my $args = {
-                ssid => $ssid,
-                node_info => $node_info,
-                switch => $switch,
-                switch_mac => $switch_mac,
-                switch_ip => $switch_ip,
-                source_ip => $source_ip,
-                stripped_user_name => $stripped_user_name,
-                realm => $realm,
-                nas_port_type => $nas_port_type,
-                eap_type => $eap_type // '',
-                mac => $mac,
-                ifIndex => $port,
-                user_name => $user_name,
-                nas_port_id => $nas_port_type // '',
-                session_id => $session_id,
-                connection_type => $connection_type,
-                connection_sub_type => $connection_sub_type,
-                radius_request => $radius_request,
-            };
-            my $role_obj = new pf::role::custom();
-            my $role = $role_obj->fetchRoleForNode($args);
-            $switch->synchronize_locationlog($port, $vlan, $mac, undef, $connection_type, $connection_sub_type, $user_name, $ssid, $stripped_user_name, $realm, $role->{role});
+            $switch->synchronize_locationlog($port, $vlan, $mac, undef, $connection_type, $connection_sub_type, $user_name, $ssid, $stripped_user_name, $realm, $locationlog_mac->{role});
             return [ $RADIUS::RLM_MODULE_OK, ('Reply-Message' => "Update locationlog from accounting ok") ];
         }
     }


### PR DESCRIPTION
# Description

Update locationlog entry based on the latest one.
Since online/offline close the locationlog on accounting stop i need to fetch the latest connection type info from the locationlog to insert a new one.
# Impacts

Switch that support supportsRoamingAccounting
# Issue

Fix the update location log with the incorrect connection type
# Delete branch after merge

YES
# NEWS file entries
## Bug Fixes
- Fix the update of the locationlog from accounting start with the wrong connection type
