### PR TITLE
Remove router_id from config template for keepalived

### DIFF
--- a/conf/keepalived.conf.example
+++ b/conf/keepalived.conf.example
@@ -5,7 +5,6 @@ global_defs {
    notification_email_from %%fromaddr%%
    smtp_server %%smtpserver%%
    smtp_connect_timeout 30
-   router_id LVS_DEVEL
 }
 
 vrrp_script haproxy {


### PR DESCRIPTION
# Description

Keepalived will use the hostname as `router_id` if not explicitly set making notifications mails much more meaningful. This is true at least for the version in Debian jessie.
