### PR TITLE
Dynamically add eduroam virtual server listening port to iptables con…

### DIFF
--- a/conf/iptables.conf.example
+++ b/conf/iptables.conf.example
@@ -44,6 +44,8 @@
 -A input-management-if --protocol udp --match udp --dport 1813 --jump ACCEPT
 -A input-management-if --protocol tcp --match tcp --dport 1815 --jump ACCEPT
 -A input-management-if --protocol udp --match udp --dport 1815 --jump ACCEPT
+# RADIUS (eduroam virtual-server)
+%%eduroam_radius_virtualserver%%
 # SNMP Traps
 -A input-management-if --protocol udp --match udp --dport 162  --jump ACCEPT
 # DHCP (for IP Helpers to mgmt to track users' IP in production VLANs)

--- a/lib/pf/iptables.pm
+++ b/lib/pf/iptables.pm
@@ -135,7 +135,7 @@ sub iptables_generate {
         $tags{'eduroam_radius_virtualserver'} .= "-A input-management-if --protocol udp --match udp --dport $eduroam_listening_port --jump ACCEPT\n";
     }
     else {
-        $tags{'eduroam_radius_virtualserver'} = "# eduroam integration is not configured";
+        $tags{'eduroam_radius_virtualserver'} = "# eduroam integration is not configured\n";
     }
 
     if (is_inline_enforcement_enabled()) {


### PR DESCRIPTION
# Description
Dynamically add eduroam virtual server listening port to iptables configuration

# Impacts
iptables service

# Issue
fixes #1836 

# Delete branch after merge
YES

# UPGRADE file entries
- Additions to iptables.conf for eduroam integration would require you to make sure you have an equivalent of conf/iptables.conf.example. Make sure to port customizations.