### PR TITLE
Forced DHCP processing on internal networks.

### DIFF
--- a/lib/pf/dhcp/processor.pm
+++ b/lib/pf/dhcp/processor.pm
@@ -323,8 +323,7 @@ sub parse_dhcp_request {
 
     # We check if we are running without dhcpd
     # This means we don't see ACK so we need to act on requests
-    if( !$self->{'net_type'} eq "internal" && 
-        !$self->pf_is_dhcp($client_ip) && 
+    if( !$self->pf_is_dhcp($client_ip) && 
         !isenabled($Config{network}{force_listener_update_on_ack}) ){
         $self->handle_new_ip($client_mac, $client_ip, $lease_length);
     }

--- a/sbin/pfdhcplistener
+++ b/sbin/pfdhcplistener
@@ -105,7 +105,19 @@ my $net_type;
 my $process;
 
 sub reload_config {
-    $process = pf::cluster::is_vip_running($interface);
+    if ( $net_type eq "internal" ) { 
+        $process = $TRUE;
+    }
+    elsif ( pf::cluster::is_vip_running($interface) ) { 
+        $process = $TRUE;
+    }
+    elsif ( !$pf::cluster::cluster_enabled ) { 
+        $process = $TRUE;
+    }
+    else { 
+        $process = $FALSE;
+    }
+
     $logger->info("Reload configuration on $interface with status $process");
 }
 
@@ -181,7 +193,7 @@ sub dhcp_detector {
 
 sub process_pkt {
     my ( $user_data, $hdr, $pkt ) = @_;
-    if ($process || !$pf::cluster::cluster_enabled){
+    if ($process){
         eval {
             my $l2 = NetPacket::Ethernet->decode($pkt);
 


### PR DESCRIPTION
# Description

Forces the DHCP listener and processor to rely on DHCPACK on internal networks, regardless of whether clustering is enabled.
# Impacts

Currently -- if running a cluster -- a client that tries to renew it's DHCP lease using a unicast DHCPREQUEST is ignored 50% of the time.
This forces each server to update the iplog for every DHCPACK it sends.
# Issue

Fixes #1667
# Delete branch after merge

YES 
# NEWS file entries
## Bug Fixes

If an issue exists on Github, please refer to it (name) along with it's number...
- Fixes ignored unicast DHCP renewals when running in clustered mode. (#1667)
