### PR TITLE
Fix/saml err output

### DIFF
--- a/conf/httpd.conf.d/httpd.webservices.tt.example
+++ b/conf/httpd.conf.d/httpd.webservices.tt.example
@@ -227,21 +227,3 @@ Listen 127.0.0.1:[% port %]
     </Location>
 </VirtualHost>
 
-Listen 127.0.0.1:9091
-
-<VirtualHost 127.0.0.1:9091 >
-  ScriptAlias / [% install_dir %]/lib/pf/web/saml/
-  DocumentRoot [% install_dir %]/lib/pf/web/saml/
-</VirtualHost>
-
-LoadModule cgi_module modules/mod_cgi.so
-LoadModule alias_module modules/mod_alias.so
-
-<Directory [% install_dir%]/lib/pf/web/saml>
-  [% IF apache_version == "2.4" %]
-  Require all granted
-  [% ELSE %]
-  Allow from all
-  [% END %]
-</Directory>
-

--- a/conf/httpd.conf.d/httpd.webservices.tt.example
+++ b/conf/httpd.conf.d/httpd.webservices.tt.example
@@ -226,3 +226,22 @@ Listen 127.0.0.1:[% port %]
         SetHandler server-status
     </Location>
 </VirtualHost>
+
+Listen 127.0.0.1:9091
+
+<VirtualHost 127.0.0.1:9091 >
+  ScriptAlias / [% install_dir %]/lib/pf/web/saml/
+  DocumentRoot [% install_dir %]/lib/pf/web/saml/
+</VirtualHost>
+
+LoadModule cgi_module modules/mod_cgi.so
+LoadModule alias_module modules/mod_alias.so
+
+<Directory [% install_dir%]/lib/pf/web/saml>
+  [% IF apache_version == "2.4" %]
+  Require all granted
+  [% ELSE %]
+  Allow from all
+  [% END %]
+</Directory>
+

--- a/lib/pf/Authentication/Source/SAMLSource.pm
+++ b/lib/pf/Authentication/Source/SAMLSource.pm
@@ -22,10 +22,6 @@ use pf::util;
 use Moose;
 extends 'pf::Authentication::Source';
 
-BEGIN {
-    Lasso::init();
-}
-
 has '+type' => ( default => 'SAML' );
 has 'authorization_source_id' => ( is => 'rw', required => 1 );
 

--- a/lib/pf/cmd/pf/saml.pm
+++ b/lib/pf/cmd/pf/saml.pm
@@ -1,0 +1,72 @@
+package pf::cmd::pf::saml;
+=head1 NAME
+
+pf::cmd::pf::saml
+
+=head1 SYNOPSIS
+
+ pfcmd saml <command> <arguments>
+
+Commands:
+
+ testsource <sourceid>
+
+=head1 DESCRIPTION
+
+pf::cmd::pf::cache
+
+=cut
+
+use strict;
+use warnings;
+use pf::authentication;
+use pf::constants::exit_code qw($EXIT_SUCCESS);
+use base qw(pf::base::cmd::action_cmd);
+
+=head1 METHODS
+
+=head2 action_testsource
+
+Handles the testsource action
+
+=cut
+
+sub action_testsource {
+    my ($self) = @_;
+    my ($sourceid) = $self->action_args;
+    print "You should see the SSO URL below, otherwise, there are errors in your configuration: \n";
+    print getAuthenticationSource($sourceid)->sso_url;
+}
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+Minor parts of this file may have been contributed. See CREDITS.
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2016 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and::or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;
+
+

--- a/lib/pf/web/saml/assertion.cgi
+++ b/lib/pf/web/saml/assertion.cgi
@@ -20,7 +20,6 @@ use JSON::MaybeXS;
 use pf::authentication;
 
 use Data::Dumper;
-print STDERR Dumper("SOURCE ID : ".param("source_id"));
 my $source_id = param("source_id");
 my $saml_response = param("SAMLResponse");
 my ($username, $msg) = getAuthenticationSource($source_id)->handle_response($saml_response);

--- a/lib/pf/web/saml/assertion.cgi
+++ b/lib/pf/web/saml/assertion.cgi
@@ -1,0 +1,57 @@
+#!/usr/bin/perl
+
+=head1 NAME
+
+assertion.cgi
+
+=cut
+
+=head1 DESCRIPTION
+
+=cut
+
+use strict;
+use warnings;
+use lib '/usr/local/pf/lib';
+
+use CGI qw(:standard);
+use JSON::MaybeXS;
+
+use pf::authentication;
+
+use Data::Dumper;
+print STDERR Dumper("SOURCE ID : ".param("source_id"));
+my $source_id = param("source_id");
+my $saml_response = param("SAMLResponse");
+my ($username, $msg) = getAuthenticationSource($source_id)->handle_response($saml_response);
+print header(), encode_json({username => $username, msg => $msg});
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2016 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
+USA.
+
+=cut
+
+1;
+

--- a/lib/pf/web/saml/sso_url.cgi
+++ b/lib/pf/web/saml/sso_url.cgi
@@ -1,0 +1,52 @@
+#!/usr/bin/perl
+
+=head1 NAME
+
+sso_url.cgi
+
+=cut
+
+=head1 DESCRIPTION
+
+=cut
+
+use strict;
+use warnings;
+use lib '/usr/local/pf/lib';
+
+use CGI qw(:standard);
+
+use pf::authentication;
+
+my $source_id = param("source_id");
+
+print header(), getAuthenticationSource($source_id)->sso_url;
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2016 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
+USA.
+
+=cut
+
+1;


### PR DESCRIPTION
# This is not ready and contains a hack to bypass a bug with mod_perl2 and liblasso.
# Description

Make liblasso calls go through a CGI webserver hosted in the webservices
Various ameliorations around error handling in SAML
# Impacts

SAML authentication
# Issue

fixes #1652 
# Delete branch after merge

YES
# NEWS file entries
## Bug Fixes
- Fixed issue with SAML running on recent versions of mod_perl2
