### PR TITLE
added RADIUS clients for management IPs

### DIFF
--- a/lib/pfconfig/namespaces/config/Switch.pm
+++ b/lib/pfconfig/namespaces/config/Switch.pm
@@ -29,7 +29,9 @@ use base 'pfconfig::namespaces::config';
 sub init {
     my ($self) = @_;
     $self->{file}            = $switches_config_file;
-    $self->{child_resources} = [ 'resource::default_switch', 'resource::switches_ranges' ];
+    $self->{child_resources} = [ 'resource::default_switch', 'resource::switches_ranges', 'interfaces::management_network' ];
+    
+    $self->{management_network} = $self->{cache}->get_cache('interfaces::management_network');
 }
 
 sub build_child {
@@ -45,6 +47,17 @@ sub build_child {
         SNMPVersionTrap   => '1',
         SNMPCommunityTrap => 'public'
     };
+
+    my @management_ips;
+    push @management_ips, $self->{management_network}->tag('vip') if(defined($self->{management_network}->tag('vip')));
+    push @management_ips, $self->{management_network}->tag('ip') if(defined($self->{management_network}->tag('ip')));
+    foreach my $management_ip (@management_ips){
+        $tmp_cfg{$management_ip} = {
+            type => 'PacketFence', 
+            mode => 'production', 
+            radiusSecret => 'testing1234', 
+        };
+    }
 
 
     my @keys;


### PR DESCRIPTION
# Description

Add RADIUS clients for the management IPs of PacketFence so that radtest can be used to monitor the FreeRADIUS server
# Impacts

RADIUS clients + PacketFence Switches
# Delete branch after merge

YES
# NEWS file entries
## Enhancements
- Added the PacketFence management IP addresses as switches so that they can be used in monitoring tools
