### PR TITLE
Dedicated pfconfig process for testing 

### DIFF
--- a/addons/packages/packetfence.spec
+++ b/addons/packages/packetfence.spec
@@ -99,6 +99,7 @@ Requires: sscep
 Requires: p0f
 Requires: net-snmp >= 5.3.2.2
 Requires: mysql, mysql-server, perl(DBD::mysql)
+Requires: perl(DBD::Mock)
 Requires: perl >= %{perl_version}
 # replaces the need for perl-suidperl which was deprecated in perl 5.12 (Fedora 14)
 Requires(pre): %{real_name}-pfcmd-suid

--- a/addons/packages/packetfence.spec
+++ b/addons/packages/packetfence.spec
@@ -99,7 +99,6 @@ Requires: sscep
 Requires: p0f
 Requires: net-snmp >= 5.3.2.2
 Requires: mysql, mysql-server, perl(DBD::mysql)
-Requires: perl(DBD::Mock)
 Requires: perl >= %{perl_version}
 # replaces the need for perl-suidperl which was deprecated in perl 5.12 (Fedora 14)
 Requires(pre): %{real_name}-pfcmd-suid

--- a/bin/pfcmd_vlan
+++ b/bin/pfcmd_vlan
@@ -74,7 +74,7 @@ This script allows to execute the following commands related to switches and VLA
 use strict;
 use warnings;
 
-use autouse 'Net::MAC::Vendor' => qw(lookup);
+use Net::MAC::Vendor;
 use Data::Dumper;
 use English qw( -no_match_vars ) ;  # Avoids regex performance penalty
 use File::Basename qw(basename);
@@ -420,7 +420,7 @@ if ($reevaluateAccess) {
             foreach my $mac ( sort @{ $hubPorts->{$port} } ) {
                 print "- $mac";
                 if ($showMacVendor) {
-                    my $oui_info = lookup($mac);
+                    my $oui_info = Net::MAC::Vendor::lookup($mac);
                     print ", " . ( $$oui_info[0] || 'unknown' );
                 }
                 if ($showPF) {
@@ -517,7 +517,7 @@ if ($reevaluateAccess) {
             foreach my $currentMac ( $switch->getMacAtIfIndex($ifIndex) ) {
                 print "$currentMac";
                 if ($showMacVendor) {
-                    my $oui_info = lookup($currentMac);
+                    my $oui_info = Net::MAC::Vendor::lookup($currentMac);
                     print ", " . ( $$oui_info[0] || 'unknown' );
                 }
                 if ($showPF) {
@@ -680,7 +680,7 @@ if ($reevaluateAccess) {
         }
     }
     if ($showMacVendor) {
-        my $oui_info = lookup($mac);
+        my $oui_info = Net::MAC::Vendor::lookup($mac);
         $mac = "$mac (" . ( $$oui_info[0] || 'unknown' ) . ")";
     }
     if ($found) {

--- a/debian/control
+++ b/debian/control
@@ -44,7 +44,7 @@ Depends: ${misc:Depends}, vlan, make,
 # perl uncategorized modules
  libapache-htpasswd-perl, libbit-vector-perl, libtext-csv-perl, libtext-csv-xs-perl,
  libcgi-session-serialize-yaml-perl, libtimedate-perl, libapache-dbi-perl,
- libdbd-mysql-perl, libfile-tail-perl, libnetwork-ipv4addr-perl,
+ libdbd-mysql-perl, libdbd-mock-perl, libfile-tail-perl, libnetwork-ipv4addr-perl,
  libiptables-parse-perl, libiptables-chainmgr-perl, iptables (>= 1.4.0),
  liblwp-useragent-determined-perl, 
  libnet-netmask-perl, libnet-pcap-perl, libnet-snmp-perl, libsnmp-perl,

--- a/debian/control
+++ b/debian/control
@@ -44,7 +44,7 @@ Depends: ${misc:Depends}, vlan, make,
 # perl uncategorized modules
  libapache-htpasswd-perl, libbit-vector-perl, libtext-csv-perl, libtext-csv-xs-perl,
  libcgi-session-serialize-yaml-perl, libtimedate-perl, libapache-dbi-perl,
- libdbd-mysql-perl, libdbd-mock-perl, libfile-tail-perl, libnetwork-ipv4addr-perl,
+ libdbd-mysql-perl, libfile-tail-perl, libnetwork-ipv4addr-perl,
  libiptables-parse-perl, libiptables-chainmgr-perl, iptables (>= 1.4.0),
  liblwp-useragent-determined-perl, 
  libnet-netmask-perl, libnet-pcap-perl, libnet-snmp-perl, libsnmp-perl,

--- a/lib/pf/db.pm
+++ b/lib/pf/db.pm
@@ -37,6 +37,8 @@ use constant PREPARE_PF_PREFIX => 'pf::';         # prefix to access exported _p
 
 our ( $DBH, $LAST_CONNECT, $DB_Config, $NO_DIE_ON_DBH_ERROR );
 
+our $DRIVER = "dbi:mysql";
+
 BEGIN {
     use Exporter ();
     our ( @ISA, @EXPORT );
@@ -92,16 +94,13 @@ sub db_connect {
     }
 
     $logger->debug("(Re)Connecting to MySQL (pid: $$)");
-
-    my $host = $DB_Config->{'host'};
-    my $port = $DB_Config->{'port'};
+        
     my $user = $DB_Config->{'user'};
     my $pass = $DB_Config->{'pass'};
-    my $db   = $DB_Config->{'db'};
 
     # TODO database prepared statements are disabled by default in dbd::mysql
     # we should test with them, see http://search.cpan.org/~capttofu/DBD-mysql-4.013/lib/DBD/mysql.pm#DESCRIPTION
-    $mydbh = DBI->connect( "dbi:mysql:dbname=$db;host=$host;port=$port",
+    $mydbh = DBI->connect( "$DRIVER:".dbi_params(),
         $user, $pass, { RaiseError => 0, PrintError => 0, mysql_auto_reconnect => 1 } );
 
     # make sure we have a database handle
@@ -117,6 +116,18 @@ sub db_connect {
         $logger->error("unable to connect to database: " . $DBI::errstr);
         $pf::StatsD::statsd->increment(called() . ".error.count" );
         return ();
+    }
+}
+
+sub dbi_params {
+    if($DRIVER eq "dbi:mysql"){
+        my $host = $DB_Config->{'host'};
+        my $port = $DB_Config->{'port'};
+        my $db   = $DB_Config->{'db'};
+        return "dbname=$db;host=$host;port=$port"
+    }
+    else {
+        return '';
     }
 }
 

--- a/lib/pf/services/util.pm
+++ b/lib/pf/services/util.pm
@@ -32,7 +32,7 @@ daemonize the service
 =cut
 
 sub daemonize {
-    my ($service) = @_;
+    my ($service, $pidfile) = @_;
     my $logger = get_logger();
     chdir '/' or $logger->logdie("Can't chdir to /: $!");
     open STDIN, '<', '/dev/null'
@@ -51,7 +51,7 @@ sub daemonize {
     if ( !POSIX::setsid() ) {
         $logger->error("could not start a new session: $!");
     }
-    createpid($service);
+    createpid($service, $pidfile);
 }
 
 =head2 createpid
@@ -61,11 +61,11 @@ creates the pid file for the service
 =cut
 
 sub createpid {
-    my ($pname) = @_;
+    my ($pname, $pidfile) = @_;
     my $logger = get_logger();
     $pname = basename($0) if ( !$pname );
     my $pid     = $$;
-    my $pidfile = $var_dir . "/run/$pname.pid";
+    $pidfile //= $var_dir . "/run/$pname.pid";
     $logger->info("$pname starting and writing $pid to $pidfile");
     if ( open ( my $outfile, ">$pidfile") ) {
         print $outfile $pid;

--- a/lib/pfconfig/config.pm
+++ b/lib/pfconfig/config.pm
@@ -19,12 +19,24 @@ use UNIVERSAL::require;
 use Config::IniFiles;
 use pf::util;
 
+=head2 new
+
+Create a new pfconfig configuration object
+
+=cut
+
 sub new {
     my ($class) = @_;
     my $self = bless {}, $class;
     $self->init();
     return $self;
 }
+
+=head2 init
+
+Init the pfconfig configuration object
+
+=cut
 
 sub init {
     my ($self) = @_;
@@ -36,10 +48,22 @@ sub init {
     $self->{cfg} = \%cfg;
 }
 
+=head2 section
+
+Get a configuration section
+
+=cut
+
 sub section {
     my ( $self, $name ) = @_;
     return $self->{cfg}{$name};
 }
+
+=head2 get_backend
+
+Get the backend object defined in the configuration or the default one
+
+=cut
 
 sub get_backend {
     my ( $self ) = @_;

--- a/lib/pfconfig/constants.pm
+++ b/lib/pfconfig/constants.pm
@@ -18,8 +18,8 @@ use strict;
 use warnings;
 use Readonly;
 
-Readonly::Scalar our $CONFIG_FILE_PATH => "/usr/local/pf/conf/pfconfig.conf";
-Readonly::Scalar our $SOCKET_PATH => "/usr/local/pf/var/run/pfconfig.sock";
+our $CONFIG_FILE_PATH = "/usr/local/pf/conf/pfconfig.conf";
+our $SOCKET_PATH = "/usr/local/pf/var/run/pfconfig.sock";
 Readonly::Scalar our $CONTROL_FILE_DIR => "/usr/local/pf/var/control";
 
 

--- a/lib/pfconfig/manager.pm
+++ b/lib/pfconfig/manager.pm
@@ -172,21 +172,7 @@ sub init_cache {
     my ($self) = @_;
     my $logger = get_logger;
 
-    my $cfg    = pfconfig::config->new->section('general');
-
-    my $name = $cfg->{backend} || $pfconfig::constants::DEFAULT_BACKEND;
-
-    my $type   = "pfconfig::backend::$name";
-
-    $type = untaint_chain($type);
-
-    # load the module to instantiate
-    if ( !( eval "$type->require()" ) ) {
-        $logger->error( "Can not load namespace $name " . "Read the following message for details: $@" );
-    }
-
-    $self->{cache} = $type->new();
-
+    $self->{cache} = pfconfig::config->new->get_backend;
     $self->{memory}       = {};
     $self->{memorized_at} = {};
 }

--- a/sbin/pfconfig
+++ b/sbin/pfconfig
@@ -15,7 +15,8 @@ pfconfig [options]
    -h                 Help
    -s SOCK_PATH       The path to the unix socket path - default $PFDIR/var/pfconfig.sock
    -n NAME            The name of process as reported in ps - default pfconfig
-   -p NAME            The prefix of pidfile - defaults to the name
+   -p PID_PATH        The path to the PID file (optional)
+   -c CONFIG_PATH     The path to the configuration file (optional) 
 
 =cut
 

--- a/sbin/pfconfig
+++ b/sbin/pfconfig
@@ -56,12 +56,16 @@ my %args = (
     n => "pfconfig",
 );
 
-getopts( 'dhs:n:p:', \%args );
+getopts( 'dhs:n:p:c:', \%args );
 
 $args{p} //= $args{n};
 
 our $PROGRAM_NAME = $0 = $args{n};
 
+if(defined($args{c})){
+    $pfconfig::constants::CONFIG_FILE_PATH = $args{c};
+    print $pfconfig::constants::CONFIG_FILE_PATH;
+}
 
 my $socket_path = $args{s};
 unlink($socket_path);
@@ -114,7 +118,7 @@ unlink glob "$pfconfig::constants::CONTROL_FILE_DIR/*";
 my $daemonize = $args{d};
 
 # standard signals and daemonize
-daemonize($PROGRAM_NAME) if ($daemonize);
+daemonize($PROGRAM_NAME, $args{p}) if ($daemonize);
 
 our %DISPATCH = (
     'expire'             => \&expire,

--- a/sbin/pfconfig
+++ b/sbin/pfconfig
@@ -59,8 +59,6 @@ my %args = (
 
 getopts( 'dhs:n:p:c:', \%args );
 
-$args{p} //= $args{n};
-
 our $PROGRAM_NAME = $0 = $args{n};
 
 if(defined($args{c})){

--- a/sbin/pfconfig
+++ b/sbin/pfconfig
@@ -61,10 +61,7 @@ getopts( 'dhs:n:p:c:', \%args );
 
 our $PROGRAM_NAME = $0 = $args{n};
 
-if(defined($args{c})){
-    $pfconfig::constants::CONFIG_FILE_PATH = $args{c};
-    print $pfconfig::constants::CONFIG_FILE_PATH;
-}
+$pfconfig::constants::CONFIG_FILE_PATH = $args{c} if($args{c});
 
 my $socket_path = $args{s};
 unlink($socket_path);

--- a/t/ConfigStore.t
+++ b/t/ConfigStore.t
@@ -19,7 +19,7 @@ use Test::Harness;
 use File::Spec::Functions;
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 runtests(

--- a/t/ConfigStore/Base.t
+++ b/t/ConfigStore/Base.t
@@ -21,7 +21,7 @@ use Test::Harness;
 use File::Spec::Functions;
 BEGIN {
     use lib qw(/usr/local/pf/t /usr/local/pf/lib);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 plan tests => 20;

--- a/t/ConfigStore/Group.t
+++ b/t/ConfigStore/Group.t
@@ -19,7 +19,7 @@ use Test::More tests => 17;
 use Test::NoWarnings;
 BEGIN {
     use lib qw(/usr/local/pf/t /usr/local/pf/lib);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use_ok("pf::ConfigStore");

--- a/t/ConfigStore/Hierarchy.t
+++ b/t/ConfigStore/Hierarchy.t
@@ -19,7 +19,7 @@ use Test::More tests => 10;
 use Test::NoWarnings;
 BEGIN {
     use lib qw(/usr/local/pf/t /usr/local/pf/lib);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 

--- a/t/IniFiles.t
+++ b/t/IniFiles.t
@@ -6,7 +6,7 @@ use warnings;
 use lib '/usr/local/pf/lib';
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use Test::More tests => 5;

--- a/t/MAC.t
+++ b/t/MAC.t
@@ -4,7 +4,7 @@ use warnings;
 use Test::More tests => 30;
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use_ok('pf::MAC') or die;

--- a/t/PfFilePaths.pm
+++ b/t/PfFilePaths.pm
@@ -15,11 +15,11 @@ Overrides the the location of config files to help with testing
 use strict;
 use warnings;
 
-use File::Slurp qw(read_file);
 
 our $PFCONFIG_TEST_PID_FILE;
 
 BEGIN {
+    use File::Slurp qw(read_file);
     use File::Path qw(remove_tree);
     use File::Spec::Functions qw(catfile catdir rel2abs);
     use File::Basename qw(dirname);

--- a/t/PfFilePaths.pm
+++ b/t/PfFilePaths.pm
@@ -15,11 +15,17 @@ Overrides the the location of config files to help with testing
 use strict;
 use warnings;
 
+use File::Slurp qw(read_file);
+
+our $PFCONFIG_TEST_PID_FILE;
+
 BEGIN {
     use File::Path qw(remove_tree);
     use File::Spec::Functions qw(catfile catdir rel2abs);
     use File::Basename qw(dirname);
     use pf::file_paths;
+    use pfconfig::constants;
+    use pfconfig::manager;
     remove_tree('/tmp/chi');
     my $test_dir = rel2abs(dirname($INC{'PfFilePaths.pm'})) if exists $INC{'PfFilePaths.pm'};
     $test_dir ||= catdir($install_dir,'t');
@@ -34,12 +40,21 @@ BEGIN {
     $pf::file_paths::firewall_sso_config_file = catfile($test_dir,'data/firewall_sso.conf');
     $pf::file_paths::config_file = catfile($test_dir,'data/pf.conf');
     $pf::file_paths::pf_config_file = catfile($test_dir,'data/pf.conf');
+
+    $pfconfig::constants::CONFIG_FILE_PATH = catfile($test_dir, 'data/pfconfig.conf');
+    $pfconfig::constants::SOCKET_PATH = "/usr/local/pf/var/run/pfconfig-test.sock";
+
+    $PFCONFIG_TEST_PID_FILE = "/usr/local/pf/var/run/pfconfig-test.pid";
+    `/usr/local/pf/sbin/pfconfig -s $pfconfig::constants::SOCKET_PATH -p $PFCONFIG_TEST_PID_FILE -c $pfconfig::constants::CONFIG_FILE_PATH -d`;
+
+    my $manager = pfconfig::manager->new;
+    $manager->expire_all;
+ }
+ 
+END {
+    my $pid = read_file($PFCONFIG_TEST_PID_FILE);
+    `kill $pid`
 }
-
-# we need to load the proper data in pfconfig
-use pfconfig::manager;
-pfconfig::manager->new->expire_all;
-
 =head1 AUTHOR
 
 Inverse inc. <info@inverse.ca>

--- a/t/Portal.t
+++ b/t/Portal.t
@@ -15,7 +15,7 @@ use warnings;
 use lib '/usr/local/pf/lib';
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use File::Basename qw(basename);

--- a/t/SNMP.t
+++ b/t/SNMP.t
@@ -15,7 +15,7 @@ my $logger = Log::Log4perl->get_logger( basename($0) );
 Log::Log4perl::MDC->put( 'proc', basename($0) );
 Log::Log4perl::MDC->put( 'tid',  0 );
 BEGIN { use lib qw(/usr/local/pf/t); }
-BEGIN { use PfFilePaths; }
+BEGIN { use setup_test_config; }
 
 use pf::SwitchFactory;
 

--- a/t/SwitchFactory.t
+++ b/t/SwitchFactory.t
@@ -10,7 +10,7 @@ use Test::NoWarnings;
 
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
     use_ok('pf::SwitchFactory');
 }
 

--- a/t/all.t
+++ b/t/all.t
@@ -19,7 +19,7 @@ use Test::Harness;
 use lib qw(/usr/local/pf/t);
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 use TestUtils;
 

--- a/t/binaries.t
+++ b/t/binaries.t
@@ -30,6 +30,11 @@ my @binaries = (
 plan tests => scalar @binaries * 1 + 1;
 
 foreach my $current_binary (@binaries) {
+    # hack: we add Taint mode to the pfcmd.pl check.
+    # See 'Switches On the "#!" Line' in perlsec
+    my $flags = ($current_binary =~ m#/usr/local/pf/bin/pfcmd(-old)?.pl#) ? '-T' : '';
+    $flags .= ' -I/usr/local/pf/t -Mtest_paths';
+
     is( system("/usr/bin/perl $flags -c $current_binary 2>&1"), 0, "$current_binary compiles" );
 }
 

--- a/t/binaries.t
+++ b/t/binaries.t
@@ -30,10 +30,7 @@ my @binaries = (
 plan tests => scalar @binaries * 1 + 1;
 
 foreach my $current_binary (@binaries) {
-    # hack: we add Taint mode to the pfcmd.pl check.
-    # See 'Switches On the "#!" Line' in perlsec
-    my $flags = ($current_binary =~ m#/usr/local/pf/bin/pfcmd(-old)?.pl#) ? '-T' : '';
-    $flags .= ' -I/usr/local/pf/t -Mtest_paths';
+    my $flags .= '-I/usr/local/pf/t -Mtest_paths';
 
     is( system("/usr/bin/perl $flags -c $current_binary 2>&1"), 0, "$current_binary compiles" );
 }

--- a/t/binaries.t
+++ b/t/binaries.t
@@ -30,7 +30,10 @@ my @binaries = (
 plan tests => scalar @binaries * 1 + 1;
 
 foreach my $current_binary (@binaries) {
-    my $flags .= '-I/usr/local/pf/t -Mtest_paths';
+    # hack: we add Taint mode to the pfcmd-old.pl check.
+    # See 'Switches On the "#!" Line' in perlsec
+    my $flags = ($current_binary =~ m#/usr/local/pf/bin/pfcmd-old.pl#) ? '-T' : '';
+    $flags .= ' -I/usr/local/pf/t -Mtest_paths';
 
     is( system("/usr/bin/perl $flags -c $current_binary 2>&1"), 0, "$current_binary compiles" );
 }

--- a/t/binaries.t
+++ b/t/binaries.t
@@ -17,7 +17,7 @@ use Test::NoWarnings;
 
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 use TestUtils qw(get_all_perl_binaries get_all_perl_cgi);
 

--- a/t/binaries.t
+++ b/t/binaries.t
@@ -30,10 +30,7 @@ my @binaries = (
 plan tests => scalar @binaries * 1 + 1;
 
 foreach my $current_binary (@binaries) {
-    # hack: we add Taint mode to the pfcmd-old.pl check.
-    # See 'Switches On the "#!" Line' in perlsec
-    my $flags = ($current_binary =~ m#/usr/local/pf/bin/pfcmd-old.pl#) ? '-T' : '';
-    $flags .= ' -I/usr/local/pf/t -Mtest_paths';
+    my $flags = '-I/usr/local/pf/t -Mtest_paths';
 
     is( system("/usr/bin/perl $flags -c $current_binary 2>&1"), 0, "$current_binary compiles" );
 }

--- a/t/captive-portal_libs.t
+++ b/t/captive-portal_libs.t
@@ -9,7 +9,7 @@ use diagnostics;
 use lib qw(/usr/local/pf/lib /usr/local/pf/html/captive-portal/lib);
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 BEGIN {

--- a/t/coding-style.t
+++ b/t/coding-style.t
@@ -17,7 +17,7 @@ use Test::More;
 use Test::NoWarnings;
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use TestUtils qw(get_all_perl_binaries get_all_perl_cgi get_all_perl_modules get_all_php);

--- a/t/config-cached.t
+++ b/t/config-cached.t
@@ -26,7 +26,7 @@ our (%DATA,%DATA1,%DATA2,%DATA3,$filename);
 
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 use pf::log;
 

--- a/t/config.t
+++ b/t/config.t
@@ -7,7 +7,7 @@ use diagnostics;
 use lib '/usr/local/pf/lib';
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use Test::More;

--- a/t/configstore-2-pfconfig.t
+++ b/t/configstore-2-pfconfig.t
@@ -7,7 +7,7 @@ use diagnostics;
 use lib '/usr/local/pf/lib';
 BEGIN {
     use lib qw(/usr/local/pf/t);
-#    use PfFilePaths;
+#    use setup_test_config;
 #    use pf::log(service => 'pfconfig');
 }
 

--- a/t/critic.t
+++ b/t/critic.t
@@ -18,7 +18,7 @@ use Test::Perl::Critic ( -profile => 'perlcriticrc' );
 use Test::More;
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 use Test::NoWarnings;
 

--- a/t/daemon.t
+++ b/t/daemon.t
@@ -17,7 +17,7 @@ use Time::HiRes qw(sleep);
 use lib '/usr/local/pf/lib';
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use Test::More tests => 14;                      # last test to print

--- a/t/dao/data.t
+++ b/t/dao/data.t
@@ -18,7 +18,7 @@ use Test::NoWarnings;
 use lib '/usr/local/pf/lib';
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use Log::Log4perl;

--- a/t/dao/graph.t
+++ b/t/dao/graph.t
@@ -16,7 +16,7 @@ use diagnostics;
 use lib '/usr/local/pf/lib';
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use Test::More tests => 11;

--- a/t/dao/node.t
+++ b/t/dao/node.t
@@ -16,7 +16,7 @@ use diagnostics;
 use lib '/usr/local/pf/lib';
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use Test::More tests => 7;

--- a/t/dao/person.t
+++ b/t/dao/person.t
@@ -18,7 +18,7 @@ use diagnostics;
 use lib '/usr/local/pf/lib';
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use Test::NoWarnings;

--- a/t/dao/report.t
+++ b/t/dao/report.t
@@ -16,7 +16,7 @@ use diagnostics;
 use lib '/usr/local/pf/lib';
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use Test::More tests => 27;

--- a/t/data/pf.conf
+++ b/t/data/pf.conf
@@ -10,5 +10,4 @@ host=127.0.0.1
 type=management
 ip=10.0.0.13
 mask=255.255.255.224
-gateway=10.0.0.13
 vip=10.0.0.13

--- a/t/data/pfconfig.conf
+++ b/t/data/pfconfig.conf
@@ -1,0 +1,2 @@
+[general]
+backend=bdb

--- a/t/db/schema.t
+++ b/t/db/schema.t
@@ -26,7 +26,7 @@ BEGIN {
     #include test libs
     use lib qw(/usr/local/pf/t);
     #Module for overriding configuration paths
-    use PfFilePaths;
+    use setup_test_config;
 }
 use pf::file_paths;
 

--- a/t/enforcement.t
+++ b/t/enforcement.t
@@ -6,7 +6,7 @@ use diagnostics;
 use lib '/usr/local/pf/lib';
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 use Test::More tests => 2;
 use Test::NoWarnings;

--- a/t/example.t
+++ b/t/example.t
@@ -19,7 +19,7 @@ BEGIN {
     #include test libs
     use lib qw(/usr/local/pf/t);
     #Module for overriding configuration paths
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use Test::More tests => 3;

--- a/t/floatingdevice.t
+++ b/t/floatingdevice.t
@@ -17,7 +17,7 @@ use Test::MockObject::Extends;
 use lib '/usr/local/pf/lib';
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
     use pf::Switch;
     use_ok('pf::floatingdevice');
     use_ok('pf::floatingdevice::custom');

--- a/t/hardware-snmp-objects.t
+++ b/t/hardware-snmp-objects.t
@@ -18,7 +18,7 @@ use lib '/usr/local/pf/lib';
 my $lib_path = '/usr/local/pf/lib';
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 use Test::More;
 use Test::NoWarnings;

--- a/t/i18n.t
+++ b/t/i18n.t
@@ -17,7 +17,7 @@ use File::Find;
 use Test::More;
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 my @translations;

--- a/t/import.t
+++ b/t/import.t
@@ -7,7 +7,7 @@ use diagnostics;
 use lib '/usr/local/pf/lib';
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 use Test::More tests => 2;
 use Test::NoWarnings;

--- a/t/inline.t
+++ b/t/inline.t
@@ -16,7 +16,7 @@ use diagnostics;
 use lib '/usr/local/pf/lib';
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use Test::More tests => 5;

--- a/t/integration.t
+++ b/t/integration.t
@@ -19,7 +19,7 @@ use Test::More tests => 10;
 use lib '/usr/local/pf/lib';
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 use English qw( -no_match_vars );
 use File::Basename qw(basename);

--- a/t/integration/Portal.t
+++ b/t/integration/Portal.t
@@ -15,7 +15,7 @@ use warnings;
 use lib '/usr/local/pf/lib';
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use File::Basename qw(basename);

--- a/t/integration/captive-portal.t
+++ b/t/integration/captive-portal.t
@@ -16,7 +16,7 @@ use diagnostics;
 use lib '/usr/local/pf/lib';
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use Test::More tests => 15;

--- a/t/integration/pfcmd.t
+++ b/t/integration/pfcmd.t
@@ -16,7 +16,7 @@ use warnings;
 use lib '/usr/local/pf/lib';
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use Test::More tests => 5;

--- a/t/integration/radius.t
+++ b/t/integration/radius.t
@@ -24,7 +24,7 @@ Log::Log4perl::MDC->put( 'proc', "integration/radius.t" );
 Log::Log4perl::MDC->put( 'tid',  0 );
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use pf::config;

--- a/t/ldap-auth-cache.t
+++ b/t/ldap-auth-cache.t
@@ -148,7 +148,7 @@ sleep(1);
 BEGIN {
     use lib qw(/usr/local/pf/lib);
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use Test::More tests => 6;    # last test to print

--- a/t/network-devices/cisco.t
+++ b/t/network-devices/cisco.t
@@ -9,7 +9,7 @@ use Test::NoWarnings;
 
 use lib '/usr/local/pf/lib';
 BEGIN { use lib qw(/usr/local/pf/t); }
-BEGIN { use PfFilePaths; }
+BEGIN { use setup_test_config; }
 use pf::config;
 use pf::SwitchFactory;
 

--- a/t/network-devices/roles.t
+++ b/t/network-devices/roles.t
@@ -21,7 +21,7 @@ use Test::NoWarnings;
 
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 use TestUtils;
 

--- a/t/network-devices/threecom.t
+++ b/t/network-devices/threecom.t
@@ -14,7 +14,7 @@ use Test::More tests => 6;
 
 use lib '/usr/local/pf/lib';
 BEGIN { use lib qw(/usr/local/pf/t); }
-BEGIN { use PfFilePaths; }
+BEGIN { use setup_test_config; }
 use pf::config;
 use pf::SwitchFactory;
 

--- a/t/network-devices/wired.t
+++ b/t/network-devices/wired.t
@@ -22,7 +22,7 @@ use Test::NoWarnings;
 
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 use TestUtils;
 

--- a/t/network-devices/wireless.t
+++ b/t/network-devices/wireless.t
@@ -24,7 +24,7 @@ use Test::MockObject::Extends;
 
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 use TestUtils;
 

--- a/t/nodecategory.t
+++ b/t/nodecategory.t
@@ -16,7 +16,7 @@ use diagnostics;
 use lib '/usr/local/pf/lib';
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use Test::More tests => 4;

--- a/t/person.t
+++ b/t/person.t
@@ -18,7 +18,7 @@ use Test::More tests => 1;
 use lib '/usr/local/pf/lib';
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 BEGIN { use_ok('pf::person') }
 

--- a/t/pf.t
+++ b/t/pf.t
@@ -10,7 +10,7 @@ use lib '/usr/local/pf/lib';
 
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 BEGIN {
 

--- a/t/pfappserver_libs.t
+++ b/t/pfappserver_libs.t
@@ -14,7 +14,7 @@ use lib qw(
 
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 BEGIN {

--- a/t/pfcmd.t
+++ b/t/pfcmd.t
@@ -16,7 +16,7 @@ use diagnostics;
 use lib '/usr/local/pf/lib';
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use Test::NoWarnings;

--- a/t/pfcmd_vlan.t
+++ b/t/pfcmd_vlan.t
@@ -16,7 +16,7 @@ use diagnostics;
 use lib '/usr/local/pf/lib';
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use Test::More tests => 2;

--- a/t/pfcmd_vlan.t
+++ b/t/pfcmd_vlan.t
@@ -27,7 +27,7 @@ use File::Basename qw(basename);
 use Log::Log4perl;
 
 # required to avoid warnings in admin guide asciidoc build
-`/usr/local/pf/bin/pfcmd_vlan -help`;
+`perl -I/usr/local/pf/t -Mtest_paths /usr/local/pf/bin/pfcmd_vlan -help`;
 is($CHILD_ERROR, 0, "pfcmd_vlan -help exits with status 0"); 
 
 =head1 AUTHOR

--- a/t/pfconfig.t
+++ b/t/pfconfig.t
@@ -7,7 +7,7 @@ use diagnostics;
 use lib '/usr/local/pf/lib';
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
     `cp $pf::file_paths::switches_config_file $pf::file_paths::switches_config_file.tmp`;
     $pf::file_paths::switches_config_file = "$pf::file_paths::switches_config_file.tmp";
 

--- a/t/pfdhcplistener.t
+++ b/t/pfdhcplistener.t
@@ -16,7 +16,7 @@ use diagnostics;
 use lib '/usr/local/pf/lib';
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use Test::More tests => 1;

--- a/t/pfsetvlan.t
+++ b/t/pfsetvlan.t
@@ -16,7 +16,7 @@ use diagnostics;
 use lib '/usr/local/pf/lib';
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use Test::More tests => 5;

--- a/t/pod.t
+++ b/t/pod.t
@@ -21,7 +21,7 @@ use Test::Pod;
 BEGIN {
     use lib qw(/usr/local/pf/lib);
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 use TestUtils qw(get_all_perl_binaries get_all_perl_cgi get_all_perl_modules);
 

--- a/t/podCoverage.t
+++ b/t/podCoverage.t
@@ -7,7 +7,7 @@ use diagnostics;
 use lib qw(/usr/local/pf/lib);
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use Test::Pod::Coverage tests => 24;

--- a/t/prepare-pfconfig.t
+++ b/t/prepare-pfconfig.t
@@ -20,7 +20,7 @@ BEGIN {
     use constant INSTALL_DIR => '/usr/local/pf';
     use lib INSTALL_DIR . "/lib";
     use lib INSTALL_DIR . "/t";
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use pfconfig::manager;

--- a/t/radius.t
+++ b/t/radius.t
@@ -16,7 +16,7 @@ use diagnostics;
 use lib '/usr/local/pf/lib';
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use File::Basename qw(basename);

--- a/t/role.t
+++ b/t/role.t
@@ -27,7 +27,7 @@ my $logger = Log::Log4perl->get_logger( basename($0) );
 Log::Log4perl::MDC->put( 'proc', basename($0) );
 Log::Log4perl::MDC->put( 'tid',  0 );
 BEGIN { use lib qw(/usr/local/pf/t); }
-BEGIN { use PfFilePaths; }
+BEGIN { use setup_test_config; }
 
 use pf::constants;
 use pf::config;

--- a/t/services.t
+++ b/t/services.t
@@ -24,7 +24,7 @@ Log::Log4perl::MDC->put( 'proc', basename($0) );
 Log::Log4perl::MDC->put( 'tid',  0 );
 
 BEGIN { use lib qw(/usr/local/pf/t); }
-BEGIN { use PfFilePaths; }
+BEGIN { use setup_test_config; }
 BEGIN { use_ok('pf::services') }
 BEGIN { use_ok('pf::services::manager::httpd') }
 BEGIN { use_ok('pf::services::manager::dhcpd') }

--- a/t/services/dummy
+++ b/t/services/dummy
@@ -6,7 +6,7 @@ use Getopt::Std;
 BEGIN {
     use lib qw(/usr/local/pf/lib /usr/local/pf/t);
     use pf::util;
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 my %args;

--- a/t/setup_test_config.pm
+++ b/t/setup_test_config.pm
@@ -29,7 +29,7 @@ BEGIN {
     remove_tree('/tmp/chi');
 
     $PFCONFIG_TEST_PID_FILE = "/usr/local/pf/var/run/pfconfig-test.pid";
-    `/usr/local/pf/sbin/pfconfig -s $pfconfig::constants::SOCKET_PATH -p $PFCONFIG_TEST_PID_FILE -c $pfconfig::constants::CONFIG_FILE_PATH -d`;
+    `/usr/local/pf/sbin/pfconfig -n pfconfig-test -s $pfconfig::constants::SOCKET_PATH -p $PFCONFIG_TEST_PID_FILE -c $pfconfig::constants::CONFIG_FILE_PATH -d`;
 
     my $manager = pfconfig::manager->new;
     $manager->expire_all;

--- a/t/setup_test_config.pm
+++ b/t/setup_test_config.pm
@@ -29,7 +29,7 @@ BEGIN {
     remove_tree('/tmp/chi');
 
     $PFCONFIG_TEST_PID_FILE = "/usr/local/pf/var/run/pfconfig-test.pid";
-    `/usr/local/pf/sbin/pfconfig -n pfconfig-test -s $pfconfig::constants::SOCKET_PATH -p $PFCONFIG_TEST_PID_FILE -c $pfconfig::constants::CONFIG_FILE_PATH -d`;
+    `perl -I/usr/local/pf/t -Mtest_paths /usr/local/pf/sbin/pfconfig -n pfconfig-test -s $pfconfig::constants::SOCKET_PATH -p $PFCONFIG_TEST_PID_FILE -c $pfconfig::constants::CONFIG_FILE_PATH -d`;
 
     my $manager = pfconfig::manager->new;
     $manager->expire_all;

--- a/t/setup_test_config.pm
+++ b/t/setup_test_config.pm
@@ -33,6 +33,26 @@ BEGIN {
 
     my $manager = pfconfig::manager->new;
     $manager->expire_all;
+    
+    use pf::db;
+    # Setup database connection infos based on ENV variables if they are defined
+    $pf::db::DB_Config->{host} = $ENV{PF_TEST_DB_HOST} // $pf::db::DB_Config->{host};
+    $pf::db::DB_Config->{user} = $ENV{PF_TEST_DB_USER} // $pf::db::DB_Config->{user};
+    $pf::db::DB_Config->{pass} = $ENV{PF_TEST_DB_PASS} // $pf::db::DB_Config->{pass};
+    $pf::db::DB_Config->{db}   = $ENV{PF_TEST_DB_NAME} // $pf::db::DB_Config->{db};
+    $pf::db::DB_Config->{port} = $ENV{PF_TEST_DB_PORT} // $pf::db::DB_Config->{port};
+
+    use pf::config;
+    # Setup IP and VIP of management network
+    if(defined($ENV{PF_TEST_MGMT_INT})){
+        my $section_name = "interface ".$ENV{PF_TEST_MGMT_INT};
+        $Config{$section_name}{ip} = $ENV{PF_TEST_MGMT_IP} // $pf::config::Config{$section_name}{ip};
+        $Config{$section_name}{vip} = $ENV{PF_TEST_MGMT_IP} // $pf::config::Config{$section_name}{vip};
+        $Config{$section_name}{mask} = $ENV{PF_TEST_MGMT_MASK} // $pf::config::Config{$section_name}{mask};
+        $management_network->tag('ip', $Config{$section_name}{ip});
+        $management_network->tag('vip', $Config{$section_name}{vip});
+        use Data::Dumper; print Dumper($Config{$section_name});
+    }
 }
  
 END {

--- a/t/setup_test_config.pm
+++ b/t/setup_test_config.pm
@@ -1,37 +1,48 @@
-#!/usr/bin/perl
-
+package setup_test_config;
 =head1 NAME
 
-linux.t
+setup_test_config
+
+=cut
 
 =head1 DESCRIPTION
 
-Linux tests
+setup_test_config
+Setups the configuration for the testing environment
 
 =cut
 
 use strict;
 use warnings;
-use diagnostics;
 
-use lib '/usr/local/pf/lib';
+
+our $PFCONFIG_TEST_PID_FILE;
+
 BEGIN {
-    use lib qw(/usr/local/pf/t);
-    use setup_test_config;
+    use test_paths;
+    use pfconfig::manager;
+    use pfconfig::constants;
+    use File::Spec::Functions qw(catfile);
+    use File::Slurp qw(read_file);
+
+    use File::Path qw(remove_tree);
+    remove_tree('/tmp/chi');
+
+    $PFCONFIG_TEST_PID_FILE = "/usr/local/pf/var/run/pfconfig-test.pid";
+    `/usr/local/pf/sbin/pfconfig -s $pfconfig::constants::SOCKET_PATH -p $PFCONFIG_TEST_PID_FILE -c $pfconfig::constants::CONFIG_FILE_PATH -d`;
+
+    my $manager = pfconfig::manager->new;
+    $manager->expire_all;
 }
-use Test::More tests => 2;
-use Test::NoWarnings;
-
-use pf::util;
-
-Log::Log4perl->init("log.conf");
-my $logger = Log::Log4perl->get_logger('linux.t');
-
-ok(defined(get_total_system_memory()), "fetch total system memory");
-
+ 
+END {
+    my $pid = read_file($PFCONFIG_TEST_PID_FILE);
+    `kill $pid`
+}
 =head1 AUTHOR
 
 Inverse inc. <info@inverse.ca>
+
 
 =head1 COPYRIGHT
 
@@ -52,7 +63,9 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
-USA.            
+USA.
 
 =cut
+
+1;
 

--- a/t/setup_test_config.pm
+++ b/t/setup_test_config.pm
@@ -51,7 +51,6 @@ BEGIN {
         $Config{$section_name}{mask} = $ENV{PF_TEST_MGMT_MASK} // $pf::config::Config{$section_name}{mask};
         $management_network->tag('ip', $Config{$section_name}{ip});
         $management_network->tag('vip', $Config{$section_name}{vip});
-        use Data::Dumper; print Dumper($Config{$section_name});
     }
 }
  

--- a/t/soh.t
+++ b/t/soh.t
@@ -17,7 +17,7 @@ use diagnostics;
 use lib '/usr/local/pf/lib';
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use Test::More tests => 19;

--- a/t/test_paths.pm
+++ b/t/test_paths.pm
@@ -25,7 +25,6 @@ BEGIN {
     use File::Basename qw(dirname);
     use pf::file_paths;
     use pfconfig::constants;
-    use pf::db;
 
     $test_dir = rel2abs(dirname($INC{'setup_test_config.pm'})) if exists $INC{'setup_test_config.pm'};
     $test_dir ||= catdir($install_dir,'t');
@@ -44,7 +43,7 @@ BEGIN {
     $pfconfig::constants::CONFIG_FILE_PATH = catfile($test_paths::test_dir, 'data/pfconfig.conf');
     $pfconfig::constants::SOCKET_PATH = "/usr/local/pf/var/run/pfconfig-test.sock";
 
-    $pf::db::DRIVER = "DBI:Mock";
+
 }
  
 =head1 AUTHOR

--- a/t/test_paths.pm
+++ b/t/test_paths.pm
@@ -25,6 +25,7 @@ BEGIN {
     use File::Basename qw(dirname);
     use pf::file_paths;
     use pfconfig::constants;
+    use pf::db;
 
     $test_dir = rel2abs(dirname($INC{'setup_test_config.pm'})) if exists $INC{'setup_test_config.pm'};
     $test_dir ||= catdir($install_dir,'t');
@@ -43,7 +44,7 @@ BEGIN {
     $pfconfig::constants::CONFIG_FILE_PATH = catfile($test_paths::test_dir, 'data/pfconfig.conf');
     $pfconfig::constants::SOCKET_PATH = "/usr/local/pf/var/run/pfconfig-test.sock";
 
-
+    $pf::db::DRIVER = "DBI:Mock";
 }
  
 =head1 AUTHOR

--- a/t/test_paths.pm
+++ b/t/test_paths.pm
@@ -1,13 +1,13 @@
-package PfFilePaths;
+package test_paths;
 =head1 NAME
 
-PfFilePaths
+test_paths
 
 =cut
 
 =head1 DESCRIPTION
 
-PfFilePaths
+test_paths
 Overrides the the location of config files to help with testing
 
 =cut
@@ -17,17 +17,15 @@ use warnings;
 
 
 our $PFCONFIG_TEST_PID_FILE;
+our $test_dir;
 
 BEGIN {
-    use File::Slurp qw(read_file);
-    use File::Path qw(remove_tree);
     use File::Spec::Functions qw(catfile catdir rel2abs);
     use File::Basename qw(dirname);
     use pf::file_paths;
     use pfconfig::constants;
-    use pfconfig::manager;
-    remove_tree('/tmp/chi');
-    my $test_dir = rel2abs(dirname($INC{'PfFilePaths.pm'})) if exists $INC{'PfFilePaths.pm'};
+
+    $test_dir = rel2abs(dirname($INC{'setup_test_config.pm'})) if exists $INC{'setup_test_config.pm'};
     $test_dir ||= catdir($install_dir,'t');
     $pf::file_paths::switches_config_file = catfile($test_dir,'data/switches.conf');
     $pf::file_paths::admin_roles_config_file = catfile($test_dir,'data/admin_roles.conf');
@@ -40,21 +38,13 @@ BEGIN {
     $pf::file_paths::firewall_sso_config_file = catfile($test_dir,'data/firewall_sso.conf');
     $pf::file_paths::config_file = catfile($test_dir,'data/pf.conf');
     $pf::file_paths::pf_config_file = catfile($test_dir,'data/pf.conf');
-
-    $pfconfig::constants::CONFIG_FILE_PATH = catfile($test_dir, 'data/pfconfig.conf');
+    
+    $pfconfig::constants::CONFIG_FILE_PATH = catfile($test_paths::test_dir, 'data/pfconfig.conf');
     $pfconfig::constants::SOCKET_PATH = "/usr/local/pf/var/run/pfconfig-test.sock";
 
-    $PFCONFIG_TEST_PID_FILE = "/usr/local/pf/var/run/pfconfig-test.pid";
-    `/usr/local/pf/sbin/pfconfig -s $pfconfig::constants::SOCKET_PATH -p $PFCONFIG_TEST_PID_FILE -c $pfconfig::constants::CONFIG_FILE_PATH -d`;
 
-    my $manager = pfconfig::manager->new;
-    $manager->expire_all;
- }
- 
-END {
-    my $pid = read_file($PFCONFIG_TEST_PID_FILE);
-    `kill $pid`
 }
+ 
 =head1 AUTHOR
 
 Inverse inc. <info@inverse.ca>
@@ -84,4 +74,5 @@ USA.
 =cut
 
 1;
+
 

--- a/t/test_paths.pm
+++ b/t/test_paths.pm
@@ -15,6 +15,7 @@ Overrides the the location of config files to help with testing
 use strict;
 use warnings;
 
+use lib "/usr/local/pf/lib";
 
 our $PFCONFIG_TEST_PID_FILE;
 our $test_dir;

--- a/t/unittest/CHI.t
+++ b/t/unittest/CHI.t
@@ -23,16 +23,16 @@ BEGIN {
 
     #Module for overriding configuration paths
     use setup_test_config;
-
 }
 
-use pf::CHI;
 
-use Test::More tests => 9;
+use Test::More tests => 10;
 use Test::Exception;
 
 #This test will running last
 use Test::NoWarnings;
+
+use_ok("pf::CHI");
 
 my $cache_miss = 0;
 

--- a/t/unittest/CHI.t
+++ b/t/unittest/CHI.t
@@ -22,7 +22,7 @@ BEGIN {
     use lib qw(/usr/local/pf/t);
 
     #Module for overriding configuration paths
-    use PfFilePaths;
+    use setup_test_config;
 
 }
 

--- a/t/unittest/Portal/ProfileFactory.t
+++ b/t/unittest/Portal/ProfileFactory.t
@@ -21,7 +21,7 @@ BEGIN {
     #include test libs
     use lib qw(/usr/local/pf/t);
     #Module for overriding configuration paths
-    use PfFilePaths;
+    use setup_test_config;
     use_ok("pf::Portal::ProfileFactory");
 }
 

--- a/t/unittest/admin_roles.t
+++ b/t/unittest/admin_roles.t
@@ -14,7 +14,7 @@ use strict;
 use warnings;
 BEGIN {
     use lib qw(/usr/local/pf/t /usr/local/pf/lib);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use Test::More tests => 7;                      # last test to print

--- a/t/unittest/authentication.t
+++ b/t/unittest/authentication.t
@@ -21,7 +21,7 @@ use diagnostics;
 use lib '/usr/local/pf/lib';
 BEGIN {
     use lib '/usr/local/pf/t';
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 

--- a/t/unittest/condition/all.t
+++ b/t/unittest/condition/all.t
@@ -21,7 +21,7 @@ BEGIN {
     #include test libs
     use lib qw(/usr/local/pf/t);
     #Module for overriding configuration paths
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 

--- a/t/unittest/condition/any.t
+++ b/t/unittest/condition/any.t
@@ -21,7 +21,7 @@ BEGIN {
     #include test libs
     use lib qw(/usr/local/pf/t);
     #Module for overriding configuration paths
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 

--- a/t/unittest/condition/date_after.t
+++ b/t/unittest/condition/date_after.t
@@ -15,7 +15,7 @@ use warnings;
 use lib qw(/usr/local/pf/lib);
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use Test::More tests => 8;                      # last test to print

--- a/t/unittest/condition/date_before.t
+++ b/t/unittest/condition/date_before.t
@@ -15,7 +15,7 @@ use warnings;
 use lib qw(/usr/local/pf/lib);
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use Test::More tests => 8;                      # last test to print

--- a/t/unittest/condition/equal.t
+++ b/t/unittest/condition/equal.t
@@ -15,7 +15,7 @@ use warnings;
 use lib qw(/usr/local/pf/lib);
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use Test::More tests => 6;                      # last test to print

--- a/t/unittest/condition/exists_in.t
+++ b/t/unittest/condition/exists_in.t
@@ -15,7 +15,7 @@ use warnings;
 use lib qw(/usr/local/pf/lib);
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use Test::More tests => 6;                      # last test to print

--- a/t/unittest/condition/includes.t
+++ b/t/unittest/condition/includes.t
@@ -13,7 +13,7 @@ use warnings;
 use lib qw(/usr/local/pf/lib);
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use Test::More tests => 6;                      # last test to print

--- a/t/unittest/condition/key.t
+++ b/t/unittest/condition/key.t
@@ -15,7 +15,7 @@ use warnings;
 use lib qw(/usr/local/pf/lib);
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use Test::More tests => 8;                      # last test to print

--- a/t/unittest/condition/matches.t
+++ b/t/unittest/condition/matches.t
@@ -15,7 +15,7 @@ use warnings;
 use lib qw(/usr/local/pf/lib);
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use Test::More tests => 6;                      # last test to print

--- a/t/unittest/condition/network.t
+++ b/t/unittest/condition/network.t
@@ -15,7 +15,7 @@ use warnings;
 use lib qw(/usr/local/pf/lib);
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 use NetAddr::IP;
 

--- a/t/unittest/condition/regex.t
+++ b/t/unittest/condition/regex.t
@@ -15,7 +15,7 @@ use warnings;
 use lib qw(/usr/local/pf/lib);
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use Test::More tests => 7;                      # last test to print

--- a/t/unittest/condition_parser.t
+++ b/t/unittest/condition_parser.t
@@ -22,7 +22,7 @@ BEGIN {
     use lib qw(/usr/local/pf/t);
 
     #Module for overriding configuration paths
-    use PfFilePaths;
+    use setup_test_config;
 
     @VALID_STRING_TESTS = (
         ['a && b',      ['AND', 'a', 'b']],

--- a/t/unittest/detect/parser/fortianalyser.t
+++ b/t/unittest/detect/parser/fortianalyser.t
@@ -21,7 +21,7 @@ BEGIN {
     #include test libs
     use lib qw(/usr/local/pf/t);
     #Module for overriding configuration paths
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use_ok('pf::factory::detect::parser');

--- a/t/unittest/detect/parser/snort.t
+++ b/t/unittest/detect/parser/snort.t
@@ -21,7 +21,7 @@ BEGIN {
     #include test libs
     use lib qw(/usr/local/pf/t);
     #Module for overriding configuration paths
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use_ok('pf::factory::detect::parser');

--- a/t/unittest/filter_engine.t
+++ b/t/unittest/filter_engine.t
@@ -21,7 +21,7 @@ BEGIN {
     #include test libs
     use lib qw(/usr/local/pf/t);
     #Module for overriding configuration paths
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 

--- a/t/unittest/firewall_sso.t
+++ b/t/unittest/firewall_sso.t
@@ -21,7 +21,7 @@ BEGIN {
     use lib qw(/usr/local/pf/t);
     use File::Spec::Functions qw(catfile catdir rel2abs);
     use File::Basename qw(dirname);
-    use PfFilePaths;
+    use setup_test_config;
 }
 use Test::More tests => 10;
 

--- a/t/unittest/merged_list.t
+++ b/t/unittest/merged_list.t
@@ -24,7 +24,7 @@ BEGIN {
     use setup_test_config;
     my $test_dir = rel2abs(dirname($INC{'setup_test_config.pm'})) if exists $INC{'setup_test_config.pm'};
     $test_dir ||= catdir($pf::file_paths::install_dir,'t');
-    $pf::file_paths::pf_config_file = catfile($test_dir,'data/pf.conf');
+    $pf::file_paths::pf_config_file = catfile($test_dir,'data/pf.conf.tmp');
 }
 use Test::More tests => 6;
 

--- a/t/unittest/merged_list.t
+++ b/t/unittest/merged_list.t
@@ -21,8 +21,8 @@ BEGIN {
     use lib qw(/usr/local/pf/t);
     use File::Spec::Functions qw(catfile catdir rel2abs);
     use File::Basename qw(dirname);
-    use PfFilePaths;
-    my $test_dir = rel2abs(dirname($INC{'PfFilePaths.pm'})) if exists $INC{'PfFilePaths.pm'};
+    use setup_test_config;
+    my $test_dir = rel2abs(dirname($INC{'setup_test_config.pm'})) if exists $INC{'setup_test_config.pm'};
     $test_dir ||= catdir($pf::file_paths::install_dir,'t');
     $pf::file_paths::pf_config_file = catfile($test_dir,'data/pf.conf');
 }

--- a/t/unittest/node.t
+++ b/t/unittest/node.t
@@ -19,7 +19,7 @@ BEGIN {
     #include test libs
     use lib qw(/usr/local/pf/t);
     #Module for overriding configuration paths
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use pf::node;

--- a/t/unittest/password.t
+++ b/t/unittest/password.t
@@ -7,6 +7,7 @@ my $FALSE = 0;
 my $TRUE = 1;
 
 BEGIN {
+    use setup_test_config;
     use_ok('pf::password') or die;
     use pf::password 'bcrypt';
 }

--- a/t/unittest/pfconfig/cached.t
+++ b/t/unittest/pfconfig/cached.t
@@ -15,7 +15,7 @@ use strict;
 use warnings;
 BEGIN {
     use lib qw(/usr/local/pf/t /usr/local/pf/lib);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use Test::More tests => 21;                      # last test to print

--- a/t/unittest/pfconfig/cached_array.t
+++ b/t/unittest/pfconfig/cached_array.t
@@ -14,7 +14,7 @@ use strict;
 use warnings;
 BEGIN {
     use lib qw(/usr/local/pf/t /usr/local/pf/lib);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use Test::More tests => 13;                      # last test to print

--- a/t/unittest/pfconfig/cached_hash.t
+++ b/t/unittest/pfconfig/cached_hash.t
@@ -14,7 +14,7 @@ use strict;
 use warnings;
 BEGIN {
     use lib qw(/usr/local/pf/t /usr/local/pf/lib);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use Test::More tests => 21;                      # last test to print

--- a/t/unittest/provisioner.t
+++ b/t/unittest/provisioner.t
@@ -17,7 +17,7 @@ use lib '/usr/local/pf/lib';
 
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 use Test::More tests => 11;
 

--- a/t/unittest/provisioner/android.t
+++ b/t/unittest/provisioner/android.t
@@ -17,7 +17,7 @@ use lib '/usr/local/pf/lib';
 
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 use Test::More tests => 5;
 

--- a/t/unittest/provisioner/mobileconfig.t
+++ b/t/unittest/provisioner/mobileconfig.t
@@ -17,7 +17,7 @@ use lib '/usr/local/pf/lib';
 
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 use Test::More tests => 5;
 

--- a/t/unittest/provisioner/symantec.t
+++ b/t/unittest/provisioner/symantec.t
@@ -16,7 +16,7 @@ use warnings;
 use lib qw(/usr/local/pf/lib);
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use Test::More tests => 7;                      # last test to print

--- a/t/unittest/switch_groups.t
+++ b/t/unittest/switch_groups.t
@@ -19,7 +19,7 @@ BEGIN {
     #include test libs
     use lib qw(/usr/local/pf/t);
     #Module for overriding configuration paths
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use pf::node;

--- a/t/unittest/util/networking.t
+++ b/t/unittest/util/networking.t
@@ -18,7 +18,7 @@ BEGIN {
     #include test libs
     use lib qw(/usr/local/pf/t);
     #Module for overriding configuration paths
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use Test::More tests => 10;

--- a/t/unittest/violations.t
+++ b/t/unittest/violations.t
@@ -22,7 +22,7 @@ BEGIN {
     #include test libs
     use lib qw(/usr/local/pf/t);
     #Module for overriding configuration paths
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use_ok('pf::violation');

--- a/t/useragent.t
+++ b/t/useragent.t
@@ -12,7 +12,7 @@ use diagnostics;
 use lib '/usr/local/pf/lib';
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use Test::More tests => 13;

--- a/t/util-dhcp.t
+++ b/t/util-dhcp.t
@@ -16,7 +16,7 @@ use diagnostics;
 use lib '/usr/local/pf/lib';
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use Test::More;

--- a/t/util-radius.t
+++ b/t/util-radius.t
@@ -16,7 +16,7 @@ use diagnostics;
 use lib '/usr/local/pf/lib';
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use Test::More tests => 2;

--- a/t/util.t
+++ b/t/util.t
@@ -6,7 +6,7 @@ use warnings;
 use lib '/usr/local/pf/lib';
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 use Test::More tests => 37;
 use Test::NoWarnings;

--- a/t/vlan_utils.t
+++ b/t/vlan_utils.t
@@ -22,7 +22,7 @@ BEGIN {
     use lib qw(/usr/local/pf/t /root/code/packetfence/t);
 
     #Module for overriding configuration paths
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use Test::More tests => 6;

--- a/t/web-auth.t
+++ b/t/web-auth.t
@@ -16,7 +16,7 @@ use diagnostics;
 use lib '/usr/local/pf/lib';
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 
 use File::Basename qw(basename);

--- a/t/web.t
+++ b/t/web.t
@@ -16,7 +16,7 @@ use diagnostics;
 use lib '/usr/local/pf/lib';
 BEGIN {
     use lib qw(/usr/local/pf/t);
-    use PfFilePaths;
+    use setup_test_config;
 }
 use Test::More tests => 23;
 use Test::MockObject::Extends;


### PR DESCRIPTION
# Description

Dedicates a pfconfig process for testing
Allows to override the configuration and PID file path of pfconfig via the command line
Makes use of a BDB backend for testing
Allow to change the backend of pfconfig via configuration
# Impacts

pfconfig for the new options introduced
The unit tests
# Delete branch after merge

YES
# NEWS file entries
## Enhancements
- The pfconfig backend can now be configured.
