### PR TITLE
SCEP PKI service url NEEDS a trailing slash

### DIFF
--- a/docs/PacketFence_MSPKI_Quick_Install_Guide.asciidoc
+++ b/docs/PacketFence_MSPKI_Quick_Install_Guide.asciidoc
@@ -238,7 +238,7 @@ Fill out the form for a PKI provider according to your Certificate of Authority 
 
 image::docs/images/scep-ms-pki-provider.png[scaledwidth="100%",alt="MSPKI configuration"]
 
-For the URL it will be `http://<ServerDNSName>/CertSrv/mscep`.
+For the URL it will be `http://<ServerDNSName>/CertSrv/mscep/`.
 
 You do not need any Username/Password combination for this configuration.
 


### PR DESCRIPTION
# Description

SCEP PKI service url NEEDS a trailing slash, else there is a redirect that isn't followed by sscep getca command, which invalidates the whole logic.
# Impacts

Makes it work.
# Delete branch after merge

YES
