### PR TITLE
Fix SSL to work with pe rl 5.x (Debian 8 Jessie) and self-signed certificate in a PaloAlto Instalation

### DIFF
--- a/conf/httpd.conf.d/httpd.portal.tt.example
+++ b/conf/httpd.conf.d/httpd.portal.tt.example
@@ -172,6 +172,15 @@ SSLMutex posixsem
 ServerLimit 512
 
 Header always set X-DNS-Prefetch-Control off
+<IfModule mod_headers.c>
+  # Security headers
+  Header always append X-Frame-Options SAMEORIGIN
+  Header set X-Content-Type-Options nosniff
+  Header set X-XSS-Protection "1; mode=block"
+  Header always set X-Frame-Options DENY
+  Header always set Strict-Transport-Security "max-age=15768000"
+</IfModule>
+
 
 <Proxy *>
   [% IF apache_version == "2.4" %]

--- a/lib/pf/firewallsso/PaloAlto.pm
+++ b/lib/pf/firewallsso/PaloAlto.pm
@@ -67,6 +67,9 @@ XML
             my $webpage = "https://".$firewall_conf."/api/?type=user-id&action=set&key=".$ConfigFirewallSSO{$firewall_conf}->{'password'};
             my $ua = LWP::UserAgent->new;
             $ua->timeout(5);
+            # to work with perl 5.x (Debian 8 Jessie) and self-signed certificate
+            $ua->ssl_opts( verify_hostname => 0 ,SSL_verify_mode => 0x00);
+
             my $response = $ua->post($webpage, Content => [ cmd => $message ]);
             if ($response->is_success) {
                 $logger->info("Node $mac registered and allowed to pass the Firewall");
@@ -101,6 +104,9 @@ XML
             my $webpage = "https://".$firewall_conf."/api/?type=user-id&action=set&key=".$ConfigFirewallSSO{$firewall_conf}->{'password'};
             my $ua = LWP::UserAgent->new;
             $ua->timeout(5);
+            # to work with perl 5.x (Debian 8 Jessie) and self-signed certificate
+            $ua->ssl_opts( verify_hostname => 0 ,SSL_verify_mode => 0x00);
+
             my $response = $ua->post($webpage, Content => [ cmd => $message ]);
             if ($response->is_success) {
                 $logger->debug("Node $mac removed from the firewall");


### PR DESCRIPTION
# Description

Fix SSL to work with pe rl 5.x (Debian 8 Jessie) and self-signed certificate in a PaloAlto Instalation
# Impacts

None
# Delete branch after merge

NO
## Bug Fixes
- Fix SSL to work with pe rl 5.x (Debian 8 Jessie) and self-signed certificate in a PaloAlto Instalation
