### PR TITLE
Protecting VRRP against attacks

### DIFF
--- a/lib/pf/services/manager/keepalived.pm
+++ b/lib/pf/services/manager/keepalived.pm
@@ -89,7 +89,7 @@ EOT
     haproxy
   }
   authentication {
-    auth_type PASS
+    auth_type AH
     auth_pass $Config{'active_active'}{'password'}
   }
   smtp_alert


### PR DESCRIPTION
# Description
Protecting VRRP against attacks
Changed from plain text to IPSEC-AH in keepalived in order to protect vrrp traffic.

# Impacts
keepalived

# Delete branch after merge
YES

# NEWS file entries

## Enhancements
* Protecting VRRP against attacks
