### PR TITLE
Gitification of a working pf installation (make devel) generates raddb certificate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ sudo:/etc/sudoers.d/packetfence.sudoers
 permissions:
 	./bin/pfcmd fixpermissions
 
-raddb/certs:
+raddb/certs/server.crt:
 	cd raddb/certs; make
 
 .PHONY: raddb-sites-enabled
@@ -105,4 +105,4 @@ fingerbank:
 	rm -f /usr/local/pf/lib/fingerbank
 	ln -s /usr/local/fingerbank/lib/fingerbank /usr/local/pf/lib/fingerbank \
 
-devel: configurations conf/ssl/server.crt conf/pf_omapi_key conf/local_secret bin/pfcmd raddb/certs sudo translation mysql-schema raddb/sites-enabled fingerbank chown_pf permissions bin/ntlm_auth_wrapper
+devel: configurations conf/ssl/server.crt conf/pf_omapi_key conf/local_secret bin/pfcmd raddb/certs/server.crt sudo translation mysql-schema raddb/sites-enabled fingerbank chown_pf permissions bin/ntlm_auth_wrapper 


### PR DESCRIPTION
# Description

(REQUIRED)
When gitificating a working packetfence installation for it to become a development station, doing a "make devel" in git cloned directory was skipping the raddb/certs part since the directory was already existing (make default behavior)  
# Impacts

(REQUIRED)
raddb certificate is regenerated when doing make devel. 
# Delete branch after merge

YES
