### PR TITLE
Add Firewall/SSO type "JSON-RPC"

### DIFF
--- a/html/pfappserver/lib/pfappserver/Form/Config/Firewall_SSO/JSONRPC.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Firewall_SSO/JSONRPC.pm
@@ -1,0 +1,119 @@
+package pfappserver::Form::Config::Firewall_SSO::JSONRPC;
+
+=head1 NAME
+
+pfappserver::Form::Config::Firewall_SSO::JSONRPC - Web form for a JSON-RPC device
+
+=head1 DESCRIPTION
+
+Form definition to create or update an JSON-RPC device.
+
+=cut
+
+use HTML::FormHandler::Moose;
+extends 'pfappserver::Form::Config::Firewall_SSO';
+with 'pfappserver::Base::Form::Role::Help';
+
+use pf::config;
+use pf::util;
+use File::Find qw(find);
+
+## Definition
+has 'roles' => (is => 'ro', default => sub {[]});
+
+has_field 'id' =>
+  (
+   type => 'Text',
+   label => 'Hostname or IP Address',
+   required => 1,
+   messages => { required => 'Please specify the hostname or IP of the JSON-RPC server' },
+  );
+has_field 'username' =>
+  (
+   type => 'Text',
+   label => 'Username',
+   required => 1,
+   messages => { required => 'Please specify the username for JSON-RPC server' },
+  );
+has_field 'password' =>
+  (
+   type => 'Password',
+   label => 'Password',
+   required => 1,
+   messages => { required => 'You must specify the password' },
+  );
+has_field 'port' =>
+  (
+   type => 'PosInteger',
+   label => 'Port of the service',
+   tags => { after_element => \&help,
+             help => 'If you use an alternative port, please specify' },
+   default => 9090,
+  );
+has_field 'type' =>
+  (
+   type => 'Hidden',
+  );
+has_field 'categories' =>
+  (
+   type => 'Select',
+   multiple => 1,
+   label => 'Roles',
+   options_method => \&options_categories,
+   element_class => ['chzn-select'],
+   element_attr => {'data-placeholder' => 'Click to add a role'},
+   tags => { after_element => \&help,
+             help => 'Nodes with the selected roles will be affected' },
+  );
+
+has_block definition =>
+  (
+   render_list => [ qw(id type username password port categories networks cache_updates cache_timeout) ],
+  );
+
+
+=head2 Methods
+
+=head2 options_categories
+
+=cut
+
+sub options_categories {
+    my $self = shift;
+
+    my ($status, $result) = $self->form->ctx->model('Roles')->list();
+    my @roles = map { $_->{name} => $_->{name} } @{$result} if ($result);
+    return ('' => '', @roles);
+}
+
+
+
+=over
+
+=back
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2016 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+__PACKAGE__->meta->make_immutable;
+1;

--- a/lib/pf/firewallsso/JSONRPC.pm
+++ b/lib/pf/firewallsso/JSONRPC.pm
@@ -1,0 +1,112 @@
+package pf::firewallsso::JSONRPC;
+
+=head1 NAME
+
+pf::firewallsso::JSONRPC
+
+=head1 SYNOPSIS
+
+The pf::firewallsso::JSONRPC module implements an object oriented interface
+to update your firewall using generic JSON-RPC calls.
+
+=cut
+
+
+use strict;
+use warnings;
+
+use base ('pf::firewallsso');
+
+use POSIX;
+
+use pf::config qw(%ConfigFirewallSSO);
+sub description { 'JSON-RPC Server' }
+use pf::node qw(node_view);
+use pf::log;
+use pf::api::jsonrpcclient;
+
+=head1 METHODS
+
+=head2 action
+
+Perform a JSON-RPC request based on the registration status of the node and its role.
+
+=cut
+
+sub action {
+    my ($self,$firewall_conf,$method,$mac,$ip,$timeout) = @_;
+    my $logger = get_logger();
+
+    my $apiclient = pf::api::jsonrpcclient->new(
+        username => $ConfigFirewallSSO{$firewall_conf}->{'username'},
+        password => $ConfigFirewallSSO{$firewall_conf}->{'password'},
+        proto => 'https',
+        host => $firewall_conf,
+        port => $ConfigFirewallSSO{$firewall_conf}->{'port'}
+        );
+
+    my $node_info = node_view($mac);
+    my $username = $node_info->{'pid'};
+    my @categories = @{$self->{categories}};
+
+    if (
+        defined($node_info) &&
+        (ref($node_info) eq 'HASH') &&
+        $node_info->{'status'} eq $pf::node::STATUS_REGISTERED &&
+        (grep $_ eq $node_info->{'category'}, @categories)
+    ){
+        # Create a request
+        my @result = $apiclient->call(
+            $method,
+            $username,
+            $mac,
+            $ip,
+            $node_info->{'category'},
+            $timeout
+            );
+
+        # Check the outcome of the response
+        if ($result[0] eq "OK") {
+            $logger->info("Username $username with node $mac was set to $method using JSON-RPC");
+        }
+        else {
+            $logger->warn("Username $username with node $mac could not be set to $method using JSON-RPC: $result[0]");
+        }
+    }
+    else {
+        $logger->warn("Not sending user $username to firewall ($mac/$ip/$timeout) because node is not registered or has unknown role");
+    }
+    return 0;
+}
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2016 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;
+
+# vim: set shiftwidth=4:
+# vim: set expandtab:
+# vim: set backspace=indent,eol,start:


### PR DESCRIPTION
# Description

This adds a rather generic json-rpc client for firewall/SSO.

We were looking to integrate packetfence with our linux firewall. Unfortunately there is no "generic" firewall/SSO type yet and I wanted something as simple as possible.

The class works well with the equally trivial server from https://github.com/tribut/ipset-rpcd

I would be happy to write some documentation/integration guide. Just let me know if you generally consider merging something like this.
# Code / PR Dependencies

Needs https://github.com/inverse-inc/packetfence/pull/1506 for http auth to work.
# NEWS file entries
## New Features
- New Firewall/SSO type: JSON-RPC
