### PR TITLE
Person Lookup Cache

### DIFF
--- a/conf/chi.conf.defaults
+++ b/conf/chi.conf.defaults
@@ -78,3 +78,10 @@ reconnect=60
 #
 # Amount of time from the current time to expire an entry
 expires_in=1d
+
+[storage person_lookup]
+#
+# storage person_lookup.expires_in
+#
+# Amount of time from the current time to expire an entry
+expires_in=10m

--- a/conf/chi.conf.defaults
+++ b/conf/chi.conf.defaults
@@ -84,4 +84,4 @@ expires_in=1d
 # storage person_lookup.expires_in
 #
 # Amount of time from the current time to expire an entry
-expires_in=1h
+expires_in=24h

--- a/conf/chi.conf.defaults
+++ b/conf/chi.conf.defaults
@@ -84,4 +84,4 @@ expires_in=1d
 # storage person_lookup.expires_in
 #
 # Amount of time from the current time to expire an entry
-expires_in=10m
+expires_in=1h

--- a/lib/pf/CHI.pm
+++ b/lib/pf/CHI.pm
@@ -67,7 +67,7 @@ Hash::Merge::specify_behavior(
     'PF_CHI_MERGE'
 );
 
-our @CACHE_NAMESPACES = qw(configfilesdata configfiles httpd.admin httpd.portal pfdns switch.overlay ldap_auth omapi fingerbank firewall_sso switch metadefender accounting clustering);
+our @CACHE_NAMESPACES = qw(configfilesdata configfiles httpd.admin httpd.portal pfdns switch.overlay ldap_auth omapi fingerbank firewall_sso switch metadefender accounting clustering person_lookup);
 
 our $chi_default_config = pf::IniFiles->new( -file => $chi_defaults_config_file) or die "Cannot open $chi_defaults_config_file";
 

--- a/lib/pf/cmd/pf/cache.pm
+++ b/lib/pf/cmd/pf/cache.pm
@@ -14,6 +14,7 @@ Namespaces:
   configfiles
   httpd.admin
   httpd.portal
+  person_lookup
   pfdns
   switch.overlay
   switch

--- a/lib/pf/lookup/person.pm
+++ b/lib/pf/lookup/person.pm
@@ -51,7 +51,7 @@ sub lookup_person {
         return undef;
     }
     my $person = $CHI_CACHE->get("$source_id.$pid");
-    unless($reply){
+    unless($person){
         $person = $source->search_attributes($pid);
         if (!$person) {
            $logger->debug("Cannot search attributes for user '$pid'");

--- a/lib/pf/lookup/person.pm
+++ b/lib/pf/lookup/person.pm
@@ -60,6 +60,7 @@ sub lookup_person {
             $CHI_CACHE->set("$source_id.$pid", $person);
             $logger->info("Successfully did a person lookup for $pid");
             person_modify($pid, %$person);
+            return undef;
         }
     }
     $logger->info("Already did a person lookup for $pid");

--- a/lib/pf/lookup/person.pm
+++ b/lib/pf/lookup/person.pm
@@ -24,6 +24,9 @@ use pf::person;
 use pf::util;
 use pf::authentication;
 use pf::pfqueue::producer::redis;
+use pf::CHI;
+
+my $CHI_CACHE = pf::CHI->new( namespace => 'person_lookup' );
 
 =head2 lookup_person
 
@@ -47,7 +50,7 @@ sub lookup_person {
     unless (person_exist($pid)) {
         return "Person $pid is not a registered user!\n";
     }
-    my ($person, $msg) = $source->search_attributes($pid);
+    my $person = $CHI_CACHE->compute("$source_id.$pid", sub {  $source->search_attributes($pid) });
     if (!$person) {
        $logger->info("Cannot search attributes for user '$pid'");
        return "Cannot search attributes for user '$pid'!\n";

--- a/lib/pf/lookup/person.pm
+++ b/lib/pf/lookup/person.pm
@@ -44,26 +44,28 @@ sub lookup_person {
     my $source = pf::authentication::getAuthenticationSource($source_id);
     if (!$source) {
        $logger->info("Unable to locate the source $source_id");
-       return undef;
+       return;
     }
 
     unless (person_exist($pid)) {
-        return undef;
+        $logger->info("Person $pid is not a registered user!");
+        return;
     }
     my $person = $CHI_CACHE->get("$source_id.$pid");
     unless($person){
         $person = $source->search_attributes($pid);
         if (!$person) {
            $logger->debug("Cannot search attributes for user '$pid'");
-           return undef;
+           return;
         } else {
             $CHI_CACHE->set("$source_id.$pid", $person);
             $logger->info("Successfully did a person lookup for $pid");
             person_modify($pid, %$person);
-            return undef;
+            return;
         }
     }
     $logger->info("Already did a person lookup for $pid");
+    return;
 }
 
 =head2 async_lookup_person

--- a/lib/pf/lookup/person.pm
+++ b/lib/pf/lookup/person.pm
@@ -39,7 +39,7 @@ sub lookup_person {
     my $logger = get_logger();
     unless (defined $source_id) {
         $logger->info("undefined source id provided");
-        return undef;
+        return;
     }
     my $source = pf::authentication::getAuthenticationSource($source_id);
     if (!$source) {

--- a/lib/pf/role.pm
+++ b/lib/pf/role.pm
@@ -443,18 +443,12 @@ sub getRegisteredRole {
             };
             $role = &pf::authentication::match([@sources], $params, $Actions::SET_ROLE, \$source);
             my $unregdate = &pf::authentication::match([@sources], $params, $Actions::SET_UNREG_DATE);
-            # create a person entry for pid if it doesn't exist
-            if ( !pf::person::person_exist($args->{'user_name'}) ) {
-                $logger->info("creating person $args->{'user_name'} because it doesn't exist");
-                pf::person::person_add($args->{'user_name'});
-            } else {
-                $logger->debug("person $args->{'user_name'} already exists");
-            }
-            pf::lookup::person::async_lookup_person($args->{'user_name'}, $source);
             pf::person::person_modify($args->{'user_name'},
                 'source'  => $source,
                 'portal'  => $profile->getName,
             );
+            # Don't do a person lookup if autoreg (already did it);
+            pf::lookup::person::async_lookup_person($args->{'user_name'}, $source) if !($args->{'autoreg'});
             $portal = $profile->getName;
             my %info = (
                 'autoreg' => 'no',


### PR DESCRIPTION
# Description
Cache the result of person lookup for 1h, it will reduce a lot the ldap search.
Optimize call to person_add in order to reduce the stress on the db.

# Impacts
pfqueue

# Delete branch after merge
YES

# NEWS file entries
## New Features
* Cache person_lookup to reduce the call to ldap_search
