### PR TITLE
fixing username error in pfqueue.log

### DIFF
--- a/lib/pf/firewallsso/PaloAlto.pm
+++ b/lib/pf/firewallsso/PaloAlto.pm
@@ -44,8 +44,6 @@ sub action {
     if ($method eq 'Start') {
         my $node_info = node_view($mac);
         my $username = $node_info->{'pid'};
-        $username =  $node_info->{'last_dot1x_username'} if ( $ConfigFirewallSSO{$firewall_conf}->{'uid'} eq '802.1x');
-        return 0 if ( $ConfigFirewallSSO{$firewall_conf}->{'uid'} eq '802.1x' && $node_info->{'last_dot1x_username'} eq '');
 
         my @categories = @{$self->{categories}};
         if (
@@ -81,8 +79,6 @@ XML
     } elsif ($method eq 'Stop') {
         my $node_info = node_view($mac);
         my $username = $node_info->{'pid'};
-        $username = $node_info->{'last_dot1x_username'} if ( $ConfigFirewallSSO{$firewall_conf}->{'uid'} eq '802.1x');
-        return 0 if ( $ConfigFirewallSSO{$firewall_conf}->{'uid'} eq '802.1x' && $node_info->{'last_dot1x_username'} eq '');
 
         my @categories = @{$self->{categories}};
         if (


### PR DESCRIPTION
# Description

fixing username error in pfqueue.log because the PaloAlto module doesn't have the UID field.
# Impacts

Firewall SSO workflow
# Delete branch after merge

YES 
## Bug Fixes

Fixing the error in pfqueue.log for PaloAlto for the UID.

Use of uninitialized value in string eq at /usr/local/pf/lib/pf/firewallsso/PaloAlto.pm line 47.
