### PR TITLE
Changing default dhcp types to extract and interpret to DHCPACK and D…

### DIFF
--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -63,7 +63,7 @@ dhcpoption82logger=disabled
 #
 # Which dhcp message types are being listened by the pfdhcplistener.
 # Do not change unless you know what you are doing
-#Possitibilities are: DHCPOFFER,DHCPREQUEST,DHCPDECLINE,DHCPACK,DHCPRELEASE
+#Possibilities are: DHCPOFFER,DHCPREQUEST,DHCPDECLINE,DHCPACK,DHCPRELEASE
 dhcp_filter_by_message_types=DHCPREQUEST,DHCPACK
 #
 # network.force_listener_update_on_ack

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -63,7 +63,8 @@ dhcpoption82logger=disabled
 #
 # Which dhcp message types are being listened by the pfdhcplistener.
 # Do not change unless you know what you are doing
-dhcp_filter_by_message_types=DHCPOFFER,DHCPREQUEST,DHCPDECLINE,DHCPACK,DHCPRELEASE
+#Possitibilities are: DHCPOFFER,DHCPREQUEST,DHCPDECLINE,DHCPACK,DHCPRELEASE
+dhcp_filter_by_message_types=DHCPREQUEST,DHCPACK
 #
 # network.force_listener_update_on_ack
 #


### PR DESCRIPTION
# Description

Changing the defaults for pfdhcplistener to only extract DHCPACK and DHCPREQUEST so that no processing and no logging is done when other types are captured.
# Impacts

Only DHCPACK and DHCPREQUEST will be processed and logged.
# Issue

fixes #1747 
# Delete branch after merge

YES
## Enhancements
- phdhcplistenr consumes less ressources since it doesn't look for dhcp subtypes it is not interested in. 
# UPGRADE file entries

If you want pfdhcplistener to parse and log about all dhcp packets received, change your pf.conf configuration back to the old value:
dhcp_filter_by_message_types=DHCPOFFER,DHCPREQUEST,DHCPDECLINE,DHCPACK,DHCPRELEASE

Else, only DHCPREQUEST and DHCPACK packets will be processed and corresponding logs generated for those packet types.
