### PR TITLE
Fix/graphite configurable tls

### DIFF
--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1777,6 +1777,13 @@ Useful if your load balancer cannot handle both tasks.
 Changing this requires to restart radiusd.
 EOT
 
+[monitoring.graphite_tls]
+type=toggle
+options=enabled|disabled
+description=<<EOT
+Query the graphite URLs in the dashboard over HTTPS.
+EOT
+
 [monitoring.graphite_host]
 type=text
 description=<<EOT

--- a/conf/httpd.conf.d/httpd.graphite.tt.example
+++ b/conf/httpd.conf.d/httpd.graphite.tt.example
@@ -159,8 +159,10 @@ ServerAdmin [% server_admin %]
     DocumentRoot  [% install_dir %]/html/pfappserver/lib
     ErrorLog      [% install_dir %]/logs/[% name %].error
     CustomLog   [% install_dir %]/logs/[% name %].access combined
+    [% IF tls == "enabled" %]
     SSLEngine on
     Include  [% var_dir %]/conf/ssl-certificates.conf
+    [% END %]
     WSGIScriptAlias  / [% install_dir %]/conf/httpd.conf.d/graphite-web.wsgi
     WSGIImportScript [% install_dir %]/conf/httpd.conf.d/graphite-web.wsgi process-group=%{GLOBAL} application-group=%{GLOBAL}
     Header           set Access-Control-Allow-Origin "*"

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -1387,6 +1387,10 @@ auth_on_management=enabled
 
 [monitoring]
 #
+# monitoring.graphite_tls
+#
+graphite_tls=enabled
+
 # monitoring.graphite_host
 #
 graphite_host=localhost

--- a/html/pfappserver/lib/pfappserver/I18N/en.po
+++ b/html/pfappserver/lib/pfappserver/I18N/en.po
@@ -8168,6 +8168,10 @@ msgid "monitoring.db_user"
 msgstr "DB User"
 
 # conf/documentation.conf
+msgid "monitoring.graphite_tls"
+msgstr "Query Graphite over HTTPS"
+
+# conf/documentation.conf
 msgid "monitoring.graphite_host"
 msgstr "Graphite Host"
 

--- a/html/pfappserver/lib/pfappserver/PacketFence/Controller/Graph.pm
+++ b/html/pfappserver/lib/pfappserver/PacketFence/Controller/Graph.pm
@@ -294,11 +294,14 @@ sub _buildGraphiteURL :Private {
       ? $management_network->tag('vip')
       : $management_network->tag('ip');
 
-    my $options =
-      {
-       graphite_host => $c->req->uri->host,
-       graphite_port => '9000'
-      };
+    my $options = {
+        graphite_protocol =>
+          isenabled $Config{'monitoring'}{'graphite_tls'}
+        ? "https"
+        : "http",
+        graphite_host => $c->req->uri->host,
+        graphite_port => '9000'
+    };
 
     if (!$width) {
         $width = 1170;
@@ -340,7 +343,8 @@ sub _buildGraphiteURL :Private {
     $params->{hideAxes} = 'false';
     $params->{colorList} = '#1f77b4,#ff7f0e,#2ca02c,#d62728,#9467bd,#8c564b,#e377c2,#7f7f7f,#bcbd22,#17becf';
 
-    my $url = sprintf('https://%s:%s/render?%s',
+    my $url = sprintf('%s://%s:%s/render?%s',
+                      $options->{graphite_protocol},
                       $options->{graphite_host},
                       $options->{graphite_port},
                       join('&', map { $_ . '=' . uri_escape($params->{$_}) }

--- a/html/pfappserver/lib/pfappserver/PacketFence/Controller/Graph.pm
+++ b/html/pfappserver/lib/pfappserver/PacketFence/Controller/Graph.pm
@@ -20,6 +20,7 @@ use Moose;
 use Readonly;
 use URI::Escape::XS qw(uri_escape uri_unescape);
 use namespace::autoclean;
+use pf::util;
 use pf::config qw(
     $management_network
     %Config
@@ -296,7 +297,7 @@ sub _buildGraphiteURL :Private {
 
     my $options = {
         graphite_protocol =>
-          isenabled $Config{'monitoring'}{'graphite_tls'}
+          isenabled($Config{'monitoring'}{'graphite_tls'})
         ? "https"
         : "http",
         graphite_host => $c->req->uri->host,

--- a/lib/pf/services/manager/httpd_graphite.pm
+++ b/lib/pf/services/manager/httpd_graphite.pm
@@ -46,6 +46,9 @@ sub generateConfig {
 
 sub vhosts { [ "0.0.0.0" ] }
 sub port { 9000 }
+sub additionalVars {
+    return ( tls => $Config{'monitoring'}{'graphite_tls'} );
+}
 
 sub generate_local_settings {
     my %tags;


### PR DESCRIPTION
# Description

Adds an option to toggle TLS usage for the graphite URLs in the dashboard.
# Impacts

Allows Firefox to use the dashboard.
# Issue

fixes #1521 
# Delete branch after merge

YES
# UPGRADE file entries

Graphite URLs are now queried over HTTPS by default in the dashboard.
An option is provided to query them over HTTP.
