### PR TITLE
Fix for corruption of /etc/sysconfig/network & new feature: 'deauthsourceip' in pf.conf

### DIFF
--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1824,3 +1824,10 @@ options=enabled|disabled
 description=<<EOT
 Show the parking portal to the device instead of the usual portal
 EOT
+
+[liupf.deauthsourceip]
+type=text
+description=<<EOT
+Source IP address for deauthentication requests.
+EOT
+

--- a/html/pfappserver/lib/pfappserver/Model/Config/System.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Config/System.pm
@@ -382,7 +382,7 @@ sub writeNetworkConfigs {
     }
 
     open IN, '<', $_network_conf_dir.$_network_conf_file;
-    chomp(my @content = <IN>);
+    my @content = <IN>;
     close IN;
 
     @content = grep !/^GATEWAY=/, @content;

--- a/lib/pf/Switch.pm
+++ b/lib/pf/Switch.pm
@@ -3130,7 +3130,7 @@ Takes into account the active/active clustering and centralized deauth
 
 =cut
 
-sub deauth_source_ip {
+sub orig_deauth_source_ip {
     my ($self) = @_;
     if($cluster_enabled){
         return isenabled($Config{active_active}{centralized_deauth}) ? pf::cluster::management_cluster_ip() : pf::cluster::current_server->{management_ip};
@@ -3138,6 +3138,11 @@ sub deauth_source_ip {
     else {
         return $management_network->tag('vip') || $management_network->tag('ip');
     }
+}
+
+
+sub deauth_source_ip {
+    return $Config{'liupf'}{'deauthsourceip'} || orig_deauth_source_ip();
 }
 
 =item logger


### PR DESCRIPTION
# Description

pfappserver sometimes corrupts /etc/sysconfig/network when it chomp():s on the old content (replaces newlines with space, causing HOSTNAME=xxx to be put on the same line as NETWORKING=yes, sometimes.

Also added a new feature - deauthsourceip=IP in pf.conf allowing you to override the automatic source IP for deauthentication requests when needed. (In our environment sending deauth requests from the MGMT interface IP is wrong).
# Impacts

Probably should put the deauthsourceip option under some other name than "liupf" (our local modifications goes under that name).
# Delete branch after merge

YES
# NEWS file entries
## New Features

deauthsourceip=IP pf.conf option
## Fixes

Corruption of /etc/sysconfig/network
