### PR TITLE
Changed FATAL to WARN in order to be able to start PacketFence if the certificate expired

### DIFF
--- a/lib/pf/pfcmd/checkup.pm
+++ b/lib/pf/pfcmd/checkup.pm
@@ -1232,7 +1232,7 @@ sub valid_certs {
 
     eval {
         if(cert_has_expired($httpd_crt)){
-            add_problem($FATAL, "The certificate used by Apache ($httpd_crt) has expired.\nRegenerate a new self-signed certificate or update your current certificate.");
+            add_problem($WARN, "The certificate used by Apache ($httpd_crt) has expired.\nRegenerate a new self-signed certificate or update your current certificate.");
         }
     };
     if($@){
@@ -1255,7 +1255,7 @@ sub valid_certs {
 
         eval {
             if(cert_has_expired($radius_crt)){
-                add_problem($FATAL, "The certificate used by FreeRADIUS ($radius_crt) has expired.\n" .
+                add_problem($WARN, "The certificate used by FreeRADIUS ($radius_crt) has expired.\n" .
                          "Regenerate a new self-signed certificate or update your current certificate.");
             }
         };


### PR DESCRIPTION
# Description

Start PacketFence even if the certificate expired.
# Impacts

No
# Issue

Start PacketFence even if the certificate expired
# Delete branch after merge

YES
# NEWS file entries
## Bug Fixes
- If a certificate expired then PacketFence is not able to start
