### PR TITLE
Fixes for WMI

### DIFF
--- a/lib/pf/api.pm
+++ b/lib/pf/api.pm
@@ -947,6 +947,8 @@ sub trigger_scan : Public : Fork {
     # post_registration (production vlan)
     # We sleep until (we hope) the device has had time issue an ACK.
     if (pf::util::is_prod_interface($postdata{'net_type'})) {
+        # We add the violation to ensure there is one opened
+        pf::violation::violation_add( $postdata{'mac'}, $pf::constants::scan::POST_SCAN_VID );
         my $top_violation = pf::violation::violation_view_top($postdata{'mac'});
         # get violation id
         my $vid = $top_violation->{'vid'};

--- a/lib/pf/api.pm
+++ b/lib/pf/api.pm
@@ -947,8 +947,11 @@ sub trigger_scan : Public : Fork {
     # post_registration (production vlan)
     # We sleep until (we hope) the device has had time issue an ACK.
     if (pf::util::is_prod_interface($postdata{'net_type'})) {
-        # We add the violation to ensure there is one opened
-        pf::violation::violation_add( $postdata{'mac'}, $pf::constants::scan::POST_SCAN_VID );
+        my $profile = pf::Portal::ProfileFactory->instantiate($postdata{'mac'});
+        my $scanner = $profile->findScan($postdata{'mac'});
+        if (defined($scanner) && pf::util::isenabled($scanner->{'post_registration'})) {
+            pf::violation::violation_add( $postdata{'mac'}, $pf::constants::scan::POST_SCAN_VID );
+        }
         my $top_violation = pf::violation::violation_view_top($postdata{'mac'});
         # get violation id
         my $vid = $top_violation->{'vid'};

--- a/lib/pf/scan.pm
+++ b/lib/pf/scan.pm
@@ -252,7 +252,7 @@ sub run_scan {
     my $epoch   = time;
     my $date    = POSIX::strftime("%Y-%m-%d %H:%M:%S", localtime($epoch));
     my $id      = generate_id($epoch, $host_mac);
-    my $type    = lc($scanner->{'type'});
+    my $type    = lc($scanner->{'_type'});
 
     # Check the scan engine
     # If set to "none" we abort the scan
@@ -265,15 +265,17 @@ sub run_scan {
             scanIp     => $host_ip,
             scanMac    => $host_mac,
             type       => $type,
-            %$scanner,
     );
+    while(my ($key, $val) = each(%scan_attributes)) {
+        $scanner->{"_".$key}=$val;
+    }
 
     db_query_execute(SCAN, $scan_statements, 'scan_insert_sql',
             $id, $host_ip, $host_mac, $type, $date, '0000-00-00 00:00:00', $STATUS_NEW, 'NULL'
     ) || return 0;
 
     # Instantiate the new scan object
-    my $scan = instantiate_scan_engine($type, %scan_attributes);
+    my $scan = $scanner;
 
     # Start the scan (it return the scan_id if it failed)
     my $failed_scan = $scan->startScan();


### PR DESCRIPTION
# Needs to be carefully tested
# Description

Ensure a post-registration scan will occur even if device hasn't gone through portal registration
Fix scan engine instantiation that created invalid scan objects
# Impacts

Scanning + DHCP processing
# Delete branch after merge

YES
# NEWS file entries
## Bug Fixes
- Fix scan engine instantiation resulting in post-registration scans breaking
- Fix post-registration scan not triggering when using 802.1x
