### PR TITLE
Fix/1626 localdomain email registration

### DIFF
--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/Email.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/Email.pm
@@ -60,6 +60,13 @@ sub do_email_registration {
     my $pid = $self->request_fields->{$self->pid_field};
     my $email = $self->request_fields->{email};
 
+    my ( $status, $status_msg ) = $source->authenticate($pid);
+    unless ( $status ) {
+        $self->app->flash->{error} = $status_msg;
+        $self->prompt_fields();
+        return;
+    }
+
     my %info;
     $info{'activation_domain'} = $source->{activation_domain} if (defined($source->{activation_domain}));
     $info{'activation_timeout'} = normalize_time($source->{email_activation_timeout});

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/Sponsor.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/Sponsor.pm
@@ -99,12 +99,19 @@ sub do_sponsor_registration {
     my %info;
     get_logger->info("registering  guest through a sponsor");
 
-    return unless($self->_validate_sponsor($self->request_fields->{sponsor}));
-
     my $source = $self->source;
     my $pid = $self->request_fields->{$self->pid_field};
     my $email = $self->request_fields->{email};
     $info{'pid'} = $pid;
+
+    my ( $status, $status_msg ) = $source->authenticate($pid);
+    unless ( $status ) {
+        $self->app->flash->{error} = $status_msg;
+        $self->prompt_fields();
+        return;
+    }
+
+    return unless($self->_validate_sponsor($self->request_fields->{sponsor}));
 
     # form valid, adding person (using modify in case person already exists)
     my $note = 'sponsored confirmation Date of arrival: ' . time2str("%Y-%m-%d %H:%M:%S", time);

--- a/lib/pf/Authentication/Source/EmailSource.pm
+++ b/lib/pf/Authentication/Source/EmailSource.pm
@@ -9,7 +9,11 @@ pf::Authentication::Source::EmailSource
 =cut
 
 use pf::Authentication::constants;
+use pf::config qw(%Config);
+use pf::constants qw($TRUE $FALSE);
 use pf::constants::authentication::messages;
+use pf::log;
+use pf::util;
 
 use Moose;
 extends 'pf::Authentication::Source';
@@ -92,6 +96,29 @@ List of mandatory fields for this source
 sub mandatoryFields {
     return qw(email);
 }
+
+
+=head2 authenticate
+
+=cut
+
+sub authenticate {
+    my ( $self, $username, $password ) = @_;
+    my $logger = pf::log::get_logger;
+
+    my $localdomain = $Config{'general'}{'domain'};
+
+    # Verify if allowed to use local domain
+    unless ( isenabled($self->allow_localdomain) ) {
+        if ( $username =~ /[@.]$localdomain$/i ) {
+            $logger->warn("Tried to authenticate using EmailSource with PID '$username' matching local domain '$localdomain' while 'allow_localdomain' is disabled");
+            return ($FALSE, $pf::constants::authentication::messages::LOCALDOMAIN_EMAIL_UNAUTHORIZED);
+        }
+    }
+
+    return $TRUE;
+}
+
 
 =head1 AUTHOR
 

--- a/lib/pf/constants/authentication/messages.pm
+++ b/lib/pf/constants/authentication/messages.pm
@@ -17,13 +17,14 @@ use warnings;
 use Readonly;
 use base qw(Exporter);
 our @EXPORT = qw(
-  $COMMUNICATION_ERROR_MSG $AUTH_FAIL_MSG $AUTH_SUCCESS_MSG $INVALID_EMAIL_MSG
+  $COMMUNICATION_ERROR_MSG $AUTH_FAIL_MSG $AUTH_SUCCESS_MSG $INVALID_EMAIL_MSG $LOCALDOMAIN_EMAIL_UNAUTHORIZED
 );
 
 Readonly our $COMMUNICATION_ERROR_MSG => 'Unable to validate credentials at the moment';
 Readonly our $AUTH_FAIL_MSG => 'Invalid login or password';
 Readonly our $AUTH_SUCCESS_MSG => 'Authentication successful.';
 Readonly our $INVALID_EMAIL_MSG => 'Invalid e-mail address';
+Readonly our $LOCALDOMAIN_EMAIL_UNAUTHORIZED => "You can't register as a guest with this corporate email address. Please register as a regular user using your email address instead.";
 
 =head1 AUTHOR
 


### PR DESCRIPTION
# Description

EmailSource and SponsorEmailSource are now responsible to validate their conditions
# Impacts
- Guest workflow (email registration, sponsor registration)
- Possibly the authenticate / login workflow
# Issue

fixes #1626 
# Delete branch after merge

YES
# NEWS file entries
## Bug Fixes
- Issue with email registration: No longer honor 'allow_local_domain' (#1626)
