### PR TITLE
Clustering guide clarifications

### DIFF
--- a/docs/PacketFence_Clustering_Guide.asciidoc
+++ b/docs/PacketFence_Clustering_Guide.asciidoc
@@ -206,11 +206,15 @@ Stop and backup previous MySQL data
 
   # service mysqld stop
   # mkdir /var/lib/mysql.bak
-  # mv /var/lib/mysql/* /var/lib/mysql.bak/
+  # mv /var/lib/mysql/* /var/lib/mysql.bak/ #Optionnal
 
 Mount the partition with:
 
   # mount /dev/drbd0 /var/lib/mysql
+
+Restore previous MariaDB data
+
+  # mv /var/lib/mysql.bak/* /var/lib/mysql/ #Optionnal
 
 Start MySQL
 
@@ -626,7 +630,7 @@ Stop and backup previous MariaDB data
 
   # systemctl stop mariadb
   # mkdir /var/lib/mysql.bak
-  # mv /var/lib/mysql/* /var/lib/mysql.bak/
+  # mv /var/lib/mysql/* /var/lib/mysql.bak/ #Optionnal
 
 Mount the partition with:
 
@@ -634,7 +638,7 @@ Mount the partition with:
 
 Restore previous MariaDB data
 
-  # mv /var/lib/mysql.bak/* /var/lib/mysql/
+  # mv /var/lib/mysql.bak/* /var/lib/mysql/ #Optionnal
 
 Start MariaDB
 

--- a/docs/PacketFence_Clustering_Guide.asciidoc
+++ b/docs/PacketFence_Clustering_Guide.asciidoc
@@ -800,12 +800,9 @@ host=127.0.0.1
 ....
 ----
 
-Make sure you restart, packetfence-config and packetfence
+Make sure you restart MySQL:
 
-  # /usr/local/pf/bin/pfcmd configreload hard
-  # /usr/local/pf/bin/pfcmd pfconfig clear_backend
-  # systemctl restart packetfence-config
-  # systemctl restart packetfence
+# systemctl restart mariadb
 
 Next, you need to remove the empty users from your MySQL database
 


### PR DESCRIPTION
# Description

Clustering guide had a  lot of changes in the recent past (3 months) but the resulting HTML documentation was not regenerated.

The main affected sections are: 
https://packetfence.org/doc/PacketFence_Clustering_Guide.html#_installation_on_centos_7

and 

https://github.com/inverse-inc/packetfence/blob/ee98505c7270b9cd607e55e251afd87d75df1903/docs/PacketFence_Clustering_Guide.asciidoc

Assumptions have changed: 
The HTML guide suppose clean installation and unconfigured PacketFence installation on top of CentOS, where the actual asciidoc file takes into consideration that at least one PacketFence server was configured (master) and desired to be put in a cluster.

We need to make sure that this is clear for everyone following the doc prior to regenerate the HTML doc.
# Impacts

Clustering use case changed.
The documentation adress the use case where a user already has one packetfence server configured and wants to put it in a an active/active cluster where only mariaDB is in active/passive.
# Delete branch after merge

(REQUIRED)
YES 
