### PR TITLE
Set Calling-Station-Id in accounting by User-Name attribute if it is undefine

### DIFF
--- a/conf/radiusd/packetfence.example
+++ b/conf/radiusd/packetfence.example
@@ -249,6 +249,9 @@ preacct {
 #  Accounting.  Log the accounting data.
 #
 accounting {
+	rewrite_user_name
+	rewrite_calling_station_id
+	rewrite_called_station_id
 	# Add in PacketFence specific configuration
 	update {
 		&request:FreeRADIUS-Client-IP-Address := "%{Packet-Src-IP-Address}"
@@ -257,9 +260,8 @@ accounting {
 		&control:PacketFence-RPC-User = ${rpc_user}
 		&control:PacketFence-RPC-Pass = ${rpc_pass}
 		&control:PacketFence-RPC-Proto = ${rpc_proto}
+		&request:Calling-Station-Id = "%{User-Name}"
 	}
-	rewrite_calling_station_id
-	rewrite_called_station_id
 	#
 	#  Log traffic to an SQL database.
 	#

--- a/conf/radiusd/packetfence.example
+++ b/conf/radiusd/packetfence.example
@@ -251,7 +251,7 @@ preacct {
 accounting {
 	rewrite_user_name
 	rewrite_calling_station_id
-	rewrite_called_station_id
+	set_calling_station_id
 	# Add in PacketFence specific configuration
 	update {
 		&request:FreeRADIUS-Client-IP-Address := "%{Packet-Src-IP-Address}"
@@ -260,7 +260,6 @@ accounting {
 		&control:PacketFence-RPC-User = ${rpc_user}
 		&control:PacketFence-RPC-Pass = ${rpc_pass}
 		&control:PacketFence-RPC-Proto = ${rpc_proto}
-		&request:Calling-Station-Id = "%{User-Name}"
 	}
 	#
 	#  Log traffic to an SQL database.

--- a/conf/radiusd/packetfence.example
+++ b/conf/radiusd/packetfence.example
@@ -249,9 +249,9 @@ preacct {
 #  Accounting.  Log the accounting data.
 #
 accounting {
-	rewrite_user_name
-	rewrite_calling_station_id
 	set_calling_station_id
+	rewrite_calling_station_id
+	rewrite_called_station_id
 	# Add in PacketFence specific configuration
 	update {
 		&request:FreeRADIUS-Client-IP-Address := "%{Packet-Src-IP-Address}"

--- a/raddb/policy.d/canonicalization
+++ b/raddb/policy.d/canonicalization
@@ -111,3 +111,15 @@ rewrite_calling_station_id {
                 noop
         }
 }
+
+rewrite_user_name {
+        if (&User-Name && (&User-Name =~ /^${policy.mac-addr-regexp}$/i)) {
+                update request {
+                        &User-Name := "%{tolower:%{1}:%{2}:%{3}:%{4}:%{5}:%{6}}"
+                }
+                updated
+        }
+        else {
+                noop
+        }
+}

--- a/raddb/policy.d/canonicalization
+++ b/raddb/policy.d/canonicalization
@@ -112,10 +112,11 @@ rewrite_calling_station_id {
         }
 }
 
-rewrite_user_name {
+set_calling_station_id {
         if (&User-Name && (&User-Name =~ /^${policy.mac-addr-regexp}$/i)) {
                 update request {
                         &User-Name := "%{tolower:%{1}:%{2}:%{3}:%{4}:%{5}:%{6}}"
+                        &Calling-Station-Id = "%{tolower:%{1}:%{2}:%{3}:%{4}:%{5}:%{6}}"
                 }
                 updated
         }


### PR DESCRIPTION
# Description

Set Calling-Station-Id if it doesn't exist by the User-Name attribute if it represent a mac address.
# Impacts

RADIUS Accounting
# Issue

Fix empty Calling-Station-Id in radius accounting
# Delete branch after merge

YES
# NEWS file entries
## Bug Fixes
- Fix empty Calling-Station-Id in radius accounting
