### PR TITLE
Feature/maintenance jobs

### DIFF
--- a/addons/iplog-cleanup.pl
+++ b/addons/iplog-cleanup.pl
@@ -29,7 +29,7 @@ use Getopt::Long;
 use Pod::Usage;
 
 my %options = (
-    expire   => $Config{'expire'}{'iplog'},
+    expire   => $Config{'maintenance'}{'iplog_cleanup_window'},
     batch    => $Config{maintenance}{iplog_cleanup_batch},
     timeout  => $Config{maintenance}{iplog_cleanup_timeout},
     help     => undef,

--- a/addons/locationlog-cleanup.pl
+++ b/addons/locationlog-cleanup.pl
@@ -29,7 +29,7 @@ use Getopt::Long;
 use Pod::Usage;
 
 my %options = (
-    expire   => $Config{'expire'}{'locationlog'},
+    expire   => $Config{'maintenance'}{'locationlog_cleanup_window'},
     batch    => $Config{maintenance}{locationlog_cleanup_batch},
     timeout  => $Config{maintenance}{locationlog_cleanup_timeout},
     help     => undef,

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1697,19 +1697,6 @@ description=<<EOT
 Interval at which PacketFence runs accounting maintenance
 EOT
 
-[maintenance.fingerbank_update_db]
-type=toggle
-options=enabled|disabled
-description=<<EOT
-Update Fingerbank upstream database (requires a valid API key to be configured)
-EOT
-
-[maintenance.fingerbank_update_db_interval]
-type=time
-description=<<EOT
-Interval at which PacketFence will update Fingerbank upstream database
-EOT
-
 [maintenance.provisioning_compliance_poll_interval]
 type=time
 description=<<EOT

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -921,57 +921,12 @@ in your network environment and inline is a DHCP-based mode where
 PacketFence acts as a filtering gateway.
 EOT
 
-[expire.iplog]
-type=time
-description=<<EOT
-Time which you would like to keep logs on IP/MAC information. 
-A value of 0d disables expiration.
-example:
-iplog=180d
-EOT
-
-[expire.locationlog]
-type=time
-description=<<EOT
-Time which you would like to keep logs on location information. 
-Please note that this table should not become too big since it 
-could degrade pfsetvlan performance. 
-A value of 0d disables expiration. 
-example: 
-locationlog=180d
-EOT
-
-[expire.radius_audit_log]
-type=time
-description=<<EOT
-Time which you would like to keep radius audit log entries
-A value of 0 disables expiration.
-EOT
-
-[expire.node]
-type=time
-description=<<EOT
-Time before a node is removed due to inactivity. 
-A value of 0d disables expiration. 
-example: 
-node=90d
-EOT
-
 [expire.person]
 type=toggle
 options=enabled|disabled
 description=<<EOT
 Users that do not own any device will be deleted.
 Locally created users will only be deleted when their account expires.
-EOT
-
-[expire.traplog]
-type=time
-description=<<EOT
-Time which you would like to keep logs on trap information 
-A value of 0d disables expiration. 
-example: 
-traplog=180d
 EOT
 
 [scan.engine]
@@ -1574,6 +1529,12 @@ description=<<EOT
 The AAA webservice port
 EOT
 
+[maintenance.iplog_cleanup_window]
+type=time
+description=<<EOT
+How long to keep a iplog_archive entry before deleting it
+EOT
+
 [maintenance.iplog_cleanup_interval]
 type=time
 description=<<EOT
@@ -1592,6 +1553,12 @@ description=<<EOT
 How long is the iplog cleanup task is allowed to run
 EOT
 
+[maintenance.node_cleanup_window]
+type=time
+description=<<EOT
+How long to keep a node entry before deleting it
+EOT
+
 [maintenance.node_cleanup_interval]
 type=time
 description=<<EOT
@@ -1602,6 +1569,12 @@ EOT
 type=time
 description=<<EOT
 Interval at which PacketFence runs person cleanup
+EOT
+
+[maintenance.locationlog_cleanup_window]
+type=time
+description=<<EOT
+How long to keep a locationlog entry before deleting it
 EOT
 
 [maintenance.locationlog_cleanup_interval]
@@ -1622,6 +1595,12 @@ description=<<EOT
 How long is the locationlog clean task is allowed to run
 EOT
 
+[maintenance.radius_audit_log_cleanup_window]
+type=time
+description=<<EOT
+How long to keep a radius_audit_log entry before deleting it
+EOT
+
 [maintenance.radius_audit_log_cleanup_interval]
 type=time
 description=<<EOT
@@ -1638,6 +1617,12 @@ EOT
 type=time
 description=<<EOT
 How long is the radius_audit_log clean task is allowed to run
+EOT
+
+[maintenance.traplog_cleanup_window]
+type=time
+description=<<EOT
+How long to keep a traplog entry before deleting it
 EOT
 
 [maintenance.traplog_cleanup_interval]

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1697,6 +1697,19 @@ description=<<EOT
 Interval at which PacketFence runs accounting maintenance
 EOT
 
+[maintenance.fingerbank_update_db]
+type=toggle
+options=enabled|disabled
+description=<<EOT
+Update Fingerbank upstream database (requires a valid API key to be configured)
+EOT
+
+[maintenance.fingerbank_update_db_interval]
+type=time
+description=<<EOT
+Interval at which PacketFence will update Fingerbank upstream database
+EOT
+
 [maintenance.provisioning_compliance_poll_interval]
 type=time
 description=<<EOT

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -921,14 +921,6 @@ in your network environment and inline is a DHCP-based mode where
 PacketFence acts as a filtering gateway.
 EOT
 
-[expire.person]
-type=toggle
-options=enabled|disabled
-description=<<EOT
-Users that do not own any device will be deleted.
-Locally created users will only be deleted when their account expires.
-EOT
-
 [scan.engine]
 type=toggle
 options=none|openvas|nessus
@@ -1577,12 +1569,6 @@ description=<<EOT
 How long a iplog_archive cleanup job can take before being killed
 EOT
 
-[maintenance.person_cleanup_interval]
-type=time
-description=<<EOT
-Interval at which PacketFence runs person cleanup
-EOT
-
 [maintenance.locationlog_cleanup_window]
 type=time
 description=<<EOT
@@ -1659,6 +1645,20 @@ EOT
 type=time
 description=<<EOT
 Interval at which PacketFence runs nodes maintenance
+EOT
+
+[maintenance.person_cleanup]
+type=toggle
+options=enabled|disabled
+description=<<EOT
+Users that do not own any device will be deleted.
+Locally created users will only be deleted when their account expires.
+EOT
+
+[maintenance.person_cleanup_interval]
+type=time
+description=<<EOT
+Interval at which PacketFence runs person cleanup
 EOT
 
 [maintenance.online_node_count_interval]

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1529,6 +1529,30 @@ description=<<EOT
 The AAA webservice port
 EOT
 
+[maintenance.iplog_rotation_window]
+type=time
+description=<<EOT
+How long to keep iplog_history entry before rotating it to iplog_archive
+EOT
+
+[maintenance.iplog_rotation_interval]
+type=time
+description=<<EOT
+At which interval to run the iplog_history rotation job
+EOT
+
+[maintenance.iplog_rotation_batch]
+type=numeric
+description=<<EOT
+How many iplog_history entries to rotate in one job
+EOT
+
+[maintenance.iplog_rotation_timeout]
+type=time
+description=<<EOT
+How long a iplog_history rotation job can take before being killed
+EOT
+
 [maintenance.iplog_cleanup_window]
 type=time
 description=<<EOT
@@ -1538,31 +1562,19 @@ EOT
 [maintenance.iplog_cleanup_interval]
 type=time
 description=<<EOT
-Interval at which PacketFence runs iplog cleanup
+At which interval to run the iplog_archive cleanup job
 EOT
 
 [maintenance.iplog_cleanup_batch]
 type=numeric
 description=<<EOT
-How many iplog entries does pfmon batch delete
+How many iplog_archive entries to clean up in one job
 EOT
 
 [maintenance.iplog_cleanup_timeout]
 type=time
 description=<<EOT
-How long is the iplog cleanup task is allowed to run
-EOT
-
-[maintenance.node_cleanup_window]
-type=time
-description=<<EOT
-How long to keep a node entry before deleting it
-EOT
-
-[maintenance.node_cleanup_interval]
-type=time
-description=<<EOT
-Interval at which PacketFence runs node cleanup
+How long a iplog_archive cleanup job can take before being killed
 EOT
 
 [maintenance.person_cleanup_interval]
@@ -1580,43 +1592,19 @@ EOT
 [maintenance.locationlog_cleanup_interval]
 type=time
 description=<<EOT
-Interval at which PacketFence runs locationlog cleanup
+At which interval to run the locationlog cleanup job
 EOT
 
 [maintenance.locationlog_cleanup_batch]
 type=numeric
 description=<<EOT
-How many locationlog entries does pfmon batch delete
+How many locationlog entries to clean up in one job
 EOT
 
 [maintenance.locationlog_cleanup_timeout]
 type=time
 description=<<EOT
-How long is the locationlog clean task is allowed to run
-EOT
-
-[maintenance.radius_audit_log_cleanup_window]
-type=time
-description=<<EOT
-How long to keep a radius_audit_log entry before deleting it
-EOT
-
-[maintenance.radius_audit_log_cleanup_interval]
-type=time
-description=<<EOT
-Interval at which PacketFence runs radius_audit_log cleanup
-EOT
-
-[maintenance.radius_audit_log_cleanup_batch]
-type=numeric
-description=<<EOT
-How many radius_audit_log entries does pfmon batch delete
-EOT
-
-[maintenance.radius_audit_log_cleanup_timeout]
-type=time
-description=<<EOT
-How long is the radius_audit_log clean task is allowed to run
+How long a locationlog cleanup job can take before being killed
 EOT
 
 [maintenance.traplog_cleanup_window]
@@ -1628,19 +1616,61 @@ EOT
 [maintenance.traplog_cleanup_interval]
 type=time
 description=<<EOT
-Interval at which PacketFence runs traplog cleanup
+At which interval to run the traplog cleanup job
 EOT
 
-[maintenance.violation_maintenance_interval]
+[maintenance.radius_audit_log_cleanup_window]
 type=time
 description=<<EOT
-Interval at which PacketFence runs violation maintenance
+How long to keep a radius_audit_log entry before deleting it
+EOT
+
+[maintenance.radius_audit_log_cleanup_interval]
+type=time
+description=<<EOT
+At which interval to run the radius_audit_log cleanup job
+EOT
+
+[maintenance.radius_audit_log_cleanup_batch]
+type=numeric
+description=<<EOT
+How many radius_audit_log entries to clean up in one job
+EOT
+
+[maintenance.radius_audit_log_cleanup_timeout]
+type=time
+description=<<EOT
+How long a radius_audit_log cleanup job can take before being killed
+EOT
+
+[maintenance.node_cleanup_window]
+type=time
+description=<<EOT
+How long to keep a node entry before deleting it
+EOT
+
+[maintenance.node_cleanup_interval]
+type=time
+description=<<EOT
+Interval at which PacketFence runs node cleanup
 EOT
 
 [maintenance.nodes_maintenance_interval]
 type=time
 description=<<EOT
 Interval at which PacketFence runs nodes maintenance
+EOT
+
+[maintenance.online_node_count_interval]
+type=time
+description=<<EOT
+Interval at which PacketFence updates the online node count
+EOT
+
+[maintenance.violation_maintenance_interval]
+type=time
+description=<<EOT
+Interval at which PacketFence runs violation maintenance
 EOT
 
 [maintenance.violation_maintenance_batch]

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -1335,16 +1335,6 @@ online_node_count_interval=15m
 #
 # Interval at which PacketFence updates the local Fingerbank data from the cloud API
 fingerbank_data_update_interval=6h
-#
-# maintenance.fingerbank_update_db
-#
-# Update Fingerbank upstream database (requires a valid API key to be configured)
-fingerbank_update_db=enabled
-#
-# maintenance.fingerbank_update_db_interval
-#
-# Interval at which PacketFence will update Fingerbank upstream database
-fingerbank_update_db_interval=1D
 
 [active_active]
 #

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -1286,16 +1286,6 @@ person_cleanup=disabled
 # person cleanup interval
 person_cleanup_interval=60s
 #
-# maintenance.traplog_cleanup_window
-#
-# How long to keep a traplog entry before deleting it
-traplog_cleanup_window=0D
-#
-# maintenance.traplog_cleanup_interval
-#
-# traplog cleanup interval
-traplog_cleanup_interval=60s
-#
 # maintenance.nodes_maintenance_interval
 #
 # nodes maintenance interval

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -360,14 +360,6 @@ port=3306
 # Server the mysql server is running on.
 host=localhost
 
-[expire]
-#
-# expire.person
-#
-# Users that do not own any device will be deleted.
-# Locally created users will only be deleted when their account expires.
-person=disabled
-
 [services]
 #
 # services.dhcpd
@@ -1282,6 +1274,12 @@ node_cleanup_window=0D
 #
 # node cleanup interval
 node_cleanup_interval=60s
+#
+# maintenance.person_cleanup
+#
+# Users that do not own any device will be deleted.
+# Locally created users will only be deleted when their account expires.
+person_cleanup=disabled
 #
 # maintenance.person_cleanup_interval
 #

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -1183,6 +1183,26 @@ aaa_port=7070
 
 [maintenance]
 #
+# maintenance.iplog_rotation_window
+#
+# How long to keep iplog_history entry before rotating it to iplog_archive
+iplog_rotation_window=1W
+#
+# maintenance.iplog_rotation_interval
+#
+# At which interval to run the iplog_history rotation job
+iplog_rotation_interval=60s
+#
+# maintenance.iplog_rotation_batch
+#
+# How many iplog_history entries to rotate in one job
+iplog_rotation_batch=100
+#
+# maintenance.iplog_rotation_timeout
+#
+# How long a iplog_history rotation job can take before being killed
+iplog_rotation_timeout=10s
+#
 # maintenance.iplog_cleanup_window
 #
 # How long to keep a iplog_archive entry before deleting it
@@ -1190,17 +1210,17 @@ iplog_cleanup_window=0D
 #
 # maintenance.iplog_cleanup_interval
 #
-# iplog cleanup interval
+# At which interval to run the iplog_archive cleanup job
 iplog_cleanup_interval=60s
 #
 # maintenance.iplog_cleanup_batch
 #
-# iplog cleanup batch
+# How many iplog_archive entries to clean up in one job
 iplog_cleanup_batch=100
 #
 # maintenance.iplog_cleanup_timeout
 #
-# iplog cleanup timeout
+# How long a iplog_archive cleanup job can take before being killed
 iplog_cleanup_timeout=10s
 #
 # maintenance.locationlog_cleanup_window
@@ -1208,20 +1228,30 @@ iplog_cleanup_timeout=10s
 # How long to keep a locationlog entry before deleting it
 locationlog_cleanup_window=0D
 #
-# maintenance.node_cleanup_interval
+# maintenance.locationlog_cleanup_interval
 #
-# locationlog cleanup interval
+# At which interval to run the locationlog cleanup job
 locationlog_cleanup_interval=60s
 #
 # maintenance.locationlog_cleanup_batch
 #
-# locationlog cleanup batch
+# How many locationlog entries to clean up in one job
 locationlog_cleanup_batch=100
 #
 # maintenance.locationlog_cleanup_timeout
 #
-# locationlog cleanup timeout
+# How long a locationlog cleanup job can take before being killed
 locationlog_cleanup_timeout=10s
+#
+# maintenance.traplog_cleanup_window
+#
+# How long to keep a traplog entry before deleting it
+traplog_cleanup_window=0D
+#
+# maintenance.traplog_cleanup_interval
+#
+# At which interval to run the traplog cleanup job
+traplog_cleanup_interval=60s
 #
 # maintenance.radius_audit_log_cleanup_window
 #
@@ -1230,17 +1260,17 @@ radius_audit_log_cleanup_window=30D
 #
 # maintenance.radius_audit_log_cleanup_interval
 #
-# radius_audit_log cleanup interval
+# At which interval to run the radius_audit_log cleanup job
 radius_audit_log_cleanup_interval=60s
 #
 # maintenance.radius_audit_log_cleanup_batch
 #
-# radius_audit_log cleanup batch
+# How many radius_audit_log entries to clean up in one job
 radius_audit_log_cleanup_batch=100
 #
 # maintenance.radius_audit_log_cleanup_timeout
 #
-# radius_audit_log cleanup timeout
+# How long a radius_audit_log cleanup job can take before being killed
 radius_audit_log_cleanup_timeout=10s
 #
 # maintenance.node_cleanup_window
@@ -1272,6 +1302,11 @@ traplog_cleanup_interval=60s
 #
 # nodes maintenance interval
 nodes_maintenance_interval=60s
+#
+# maintenance.online_node_count_interval
+#
+# Interval at which PacketFence updates the online node count
+online_node_count_interval=15m
 #
 # maintenance.violation_maintenance_interval
 #

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -362,53 +362,11 @@ host=localhost
 
 [expire]
 #
-# expire.node
-#
-# Time before a node is removed due to inactivity.
-# A value of 0D disables expiration.
-# example:
-# node=90D
-node=0D
-#
 # expire.person
 #
 # Users that do not own any device will be deleted.
 # Locally created users will only be deleted when their account expires.
 person=disabled
-#
-# expire.iplog
-#
-# Time which you would like to keep logs on IP/MAC information.
-# A value of 0D disables expiration.
-# example:
-# iplog=180D
-iplog=0D
-#
-# expire.traplog
-#
-# Time which you would like to keep logs on trap information.
-# A value of 0D disables expiration.
-# example:
-# traplog=180D
-traplog=0D
-#
-# expire.locationlog
-#
-# Time which you would like to keep logs on location information
-# Please note that this table should not become too big since it 
-# could degrade pfsetvlan performance.
-# A value of 0D disables expiration.
-# example:
-# locationlog=180D
-locationlog=0D
-#
-# expire.radius_audit_log
-#
-# Time which you would like to keep radius audit log entries
-# A value of 0D disables expiration.
-# example:
-# radius_audit_log=30D
-radius_audit_log=30D
 
 [services]
 #
@@ -1225,6 +1183,11 @@ aaa_port=7070
 
 [maintenance]
 #
+# maintenance.iplog_cleanup_window
+#
+# How long to keep a iplog_archive entry before deleting it
+iplog_cleanup_window=0D
+#
 # maintenance.iplog_cleanup_interval
 #
 # iplog cleanup interval
@@ -1239,6 +1202,11 @@ iplog_cleanup_batch=100
 #
 # iplog cleanup timeout
 iplog_cleanup_timeout=10s
+#
+# maintenance.locationlog_cleanup_window
+#
+# How long to keep a locationlog entry before deleting it
+locationlog_cleanup_window=0D
 #
 # maintenance.node_cleanup_interval
 #
@@ -1255,6 +1223,11 @@ locationlog_cleanup_batch=100
 # locationlog cleanup timeout
 locationlog_cleanup_timeout=10s
 #
+# maintenance.radius_audit_log_cleanup_window
+#
+# How long to keep a radius_audit_log entry before deleting it
+radius_audit_log_cleanup_window=30D
+#
 # maintenance.radius_audit_log_cleanup_interval
 #
 # radius_audit_log cleanup interval
@@ -1270,6 +1243,11 @@ radius_audit_log_cleanup_batch=100
 # radius_audit_log cleanup timeout
 radius_audit_log_cleanup_timeout=10s
 #
+# maintenance.node_cleanup_window
+#
+# How long to keep a node entry before deleting it
+node_cleanup_window=0D
+#
 # maintenance.node_cleanup_interval
 #
 # node cleanup interval
@@ -1279,6 +1257,11 @@ node_cleanup_interval=60s
 #
 # person cleanup interval
 person_cleanup_interval=60s
+#
+# maintenance.traplog_cleanup_window
+#
+# How long to keep a traplog entry before deleting it
+traplog_cleanup_window=0D
 #
 # maintenance.traplog_cleanup_interval
 #

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -1335,6 +1335,16 @@ online_node_count_interval=15m
 #
 # Interval at which PacketFence updates the local Fingerbank data from the cloud API
 fingerbank_data_update_interval=6h
+#
+# maintenance.fingerbank_update_db
+#
+# Update Fingerbank upstream database (requires a valid API key to be configured)
+fingerbank_update_db=enabled
+#
+# maintenance.fingerbank_update_db_interval
+#
+# Interval at which PacketFence will update Fingerbank upstream database
+fingerbank_update_db_interval=1D
 
 [active_active]
 #

--- a/html/pfappserver/lib/pfappserver/I18N/en.po
+++ b/html/pfappserver/lib/pfappserver/I18N/en.po
@@ -7594,6 +7594,10 @@ msgstr "Violation Maintenance Interval"
 msgid "maintenance.violation_maintenance_timeout"
 msgstr "Violation Maintenance Timeout"
 
+# conf/documentation.conf
+msgid "maintenance.fingerbank_data_update_interval"
+msgstr "Fingerbank Data Update Interval"
+
 # conf/documentation.conf (advanced.reevaluate_access_reasons options)
 msgid "manage_deregister"
 msgstr ""

--- a/html/pfappserver/lib/pfappserver/I18N/en.po
+++ b/html/pfappserver/lib/pfappserver/I18N/en.po
@@ -7594,6 +7594,14 @@ msgstr "Violation Maintenance Interval"
 msgid "maintenance.violation_maintenance_timeout"
 msgstr "Violation Maintenance Timeout"
 
+# conf/documentation.conf
+msgid "maintenance.fingerbank_update_db"
+msgstr "Fingerbank upstream DB update"
+
+# conf/documentation.conf
+msgid "maintenance.fingerbank_update_db_interval"
+msgstr "Fingerbank upstream DB update interval"
+
 # conf/documentation.conf (advanced.reevaluate_access_reasons options)
 msgid "manage_deregister"
 msgstr ""

--- a/html/pfappserver/lib/pfappserver/I18N/en.po
+++ b/html/pfappserver/lib/pfappserver/I18N/en.po
@@ -7196,7 +7196,7 @@ msgid "expire.node"
 msgstr "Node"
 
 # conf/documentation.conf
-msgid "expire.person"
+msgid "maintenance.person_cleanup"
 msgstr "Person"
 
 # conf/documentation.conf

--- a/html/pfappserver/lib/pfappserver/I18N/en.po
+++ b/html/pfappserver/lib/pfappserver/I18N/en.po
@@ -7179,34 +7179,6 @@ msgstr ""
 msgid "event_type"
 msgstr "Event Type"
 
-# conf/documentation.conf
-msgid "expire"
-msgstr "Expiration"
-
-# conf/documentation.conf
-msgid "expire.iplog"
-msgstr "IP/MAC logs"
-
-# conf/documentation.conf
-msgid "expire.locationlog"
-msgstr "Location logs"
-
-# conf/documentation.conf
-msgid "expire.node"
-msgstr "Node"
-
-# conf/documentation.conf
-msgid "maintenance.person_cleanup"
-msgstr "Person"
-
-# conf/documentation.conf
-msgid "expire.radius_audit_log"
-msgstr "RADIUS Audit Log"
-
-# conf/documentation.conf
-msgid "expire.traplog"
-msgstr "Trap logs"
-
 # pf::action (VIOLATION_ACTIONS)
 msgid "external_action"
 msgstr ""
@@ -7511,6 +7483,10 @@ msgid "maintenance.inline_accounting_maintenance_interval"
 msgstr "Inline Accounting Maintenance Interval"
 
 # conf/documentation.conf
+msgid "maintenance.iplog_cleanup_window"
+msgstr "Iplog Cleanup Window"
+
+# conf/documentation.conf
 msgid "maintenance.iplog_cleanup_batch"
 msgstr "Iplog Cleanup Batch"
 
@@ -7523,8 +7499,28 @@ msgid "maintenance.iplog_cleanup_timeout"
 msgstr "Iplog Cleanup Timeout"
 
 # conf/documentation.conf
+msgid "maintenance.iplog_rotation_window"
+msgstr "Iplog Rotation Window"
+
+# conf/documentation.conf
+msgid "maintenance.iplog_rotation_batch"
+msgstr "Iplog Rotation Batch"
+
+# conf/documentation.conf
+msgid "maintenance.iplog_rotation_interval"
+msgstr "Iplog Rotation Interval"
+
+# conf/documentation.conf
+msgid "maintenance.iplog_rotation_timeout"
+msgstr "Iplog Rotation Timeout"
+
+# conf/documentation.conf
 msgid "maintenance.locationlog_cleanup_batch"
 msgstr "Locationlog Cleanup Batch"
+
+# conf/documentation.conf
+msgid "maintenance.locationlog_cleanup_window"
+msgstr "Locationlog Cleanup Window"
 
 # conf/documentation.conf
 msgid "maintenance.locationlog_cleanup_interval"
@@ -7535,8 +7531,16 @@ msgid "maintenance.locationlog_cleanup_timeout"
 msgstr "Locationlog Cleanup Timeout"
 
 # conf/documentation.conf
+msgid "maintenance.node_cleanup_window"
+msgstr "Node Cleanup Window"
+
+# conf/documentation.conf
 msgid "maintenance.node_cleanup_interval"
 msgstr "Node Cleanup Interval"
+
+# conf/documentation.conf
+msgid "maintenance.person_cleanup"
+msgstr "Users Cleanup"
 
 # conf/documentation.conf
 msgid "maintenance.person_cleanup_interval"
@@ -7555,6 +7559,10 @@ msgid "maintenance.provisioning_compliance_poll_interval"
 msgstr "Provisioning Compliance Poll Interval"
 
 # conf/documentation.conf
+msgid "maintenance.radius_audit_log_cleanup_window"
+msgstr "RADIUS Audit Log Cleanup Window"
+
+# conf/documentation.conf
 msgid "maintenance.radius_audit_log_cleanup_batch"
 msgstr "RADIUS Audit Log Cleanup Batch"
 
@@ -7565,6 +7573,10 @@ msgstr "RADIUS Audit Log Cleanup Interval"
 # conf/documentation.conf
 msgid "maintenance.radius_audit_log_cleanup_timeout"
 msgstr "RADIUS Audit Log Cleanup Timeout"
+
+# conf/documentation.conf
+msgid "maintenance.traplog_cleanup_window"
+msgstr "Traplog Cleanup Window"
 
 # conf/documentation.conf
 msgid "maintenance.traplog_cleanup_interval"

--- a/html/pfappserver/lib/pfappserver/I18N/en.po
+++ b/html/pfappserver/lib/pfappserver/I18N/en.po
@@ -7594,14 +7594,6 @@ msgstr "Violation Maintenance Interval"
 msgid "maintenance.violation_maintenance_timeout"
 msgstr "Violation Maintenance Timeout"
 
-# conf/documentation.conf
-msgid "maintenance.fingerbank_update_db"
-msgstr "Fingerbank upstream DB update"
-
-# conf/documentation.conf
-msgid "maintenance.fingerbank_update_db_interval"
-msgstr "Fingerbank upstream DB update interval"
-
 # conf/documentation.conf (advanced.reevaluate_access_reasons options)
 msgid "manage_deregister"
 msgstr ""

--- a/html/pfappserver/root/admin/configuration.tt
+++ b/html/pfappserver/root/admin/configuration.tt
@@ -92,7 +92,6 @@ table.sources {
               [% pf_section_entry( 'guests_self_registration', 'Self Registration') | none %]
               [% pf_section_entry( 'alerting', 'Alerting') | none %]
               [% pf_section_entry( 'maintenance', 'Maintenance') | none %]
-              [% pf_section_entry( 'expire', 'Expiration') | none %]
               [% pf_section_entry( 'services', 'Services') | none %]
               [% pf_section_entry( 'vlan', 'SNMP') | none %]
               [% pf_section_entry( 'inline', 'Inline') | none %]

--- a/lib/pf/db.pm
+++ b/lib/pf/db.pm
@@ -332,13 +332,13 @@ sub db_query_execute {
 
 =item db_transaction_execute
 
-Intended to run db_query_execute commands in a transactionnal mode
+Intended to run db_query_execute commands in a transactional mode
 
 =cut
 
 sub db_transaction_execute {
     my ( $sub ) = @_;
-    my $logger = get_logger();    
+    my $logger = get_logger();
 
     my $dbh = get_db_handle();
     unless ( $dbh->{AutoCommit} ) {
@@ -351,7 +351,7 @@ sub db_transaction_execute {
         return;
     }
 
-    eval {
+    my $rc = eval {
         $sub->();
         $dbh->commit;
     };
@@ -360,6 +360,7 @@ sub db_transaction_execute {
     }
 
     $dbh->{AutoCommit} = 1;
+    return $rc;
 }
 
 our $PREPARED_NOW_STMT;

--- a/sbin/pfmon
+++ b/sbin/pfmon
@@ -257,7 +257,16 @@ sub registertasks  {
         \&update_node_online_stats
     );
     register_task(
-        'fingerbank data update', 'fingerbank_data_update_interval', \&update_fingerbank_data
+        'fingerbank data update', 
+        'fingerbank_data_update_interval', 
+        \&update_fingerbank_data
+    );
+    register_task(
+        'fingerbank update upstream database',
+        'fingerbank_update_db_interval',
+        sub {
+            fingerbank::DB::update_upstream() if ( (isenabled($Config{'maintenance'}{'fingerbank_update_db'})) && (fingerbank::Config::is_api_key_configured) );
+        }
     );
 }
 

--- a/sbin/pfmon
+++ b/sbin/pfmon
@@ -261,13 +261,6 @@ sub registertasks  {
         'fingerbank_data_update_interval', 
         \&update_fingerbank_data
     );
-    register_task(
-        'fingerbank update upstream database',
-        'fingerbank_update_db_interval',
-        sub {
-            fingerbank::DB::update_upstream() if ( (isenabled($Config{'maintenance'}{'fingerbank_update_db'})) && (fingerbank::Config::is_api_key_configured) );
-        }
-    );
 }
 
 =head2 cleanup

--- a/sbin/pfmon
+++ b/sbin/pfmon
@@ -189,9 +189,10 @@ sub registertasks  {
         }
     );
     register_task(
-        'person cleanup','person_cleanup_interval',sub {
-            person_cleanup()
-              if ( isenabled($Config{'expire'}{'person'}) );
+        'person cleanup',
+        'person_cleanup_interval',
+        sub {
+            person_cleanup() if ( isenabled($Config{'maintenance'}{'person_cleanup'}) );
         }
     );
     register_task(

--- a/sbin/pfmon
+++ b/sbin/pfmon
@@ -168,21 +168,24 @@ exit(0);
 
 sub registertasks  {
     register_task(
-        'locationlog cleanup','locationlog_cleanup_interval',sub {
-            locationlog_cleanup( $Config{'expire'}{'locationlog'}, $Config{maintenance}{locationlog_cleanup_batch},$Config{maintenance}{locationlog_cleanup_timeout})
-              if ( $Config{'expire'}{'locationlog'} );
+        'locationlog cleanup',
+        'locationlog_cleanup_interval',
+        sub {
+            locationlog_cleanup( $Config{'expire'}{'locationlog'}, $Config{maintenance}{locationlog_cleanup_batch}, $Config{maintenance}{locationlog_cleanup_timeout} ) if ( $Config{'expire'}{'locationlog'} );
         }
     );
     register_task(
-        'radius audit log cleanup','radius_audit_log_cleanup_interval',sub {
-            radius_audit_log_cleanup( $Config{'expire'}{'radius_audit_log'}, $Config{maintenance}{radius_audit_log_cleanup_batch},$Config{maintenance}{radius_audit_log_cleanup_timeout})
-              if ( $Config{'expire'}{'radius_audit_log'} );
+        'radius audit log cleanup',
+        'radius_audit_log_cleanup_interval',
+        sub {
+            radius_audit_log_cleanup( $Config{'expire'}{'radius_audit_log'}, $Config{maintenance}{radius_audit_log_cleanup_batch}, $Config{maintenance}{radius_audit_log_cleanup_timeout}) if ( $Config{'expire'}{'radius_audit_log'} );
         }
     );
     register_task(
-        'node cleanup','node_cleanup_interval',sub {
-            node_cleanup( $Config{'expire'}{'node'} )
-              if ( $Config{'expire'}{'node'} );
+        'node cleanup',
+        'node_cleanup_interval',
+        sub {
+            node_cleanup( $Config{'expire'}{'node'} ) if ( $Config{'expire'}{'node'} );
         }
     );
     register_task(
@@ -192,40 +195,51 @@ sub registertasks  {
         }
     );
     register_task(
-        'traplog cleanup','traplog_cleanup_interval',sub {
-            traplog_cleanup( $Config{'expire'}{'traplog'} )
-              if ( $Config{'expire'}{'traplog'} );
+        'traplog cleanup',
+        'traplog_cleanup_interval',
+        sub {
+            traplog_cleanup( $Config{'expire'}{'traplog'} ) if ( $Config{'expire'}{'traplog'} );
         }
     );
     register_task(
-        'checking registered nodes for expiration','nodes_maintenance_interval',sub {
+        'checking registered nodes for expiration',
+        'nodes_maintenance_interval',
+        sub {
             nodes_maintenance();
         }
     );
     register_task(
-        'checking violations for expiration','violation_maintenance_interval',sub {
-            violation_maintenance($Config{maintenance}{violation_maintenance_batch},$Config{maintenance}{violation_maintenance_timeout});
+        'checking violations for expiration',
+        'violation_maintenance_interval',
+        sub {
+            violation_maintenance( $Config{maintenance}{violation_maintenance_batch}, $Config{maintenance}{violation_maintenance_timeout} );
         }
     );
     register_task(
-        'checking accounting data for potential bandwidth abuse','inline_accounting_maintenance_interval',sub {
-            if (isenabled($Config{'inline'}{'accounting'})) {
-                inline_accounting_maintenance($Config{'inline'}{'layer3_accounting_session_timeout'});
-            }
+        'checking accounting data for potential bandwidth abuse',
+        'inline_accounting_maintenance_interval',
+        sub {
+            inline_accounting_maintenance( $Config{'inline'}{'layer3_accounting_session_timeout'} ) if isenabled($Config{'inline'}{'accounting'});
         }
     );
     register_task(
-        'provisioner polling enforcement','provisioning_compliance_poll_interval',sub {
+        'provisioner polling enforcement',
+        'provisioning_compliance_poll_interval',
+        sub {
             provisioner_compliance_poll();
         }
     );
     register_task(
-        'account maintenance','acct_maintenance_interval',sub {
+        'account maintenance',
+        'acct_maintenance_interval',
+        sub {
             acct_maintenance();
         }
     );
     register_task(
-        'update node online stats', 'online_node_count_interval', \&update_node_online_stats
+        'update node online stats', 
+        'online_node_count_interval', 
+        \&update_node_online_stats
     );
     register_task(
         'fingerbank data update', 'fingerbank_data_update_interval', \&update_fingerbank_data

--- a/sbin/pfmon
+++ b/sbin/pfmon
@@ -175,6 +175,13 @@ sub registertasks  {
         }
     );
     register_task(
+        'iplog cleanup',
+        'iplog_cleanup_interval',
+        sub {
+            pf::iplog::cleanup( $Config{'maintenance'}{'iplog_cleanup_window'}, $Config{maintenance}{iplog_cleanup_batch}, $Config{maintenance}{iplog_cleanup_timeout} ) if ( $Config{'maintenance'}{'iplog_cleanup_window'} );
+        }
+    );
+    register_task(
         'locationlog cleanup',
         'locationlog_cleanup_interval',
         sub {

--- a/sbin/pfmon
+++ b/sbin/pfmon
@@ -168,6 +168,13 @@ exit(0);
 
 sub registertasks  {
     register_task(
+        'iplog rotation',
+        'iplog_rotation_interval',
+        sub {
+            pf::iplog::rotate( $Config{'maintenance'}{'iplog_rotation_window'}, $Config{maintenance}{iplog_rotation_batch}, $Config{maintenance}{iplog_rotation_timeout} ) if ( $Config{'maintenance'}{'iplog_rotation_window'} );
+        }
+    );
+    register_task(
         'locationlog cleanup',
         'locationlog_cleanup_interval',
         sub {

--- a/sbin/pfmon
+++ b/sbin/pfmon
@@ -171,21 +171,21 @@ sub registertasks  {
         'locationlog cleanup',
         'locationlog_cleanup_interval',
         sub {
-            locationlog_cleanup( $Config{'expire'}{'locationlog'}, $Config{maintenance}{locationlog_cleanup_batch}, $Config{maintenance}{locationlog_cleanup_timeout} ) if ( $Config{'expire'}{'locationlog'} );
+            locationlog_cleanup( $Config{'maintenance'}{'locationlog_cleanup_window'}, $Config{maintenance}{locationlog_cleanup_batch}, $Config{maintenance}{locationlog_cleanup_timeout} ) if ( $Config{'maintenance'}{'locationlog_cleanup_window'} );
         }
     );
     register_task(
         'radius audit log cleanup',
         'radius_audit_log_cleanup_interval',
         sub {
-            radius_audit_log_cleanup( $Config{'expire'}{'radius_audit_log'}, $Config{maintenance}{radius_audit_log_cleanup_batch}, $Config{maintenance}{radius_audit_log_cleanup_timeout}) if ( $Config{'expire'}{'radius_audit_log'} );
+            radius_audit_log_cleanup( $Config{'maintenance'}{'radius_audit_log_cleanup_window'}, $Config{maintenance}{radius_audit_log_cleanup_batch}, $Config{maintenance}{radius_audit_log_cleanup_timeout}) if ( $Config{'maintenance'}{'radius_audit_log_cleanup_window'} );
         }
     );
     register_task(
         'node cleanup',
         'node_cleanup_interval',
         sub {
-            node_cleanup( $Config{'expire'}{'node'} ) if ( $Config{'expire'}{'node'} );
+            node_cleanup( $Config{'maintenance'}{'node_cleanup_window'} ) if ( $Config{'maintenance'}{'node_cleanup_window'} );
         }
     );
     register_task(
@@ -198,7 +198,7 @@ sub registertasks  {
         'traplog cleanup',
         'traplog_cleanup_interval',
         sub {
-            traplog_cleanup( $Config{'expire'}{'traplog'} ) if ( $Config{'expire'}{'traplog'} );
+            traplog_cleanup( $Config{'maintenance'}{'traplog_cleanup_window'} ) if ( $Config{'maintenance'}{'traplog_cleanup_window'} );
         }
     );
     register_task(


### PR DESCRIPTION
# Description

More "standards" maintenance jobs by regrouping "expire" and "maintenance" configuration parameters
Also, reintegrating iplog maintenance jobs (rotation and cleanup)
# Impacts

pfmon
iplog_history table
iplog_archive table
performance under heavy load even if we used batched jobs
# Delete branch after merge

YES
# NEWS file entries
## Enhancements
- Reinstating iplog (iplog_history and iplog_archive) rotation/cleanup jobs runned by pfmon
# UPGRADE guide file entry
## pf.conf configuration parameters
- 'expire' section have been removed. Make sure to adjust with the followings:
  *\* expire.node -> maintenance.node_cleanup_window
  *\* expire.iplog -> maintenance.iplog_cleanup_window
  *\* expire.locationlog -> maintenance.locationlog_cleanup_window
  *\* expire.radius_audit_log -> maintenance.radius_audit_log_cleanup_window
  *\* expire.traplog -> maintenance.traplog_cleanup_window
