### PR TITLE
Escape the attribute before trying to do a search

### DIFF
--- a/lib/pf/Authentication/Source/LDAPSource.pm
+++ b/lib/pf/Authentication/Source/LDAPSource.pm
@@ -345,7 +345,7 @@ sub match_in_subclass {
         # Perform match on a static group condition since they require a second LDAP search
         foreach $condition (grep { $_->{'operator'} eq $Conditions::IS_MEMBER } @{$own_conditions}) {
             $value = escape_filter_value($condition->{'value'});
-            $attribute = $entry->get_value($condition->{'attribute'});
+            $attribute = $entry->get_value($condition->{'attribute'}) // '';
             $attribute = escape_filter_value($attribute);
             # Search for any type of group definition:
             # - groupOfNames       => member (dn)

--- a/lib/pf/Authentication/Source/LDAPSource.pm
+++ b/lib/pf/Authentication/Source/LDAPSource.pm
@@ -346,6 +346,7 @@ sub match_in_subclass {
         foreach $condition (grep { $_->{'operator'} eq $Conditions::IS_MEMBER } @{$own_conditions}) {
             $value = escape_filter_value($condition->{'value'});
             $attribute = $entry->get_value($condition->{'attribute'});
+            $attribute = escape_filter_value($attribute);
             # Search for any type of group definition:
             # - groupOfNames       => member (dn)
             # - groupOfUniqueNames => uniqueMember (dn)


### PR DESCRIPTION
# Description

Escape the ldap value (sometimes it can contain unescape caracters)
# Impacts

NO
# Issue

Fix wrong filter if the value returned by ldap is not escaped.
# Delete branch after merge

YES
# NEWS file entries
## Bug Fixes
- Fix unescape value in ldap search
