### PR TITLE
Use correct constant in CURLOPT_HTTPAUTH

### DIFF
--- a/lib/pf/api/jsonrpcclient.pm
+++ b/lib/pf/api/jsonrpcclient.pm
@@ -183,7 +183,7 @@ sub curl {
             $curl->setopt(CURLOPT_PASSWORD, $self->password);
         }
 
-        $curl->setopt(CURLOPT_HTTPAUTH, CURLOPT_HTTPAUTH);
+        $curl->setopt(CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
         # Removed SSL verification
         $curl->setopt(CURLOPT_SSL_VERIFYHOST, 0);
         $curl->setopt(CURLOPT_SSL_VERIFYPEER, 0);


### PR DESCRIPTION
# Description

Packetfence never actually sent username/password with the jsonrpcclient class, because a wrong flag was used. This patch fixes that problem.
# NEWS file entries
## Bug Fixes
- Send username/password in RPC requests when https is used
