### PR TITLE
Changed from timestamp to datatime for iplog_history.end_time

### DIFF
--- a/db/pf-schema-X.Y.Z.sql
+++ b/db/pf-schema-X.Y.Z.sql
@@ -275,7 +275,7 @@ CREATE TABLE iplog_history (
   mac varchar(17) NOT NULL,
   ip varchar(45) NOT NULL,
   start_time datetime NOT NULL,
-  end_time timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  end_time datetime NOT NULL,
   KEY iplog_history_mac_end_time (mac,end_time),
   KEY end_time (end_time),
   KEY start_time (start_time)

--- a/db/upgrade-X.X.X-X.Y.Z.sql
+++ b/db/upgrade-X.X.X-X.Y.Z.sql
@@ -351,3 +351,10 @@ ALTER TABLE `locationlog` modify `port` VARCHAR(20);
 --
 
 ALTER TABLE `locationlog_archive` modify `port` VARCHAR(20);
+
+--
+-- Change end_time from timestamp to datetime in iplog_history
+--
+
+ALTER TABLE iplog_history MODIFY end_time datetime NOT NULL;
+


### PR DESCRIPTION
# Description
Chang from timestamp to datatime for iplog_history.end_time

# Impacts
iplog rotation

# Issue
On older mysql version the query take time with timestamp instead of datetime format

# Delete branch after merge
YES

# NEWS file entries

## Bug Fixes
* make iplog rotate faster
