### PR TITLE
Support register node by IP address in webservice

### DIFF
--- a/lib/pf/api.pm
+++ b/lib/pf/api.pm
@@ -566,29 +566,9 @@ sub register_node : Public {
     my ($class, %postdata )  = @_;
     my @require = qw(mac pid);
     my @found = grep {exists $postdata{$_}} @require;
-    return unless pf::util::validate_argv(\@require,  \@found);
+    return (0) unless pf::util::validate_argv(\@require,  \@found);
 
-    pf::node::node_register($postdata{'mac'}, $postdata{'pid'}, %postdata);
-    return;
-}
-
-=head2 register_node_ip
-
-Register a node by ip address
-
-=cut
-
-sub register_node_ip : Public {
-    my ($class, %postdata )  = @_;
-    my @require = qw(ip pid);
-    my @found = grep {exists $postdata{$_}} @require;
-    return unless pf::util::validate_argv(\@require,  \@found);
-
-    my $mac = pf::iplog::ip2mac($postdata{'ip'});
-    die "Cannot find host with IP address $postdata{'ip'}" unless $mac;
-
-    pf::node::node_register($mac, $postdata{'pid'}, %postdata);
-    return;
+    return pf::node::node_register($postdata{'mac'}, $postdata{'pid'}, %postdata);
 }
 
 =head2 deregister_node
@@ -601,10 +581,45 @@ sub deregister_node : Public {
     my ($class, %postdata )  = @_;
     my @require = qw(mac);
     my @found = grep {exists $postdata{$_}} @require;
-    return unless pf::util::validate_argv(\@require,  \@found);
+    return (0) unless pf::util::validate_argv(\@require,  \@found);
 
-    pf::node::node_deregister($postdata{'mac'}, %postdata);
-    return;
+    return pf::node::node_deregister($postdata{'mac'}, %postdata);
+}
+
+=head2 register_node_ip
+
+Register a node by IP address
+
+=cut
+
+sub register_node_ip : Public {
+    my ($class, %postdata )  = @_;
+    my @require = qw(ip pid);
+    my @found = grep {exists $postdata{$_}} @require;
+    return (0) unless pf::util::validate_argv(\@require,  \@found);
+
+    my $mac = pf::iplog::ip2mac($postdata{'ip'});
+    die "Cannot find host with IP address $postdata{'ip'}" unless $mac;
+
+    return pf::node::node_register($mac, $postdata{'pid'}, %postdata);
+}
+
+=head2 deregister_node_ip
+
+Deregister a node by IP address
+
+=cut
+
+sub deregister_node_ip : Public {
+    my ($class, %postdata )  = @_;
+    my @require = qw(ip);
+    my @found = grep {exists $postdata{$_}} @require;
+    return (0) unless pf::util::validate_argv(\@require,  \@found);
+
+    my $mac = pf::iplog::ip2mac($postdata{'ip'});
+    die "Cannot find host with IP address $postdata{'ip'}" unless $mac;
+
+    return pf::node::node_deregister($mac, %postdata);
 }
 
 =head2 node_information

--- a/lib/pf/api.pm
+++ b/lib/pf/api.pm
@@ -566,7 +566,7 @@ sub register_node : Public {
     my ($class, %postdata )  = @_;
     my @require = qw(mac pid);
     my @found = grep {exists $postdata{$_}} @require;
-    return (0) unless pf::util::validate_argv(\@require,  \@found);
+    return unless pf::util::validate_argv(\@require,  \@found);
 
     return pf::node::node_register($postdata{'mac'}, $postdata{'pid'}, %postdata);
 }
@@ -581,7 +581,7 @@ sub deregister_node : Public {
     my ($class, %postdata )  = @_;
     my @require = qw(mac);
     my @found = grep {exists $postdata{$_}} @require;
-    return (0) unless pf::util::validate_argv(\@require,  \@found);
+    return unless pf::util::validate_argv(\@require,  \@found);
 
     return pf::node::node_deregister($postdata{'mac'}, %postdata);
 }
@@ -596,7 +596,7 @@ sub register_node_ip : Public {
     my ($class, %postdata )  = @_;
     my @require = qw(ip pid);
     my @found = grep {exists $postdata{$_}} @require;
-    return (0) unless pf::util::validate_argv(\@require,  \@found);
+    return unless pf::util::validate_argv(\@require,  \@found);
 
     my $mac = pf::iplog::ip2mac($postdata{'ip'});
     die "Cannot find host with IP address $postdata{'ip'}" unless $mac;
@@ -614,7 +614,7 @@ sub deregister_node_ip : Public {
     my ($class, %postdata )  = @_;
     my @require = qw(ip);
     my @found = grep {exists $postdata{$_}} @require;
-    return (0) unless pf::util::validate_argv(\@require,  \@found);
+    return unless pf::util::validate_argv(\@require,  \@found);
 
     my $mac = pf::iplog::ip2mac($postdata{'ip'});
     die "Cannot find host with IP address $postdata{'ip'}" unless $mac;

--- a/lib/pf/api.pm
+++ b/lib/pf/api.pm
@@ -572,6 +572,25 @@ sub register_node : Public {
     return;
 }
 
+=head2 register_node_ip
+
+Register a node by ip address
+
+=cut
+
+sub register_node_ip : Public {
+    my ($class, %postdata )  = @_;
+    my @require = qw(ip pid);
+    my @found = grep {exists $postdata{$_}} @require;
+    return unless pf::util::validate_argv(\@require,  \@found);
+
+    my $mac = pf::iplog::ip2mac($postdata{'ip'});
+    die "Cannot find host with IP address $postdata{'ip'}" unless $mac;
+
+    pf::node::node_register($mac, $postdata{'pid'}, %postdata);
+    return;
+}
+
 =head2 deregister_node
 
 Deregister a node


### PR DESCRIPTION
# Description

(REQUIRED)
Allow PacketFence to provide Web Service API to register a node by an IP address, this is useful when a captive portal is from a 3rd party, and the client host is proxied or redirect to the 3rd party captive portal.
The captive portal will know the IP address of the client (via X-Fowarded-For or HTTP Request origin), with the IP address, the captive portal can decide on its own strategy to register (or not) the node by IP.
# Impacts

(REQUIRED)
Web Services
# Delete branch after merge

(REQUIRED)
NO
# NEWS file entries

(REQUIRED, but may be optional...)
## Enhancements
- Register node via IP address in Web Services
