### PR TITLE
Renamed metascan to Metadefender

### DIFF
--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1817,13 +1817,13 @@ The password to access the database storing the Graphite dashboard settings.
 Will default to database.pass if none is provided.
 EOT
 
-[metascan.api_key]
+[metadefender.api_key]
 type=text
 description=<<EOT
 OPSWAT Metadefender Cloud Scanner API key
 EOT
 
-[metascan.query_url_hash]
+[metadefender.query_url_hash]
 type=text
 description=<<EOT
 OPSWAT Metadefender Cloud Scanner URL for hash queries

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -1416,18 +1416,18 @@ db_user=
 #
 db_pass=
 
-[metascan]
+[metadefender]
 #
-# metascan.api_key
+# metadefender.api_key
 #
 # OPSWAT Metadefender Cloud Scanner API key
 api_key=
 
 #
-# metascan.query_url_hash
+# metadefender.query_url_hash
 #
 # OPSWAT Metadefender Cloud Scanner URL for hash queries
-query_url_hash=https://hashlookup.metascan-online.com/v2/hash/
+query_url_hash=https://hashlookup.metadefender.com/v2/hash/
 
 [parking]
 #

--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -2769,7 +2769,7 @@ Configuration of a new 'syslog parser' should use the followings:
 
 Configuration of a new violation can use the following trigger types:
 
-  Type: metascan
+  Type: metadefender
   Triggers ID: The scan result returned by Metadefender Cloud online
 
   Type: suricata_md5

--- a/html/pfappserver/lib/pfappserver/I18N/en.po
+++ b/html/pfappserver/lib/pfappserver/I18N/en.po
@@ -3508,11 +3508,11 @@ msgstr ""
 msgid "OMAPI"
 msgstr ""
 
-# conf/documentation.conf (metascan.api_key)
+# conf/documentation.conf (metadefender.api_key)
 msgid "OPSWAT Metadefender Cloud Scanner API key"
 msgstr ""
 
-# conf/documentation.conf (metascan.query_url_hash)
+# conf/documentation.conf (metadefender.query_url_hash)
 msgid "OPSWAT Metadefender Cloud Scanner URL for hash queries"
 msgstr ""
 
@@ -8116,15 +8116,15 @@ msgid "memberOf:1.2.840.113556.1.4.1941:"
 msgstr "nested group"
 
 # conf/documentation.conf
-msgid "metascan"
+msgid "metadefender"
 msgstr "OPSWAT Metadefender Cloud Scanner"
 
 # conf/documentation.conf
-msgid "metascan.api_key"
+msgid "metadefender.api_key"
 msgstr "API key"
 
 # conf/documentation.conf
-msgid "metascan.query_url_hash"
+msgid "metadefender.query_url_hash"
 msgstr "Query URL hash"
 
 # pf::config (SoH Status)

--- a/html/pfappserver/lib/pfappserver/I18N/fr.po
+++ b/html/pfappserver/lib/pfappserver/I18N/fr.po
@@ -3788,11 +3788,11 @@ msgstr "Nombre de processus parser que pfsetvlan devrait démarrer"
 msgid "OMAPI"
 msgstr "OMAPI"
 
-# conf/documentation.conf (metascan.api_key)
+# conf/documentation.conf (metadefender.api_key)
 msgid "OPSWAT Metadefender Cloud Scanner API key"
 msgstr "Clé d'API de d'OPSWAT Metadefender Cloud Scanner"
 
-# conf/documentation.conf (metascan.query_url_hash)
+# conf/documentation.conf (metadefender.query_url_hash)
 msgid "OPSWAT Metadefender Cloud Scanner URL for hash queries"
 msgstr "URL pour les requêtes de hash de OPSWAT Metadefender Cloud Scanner"
 
@@ -8599,15 +8599,15 @@ msgid "memberOf:1.2.840.113556.1.4.1941:"
 msgstr "groupe imbriqué (dn)"
 
 # conf/documentation.conf
-msgid "metascan"
+msgid "metadefender"
 msgstr "OPSWAT Metadefender Cloud Scanner"
 
 # conf/documentation.conf
-msgid "metascan.api_key"
+msgid "metadefender.api_key"
 msgstr "Clé de l'API"
 
 # conf/documentation.conf
-msgid "metascan.query_url_hash"
+msgid "metadefender.query_url_hash"
 msgstr "Hash de l'url pour la requête "
 
 # pf::config (SoH Status)

--- a/lib/pf/CHI.pm
+++ b/lib/pf/CHI.pm
@@ -67,7 +67,7 @@ Hash::Merge::specify_behavior(
     'PF_CHI_MERGE'
 );
 
-our @CACHE_NAMESPACES = qw(configfilesdata configfiles httpd.admin httpd.portal pfdns switch.overlay ldap_auth omapi fingerbank firewall_sso switch metascan accounting);
+our @CACHE_NAMESPACES = qw(configfilesdata configfiles httpd.admin httpd.portal pfdns switch.overlay ldap_auth omapi fingerbank firewall_sso switch metadefender accounting);
 
 our $chi_default_config = pf::IniFiles->new( -file => $chi_defaults_config_file) or die "Cannot open $chi_defaults_config_file";
 

--- a/lib/pf/api.pm
+++ b/lib/pf/api.pm
@@ -45,7 +45,7 @@ use File::Slurp;
 use pf::file_paths qw($captiveportal_profile_templates_path);
 use pf::CHI;
 use pf::access_filter::dhcp;
-use pf::metascan();
+use pf::metadefender();
 use pf::services();
 
 use List::MoreUtils qw(uniq);
@@ -1259,18 +1259,18 @@ sub copy_directory : Public {
     return dircopy($source_dir, $dest_dir);
 }
 
-=head2 metascan_process
+=head2 metadefender_process
 
 =cut
 
-sub metascan_process : Public {
+sub metadefender_process : Public {
     my ( $class, $data ) = @_;
 
-    my $metascan_scan_result_id = pf::metascan->hash_lookup($data);
-    return if !defined($metascan_scan_result_id);
+    my $metadefender_scan_result_id = pf::metadefender->hash_lookup($data);
+    return if !defined($metadefender_scan_result_id);
 
     my $violation_note = "Filename: " . $data->{'filename'} . "\n From host: " . $data->{'http_host'};
-    pf::violation::violation_trigger( { 'mac' => $data->{'mac'}, 'tid' => $metascan_scan_result_id, 'type' => "metascan", 'notes' => $violation_note } );
+    pf::violation::violation_trigger( { 'mac' => $data->{'mac'}, 'tid' => $metadefender_scan_result_id, 'type' => "metadefender", 'notes' => $violation_note } );
 }
 
 sub rest_ping :Public :RestPath(/rest/ping){

--- a/lib/pf/constants/trigger.pm
+++ b/lib/pf/constants/trigger.pm
@@ -15,7 +15,7 @@ use strict;
 use warnings;
 use base qw(Exporter);
 use Readonly;
-use pf::metascan();
+use pf::metadefender();
 use pf::file_paths qw($suricata_categories_file);
 use File::Slurp;
 use pf::SwitchFactory;
@@ -25,7 +25,7 @@ use pf::config qw(
 );
 
 our @EXPORT_OK = qw(
-        $TRIGGER_TYPE_ACCOUNTING $TRIGGER_TYPE_DETECT $TRIGGER_TYPE_INTERNAL $TRIGGER_TYPE_MAC $TRIGGER_TYPE_NESSUS $TRIGGER_TYPE_OPENVAS $TRIGGER_TYPE_METASCAN $TRIGGER_TYPE_OS $TRIGGER_TYPE_SOH $TRIGGER_TYPE_USERAGENT $TRIGGER_TYPE_VENDORMAC $TRIGGER_TYPE_PROVISIONER $TRIGGER_TYPE_SWITCH $TRIGGER_TYPE_SWITCH_GROUP @VALID_TRIGGER_TYPES
+        $TRIGGER_TYPE_ACCOUNTING $TRIGGER_TYPE_DETECT $TRIGGER_TYPE_INTERNAL $TRIGGER_TYPE_MAC $TRIGGER_TYPE_NESSUS $TRIGGER_TYPE_OPENVAS $TRIGGER_TYPE_METADEFENDER $TRIGGER_TYPE_OS $TRIGGER_TYPE_SOH $TRIGGER_TYPE_USERAGENT $TRIGGER_TYPE_VENDORMAC $TRIGGER_TYPE_PROVISIONER $TRIGGER_TYPE_SWITCH $TRIGGER_TYPE_SWITCH_GROUP @VALID_TRIGGER_TYPES
         $TRIGGER_ID_PROVISIONER
         $TRIGGER_MAP
 );
@@ -37,7 +37,7 @@ Readonly::Scalar our $TRIGGER_TYPE_INTERNAL => 'internal';
 Readonly::Scalar our $TRIGGER_TYPE_MAC => 'mac';
 Readonly::Scalar our $TRIGGER_TYPE_NESSUS => 'nessus';
 Readonly::Scalar our $TRIGGER_TYPE_OPENVAS => 'openvas';
-Readonly::Scalar our $TRIGGER_TYPE_METASCAN => 'metascan';
+Readonly::Scalar our $TRIGGER_TYPE_METADEFENDER => 'metadefender';
 Readonly::Scalar our $TRIGGER_TYPE_OS => 'os';
 Readonly::Scalar our $TRIGGER_TYPE_SOH => 'soh';
 Readonly::Scalar our $TRIGGER_TYPE_SURICATA_EVENT => 'suricata_event';
@@ -68,7 +68,7 @@ Readonly::Scalar our $TRIGGER_MAP => {
     $TRIGGER_ID_PROVISIONER => "Check status",
   },
   $TRIGGER_TYPE_SURICATA_EVENT => $SURICATA_CATEGORIES,
-  $TRIGGER_TYPE_METASCAN => $pf::metascan::METASCAN_RESULT_IDS,
+  $TRIGGER_TYPE_METADEFENDER => $pf::metadefender::METADEFENDER_RESULT_IDS,
   $TRIGGER_TYPE_SWITCH => \%ConfigSwitchesList,
   $TRIGGER_TYPE_SWITCH_GROUP => \%ConfigSwitchesGroup,
 };

--- a/lib/pf/detect/parser/suricata_http.pm
+++ b/lib/pf/detect/parser/suricata_http.pm
@@ -55,7 +55,7 @@ sub parse {
     # We do the process async using API rather than going through pfdetect since it requires external resources evaluation that may take some time
     my $apiclient = pf::api::queue->new;
     $apiclient->notify('trigger_violation', ( 'mac' => $mac, 'tid' => $md5_hash, 'type' => 'suricata_md5' ));   # Process Suricata MD5 based violations
-    $apiclient->notify('metascan_process', $data);  # Process Metascan MD5 hash lookup
+    $apiclient->notify('metadefender_process', $data);  # Process Metadefender MD5 hash lookup
     
     return 0;   # Returning 0 to pfdetect indicates "job's done"
 }

--- a/lib/pf/factory/condition/violation.pm
+++ b/lib/pf/factory/condition/violation.pm
@@ -36,7 +36,7 @@ our %TRIGGER_TYPE_TO_CONDITION_TYPE = (
     'mac_vendor'        => {type => 'equals',        key  => 'mac_vendor_id'},
     'nessus'            => {type => 'equals',        key  => 'last_nessus_id',          event => $TRUE},
     'openvas'           => {type => 'equals',        key  => 'last_openvas_id',         event => $TRUE},
-    'metascan'          => {type => 'equals',        key  => 'last_metascan_id',        event => $TRUE},
+    'metadefender'      => {type => 'equals',        key  => 'last_metadefender_id',    event => $TRUE},
     'provisioner'       => {type => 'equals',        key  => 'last_provisioner_id',     event => $TRUE},
     'soh'               => {type => 'equals',        key  => 'last_soh_id',             event => $TRUE},
     'suricata_event'    => {type => 'starts_with',   key  => 'last_suricata_event',     event => $TRUE},


### PR DESCRIPTION
# Description

OPSWAT metascan is now known as Metadefender. Adjusting integration
# Impacts
- Metadefender integration
- violation triggering (both with or without using "metadefender" (previously "metascan") trigger type)
- configuration
# Issue

fixes #1445 
# Delete branch after merge

YES
# UPGRADE file entries

pf.conf configuration parameters
- 'metascan' configuration section is now 'metadefender', which means that;
- 'metascan.api_key' is now 'metadefender.api_key'
- 'metascan.query_url_hash' is now 'metadefender.query_url_hash'
  also, 
- the value of 'metadefender.query_url_hash' changed from "https://hashlookup.metascan-online.com/v2/hash/" to "https://hashlookup.metadefender.com/v2/hash/"

violations.conf
- 'metascan' trigger type changed to 'metadefender'
