### PR TITLE
Fixed graphite retention on non-averageable metric.

### DIFF
--- a/addons/packages/packetfence.spec
+++ b/addons/packages/packetfence.spec
@@ -1100,6 +1100,8 @@ fi
                         /usr/local/pf/conf/monitoring/statsd_config.js.example
 %config(noreplace)      /usr/local/pf/conf/monitoring/storage-schemas.conf
                         /usr/local/pf/conf/monitoring/storage-schemas.conf.example
+%config(noreplace)      /usr/local/pf/conf/monitoring/storage-aggregation.conf
+                        /usr/local/pf/conf/monitoring/storage-aggregation.conf.example
 %config(noreplace)      /usr/local/pf/conf/monitoring/types.db
                         /usr/local/pf/conf/monitoring/types.db.example
 %config(noreplace)      /usr/local/pf/conf/profiles.conf

--- a/conf/monitoring/carbon.conf.example
+++ b/conf/monitoring/carbon.conf.example
@@ -97,7 +97,7 @@ LOG_LISTENER_CONNECTIONS = True
 # Set this to True to revert to the old-fashioned insecure unpickler.
 USE_INSECURE_UNPICKLER = False
 
-CACHE_QUERY_INTERFACE = %%management_ip%%
+CACHE_QUERY_INTERFACE = 127.0.0.1
 CACHE_QUERY_PORT = 7002
 
 # Set this to False to drop datapoints received after the cache

--- a/conf/monitoring/storage-aggregation.conf.example
+++ b/conf/monitoring/storage-aggregation.conf.example
@@ -17,12 +17,12 @@ xFilesFactor = 0.1
 aggregationMethod = min
 
 [lower]
-pattern = \.lower$
+pattern = \.low(er)?$
 xFilesFactor = 0.1
 aggregationMethod = min
 
 [max]
-pattern = \.max$
+pattern = \.(max|high)$
 xFilesFactor = 0.1
 aggregationMethod = max
 

--- a/conf/monitoring/storage-aggregation.conf.example
+++ b/conf/monitoring/storage-aggregation.conf.example
@@ -1,0 +1,57 @@
+# Aggregation methods for whisper files. Entries are scanned in order,
+# and first match wins. This file is scanned for changes every 60 seconds
+#
+#  [name]
+#  pattern = <regex>
+#  xFilesFactor = <float between 0 and 1>
+#  aggregationMethod = <average|sum|last|max|min>
+#
+#  name: Arbitrary unique name for the rule
+#  pattern: Regex pattern to match against the metric name
+#  xFilesFactor: Ratio of valid data points required for aggregation to the next retention to occur
+#  aggregationMethod: function to apply to data points for aggregation
+#
+[min]
+pattern = \.min$
+xFilesFactor = 0.1
+aggregationMethod = min
+
+[lower]
+pattern = \.lower$
+xFilesFactor = 0.1
+aggregationMethod = min
+
+[max]
+pattern = \.max$
+xFilesFactor = 0.1
+aggregationMethod = max
+
+[upper]
+pattern = \.upper(_\d+)?$
+xFilesFactor = 0.1
+aggregationMethod = max
+
+[count]
+pattern = \.count$
+xFilesFactor = 0
+aggregationMethod = sum
+
+[sum]
+pattern = \.sum(_\d+)?$
+xFilesFactor = 0
+aggregationMethod = sum
+
+[radius_count]
+pattern = radsniff-exchanged\.radius_count-
+xFilesFactor = 0
+aggregationMethod = sum
+
+[radius_rtx]
+pattern = radsniff-exchanged\.radius_rtx-
+xFilesFactor = 0
+aggregationMethod = sum
+
+[default_average]
+pattern = .*
+xFilesFactor = 0.5
+aggregationMethod = average

--- a/debian/packetfence.conffiles
+++ b/debian/packetfence.conffiles
@@ -90,6 +90,7 @@
 /usr/local/pf/conf/monitoring/local_settings.py.debian
 /usr/local/pf/conf/monitoring/statsd_config.js
 /usr/local/pf/conf/monitoring/storage-schemas.conf
+/usr/local/pf/conf/monitoring/storage-aggregation.conf
 /usr/local/pf/conf/monitoring/types.db
 /usr/local/pf/html/captive-portal/captiveportal.conf
 /usr/local/pf/html/common/styles.css


### PR DESCRIPTION
# Description

The default metric aggregation in graphite is to average data points.
That is not actually correct in all cases, e.g. when a metric is actually the max or the min of a value.
This change ensures that metrics are aggregated according to their types.
# Impacts

Will only apply to metrics once they have to be aggregated.
For instance, if we keep 10s of a metric for a day and then aggregate them per minute the change will only apply after 24 hours when the first aggregation is done.
# Delete branch after merge

YES 
# NEWS file entries
## Bug Fixes
- Fixes incorrect graphite aggregation of metrics when data is not "averageable".
