### PR TITLE
Honor "controllerPort" configuration parameter in WLC radiusDisconnect

### DIFF
--- a/lib/pf/Switch/Cisco/WLC.pm
+++ b/lib/pf/Switch/Cisco/WLC.pm
@@ -490,6 +490,10 @@ sub radiusDisconnect {
             nas_port => $nas_port,
         };
 
+        if (defined($self->{'_controllerPort'}) && $self->{'_controllerPort'} ne '') {
+            $connection_info->{'nas_port'} = $self->{'_controllerPort'};
+        }
+
         $logger->debug("network device (".$self->{'_id'}.") supports roles. Evaluating role to be returned");
         my $roleResolver = pf::roles::custom->instance();
         my $role = $roleResolver->getRoleForNode($mac, $self);
@@ -542,6 +546,11 @@ sub radiusDisconnect {
                 LocalAddr => $self->deauth_source_ip(),
                 nas_port => $nas_port,
             };
+
+            if (defined($self->{'_controllerPort'}) && $self->{'_controllerPort'} ne '') {
+                $connection_info->{'nas_port'} = $self->{'_controllerPort'};
+            }
+
             $response = perform_disconnect($connection_info, $attributes_ref);
         }
     } catch {


### PR DESCRIPTION
# Description
See issue (#1840)

# Impacts
WLC radiusDisconnect

# Issue
fixes #1840 

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
If an issue exists on Github, please refer to it (name) along with it's number...
* Cisco WLC do not honor controllerPort for CoA/Disconnect (#1840)