### PR TITLE
Handle bond interface

### DIFF
--- a/html/pfappserver/lib/pfappserver/Form/Interface/CreateBond.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Interface/CreateBond.pm
@@ -1,0 +1,65 @@
+package pfappserver::Form::Interface::CreateBond;
+
+=head1 NAME
+
+pfappserver::Form::Interface::CreateBond - Web form to add a Bond
+
+=head1 DESCRIPTION
+
+Form definition to add a Bond to the network configuration.
+
+=cut
+
+use HTML::FormHandler::Moose;
+extends 'pfappserver::Form::Interface';
+with 'pfappserver::Base::Form::Role::Help';
+
+
+# Form fields
+has_field 'interface1' =>
+  (
+   type => 'Select',
+   label => 'Interface 1',
+   required => 1,
+   element_class => ['chzn-deselect'],
+   element_attr => { 'data-placeholder' => 'None' },
+   tags => { after_element => \&help,
+             help => 'Select your first interface' },
+  );
+
+has_field 'interfacer2' =>
+  (
+   type => 'Select',
+   label => 'Interface 2',
+   required => 1,
+   element_class => ['chzn-deselect'],
+   element_attr => { 'data-placeholder' => 'None' },
+   tags => { after_element => \&help,
+             help => 'Select your second interface' },
+  );
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2016 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+__PACKAGE__->meta->make_immutable;
+1;

--- a/html/pfappserver/lib/pfappserver/Form/Interface/CreateBond.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Interface/CreateBond.pm
@@ -43,9 +43,14 @@ has_field 'mode' =>
    default => 'active-backup',
   );
 
+use pf::log;
+use Data::Dumper;
+my $logger = get_logger();
+
 sub ACCEPT_CONTEXT {
     my ($self, $c, @args) = @_;
     my $interfaces = $c->model('Interface')->get('all');
+    $logger->info('test' . Dumper($interfaces));
     my $types = $c->model('Enforcement')->getAvailableTypes('all');
     return $self->SUPER::ACCEPT_CONTEXT($c, interfaces => $interfaces,  types => $types, @args);
 }
@@ -54,6 +59,7 @@ sub options_interfaces {
     my $self = shift;
     my $interfaces_list = [
         keys %{$self->form->interfaces} ];
+    $logger->info('test2' . Dumper($interfaces_list));
     return sort ( $interfaces_list );
 }
 

--- a/html/pfappserver/lib/pfappserver/Form/Interface/CreateBond.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Interface/CreateBond.pm
@@ -44,10 +44,10 @@ has_field 'mode' =>
    value => 'active-backup',
   );
 
-has_block definition =>
-  (
-   render_list => [ qw(name interfaces ipaddress netmask type additional_listening_daemons dns vip dhcpd_enabled nat_enabled) ],
-  );
+#has_block definition =>
+#  (
+#   render_list => [ qw(name interfaces ipaddress netmask type additional_listening_daemons dns vip dhcpd_enabled nat_enabled) ],
+#  );
 
 
 use Data::Dumper;

--- a/html/pfappserver/lib/pfappserver/Form/Interface/CreateBond.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Interface/CreateBond.pm
@@ -49,21 +49,17 @@ my $logger = get_logger();
 
 sub ACCEPT_CONTEXT {
     my ($self, $c, @args) = @_;
-    my $interfaces = $c->model('Interface')->get('all');
+    my @interfaces = grep {!defined $_->{master}} $c->model('Interface')->_listInterfaces('all');
+    $logger->info('my int' . Dumper(@interfaces));
     my $types = $c->model('Enforcement')->getAvailableTypes('all');
-    return $self->SUPER::ACCEPT_CONTEXT($c, interfaces => $interfaces,  types => $types, @args);
+    return $self->SUPER::ACCEPT_CONTEXT($c, interfaces => @interfaces,  types => $types, @args);
 }
 
 sub options_interfaces {
     my $self = shift;
-    my $interfaces_list = [
-        keys %{$self->form->interfaces} ];
+    my $interfaces_list = [ #$self->form->interfaces->{name} ];
+        values %{$self->form->interfaces->{name}} ];
     $logger->info('test2' . Dumper($interfaces_list));
-    my $match = /\.(.*)$/;
-    #foreach my $int ($interfaces_list) {
-    #    $match, $interfaces_list;
-    #}
-    #$logger->info('test4' . Dumper($int, $match));
     return sort ( $interfaces_list );
 }
 

--- a/html/pfappserver/lib/pfappserver/Form/Interface/CreateBond.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Interface/CreateBond.pm
@@ -14,6 +14,7 @@ use HTML::FormHandler::Moose;
 extends 'pfappserver::Form::Interface';
 with 'pfappserver::Base::Form::Role::Help';
 
+has 'interfaces' => ( is => 'ro' );
 
 # Form fields
 has_field 'interface1' =>
@@ -21,22 +22,36 @@ has_field 'interface1' =>
    type => 'Select',
    label => 'Interface 1',
    required => 1,
+   option_method => \&options_interfaces,
    element_class => ['chzn-deselect'],
    element_attr => { 'data-placeholder' => 'None' },
    tags => { after_element => \&help,
              help => 'Select your first interface' },
   );
 
-has_field 'interfacer2' =>
+has_field 'interface2' =>
   (
    type => 'Select',
    label => 'Interface 2',
    required => 1,
+   option_method => \&options_interfaces,
    element_class => ['chzn-deselect'],
    element_attr => { 'data-placeholder' => 'None' },
    tags => { after_element => \&help,
              help => 'Select your second interface' },
   );
+
+sub ACCEPT_CONTEXT {
+    my ($self, $c, @args) = @_;
+    my ($status, $roles) = $c->model('Interface')->list();
+    my @interfaces;
+    return $self->SUPER::ACCEPT_CONTEXT($c, interfaces => @interfaces);
+}
+
+sub options_interfaces {
+    my $self = shift;
+    return $self->form->interfaces;
+}
 
 =head1 COPYRIGHT
 

--- a/html/pfappserver/lib/pfappserver/Form/Interface/CreateBond.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Interface/CreateBond.pm
@@ -60,10 +60,10 @@ sub options_interfaces {
         keys %{$self->form->interfaces} ];
     $logger->info('test2' . Dumper($interfaces_list));
     my $match = /\.(.*)$/;
-    foreach my $int ($interfaces_list) {
-        $match, $interfaces_list;
-    }
-    $logger->info('test4' . Dumper($int, $match));
+    #foreach my $int ($interfaces_list) {
+    #    $match, $interfaces_list;
+    #}
+    #$logger->info('test4' . Dumper($int, $match));
     return sort ( $interfaces_list );
 }
 

--- a/html/pfappserver/lib/pfappserver/Form/Interface/CreateBond.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Interface/CreateBond.pm
@@ -19,7 +19,7 @@ has 'interfaces' => ( is => 'ro' );
 
 # Form fields
 
-has_field 'name' =>
+has_field 'bond_name' =>
   (
    type => 'Text',
    label => 'Name',

--- a/html/pfappserver/lib/pfappserver/Form/Interface/CreateBond.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Interface/CreateBond.pm
@@ -50,7 +50,6 @@ my $logger = get_logger();
 sub ACCEPT_CONTEXT {
     my ($self, $c, @args) = @_;
     my $interfaces = $c->model('Interface')->get('all');
-    $logger->info('test' . Dumper($interfaces));
     my $types = $c->model('Enforcement')->getAvailableTypes('all');
     return $self->SUPER::ACCEPT_CONTEXT($c, interfaces => $interfaces,  types => $types, @args);
 }
@@ -60,6 +59,11 @@ sub options_interfaces {
     my $interfaces_list = [
         keys %{$self->form->interfaces} ];
     $logger->info('test2' . Dumper($interfaces_list));
+    my $match = /\.(.*)$/;
+    foreach my $int ($interfaces_list) {
+        $match, $interfaces_list;
+    }
+    $logger->info('test4' . Dumper($int, $match));
     return sort ( $interfaces_list );
 }
 

--- a/html/pfappserver/lib/pfappserver/Form/Interface/CreateBond.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Interface/CreateBond.pm
@@ -11,7 +11,6 @@ Form definition to add a Bond to the network configuration.
 =cut
 
 use HTML::FormHandler::Moose;
-use pf::log;
 extends 'pfappserver::Form::Interface';
 with 'pfappserver::Base::Form::Role::Help';
 
@@ -41,23 +40,14 @@ has_field 'mode' =>
   (
    type => 'Hidden',
    label => 'Mode',
-   value => 'active-backup',
+   default => 'active-backup',
   );
-
-#has_block definition =>
-#  (
-#   render_list => [ qw(name interfaces ipaddress netmask type additional_listening_daemons dns vip dhcpd_enabled nat_enabled) ],
-#  );
-
-
-use Data::Dumper;
-
-my $logger = get_logger();
 
 sub ACCEPT_CONTEXT {
     my ($self, $c, @args) = @_;
     my $interfaces = $c->model('Interface')->get('all');
-    return $self->SUPER::ACCEPT_CONTEXT($c, interfaces => $interfaces, @args);
+    my $types = $c->model('Enforcement')->getAvailableTypes('all');
+    return $self->SUPER::ACCEPT_CONTEXT($c, interfaces => $interfaces,  types => $types, @args);
 }
 
 sub options_interfaces {

--- a/html/pfappserver/lib/pfappserver/Form/Interface/CreateBond.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Interface/CreateBond.pm
@@ -18,6 +18,13 @@ with 'pfappserver::Base::Form::Role::Help';
 has 'interfaces' => ( is => 'ro' );
 
 # Form fields
+
+has_field 'name' =>
+  (
+   type => 'Text',
+   label => 'Name',
+  );
+
 has_field 'interfaces' =>
   (
    type => 'Select',
@@ -36,6 +43,12 @@ has_field 'mode' =>
    label => 'Mode',
    value => 'active-backup',
   );
+
+has_block definition =>
+  (
+   render_list => [ qw(name interfaces ipaddress netmask type additional_listening_daemons dns vip dhcpd_enabled nat_enabled) ],
+  );
+
 
 use Data::Dumper;
 

--- a/html/pfappserver/lib/pfappserver/Form/Interface/CreateBond.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Interface/CreateBond.pm
@@ -11,46 +11,47 @@ Form definition to add a Bond to the network configuration.
 =cut
 
 use HTML::FormHandler::Moose;
+use pf::log;
 extends 'pfappserver::Form::Interface';
 with 'pfappserver::Base::Form::Role::Help';
 
 has 'interfaces' => ( is => 'ro' );
 
 # Form fields
-has_field 'interface1' =>
+has_field 'interfaces' =>
   (
    type => 'Select',
-   label => 'Interface 1',
-   required => 1,
-   option_method => \&options_interfaces,
-   element_class => ['chzn-deselect'],
+   label => 'Interfaces',
+   multiple => 1,
+   options_method => \&options_interfaces,
+   element_class => ['chzn-select'],
    element_attr => { 'data-placeholder' => 'None' },
    tags => { after_element => \&help,
-             help => 'Select your first interface' },
+             help => 'Select your interfaces' },
   );
 
-has_field 'interface2' =>
+has_field 'mode' =>
   (
-   type => 'Select',
-   label => 'Interface 2',
-   required => 1,
-   option_method => \&options_interfaces,
-   element_class => ['chzn-deselect'],
-   element_attr => { 'data-placeholder' => 'None' },
-   tags => { after_element => \&help,
-             help => 'Select your second interface' },
+   type => 'Hidden',
+   label => 'Mode',
+   value => 'active-backup',
   );
+
+use Data::Dumper;
+
+my $logger = get_logger();
 
 sub ACCEPT_CONTEXT {
     my ($self, $c, @args) = @_;
-    my ($status, $roles) = $c->model('Interface')->list();
-    my @interfaces;
-    return $self->SUPER::ACCEPT_CONTEXT($c, interfaces => @interfaces);
+    my $interfaces = $c->model('Interface')->get('all');
+    return $self->SUPER::ACCEPT_CONTEXT($c, interfaces => $interfaces, @args);
 }
 
 sub options_interfaces {
     my $self = shift;
-    return $self->form->interfaces;
+    my $interfaces_list = [
+        keys %{$self->form->interfaces} ];
+    return sort ( $interfaces_list );
 }
 
 =head1 COPYRIGHT

--- a/html/pfappserver/lib/pfappserver/Form/Interface/CreateBond.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Interface/CreateBond.pm
@@ -43,24 +43,22 @@ has_field 'mode' =>
    default => 'active-backup',
   );
 
-use pf::log;
-use Data::Dumper;
-my $logger = get_logger();
-
 sub ACCEPT_CONTEXT {
     my ($self, $c, @args) = @_;
-    my @interfaces = grep {!defined $_->{master}} $c->model('Interface')->_listInterfaces('all');
-    $logger->info('my int' . Dumper(@interfaces));
+    my $inter_list = $c->model('Interface')->get('all');
+    my @interfaces = grep {!defined $_->{'vlan'}} values %{$inter_list};
     my $types = $c->model('Enforcement')->getAvailableTypes('all');
-    return $self->SUPER::ACCEPT_CONTEXT($c, interfaces => @interfaces,  types => $types, @args);
+    return $self->SUPER::ACCEPT_CONTEXT($c, interfaces => \@interfaces,  types => $types, @args);
 }
 
 sub options_interfaces {
     my $self = shift;
-    my $interfaces_list = [ #$self->form->interfaces->{name} ];
-        values %{$self->form->interfaces->{name}} ];
-    $logger->info('test2' . Dumper($interfaces_list));
-    return sort ( $interfaces_list );
+    my $interfaces_list = [
+    map { 
+        { value => $_->{name},
+          label => $_->{name}}
+        } @{$self->form->interfaces}];
+    return $interfaces_list;
 }
 
 =head1 COPYRIGHT

--- a/html/pfappserver/lib/pfappserver/Model/Config/System.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Config/System.pm
@@ -348,17 +348,27 @@ sub writeNetworkConfigs {
 
         my $vars = {
             logical_name    => $interface,
+            name_bond       => $interfaces_ref->[$interface]->{'name'},
             vlan_device     => $interfaces_ref->{$interface}->{'vlan'},
             hwaddr          => $interfaces_ref->{$interface}->{'hwaddress'},
             ipaddr          => $interfaces_ref->{$interface}->{'ipaddress'},
             netmask         => $interfaces_ref->{$interface}->{'netmask'},
+            mode            => $interfaces_ref->{$interface}->{'mode'},
+            bond_slave      => $interfaces_ref->{$interface}->{'interfaces'},
         };
 
         my $template = Template->new({
             INCLUDE_PATH    => "/usr/local/pf/html/pfappserver/root/interface",
             OUTPUT_PATH     => $var_dir,
         });
-        $template->process( "interface_rhel.tt", $vars, $_interface_conf_file.$interface );
+        
+        if ( defined $vars->{'mode'} ) {
+            $template->process( "interface_bond_rhel.tt", $vars, $_interface_conf_file.$interface );
+            $template->process( "interface_bond_slave_rhel.tt", $vars, $_interface_conf_file.$interface );
+
+        } else {
+            $template->process( "interface_rhel.tt", $vars, $_interface_conf_file.$interface );
+        }
 
         if ( $template->error() ) {
             $status_msg = "Error while writing system network interfaces configuration";

--- a/html/pfappserver/lib/pfappserver/Model/Config/System.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Config/System.pm
@@ -329,6 +329,7 @@ our $_network_conf_dir    = "/etc/sysconfig/";
 our $_interfaces_conf_dir = "network-scripts/";
 our $_network_conf_file   = "network";
 our $_interface_conf_file = "ifcfg-";
+our $__bond_salve         = "bond-slave-";
 our $var_dir              = "/usr/local/pf/var/";
 
 =head1 METHODS
@@ -368,7 +369,7 @@ sub writeNetworkConfigs {
         
         if ( defined $interfaces_ref->{$interface}->{'mode'} ) {
             $template->process( "interface_bond_rhel.tt", $vars, $_interface_conf_file.$interface );
-            $template->process( "interface_bond_slave_rhel.tt", $vars, $_interface_conf_file.$interface );
+            $template->process( "interface_bond_slave_rhel.tt", $vars, $_interface_conf_file.$_bond_slave.$interface );
 
         } else {
             $template->process( "interface_rhel.tt", $vars, $_interface_conf_file.$interface );

--- a/html/pfappserver/lib/pfappserver/Model/Config/System.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Config/System.pm
@@ -329,7 +329,7 @@ our $_network_conf_dir    = "/etc/sysconfig/";
 our $_interfaces_conf_dir = "network-scripts/";
 our $_network_conf_file   = "network";
 our $_interface_conf_file = "ifcfg-";
-our $__bond_salve         = "bond-slave-";
+our $_bond_slave         = "bond-slave-";
 our $var_dir              = "/usr/local/pf/var/";
 
 =head1 METHODS

--- a/html/pfappserver/lib/pfappserver/Model/Interface.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Interface.pm
@@ -80,6 +80,7 @@ sub create_bond {
     my ( $self, $interface ) = @_;
     my $logger = get_logger();
 
+    use Data::Dumper;
     my ($status, $status_msg);
 
     # This method does not handle the 'all' interface neither the 'lo' one
@@ -96,7 +97,7 @@ sub create_bond {
     #my ($physical_interface, $vlan_id) = split( /\./, $interface );
 
     # Check if interfaces exists
-    my $interfaces = $interface_ref->interface->{'interfaces'};
+    my $interfaces = $interface->{interfaces};
     ($status, $status_msg) = $self->exists($interfaces);
     if ( is_error($status) ) {
         $status_msg = ["Interfaces [_1] does not exists so can't create Bond on it",$interfaces];
@@ -105,8 +106,8 @@ sub create_bond {
     }
 
     # Create requested virtual interface
-    my $bond_name = $interface_ref->interface->{'name'};
-    my $mode = $interface_ref->interface->{'mode'};
+    my $bond_name = $interface->{name};
+    my $mode = $interface->{mode};
     my $cmd = "sudo nmcli con add type bond con-name $bond_name ifname $bond_name mode $mode";
     eval { $status = pf_run($cmd) };
     if ( $@ || !$status ) {
@@ -119,7 +120,7 @@ sub create_bond {
     # Enable the newly created virtual interface
     $self->up($interface);
 
-    return ($STATUS::CREATED, ["Interface VLAN [_1] successfully created",$interface]);
+    return ($STATUS::CREATED, ["Interface Bond [_1] successfully created",$interface]);
 }
 =head2 delete
 

--- a/html/pfappserver/lib/pfappserver/Model/Interface.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Interface.pm
@@ -77,12 +77,13 @@ sub create {
 =cut
 
 sub create_bond {
-    my ( $self, $interface ) = @_;
+    my ( $self, $interface, $data ) = @_;
     my $logger = get_logger();
 
     use Data::Dumper;
     my ($status, $status_msg);
 
+    $logger->info('ma super interface' . Dumper($interface));
     # This method does not handle the 'all' interface neither the 'lo' one
     return ($STATUS::FORBIDDEN, "This method does not handle interface $interface")
         if ( ($interface eq 'all') || ($interface eq 'lo') );
@@ -94,10 +95,9 @@ sub create_bond {
         return ($STATUS::OK, $status_msg);
     }
 
-    #my ($physical_interface, $vlan_id) = split( /\./, $interface );
-
     # Check if interfaces exists
-    my $interfaces = $interface->{interfaces};
+    my $interfaces = $data->{interfaces};
+    $logger->info('my interfaces' . Dumper($interfaces));
     ($status, $status_msg) = $self->exists($interfaces);
     if ( is_error($status) ) {
         $status_msg = ["Interfaces [_1] does not exists so can't create Bond on it",$interfaces];
@@ -106,9 +106,8 @@ sub create_bond {
     }
 
     # Create requested virtual interface
-    my $bond_name = $interface->{name};
-    my $mode = $interface->{mode};
-    my $cmd = "sudo nmcli con add type bond con-name $bond_name ifname $bond_name mode $mode";
+    my $mode = $data->{mode};
+    my $cmd = "sudo nmcli con add type bond con-name $interface ifname $interface mode $mode";
     eval { $status = pf_run($cmd) };
     if ( $@ || !$status ) {
         $status_msg = ["Error in creating interface Bond [_1]",$interface];

--- a/html/pfappserver/lib/pfappserver/Model/Interface.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Interface.pm
@@ -116,13 +116,13 @@ sub create_bond {
     }
 
     # Creating requested slave bond interfaces
-    my $cmd_slave = "sudo nmcli con add type bond-slave con-name $interfaces[$_] master $interface";
-    eval { $status = pf_run($cmd_slave) };
-    if ( $@ || !$status ) {
-        $status_msg = ["Error in creating interface Bond Slave [_1]",$interface[$_]];
-        $logger->error($status_msg);
-        return ($STATUS::INTERNAL_SERVER_ERROR, $status_msg);
-    }
+    #my $cmd_slave = "sudo nmcli con add type bond-slave con-name $interfaces[$_] ifname $interfaces[$_] master $interface";
+    #eval { $status = pf_run($cmd_slave) };
+    #if ( $@ || !$status ) {
+    #    $status_msg = ["Error in creating interface Bond Slave [_1]",$interface[$_]];
+    #    $logger->error($status_msg);
+    #    return ($STATUS::INTERNAL_SERVER_ERROR, $status_msg);
+    #}
 
     # Might want to move this one in the controller... create doesn't invoke up...
     # Enable the newly created bond interface

--- a/html/pfappserver/lib/pfappserver/Model/Interface.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Interface.pm
@@ -282,6 +282,7 @@ sub get {
     my ( $self, $interface) = @_;
     my $logger = get_logger();
     my $models = $self->{models};
+    use Data::Dumper;
 
     # Put requested interfaces into an array
     my @interfaces = $self->_listInterfaces($interface);

--- a/html/pfappserver/lib/pfappserver/Model/Interface.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Interface.pm
@@ -83,7 +83,6 @@ sub create_bond {
     use Data::Dumper;
     my ($status, $status_msg);
 
-    $logger->info('ma super interface' . Dumper($interface));
     # This method does not handle the 'all' interface neither the 'lo' one
     return ($STATUS::FORBIDDEN, "This method does not handle interface $interface")
         if ( ($interface eq 'all') || ($interface eq 'lo') );
@@ -96,13 +95,16 @@ sub create_bond {
     }
 
     # Check if interfaces exists
-    my $interfaces = $data->{interfaces};
-    $logger->info('my interfaces' . Dumper($interfaces));
-    ($status, $status_msg) = $self->exists($interfaces);
-    if ( is_error($status) ) {
-        $status_msg = ["Interfaces [_1] does not exists so can't create Bond on it",$interfaces];
-        $logger->warn($status_msg);
-        return ($STATUS::PRECONDITION_FAILED, $status_msg);
+    my @interfaces_bond = $data->{interfaces};
+    $logger->info('interfaces' . Dumper(@interfaces_bond));
+    foreach my $bond_interface (@interfaces_bond) {
+        $logger->info('tbond' . Dumper($bond_interface));
+        ($status, $status_msg) = $self->exists($bond_interface);
+        if ( is_error($status) ) {
+            $status_msg = ["Interfaces [_1] does not exists so can't create Bond on it",$bond_interface];
+            $logger->warn($status_msg);
+            return ($STATUS::PRECONDITION_FAILED, $status_msg);
+        }
     }
 
     # Create requested bond interface
@@ -126,7 +128,7 @@ sub create_bond {
 
     # Might want to move this one in the controller... create doesn't invoke up...
     # Enable the newly created bond interface
-    $self->up($interfaces, $interface);
+    $self->up(@interfaces_bond, $interface);
 
     return ($STATUS::CREATED, ["Interface Bond [_1] successfully created",$interface]);
 }

--- a/html/pfappserver/lib/pfappserver/Model/Interface.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Interface.pm
@@ -105,7 +105,7 @@ sub create_bond {
         return ($STATUS::PRECONDITION_FAILED, $status_msg);
     }
 
-    # Create requested virtual interface
+    # Create requested bond interface
     my $mode = $data->{mode};
     my $cmd = "sudo nmcli con add type bond con-name $interface ifname $interface mode $mode";
     eval { $status = pf_run($cmd) };
@@ -115,9 +115,18 @@ sub create_bond {
         return ($STATUS::INTERNAL_SERVER_ERROR, $status_msg);
     }
 
+    # Creating requested slave bond interfaces
+    my $cmd_slave = "sudo nmcli con add type bond-slave con-name $interfaces[$_] master $interface";
+    eval { $status = pf_run($cmd_slave) };
+    if ( $@ || !$status ) {
+        $status_msg = ["Error in creating interface Bond Slave [_1]",$interface[$_]];
+        $logger->error($status_msg);
+        return ($STATUS::INTERNAL_SERVER_ERROR, $status_msg);
+    }
+
     # Might want to move this one in the controller... create doesn't invoke up...
-    # Enable the newly created virtual interface
-    $self->up($interface);
+    # Enable the newly created bond interface
+    $self->up($interfaces, $interface);
 
     return ($STATUS::CREATED, ["Interface Bond [_1] successfully created",$interface]);
 }

--- a/html/pfappserver/lib/pfappserver/Model/Interface.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Interface.pm
@@ -117,10 +117,10 @@ sub create_bond {
 
     # Creating requested slave bond interfaces
     foreach my $bond_interface (@$interfaces_bond) {
-        my $cmd_slave = "sudo nmcli con add type bond-slave con-name $bond_interface ifname $bond_interface master $interface";
+        my $cmd_slave = "sudo nmcli con add type bond-slave con-name $bond_interface-slave ifname $bond_interface-slave master $interface";
         eval { $status = pf_run($cmd_slave) };
         if ( $@ || !$status ) {
-            $status_msg = ["Error in creating interface Bond Slave [_1]",$bond_interface];
+            $status_msg = ["Error in creating interface Bond Slave [_1]",$bond_interface . "-slave"];
             $logger->error($status_msg);
             return ($STATUS::INTERNAL_SERVER_ERROR, $status_msg);
         }
@@ -129,7 +129,7 @@ sub create_bond {
     # Might want to move this one in the controller... create doesn't invoke up...
     # Enable the newly created bond-slave interface
     foreach my $bond_interface (@$interfaces_bond) {
-        $self->($bond_interface);
+        $self->up($bond_interface);
         return ($STATUS::CREATED, ["Interface Bond Slave [_1] successfully created",$bond_interface]);
     }
     # Enable the newly created bond interface

--- a/html/pfappserver/lib/pfappserver/Model/Interface.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Interface.pm
@@ -95,10 +95,8 @@ sub create_bond {
     }
 
     # Check if interfaces exists
-    my @interfaces_bond = $data->{interfaces};
-    $logger->info('interfaces' . Dumper(@interfaces_bond));
-    foreach my $bond_interface (@interfaces_bond) {
-        $logger->info('tbond' . Dumper($bond_interface));
+    my $interfaces_bond = $data->{interfaces};
+    foreach my $bond_interface (@$interfaces_bond) {
         ($status, $status_msg) = $self->exists($bond_interface);
         if ( is_error($status) ) {
             $status_msg = ["Interfaces [_1] does not exists so can't create Bond on it",$bond_interface];
@@ -109,7 +107,7 @@ sub create_bond {
 
     # Create requested bond interface
     my $mode = $data->{mode};
-    my $cmd = "sudo nmcli con add type bond con-name $interface ifname $interface mode $mode";
+    my $cmd = "nmcli con add type bond con-name $interface ifname $interface mode $mode";
     eval { $status = pf_run($cmd) };
     if ( $@ || !$status ) {
         $status_msg = ["Error in creating interface Bond [_1]",$interface];
@@ -128,7 +126,7 @@ sub create_bond {
 
     # Might want to move this one in the controller... create doesn't invoke up...
     # Enable the newly created bond interface
-    $self->up(@interfaces_bond, $interface);
+    $self->up($interfaces_bond, $interface);
 
     return ($STATUS::CREATED, ["Interface Bond [_1] successfully created",$interface]);
 }

--- a/html/pfappserver/lib/pfappserver/PacketFence/Controller/Interface.pm
+++ b/html/pfappserver/lib/pfappserver/PacketFence/Controller/Interface.pm
@@ -202,8 +202,6 @@ sub create_bond :Local :AdminRole('INTERFACES_CREATE') {
             my $data = $form->value;
             my $interface = $data->{bond_name};
             $logger->info('data' . Dumper($data));
-            $logger->info('interfaces' . Dumper($data->{interfaces}));
-            $logger->info('bond name' . Dumper($interface));
             ($status, $result) = $c->model('Interface')->create_bond($interface, $data);
             if (is_success($status)) {
                 ($status, $result) = $c->model('Interface')->update($interface, $data);

--- a/html/pfappserver/lib/pfappserver/PacketFence/Controller/Interface.pm
+++ b/html/pfappserver/lib/pfappserver/PacketFence/Controller/Interface.pm
@@ -183,7 +183,8 @@ sub create_bond :Local :AdminRole('INTERFACES_CREATE') {
     my ($status, $result, $form);
 
     if ($c->request->method eq 'POST') {
-        $form = pfappserver::Form::Interface::CreateBond->new(ctx => $c, types => $types);
+        $form = $c->form('Interface::CreateBond');
+        #$form = pfappserver::Form::Interface::CreateBond->new(ctx => $c, types => $types);
         $form->process(params => $c->req->params);
         if ($form->has_errors) {
             $status = HTTP_BAD_REQUEST;
@@ -204,9 +205,10 @@ sub create_bond :Local :AdminRole('INTERFACES_CREATE') {
         $c->stash->{current_view} = 'JSON';
     }
     else {
-        $form = pfappserver::Form::Interface::CreateBond->new(ctx => $c,
-                                                          types => $types,
-                                                          init_object => { name => $c->stash->{interface} });
+        #$form = pfappserver::Form::Interface::CreateBond->new(ctx => $c,
+        #                                                  types => $types,
+        #                                                  init_object => { name => $c->stash->{interface} });
+        $form = $c->form('Interface::CreateBond');
         $form->process();
         $c->stash->{form} = $form;
 

--- a/html/pfappserver/lib/pfappserver/PacketFence/Controller/Interface.pm
+++ b/html/pfappserver/lib/pfappserver/PacketFence/Controller/Interface.pm
@@ -182,12 +182,13 @@ sub create_bond :Local :AdminRole('INTERFACES_CREATE') {
         $mechanism = [ keys %{$c->session->{'enforcements'}} ];
     }
     my $types = $c->model('Enforcement')->getAvailableTypes($mechanism);
+    
+    $c->stash->{type} = $types;
 
     my ($status, $result, $form);
 
     if ($c->request->method eq 'POST') {
         $form = $c->form('Interface::CreateBond');
-        #$form = pfappserver::Form::Interface::CreateBond->new(ctx => $c, types => $types);
         $form->process(params => $c->req->params);
         if ($form->has_errors) {
             $status = HTTP_BAD_REQUEST;
@@ -209,9 +210,6 @@ sub create_bond :Local :AdminRole('INTERFACES_CREATE') {
         $c->stash->{current_view} = 'JSON';
     }
     else {
-        #$form = pfappserver::Form::Interface::CreateBond->new(ctx => $c,
-        #                                                  types => $types,
-        #                                                  init_object => { name => $c->stash->{interface} });
         $form = $c->form('Interface::CreateBond');
         $form->process();
         $c->stash->{form} = $form;

--- a/html/pfappserver/lib/pfappserver/PacketFence/Controller/Interface.pm
+++ b/html/pfappserver/lib/pfappserver/PacketFence/Controller/Interface.pm
@@ -123,10 +123,6 @@ Usage: /interface/<logical_name>/create
 sub create :Chained('object') :PathPart('create') :Args(0) :AdminRole('INTERFACES_CREATE') {
     my ( $self, $c ) = @_;
 
-    use Data::Dumper;
-    use pf::log;
-    my $logger = get_logger();
-
     my $mechanism = 'all';
     if ($c->session->{'enforcements'}) {
         $mechanism = [ keys %{$c->session->{'enforcements'}} ];
@@ -144,9 +140,7 @@ sub create :Chained('object') :PathPart('create') :Args(0) :AdminRole('INTERFACE
         }
         else {
             my $data = $form->value;
-            $logger->info('test1' . Dumper($data));
             my $interface = $c->stash->{interface} . "." . $data->{vlan};
-            $logger->info('test' . Dumper($interface));
             ($status, $result) = $c->model('Interface')->create($interface);
             if (is_success($status)) {
                 ($status, $result) = $c->model('Interface')->update($interface, $data);
@@ -201,10 +195,9 @@ sub create_bond :Local :AdminRole('INTERFACES_CREATE') {
         else {
             my $data = $form->value;
             my $interface = $data->{bond_name};
-            $logger->info('data' . Dumper($data));
             ($status, $result) = $c->model('Interface')->create_bond($interface, $data);
             if (is_success($status)) {
-                ($status, $result) = $c->model('Interface')->update($interface, $data);
+                ($status, $result) = $c->model('Interface')->update_bond($interface, $data);
             }
             $self->audit_current_action($c, status => $status, interface => $interface, data => $data );
 

--- a/html/pfappserver/lib/pfappserver/PacketFence/Controller/Interface.pm
+++ b/html/pfappserver/lib/pfappserver/PacketFence/Controller/Interface.pm
@@ -174,6 +174,9 @@ Usage: /interface/create_bond
 sub create_bond :Local :AdminRole('INTERFACES_CREATE') {
     my ( $self, $c ) = @_;
 
+    use Data::Dumper;
+    use pf::log;
+    my $logger = get_logger();
     my $mechanism = 'all';
     if ($c->session->{'enforcements'}) {
         $mechanism = [ keys %{$c->session->{'enforcements'}} ];
@@ -192,7 +195,8 @@ sub create_bond :Local :AdminRole('INTERFACES_CREATE') {
         }
         else {
             my $data = $form->value;
-            my $interface = $c->stash->{interface} . "." . $data->{bond};
+            my $interface = $c->stash->{bond_name}; # . "." . $data->{bond};
+            $logger->info('bond name' . Dumper($interface));
             ($status, $result) = $c->model('Interface')->create_bond($interface);
             if (is_success($status)) {
                 ($status, $result) = $c->model('Interface')->update($interface, $data);

--- a/html/pfappserver/lib/pfappserver/PacketFence/Controller/Interface.pm
+++ b/html/pfappserver/lib/pfappserver/PacketFence/Controller/Interface.pm
@@ -167,7 +167,7 @@ sub create :Chained('object') :PathPart('create') :Args(0) :AdminRole('INTERFACE
 
 Create an bond interface
 
-Usage: /interface/<logical_name_bond>/create
+Usage: /interface/create
 
 =cut
 
@@ -204,7 +204,7 @@ sub create_bond :Local :AdminRole('INTERFACES_CREATE') {
         $c->stash->{current_view} = 'JSON';
     }
     else {
-        $form = pfappserver::Form::Interface::Create->new(ctx => $c,
+        $form = pfappserver::Form::Interface::CreateBond->new(ctx => $c,
                                                           types => $types,
                                                           init_object => { name => $c->stash->{interface} });
         $form->process();

--- a/html/pfappserver/lib/pfappserver/PacketFence/Controller/Interface.pm
+++ b/html/pfappserver/lib/pfappserver/PacketFence/Controller/Interface.pm
@@ -171,7 +171,7 @@ Usage: /interface/<logical_name_bond>/create
 
 =cut
 
-sub create_bond :Chained('object') :PathPart('create_bond') :Args(0) :AdminRole('INTERFACES_CREATE') {
+sub create_bond :Local :AdminRole('INTERFACES_CREATE') {
     my ( $self, $c ) = @_;
 
     my $mechanism = 'all';
@@ -183,7 +183,7 @@ sub create_bond :Chained('object') :PathPart('create_bond') :Args(0) :AdminRole(
     my ($status, $result, $form);
 
     if ($c->request->method eq 'POST') {
-        $form = pfappserver::Form::Interface::Create->new(ctx => $c, types => $types);
+        $form = pfappserver::Form::Interface::CreateBond->new(ctx => $c, types => $types);
         $form->process(params => $c->req->params);
         if ($form->has_errors) {
             $status = HTTP_BAD_REQUEST;

--- a/html/pfappserver/lib/pfappserver/PacketFence/Controller/Interface.pm
+++ b/html/pfappserver/lib/pfappserver/PacketFence/Controller/Interface.pm
@@ -167,7 +167,7 @@ sub create :Chained('object') :PathPart('create') :Args(0) :AdminRole('INTERFACE
 
 Create an bond interface
 
-Usage: /interface/create
+Usage: /interface/create_bond
 
 =cut
 

--- a/html/pfappserver/root/interface/create_bond.tt
+++ b/html/pfappserver/root/interface/create_bond.tt
@@ -5,9 +5,8 @@
   </div>
   <div class="modal-body">
     [% form.field('name').render_element | none %]
-    [% form.field('interface1').render | none %]
-    [% form.field('interface2').render | none %]
-    [% form.field('ipaddess').render | none %]
+    [% form.field('interfaces').render | none %]
+    [% form.field('ipaddress').render | none %]
     [% form.field('netmask').render | none %]
     [% form.field('type').render | none %]
     [% form.field('additional_listening_daemons').render | none %]

--- a/html/pfappserver/root/interface/create_bond.tt
+++ b/html/pfappserver/root/interface/create_bond.tt
@@ -1,7 +1,7 @@
-<form name="modalCreateBond" class="form-horizontal" action="[% c.uri_for(c.controller('Interface').action_for('create_bond'), [interface]) %]">
+<form name="modalCreateBond" class="form-horizontal" action="[% c.uri_for(c.controller('Interface').action_for('create_bond')) %]">
   <div class="modal-header">
     <a class="close" data-dismiss="modal">&times;</a>
-    <h3><i>[% l('New Bond for') %]</i> <span>[% interface | html %]</span></h3>
+    <h3><i>[% l('New Bond') %]</i></h3>
   </div>
   <div class="modal-body">
     [% form.field('name').render_element | none %]
@@ -9,10 +9,6 @@
     [% form.field('interface2').render | none %]
     [% form.field('ipaddess').render | none %]
     [% form.field('netmask').render | none %]
-    [% form.field('interface1_ip').render | none %]
-    [% form.field('interface1_netmask').render | none %]
-    [% form.field('interface2_ip').render | none %]
-    [% form.field('interface2_netmask').render | none %]
     [% form.field('type').render | none %]
     [% form.field('additional_listening_daemons').render | none %]
     [% form.field('mode').render | none %]

--- a/html/pfappserver/root/interface/create_bond.tt
+++ b/html/pfappserver/root/interface/create_bond.tt
@@ -4,7 +4,7 @@
     <h3><i>[% l('New Bond') %]</i></h3>
   </div>
   <div class="modal-body">
-    [% form.field('name').render_element | none %]
+    [% form.field('name').render | none %]
     [% form.field('interfaces').render | none %]
     [% form.field('ipaddress').render | none %]
     [% form.field('netmask').render | none %]

--- a/html/pfappserver/root/interface/create_bond.tt
+++ b/html/pfappserver/root/interface/create_bond.tt
@@ -1,0 +1,30 @@
+<form name="modalCreateBond" class="form-horizontal" action="[% c.uri_for(c.controller('Interface').action_for('create_bond'), [interface]) %]">
+  <div class="modal-header">
+    <a class="close" data-dismiss="modal">&times;</a>
+    <h3><i>[% l('New Bond for') %]</i> <span>[% interface | html %]</span></h3>
+  </div>
+  <div class="modal-body">
+    [% form.field('name').render_element | none %]
+    [% form.field('interface1').render | none %]
+    [% form.field('interface2').render | none %]
+    [% form.field('ipaddess').render | none %]
+    [% form.field('netmask').render | none %]
+    [% form.field('interface1_ip').render | none %]
+    [% form.field('interface1_netmask').render | none %]
+    [% form.field('interface2_ip').render | none %]
+    [% form.field('interface2_netmask').render | none %]
+    [% form.field('type').render | none %]
+    [% form.field('additional_listening_daemons').render | none %]
+    [% form.field('mode').render | none %]
+    [% form.field('dns').render | none %]
+    [% form.field('vip').render | none %]
+    [% form.field('dhcpd_enabled').render | none %]
+    [% form.field('nat_enabled').render | none %]
+    <p class="info_inline">[% l('Remember to enable ip_forward on your operating system for the inline mode to work.') %]</p>
+    <p class="info_routed">[% l('Since NATting mode is disabled, PacketFence will adjust iptables to rules to route traffic rather than natting it. Make sure to add the routes on the system.') %]</p>
+  </div>
+  <div class="modal-footer">
+    <a href="#" class="btn" data-dismiss="modal">[% l('Cancel') %]</a>
+    <button type="submit" class="btn btn-primary" data-loading-text="[% l('Creating') %]">[% l('Create') %]</button>
+  </div>
+</form>

--- a/html/pfappserver/root/interface/create_bond.tt
+++ b/html/pfappserver/root/interface/create_bond.tt
@@ -4,7 +4,7 @@
     <h3><i>[% l('New Bond') %]</i></h3>
   </div>
   <div class="modal-body">
-    [% form.field('name').render | none %]
+    [% form.field('bond_name').render | none %]
     [% form.field('interfaces').render | none %]
     [% form.field('ipaddress').render | none %]
     [% form.field('netmask').render | none %]

--- a/html/pfappserver/root/interface/index.tt
+++ b/html/pfappserver/root/interface/index.tt
@@ -5,5 +5,6 @@
 [%- IF can_access("INTERFACES_CREATE") %]
 <div class="form-actions">
   <a id="createNetwork" class="btn" href="[% c.uri_for(c.controller('Config::Networks').action_for('create')) %]">[% l('Add routed network') %]</a>
+  <a id="createBond" class="btn" href="[% c.uri_for(c.controller('Interface').action_for('create_bond')) %]">[% l('Create Bond Interface') %]</a>
 </div>
 [%- END %]

--- a/html/pfappserver/root/interface/interface_bond_rhel.tt
+++ b/html/pfappserver/root/interface/interface_bond_rhel.tt
@@ -1,12 +1,10 @@
-DEVICE=[% logical_name_bond %]
-NAME=[% logical_name_bond %]
-[% IF !vlan_device %]HWADDR=[% hwaddr %][% END %][% IF vlan_device %]VLAN=yes[% END %]
+DEVICE=[% name_bond %]
+NAME=[% name_bond %]
 ONBOOT=yes
 BOOTPROTO=none
 NM_CONTROLLED=yes
 IPADDR=[% ipaddr %]
 NETMASK=[% netmask %]
-GATEWAY=[% gateway %]
 TYPE=Bond
 BONDING_OPTS=mode=[% mode %]
 BONDING_MASTER=yes

--- a/html/pfappserver/root/interface/interface_bond_rhel.tt
+++ b/html/pfappserver/root/interface/interface_bond_rhel.tt
@@ -1,0 +1,12 @@
+DEVICE=[% logical_name_bond %]
+NAME=[% logical_name_bond %]
+[% IF !vlan_device %]HWADDR=[% hwaddr %][% END %][% IF vlan_device %]VLAN=yes[% END %]
+ONBOOT=yes
+BOOTPROTO=none
+NM_CONTROLLED=yes
+IPADDR=[% ipaddr %]
+NETMASK=[% netmask %]
+GATEWAY=[% gateway %]
+TYPE=Bond
+BONDING_OPTS=mode=[% mode %]
+BONDING_MASTER=yes

--- a/html/pfappserver/root/interface/interface_bond_slave_rhel.tt
+++ b/html/pfappserver/root/interface/interface_bond_slave_rhel.tt
@@ -1,4 +1,4 @@
-DEVICE=[% logical_name %]
+DEVICE=bond_[% logical_name %]
 ONBOOT=yes
 BOOTPROTO=none
 NM_CONTROLLED=no

--- a/html/pfappserver/root/interface/interface_bond_slave_rhel.tt
+++ b/html/pfappserver/root/interface/interface_bond_slave_rhel.tt
@@ -1,0 +1,6 @@
+DEVICE=[% logical_name %]
+ONBOOT=yes
+BOOTPROTO=none
+NM_CONTROLLED=no
+MASTER=[% name_bond %]
+SLAVE=yes

--- a/html/pfappserver/root/interface/interface_bond_slave_rhel.tt
+++ b/html/pfappserver/root/interface/interface_bond_slave_rhel.tt
@@ -1,6 +1,6 @@
 DEVICE=bond_[% logical_name %]
 ONBOOT=yes
 BOOTPROTO=none
-NM_CONTROLLED=no
+NM_CONTROLLED=yes
 MASTER=[% name_bond %]
 SLAVE=yes

--- a/html/pfappserver/root/interface/list.tt
+++ b/html/pfappserver/root/interface/list.tt
@@ -39,6 +39,7 @@
                 [% IF can_access("INTERFACES_DELETE") %]<a class="btn btn-mini btn-danger" interface="[% i | html %]" href="[% c.uri_for(c.controller('Interface').action_for('delete'), [i]) %]">[% l('Delete') %]</a>[% END %]
                 [% ELSE -%]
                 [% IF can_access("INTERFACES_CREATE") %]<a class="btn btn-mini" data-toggle="modal" interface="[% i | html %]" href="[% c.uri_for(c.controller('Interface').action_for('create'), [i]) %]">[% l('Add VLAN') %]</a>[% END %]
+                [% IF can_access("INTERFACES_CREATE") %]<a class="btn btn-mini" data-toggle="modal" interface="[% i | html %]" href="[% c.uri_for(c.controller('Interface').action_for('create_bond'), [i]) %]">[% l('Create Bond') %]</a>[% END %]
                 [% END -%]
               </td>
             </tr>

--- a/html/pfappserver/root/interface/list.tt
+++ b/html/pfappserver/root/interface/list.tt
@@ -39,7 +39,6 @@
                 [% IF can_access("INTERFACES_DELETE") %]<a class="btn btn-mini btn-danger" interface="[% i | html %]" href="[% c.uri_for(c.controller('Interface').action_for('delete'), [i]) %]">[% l('Delete') %]</a>[% END %]
                 [% ELSE -%]
                 [% IF can_access("INTERFACES_CREATE") %]<a class="btn btn-mini" data-toggle="modal" interface="[% i | html %]" href="[% c.uri_for(c.controller('Interface').action_for('create'), [i]) %]">[% l('Add VLAN') %]</a>[% END %]
-                [% IF can_access("INTERFACES_CREATE") %]<a class="btn btn-mini" data-toggle="modal" interface="[% i | html %]" href="[% c.uri_for(c.controller('Interface').action_for('create_bond'), [i]) %]">[% l('Create Bond') %]</a>[% END %]
                 [% END -%]
               </td>
             </tr>

--- a/html/pfappserver/root/static/admin/config/interfaces.js
+++ b/html/pfappserver/root/static/admin/config/interfaces.js
@@ -4,4 +4,5 @@ $(function() { // DOM ready
 
     var read = $.proxy(view.readInterface, view);
     $('#section').on('click', '#createNetwork', read);
+    $('#section').on('click', '#createBond', read);
 });

--- a/html/pfappserver/root/static/js/interface.js
+++ b/html/pfappserver/root/static/js/interface.js
@@ -56,6 +56,9 @@ var InterfaceView = function(options) {
     var update = $.proxy(this.updateInterface, this);
     options.parent.on('submit', 'form[name="modalEditInterface"], form[name="modalCreateVlan"]', update);
 
+    var update = $.proxy(this.updateBondInterface, this);
+    options.parent.on('submit', 'form[name="modalEditInterface"], form[name="modalCreateBond"]', update);
+
     var delete_i = $.proxy(this.deleteInterface, this);
     options.parent.on('click', '#interfaces [href$="/delete"]', delete_i);
 
@@ -261,6 +264,34 @@ InterfaceView.prototype.fakeMacChanged = function(e) {
 };
 
 InterfaceView.prototype.updateInterface = function(e) {
+    e.preventDefault();
+
+    var that = this;
+    var form = $(e.target);
+    var btn = form.find('.btn-primary');
+    var modal = $('#modalEditInterface');
+    var valid = isFormValid(form);
+    if (valid) {
+        var modal_body = modal.find('.modal-body').first();
+        resetAlert(modal_body);
+        btn.button('loading');
+        this.interfaces.post({
+            url: form.attr('action'),
+            data: form.serialize(),
+            always: function() {
+                btn.button('reset');
+            },
+            success: function(data) {
+                modal.modal('toggle');
+                showSuccess($('#interfaces table'), data.status_msg);
+                that.list();
+            },
+            errorSibling: modal_body.children().first()
+        });
+    }
+};
+
+InterfaceView.prototype.updateBondInterface = function(e) {
     e.preventDefault();
 
     var that = this;

--- a/html/pfappserver/root/static/js/interface.js
+++ b/html/pfappserver/root/static/js/interface.js
@@ -51,7 +51,7 @@ var InterfaceView = function(options) {
     this.disableToggle = false;
 
     var read = $.proxy(this.readInterface, this);
-    options.parent.on('click', '#interfaces [href$="/read"], #interfaces [href$="/create"], #interfaces [href$="/view"]', read);
+    options.parent.on('click', '#interfaces [href$="/read"], #interfaces [href$="/create"], #interfaces [href$="/create_bond"],  #interfaces [href$="/view"]', read);
 
     var update = $.proxy(this.updateInterface, this);
     options.parent.on('submit', 'form[name="modalEditInterface"], form[name="modalCreateVlan"]', update);


### PR DESCRIPTION
# Description

Allow the creation of Bond interface from the admin and the configurator
# Impacts

Admin section "interfaces", configurator section "networks"
# Issue

fixes #1475
# Delete branch after merge

NO
# NEWS file entries
## New Features
- PacketFence now handle the creation of bonding interfaces from the admin or the configurator.
