### PR TITLE
Fix/fr cluster clients

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,9 @@ conf/ssl/server.crt:
 conf/pf_omapi_key:
 	/usr/bin/openssl rand -base64 -out /usr/local/pf/conf/pf_omapi_key 32
 
+conf/local_secret:
+	date +%s | sha256sum | base64 | head -c 32 > /usr/local/pf/conf/local_secret
+
 bin/pfcmd: src/pfcmd.c
 	$(CC) -O2 -g -std=c99  -Wall $< -o $@
 
@@ -135,4 +138,4 @@ fingerbank:
 	rm -f /usr/local/pf/lib/fingerbank
 	ln -s /usr/local/fingerbank/lib/fingerbank /usr/local/pf/lib/fingerbank \
 
-devel: configurations conf/ssl/server.crt conf/pf_omapi_key bin/pfcmd raddb/certs sudo translation mysql-schema raddb/sites-enabled fingerbank chown_pf permissions bin/ntlm_auth_wrapper
+devel: configurations conf/ssl/server.crt conf/pf_omapi_key conf/local_secret bin/pfcmd raddb/certs sudo translation mysql-schema raddb/sites-enabled fingerbank chown_pf permissions bin/ntlm_auth_wrapper

--- a/addons/packages/packetfence.spec
+++ b/addons/packages/packetfence.spec
@@ -649,6 +649,11 @@ if [ ! -f /usr/local/pf/conf/pf_omapi_key ]; then
     /usr/bin/openssl rand -base64 -out /usr/local/pf/conf/pf_omapi_key 32
 fi
 
+# Create server local RADIUS secret
+if [ ! -f /usr/local/pf/conf/local_secret ]; then
+    date +%s | sha256sum | base64 | head -c 32 > /usr/local/pf/conf/local_secret
+fi
+
 for service in snortd httpd snmptrapd portreserve redis
 do
 %if 0%{?el6}

--- a/bin/cluster/sync
+++ b/bin/cluster/sync
@@ -55,6 +55,7 @@ use pf::file_paths qw(
     $server_key
     $server_pem
     $conf_dir
+    $local_secret_file
 );
 use pf::cluster;
 use fingerbank::FilePath;
@@ -100,7 +101,7 @@ foreach my $store (@tmp_stores){
     push @stores, $store;
 }
 
-my @files = ($server_cert, $server_key, $server_pem, $pfconfig::constants::CONFIG_FILE_PATH, "$conf_dir/iptables.conf", $fingerbank::FilePath::CONF_FILE, $fingerbank::FilePath::LOCAL_DB_FILE);
+my @files = ($server_cert, $server_key, $server_pem, $local_secret_file, $pfconfig::constants::CONFIG_FILE_PATH, "$conf_dir/iptables.conf", $fingerbank::FilePath::CONF_FILE, $fingerbank::FilePath::LOCAL_DB_FILE);
 
 if (-e '/usr/local/pf/conf/cluster-files.txt') {
     open(my $fh, '<', '/usr/local/pf/conf/cluster-files.txt')

--- a/debian/packetfence.postinst
+++ b/debian/packetfence.postinst
@@ -93,6 +93,12 @@ case "$1" in
             /usr/bin/openssl rand -base64 -out /usr/local/pf/conf/pf_omapi_key 32
         fi
 
+        # Create server local RADIUS secret
+        if [ ! -f /usr/local/pf/conf/local_secret ]; then
+            date +%s | sha256sum | base64 | head -c 32 > /usr/local/pf/conf/local_secret
+        fi
+
+
 	if [ ! -f /usr/local/pf/raddb/certs/dh ]; then
 	    echo "Building default RADIUS certificates..."
 	    cd /usr/local/pf/raddb/certs

--- a/lib/pf/config.pm
+++ b/lib/pf/config.pm
@@ -140,6 +140,8 @@ our (
     %ConfigAdminRoles,
 #portal_modules.conf
     %ConfigPortalModules,
+#conf/local_secret
+    $local_secret,
 );
 
 BEGIN {
@@ -193,6 +195,7 @@ BEGIN {
         %ConfigBillingTiers
         %ConfigAdminRoles
         %ConfigPortalModules
+        $local_secret
     );
 }
 
@@ -264,6 +267,8 @@ tie %ConfigBillingTiers, 'pfconfig::cached_hash', 'config::BillingTiers';
 tie %ConfigAdminRoles, 'pfconfig::cached_hash', 'config::AdminRoles';
 
 tie %ConfigPortalModules, 'pfconfig::cached_hash', 'config::PortalModules';
+
+tie $local_secret, 'pfconfig::cached_scalar', 'resource::local_secret';
 
 use pf::util::apache qw(url_parser);
 

--- a/lib/pf/file_paths.pm
+++ b/lib/pf/file_paths.pm
@@ -44,6 +44,8 @@ our (
     $oui_file, $oui_url,
     #DHCP OMAPI key file
     $pf_omapi_key_file,
+    # Local secret file for RADIUS
+    $local_secret_file,
     #profiles.conf variables
     $profiles_config_file, %Profiles_Config,
     #Other configuraton files variables
@@ -102,6 +104,7 @@ BEGIN {
         $dhcp_fingerprints_file $dhcp_fingerprints_url
         $oui_file $oui_url
         $pf_omapi_key_file
+        $local_secret_file
         $profiles_config_file %Profiles_Config
         $switches_config_file $violations_config_file $authentication_config_file
         $chi_config_file $ui_config_file $floating_devices_file $log_config_file
@@ -163,6 +166,7 @@ $pfcmd_binary   = catfile($bin_dir, "pfcmd");
 $oui_file           = catfile($conf_dir, "oui.txt");
 $suricata_categories_file = catfile($conf_dir, "suricata_categories.txt");
 $pf_omapi_key_file  = catfile($conf_dir, "pf_omapi_key");
+$local_secret_file  = catfile($conf_dir, "local_secret");
 $pf_doc_file        = catfile($conf_dir, "documentation.conf");
 $oauth_ip_file      = catfile($conf_dir, "oauth2-ips.conf");
 $ui_config_file     = catfile($conf_dir, "ui.conf");

--- a/lib/pf/services/manager/radiusd_child.pm
+++ b/lib/pf/services/manager/radiusd_child.pm
@@ -28,6 +28,7 @@ use pf::config qw(
     %Config
     $management_network
     %ConfigDomain
+    $local_secret
 );
 use NetAddr::IP;
 use pf::cluster;
@@ -247,7 +248,7 @@ home_server pf$i.cluster {
         ipaddr = $radius_back
         src_ipaddr = $cluster_ip
         port = 1812
-        secret = testing1234
+        secret = $local_secret
         response_window = 6
         status_check = status-server
         revive_interval = 120
@@ -273,7 +274,7 @@ EOT
         foreach my $radius_back (@radius_backend) {
             $tags{'config'} .= <<"EOT";
 client $radius_back {
-        secret = testing1234
+        secret = $local_secret
         shortname = pf
 }
 EOT

--- a/lib/pf/services/manager/radiusd_child.pm
+++ b/lib/pf/services/manager/radiusd_child.pm
@@ -268,24 +268,23 @@ EOT
         $tags{'pid_file'} = "$var_dir/run/radiusd-load_balancer.pid";
         $tags{'socket_file'} = "$var_dir/run/radiusd-load_balancer.sock";
         parse_template( \%tags, $tags{'template'}, "$install_dir/raddb/load_balancer.conf");
-    } else {
-        my $file = $install_dir."/raddb/sites-enabled/packetfence-cluster";
-        unlink($file);
-    }
-    $tags{'template'} = "$conf_dir/radiusd/clients.conf.inc";
-    my $ip = NetAddr::IP::Lite->new($cfg->{'ip'}, $cfg->{'mask'});
-    my $net = $ip->network();
-    if ($pf::cluster::cluster_enabled) {
-        $tags{'config'} .= <<"EOT";
-client $net {
+        
+        push @radius_backend, $cluster_ip;
+        foreach my $radius_back (@radius_backend) {
+            $tags{'config'} .= <<"EOT";
+client $radius_back {
         secret = testing1234
         shortname = pf
 }
 EOT
+        }
+
+        $tags{'template'} = "$conf_dir/radiusd/clients.conf.inc";
+        parse_template( \%tags, "$conf_dir/radiusd/clients.conf.inc", "$install_dir/raddb/clients.conf.inc" );
     } else {
-        $tags{'config'} = '';
+        my $file = $install_dir."/raddb/sites-enabled/packetfence-cluster";
+        unlink($file);
     }
-    parse_template( \%tags, "$conf_dir/radiusd/clients.conf.inc", "$install_dir/raddb/clients.conf.inc" );
 }
 
 =head1 AUTHOR

--- a/lib/pfconfig/namespaces/resource/local_secret.pm
+++ b/lib/pfconfig/namespaces/resource/local_secret.pm
@@ -1,0 +1,69 @@
+package pfconfig::namespaces::resource::local_secret;
+
+=head1 NAME
+
+pfconfig::namespaces::resource::local_secret
+
+=cut
+
+=head1 DESCRIPTION
+
+pfconfig::namespaces::resource::local_secret
+
+=cut
+
+use strict;
+use warnings;
+
+use base 'pfconfig::namespaces::resource';
+
+use pf::file_paths qw($local_secret_file);
+use File::Slurp qw(read_file);
+
+sub init {
+    my ($self) = @_;
+
+    $self->{child_resources} = [ 'config::Switch' ];
+}
+
+sub build {
+    my ($self) = @_;
+    return read_file($local_secret_file);
+}
+
+=back
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2016 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;
+
+# vim: set shiftwidth=4:
+# vim: set expandtab:
+# vim: set backspace=indent,eol,start:
+
+


### PR DESCRIPTION
# Description

Declare cluster members individually in cluster clients
Change generic cluster secret to an on-install generated one.
# Impacts

FR clustering
Local test scripts
# Issue

fixes #1245 
# Delete branch after merge

YES
# NEWS file entries
## Bug Fixes

If an issue exists on Github, please refer to it (name) along with it's number...
- Declare cluster members individually in cluster clients (#1245)
- Change generic cluster secret to an on-install generated one.
# UPGRADE file entries

The management IP(s) of PacketFence are now defined as switches with a forced RADIUS secret defined in `/usr/local/pf/conf/local_secret`. Make sure you reconfigure the secret in the file if necessary and that this file is synchronized on all your cluster members if that applies. Note that this doesn't affect the RADIUS secret you have configured for wireless controllers and switches. It only affects RADIUS requests that originate from the management IP(s)
