### PR TITLE
NetworkManager workarounds to make sure it doesn't mess with DNS configuration

### DIFF
--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -210,6 +210,12 @@ RedHat-based systems
 
 NOTE: Applies to CentOS and Scientific Linux but only the x86_64 architecture is supported.
 
+Explicitly instruct NetworkManager to never interact with your DNS configuration (https://bugzilla.redhat.com/show_bug.cgi?id=1344303[Source]):
+
+  echo "[main]
+  dns=none" > /etc/NetworkManager/conf.d/99-no-dns.conf
+  service NetworkManager restart
+
 RHEL 6.x
 ^^^^^^^^
 

--- a/docs/PacketFence_Clustering_Guide.asciidoc
+++ b/docs/PacketFence_Clustering_Guide.asciidoc
@@ -371,7 +371,9 @@ First make sure that you system is correctly configured and up-to-date
   ha_interface_ip_address_2 pf2_server_name
 
 Set hostname on each server:
-
+  
+NOTE: An active NetworkManager will overwrite your DNS configuration if not explicitely instructed to not do so before executing the following commands. (https://bugzilla.redhat.com/show_bug.cgi?id=1344303[Bug Report]) (https://packetfence.org/doc/PacketFence_Administration_Guide.html#_os_installation[Corrective Measures])
+ 
   # hostnamectl set-hostname pf1_server_name
   # hostnamectl set-hostname pf2_server_name
 

--- a/lib/pf/services/manager/winbindd_child.pm
+++ b/lib/pf/services/manager/winbindd_child.pm
@@ -74,6 +74,12 @@ sub build_namespaces(){
         my $OUTERLOGDIRECTORY="$CHROOT_PATH/$LOGDIRECTORY";
         my $OUTERRUNDIRECTORY="$CHROOT_PATH/var/run/samba$domain";
         my $PIDDIRECTORY="$var_dir/run/$domain";
+        my $DOMAIN_IF="$domain-b";
+        my $DOMAIN_IFCFG_VIRT_INT="/etc/sysconfig/network-scripts/ifcfg-$DOMAIN_IF";
+        unless (-e $DOMAIN_IFCFG_VIRT_INT) {
+           my $cmd='echo -e "DEVICE='.$DOMAIN_IF.'\nNM_CONTROLLED=no" |sudo tee '.$DOMAIN_IFCFG_VIRT_INT;
+           pf_run("$cmd");
+        }
         pf_run("sudo mkdir -p $OUTERLOGDIRECTORY && sudo chown root.root $OUTERLOGDIRECTORY");
         pf_run("sudo mkdir -p $OUTERRUNDIRECTORY && sudo chown root.root $OUTERRUNDIRECTORY");
         pf_run("sudo mkdir -p $PIDDIRECTORY && sudo chown root.root $PIDDIRECTORY");


### PR DESCRIPTION
# Description

windbindd_child.pm: ifcg file (/etc/sysconfig/network-scripts/ifcfg) is generated if it doesn't exist yet so NetworkManager will not manage AD's virtual interface.

PacketFence_Administration_Guide.asciidoc: Big fat warning and commands to run to deactivate DNS management of NetworkManager if still active.

PacketFence_Clustering_Guide.asciidoc: Warning before running hostname related commands, since doing so with an active NetworkManager who manages dns (default)  will replace /etc/resolv.conf file with an empty file. Link to bug still currently open at RedHat.
# Impacts

winbindd_child.pm creates AD associated ifcfg file.
Cluster documentation refers to the NetworkManager bug, and to the administration guide where corrective actions need to be taken at system initial installation.

NOTE: if NetworkManager is not deactivated/instructed to not mess with DNS config, it will since it listens on hostname file changes!
# Delete branch after merge

YES
## Enhancements
- All PF' created interfaces are excluded from NetworkManager
