### PR TITLE
Fix 1681 iptables parking redirect

### DIFF
--- a/conf/iptables.conf.example
+++ b/conf/iptables.conf.example
@@ -6,8 +6,6 @@
 :INPUT DROP [0:0]
 # accept loopback stuff
 -A INPUT --in-interface lo --jump ACCEPT
-# accept anything related
--A INPUT --match state --state ESTABLISHED,RELATED --jump ACCEPT
 # Accept Ping (easier troubleshooting)
 -A INPUT --protocol icmp --icmp-type echo-request --jump ACCEPT
 
@@ -138,6 +136,10 @@
 # These will redirect to the proper chains based on conf/pf.conf's configuration
 %%filter_if_src_to_chain%%
 %%filter_forward_domain%%
+
+# accept anything related
+-A INPUT --match state --state ESTABLISHED,RELATED --jump ACCEPT
+
 COMMIT
 
 *mangle


### PR DESCRIPTION
# Description

Moving the INPUT RELATED,ESTABLISHED iptables at the end of the FILTER table since it is kind of act as a "default" rule.
# Impacts
- VLAN enforcement
- Inline enforcement
- Web auth enforcement
- Firewalling
# Issue

fixes #1681 
# Delete branch after merge

YES
# NEWS file entries
## Bug Fixes

If an issue exists on Github, please refer to it (name) along with it's number...
- iptables rules for parking (#1681)
# UPGRADE file entries
- iptables.conf template file have been modified. Make sure to use latest template and migrate custom if required.
