### PR TITLE
Feature/p0f with drbd bpf

### DIFF
--- a/docs/PacketFence_Clustering_Guide.asciidoc
+++ b/docs/PacketFence_Clustering_Guide.asciidoc
@@ -783,6 +783,15 @@ db_host=127.0.0.1
 ....
 ----
 
+While you are in that file, add "high-availibility" statement at the end of your management interface, to be consistent with what will be found in cluster.conf:
+
+----
+[interface eth0]
+....
+type=management,high-availibility
+....
+----
+
 In `conf/pfconfig.conf` :
 
 ----

--- a/docs/PacketFence_Clustering_Guide.asciidoc
+++ b/docs/PacketFence_Clustering_Guide.asciidoc
@@ -783,12 +783,12 @@ db_host=127.0.0.1
 ....
 ----
 
-While you are in that file, add "high-availibility" statement at the end of your management interface:
+While you are in that file, add "high-availability" statement at the end of your management interface:
 
 ----
 [interface eth0]
 ....
-type=management,portal,high-availibility
+type=management,portal,high-availability
 ....
 ----
 

--- a/docs/PacketFence_Clustering_Guide.asciidoc
+++ b/docs/PacketFence_Clustering_Guide.asciidoc
@@ -783,15 +783,6 @@ db_host=127.0.0.1
 ....
 ----
 
-While you are in that file, add "high-availability" statement at the end of your management interface:
-
-----
-[interface eth0]
-....
-type=management,portal,high-availability
-....
-----
-
 In `conf/pfconfig.conf` :
 
 ----

--- a/html/pfappserver/lib/pfappserver/PacketFence/Controller/Interface.pm
+++ b/html/pfappserver/lib/pfappserver/PacketFence/Controller/Interface.pm
@@ -109,7 +109,7 @@ sub object :Chained('/') :PathPart('interface') :CaptureArgs(1) {
         $c->stash->{ifname} = $name;
         $c->stash->{vlan} = $vlan;
     }
-    $c->stash->{high_availability} = scalar @pf::config::ha_ints && all { $interface ne $_ } @pf::config::ha_ints ;
+    $c->stash->{high_availability} = scalar @pf::config::ha_ints && all { $interface ne $_->{Tint} } @pf::config::ha_ints ;
 }
 
 =item create

--- a/lib/pf/iptables.pm
+++ b/lib/pf/iptables.pm
@@ -242,7 +242,7 @@ sub generate_filter_if_src_to_chain {
     }
 
     # high-availability interfaces handling
-    foreach my $interface (@ha_ints) {
+    foreach my $interface (map { $_->{Tint}} @ha_ints) {
         $rules .= "-A INPUT --in-interface $interface --jump $FW_FILTER_INPUT_INT_HA\n";
     }
 

--- a/lib/pf/services/manager/p0f.pm
+++ b/lib/pf/services/manager/p0f.pm
@@ -47,7 +47,7 @@ has '+launcher' => (
         {
             $p0f_cmdline="sudo %1\$s -d -i any -p -f $p0f_map -s $p0f_sock > /dev/null && pidof $name > $pid_file";    
         }
-        print $p0f_cmdline;
+        return $p0f_cmdline;
     }
 );
 

--- a/lib/pf/services/manager/p0f.pm
+++ b/lib/pf/services/manager/p0f.pm
@@ -31,6 +31,7 @@ has '+launcher' => (
         my $p0f_sock = $FingerbankConfig->{tcp_fingerprinting}{p0f_socket_path};
         my $pid_file = $self->pidFile;
         my $name = $self->name;
+        my $p0f_cmdline;
         if (@ha_ints)
         {
             my @ha_ips;
@@ -38,15 +39,15 @@ has '+launcher' => (
             {
                 push (@ha_ips, $ha_int->{Tip});
             }
-            my @tmp_bpf_filter = map { "( host $_ and port 7288)"} @ha_ips;
+            my @tmp_bpf_filter = map { "( host $_ and port 7788)"} @ha_ips;
             my $p0f_bpf_filter = join(" or not", @tmp_bpf_filter);
-            my $p0f_cmdline="sudo %1\$s -d -i any -p -f p0f_map -s p0f_sock" . " 'not $p0f_bpf_filter' " . " > /dev/null && pidof name > pid_file";
-            print $p0f_cmdline;
+            $p0f_cmdline="sudo %1\$s -d -i any -p -f $p0f_map -s $p0f_sock" . " 'not $p0f_bpf_filter' " . " > /dev/null && pidof $name > $pid_file";
         }
         else
         {
-            "sudo %1\$s -d -i any -p -f $p0f_map -s $p0f_sock > /dev/null && pidof $name > $pid_file";    
+            $p0f_cmdline="sudo %1\$s -d -i any -p -f $p0f_map -s $p0f_sock > /dev/null && pidof $name > $pid_file";    
         }
+        print $p0f_cmdline;
     }
 );
 

--- a/lib/pf/services/manager/p0f.pm
+++ b/lib/pf/services/manager/p0f.pm
@@ -40,7 +40,7 @@ has '+launcher' => (
                 push (@ha_ips, $ha_int->{Tip});
             }
             my @tmp_bpf_filter = map { "( host $_ and port 7788)"} @ha_ips;
-            my $p0f_bpf_filter = join(" or not", @tmp_bpf_filter);
+            my $p0f_bpf_filter = join(" and not", @tmp_bpf_filter);
             $p0f_cmdline="sudo %1\$s -d -i any -p -f $p0f_map -s $p0f_sock" . " 'not $p0f_bpf_filter' " . " > /dev/null && pidof $name > $pid_file";
         }
         else

--- a/lib/pf/services/manager/p0f.pm
+++ b/lib/pf/services/manager/p0f.pm
@@ -39,9 +39,9 @@ has '+launcher' => (
             {
                 push (@ha_ips, $ha_int->{Tip});
             }
-            my @tmp_bpf_filter = map { "( host $_ and port 7788)"} @ha_ips;
-            my $p0f_bpf_filter = join(" and not", @tmp_bpf_filter);
-            $p0f_cmdline="sudo %1\$s -d -i any -p -f $p0f_map -s $p0f_sock" . " 'not $p0f_bpf_filter' " . " > /dev/null && pidof $name > $pid_file";
+            my @tmp_bpf_filter = map { "not ( host $_ and port 7788 )"} @ha_ips;
+            my $p0f_bpf_filter = join(" and ", @tmp_bpf_filter);
+            $p0f_cmdline="sudo %1\$s -d -i any -p -f $p0f_map -s $p0f_sock" . " '$p0f_bpf_filter' " . " > /dev/null && pidof $name > $pid_file";
         }
         else
         {

--- a/lib/pf/services/manager/p0f.pm
+++ b/lib/pf/services/manager/p0f.pm
@@ -16,6 +16,7 @@ use strict;
 use warnings;
 use Moo;
 use fingerbank::Config;
+use pf::config qw(@ha_ints);
 
 extends 'pf::services::manager';
 
@@ -30,7 +31,22 @@ has '+launcher' => (
         my $p0f_sock = $FingerbankConfig->{tcp_fingerprinting}{p0f_socket_path};
         my $pid_file = $self->pidFile;
         my $name = $self->name;
-        "sudo %1\$s -d -i any -p -f $p0f_map -s $p0f_sock > /dev/null && pidof $name > $pid_file";
+        if (@ha_ints)
+        {
+            my @ha_ips;
+            foreach my $ha_int (@ha_ints)
+            {
+                push (@ha_ips, $ha_int->{Tip});
+            }
+            my @tmp_bpf_filter = map { "( host $_ and port 7288)"} @ha_ips;
+            my $p0f_bpf_filter = join(" or not", @tmp_bpf_filter);
+            my $p0f_cmdline="sudo %1\$s -d -i any -p -f p0f_map -s p0f_sock" . " 'not $p0f_bpf_filter' " . " > /dev/null && pidof name > pid_file";
+            print $p0f_cmdline;
+        }
+        else
+        {
+            "sudo %1\$s -d -i any -p -f $p0f_map -s $p0f_sock > /dev/null && pidof $name > $pid_file";    
+        }
     }
 );
 

--- a/lib/pfconfig/namespaces/interfaces.pm
+++ b/lib/pfconfig/namespaces/interfaces.pm
@@ -122,7 +122,7 @@ sub build {
                 push @{ $self->{_interfaces}->{dhcplistener_ints} }, $int;
             }
             elsif ( $type eq 'high-availability' ) {
-                push @{ $self->{_interfaces}->{ha_ints} }, $int;
+                push @{ $self->{_interfaces}->{ha_ints} }, $int_obj;
             }
             elsif ( $type eq 'portal' ) {
                 $int_obj->tag( "vip", $self->_fetch_virtual_ip( $int, $interface ) );


### PR DESCRIPTION
# Description
- Requires https://github.com/jrouzierinverse/packetfence/tree/feature/ha_int_for_reals
- If "high-availability" is defined on interfaces in cluster.conf, extract the ip adresses of those interfaces and exclude DRBD port in a bpf at p0f launch.
- Modify PacketFence_Cluster docs part saying that high-availability is required: high-avail in pf.conf is there only for consistency in regard of cluster.conf
# Impacts
- DRBD traffic will not be inspected by p0f.
# Issue

fixes #1745 
# Delete branch after merge

YES
# NEWS file entries
## Enhancements
- more lightweight P0f processing, excluding DRDB traffic for high-availibility interfaces.
