### PR TITLE
Feature/rate limit dhcp

### DIFF
--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -42,6 +42,15 @@ are broadcasts, meaning a span port is not necessary.  This feature is
 highly recommended if the internal network is DHCP-based.
 EOT
 
+[network.dhcp_rate_limiting]
+type=time
+description=<<EOT
+Will rate-limit DHCP packets that contain the same information.
+For example, a DHCPREQUEST for the same MAC/IP will only be processed once in the timeframe configured below.
+This is independant of the DHCP server/relay handling the packet and is only based on the IP, MAC Address and DHCP type inside the packet.
+A value of 0 will disable the rate limitation.
+EOT
+
 [network.dhcpoption82logger]
 type=toggle
 options=enabled|disabled

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -35,6 +35,14 @@ timezone=America/Montreal
 # meaning a span port is not necessary.  This feature is highly recommended if the internal network is DHCP-based.
 dhcpdetector=enabled
 #
+# network.dhcp_rate_limiting
+#
+# Will rate-limit DHCP packets that contain the same information.
+# For example, a DHCPREQUEST for the same MAC/IP will only be processed once in the timeframe configured below.
+# This is independant of the DHCP server/relay handling the packet and is only based on the IP, MAC Address and DHCP type inside the packet.
+# A value of 0 will disable the rate limitation.
+dhcp_rate_limiting=5s
+#
 # network.rogue_dhcp_detection
 #
 # Tries to identify Rogue DHCP Servers and triggers the 1100010 violation if one is found.

--- a/html/pfappserver/lib/pfappserver/I18N/en.po
+++ b/html/pfappserver/lib/pfappserver/I18N/en.po
@@ -9527,6 +9527,10 @@ msgid "network.dhcpdetector"
 msgstr "DHCP detector"
 
 # conf/documentation.conf
+msgid "network.dhcp_rate_limiting"
+msgstr "DHCP detector rate limiting"
+
+# conf/documentation.conf
 msgid "network.dhcpoption82logger"
 msgstr "DHCP option82"
 

--- a/lib/pf/api.pm
+++ b/lib/pf/api.pm
@@ -1194,11 +1194,10 @@ The UDP payload must be base 64 encoded.
 
 sub process_dhcp : Public {
     my ($class, %postdata) = @_;
-    my @require = qw(src_mac src_ip dest_mac dest_ip is_inline_vlan interface interface_ip interface_vlan net_type udp_payload_b64);
+    my @require = qw(src_mac src_ip dest_mac dest_ip is_inline_vlan interface interface_ip interface_vlan net_type);
     my @found = grep {exists $postdata{$_}} @require;
     return unless pf::util::validate_argv(\@require,\@found);
 
-    $postdata{udp_payload} = MIME::Base64::decode($postdata{udp_payload_b64});
     pf::dhcp::processor->new(%postdata)->process_packet();
 
     return $pf::config::TRUE;

--- a/lib/pf/dhcp/processor.pm
+++ b/lib/pf/dhcp/processor.pm
@@ -150,17 +150,7 @@ sub process_packet {
     my $timer = pf::StatsD::Timer->new();
     my ( $self ) = @_;
 
-    my ($dhcp);
-
-    # we need success flag here because we can't next inside try catch
-    my $success;
-    try {
-        $dhcp = decode_dhcp($self->{'udp_payload'});
-        $success = 1;
-    } catch {
-        $logger->warn("Unable to parse DHCP packet: $_");
-    };
-    return if (!$success);
+    my $dhcp = $self->{dhcp};
 
     # adding to dhcp hashref some frame information we care about
     $dhcp->{'src_mac'} = $self->{'src_mac'};

--- a/lib/pf/dhcp/processor.pm
+++ b/lib/pf/dhcp/processor.pm
@@ -152,31 +152,6 @@ sub process_packet {
 
     my $dhcp = $self->{dhcp};
 
-    # adding to dhcp hashref some frame information we care about
-    $dhcp->{'src_mac'} = $self->{'src_mac'};
-    $dhcp->{'dest_mac'} = $self->{'dest_mac'};
-    $dhcp->{'src_ip'} = $self->{'src_ip'};
-    $dhcp->{'dest_ip'} = $self->{'dest_ip'};
-
-    if (!valid_mac($dhcp->{'src_mac'})) {
-        $logger->debug("Source MAC is invalid. skipping");
-        return;
-    }
-
-    # grab DHCP information
-    if ( !defined($dhcp->{'chaddr'}) ) {
-        $logger->debug("chaddr is undefined in DHCP packet");
-        return;
-    }
-
-    $dhcp->{'chaddr'} = clean_mac( substr( $dhcp->{'chaddr'}, 0, 12 ) );
-    if ( $dhcp->{'chaddr'} ne "00:00:00:00:00:00" && !valid_mac($dhcp->{'chaddr'}) ) {
-        $logger->debug( sub {
-            "invalid CHADDR value ($dhcp->{'chaddr'}) in DHCP packet from $dhcp->{src_mac} ($dhcp->{src_ip})"
-        });
-        return;
-    }
-
     if ( !node_exist($dhcp->{'chaddr'}) ) {
         $logger->debug( sub { "Unseen before node added: $dhcp->{'chaddr'}" } );
         node_add_simple($dhcp->{'chaddr'});

--- a/sbin/pfdhcplistener
+++ b/sbin/pfdhcplistener
@@ -107,6 +107,9 @@ my $pcap;
 my $net_type;
 my $process;
 
+my $rate_limit_hash = {};
+my $rate_limit_cache = CHI->new( driver => 'Memory', datastore => $rate_limit_hash );
+
 sub reload_config {
     if ( $net_type eq "internal" ) { 
         $process = $TRUE;
@@ -258,6 +261,41 @@ sub process_pkt {
                 };
                 return if (!$success);
                 $args{dhcp} = $dhcp;
+                
+                # adding to dhcp hashref some frame information we care about
+                $dhcp->{'src_mac'} = $args{'src_mac'};
+                $dhcp->{'dest_mac'} = $args{'dest_mac'};
+                $dhcp->{'src_ip'} = $args{'src_ip'};
+                $dhcp->{'dest_ip'} = $args{'dest_ip'};
+
+
+                # grab DHCP information
+                if ( !defined($dhcp->{'chaddr'}) ) {
+                    $logger->debug("chaddr is undefined in DHCP packet");
+                    return;
+                }
+
+                $dhcp->{'chaddr'} = clean_mac( substr( $dhcp->{'chaddr'}, 0, 12 ) );
+
+                if (!valid_mac($dhcp->{'src_mac'})) {
+                    $logger->debug("Source MAC is invalid. skipping");
+                    return;
+                }
+
+                if ( $dhcp->{'chaddr'} ne "00:00:00:00:00:00" && !valid_mac($dhcp->{'chaddr'}) ) {
+                    $logger->debug( sub {
+                        "invalid CHADDR value ($dhcp->{'chaddr'}) in DHCP packet from $dhcp->{src_mac} ($dhcp->{src_ip})"
+                    });
+                    return;
+                }
+
+
+                my $dhcp_mac = $dhcp->{'chaddr'};
+                # If its a DHCPREQUEST, we take the IP address from the options
+                my $dhcp_ip = ( $dhcp->{'options'}{'53'} == 3 ) ? $dhcp->{'options'}{'50'} : $dhcp->{yiaddr};
+                # Key is with BOOT type, DHCP type, IP and MAC
+                my $rate_limit_key = $dhcp->{'op'} . "-" . $dhcp->{'options'}{'53'} . "-$dhcp_ip-" . $dhcp_mac;
+                $logger->trace("Rate limit key : $rate_limit_key");
 
                 if ($is_inline_vlan) {
                     my $ip = new NetAddr::IP::Lite clean_ip($l3->{'src_ip'});
@@ -267,8 +305,14 @@ sub process_pkt {
                         $args{inline_sub_connection_type} = $NET_TYPE_INLINE_L3;
                    }
                 }
-                my $apiclient = pf::api::queue->new(queue => 'pfdhcplistener');
-                $apiclient->notify('process_dhcp', %args, udp_payload_b64 => $udp_payload_b64);
+                if(!$rate_limit_cache->get($rate_limit_key)) {
+                    my $apiclient = pf::api::queue->new(queue => 'pfdhcplistener');
+                    $apiclient->notify('process_dhcp', %args, udp_payload_b64 => $udp_payload_b64);
+                    $rate_limit_cache->set($rate_limit_key, 1, "5 second");
+                }
+                else {
+                    $logger->info("Ignoring packet due to rate-limiting");
+                }
             }
             else {
                 my $apiclient = pf::api::queue->new;

--- a/sbin/pfdhcplistener
+++ b/sbin/pfdhcplistener
@@ -262,31 +262,29 @@ sub process_pkt {
                 return if (!$success);
                 $args{dhcp} = $dhcp;
                 
+                my $dhcp_mac = clean_mac( substr( $dhcp->{'chaddr'}, 0, 12 ) );
+                if ( $dhcp_mac ne "00:00:00:00:00:00" && !valid_mac($dhcp_mac) ) {
+                    $logger->debug( sub {
+                        "invalid CHADDR value ($dhcp_mac) in DHCP packet from $dhcp->{src_mac} ($dhcp->{src_ip})"
+                    });
+                    return;
+                }
+
                 # adding to dhcp hashref some frame information we care about
                 $dhcp->{'src_mac'} = $args{'src_mac'};
                 $dhcp->{'dest_mac'} = $args{'dest_mac'};
                 $dhcp->{'src_ip'} = $args{'src_ip'};
                 $dhcp->{'dest_ip'} = $args{'dest_ip'};
-
+                $dhcp->{'chaddr'} = $dhcp_mac;
 
                 # grab DHCP information
-                if ( !defined($dhcp->{'chaddr'}) ) {
+                if ( !defined($dhcp_mac) ) {
                     $logger->debug("chaddr is undefined in DHCP packet");
                     return;
                 }
 
-                my $dhcp_mac = clean_mac( substr( $dhcp->{'chaddr'}, 0, 12 ) );
-                $dhcp->{'chaddr'} = $dhcp_mac;
-
                 if (!valid_mac($dhcp->{'src_mac'})) {
                     $logger->debug("Source MAC is invalid. skipping");
-                    return;
-                }
-
-                if ( $dhcp_mac ne "00:00:00:00:00:00" && !valid_mac($dhcp_mac) ) {
-                    $logger->debug( sub {
-                        "invalid CHADDR value ($dhcp_mac) in DHCP packet from $dhcp->{src_mac} ($dhcp->{src_ip})"
-                    });
                     return;
                 }
 
@@ -321,7 +319,7 @@ sub process_pkt {
                     }
                 }
                 else {
-                    $logger->info("Ignoring packet due to rate-limiting");
+                    $logger->debug("[$dhcp_mac] Ignoring packet due to rate-limiting ($rate_limit_key)");
                 }
             }
             else {

--- a/sbin/pfdhcplistener
+++ b/sbin/pfdhcplistener
@@ -229,7 +229,6 @@ sub process_pkt {
 
             my $l3 = $l2->{type} eq ETH_TYPE_IP ? NetPacket::IP->decode($l2->{'data'}) : NetPacket::IPv6->decode($l2->{'data'});
             my $l4 = NetPacket::UDP->decode($l3->{'data'});
-            my $udp_payload_b64 = MIME::Base64::encode($l4->{data});
             my %args = (
                 src_mac => clean_mac($l2->{'src_mac'}),
                 dest_mac => clean_mac($l2->{'dest_mac'}),
@@ -313,7 +312,7 @@ sub process_pkt {
                 #  - there is no cache entry (packet wasn't seen in the last $rate_limiting seconds)
                 if(!defined($rate_limit_key) || $rate_limiting == 0 || !$rate_limit_cache->get($rate_limit_key)) {
                     my $apiclient = pf::api::queue->new(queue => 'pfdhcplistener');
-                    $apiclient->notify('process_dhcp', %args, udp_payload_b64 => $udp_payload_b64);
+                    $apiclient->notify('process_dhcp', %args);
                     if(defined($rate_limit_key) && $rate_limiting != 0) {
                         $rate_limit_cache->set($rate_limit_key, 1, $rate_limiting);
                     }
@@ -324,7 +323,7 @@ sub process_pkt {
             }
             else {
                 my $apiclient = pf::api::queue->new;
-                $apiclient->notify('process_dhcpv6', $udp_payload_b64);
+                $apiclient->notify('process_dhcpv6', MIME::Base64::encode($l4->{data}));
             }
         };
 

--- a/sbin/pfdhcplistener
+++ b/sbin/pfdhcplistener
@@ -268,6 +268,13 @@ sub process_pkt {
                     });
                     return;
                 }
+                
+                # grab DHCP information
+                if ($dhcp_mac) {
+                    $logger->debug("chaddr is undefined in DHCP packet");
+                    return;
+                }
+
 
                 # adding to dhcp hashref some frame information we care about
                 $dhcp->{'src_mac'} = $args{'src_mac'};
@@ -275,12 +282,6 @@ sub process_pkt {
                 $dhcp->{'src_ip'} = $args{'src_ip'};
                 $dhcp->{'dest_ip'} = $args{'dest_ip'};
                 $dhcp->{'chaddr'} = $dhcp_mac;
-
-                # grab DHCP information
-                if ( !defined($dhcp_mac) ) {
-                    $logger->debug("chaddr is undefined in DHCP packet");
-                    return;
-                }
 
                 if (!valid_mac($dhcp->{'src_mac'})) {
                     $logger->debug("Source MAC is invalid. skipping");

--- a/sbin/pfdhcplistener
+++ b/sbin/pfdhcplistener
@@ -275,22 +275,22 @@ sub process_pkt {
                     return;
                 }
 
-                $dhcp->{'chaddr'} = clean_mac( substr( $dhcp->{'chaddr'}, 0, 12 ) );
+                my $dhcp_mac = clean_mac( substr( $dhcp->{'chaddr'}, 0, 12 ) );
+                $dhcp->{'chaddr'} = $dhcp_mac;
 
                 if (!valid_mac($dhcp->{'src_mac'})) {
                     $logger->debug("Source MAC is invalid. skipping");
                     return;
                 }
 
-                if ( $dhcp->{'chaddr'} ne "00:00:00:00:00:00" && !valid_mac($dhcp->{'chaddr'}) ) {
+                if ( $dhcp_mac ne "00:00:00:00:00:00" && !valid_mac($dhcp_mac) ) {
                     $logger->debug( sub {
-                        "invalid CHADDR value ($dhcp->{'chaddr'}) in DHCP packet from $dhcp->{src_mac} ($dhcp->{src_ip})"
+                        "invalid CHADDR value ($dhcp_mac) in DHCP packet from $dhcp->{src_mac} ($dhcp->{src_ip})"
                     });
                     return;
                 }
 
 
-                my $dhcp_mac = $dhcp->{'chaddr'};
                 # If its a DHCPREQUEST, we take the IP address from the option
                 my $dhcp_ip = ( $dhcp->{'op'} == 1 && $dhcp->{'options'}{'53'} == 3 ) ? $dhcp->{'options'}{'50'} : $dhcp->{yiaddr};
                 my $rate_limit_key;

--- a/sbin/pfdhcplistener
+++ b/sbin/pfdhcplistener
@@ -305,10 +305,13 @@ sub process_pkt {
                         $args{inline_sub_connection_type} = $NET_TYPE_INLINE_L3;
                    }
                 }
-                if(!$rate_limit_cache->get($rate_limit_key)) {
+                my $rate_limiting = $Config{network}->{dhcp_rate_limiting};
+                if($rate_limiting == 0 || !$rate_limit_cache->get($rate_limit_key)) {
                     my $apiclient = pf::api::queue->new(queue => 'pfdhcplistener');
                     $apiclient->notify('process_dhcp', %args, udp_payload_b64 => $udp_payload_b64);
-                    $rate_limit_cache->set($rate_limit_key, 1, "5 second");
+                    if($rate_limiting != 0) {
+                        $rate_limit_cache->set($rate_limit_key, 1, $rate_limiting);
+                    }
                 }
                 else {
                     $logger->info("Ignoring packet due to rate-limiting");

--- a/sbin/pfdhcplistener
+++ b/sbin/pfdhcplistener
@@ -29,6 +29,8 @@ BEGIN {
     use pf::log(service => 'pfdhcplistener');
 }
 
+use Try::Tiny;
+use pf::util::dhcp;
 use pf::constants;
 use pf::constants::config qw( $NET_TYPE_INLINE_L2 $NET_TYPE_INLINE_L3 );
 use pf::clustermgmt;
@@ -244,6 +246,19 @@ sub process_pkt {
 
             # we send all IPv4 DHCPv4 codepath
             if ( $l2->{type} eq ETH_TYPE_IP ) {
+                my ($dhcp);
+
+                # we need success flag here because we can't next inside try catch
+                my $success;
+                try {
+                    $dhcp = decode_dhcp($l4->{'data'});
+                    $success = 1;
+                } catch {
+                    $logger->warn("Unable to parse DHCP packet: $_");
+                };
+                return if (!$success);
+                $args{dhcp} = $dhcp;
+
                 if ($is_inline_vlan) {
                     my $ip = new NetAddr::IP::Lite clean_ip($l3->{'src_ip'});
                     if ($net_addr->contains($ip)) {

--- a/sbin/pfdhcplistener
+++ b/sbin/pfdhcplistener
@@ -269,8 +269,8 @@ sub process_pkt {
                     return;
                 }
                 
-                # grab DHCP information
-                if ($dhcp_mac) {
+                # don't process a packet for which we don't have a MAC address
+                unless($dhcp_mac) {
                     $logger->debug("chaddr is undefined in DHCP packet");
                     return;
                 }

--- a/sbin/pfdhcplistener
+++ b/sbin/pfdhcplistener
@@ -291,11 +291,14 @@ sub process_pkt {
 
 
                 my $dhcp_mac = $dhcp->{'chaddr'};
-                # If its a DHCPREQUEST, we take the IP address from the options
-                my $dhcp_ip = ( $dhcp->{'options'}{'53'} == 3 ) ? $dhcp->{'options'}{'50'} : $dhcp->{yiaddr};
-                # Key is with BOOT type, DHCP type, IP and MAC
-                my $rate_limit_key = $dhcp->{'op'} . "-" . $dhcp->{'options'}{'53'} . "-$dhcp_ip-" . $dhcp_mac;
-                $logger->trace("Rate limit key : $rate_limit_key");
+                # If its a DHCPREQUEST, we take the IP address from the option
+                my $dhcp_ip = ( $dhcp->{'op'} == 1 && $dhcp->{'options'}{'53'} == 3 ) ? $dhcp->{'options'}{'50'} : $dhcp->{yiaddr};
+                my $rate_limit_key;
+                if(defined($dhcp_ip)) {
+                    # Key is with BOOT type, DHCP type, IP and MAC
+                    $rate_limit_key = $dhcp->{'op'} . "-" . $dhcp->{'options'}{'53'} . "-$dhcp_ip-" . $dhcp_mac;
+                    $logger->trace("Rate limit key : $rate_limit_key");
+                }
 
                 if ($is_inline_vlan) {
                     my $ip = new NetAddr::IP::Lite clean_ip($l3->{'src_ip'});
@@ -306,10 +309,14 @@ sub process_pkt {
                    }
                 }
                 my $rate_limiting = $Config{network}->{dhcp_rate_limiting};
-                if($rate_limiting == 0 || !$rate_limit_cache->get($rate_limit_key)) {
+                # We send the packet to be processed if:
+                #  - there is no rate limit key (packet doesn't contain info to be rate-limited)
+                #  - there is no rate limiting configured
+                #  - there is no cache entry (packet wasn't seen in the last $rate_limiting seconds)
+                if(!defined($rate_limit_key) || $rate_limiting == 0 || !$rate_limit_cache->get($rate_limit_key)) {
                     my $apiclient = pf::api::queue->new(queue => 'pfdhcplistener');
                     $apiclient->notify('process_dhcp', %args, udp_payload_b64 => $udp_payload_b64);
-                    if($rate_limiting != 0) {
+                    if(defined($rate_limit_key) && $rate_limiting != 0) {
                         $rate_limit_cache->set($rate_limit_key, 1, $rate_limiting);
                     }
                 }


### PR DESCRIPTION
# Description
Rate limit the pfdhcplistener
Move the decoding logic back in the pfdhcplistener (since it has to take decision on the L4 payload)

# Impacts
pfdhcplistener

# Issue
fixes #1722 

# Delete branch after merge
NO (to backport on setup)

# NEWS file entries
## Enhancements
* Rate limited the DHCP listener processes to prevent specific device(s) from performing a denial of service on the DHCP listening processes (#1722)
