### PR TITLE
Add missing username field for Debian crontab

### DIFF
--- a/debian/packetfence.cron.d
+++ b/debian/packetfence.cron.d
@@ -3,5 +3,4 @@
 SHELL=/bin/sh
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 
-30 00 * * * /usr/local/pf/addons/database-backup-and-maintenance.sh
-
+30 0 * * * root /usr/local/pf/addons/database-backup-and-maintenance.sh


### PR DESCRIPTION
# Description

Fixes a syntax error in `/etc/cron.d/packetfence`
# Impacts

Currently, `/etc/cron.d/packetfence` is ignored due to the missing `user` field, see `man 8 cron`.
# NEWS file entries
## Bug Fixes
- Fix crontab on Debian
