### PR TITLE
Delete environment variable `LANGUAGE` when initializing i18n

### DIFF
--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Root.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Root.pm
@@ -152,6 +152,7 @@ sub setupLanguage : Private {
         $logger->error("Error while setting locale to $locale.utf8. Is the locale generated on your system?");
     }
     $c->stash->{locale} = $newlocale;
+    delete $ENV{'LANGUAGE'}; # Make sure $LANGUAGE is empty otherwise it will override LC_MESSAGES
     bindtextdomain( "packetfence", "$conf_dir/locale" );
     bind_textdomain_codeset( "packetfence", "utf-8" );
     textdomain("packetfence");

--- a/lib/pf/Portal/Session.pm
+++ b/lib/pf/Portal/Session.pm
@@ -204,6 +204,7 @@ sub _initializeI18n {
         $logger->error("Error while setting locale to $locale.utf8. Is the locale generated on your system?");
     }
     $self->stash->{locale} = $newlocale;
+    delete $ENV{'LANGUAGE'}; # Make sure $LANGUAGE is empty otherwise it will override LC_MESSAGES
     bindtextdomain( "packetfence", "$conf_dir/locale" );
     bind_textdomain_codeset( "packetfence", "utf-8" );
     textdomain("packetfence");


### PR DESCRIPTION
# Description

From `man 3 gettext`:

```
If the LANGUAGE environment variable is set to a nonempty  value,
and the  locale  is not the "C" locale, the value of LANGUAGE is
assumed to contain a colon separated list of  locale  names.  The
functions will attempt  to  look  up  a translation of msgid in
each of the locales in turn. This is a GNU extension.
```

Therefore, we have to make sure `$LANGUAGE` is empty, otherwise it will override our setting for `LC_MESSAGES`. On Debian, the Installer sets this in `/etc/default/locale` when a different language and locale are selected (such as `english` and `de_DE.UTF-8`).
# NEWS file entries
## Bug Fixes
- Localization now works even if the LANGUAGE environment variable is set
