### PR TITLE
ERSPAN support on Security Onion 14.04 through rcdcap

### DIFF
--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -2934,11 +2934,11 @@ On Security Onion:
   gpg --export --armor 19CDA6A9810273C4 | sudo apt-key add -
 
  * Install rcdcap
+
   sudo apt-get update
   sudo apt-get install rcdcap  
 
  * Create the file /etc/init.d/rcdcap with a similar content:  
-
 ----
 #!/bin/sh
 ### BEGIN INIT INFO

--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -2920,7 +2920,7 @@ One way of accessing encapsulated traffic at the destination host is through a s
 
 
 Assomptions for the example:
-The switch is at IP 172.16.0.1, the monitored switch port is GigabitEthernet10 and the Security Onion monitoring destination IP is 10.10.10.10 on eth2, eth2 ideally being a dedicated interface.
+The switch is at IP 172.16.0.1, the monitored switch port is GigabitEthernet0/10 and the Security Onion monitoring destination IP is 10.10.10.10 on eth2, eth2 ideally being a dedicated interface.
 
 On Security Onion:
 

--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -2916,7 +2916,7 @@ ERSPAN
 
 ERSPAN permits to mirror a local port traffic (low bandwidth) to a remote IP, E.G: your Security Onion already deployed box. ERSPAN encapsulates port traffic into ERSPAN then GRE and send that traffic to one/multiple destination(s). ERSPAN is a Cisco technology which is available only on some platforms, including: Catalyst 6500, 7600, Nexus, and ASR 1000.
 
-One way of accessing encapsulated traffic at the destination host is through a software called RCDCAP, which is a daemon that creates a virtual interface if not existing, on which both GRE and ERSPAN headers are decapsultated prior to the traffic being injected to the previous interface. Security Onion can then feed on that interface like it would on any other, and if the daemon dies, continueto listen to that interface even though decapsulated traffic won't be available anymore.
+One way of accessing encapsulated traffic at the destination host is through a software called RCDCAP, which is a daemon that creates a virtual interface if not existing, on which both GRE and ERSPAN headers are decapsultated prior to the traffic being injected to the previous interface. Security Onion can then feed on that interface like it would on any other, and if the RCDCAP daemon dies, continue to listen to that interface even though decapsulated traffic won't be available anymore.
 
 
 Assomptions for the example:

--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -2914,13 +2914,13 @@ Configuration of a new violation can use the following trigger types:
 ERSPAN
 ++++++
 
-ERSPAN permits to mirror a local port traffic (low bandwidth) to a remote IP, E.G: your Security Onion already deployed box. ERSPAN encapsulates port traffic into ERSPAN then GRE and send that traffic to one/multiple destination(s). ERSPAN is a Cisco technology which is available only on some platforms which are namely but not limited to Catalyst 6500, 7600, Nexus, and ASR 1000.
+ERSPAN permits to mirror a local port traffic (low bandwidth) to a remote IP, E.G: your Security Onion already deployed box. ERSPAN encapsulates port traffic into ERSPAN then GRE and send that traffic to one/multiple destination(s). ERSPAN is a Cisco technology which is available only on some platforms, including: Catalyst 6500, 7600, Nexus, and ASR 1000.
 
-One way of accessing encapsulated traffic at the destination host is through a software called RCDCAP, which is a daemon that creates a virtual interface on which both GRE and ERSPAN headers are decapsultated prior to the traffic being injected on the configured interface. Security Onion can then feed on that interface like it would on any other.
+One way of accessing encapsulated traffic at the destination host is through a software called RCDCAP, which is a daemon that creates a virtual interface if not existing, on which both GRE and ERSPAN headers are decapsultated prior to the traffic being injected to the previous interface. Security Onion can then feed on that interface like it would on any other, and if the daemon dies, continueto listen to that interface even though decapsulated traffic won't be available anymore.
 
 
 Assomptions for the example:
-The switch is at IP 172.16.0.1, the monitored switch port is GigabitEthernet10 and the Security Onion monitoring destination IP is 10.10.10.10 on eth2, ideally on a dedicated interface.
+The switch is at IP 172.16.0.1, the monitored switch port is GigabitEthernet10 and the Security Onion monitoring destination IP is 10.10.10.10 on eth2, eth2 ideally being a dedicated interface.
 
 On Security Onion:
 
@@ -2933,7 +2933,7 @@ On Security Onion:
   gpg --keyserver keyserver.ubuntu.com --recv 19CDA6A9810273C4
   gpg --export --armor 19CDA6A9810273C4 | sudo apt-key add -
 
- * Install rcdcap
+ * Install RCDCAP
 
   sudo apt-get update
   sudo apt-get install rcdcap  

--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -2914,13 +2914,13 @@ Configuration of a new violation can use the following trigger types:
 ERSPAN
 ++++++
 
-ERSPAN comes handy when a switch port traffic (low bandwidth) needs to be monitored from a remote location, E.G: your Security Onion already deployed box. ERSPAN encapsulates the desired port traffic in GRE packets to one/multiple destination(s).
+ERSPAN comes handy when a switch port traffic (low bandwidth) needs to be monitored from a remote location, E.G: your Security Onion already deployed box. ERSPAN encapsulates the desired port traffic in GRE packets to one/multiple destination(s). ERSPAN is a Cisco technology which is available selected platforms, namely but not limited to Catalyst 6500, 7600, Nexus, and ASR 1000.
 
-One of the way of dealing easily with that GRE encapsulated traffic on the destination is through RCDCAP, which creates a virtual interface on which GRE traffic is already decapsultated. Security Onion can then feed on that interface like any other interface.
+One way of accessing encapsulated traffic at the destination is through RCDCAP software, which creates a virtual interface on which GRE and ERSPAN headers are decapsultated. Security Onion can then feed on that interface like any other.
+
 
 Example:
-The switch is at 10.10.10.1, the monitored switch port is GigabitEthernet10 and the Security Onion monitoring destination IP is 10.10.10.10 on eth2, ideally on a seperate interface optimized for monitoring.
-
+The switch is at IP 10.10.10.1, the monitored switch port is GigabitEthernet10 and the Security Onion monitoring destination IP is 10.10.10.10 on eth2, ideally on a seperate interface optimized for monitoring.
 
 On the Switch:
 
@@ -3001,7 +3001,6 @@ esac
   * Start service
 
    sudo /etc/init.d/rcdcap start
-
   
 
 Violations

--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -2965,7 +2965,7 @@ On the Switch:
 
   monitor session 10 type erspan-source
   description ERSPAN to 10.10.10.10
-  source interface GigabitEthernet10
+  source interface GigabitEthernet0/10
   destination
   erspan-id 10
   ip address 10.10.10.10

--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -2925,6 +2925,8 @@ The switch is at IP 10.10.10.1, the monitored switch port is GigabitEthernet10 a
 On Security Onion:
 
  * install RCDCAP from Inverse's SecurityOnion repository:
+  
+  REPOSITORY INFORMATION
 
  * Create the file /etc/init.d/rcdcap with a similar content:  
 
@@ -2982,28 +2984,29 @@ esac
 ----
   * Add executable flag on the file:
 
-   chmod +x /etc/init.d/rcdcap
+  chmod +x /etc/init.d/rcdcap
  
   * Enable rcdcap service
 
-   sudo update-rc.d rcdcap defaults 18 02
+  sudo update-rc.d rcdcap defaults 18 02
 
   * Start service
 
-   sudo /etc/init.d/rcdcap start
+  sudo /etc/init.d/rcdcap start
 
   * Rerun Security Onion wizard to configure tweak mon1 interface and include it to be monitored. Attention: network configuration file will be overwritten. Backup if needed, or skip that part in the wizard and adapt manually.
    
-   sudo sosetup
+  sudo sosetup
 
   * Modify network file (/etc/network/inferfaces) so that eth2 has an IP and a proper MTU.
 
-   auto eth2
-   iface eth2 inet static
-   address 10.10.10.10
-   netmask 255.255.255.240
-   up ifconfig $IFACE arp up
-   up ip link set dev $IFACE mtu 1900
+  auto eth2
+  iface eth2 inet static
+  address 10.10.10.10
+  netmask 255.255.255.240
+  up ifconfig $IFACE arp up
+  up ip link set dev $IFACE mtu 1900
+
 
 On the Switch:
 

--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -2924,9 +2924,18 @@ The switch is at IP 10.10.10.1, the monitored switch port is GigabitEthernet10 a
 
 On Security Onion:
 
- * install RCDCAP from Inverse's SecurityOnion repository:
-  
-  REPOSITORY INFORMATION
+ * Enable Inverse repository for Security Onion:
+
+  sudo cat << EOL >/etc/apt/sources.list.d/securityonion-inverse.list
+  deb http://inverse.ca/downloads/PacketFence/securityonion trusty trusty
+  EOL
+
+  gpg --keyserver keyserver.ubuntu.com --recv 19CDA6A9810273C4
+  gpg --export --armor 19CDA6A9810273C4 | sudo apt-key add -
+
+ * Install rcdcap
+  sudo apt-get update
+  sudo apt-get install rcdcap  
 
  * Create the file /etc/init.d/rcdcap with a similar content:  
 

--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -2914,12 +2914,11 @@ Configuration of a new violation can use the following trigger types:
 ERSPAN
 ++++++
 
-ERSPAN comes handy when a switch port traffic (low bandwidth) needs to be monitored from a remote location, E.G: your Security Onion already deployed box. ERSPAN encapsulates the desired port traffic in GRE packets to one/multiple destination(s). ERSPAN is a Cisco technology which is available selected platforms, namely but not limited to Catalyst 6500, 7600, Nexus, and ASR 1000.
+ERSPAN permits to mirror a local port traffic (low bandwidth) to a remote IP, E.G: your Security Onion already deployed box. ERSPAN encapsulates port traffic in GRE packets to one/multiple destination(s). ERSPAN is a Cisco technology which is available on some platforms which are namely but not limited to Catalyst 6500, 7600, Nexus, and ASR 1000.
 
-One way of accessing encapsulated traffic at the destination is through RCDCAP software, which creates a virtual interface on which GRE and ERSPAN headers are decapsultated. Security Onion can then feed on that interface like any other.
+One way of accessing encapsulated traffic at the destination host is through RCDCAP, which is a daemon that creates a virtual interface on which both GRE and ERSPAN headers are decapsultated prior to being injected on the specified interface. Security Onion can then feed on that interface like any other.
 
-
-Example:
+Example Scenario:
 The switch is at IP 10.10.10.1, the monitored switch port is GigabitEthernet10 and the Security Onion monitoring destination IP is 10.10.10.10 on eth2, ideally on a seperate interface optimized for monitoring.
 
 On the Switch:
@@ -2935,7 +2934,8 @@ On the Switch:
 
 On Security Onion:
 
- * Download, compile and install RCDCAP.
+ * install RCDCAP from Inverse's SecurityOnion repository:
+
  * Create the file /etc/init.d/rcdcap with a similar content:  
 
 ----
@@ -3001,6 +3001,8 @@ esac
   * Start service
 
    sudo /etc/init.d/rcdcap start
+
+  * Rerun Security Onion wizard to configure mon1 interface and include it to be monitored.
   
 
 Violations

--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -2911,6 +2911,99 @@ Configuration of a new violation can use the following trigger types:
   Type: suricata_event
   Trigger ID: The rule class of the triggered IDS alert
 
+ERSPAN
+++++++
+
+ERSPAN comes handy when a switch port traffic (low bandwidth) needs to be monitored from a remote location, E.G: your Security Onion already deployed box. ERSPAN encapsulates the desired port traffic in GRE packets to one/multiple destination(s).
+
+One of the way of dealing easily with that GRE encapsulated traffic on the destination is through RCDCAP, which creates a virtual interface on which GRE traffic is already decapsultated. Security Onion can then feed on that interface like any other interface.
+
+Example:
+The switch is at 10.10.10.1, the monitored switch port is GigabitEthernet10 and the Security Onion monitoring destination IP is 10.10.10.10 on eth2, ideally on a seperate interface optimized for monitoring.
+
+
+On the Switch:
+
+  monitor session 10 type erspan-source
+  description ERSPAN to 10.10.10.10
+  source interface GigabitEthernet10
+  destination
+  erspan-id 10
+  ip address 10.10.10.10
+  origin ip address 10.10.10.1
+  no shutdown   !   Default is shutdown 
+
+On Security Onion:
+
+ * Download, compile and install RCDCAP.
+ * Create the file /etc/init.d/rcdcap with a similar content:  
+
+----
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          rcdcap
+# Required-Start:    $local_fs $network $named $time $syslog
+# Required-Stop:     $local_fs $network $named $time $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Description:       rcdcap - remote capture preprocessor
+### END INIT INFO
+
+PIDFILE=/var/run/rcdcap.pid
+
+start() {
+  if [ -f /var/run/$PIDNAME ] && kill -0 $(cat /var/run/$PIDNAME); then
+    echo 'Service already running' >&2
+    return 1
+  fi
+  echo 'Starting service…' >&2
+  local CMD="$SCRIPT &> \"$LOGFILE\" & echo \$!"
+  rcdcap -i eth2 --erspan --tap-persist --tap-device mon1 -d
+  pidof rcdcap > "$PIDFILE"
+  return 0
+  echo 'Service started' >&2
+}
+
+stop() {
+  if [ ! -f "$PIDFILE" ]; then
+    echo 'Service not running' >&2
+    return 1
+  fi
+  echo 'Stopping service…' >&2
+  kill -9 $(cat "$PIDFILE") && rm -f "$PIDFILE"
+  echo 'Service stopped' >&2
+}
+
+
+case "$1" in
+  start)
+    start
+    ;;
+  stop)
+    stop
+    ;;
+  restart)
+    stop
+    start
+    ;;
+  *)
+    echo "Usage: $0 {start|stop|restart|uninstall}"
+esac    
+----
+  * Add executable flag on the file:
+
+  chmod +x /etc/init.d/rcdcap
+ 
+  * Enable rcdcap service
+
+   sudo update-rc.d rcdcap defaults 18 02
+
+  * Start service
+
+   sudo /etc/init.d/rcdcap start
+
+  
+
 Violations
 ^^^^^^^^^^
 

--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -2926,9 +2926,9 @@ On Security Onion:
 
  * Enable Inverse repository for Security Onion:
 
-  sudo cat << EOL >/etc/apt/sources.list.d/securityonion-inverse.list
+  sudo bash -c 'cat << EOL >/etc/apt/sources.list.d/securityonion-inverse.list
   deb http://inverse.ca/downloads/PacketFence/securityonion trusty trusty
-  EOL
+  EOL'
 
   gpg --keyserver keyserver.ubuntu.com --recv 19CDA6A9810273C4
   gpg --export --armor 19CDA6A9810273C4 | sudo apt-key add -

--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -3003,7 +3003,8 @@ esac
 
   sudo /etc/init.d/rcdcap start
 
-  * Rerun Security Onion wizard to configure tweak mon1 interface and include it to be monitored. Attention: network configuration file will be overwritten. Backup if needed, or skip that part in the wizard and adapt manually.
+WARNING: network configuration file will be overwritten by sosetup Network Configuration. Backup /etc/network/interface if needed, or skip that part in the wizard and adapt manually.
+  * Rerun Security Onion wizard to configure/tweak mon1 interface and include it to be monitored.
    
   sudo sosetup
 

--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -2920,7 +2920,7 @@ One way of accessing encapsulated traffic at the destination host is through a s
 
 
 Assomptions for the example:
-The switch is at IP 10.10.10.1, the monitored switch port is GigabitEthernet10 and the Security Onion monitoring destination IP is 10.10.10.10 on eth2, ideally on a seperate interface optimized for monitoring.
+The switch is at IP 172.16.0.1, the monitored switch port is GigabitEthernet10 and the Security Onion monitoring destination IP is 10.10.10.10 on eth2, ideally on a dedicated interface.
 
 On Security Onion:
 
@@ -2938,85 +2938,28 @@ On Security Onion:
   sudo apt-get update
   sudo apt-get install rcdcap  
 
- * Create the file /etc/init.d/rcdcap with a similar content:  
-----
-#!/bin/sh
-### BEGIN INIT INFO
-# Provides:          rcdcap
-# Required-Start:    $local_fs $network $named $time $syslog
-# Required-Stop:     $local_fs $network $named $time $syslog
-# Default-Start:     2 3 4 5
-# Default-Stop:      0 1 6
-# Description:       rcdcap - remote capture preprocessor
-### END INIT INFO
-
-PIDFILE=/var/run/rcdcap.pid
-
-start() {
-  if [ -f /var/run/$PIDNAME ] && kill -0 $(cat /var/run/$PIDNAME); then
-    echo 'Service already running' >&2
-    return 1
-  fi
-  echo 'Starting service…' >&2
-  local CMD="$SCRIPT &> \"$LOGFILE\" & echo \$!"
-  rcdcap -i eth2 --erspan --tap-persist --tap-device mon1 -d
-  pidof rcdcap > "$PIDFILE"
-  return 0
-  echo 'Service started' >&2
-}
-
-stop() {
-  if [ ! -f "$PIDFILE" ]; then
-    echo 'Service not running' >&2
-    return 1
-  fi
-  echo 'Stopping service…' >&2
-  kill -9 $(cat "$PIDFILE") && rm -f "$PIDFILE"
-  echo 'Service stopped' >&2
-}
-
-
-case "$1" in
-  start)
-    start
-    ;;
-  stop)
-    stop
-    ;;
-  restart)
-    stop
-    start
-    ;;
-  *)
-    echo "Usage: $0 {start|stop|restart|uninstall}"
-esac    
-----
-  * Add executable flag on the file:
-
-  chmod +x /etc/init.d/rcdcap
- 
-  * Enable rcdcap service
-
-  sudo update-rc.d rcdcap defaults 18 02
-
-  * Start service
-
-  sudo /etc/init.d/rcdcap start
-
-WARNING: network configuration file will be overwritten by sosetup Network Configuration. Backup /etc/network/interface if needed, or skip that part in the wizard and adapt manually.
-  * Rerun Security Onion wizard to configure/tweak mon1 interface and include it to be monitored.
-   
-  sudo sosetup
-
-  * Modify network file (/etc/network/inferfaces) so that eth2 has an IP and a proper MTU.
+  * Modify network file (/etc/network/inferfaces) so that eth2 has an IP and a proper MTU. Decapsulated traffic will be injected on mon1. Make sure that the configuration is similar to the following:
 
   auto eth2
   iface eth2 inet static
-  address 10.10.10.10
-  netmask 255.255.255.240
-  up ifconfig $IFACE arp up
-  up ip link set dev $IFACE mtu 1900
+    address 10.10.10.10
+    netmask 255.255.255.240
+    up ip link set $IFACE arp on up
+    up ip link set dev $IFACE mtu 1900
+    post-up ethtool -G $IFACE rx 4096; for i in rx tx sg tso ufo gso gro lro; do ethtool -K $IFACE $i off; done
+    post-up echo 1 > /proc/sys/net/ipv6/conf/$IFACE/disable_ipv6
 
+  auto mon1
+  iface mon1 inet manual
+    pre-up rcdcap -i eth1 --erspan --tap-persist --tap-device $IFACE --expression "host 172.16.0.1" -d
+    up ip link set $IFACE promisc on arp off up
+    down ip link set $IFACE promisc off down
+    post-up ethtool -G $IFACE rx ; for i in rx tx sg tso ufo gso gro lro; do ethtool -K $IFACE $i off; done
+    post-up echo 1 > /proc/sys/net/ipv6/conf/$IFACE/disable_ipv6
+
+  * Rerun Security Onion wizard and make sure to skip network configuration step. Make sure that mon1 is selected for monitoring purposes, note that eth2 doesn't need to.
+   
+  sudo sosetup
 
 On the Switch:
 
@@ -3026,7 +2969,7 @@ On the Switch:
   destination
   erspan-id 10
   ip address 10.10.10.10
-  origin ip address 10.10.10.1
+  origin ip address 172.16.0.1
   no shutdown   !   Default is shutdown 
 
 


### PR DESCRIPTION
# Description

ERSPAN decapsulation on SecurityOnion through rcdcap usage.
This include documentation to install rcdcap through Inverse repositoy and configuration so that rcdcap creates a new interface beofre nsm-sensor inspect traffic on newly create virtual interface.
# Delete branch after merge

YES 
# NEWS file entries

ERSPAN support on Security Onion: new package and repository with relative documentation.
