### PR TITLE
Fix some typos

### DIFF
--- a/NEWS.asciidoc
+++ b/NEWS.asciidoc
@@ -204,7 +204,7 @@ Enhancements
 * Added ability to e-mail device owner as a violation action
 * The PacketFence syslog parser (pfdetect) has been reworked to allow multiple logs to be parsed concurently
 * New ntlm_auth wrapper will log authentication latency to StatsD automatically
-* Handle Microsoft Windows based captive-portal detection mecanisms
+* Handle Microsoft Windows based captive-portal detection mechanisms
 * Manage pfdhcplistener status with keepalived and run pfdhcplistener on all cluster's members
 * New portal profile filter (sub connection type)
 * Added switch IP and description in the available columns in the node list view

--- a/UPGRADE.old
+++ b/UPGRADE.old
@@ -545,7 +545,7 @@ Upgrading from a version prior to 3.1.0
     - dhcp_dumper.pl addon changes
     Deep and important refactoring of the addon. Output format changed.
 
-    - SNMP traps limit mecanism
+    - SNMP traps limit mechanism
     PacketFence can now limits the number of SNMP traps coming from a single
     ifIndex. See pf/conf/documentation.conf under vlan for more infos.
 

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -901,7 +901,7 @@ Describes type of the named interface.
  * "monitor" is the interface that snort listens on.
  * "dhcp-listener" is an interface where the DHCP traffic is coming in either via a network SPAN or IP-Helpers configuration.
  * "high-availability" is for an interface between two PacketFence servers dedicated to high-availability (drbd, corosync).
- * "portal" interface have the captive-portal running on them without the need of having any enforcement mecanism.
+ * "portal" interface have the captive-portal running on them without the need of having any enforcement mechanism.
 EOT
 
 [interface.enforcement]
@@ -1207,14 +1207,14 @@ EOT
 type=toggle
 options=enabled|disabled
 description=<<EOT
-Bypass the captive-portal detection mecanism of some browsers / end-points by proxying the detection request.
+Bypass the captive-portal detection mechanism of some browsers / end-points by proxying the detection request.
 EOT
 
 [captive_portal.detection_mecanism_urls]
 type=merged_list
 description=<<EOT
 Comma-delimited list of URLs known to be used by devices to detect the presence 
-of a captive portal and trigger their captive portal mecanism.
+of a captive portal and trigger their captive portal mechanism.
 EOT
 
 [captive_portal.wispr_redirection]

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -911,13 +911,13 @@ status_only_on_production=disabled
 #
 # captive_portal.detection_mecanism_bypass
 #
-# Bypass the captive-portal detection mecanism of some browsers / end-points by proxying the detection request.
+# Bypass the captive-portal detection mechanism of some browsers / end-points by proxying the detection request.
 detection_mecanism_bypass = disabled
 #
 # captive_portal.detection_mecanism_urls
 #
 # Comma-delimited list of URLs known to be used by devices to detect the presence 
-# of a captive portal and trigger their captive portal mecanism.
+# of a captive portal and trigger their captive portal mechanism.
 detection_mecanism_urls = http://www.gstatic.com/generate_204,http://clients3.google.com/generate_204,http://www.apple.com/library/test/success,http://connectivitycheck.android.com/generate_204,http://www.msftncsi.com/ncsi.txt
 #
 # captive_portal.wispr_redirection

--- a/conf/vlan_filters.conf.defaults
+++ b/conf/vlan_filters.conf.defaults
@@ -1,6 +1,6 @@
 # defaults PacketFence's rules for PacketFence
 
-# This rules are predefined in PacketFence and disconnect device that comming from a secure connection to an open one.
+# This rules are predefined in PacketFence and disconnect device that coming from a secure connection to an open one.
 
 [pf_wired_mac_auth]
 filter = connection_type

--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -2770,7 +2770,7 @@ Since a security suite consists of multiple pieces of software tied together, yo
 PacketFence integration
 +++++++++++++++++++++++
 
-Once Security Onion is installed and minimally configured, integration with PacketFence is required to be able to raise violations based on sensor(s) alerts. syslog is used to forward sensor(s) alerts from Security Onion to the PacketFence detection mecanisms.
+Once Security Onion is installed and minimally configured, integration with PacketFence is required to be able to raise violations based on sensor(s) alerts. syslog is used to forward sensor(s) alerts from Security Onion to the PacketFence detection mechanisms.
 
 The simplest way is as follow (based on https://github.com/Security-Onion-Solutions/security-onion/wiki/ThirdPartyIntegration);
 

--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -835,7 +835,7 @@ Example with the most common ones:
 
 CAUTION: Node role will take effect only with a 802.1X connection or if you use VLAN filters.
 
-PacketFence relies extensively on Apache for its captive portal, administrative interface and Web services. The PacketFence´s Apache configuration are located in `/usr/local/pf/conf/httpd.conf.d/`.
+PacketFence relies extensively on Apache for its captive portal, administrative interface and Web services. The PacketFence Apache configuration is located in `/usr/local/pf/conf/httpd.conf.d/`.
 
 In this directory you have three important files: `httpd.admin`, `httpd.portal`, `httpd.webservices`, `httpd.aaa`.
 

--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -821,7 +821,7 @@ Here are the different configuration parameters that can be set for each portal 
 
 Portal profiles should be managed from PacketFence's Web administrative GUI - from the *Configuration -> Portal Profiles* section. Adding a portal profile from that interface will correctly copy templates over - which can then be modified as you wish.
 
-* Filters under *Configuration -> Portal Profile -> Portal Name -> Fitlers*
+* Filters under *Configuration -> Portal Profile -> Portal Name -> Filters*
 
 PacketFence offers the following filters: Connection Type, Network, Node Role, Port, realm, SSID, Switch, Switch Port, URI, VLAN and Time period.
 

--- a/html/pfappserver/lib/pfappserver/Base/Model/Search.pm
+++ b/html/pfappserver/lib/pfappserver/Base/Model/Search.pm
@@ -38,7 +38,7 @@ my %OP_MAP = (
 =item process_query
 
 transform search queries from search form
-To create where arguements for the sql builder
+To create where arguments for the sql builder
 
 =cut
 

--- a/html/pfappserver/lib/pfappserver/I18N/en.po
+++ b/html/pfappserver/lib/pfappserver/I18N/en.po
@@ -779,7 +779,7 @@ msgid "Bypass VLAN"
 msgstr "Bypass VLAN"
 
 # conf/documentation.conf (captive_portal.detection_mecanism_bypass)
-msgid "Bypass the captive-portal detection mecanism of some browsers / end-points by proxying the detection request."
+msgid "Bypass the captive-portal detection mechanism of some browsers / end-points by proxying the detection request."
 msgstr ""
 
 # html/pfappserver/lib/pfappserver/Form/Config/PKI_Provider/packetfence_local.pm
@@ -1123,7 +1123,7 @@ msgid "Comma-delimited list of MAC addresses that are immune to isolation. In in
 msgstr ""
 
 # conf/documentation.conf (captive_portal.detection_mecanism_urls)
-msgid "Comma-delimited list of URLs known to be used by devices to detect the presence of a captive portal and trigger their captive portal mecanism."
+msgid "Comma-delimited list of URLs known to be used by devices to detect the presence of a captive portal and trigger their captive portal mechanism."
 msgstr ""
 
 # conf/documentation.conf (trapping.passthroughs)
@@ -1734,7 +1734,7 @@ msgid "Describes the technique PacketFence will use to enforce network access.VL
 msgstr ""
 
 # conf/documentation.conf (interface.type)
-msgid "Describes type of the named interface.<ul><li><i>internal</i> describes interfaces where PacketFence will enforce network access.</li><li><i>management</i> (or managed) interfaces have the administrative GUI running on them, host SNMP trap receiver and RADIUS server.</li><li><i>monitor</i> is the interface that snort listens on.</li><li><i>dhcp-listener</i> is an interface where the DHCP traffic is coming in either via a network SPAN or IP-Helpers configuration.</li><li><i>high-availability</i> is for an interface between two PacketFence servers dedicated to high-availability (drbd, corosync).</li><li><i>portal</i> interface have the captive-portal running on them without the need of having any enforcement mecanism.</li></ul>"
+msgid "Describes type of the named interface.<ul><li><i>internal</i> describes interfaces where PacketFence will enforce network access.</li><li><i>management</i> (or managed) interfaces have the administrative GUI running on them, host SNMP trap receiver and RADIUS server.</li><li><i>monitor</i> is the interface that snort listens on.</li><li><i>dhcp-listener</i> is an interface where the DHCP traffic is coming in either via a network SPAN or IP-Helpers configuration.</li><li><i>high-availability</i> is for an interface between two PacketFence servers dedicated to high-availability (drbd, corosync).</li><li><i>portal</i> interface have the captive-portal running on them without the need of having any enforcement mechanism.</li></ul>"
 msgstr ""
 
 # html/pfappserver/lib/pfappserver/Form/Config/Authentication/Rule.pm
@@ -7163,11 +7163,11 @@ msgstr "Captive portal"
 
 # conf/documentation.conf
 msgid "captive_portal.detection_mecanism_bypass"
-msgstr "Captive Portal detection mecanism bypass"
+msgstr "Captive Portal detection mechanism bypass"
 
 # conf/documentation.conf
 msgid "captive_portal.detection_mecanism_urls"
-msgstr "Captive Portal detection mecanism URLs"
+msgstr "Captive Portal detection mechanism URLs"
 
 # conf/documentation.conf
 msgid "captive_portal.httpd_mod_evasive"

--- a/html/pfappserver/lib/pfappserver/I18N/fr.po
+++ b/html/pfappserver/lib/pfappserver/I18N/fr.po
@@ -832,7 +832,7 @@ msgstr "VLAN de contournement"
 
 # conf/documentation.conf (captive_portal.detection_mecanism_bypass)
 msgid ""
-"Bypass the captive-portal detection mecanism of some browsers / end-points "
+"Bypass the captive-portal detection mechanism of some browsers / end-points "
 "by proxying the detection request."
 msgstr "Contourne le mécanisme de détection du portail captif de certains navigateurs / appareils en proxyant la requête de détection"
 
@@ -1196,7 +1196,7 @@ msgstr "Liste séparée par des virgules des adresses MAC pour lequel l'isolemen
 # conf/documentation.conf (captive_portal.detection_mecanism_urls)
 msgid ""
 "Comma-delimited list of URLs known to be used by devices to detect the "
-"presence of a captive portal and trigger their captive portal mecanism."
+"presence of a captive portal and trigger their captive portal mechanism."
 msgstr "Liste, délimitée par des virgules, des URLs connues à utiliser par les appareils pour détecter la présence d'un portail captif et lancer leur mécanisme de portail captif."
 
 # conf/documentation.conf (trapping.passthroughs)
@@ -1855,7 +1855,7 @@ msgid ""
 ">high-availability</i> is for an interface between two PacketFence servers "
 "dedicated to high-availability (drbd, corosync).</li><li><i>portal</i> "
 "interface have the captive-portal running on them without the need of having"
-" any enforcement mecanism.</li></ul>"
+" any enforcement mechanism.</li></ul>"
 msgstr "Décrit le type de l'interface nommée. <ul> <li>Interne<i> </i> décrit les interfaces où PacketFence donnera l'accès au réseau. </lii> <li> <i> gestion </i> les interfaces internes ont l'écoute de l'administration web, hôte pour les traps SNMP et le serveur RADIUS. </li> <li> <i> Moniteur </i> est l'interface de snort qui écoute. </li> <li> <i> dhcp -listener </i> est une interface où le trafic DHCP vient soit via un réseau configuration SPAN ou IP-Helpers. </li> <li> <i>haute disponibilité</i> est une interface entre deux serveurs PacketFence dédiés à la haute disponibilité (drbd, corosync). </li><li><i>portail</i> cette interface a le portail captif en écoute sans la nécessité d'avoir un mécanisme d'enregistrement</li> </ ul>"
 
 # html/pfappserver/lib/pfappserver/Form/Config/Authentication/Rule.pm

--- a/lib/pf/access_filter.pm
+++ b/lib/pf/access_filter.pm
@@ -61,7 +61,7 @@ sub test {
 
 =head2 filter
 
- Filter the arguements passed
+ Filter the arguments passed
 
 =cut
 

--- a/lib/pf/cmd/pf/cache.pm
+++ b/lib/pf/cmd/pf/cache.pm
@@ -42,7 +42,7 @@ use List::MoreUtils qw(any);
 
 =head2 parseArgs
 
-parsing the arguements for the cache command
+parsing the arguments for the cache command
 
 =cut
 
@@ -50,7 +50,7 @@ sub parseArgs {
     my ($self) = @_;
     my @args = $self->args;
     if (@args <= 1 || @args > 3 ) {
-        print STDERR  "invalid arguements\n";
+        print STDERR  "invalid arguments\n";
         return 0;
     }
     my $namespace = shift @args;

--- a/lib/pf/config/cached.pm
+++ b/lib/pf/config/cached.pm
@@ -313,8 +313,8 @@ Readonly::Scalar our $WRITE_PERMISSIONS => '0664';
 
 Creates a new pf::config::cached
 
-Accepts all the arguements from L<Config::IniFiles-E<gt>new|Config::IniFiles/new>
-With the the following additional arguements
+Accepts all the arguments from L<Config::IniFiles-E<gt>new|Config::IniFiles/new>
+With the the following additional arguments
 
 =over
 

--- a/lib/pf/filter_engine.pm
+++ b/lib/pf/filter_engine.pm
@@ -72,7 +72,7 @@ sub match_all {
 
 =head2 build_match_arg
 
-Build the arguement for matching
+Build the argument for matching
 
 =cut
 

--- a/lib/pf/services/manager.pm
+++ b/lib/pf/services/manager.pm
@@ -423,7 +423,7 @@ sub generateConfig { 1 }
 
 =head2 launchService
 
-launch the service using the launcher and arguements passed
+launch the service using the launcher and arguments passed
 
 =cut
 

--- a/lib/pf/web/dispatcher.pm
+++ b/lib/pf/web/dispatcher.pm
@@ -83,15 +83,15 @@ sub handler {
         return proxy_redirect($r);
     }
 
-    # Captive-portal detection mecanism
-    # Ability to bypass captive-portal detection mecanism
-    my $captive_portal_detection_mecanism_urls = pf::web::util::build_captive_portal_detection_mecanisms_regex;
-    if ( ($url =~ /$captive_portal_detection_mecanism_urls/o || $user_agent =~ /CaptiveNetworkSupport/s) && isenabled($Config{'captive_portal'}{'detection_mecanism_bypass'}) ) {
-        $logger->info("Dealing with a endpoint / browser with captive-portal detection capabilities while having captive-portal detection mecanism bypass enabled. Proxying");
+    # Captive-portal detection mechanism
+    # Ability to bypass captive-portal detection mechanism
+    my $captive_portal_detection_mechanism_urls = pf::web::util::build_captive_portal_detection_mechanisms_regex;
+    if ( ($url =~ /$captive_portal_detection_mechanism_urls/o || $user_agent =~ /CaptiveNetworkSupport/s) && isenabled($Config{'captive_portal'}{'detection_mecanism_bypass'}) ) {
+        $logger->info("Dealing with a endpoint / browser with captive-portal detection capabilities while having captive-portal detection mechanism bypass enabled. Proxying");
         return proxy_redirect($r);
     }
-    # Enforce HTTP instead of HTTPS when dealing with captive-portal detection mecanism and having a self-signed SSL certificate
-    elsif ( ($url =~ /$captive_portal_detection_mecanism_urls/o || $user_agent =~ /CaptiveNetworkSupport/s)
+    # Enforce HTTP instead of HTTPS when dealing with captive-portal detection mechanism and having a self-signed SSL certificate
+    elsif ( ($url =~ /$captive_portal_detection_mechanism_urls/o || $user_agent =~ /CaptiveNetworkSupport/s)
       && isenabled($Config{'captive_portal'}{'secure_redirect'}) && pf::web::util::is_certificate_self_signed ) {
         $logger->info("Dealing with a endpoint / browser with captive-portal detection capabilities while having a self-signed SSL certificate. Using HTTP instead of HTTPS");
         return html_redirect($r, { secure => $FALSE });
@@ -177,13 +177,13 @@ sub html_redirect {
     # Destination URL handling
     # We first must detect the destination URL for different use cases:
     # - We want to keep it so we can redirect the user to the originally requested URL once the registration completed
-    # - We want to be able to detect a potential captive-portal detection mecanism to disable HTTPS since it may cause issues
+    # - We want to be able to detect a potential captive-portal detection mechanism to disable HTTPS since it may cause issues
     my $destination_url = "";
     my $url = $r->construct_url;
 
     # Keeping destination URL unless it is the captive-portal itself or some sort of captive-portal detection URLs
-    my $captive_portal_detection_mecanism_urls = pf::web::util::build_captive_portal_detection_mecanisms_regex;
-    if ( ($url !~ m#://\Q$captive_portal_domain\E/#) && ($url !~ /$captive_portal_detection_mecanism_urls/o) && ($user_agent !~ /CaptiveNetworkSupport/s) ) {
+    my $captive_portal_detection_mechanism_urls = pf::web::util::build_captive_portal_detection_mechanisms_regex;
+    if ( ($url !~ m#://\Q$captive_portal_domain\E/#) && ($url !~ /$captive_portal_detection_mechanism_urls/o) && ($user_agent !~ /CaptiveNetworkSupport/s) ) {
         $destination_url = Apache2::Util::escape_path($url,$r->pool);
         $logger->debug("We set the destination URL to $destination_url for further usage");
         $r->pnotes(destination_url => $destination_url);

--- a/lib/pf/web/util.pm
+++ b/lib/pf/web/util.pm
@@ -232,24 +232,24 @@ sub getcookie {
     }
 }
 
-=item build_captive_portal_detection_mecanisms_regex
+=item build_captive_portal_detection_mechanisms_regex
 
-Build a regex that detects if the request is a captive portal detection mecanism request.
+Build a regex that detects if the request is a captive portal detection mechanism request.
 
-Such mecanisms are used by end-points to detect the presence of captive portal and then prompt the end-user accordingly.
+Such mechanisms are used by end-points to detect the presence of captive portal and then prompt the end-user accordingly.
 
 Using configuration values from 'captive_portal.detection_mecanism_urls'.
 
 =cut
 
-sub build_captive_portal_detection_mecanisms_regex {
-    my @captive_portal_detection_mecanism_urls = @{ $Config{'captive_portal'}{'detection_mecanism_urls'} };
+sub build_captive_portal_detection_mechanisms_regex {
+    my @captive_portal_detection_mechanism_urls = @{ $Config{'captive_portal'}{'detection_mecanism_urls'} };
 
-    foreach ( @captive_portal_detection_mecanism_urls ) { s{([^/])$}{$1\$} };
+    foreach ( @captive_portal_detection_mechanism_urls ) { s{([^/])$}{$1\$} };
 
-    my $captive_portal_detection_mecanism_urls = join( '|', @captive_portal_detection_mecanism_urls ) if ( @captive_portal_detection_mecanism_urls ne '0' );
-    if ( defined($captive_portal_detection_mecanism_urls) ) {
-        return qr/ ^(?: $captive_portal_detection_mecanism_urls ) /x; # eXtended pattern
+    my $captive_portal_detection_mechanism_urls = join( '|', @captive_portal_detection_mechanism_urls ) if ( @captive_portal_detection_mechanism_urls ne '0' );
+    if ( defined($captive_portal_detection_mechanism_urls) ) {
+        return qr/ ^(?: $captive_portal_detection_mechanism_urls ) /x; # eXtended pattern
     } else {
         return '';
     }


### PR DESCRIPTION
# Description

Just some typos I found reading the source.
# Impacts

Even though "mechanism" is misspelled in two configuration variables, I have not touched them. This is what happened to `Referer` in the http standard, so I guess we can deal with it as well :)

I have also not touched the changelog files, because we can't change the typos in the commit messages.
