### PR TITLE
Fixed graphite URLs to point to same host as admin GUI and https.

### DIFF
--- a/conf/httpd.conf.d/httpd.graphite.tt.example
+++ b/conf/httpd.conf.d/httpd.graphite.tt.example
@@ -22,6 +22,9 @@
   <IfModule !mod_log_config.c>
     LoadModule log_config_module /usr/lib/apache2/modules/mod_log_config.so
   </IfModule>
+  <IfModule !mod_ssl.c>
+    LoadModule ssl_module /usr/lib/apache2/modules/mod_ssl.so
+  </IfModule>
   <IfModule !mod_headers.c>
     LoadModule headers_module /usr/lib/apache2/modules/mod_headers.so
   </IfModule>
@@ -66,6 +69,9 @@
   [% END %]
   <IfModule !mod_log_config.c>
     LoadModule log_config_module modules/mod_log_config.so
+  </IfModule>
+  <IfModule !mod_ssl.c>
+    LoadModule ssl_module modules/mod_ssl.so
   </IfModule>
   <IfModule !mod_headers.c>
     LoadModule headers_module modules/mod_headers.so
@@ -117,6 +123,27 @@ MaxSpareServers 1
 HostnameLookups off
 MaxRequestsPerChild 1000
 
+SSLPassPhraseDialog  builtin
+SSLSessionCacheTimeout  300
+SSLRandomSeed startup builtin
+SSLRandomSeed startup file:/dev/urandom 1024
+SSLRandomSeed connect builtin
+SSLRandomSeed connect file:/dev/urandom 1024
+
+[% IF apache_version == "2.4" %]
+SSLSessionCache shmcb:[% install_dir %]/var/ssl_acache(512000)
+Mutex file:[% install_dir %]/var/ssl_mutex ssl-cache
+SSLProtocol All -SSLv2 -SSLv3
+SSLCipherSuite EECDH+AES:EDH+AES:-SHA1:EECDH+RC4:EDH+RC4:RC4-SHA:EECDH+AES256:EDH+AES256:AES256-SHA:!aNULL:!eNULL:!EXP:!LOW:!MD5
+[% ELSE %]
+SSLSessionCache  shm:[% install_dir %]/var/ssl_acache(512000)
+SSLMutex  file:[% install_dir %]/var/ssl_mutex
+SSLProtocol All -SSLv2 -SSLv3
+SSLCipherSuite ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA
+[% END %]
+
+SSLHonorCipherOrder  on
+
 ErrorLog  [% install_dir %]/logs/[% name %].error
 
 ServerAdmin [% server_admin %]
@@ -127,14 +154,14 @@ ServerAdmin [% server_admin %]
 
   NameVirtualHost [% vhost %]:[% port %]
 
-  <VirtualHost [% vhost %]:[% port %] >
-      ServerName [% server_name %]
-      DocumentRoot  [% install_dir %]/html/pfappserver/lib
-      ErrorLog      [% install_dir %]/logs/[% name %].error
-      CustomLog   [% install_dir %]/logs/[% name %].access combined
-      WSGIScriptAlias  / [% install_dir %]/conf/httpd.conf.d/graphite-web.wsgi
-      WSGIImportScript [% install_dir %]/conf/httpd.conf.d/graphite-web.wsgi process-group=%{GLOBAL} application-group=%{GLOBAL}
-      Header           set Access-Control-Allow-Origin "*"
-  </VirtualHost>
-
-[% END %]
+<VirtualHost [% vhost %]:[% port %] >
+    ServerName [% server_name %]
+    DocumentRoot  [% install_dir %]/html/pfappserver/lib
+    ErrorLog      [% install_dir %]/logs/[% name %].error
+    CustomLog   [% install_dir %]/logs/[% name %].access combined
+    SSLEngine on
+    Include  [% var_dir %]/conf/ssl-certificates.conf
+    WSGIScriptAlias  / [% install_dir %]/conf/httpd.conf.d/graphite-web.wsgi
+    WSGIImportScript [% install_dir %]/conf/httpd.conf.d/graphite-web.wsgi process-group=%{GLOBAL} application-group=%{GLOBAL}
+    Header           set Access-Control-Allow-Origin "*"
+</VirtualHost>

--- a/html/pfappserver/lib/pfappserver/PacketFence/Controller/Graph.pm
+++ b/html/pfappserver/lib/pfappserver/PacketFence/Controller/Graph.pm
@@ -296,7 +296,7 @@ sub _buildGraphiteURL :Private {
 
     my $options =
       {
-       graphite_host => $management_ip,
+       graphite_host => $c->req->uri->host,
        graphite_port => '9000'
       };
 
@@ -340,7 +340,7 @@ sub _buildGraphiteURL :Private {
     $params->{hideAxes} = 'false';
     $params->{colorList} = '#1f77b4,#ff7f0e,#2ca02c,#d62728,#9467bd,#8c564b,#e377c2,#7f7f7f,#bcbd22,#17becf';
 
-    my $url = sprintf('http://%s:%s/render?%s',
+    my $url = sprintf('https://%s:%s/render?%s',
                       $options->{graphite_host},
                       $options->{graphite_port},
                       join('&', map { $_ . '=' . uri_escape($params->{$_}) }


### PR DESCRIPTION
# Description

Enforce SSL access to graphite URLs in the admin and sets the URL to point to hostname instead of IP.
# Impacts

The httpd.graphite config will now require SSL.
# Issue

Fixes #658 
# Delete branch after merge

YES 
# NEWS file entries
## Bug Fixes
- Graphite URLs are now requested over HTTPS (#658)
