### PR TITLE
suricata_http: syslog parser was deleted (deprecated) and replaced/extended by suricata_md5

### DIFF
--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -2714,31 +2714,6 @@ When running locally, PacketFence provides a basic `suricata.yaml` that can be m
 
 In the case that Suricata is running on a separate server, Suricata configuration will have to be handled separately, which is not the purpose of the present guide.
 
-The following section parameters are required under suricata.yaml to have proper md5 checksuming and filetype recognition:
-
-file-store:
- 
-  force-magic: yes   # force logging magic on all stored files
-  force-md5: yes     # force logging of md5 checksums
-
-file-log:
-
-  enabled: yes
-  filename: files-json.log
-  append: yes
-
-stream:
-
-  reassembly:
-    depth: 0         # reassemble all files until memcap is fulled.
-
-libhtp:
-
-  default-config:
-     request-body-limit: 0
-     response-body-limit: 0
-
-
 OPSWAT Metadefender Cloud
 +++++++++++++++++++++++++
 
@@ -2764,7 +2739,7 @@ Configure `/etc/syslog-ng/syslog-ng.conf` by adding the following to enable send
   source s_suricata_files { file("/MY_SURICATA_LOG_FILES_PATH/files-json.log" program_override("suricata_files") flags(no-parse)); };
   # This line tells syslog-ng to send the data read to the PacketFence management interface IP address using UDP 514
   # -> Make sure to configure the right PacketFence management interface IP address
-  destination d_packetfence_md5 { udp("PACKENTFENCE_MGMT_IP" port(514)); };
+  destination d_packetfence_md5 { udp("PACKETFENCE_MGMT_IP" port(514)); };
   # This line indicates syslog-ng to use the s_suricata_files source and send it to the d_packetfence destination
   log { source(s_suricata_files); destination(d_packetfence_md5); };
 
@@ -2840,7 +2815,7 @@ Configure `/etc/syslog-ng/syslog-ng.conf` by adding the following to enable send
   filter f_sguil { match("Alert Received"); };
   # This line tells syslog-ng to send the data read to the PacketFence management IP address using UDP 514
   # -> Make sure to configure the right PacketFence management interface IP address
-  destination d_packetfence_alerts { udp("PACKENTFENCE_MGMT_IP" port(514)); };
+  destination d_packetfence_alerts { udp("PACKETFENCE_MGMT_IP" port(514)); };
   # This line indicates syslog-ng to use the s_sguil source, apply the f_sguil filter and send it to the d_packetfence destination
   log { source(s_sguil); filter(f_sguil); destination(d_packetfence_alerts); };
 

--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -2727,6 +2727,8 @@ Along with the OPSWAT API key for Metadefender Cloud (they call it 'License Key'
 
 Assuming that all the steps for Suricata MD5 extraction have been followed, here's what to do next.
 
+On PacketFence, under Configuration->Metadefender, enter your 'Licence Key'.
+
 On the Suricata server (syslog-ng is preferred due to easier and more powerful configuration. If not installed, it might be an idea):
 
 Configure `/etc/syslog-ng/syslog-ng.conf` by adding the following to enable sending MD5 file store log entries to PacketFence:
@@ -2737,9 +2739,9 @@ Configure `/etc/syslog-ng/syslog-ng.conf` by adding the following to enable send
   source s_suricata_files { file("/MY_SURICATA_LOG_FILES_PATH/files-json.log" program_override("suricata_files") flags(no-parse)); };
   # This line tells syslog-ng to send the data read to the PacketFence management interface IP address using UDP 514
   # -> Make sure to configure the right PacketFence management interface IP address
-  destination d_packetfence { udp("PACKETFENCE_MGMT_IP" port(514)); };
+  destination d_packetfence_md5 { udp("PACKENTFENCE_MGMT_IP" port(514)); };
   # This line indicates syslog-ng to use the s_suricata_files source and send it to the d_packetfence destination
-  log { source(s_suricata_files); destination(d_packetfence); };
+  log { source(s_suricata_files); destination(d_packetfence_md5); };
 
 A restart of the syslog-ng daemon is required
 
@@ -2771,7 +2773,7 @@ A configuration of a new 'syslog parser' as well as some violations are the only
 
 Configuration of a new 'syslog parser' (Configuration->Syslog Parsers) should use the followings:
 
-  Type: suricata_http
+  Type: suricata_md5
   Alert pipe: the previously created alert pipe (FIFO) which is, in this case, /usr/local/pf/var/suricata_files
 
 Configuration of a new violation can use the following trigger types:
@@ -2813,9 +2815,9 @@ Configure `/etc/syslog-ng/syslog-ng.conf` by adding the following to enable send
   filter f_sguil { match("Alert Received"); };
   # This line tells syslog-ng to send the data read to the PacketFence management IP address using UDP 514
   # -> Make sure to configure the right PacketFence management interface IP address
-  destination d_packetfence { udp("PACKENTFENCE_MGMT_IP" port(514)); };
+  destination d_packetfence_alerts { udp("PACKENTFENCE_MGMT_IP" port(514)); };
   # This line indicates syslog-ng to use the s_sguil source, apply the f_sguil filter and send it to the d_packetfence destination
-  log { source(s_sguil); filter(f_sguil); destination(d_packetfence); };
+  log { source(s_sguil); filter(f_sguil); destination(d_packetfence_alerts); };
 
 Sending sguild alert output to syslog requires DEBUG to be changed from 1 to 2 under `/etc/sguild/sguild.conf`
   

--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -2714,6 +2714,31 @@ When running locally, PacketFence provides a basic `suricata.yaml` that can be m
 
 In the case that Suricata is running on a separate server, Suricata configuration will have to be handled separately, which is not the purpose of the present guide.
 
+The following section parameters are required under suricata.yaml to have proper md5 checksuming and filetype recognition:
+
+file-store:
+ 
+  force-magic: yes   # force logging magic on all stored files
+  force-md5: yes     # force logging of md5 checksums
+
+file-log:
+
+  enabled: yes
+  filename: files-json.log
+  append: yes
+
+stream:
+
+  reassembly:
+    depth: 0         # reassemble all files until memcap is fulled.
+
+libhtp:
+
+  default-config:
+     request-body-limit: 0
+     response-body-limit: 0
+
+
 OPSWAT Metadefender Cloud
 +++++++++++++++++++++++++
 

--- a/t/unittest/detect/parser/suricata_md5_http.t
+++ b/t/unittest/detect/parser/suricata_md5_http.t
@@ -1,0 +1,69 @@
+=head1 NAME
+
+suricata_md5_http
+
+=cut
+
+=head1 DESCRIPTION
+
+suricata http extraction
+
+=cut
+
+use strict;
+use warnings;
+#
+use lib '/usr/local/pf/lib';
+
+use Test::More tests => 5;
+
+BEGIN {
+    #include test libs
+    use lib qw(/usr/local/pf/t);
+    #Module for overriding configuration paths
+    use setup_test_config;
+}
+
+use_ok('pf::factory::detect::parser');
+
+my $alert = 'Jul  7 15:48:02 Thierry-SecurityOnion suricata_files: { "timestamp": "07\/07\/2016-15:48:01.623845", "ipver": 4, "srcip": "104.28.13.103", "dstip": "172.20.20.211", "protocol": 6, "sp": 80, "dp": 59131, "http_uri": "\/billing\/includes\/jscript\/db\/3july2.exe", "http_host": "snthostings.com", "http_referer": "<unknown>", "http_user_agent": "Wget\/1.15 (linux-gnu)", "filename": "\/billing\/includes\/jscript\/db\/3july2.exe", "magic": "PE32 executable (GUI) Intel 80386, for MS Windows", "state": "CLOSED", "md5": "0806b949be8f93127a9fbf909221a121", "stored": false, "size": 1145856 }'; 
+my $parser = pf::factory::detect::parser->new('suricata_md5');
+my $result = $parser->_parse($alert);
+
+ok(defined($result->{http_host}), "checking that http method is recognised so we know who is the possible infected endpoint.");
+is($result->{dstip}, "172.20.20.211", "checking destination IP is properly parsed.");
+is($result->{md5}, "0806b949be8f93127a9fbf909221a121", "checking that md5 is properly parsed.");
+
+
+
+#This test will running last
+use Test::NoWarnings;
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2015 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;

--- a/t/unittest/detect/parser/suricata_md5_smtp.t
+++ b/t/unittest/detect/parser/suricata_md5_smtp.t
@@ -1,0 +1,68 @@
+=head1 NAME
+
+suricata_md5_smtp
+
+=cut
+
+=head1 DESCRIPTION
+
+suricata smtp extraction
+
+=cut
+
+use strict;
+use warnings;
+#
+use lib '/usr/local/pf/lib';
+
+use Test::More tests => 5;
+
+BEGIN {
+    #include test libs
+    use lib qw(/usr/local/pf/t);
+    #Module for overriding configuration paths
+    use setup_test_config;
+}
+
+use_ok('pf::factory::detect::parser');
+
+my $alert = 'Jul  7 15:49:43 Thierry-SecurityOnion suricata_files: { "timestamp": "07\/07\/2016-15:49:42.981092", "ipver": 4, "srcip": "172.20.20.211", "dstip": "10.0.0.6", "protocol": 6, "sp": 54591, "dp": 25, "message-id": "<20160707154942.GA2239@Thierry-SecurityOnion>", "sender": "tlaurion <tlaurion@Thierry-SecurityOnion>", "filename": "3july2.exe", "magic": "PE32 executable (GUI) Intel 80386, for MS Windows", "state": "CLOSED", "md5": "0806b949be8f93127a9fbf909221a121", "stored": false, "size": 1145856 }';
+my $parser = pf::factory::detect::parser->new('suricata_md5');
+my $result = $parser->_parse($alert);
+
+ok(defined($result->{sender}), "checking that smtp method is recognised so we know who is the possible infected endpoint.");
+is($result->{srcip}, "172.20.20.211", "checking source IP is properly parsed.");
+is($result->{md5}, "0806b949be8f93127a9fbf909221a121", "checking that md5 is properly parsed.");
+
+
+#This test will running last
+use Test::NoWarnings;
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2015 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;


### PR DESCRIPTION
# Description

suricata_md5: new syslog parser for suricata that takes JSON keywords to determine if the endpoint is dstip or srcip. A violation taking into account md5 (metadefender) can be triggered for that detected endpoint ip and actions can be defined for that trigger. Extending suricata_md5 protocols requires selection of JSON tags to determine who is the endpoint in that protocol exchange.

Admin guide:
-suricata destinations are now differenciated so there is no conflict when both alerts and md5 activated
-suricata_http is syslog parser is depracated. Documentation takes into account suricata_md5 syslog parser for both http and smtp, and can be generalized to other protocols easily.
-minimal required suricata.yuml modifcations added.
# Impacts
- suricata_http syslog parser is deprecated and merged into suricata_md5. Read UPGRADE note.
# Delete branch after merge

YES
# NEWS file entries
- Support for Suricata md5 extraction over SMTP protocol. Suricata md5 extraction for other protocols is eased.
## Enhancements
- suricata_md5 syslog parser deprecates suricata_http while adding support for SMTP. Additional protocol support is eased; protocol keywords need to be added to determine who is the endpoint (sr or dst). Metadefender violation triggers work as before to validate generated md5 for a possible infected endpoints. 
# UPGRADE file entries

Under Configuration->Syslog Parsers, any reference to suricata_http needs to be replaced to suricata_md5.
