### PR TITLE
Feature/1797 register node return status

### DIFF
--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Root.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Root.pm
@@ -246,7 +246,9 @@ sub apply_new_node_info {
         $self->new_node_info->{unregdate} = $self->node_info->{unregdate};
     }
 
-    if(node_register($self->current_mac, $self->username, %{$self->new_node_info()})){
+    my ( $status, $status_msg );
+    ( $status, $status_msg ) = pf::node::node_register($self->current_mac, $self->username, %{$self->new_node_info()});
+    if ($status) {
         $self->app->flash->{notice} = [ "Role %s has been assigned to your device with unregistration date : %s", $self->new_node_info->{category}, $self->new_node_info->{unregdate} ];
         return $TRUE;
     }

--- a/html/pfappserver/lib/pfappserver/Model/Node.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Node.pm
@@ -217,13 +217,13 @@ sub create {
     my ($self, $data) = @_;
 
     my $logger = get_logger();
-    my ($status, $result) = ($STATUS::CREATED);
+    my ($status, $result, $status_msg) = ($STATUS::CREATED);
     my $mac = $data->{mac};
     my $pid = $data->{pid} || $default_pid;
 
     # Adding person (using modify in case person already exists)
-    $result = node_register($mac, $pid, %{$data});
-    if ($result) {
+    ( $result, $status_msg ) = pf::node::node_register($mac, $pid, %{$data});
+    if ( $result ) {
         $logger->info("Created node $mac");
     }
     else {
@@ -244,7 +244,7 @@ sub update {
     my ($self, $mac, $node_ref) = @_;
 
     my $logger = get_logger();
-    my ($status, $result) = ($STATUS::OK);
+    my ($status, $result, $status_msg) = ($STATUS::OK);
     my $previous_node_ref;
 
     $previous_node_ref = node_view($mac);
@@ -253,7 +253,7 @@ sub update {
         my $option;
         if ($node_ref->{status} eq $pf::node::STATUS_REGISTERED) {
             $option = "register";
-            $result = node_register($mac, $previous_node_ref->{pid}, %{$node_ref});
+            ( $result, $status_msg ) = pf::node::node_register($mac, $previous_node_ref->{pid}, %{$node_ref});
         }
         elsif ($node_ref->{status} eq $pf::node::STATUS_UNREGISTERED) {
             $option = "deregister";

--- a/html/pfappserver/lib/pfappserver/Model/User.pm
+++ b/html/pfappserver/lib/pfappserver/Model/User.pm
@@ -602,7 +602,8 @@ sub bulkRegister {
     foreach my $node (map {person_nodes($_)} @ids  ) {
         if($node->{status} eq $pf::node::STATUS_UNREGISTERED) {
             my $mac = $node->{mac};
-            if(node_register($mac, $node->{pid}, %{$node})) {
+            ( $status, $status_msg ) = pf::node::node_register($mac, $node->{pid}, %{$node});
+            if( $status ) {
                 reevaluate_access($mac, "node_modify");
                 $count++;
             }

--- a/lib/pf/action.pm
+++ b/lib/pf/action.pm
@@ -357,12 +357,15 @@ sub action_autoregister {
     my ($mac, $vid) = @_;
     my $logger = get_logger();
 
+    my ( $status, $status_msg );
+
     if(pf::node::is_node_registered($mac)){
         $logger->debug("Calling autoreg on already registered node. Doing nothing.");
     }
     else {
         require pf::role::custom;
-        if(!pf::node::node_register($mac, "default")){
+        ( $status, $status_msg ) = pf::node::node_register($mac, "default");
+        if(!$status){
             $logger->error("auto-registration of node $mac failed");
             return;
         }

--- a/lib/pf/node.pm
+++ b/lib/pf/node.pm
@@ -937,6 +937,8 @@ sub node_register {
     $mac = lc($mac);
     my $auto_registered = 0;
 
+    my $status_msg = "";
+
     # hack to support an additional autoreg param to the sub without changing the hash to a reference everywhere
     if (defined($info{'auto_registered'})) {
         $auto_registered = 1;
@@ -976,8 +978,9 @@ sub node_register {
     else {
     # do not check for max_node if it's for auto-register
         if ( is_max_reg_nodes_reached($mac, $pid, $info{'category'}, $info{'category_id'}) ) {
-            $logger->error( "max nodes per pid met or exceeded - registration of $mac to $pid failed" );
-            return (0);
+            $status_msg = "max nodes per pid met or exceeded";
+            $logger->error( "$status_msg - registration of $mac to $pid failed" );
+            return (0, $status_msg);
         }
     }
 

--- a/lib/pf/node.pm
+++ b/lib/pf/node.pm
@@ -980,7 +980,7 @@ sub node_register {
         if ( is_max_reg_nodes_reached($mac, $pid, $info{'category'}, $info{'category_id'}) ) {
             $status_msg = "max nodes per pid met or exceeded";
             $logger->error( "$status_msg - registration of $mac to $pid failed" );
-            return (0, $status_msg);
+            return ($FALSE, $status_msg);
         }
     }
 

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -216,13 +216,15 @@ sub authorize {
     
     $args->{'autoreg'} = 0;
     # should we auto-register? let's ask the VLAN object
+    my ( $status, $status_msg );
     if ($role_obj->shouldAutoRegister($args)) {
         $args->{'autoreg'} = 1;
         # automatic registration
         my %autoreg_node_defaults = $role_obj->getNodeInfoForAutoReg($args);
         $args->{'node_info'} = merge($args->{'node_info'}, \%autoreg_node_defaults);
         $logger->debug("[$mac] auto-registering node");
-        if (!node_register($mac, $autoreg_node_defaults{'pid'}, %autoreg_node_defaults)) {
+        ( $status, $status_msg ) = pf::node::node_register($mac, $autoreg_node_defaults{'pid'}, %autoreg_node_defaults);
+        if (!$status) {
             $logger->error("auto-registration of node failed");
         }
     }

--- a/sbin/pfsetvlan
+++ b/sbin/pfsetvlan
@@ -1839,7 +1839,9 @@ sub node_update_PF {
         my %autoreg_node_defaults = $role_obj->getNodeInfoForAutoReg({ switch => $switch, ifIndex => $switch_port,
             mac => $mac, vlan => $vlan, violation_autoreg => 0, isPhone => $isPhone, connection_type => $WIRED_SNMP_TRAPS});
         $logger->debug("auto-registering node $mac");
-        if (!node_register($mac, $autoreg_node_defaults{'pid'}, %autoreg_node_defaults)) {
+        my ( $status, $status_msg );
+        ( $status, $status_msg ) = pf::node::node_register($mac, $autoreg_node_defaults{'pid'}, %autoreg_node_defaults);
+        if (!$status) {
             $logger->error("auto-registration of node $mac failed");
             return 0;
         }


### PR DESCRIPTION
# Description

pf::node::node_register is able to return status message to inform end users on failure per example 
# Impacts

There shouldn't be any impact since we basically return a string along with the return code (0,1)
Should just make sure all the caller are handling the return code as they should (curl ?)
pf::node::node_register flow
- registration
- auto-registration
- wispr
- node import
- administration interface (user / nodes)
- portal
- vlan_filters (action = register_node)
- wmi (action = dynamic_register_node)

# Delete branch after merge

YES
# NEWS file entries
## Enhancements
- Portal is giving more indication on node registration error
## Bug Fixes
- pf::node::node_register | Refactor to add return code + status code/message (#1797)
