### PR TITLE
Only load the configured switches for services

### DIFF
--- a/conf/httpd.conf.d/httpd.admin.tt.example
+++ b/conf/httpd.conf.d/httpd.admin.tt.example
@@ -104,9 +104,9 @@ AcceptMutex posixsem
 PerlSwitches -I[% install_dir %]/lib
 PerlSwitches -I[% install_dir %]/html/pfappserver/lib
 PerlLoadModule pfappserver
-PerlLoadModule pf::WebAPI::InitHandler
-PerlPostConfigHandler pf::WebAPI::InitHandler::post_config
-PerlChildInitHandler pf::WebAPI::InitHandler::child_init
+PerlLoadModule pf::WebAPI::InitHandler->Admin
+PerlPostConfigHandler pf::WebAPI::InitHandler->Admin->post_config
+PerlChildInitHandler pf::WebAPI::InitHandler->Admin->child_init
 PidFile [% install_dir %]/var/run/[% name %].pid
 Include [% install_dir %]/conf/httpd.conf.d/log.conf
 User pf

--- a/conf/httpd.conf.d/httpd.admin.tt.example
+++ b/conf/httpd.conf.d/httpd.admin.tt.example
@@ -104,9 +104,9 @@ AcceptMutex posixsem
 PerlSwitches -I[% install_dir %]/lib
 PerlSwitches -I[% install_dir %]/html/pfappserver/lib
 PerlLoadModule pfappserver
-PerlLoadModule pf::WebAPI::InitHandler->Admin
-PerlPostConfigHandler pf::WebAPI::InitHandler->Admin->post_config
-PerlChildInitHandler pf::WebAPI::InitHandler->Admin->child_init
+PerlLoadModule pf::WebAPI::InitHandler::Admin
+PerlPostConfigHandler pf::WebAPI::InitHandler::Admin->post_config
+PerlChildInitHandler pf::WebAPI::InitHandler::Admin->child_init
 PidFile [% install_dir %]/var/run/[% name %].pid
 Include [% install_dir %]/conf/httpd.conf.d/log.conf
 User pf

--- a/conf/httpd.conf.d/httpd.portal.tt.example
+++ b/conf/httpd.conf.d/httpd.portal.tt.example
@@ -156,7 +156,7 @@ PerlLoadModule pf::web::apache2_version
 PerlLoadModule pf::web::dispatcher
 PerlLoadModule pf::WebAPI::InitHandler
 PerlLoadModule pf::web::billinghook
-PerlPostConfigHandler pf::WebAPI::InitHandler::post_config
+PerlPostConfigHandler pf::WebAPI::InitHandler->post_config
 
 # The TransHandler handles the 'captive-portal' core piece redirecting to the
 # portal if the URL is not otherwised allowed by passthrough or part of the
@@ -261,7 +261,7 @@ QS_SrvMaxConnPerIP [% captive_portal.httpd_mod_qos_maximum_connections_per_devic
 HostnameLookups off
 MaxRequestsPerChild 1000
 PerlInitHandler pf::WebAPI::InitHandler
-PerlChildInitHandler pf::WebAPI::InitHandler::child_init
+PerlChildInitHandler pf::WebAPI::InitHandler->child_init
 
 SSLPassPhraseDialog builtin
 SSLSessionCacheTimeout 300

--- a/conf/httpd.conf.d/httpd.proxy.tt.example
+++ b/conf/httpd.conf.d/httpd.proxy.tt.example
@@ -106,8 +106,8 @@ PerlSwitches -I[% install_dir %]/lib
 PerlSwitches -I[% install_dir %]/html/pfappserver/lib
 PerlLoadModule pfappserver
 PerlLoadModule pf::WebAPI::InitHandler
-PerlPostConfigHandler pf::WebAPI::InitHandler::post_config
-PerlChildInitHandler pf::WebAPI::InitHandler::child_init
+PerlPostConfigHandler pf::WebAPI::InitHandler->post_config
+PerlChildInitHandler pf::WebAPI::InitHandler->child_init
 PidFile [% install_dir %]/var/run/[% name %].pid
 Include [% install_dir %]/conf/httpd.conf.d/log.conf
 User pf

--- a/conf/httpd.conf.d/httpd.webservices.tt.example
+++ b/conf/httpd.conf.d/httpd.webservices.tt.example
@@ -114,9 +114,9 @@ PerlSwitches -I[% install_dir %]/html/pfappserver/lib
 PerlPostConfigRequire [% install_dir %]/lib/pf/web/[% name %]_modperl_require.pl
 PerlLoadModule pf::WebAPI
 PerlLoadModule pf::WebAPI::InitHandler
-PerlPostConfigHandler pf::WebAPI::InitHandler::post_config
+PerlPostConfigHandler pf::WebAPI::InitHandler->post_config
 PerlInitHandler pf::WebAPI::InitHandler
-PerlChildInitHandler pf::WebAPI::InitHandler::child_init
+PerlChildInitHandler pf::WebAPI::InitHandler->child_init
 SetEnvIf User-Agent collectd is_collectd
 
 PidFile [% install_dir %]/var/run/[% name %].pid

--- a/html/pfappserver/lib/pfappserver.pm
+++ b/html/pfappserver/lib/pfappserver.pm
@@ -44,7 +44,7 @@ BEGIN {
 use pf::config::cached;
 use pf::CHI;
 use pf::SwitchFactory;
-pf::SwitchFactory::preLoadModules();
+pf::SwitchFactory->preloadConfiguredModules();
 
 extends 'Catalyst';
 

--- a/html/pfappserver/lib/pfappserver.pm
+++ b/html/pfappserver/lib/pfappserver.pm
@@ -44,7 +44,7 @@ BEGIN {
 use pf::config::cached;
 use pf::CHI;
 use pf::SwitchFactory;
-pf::SwitchFactory->preloadConfiguredModules();
+pf::SwitchFactory->preloadAllModules();
 
 extends 'Catalyst';
 

--- a/lib/pf/WebAPI/InitHandler.pm
+++ b/lib/pf/WebAPI/InitHandler.pm
@@ -67,7 +67,7 @@ sub post_config {
 
 =head2 preloadSwitches
 
-TODO: documention
+Preload switches in the post_config
 
 =cut
 

--- a/lib/pf/WebAPI/InitHandler.pm
+++ b/lib/pf/WebAPI/InitHandler.pm
@@ -61,7 +61,7 @@ sub post_config {
     pf::StatsD->closeStatsd;
     db_disconnect();
     pf::CHI->clear_memoized_cache_objects;
-    pf::SwitchFactory::preLoadModules();
+    pf::SwitchFactory->preloadConfiguredModules();
     return Apache2::Const::OK;
 }
 

--- a/lib/pf/WebAPI/InitHandler.pm
+++ b/lib/pf/WebAPI/InitHandler.pm
@@ -38,7 +38,7 @@ Refresh any configurations
 =cut
 
 sub child_init {
-    my ($child_pool, $s) = @_;
+    my ($class, $child_pool, $s) = @_;
     #Avoid child processes having the same random seed
     srand();
     pf::StatsD->initStatsd;
@@ -57,12 +57,23 @@ Close connections to avoid any sharing of sockets
 =cut
 
 sub post_config {
-    my ($conf_pool, $log_pool, $temp_pool, $s) = @_;
+    my ($class, $conf_pool, $log_pool, $temp_pool, $s) = @_;
     pf::StatsD->closeStatsd;
     db_disconnect();
+    $class->preloadSwitches();
     pf::CHI->clear_memoized_cache_objects;
-    pf::SwitchFactory->preloadConfiguredModules();
     return Apache2::Const::OK;
+}
+
+=head2 preloadSwitches
+
+TODO: documention
+
+=cut
+
+sub preloadSwitches {
+    my ($class) = @_;
+    pf::SwitchFactory->preloadConfiguredModules();
 }
 
 =head1 AUTHOR

--- a/lib/pf/WebAPI/InitHandler/Admin.pm
+++ b/lib/pf/WebAPI/InitHandler/Admin.pm
@@ -1,0 +1,55 @@
+package pf::WebAPI::InitHandler::Admin::Admin;
+
+=head1 NAME
+
+pf::WebAPI::InitHandler::Admin
+
+=cut
+
+=head1 DESCRIPTION
+
+pf::WebAPI::InitHandler::Admin
+
+=cut
+
+use strict;
+use warnings;
+
+use pf::SwitchFactory();
+
+use base qw(pf::WebAPI::InitHandler);
+
+sub preloadSwitches {
+    pf::SwitchFactory->preloadAllModules();
+}
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2016 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;
+

--- a/lib/pf/WebAPI/InitHandler/Admin.pm
+++ b/lib/pf/WebAPI/InitHandler/Admin.pm
@@ -1,4 +1,4 @@
-package pf::WebAPI::InitHandler::Admin::Admin;
+package pf::WebAPI::InitHandler::Admin;
 
 =head1 NAME
 

--- a/lib/pf/WebAPI/InitHandler/Admin.pm
+++ b/lib/pf/WebAPI/InitHandler/Admin.pm
@@ -19,6 +19,12 @@ use pf::SwitchFactory();
 
 use base qw(pf::WebAPI::InitHandler);
 
+=head2 preloadSwitches
+
+Preload all the switches
+
+=cut
+
 sub preloadSwitches {
     pf::SwitchFactory->preloadAllModules();
 }

--- a/lib/pfconfig/namespaces/config/Switch.pm
+++ b/lib/pfconfig/namespaces/config/Switch.pm
@@ -29,8 +29,8 @@ use base 'pfconfig::namespaces::config';
 sub init {
     my ($self) = @_;
     $self->{file}            = $switches_config_file;
-    $self->{child_resources} = [ 'resource::default_switch', 'resource::switches_ranges', 'interfaces::management_network' ];
-    
+    $self->{child_resources} = [ 'resource::default_switch', 'resource::switches_ranges', 'interfaces::management_network', 'resource::SwitchTypesConfigured' ];
+
     $self->{management_network} = $self->{cache}->get_cache('interfaces::management_network');
 }
 
@@ -54,9 +54,9 @@ sub build_child {
         push @management_ips, $self->{management_network}->tag('ip') if(defined($self->{management_network}->tag('ip')));
         foreach my $management_ip (@management_ips){
             $tmp_cfg{$management_ip} = {
-                type => 'PacketFence', 
-                mode => 'production', 
-                radiusSecret => 'testing1234', 
+                type => 'PacketFence',
+                mode => 'production',
+                radiusSecret => 'testing1234',
             };
         }
     }

--- a/lib/pfconfig/namespaces/resource/SwitchTypesConfigured.pm
+++ b/lib/pfconfig/namespaces/resource/SwitchTypesConfigured.pm
@@ -1,0 +1,74 @@
+package pfconfig::namespaces::resource::SwitchTypesConfigured;
+
+=head1 NAME
+
+pfconfig::namespaces::resource::SwitchTypesConfigured
+
+=cut
+
+=head1 DESCRIPTION
+
+pfconfig::namespaces::resource::SwitchTypesConfigured
+
+This module creates the configuration hash of all the switches ranges (ex : 192.168.1.0/24)
+
+=cut
+
+use strict;
+use warnings;
+
+use base 'pfconfig::namespaces::resource';
+
+use NetAddr::IP;
+
+sub init {
+    my ($self) = @_;
+    # we depend on the switch configuration object (russian doll style)
+    $self->{switches} = $self->{cache}->get_cache('config::Switch');
+}
+
+sub build {
+    my ($self) = @_;
+    my %types;
+    my @ranges;
+    foreach my $data ( values %{$self->{switches}} ) {
+        my $type = $data->{type};
+        next if !defined $type;
+        $types{"pf::Switch::$type"} = 1;
+    }
+    return \%types;
+}
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2016 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;
+
+# vim: set shiftwidth=4:
+# vim: set expandtab:
+# vim: set backspace=indent,eol,start:
+

--- a/lib/pfconfig/namespaces/resource/SwitchTypesConfigured.pm
+++ b/lib/pfconfig/namespaces/resource/SwitchTypesConfigured.pm
@@ -10,7 +10,7 @@ pfconfig::namespaces::resource::SwitchTypesConfigured
 
 pfconfig::namespaces::resource::SwitchTypesConfigured
 
-This module creates the configuration hash of all the switches ranges (ex : 192.168.1.0/24)
+This module creates a hash of all the configured switches
 
 =cut
 
@@ -21,11 +21,23 @@ use base 'pfconfig::namespaces::resource';
 
 use NetAddr::IP;
 
+=head2 init
+
+Initialize the pfconfig::namespaces::resource::SwitchTypesConfigured object
+
+=cut
+
 sub init {
     my ($self) = @_;
     # we depend on the switch configuration object (russian doll style)
     $self->{switches} = $self->{cache}->get_cache('config::Switch');
 }
+
+=head2 build
+
+Builds a hash of all the configured switches
+
+=cut
 
 sub build {
     my ($self) = @_;

--- a/sbin/pfdetect
+++ b/sbin/pfdetect
@@ -41,7 +41,7 @@ use pf::services::util;
 use pf::violation;
 use pf::SwitchFactory;
 
-pf::SwitchFactory::preLoadModules();
+pf::SwitchFactory->preloadConfiguredModules();
 use pf::factory::detect::parser;
 use pf::client;
 use pfconfig::cached_hash;

--- a/sbin/pfdhcplistener
+++ b/sbin/pfdhcplistener
@@ -48,7 +48,7 @@ use NetPacket::IPv6;
 use NetPacket::UDP;
 
 
-pf::SwitchFactory::preLoadModules();
+pf::SwitchFactory->preloadConfiguredModules();
 
 # initialization
 # --------------

--- a/sbin/pfdns
+++ b/sbin/pfdns
@@ -47,7 +47,7 @@ use pf::node;
 use Storable 'dclone';
 use pf::access_filter::dns;
 
-pf::SwitchFactory::preLoadModules();
+pf::SwitchFactory->preloadConfiguredModules();
 
 # initialization
 # --------------

--- a/sbin/pfmon
+++ b/sbin/pfmon
@@ -57,7 +57,7 @@ use fingerbank::Config;
 use fingerbank::Redis;
 use fingerbank::DB;
 
-pf::SwitchFactory::preLoadModules();
+pf::SwitchFactory->preloadConfiguredModules();
 
 # initialization
 # --------------

--- a/sbin/pfqueue
+++ b/sbin/pfqueue
@@ -89,7 +89,7 @@ daemonize($PROGRAM_NAME) if ($daemonize);
 our $PARENT_PID = $$;
 Log::Log4perl::MDC->put( 'tid', $$ );
 
-pf::SwitchFactory::preLoadModules();
+pf::SwitchFactory->preloadConfiguredModules();
 
 register_tasks();
 wait_for_it();

--- a/sbin/pfsetvlan
+++ b/sbin/pfsetvlan
@@ -72,7 +72,7 @@ use pf::services::util;
 use pf::violation;
 use pf::role::custom $ROLE_API_LEVEL;
 
-pf::SwitchFactory::preLoadModules();
+pf::SwitchFactory->preloadConfiguredModules();
 
 use threads;
 use threads::shared;

--- a/t/benchmarks/pf-switchfactory-preload.pl
+++ b/t/benchmarks/pf-switchfactory-preload.pl
@@ -28,7 +28,7 @@ BEGIN {
 }
 use pfconfig::manager;
 pfconfig::manager->new->expire_all;
-pf::SwitchFactory::preLoadModules() if $ARGV[0];
+pf::SwitchFactory->preloadConfiguredModules() if $ARGV[0];
 
 my @SWITCHES = (keys %pf::SwitchFactory::SwitchConfig);
 


### PR DESCRIPTION
## Description

To avoid using too much memory only load switches that are configured
## Impacts

All pf services that preload switches
## NEWS file entries

Enhancements
++++++++++++
- Only preload switch modules that are configured to reduce memory usage

Bug Fixes
+++++++++
Fixes #1308 
## Delete branch after merge

NO

NOTES
++++++++
Remove your old conf/httpd.conf/*.tt files as they the example file have changed
