### PR TITLE
don't record dummy requests in radius audit log

### DIFF
--- a/conf/radiusd/packetfence-tunnel.example
+++ b/conf/radiusd/packetfence-tunnel.example
@@ -235,12 +235,10 @@ post-auth {
 	}
 	rest
         if (&reply:PacketFence-Authorization-Status == "deny") {
-                request-timing
-                -sql_reject
+                packetfence-audit-log-reject
                 reject
         } else {
-                request-timing
-                -sql
+                packetfence-audit-log-accept
         }
 
 	#
@@ -281,9 +279,7 @@ post-auth {
 		update {
 			&request: += &outer.request:[*]
 		}
-		request-timing
-		# log failed authentications in SQL, too.
-		-sql_reject
+    packetfence-audit-log-reject
 		attr_filter.access_reject
 
 		#

--- a/conf/radiusd/packetfence.example
+++ b/conf/radiusd/packetfence.example
@@ -331,12 +331,10 @@ post-auth {
 	if (! EAP-Type || (EAP-Type != TTLS  && EAP-Type != PEAP) ) {
 		rest
 		if (&reply:PacketFence-Authorization-Status == "deny") {
-			request-timing
-			-sql_reject
+      packetfence-audit-log-reject
 			reject
 		} else {
-			request-timing
-			-sql
+      packetfence-audit-log-accept
 		}
 	}
 
@@ -353,9 +351,7 @@ post-auth {
 	#
 	Post-Auth-Type REJECT {
 		if (! EAP-Type || (EAP-Type != TTLS  && EAP-Type != PEAP) ) {
-			request-timing
-			# log failed authentications in SQL, too.
-			-sql_reject
+      packetfence-audit-log-reject
 		}
 		attr_filter.access_reject
 		attr_filter.packetfence_post_auth

--- a/raddb/policy.d/packetfence
+++ b/raddb/policy.d/packetfence
@@ -67,3 +67,17 @@ packetfence-eap-mac-policy {
     }
     noop
 }
+
+packetfence-audit-log-accept {
+    if(&User-Name != "dummy") {
+        request-timing
+        -sql
+    }
+}
+
+packetfence-audit-log-reject {
+    if(&User-Name != "dummy") {
+        request-timing
+        -sql_reject
+    }
+}


### PR DESCRIPTION
# Description

Don't record requests with username 'dummy' in the RADIUS audit log.
- Reduces number of rows when having switches with auto-test
- Makes RADIUS audit log clearer
# Impacts

RADIUS audit log
# Delete branch after merge

YES
# NEWS file entries
## Enhancements
- Requests made with username 'dummy' will not be recorded in the RADIUS audit log anymore
