### PR TITLE
limit httpd.portal's mod_perl to 1024MB of RAM

### DIFF
--- a/conf/httpd.conf.d/httpd.portal.tt.example
+++ b/conf/httpd.conf.d/httpd.portal.tt.example
@@ -141,6 +141,11 @@
 # We don't allow the TRACE HTTP method
 TraceEnable off
 
+# Limit mod_perl to 1024MB of RAM
+PerlModule Apache2::Resource
+PerlSetEnv PERL_RLIMIT_AS 1024
+PerlChildInitHandler Apache2::Resource
+
 PerlSwitches -I[% install_dir %]/lib
 PerlSwitches -I[% install_dir %]/html/captive-portal/lib
 # mod_perl handlers are virtually assigned to /perl/


### PR DESCRIPTION
# Description

limit httpd.portal's mod_perl to 1024MB of RAM
Prevents the process from eating up all the RAM of a server because of an infinite loop or a memory leak that occurs before the 1000 requests per child
# Impacts

httpd.portal
# Delete branch after merge

YES
# NEWS file entries
## Enhancements
- Added memory limitation for httpd.portal processes
