### PR TITLE
Invalidate email registration URL upon their timeout

### DIFF
--- a/lib/pf/activation.pm
+++ b/lib/pf/activation.pm
@@ -344,17 +344,18 @@ Returns the activation code
 sub create {
     my $args = shift;
     my ($mac, $pid, $pending_addr, $type, $portal, $provider_id, $timeout);
-    (	$mac 		= $args->{'mac'}, 
-        $pid 		= $args->{'pid'}, 
-	$pending_addr 	= $args->{'pending'}, 
-	$type 		= $args->{'type'}, 
-	$portal 	= $args->{'portal'}, 
-	$provider_id 	= $args->{'provider_id'}, 
-	$timeout 	= $args->{'timeout'} );
-	
+    (
+        $mac          = $args->{'mac'},
+        $pid          = $args->{'pid'},
+        $pending_addr = $args->{'pending'},
+        $type         = $args->{'type'},
+        $portal       = $args->{'portal'},
+        $provider_id  = $args->{'provider_id'},
+        $timeout      = $args->{'timeout'}
+    );
+
     my $logger = get_logger();
 
-    $mac = $args->{'mac'}; 
     unless($mac){
         $mac = undef;
     }
@@ -514,9 +515,15 @@ sub create_and_send_activation_code {
     my ($mac, $pid, $pending_addr, $template, $type, $portal, %info) = @_;
 
     my ($success, $err) = ($TRUE, 0);
-    my %args = ( 
-	mac 	=> $mac,  pid 	 => $pid, 	pending => $pending_addr, 
-	type 	=> $type, portal => $portal, 	timeout => $info{'activation_timeout'});
+    my %args = (
+        mac     => $mac,
+        pid     => $pid,
+        pending => $pending_addr,
+        type    => $type,
+        portal  => $portal,
+        timeout => $info{'activation_timeout'}
+    );
+
     my $activation_code = create(\%args);
     if (defined($activation_code)) {
       unless (send_email($activation_code, $template, %info)) {
@@ -589,10 +596,16 @@ sub sms_activation_create_send {
     # Strip non-digits
     $phone_number =~ s/\D//g;
 
-    my ($success, $err) = ($TRUE, 0);
-    my %args = ( 
-	mac  => $mac,  pid    => $pid,    pending     => $phone_number, 
-	type => "sms", portal => $portal, provider_id => $provider_id);
+    my ( $success, $err ) = ( $TRUE, 0 );
+    my %args = (
+        mac         => $mac,
+        pid         => $pid,
+        pending     => $phone_number,
+        type        => "sms",
+        portal      => $portal,
+        provider_id => $provider_id
+    );
+
     my $activation_code = create(\%args);
     if (defined($activation_code)) {
       unless (send_sms($activation_code, %info)) {


### PR DESCRIPTION
# Description

Email activations URLs were hard-coded to expire after 31 days.
This makes them expire when the email source times out.
# Impacts

Try to use a registration URL after the email source has timed out (e.g. 10 minutes).
It should not be allowed.
# Issue

fixes #1670
# Delete branch after merge

YES 
## Bug Fixes
- Fixes email registration URL not expiring at same time as the source times out (#1670)
