### PR TITLE
Implement configuration of autoregistration from the profiles.

### DIFF
--- a/html/pfappserver/lib/pfappserver/Form/Config/ProfileCommon.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/ProfileCommon.pm
@@ -37,7 +37,7 @@ The main definition block
 
 has_block 'definition' =>
   (
-    render_list => [qw(id description root_module preregistration reuse_dot1x_credentials dot1x_recompute_role_from_portal)],
+    render_list => [qw(id description root_module preregistration autoregister reuse_dot1x_credentials dot1x_recompute_role_from_portal)],
   );
 
 =head2 captive_portal
@@ -176,6 +176,23 @@ has_field 'preregistration' =>
    unchecked_value => 'disabled',
    tags => { after_element => \&help,
              help => 'This activates preregistration on the portal profile. Meaning, instead of applying the access to the currently connected device, it displays a local account that is created while registering. Note that activating this disables the on-site registration on this portal profile. Also, make sure the sources on the portal profile have "Create local account" enabled.' },
+  );
+
+
+=head2 autoregister
+
+Controls whether or not this portal profile will autoregister users
+
+=cut
+
+has_field 'autoregister' =>
+  (
+   type => 'Toggle',
+   label => 'Automatically register devices',
+   checkbox_value => 'enabled',
+   unchecked_value => 'disabled',
+   tags => { after_element => \&help,
+             help => 'This activates automatic registation of devices for the profile. Devices will not be shown a captive portal and RADIUS authentication credentials will be used to register the device. This option only makes sense in the context of an 802.1x authentication.' },
   );
 
 =head2 sources

--- a/lib/pf/role.pm
+++ b/lib/pf/role.pm
@@ -378,17 +378,8 @@ sub getRegisteredRole {
     my ($self, $args) = @_;
     my $logger = $self->logger;
 
-    my $options = {};
-    $options->{'last_connection_type'} = connection_type_to_str($args->{'connection_type'}) if (defined( $args->{'connection_type'}));
-    $options->{'last_switch'}          = $args->{'switch'}->{_id} if (defined($args->{'switch'}->{_id}));
-    $options->{'last_port'}            = $args->{'ifIndex'} if (defined($args->{'ifIndex'}));
-    $options->{'last_ssid'}            = $args->{'ssid'} if (defined($args->{'ssid'}));
-    $options->{'last_dot1x_username'}  = $args->{'user_name'} if (defined($args->{'user_name'}));
-    $options->{'realm'}                = $args->{'realm'} if (defined($args->{'realm'}));
-
-    my $profile = pf::Portal::ProfileFactory->instantiate($args->{'mac'},$options);
-
     my ($vlan, $role, $result, $person, $source, $portal);
+    my $profile = $args->{'profile'};
 
     if (defined($args->{'node_info'}->{'pid'})) {
         $person = pf::person::person_view_simple($args->{'node_info'}->{'pid'});
@@ -546,19 +537,8 @@ sub getNodeInfoForAutoReg {
     my ($self, $args) = @_;
     my $logger = $self->logger;
 
-    #define the current connection value to instantiate the correct portal
-    my $options = {};
 
-    $options->{'last_connection_type'} = connection_type_to_str($args->{'connection_type'}) if (defined( $args->{'connection_type'}));
-    $options->{'last_switch'}          = $args->{'switch'}->{_id} if (defined($args->{'switch'}->{_id}));
-    $options->{'last_port'}            = $args->{'switch'}->{switch_port} if (defined($args->{'switch'}->{switch_port}));
-    $options->{'last_vlan'}            = $args->{'vlan'} if (defined($args->{'vlan'}));
-    $options->{'last_ssid'}            = $args->{'ssid'} if (defined($args->{'ssid'}));
-    $options->{'last_dot1x_username'}  = $args->{'user_name'} if (defined($args->{'user_name'}));
-    $options->{'realm'}                = $args->{'realm'} if (defined($args->{'realm'}));
-
-    my $profile = pf::Portal::ProfileFactory->instantiate($args->{'mac'},$options);
-
+    my $profile = $args->{'profile'};
     my $role = $self->filterVlan('NodeInfoForAutoReg', $args);
 
     # we do not set a default VLAN here so that node_register will set the default normalVlan from switches.conf
@@ -648,6 +628,7 @@ sub shouldAutoRegister {
     #$args->{'connection'}_type is set to the connnection type expressed as the constant in pf::config
     #$args->{'user_name'} is set to the RADIUS User-Name attribute (802.1X Username or MAC address under MAC Authentication)
     #$args->{'ssid'} is set to the wireless ssid (will be empty if radius and not wireless, undef if not radius)
+    #$args->{'profile'} is set to the portal profile for the connection.
     my ($self, $args) = @_;
     my $logger = $self->logger;
 
@@ -677,6 +658,10 @@ sub shouldAutoRegister {
         } else {
             return $role;
         }
+    }
+    if ($args->{'profile'}->{'_autoregister'} eq "enabled") { 
+        $logger->debug("Autoregistration set on profile " . $args->{'profile'}->getName() );
+        return 1;
     }
 
     # custom example: auto-register 802.1x users

--- a/lib/pf/role.pm
+++ b/lib/pf/role.pm
@@ -638,12 +638,12 @@ sub shouldAutoRegister {
     # handling switch-config first because I think it's the most important to honor
     if (defined($switch->{switch_in_autoreg_mode}) && $switch->{switch_in_autoreg_mode}) {
         $logger->trace("returned yes because it's from the switch's config (" . $args->{'switch'}->{_id} . ")");
-        return 1;
+        return $TRUE;
 
     # if we have a violation action set to autoreg
     } elsif (defined($args->{'violation_autoreg'}) && $args->{'violation_autoreg'}) {
         $logger->trace("returned yes because it's from a violation with action autoreg");
-        return 1;
+        return $TRUE;
     }
 
     if ($args->{'isPhone'}) {
@@ -654,25 +654,25 @@ sub shouldAutoRegister {
     if ($role) {
         my $vlan = $switch->getVlanByName($role);
         if (defined($vlan) && $vlan eq "-1") {
-            return 0;
+            return $FALSE;
         } else {
             return $role;
         }
     }
-    if ($args->{'profile'}->{'_autoregister'} eq "enabled") { 
+    if (isenabled $args->{'profile'}->{'_autoregister'}) { 
         $logger->debug("Autoregistration set on profile " . $args->{'profile'}->getName() );
-        return 1;
+        return $TRUE;
     }
 
     # custom example: auto-register 802.1x users
     # Since they already have validated credentials through EAP to do 802.1X
     #if (defined($conn_type) && (($conn_type & $EAP) == $EAP)) {
     #    $logger->trace("returned yes because it's a 802.1X client that successfully authenticated already");
-    #    return 1;
+    #    return $TRUE;
     #}
 
     # otherwise don't autoreg
-    return 0;
+    return $FALSE;
 }
 
 =head2 isInlineTrigger


### PR DESCRIPTION
# Description

Allows autoregistration to be enabled from the GUI, per profile.
# Impacts

No longer need a vlan filter or custom code to autoregister.
Even Mamadou can do it.
This seems too easy. I must be missing something.
# Issue

Fixes my annoyance at not having done this sooner
# Would like to thank

@fdurand for the radius.pm refactor which allowed this.
My mother, the academy.
# Delete branch after merge

YES 
# NEWS file entries

(REQUIRED, but may be optional...)
## New Features
- Automatic registration of devices is now configurable from the GUI on a per profile basis.
