### PR TITLE
Adds a grace time to iplog for devices that don't respect lease time

### DIFF
--- a/lib/pf/iplog.pm
+++ b/lib/pf/iplog.pm
@@ -55,13 +55,15 @@ sub iplog_db_prepare {
     $logger->debug("Preparing pf::iplog database queries");
 
     # We could have used the iplog_list_open_by_ip_sql statement but for performances, we enforce the LIMIT 1
+    # We add a 30 seconds grace time for devices that don't actually respect lease times 
     $iplog_statements->{'iplog_view_by_ip_sql'} = get_db_handle()->prepare(
-        qq [ SELECT * FROM iplog WHERE ip = ? AND (end_time = 0 OR end_time > NOW()) ORDER BY start_time DESC LIMIT 1 ]
+        qq [ SELECT * FROM iplog WHERE ip = ? AND (end_time = 0 OR ( end_time + INTERVAL 30 SECONDS ) > NOW()) ORDER BY start_time DESC LIMIT 1 ]
     );
 
     # We could have used the iplog_list_open_by_mac_sql statement but for performances, we enforce the LIMIT 1
+    # We add a 30 seconds grace time for devices that don't actually respect lease times 
     $iplog_statements->{'iplog_view_by_mac_sql'} = get_db_handle()->prepare(
-        qq [ SELECT * FROM iplog WHERE mac = ? AND (end_time = 0 OR end_time > NOW()) ORDER BY start_time DESC LIMIT 1 ]
+        qq [ SELECT * FROM iplog WHERE mac = ? AND (end_time = 0 OR ( end_time + INTERVAL 30 SECONDS ) > NOW()) ORDER BY start_time DESC LIMIT 1 ]
     );
 
     $iplog_statements->{'iplog_list_open_sql'} = get_db_handle()->prepare(


### PR DESCRIPTION
# Description

Some devices don't actually respect the lease time send by the DHCP server, especially when the leases are short.
This PR adds a 30 second window around the search in the IPlog to account for devices that are still using their old lease even though it is technically expired based on the lease issued by the server.
If the server allocates the IP to another device we should still find it in the iplog as the previous entry would be closed.
# Impacts

mac2ip for devices with short leases.
# Issue

fixes #1673
# Delete branch after merge

YES 
## Bug Fixes

If an issue exists on Github, please refer to it (name) along with it's number...
- Adds a workaround for dhcpclients that do not respect short lease times (#1673).
