### PR TITLE
feature/traplog-remove

### DIFF
--- a/UPGRADE.asciidoc
+++ b/UPGRADE.asciidoc
@@ -68,6 +68,12 @@ Upgrading from a version prior to X.Y.Z
 
 Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence X.Y.Z).
 
+Database schema updates
+^^^^^^^^^^^^^^^^^^^^^^^
+The traplog table is now deprecated.
+If wish to reclaim the space in the database.
+The table should be manually removed.
+
 Upgrading from a version prior to 6.4.0
 ---------------------------------------
 

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1615,18 +1615,6 @@ description=<<EOT
 How long an auth_log cleanup job can take before being killed
 EOT
 
-[maintenance.traplog_cleanup_window]
-type=time
-description=<<EOT
-How long to keep a traplog entry before deleting it
-EOT
-
-[maintenance.traplog_cleanup_interval]
-type=time
-description=<<EOT
-At which interval to run the traplog cleanup job
-EOT
-
 [maintenance.radius_audit_log_cleanup_window]
 type=time
 description=<<EOT

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -1247,16 +1247,6 @@ auth_log_cleanup_batch=100
 # How long an auth_log cleanup job can take before being killed
 auth_log_cleanup_timeout=10s
 #
-# maintenance.traplog_cleanup_window
-#
-# How long to keep a traplog entry before deleting it
-traplog_cleanup_window=1W
-#
-# maintenance.traplog_cleanup_interval
-#
-# At which interval to run the traplog cleanup job
-traplog_cleanup_interval=60s
-#
 # maintenance.radius_audit_log_cleanup_window
 #
 # How long to keep a radius_audit_log entry before deleting it

--- a/db/pf-schema-X.Y.Z.sql
+++ b/db/pf-schema-X.Y.Z.sql
@@ -358,15 +358,6 @@ CREATE TABLE `ifoctetslog` (
   PRIMARY KEY  (`switch`,`port`,`read_time`)
 ) ENGINE=InnoDB;
 
-CREATE TABLE `traplog` (
-  `switch` varchar(30) NOT NULL default '',
-  `ifIndex` smallint(6) NOT NULL default '0',
-  `parseTime` datetime NOT NULL default '0000-00-00 00:00:00',
-  `type` varchar(30) NOT NULL default '',
-  KEY `switch` (`switch`,`ifIndex`),
-  KEY `parseTime` (`parseTime`)
-) ENGINE=InnoDB;
-
 --
 -- Table structure for table `password`
 --

--- a/html/pfappserver/lib/pfappserver/I18N/en.po
+++ b/html/pfappserver/lib/pfappserver/I18N/en.po
@@ -733,10 +733,6 @@ msgstr ""
 msgid "At which interval to run the radius audit log cleanup job"
 msgstr ""
 
-# conf/documentation.conf (maintenance.traplog_cleanup_interval)
-msgid "At which interval to run the traplog cleanup job"
-msgstr ""
-
 # html/pfappserver/lib/pfappserver/Form/Config/Authentication/Source/SAML.pm
 msgid "Attribute of the username in the SAML response"
 msgstr ""
@@ -2869,10 +2865,6 @@ msgstr ""
 
 # conf/documentation.conf (maintenance.radius_audit_log_cleanup_window)
 msgid "How long to keep a radius audit log entry before deleting it"
-msgstr ""
-
-# conf/documentation.conf (maintenance.traplog_cleanup_window)
-msgid "How long to keep a traplog entry before deleting it"
 msgstr ""
 
 # conf/documentation.conf (maintenance.auth_log_cleanup_window)
@@ -9287,14 +9279,6 @@ msgstr "RADIUS Audit Log Cleanup Timeout"
 # conf/documentation.conf
 msgid "maintenance.radius_audit_log_cleanup_window"
 msgstr "RADIUS Audit Log Cleanup Window"
-
-# conf/documentation.conf
-msgid "maintenance.traplog_cleanup_interval"
-msgstr "Traplog Cleanup Interval"
-
-# conf/documentation.conf
-msgid "maintenance.traplog_cleanup_window"
-msgstr "Traplog Cleanup Window"
 
 # conf/documentation.conf
 msgid "maintenance.violation_maintenance_batch"

--- a/html/pfappserver/lib/pfappserver/I18N/fr.po
+++ b/html/pfappserver/lib/pfappserver/I18N/fr.po
@@ -790,10 +790,6 @@ msgstr "Fréquence de nettoyage du journal de locationlog"
 msgid "At which interval to run the radius audit log cleanup job"
 msgstr "Fréquence de nettoyage de l’audit de radius"
 
-# conf/documentation.conf (maintenance.traplog_cleanup_interval)
-msgid "At which interval to run the traplog cleanup job"
-msgstr "Fréquence de nettoyage de traplog"
-
 # html/pfappserver/lib/pfappserver/Form/Config/Authentication/Source/SAML.pm
 msgid "Attribute of the username in the SAML response"
 msgstr "Attribut du nom d’utilisateur dans la réponse SAML"
@@ -3062,10 +3058,6 @@ msgstr "Combien de temps garder un appareil avant de la supprimer"
 # conf/documentation.conf (maintenance.radius_audit_log_cleanup_window)
 msgid "How long to keep a radius audit log entry before deleting it"
 msgstr "Combien de temps garder une entrée de radius audit log avant de la supprimer"
-
-# conf/documentation.conf (maintenance.traplog_cleanup_window)
-msgid "How long to keep a traplog entry before deleting it"
-msgstr "Combien de temps garder une entrée de traplog avant de la supprimer"
 
 # conf/documentation.conf (maintenance.auth_log_cleanup_window)
 msgid "How long to keep an auth_log entry before deleting it"
@@ -9910,14 +9902,6 @@ msgstr "Temps maximum du nettoyage du journal d’audit RADIUS"
 # conf/documentation.conf
 msgid "maintenance.radius_audit_log_cleanup_window"
 msgstr "Plage horaire de nettoyage du journal d’audit RADIUS"
-
-# conf/documentation.conf
-msgid "maintenance.traplog_cleanup_interval"
-msgstr "Fréquence de nettoyage du Traplog"
-
-# conf/documentation.conf
-msgid "maintenance.traplog_cleanup_window"
-msgstr "Plage horaire de nettoyage du Traplog"
 
 # conf/documentation.conf
 msgid "maintenance.violation_maintenance_batch"

--- a/html/pfappserver/lib/pfappserver/I18N/packetfence.pot
+++ b/html/pfappserver/lib/pfappserver/I18N/packetfence.pot
@@ -420,10 +420,6 @@ msgstr ""
 msgid "expire.iplog"
 msgstr ""
 
-#: conf/pf.conf.defaults:534
-msgid "expire.traplog"
-msgstr ""
-
 #: conf/pf.conf.defaults:544
 msgid "expire.locationlog"
 msgstr ""

--- a/sbin/pfmon
+++ b/sbin/pfmon
@@ -43,7 +43,6 @@ use pf::auth_log;
 use pf::node;
 use pf::db;
 use pf::services;
-use pf::traplog;
 use pf::util;
 use pf::services::util;
 use pf::violation qw(violation_maintenance);
@@ -233,14 +232,6 @@ sub registertasks  {
             person_cleanup();
         }
     ) if ( isenabled($Config{'maintenance'}{'person_cleanup'}) );
-
-    register_task(
-        'traplog cleanup',
-        'traplog_cleanup_interval',
-        sub {
-            traplog_cleanup( $Config{'maintenance'}{'traplog_cleanup_window'} );
-        }
-    ) if ( $Config{'maintenance'}{'traplog_cleanup_window'} );
 
     register_task(
         'checking registered nodes for expiration',

--- a/sbin/pfsetvlan
+++ b/sbin/pfsetvlan
@@ -80,7 +80,6 @@ use pf::Switch 2.00;
 use pf::Switch::constants;
 use pf::SwitchFactory;
 
-use pf::traplog;
 use pf::util;
 use pf::config::util;
 use pf::services::util;
@@ -502,11 +501,6 @@ sub signalHandlerTrapListQueued {
                                 "added trap $trapType at $switch_id ifindex $switch_port to queued threadList"
                             );
 
-                            traplog_insert( $switch_id, $switch_port,
-                                $trapType );
-                            $lockLogger->trace(
-                                "locking - sending signal for threadList_queued in signalHanderTrapListQueued"
-                            );
                             cond_signal(@threadList_queued);
                         }
                     }

--- a/t/dao/data.t
+++ b/t/dao/data.t
@@ -51,7 +51,6 @@ BEGIN {
     use_ok('pf::person');
     use_ok('pf::scan');
     use_ok('pf::switchlocation');
-    use_ok('pf::traplog');
     use_ok('pf::trigger');
     use_ok('pf::useragent');
     use_ok('pf::violation');
@@ -74,7 +73,6 @@ my @data_modules = qw(
     pf::person
     pf::scan
     pf::switchlocation
-    pf::traplog
     pf::trigger
     pf::useragent
     pf::violation


### PR DESCRIPTION
# Description

Remove the traplog table
# Impacts

pfsetvlan
# Issue

Fixes #367

# NEWS file entries

# Delete branch after merge

NO

# Upgrade file entries

The traplog table is now deprecated.
If wish to reclaim the space in the database.
The table should be manually removed.
