### PR TITLE
Replaced call to packetfence.pm with an unlang policy.

### DIFF
--- a/conf/radiusd/packetfence.example
+++ b/conf/radiusd/packetfence.example
@@ -94,7 +94,7 @@ authorize {
 			&control:Auth-Type := Accept
 		}
 	}
-	packetfence
+	packetfence-eap-mac-policy
 	#
 	#  Look in an SQL database.  The schema of the database
 	#  is meant to mirror the "users" file.

--- a/raddb/policy.d/packetfence
+++ b/raddb/policy.d/packetfence
@@ -49,3 +49,21 @@ request-timing {
         }
     }
 }
+
+packetfence-eap-mac-policy {
+    if ( &EAP-Type ) {
+
+        if (&Calling-Station-Id && (&Calling-Station-Id =~ /^${policy.mac-addr-regexp}$/i)) {
+            update {
+                &request:Tmp-String-1 := "%{tolower:%{1}%{2}%{3}%{4}%{5}%{6}}"
+            }
+            if  ( &Tmp-String-1 == "%{tolower:%{User-Name}}" ) {
+                update {
+                    &control:Cleartext-Password := &request:User-Name
+                }
+                updated
+            }
+        }
+    }
+    noop
+}


### PR DESCRIPTION
# Description

Fixes broken eap-tls authentication in FR 3.
EAP-TLS sometimes sends very long "EAP-Message" attributes which it can't seem to pass to packetfence.pm.
This PR removes the need to call packetfence.pm in "authorize", thus obviating the risk of such an occurence.
Performance improvements are also a possible benefit.
# Impacts

All RADIUS authentication will hit this policy.
Nothing should actually trigger it unless it's EAP-MAC auth which is rare.
# Delete branch after merge

YES 
# NEWS file entries

This is purely internal.
I don't think it warrants an entry an in the NEWS file.
## Bug Fixes

None that were known before I hit one and fixed it here.
