### PR TITLE
Fix if mac or port is undefined in radius authentication

### DIFF
--- a/lib/pf/Switch/ArubaSwitch.pm
+++ b/lib/pf/Switch/ArubaSwitch.pm
@@ -124,7 +124,7 @@ Fetch the ifindex on the switch by NAS-Port-Id radius attribute
 sub getIfIndexByNasPortId {
     my ($self, $ifDesc_param) = @_;
 
-    if ( !$self->connectRead() ) {
+    if ( !$self->connectRead() || !defined($ifDesc_param)) {
         return 0;
     }
 

--- a/lib/pf/Switch/Cisco/Catalyst_2950.pm
+++ b/lib/pf/Switch/Cisco/Catalyst_2950.pm
@@ -1181,7 +1181,7 @@ Fetch the ifindex on the switch by NAS-Port-Id radius attribute
 sub getIfIndexByNasPortId {
     my ($self, $ifDesc_param) = @_;
 
-    if ( !$self->connectRead() ) {
+    if ( !$self->connectRead() || !defined($ifDesc_param)) {
         return 0;
     }
 

--- a/lib/pf/Switch/Cisco/Catalyst_4500.pm
+++ b/lib/pf/Switch/Cisco/Catalyst_4500.pm
@@ -39,7 +39,7 @@ Fetch the ifindex on the switch by NAS-Port-Id radius attribute
 sub getIfIndexByNasPortId {
     my ($self, $ifDesc_param) = @_;
 
-    if ( !$self->connectRead() ) {
+    if ( !$self->connectRead() || !defined($ifDesc_param)) {
         return 0;
     }
 

--- a/lib/pf/Switch/Dell/Force10.pm
+++ b/lib/pf/Switch/Dell/Force10.pm
@@ -47,9 +47,11 @@ Fetch the ifindex on the switch by NAS-Port-Id radius attribute
 sub getIfIndexByNasPortId {
     my ($self, $ifDesc_param) = @_;
     my $logger = $self->logger;
-    if ( !$self->connectRead() ) {
+
+    if ( !$self->connectRead() || !defined($ifDesc_param)) {
         return 0;
     }
+
     my @ifDesc_val = split('/',$ifDesc_param);
     my $OID_ifDesc = '1.3.6.1.2.1.17.1.4.1.2.'.$ifDesc_param;
     my $result = $self->cachedSNMPRequest([-varbindlist => [ $OID_ifDesc ]]);

--- a/lib/pf/Switch/ThreeCom.pm
+++ b/lib/pf/Switch/ThreeCom.pm
@@ -92,7 +92,7 @@ sub getIfIndexByNasPortId {
     my ($self, $ifDesc_param) = @_;
     my $logger = $self->logger;
 
-    if ( !$self->connectRead() ) {
+    if ( !$self->connectRead() || !defined($ifDesc_param)) {
         return 0;
     }
     if ($ifDesc_param =~ /(unit|slot)=(\d+);subslot=(\d+);port=(\d+)/) {

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -237,7 +237,7 @@ sub authorize {
     }
 
     # if it's an IP Phone, let _authorizeVoip decide (extension point)
-    if ($isPhone) {
+    if ($args->{'isPhone'}) {
         $RAD_REPLY_REF = $self->_authorizeVoip($args);
         $args->{'user_role'} = $VOICE_ROLE;
         goto CLEANUP;

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -111,6 +111,11 @@ sub authorize {
 
 
     my ($nas_port_type, $eap_type, $mac, $port, $user_name, $nas_port_id, $session_id) = $switch->parseRequest($radius_request);
+
+    if (!$mac) {
+        return [$RADIUS::RLM_MODULE_FAIL, ('Reply-Message' => "Mac is empty")];
+    }
+
     Log::Log4perl::MDC->put( 'mac', $mac );
     my $connection = pf::Connection->new;
     $connection->identifyType($nas_port_type, $eap_type, $mac, $user_name, $switch);
@@ -195,9 +200,13 @@ sub authorize {
     my $result = $role_obj->filterVlan('IsPhone',$args);
     # determine if we need to perform automatic registration
     # either the switch detects that this is a phone or we take the result from the vlan filters
-    my $isPhone = $switch->isPhoneAtIfIndex($mac, $port) || defined($result);
-
-    $args->{'isPhone'} = $isPhone;
+    if (defined($result)) {
+        $args->{'isPhone'} = $result;
+    } elsif ($port) {
+       $args->{'isPhone'} =$switch->isPhoneAtIfIndex($mac, $port);
+    } else {
+        $args->{'isPhone'} = $FALSE;
+    }
 
     #define the current connection value to instantiate the correct portal
     my $options = {};
@@ -260,7 +269,7 @@ sub authorize {
     #closes old locationlog entries and create a new one if required
     #TODO: Better deal with INLINE RADIUS
     $switch->synchronize_locationlog($port, $vlan, $mac,
-        $isPhone ? $VOIP : $NO_VOIP, $connection_type, $connection_sub_type, $user_name, $ssid, $stripped_user_name, $realm, $args->{'user_role'}
+        $args->{'isPhone'} ? $VOIP : $NO_VOIP, $connection_type, $connection_sub_type, $user_name, $ssid, $stripped_user_name, $realm, $args->{'user_role'}
     ) if ( (!$role->{wasInline}) && ($vlan ne "-1") );
 
     # does the switch support Dynamic VLAN Assignment, bypass if using Inline


### PR DESCRIPTION
# Description
Fix when the mac is empty and when PacketFence is not able to find the port

# Impacts
RADIUS authorize workflow

# Issue
When we configure a switch to test radius status the request doesn't include a mac address and a nas port id.

# Delete branch after merge
YES

# NEWS file entries

## Bug Fixes
* Remove error when we receive a radius request to test the radius status
