### PR TITLE
Fix/rhel7 domain join

### DIFF
--- a/addons/AD/smb.tt
+++ b/addons/AD/smb.tt
@@ -10,8 +10,8 @@ netbios name = [% server_name %]
 server string =  [% server_name %]
 
 pid directory = /usr/local/pf/var/run/[% domain %]
-lock directory = /var/cache/samba[% domain %]
-private dir = /var/cache/samba[% domain %]
+lock directory = /var/cache/samba
+private dir = /var/cache/samba
 
 security = ADS
 winbind use default domain = no

--- a/addons/create_chroot.sh
+++ b/addons/create_chroot.sh
@@ -19,10 +19,10 @@ DIRS=(proc lib lib64 bin usr sbin sys dev var/log/samba $ETC_DIRS)
 MOUNTS=(`mount | awk '{print $3}'`)
 
 for dir in "${DIRS[@]}"; do
-    value=$BASE/$NS/$dir
-    if [[ ! " ${MOUNTS[@]} " =~ " ${value} " ]]; then
-        mount -o bind /$dir $BASE/$NS/$dir
-    fi
+   value=$BASE/$NS/$dir
+   if [[ ! " ${MOUNTS[@]} " =~ " ${value} " ]]; then
+       mount -o bind /$dir $BASE/$NS/$dir
+   fi
 done
 
 ETC_FILES=$(find /etc -maxdepth 1 -type f|grep -v resolv.conf)

--- a/addons/create_chroot.sh
+++ b/addons/create_chroot.sh
@@ -19,10 +19,10 @@ DIRS=(proc lib lib64 bin usr sbin sys dev var/log/samba $ETC_DIRS)
 MOUNTS=(`mount | awk '{print $3}'`)
 
 for dir in "${DIRS[@]}"; do
-   value=$BASE/$NS/$dir
-   if [[ ! " ${MOUNTS[@]} " =~ " ${value} " ]]; then
-       mount -o bind /$dir $BASE/$NS/$dir
-   fi
+    value=$BASE/$NS/$dir
+    if [[ ! " ${MOUNTS[@]} " =~ " ${value} " ]]; then
+        mount -o bind /$dir $BASE/$NS/$dir
+    fi
 done
 
 ETC_FILES=$(find /etc -maxdepth 1 -type f|grep -v resolv.conf)

--- a/addons/create_chroot.sh
+++ b/addons/create_chroot.sh
@@ -1,24 +1,19 @@
-#!/bin/bash
-NS=$1
+=$1
 BASE=$2
-
-#May be needed later on to differenciate CentOS and Debian. Useless now since CentOS code is the same for RHEL6 and RHEL7
-#if [ -e /etc/redhat-release ]; then
-#    RHEL=$(cat /etc/redhat-release | grep -Eo "[0-9]+(\.[0-9]+)*" | cut -d '.' -f1);
-#fi
 
 if [ -z "$NS" ] || [ -z "$BASE" ]; then
     echo "Missing parameters. First is NS second is BASE."
     exit 1;
 fi
 
-DIRS=(proc var etc lib lib64 usr sbin bin var/cache/samba sys var/lib/samba dev tmp run/samba var/log/samba)
+ETC_DIRS=$(find /etc -maxdepth 1 -type d|tail -n+2|sed 's|/||')
+DIRS=(proc var etc lib lib64 usr sbin bin var/cache/samba sys var/lib/samba dev tmp run/samba var/log/samba $ETC_DIRS)
 
 for dir in "${DIRS[@]}"; do
   [ -d $BASE/$NS/$dir ]                || mkdir -p $BASE/$NS/$dir
 done
 
-DIRS=(proc lib lib64 bin usr sbin sys dev var/log/samba)
+DIRS=(proc lib lib64 bin usr sbin sys dev var/log/samba $ETC_DIRS)
 
 MOUNTS=(`mount | awk '{print $3}'`)
 
@@ -26,19 +21,9 @@ for dir in "${DIRS[@]}"; do
     value=$BASE/$NS/$dir
     if [[ ! " ${MOUNTS[@]} " =~ " ${value} " ]]; then
         mount -o bind /$dir $BASE/$NS/$dir
-        if [ ! -f $BASE/$NS/$dir/resolv.conf ]; then
-            ETC_DIRS=$(find /etc -maxdepth 1 -type d|tail -n+2);
-            ETC_FILES=$(find /etc -maxdepth 1 -type f|grep -v resolv.conf)
-            echo "$ETC_DIRS"|while read etc_dir;
-            do
-                if [ ! -d "/$BASE/$NS$etc_dir" ]; then
-                    mkdir -p /$BASE/$NS$etc_dir;
-                    mount -o bind $etc_dir /$BASE/$NS$etc_dir;
-                fi
-            done
-            echo "$ETC_FILES"|while read etc_file; do yes 2>/dev/null|cp $etc_file /$BASE/$NS$etc_file; done
-            cp /etc/netns/$NS/resolv.conf /$BASE/$NS/etc
-        fi
     fi
 done
 
+ETC_FILES=$(find /etc -maxdepth 1 -type f|grep -v resolv.conf)
+echo "$ETC_FILES"|while read etc_file; do yes 2>/dev/null|cp $etc_file /$BASE/$NS$etc_file; done
+yes 2>/dev/null|cp /etc/netns/$NS/resolv.conf /$BASE/$NS/etc

--- a/addons/create_chroot.sh
+++ b/addons/create_chroot.sh
@@ -13,7 +13,7 @@ for dir in "${DIRS[@]}"; do
   [ -d $BASE/$NS/$dir ]                || mkdir -p $BASE/$NS/$dir
 done
 
-DIRS=(proc etc lib lib64 bin usr sbin sys var/lib/samba dev var/log/samba)
+DIRS=(proc etc lib lib64 bin usr sbin sys dev var/log/samba)
 
 MOUNTS=(`mount | awk '{print $3}'`)
 

--- a/addons/create_chroot.sh
+++ b/addons/create_chroot.sh
@@ -1,4 +1,5 @@
-=$1
+#!/bin/bash
+NS=$1
 BASE=$2
 
 if [ -z "$NS" ] || [ -z "$BASE" ]; then

--- a/addons/create_chroot.sh
+++ b/addons/create_chroot.sh
@@ -7,7 +7,7 @@ if [ -z "$NS" ] || [ -z "$BASE" ]; then
     exit 1;
 fi
 
-DIRS=(proc var etc lib lib64 usr sbin bin var/cache sys var/lib/samba dev tmp run/samba var/log/samba var/lock)
+DIRS=(proc var etc lib lib64 usr sbin bin var/cache sys var/lib/samba dev tmp run/samba var/log/samba var/lock var/run)
 
 for dir in "${DIRS[@]}"; do
   [ -d $BASE/$NS/$dir ]                || mkdir -p $BASE/$NS/$dir
@@ -16,7 +16,7 @@ done
 touch /var/cache/samba$NS/secrets.tdb
 cp -fr /var/cache/samba$NS $BASE/$NS/var/cache/
 
-DIRS=(proc etc lib lib64 bin usr sbin sys var/lib/samba dev var/log/samba var/lock)
+DIRS=(proc lib lib64 bin usr sbin sys var/lib/samba dev var/log/samba var/lock )
 
 MOUNTS=(`mount | awk '{print $3}'`)
 
@@ -26,4 +26,8 @@ for dir in "${DIRS[@]}"; do
     mount -o bind /$dir           $BASE/$NS/$dir
   fi
 done
+
+#We make sure we use /etc/resolv.conf of the namespace  (RHEL7+)
+mkdir /tmp/$NS
+mount -t overlay -o lowerdir=/etc,upperdir=/etc/netns/$NS,workdir=/tmp/$NS overlay /chroots/$NS/etc
 

--- a/addons/create_chroot.sh
+++ b/addons/create_chroot.sh
@@ -7,25 +7,25 @@ if [ -z "$NS" ] || [ -z "$BASE" ]; then
     exit 1;
 fi
 
-DIRS=(proc var etc lib lib64 usr sbin bin var/cache/samba sys var/lib/samba dev tmp run/samba var/log/samba var/lock var/run)
+DIRS=(proc var etc lib lib64 usr sbin bin var/cache/samba sys var/lib/samba dev tmp run/samba var/log/samba)
 
 for dir in "${DIRS[@]}"; do
   [ -d $BASE/$NS/$dir ]                || mkdir -p $BASE/$NS/$dir
 done
 
-DIRS=(etc proc lib lib64 bin usr sbin sys var/lib/samba dev var/log/samba)
+DIRS=(proc etc lib lib64 bin usr sbin sys var/lib/samba dev var/log/samba)
 
 MOUNTS=(`mount | awk '{print $3}'`)
 
 for dir in "${DIRS[@]}"; do
-  value=$BASE/$NS/$dir
-  if [[ ! " ${MOUNTS[@]} " =~ " ${value} " ]]; then
-    if [[ "$dir" != "etc" ]]; then
-      mount -o bind /$dir           $BASE/$NS/$dir
-      else
-        #We make sure we use /etc/resolv.conf of the namespace  (RHEL7+)
-        mkdir -p /tmp/$NS
-        mount -t overlay -o lowerdir=/etc,upperdir=/etc/netns/$NS,workdir=/tmp/$NS overlay /chroots/$NS/etc
-      fi
+    value=$BASE/$NS/$dir
+    if [[ ! " ${MOUNTS[@]} " =~ " ${value} " ]]; then
+        if [[ "$dir" != "etc" ]]; then
+            mount -o bind /$dir           $BASE/$NS/$dir
+        else
+            #We make sure we use /etc/resolv.conf of the namespace  (RHEL7+)
+            mkdir -p /tmp/$NS
+            mount -t overlay -o lowerdir=/etc,upperdir=/etc/netns/$NS,workdir=/tmp/$NS overlay /chroots/$NS/etc
+        fi
     fi
 done

--- a/addons/create_chroot.sh
+++ b/addons/create_chroot.sh
@@ -7,16 +7,13 @@ if [ -z "$NS" ] || [ -z "$BASE" ]; then
     exit 1;
 fi
 
-DIRS=(proc var etc lib lib64 usr sbin bin var/cache sys var/lib/samba dev tmp run/samba var/log/samba var/lock var/run)
+DIRS=(proc var etc lib lib64 usr sbin bin var/cache/samba sys var/lib/samba dev tmp run/samba var/log/samba var/lock var/run)
 
 for dir in "${DIRS[@]}"; do
   [ -d $BASE/$NS/$dir ]                || mkdir -p $BASE/$NS/$dir
 done
 
-touch /var/cache/samba$NS/secrets.tdb
-cp -fr /var/cache/samba$NS $BASE/$NS/var/cache/
-
-DIRS=(etc proc lib lib64 bin usr sbin sys var/lib/samba dev var/log/samba var/lock )
+DIRS=(etc proc lib lib64 bin usr sbin sys var/lib/samba dev var/log/samba)
 
 MOUNTS=(`mount | awk '{print $3}'`)
 

--- a/addons/create_chroot.sh
+++ b/addons/create_chroot.sh
@@ -7,7 +7,7 @@ if [ -z "$NS" ] || [ -z "$BASE" ]; then
     exit 1;
 fi
 
-DIRS=(proc var etc lib lib64 usr sbin bin var/cache sys var/lib/samba dev tmp run/samba var/log/samba)
+DIRS=(proc var etc lib lib64 usr sbin bin var/cache sys var/lib/samba dev tmp run/samba var/log/samba var/lock)
 
 for dir in "${DIRS[@]}"; do
   [ -d $BASE/$NS/$dir ]                || mkdir -p $BASE/$NS/$dir
@@ -16,7 +16,7 @@ done
 touch /var/cache/samba$NS/secrets.tdb
 cp -fr /var/cache/samba$NS $BASE/$NS/var/cache/
 
-DIRS=(proc etc lib lib64 bin usr sbin sys var/lib/samba dev var/log/samba)
+DIRS=(proc etc lib lib64 bin usr sbin sys var/lib/samba dev var/log/samba var/lock)
 
 MOUNTS=(`mount | awk '{print $3}'`)
 

--- a/addons/create_chroot.sh
+++ b/addons/create_chroot.sh
@@ -2,8 +2,13 @@
 NS=$1
 BASE=$2
 
+#May be needed later on to differenciate CentOS and Debian. Useless now since CentOS code is the same for RHEL6 and RHEL7
+#if [ -e /etc/redhat-release ]; then
+#    RHEL=$(cat /etc/redhat-release | grep -Eo "[0-9]+(\.[0-9]+)*" | cut -d '.' -f1);
+#fi
+
 if [ -z "$NS" ] || [ -z "$BASE" ]; then
-    echo "Missing parameter"
+    echo "Missing parameters. First is NS second is BASE."
     exit 1;
 fi
 
@@ -13,19 +18,27 @@ for dir in "${DIRS[@]}"; do
   [ -d $BASE/$NS/$dir ]                || mkdir -p $BASE/$NS/$dir
 done
 
-DIRS=(proc etc lib lib64 bin usr sbin sys dev var/log/samba)
+DIRS=(proc lib lib64 bin usr sbin sys dev var/log/samba)
 
 MOUNTS=(`mount | awk '{print $3}'`)
 
 for dir in "${DIRS[@]}"; do
     value=$BASE/$NS/$dir
     if [[ ! " ${MOUNTS[@]} " =~ " ${value} " ]]; then
-        if [[ "$dir" != "etc" ]]; then
-            mount -o bind /$dir           $BASE/$NS/$dir
-        else
-            #We make sure we use /etc/resolv.conf of the namespace  (RHEL7+)
-            mkdir -p /tmp/$NS
-            mount -t overlay -o lowerdir=/etc,upperdir=/etc/netns/$NS,workdir=/tmp/$NS overlay /chroots/$NS/etc
+        mount -o bind /$dir $BASE/$NS/$dir
+        if [ ! -f $BASE/$NS/$dir/resolv.conf ]; then
+            ETC_DIRS=$(find /etc -maxdepth 1 -type d|tail -n+2);
+            ETC_FILES=$(find /etc -maxdepth 1 -type f|grep -v resolv.conf)
+            echo "$ETC_DIRS"|while read etc_dir;
+            do
+                if [ ! -d "/$BASE/$NS$etc_dir" ]; then
+                    mkdir -p /$BASE/$NS$etc_dir;
+                    mount -o bind $etc_dir /$BASE/$NS$etc_dir;
+                fi
+            done
+            echo "$ETC_FILES"|while read etc_file; do yes 2>/dev/null|cp $etc_file /$BASE/$NS$etc_file; done
+            cp /etc/netns/$NS/resolv.conf /$BASE/$NS/etc
         fi
     fi
 done
+

--- a/lib/pf/domain.pm
+++ b/lib/pf/domain.pm
@@ -46,10 +46,6 @@ Executes a command and returns the results as the domain interfaces expect it
 
 sub run {
     my ($cmd) = @_;
- 
-    my $logger = get_logger();
-    $logger->info("COMMAND:" . $cmd);   
-
     my $result = `$cmd`;
     my $code = $? >> 8;
 
@@ -65,7 +61,7 @@ Executes the command in the OS to test the domain join
 sub test_join {
     my ($domain) = @_;
     my $chroot_path = chroot_path($domain);
-    my ($status, $output) = run("/usr/bin/sudo /sbin/ip netns exec $domain /usr/sbin/chroot $chroot_path /usr/bin/net ads testjoin -s /etc/samba/$domain.conf -d 10 2>&1");
+    my ($status, $output) = run("/usr/bin/sudo /sbin/ip netns exec $domain /usr/sbin/chroot $chroot_path /usr/bin/net ads testjoin -s /etc/samba/$domain.conf");
     return ($status, $output);
 }
 

--- a/lib/pf/domain.pm
+++ b/lib/pf/domain.pm
@@ -93,7 +93,7 @@ sub join_domain {
     my $chroot_path = chroot_path($domain);
 
     regenerate_configuration();
- 
+
     my $info = $ConfigDomain{$domain};
     my ($status, $output) = run("/usr/bin/sudo /sbin/ip netns exec $domain /usr/sbin/chroot $chroot_path net ads join -s /etc/samba/$domain.conf -U '$info->{bind_dn}%$info->{bind_pass}'");
     $logger->info("domain join : ".$output);

--- a/lib/pf/domain.pm
+++ b/lib/pf/domain.pm
@@ -65,7 +65,7 @@ Executes the command in the OS to test the domain join
 sub test_join {
     my ($domain) = @_;
     my $chroot_path = chroot_path($domain);
-    my ($status, $output) = run("/usr/bin/sudo /sbin/ip netns exec $domain /usr/sbin/chroot $chroot_path /usr/bin/net ads testjoin -s /etc/samba/$domain.conf");
+    my ($status, $output) = run("/usr/bin/sudo /sbin/ip netns exec $domain /usr/sbin/chroot $chroot_path /usr/bin/net ads testjoin -s /etc/samba/$domain.conf -d 10 2>&1");
     return ($status, $output);
 }
 
@@ -98,7 +98,8 @@ sub join_domain {
     regenerate_configuration();
 
     my $info = $ConfigDomain{$domain};
-    my ($status, $output) = run("/usr/bin/sudo /sbin/ip netns exec $domain /usr/sbin/chroot $chroot_path net ads join -S $info->{ad_server} $info->{dns_name} -s /etc/samba/$domain.conf -U '$info->{bind_dn}%$info->{bind_pass}'");
+    my ($status2, $output2) = run("/usr/bin/sudo /sbin/ip netns exec $domain /usr/sbin/chroot $chroot_path net ads join -S $info->{ad_server} $info->{dns_name} -s /etc/samba/$domain.conf -U '$info->{bind_dn}%$info->{bind_pass}' -d 10 2>&1");
+    
     $logger->info("domain join : ".$output);
 
     restart_winbinds();

--- a/lib/pf/domain.pm
+++ b/lib/pf/domain.pm
@@ -98,8 +98,7 @@ sub join_domain {
     regenerate_configuration();
 
     my $info = $ConfigDomain{$domain};
-    my ($status, $output) = run("/usr/bin/sudo /sbin/ip netns exec $domain /usr/sbin/chroot $chroot_path net ads join -S $info->{ad_server} $info->{dns_name} -s /etc/samba/$domain.conf -U '$info->{bind_dn}%$info->{bind_pass}' -d 10 2>&1");
-    
+    my ($status, $output) = run("/usr/bin/sudo /sbin/ip netns exec $domain /usr/sbin/chroot $chroot_path net ads join -s /etc/samba/$domain.conf -U '$info->{bind_dn}%$info->{bind_pass}'
     $logger->info("domain join : ".$output);
 
     restart_winbinds();
@@ -139,7 +138,7 @@ sub unjoin_domain {
 
     my $info = $ConfigDomain{$domain};
     if($info){
-        my ($status, $output) = run("/usr/bin/sudo /sbin/ip netns exec $domain net ads leave -S $info->{ad_server} $info->{dns_name} -s /etc/samba/$domain.conf -U '$info->{bind_dn}%$info->{bind_pass}'");
+        my ($status, $output) = run("/usr/bin/sudo /sbin/ip netns exec $domain /usr/sbin/chroot $chroot_path net ads leave -s /etc/samba/$domain.conf -U '$info->{bind_dn}%$info->{bind_pass}'");
         $logger->info("domain leave : ".$output);
         $logger->info("netns deletion : ".run("/usr/bin/sudo /sbin/ip netns delete $domain"));
         return $output;

--- a/lib/pf/domain.pm
+++ b/lib/pf/domain.pm
@@ -46,6 +46,9 @@ Executes a command and returns the results as the domain interfaces expect it
 
 sub run {
     my ($cmd) = @_;
+ 
+    my $logger = get_logger();
+    $logger->info("COMMAND:" . $cmd);   
 
     my $result = `$cmd`;
     my $code = $? >> 8;

--- a/lib/pf/domain.pm
+++ b/lib/pf/domain.pm
@@ -135,6 +135,7 @@ Joins the domain through the ip namespace
 sub unjoin_domain {
     my ($domain) = @_;
     my $logger = get_logger();
+    my $chroot_path = chroot_path($domain);
 
     my $info = $ConfigDomain{$domain};
     if($info){

--- a/lib/pf/domain.pm
+++ b/lib/pf/domain.pm
@@ -98,7 +98,7 @@ sub join_domain {
     regenerate_configuration();
 
     my $info = $ConfigDomain{$domain};
-    my ($status2, $output2) = run("/usr/bin/sudo /sbin/ip netns exec $domain /usr/sbin/chroot $chroot_path net ads join -S $info->{ad_server} $info->{dns_name} -s /etc/samba/$domain.conf -U '$info->{bind_dn}%$info->{bind_pass}' -d 10 2>&1");
+    my ($status, $output) = run("/usr/bin/sudo /sbin/ip netns exec $domain /usr/sbin/chroot $chroot_path net ads join -S $info->{ad_server} $info->{dns_name} -s /etc/samba/$domain.conf -U '$info->{bind_dn}%$info->{bind_pass}' -d 10 2>&1");
     
     $logger->info("domain join : ".$output);
 

--- a/lib/pf/domain.pm
+++ b/lib/pf/domain.pm
@@ -95,10 +95,6 @@ sub join_domain {
     
     my $info = $ConfigDomain{$domain};
     
-    use Data::Dumper;
-    print Dumper("join_domain: info=" . $info);
-    print Dumper("join_domain: domain=" . $domain);
-    
     my ($status, $output) = run("/usr/bin/sudo /sbin/ip netns exec $domain /usr/sbin/chroot $chroot_path net ads join -s /etc/samba/$domain.conf -U '$info->{bind_dn}%$info->{bind_pass}'");
     $logger->info("domain join : ".$output);
 
@@ -140,10 +136,6 @@ sub unjoin_domain {
 
     my $info = $ConfigDomain{$domain};
     
-    use Data::Dumper;
-    print Dumper("unjoin_domain: info=" . $info);
-    print Dumper("unjoin_domain: domain=" . $domain);
-
     if($info){
         my ($status, $output) = run("/usr/bin/sudo /sbin/ip netns exec $domain /usr/sbin/chroot $chroot_path net ads leave -s /etc/samba/$domain.conf -U '$info->{bind_dn}%$info->{bind_pass}'");
         $logger->info("domain leave : ".$output);

--- a/lib/pf/domain.pm
+++ b/lib/pf/domain.pm
@@ -47,6 +47,7 @@ Executes a command and returns the results as the domain interfaces expect it
 sub run {
     my ($cmd) = @_;
     my $result = `$cmd`;
+
     my $code = $? >> 8;
 
     return ($code , $result);
@@ -92,9 +93,8 @@ sub join_domain {
     my $chroot_path = chroot_path($domain);
 
     regenerate_configuration();
-    
+ 
     my $info = $ConfigDomain{$domain};
-    
     my ($status, $output) = run("/usr/bin/sudo /sbin/ip netns exec $domain /usr/sbin/chroot $chroot_path net ads join -s /etc/samba/$domain.conf -U '$info->{bind_dn}%$info->{bind_pass}'");
     $logger->info("domain join : ".$output);
 
@@ -135,7 +135,6 @@ sub unjoin_domain {
     my $chroot_path = chroot_path($domain);
 
     my $info = $ConfigDomain{$domain};
-    
     if($info){
         my ($status, $output) = run("/usr/bin/sudo /sbin/ip netns exec $domain /usr/sbin/chroot $chroot_path net ads leave -s /etc/samba/$domain.conf -U '$info->{bind_dn}%$info->{bind_pass}'");
         $logger->info("domain leave : ".$output);

--- a/lib/pf/domain.pm
+++ b/lib/pf/domain.pm
@@ -46,8 +46,8 @@ Executes a command and returns the results as the domain interfaces expect it
 
 sub run {
     my ($cmd) = @_;
-    my $result = `$cmd`;
 
+    my $result = `$cmd`;
     my $code = $? >> 8;
 
     return ($code , $result);

--- a/lib/pf/domain.pm
+++ b/lib/pf/domain.pm
@@ -147,6 +147,7 @@ sub unjoin_domain {
     if($info){
         my ($status, $output) = run("/usr/bin/sudo /sbin/ip netns exec $domain /usr/sbin/chroot $chroot_path net ads leave -s /etc/samba/$domain.conf -U '$info->{bind_dn}%$info->{bind_pass}'");
         $logger->info("domain leave : ".$output);
+        $logger->info("netns deletion : ".run("/usr/bin/sudo /sbin/ip netns delete $domain"));
         return $output;
     }
     else{

--- a/lib/pf/domain.pm
+++ b/lib/pf/domain.pm
@@ -65,7 +65,7 @@ Executes the command in the OS to test the domain join
 sub test_join {
     my ($domain) = @_;
     my $chroot_path = chroot_path($domain);
-    my ($status, $output) = run("/usr/bin/sudo /sbin/ip netns exec $domain /usr/sbin/chroot $chroot_path /usr/bin/net ads testjoin -s /etc/samba/$domain.conf -d 10 2>&1");
+    my ($status, $output) = run("/usr/bin/sudo /sbin/ip netns exec $domain /usr/sbin/chroot $chroot_path /usr/bin/net ads testjoin -s /etc/samba/$domain.conf");
     return ($status, $output);
 }
 
@@ -98,7 +98,7 @@ sub join_domain {
     regenerate_configuration();
 
     my $info = $ConfigDomain{$domain};
-    my ($status, $output) = run("/usr/bin/sudo /sbin/ip netns exec $domain /usr/sbin/chroot $chroot_path net ads join -s /etc/samba/$domain.conf -U '$info->{bind_dn}%$info->{bind_pass}'
+    my ($status, $output) = run("/usr/bin/sudo /sbin/ip netns exec $domain /usr/sbin/chroot $chroot_path net ads join -s /etc/samba/$domain.conf -U '$info->{bind_dn}%$info->{bind_pass}'");
     $logger->info("domain join : ".$output);
 
     restart_winbinds();

--- a/lib/pf/services/manager/winbindd.pm
+++ b/lib/pf/services/manager/winbindd.pm
@@ -52,7 +52,7 @@ sub _build_winbinddManagers {
         pf::services::manager::winbindd_child->new ({
             executable => $self->executable,
             name => "winbindd-$_.conf",
-            launcher => "sudo chroot $CHROOT_PATH $binary -D -s $CONFIGFILE -l $LOGDIRECTORY",
+            launcher => "sudo chroot $CHROOT_PATH $binary -d 10 -D -s $CONFIGFILE -l $LOGDIRECTORY",
             forceManaged => $self->isManaged,
             orderIndex => $self->orderIndex,
             domain => $_,

--- a/lib/pf/services/manager/winbindd.pm
+++ b/lib/pf/services/manager/winbindd.pm
@@ -52,7 +52,7 @@ sub _build_winbinddManagers {
         pf::services::manager::winbindd_child->new ({
             executable => $self->executable,
             name => "winbindd-$_.conf",
-            launcher => "sudo chroot $CHROOT_PATH $binary -d 10 -D -s $CONFIGFILE -l $LOGDIRECTORY",
+            launcher => "sudo chroot $CHROOT_PATH $binary -D -s $CONFIGFILE -l $LOGDIRECTORY",
             forceManaged => $self->isManaged,
             orderIndex => $self->orderIndex,
             domain => $_,

--- a/lib/pf/services/manager/winbindd.pm
+++ b/lib/pf/services/manager/winbindd.pm
@@ -61,26 +61,6 @@ sub _build_winbinddManagers {
     return \@managers;
 }
 
-
-
-=head2 _setupWatchForPidCreate
-
-Setting up inotify to watch for the creation of pidFiles for each winbindd instance
-
-=cut
-
-sub _setupWatchForPidCreate {
-    my ($self) = @_;
-    my $inotify = $self->inotify;
-    my %pidFiles = map { $_->pidFile => undef } $self->managers;
-    my $run_dir = "$var_dir/run";
-    $inotify->watch ($run_dir, IN_CREATE, sub {
-        my $e = shift;
-        delete @pidFiles{ grep { -e $_ } keys %pidFiles };
-        $e->w->cancel unless keys %pidFiles;
-    });
-}
-
 sub postStartCleanup {
     my ($self,$quick) = @_;
     my $result = 0;

--- a/lib/pf/services/manager/winbindd_child.pm
+++ b/lib/pf/services/manager/winbindd_child.pm
@@ -117,7 +117,7 @@ sub pidFile {
 
 =head2 _setupWatchForPidCreate
 
-This setups a watch on the run directory to wait for the pid to
+This setups a watch on the run directory and its childs to wait for the pid file to appear
 
 =cut
 

--- a/lib/pf/services/manager/winbindd_child.pm
+++ b/lib/pf/services/manager/winbindd_child.pm
@@ -75,12 +75,6 @@ sub build_namespaces(){
         my $OUTERLOGDIRECTORY="$CHROOT_PATH/$LOGDIRECTORY";
         my $OUTERRUNDIRECTORY="$CHROOT_PATH/var/run/samba$domain";
         my $PIDDIRECTORY="$var_dir/run/$domain";
-        my $DOMAIN_IF="$domain-b";
-        my $DOMAIN_IFCFG_VIRT_INT="/etc/sysconfig/network-scripts/ifcfg-$DOMAIN_IF";
-        unless (-e $DOMAIN_IFCFG_VIRT_INT) {
-           my $cmd='echo -e "DEVICE='.$DOMAIN_IF.'\nNM_CONTROLLED=no" |sudo tee '.$DOMAIN_IFCFG_VIRT_INT;
-           pf_run("$cmd");
-        }
         pf_run("sudo mkdir -p $OUTERLOGDIRECTORY && sudo chown root.root $OUTERLOGDIRECTORY");
         pf_run("sudo mkdir -p $OUTERRUNDIRECTORY && sudo chown root.root $OUTERRUNDIRECTORY");
         pf_run("sudo mkdir -p $PIDDIRECTORY && sudo chown root.root $PIDDIRECTORY");
@@ -108,7 +102,7 @@ sub pidFile {
     my ($self) = @_;
     my $name = $self->name;
     my $domain = $self->domain;
-    if ( ( ($DISTRIB eq 'centos') || ($DISTRIB eq 'redhat') ) && ($DIST_VERSION gt 7)) {
+    if (( ( ($DISTRIB eq 'centos') || ($DISTRIB eq 'redhat') ) && ($DIST_VERSION gt 7)) || ( ($DISTRIB eq 'debian') && ($DIST_VERSION gt 8) ) ) {
         return "$var_dir/run/$domain/winbindd.pid";
     } else {
         return "$var_dir/run/$domain/$name.pid";

--- a/lib/pf/util.pm
+++ b/lib/pf/util.pm
@@ -771,6 +771,8 @@ with code 1, 2 or 3 without reporting it as an error.
 sub pf_run {
     my ($command, %options) = @_;
     my $logger = get_logger();
+    
+    $logger->info("COMMAND:" . $command);
 
     # Prefixing command using LANG=C to avoid system locale messing up with return
     $command = 'LANG=C ' . $command;

--- a/lib/pf/util.pm
+++ b/lib/pf/util.pm
@@ -770,6 +770,8 @@ with code 1, 2 or 3 without reporting it as an error.
 
 sub pf_run {
     my ($command, %options) = @_;
+    my $logger = get_logger();
+
     # Prefixing command using LANG=C to avoid system locale messing up with return
     $command = 'LANG=C ' . $command;
 

--- a/lib/pf/util.pm
+++ b/lib/pf/util.pm
@@ -770,7 +770,6 @@ with code 1, 2 or 3 without reporting it as an error.
 
 sub pf_run {
     my ($command, %options) = @_;
-    
     # Prefixing command using LANG=C to avoid system locale messing up with return
     $command = 'LANG=C ' . $command;
 

--- a/lib/pf/util.pm
+++ b/lib/pf/util.pm
@@ -770,10 +770,7 @@ with code 1, 2 or 3 without reporting it as an error.
 
 sub pf_run {
     my ($command, %options) = @_;
-    my $logger = get_logger();
     
-    $logger->info("COMMAND:" . $command);
-
     # Prefixing command using LANG=C to avoid system locale messing up with return
     $command = 'LANG=C ' . $command;
 


### PR DESCRIPTION
# Description

-Fixes domain join issues encountered with CentOS7 linked to passing to version changes of samba tighter ip namespace implementation of newer kernels
-Domain join progress bar now returns before 300 seconds, thanks to inotify code now checking subtree for pid creation where it should (instead of timeout for active process check for file never being created). 

Fixes:
-Path to Samba credential cache is not overwritten anymore every time winbind is relaunched, resulting in a a possible testjoin. 
-Using chroot inside a ip netns invalidates netns automatic usage of netns's resolv.conf. bind mounting each first level directory under /etc, and copying over first level files under /etc over to be chrooted directory.
-Leaving the domain wasn't done in the chroot.
-Winbind pid inotify was watching for file creation in the wrong directory,resulting in superlong winbind restarts (timeout, after which process existence was actively validated.)
-Domain join was made with "-S IP DOMAIN_NAME". Joining domain with -S required PDC name, and fails otherwise. The code for join and leave don't supply it anymore. How was it working with prior version?
-Debian8 pid creation is the same behavior that CentoOS7. Code patched for
# Impacts

-None. Tested against CentOS6/7, Debian7/8.
# Code / PR Dependencies

-pid watch is now relative to OS validated pid path.
# Issue

fixes #1661 
# Delete branch after merge

YES
## Bug Fixes
- Issue with joining multiple domains with CentOS7  (#1661)
- Fixes CentOS6 domain join that actually overwrote credential files each time create_chroot was called.
- Domain join progression bar fix for Centos7/Debian8.
