### PR TITLE
Add Radius CLI login support on brocade ICX series

### DIFF
--- a/lib/pf/Switch/Brocade.pm
+++ b/lib/pf/Switch/Brocade.pm
@@ -354,6 +354,47 @@ sub ifIndexToLldpLocalPort {
     return;
 }
 
+=item returnAuthorizeWrite
+
+Return radius attributes to allow write access
+
+=cut
+
+sub returnAuthorizeWrite {
+   my ($self, $args) = @_;
+   my $logger = $self->logger;
+   my $radius_reply_ref;
+   my $status;
+   $radius_reply_ref->{'Foundry-Privilege-Level'} = '0';
+   $radius_reply_ref->{'Reply-Message'} = "Switch enable access granted by PacketFence";
+   $logger->info("User $args->{'user_name'} logged in $args->{'switch'}{'_id'} with write access");
+   my $filter = pf::access_filter::radius->new;
+   my $rule = $filter->test('returnAuthorizeWrite', $args);
+   ($radius_reply_ref, $status) = $filter->handleAnswerInRule($rule,$args,$radius_reply_ref);
+   return [$status, %$radius_reply_ref];
+
+}
+
+=item returnAuthorizeRead
+
+Return radius attributes to allow read access
+
+=cut
+
+sub returnAuthorizeRead {
+   my ($self, $args) = @_;
+   my $logger = $self->logger;
+   my $radius_reply_ref;
+   my $status;
+   $radius_reply_ref->{'Foundry-Privilege-Level'} = '5';
+   $radius_reply_ref->{'Reply-Message'} = "Switch read access granted by PacketFence";
+   $logger->info("User $args->{'user_name'} logged in $args->{'switch'}{'_id'} with read access");
+   my $filter = pf::access_filter::radius->new;
+   my $rule = $filter->test('returnAuthorizeRead', $args);
+   ($radius_reply_ref, $status) = $filter->handleAnswerInRule($rule,$args,$radius_reply_ref);
+   return [$status, %$radius_reply_ref];
+}
+
 =back
 
 =head1 AUTHOR

--- a/lib/pf/Switch/Brocade.pm
+++ b/lib/pf/Switch/Brocade.pm
@@ -363,7 +363,7 @@ Return radius attributes to allow write access
 sub returnAuthorizeWrite {
    my ($self, $args) = @_;
    my $logger = $self->logger;
-   my $radius_reply_ref;
+   my $radius_reply_ref = {};
    my $status;
    $radius_reply_ref->{'Foundry-Privilege-Level'} = '0';
    $radius_reply_ref->{'Reply-Message'} = "Switch enable access granted by PacketFence";
@@ -384,7 +384,7 @@ Return radius attributes to allow read access
 sub returnAuthorizeRead {
    my ($self, $args) = @_;
    my $logger = $self->logger;
-   my $radius_reply_ref;
+   my $radius_reply_ref = {};
    my $status;
    $radius_reply_ref->{'Foundry-Privilege-Level'} = '5';
    $radius_reply_ref->{'Reply-Message'} = "Switch read access granted by PacketFence";


### PR DESCRIPTION
# Description

Add Radius CLI login support on brocade ICX series. It uses the Radius attribute Foundry-Privilege-Level.

You need to assign the Write or Read access via an Administration role
# Impacts

NONE
# Delete branch after merge

YES 
# NEWS file entries
## New Features
- Brocade CLI authentication over RADIUS
