### PR TITLE
Fix/no log die

### DIFF
--- a/conf/log.conf.d/httpd.aaa.conf.example
+++ b/conf/log.conf.d/httpd.aaa.conf.example
@@ -6,7 +6,7 @@ log4perl.rootLogger = INFO, HTTPD_AAA
 #log4perl.category.pf.SNMP = WARN
 
 ### Logging for httpd.aaa
-log4perl.appender.HTTPD_AAA                              = Log::Log4perl::Appender::File
+log4perl.appender.HTTPD_AAA                              = pf::log::FileAppender
 # Replace /usr/local/pf/logs/packetfence.log by /usr/local/pf/logs/httpd.aaa.log to allow
 # httpd.aaa to log in its own log file.
 log4perl.appender.HTTPD_AAA.filename                     = /usr/local/pf/logs/packetfence.log

--- a/conf/log.conf.d/httpd.admin.conf.example
+++ b/conf/log.conf.d/httpd.admin.conf.example
@@ -18,7 +18,7 @@ log4perl.additivity.fingerbank = 0
 #log4perl.category.pf.SNMP = WARN
 
 ### Logging for httpd.admin
-log4perl.appender.HTTPD_ADMIN                              = Log::Log4perl::Appender::File
+log4perl.appender.HTTPD_ADMIN                              = pf::log::FileAppender
 log4perl.appender.HTTPD_ADMIN.filename                     = /usr/local/pf/logs/httpd.admin.log
 log4perl.appender.HTTPD_ADMIN.syswrite                     = 1
 log4perl.appender.HTTPD_ADMIN.mode                         = append
@@ -30,7 +30,7 @@ log4perl.appender.HTTPD_ADMIN.group                        = pf
 log4perl.appender.HTTPD_ADMIN.binmode                      = utf8
 
 ### General Catalyst (pfappserver) log facility configuration ###
-log4perl.appender.CATALYST                                 = Log::Log4perl::Appender::File
+log4perl.appender.CATALYST                                 = pf::log::FileAppender
 log4perl.appender.CATALYST.filename                        = /usr/local/pf/logs/httpd.admin.catalyst
 log4perl.appender.CATALYST.mode                            = append
 log4perl.appender.CATALYST.layout                          = PatternLayout
@@ -41,7 +41,7 @@ log4perl.appender.CATALYST.group                           = pf
 log4perl.appender.CATALYST.binmode                         = utf8
 
 ### General Fingerbank log facility configuration ###
-log4perl.appender.FINGERBANK                               = Log::Log4perl::Appender::File
+log4perl.appender.FINGERBANK                               = pf::log::FileAppender
 log4perl.appender.FINGERBANK.filename                      = /usr/local/fingerbank/logs/fingerbank.log
 log4perl.appender.FINGERBANK.mode                          = append
 log4perl.appender.FINGERBANK.layout                        = PatternLayout

--- a/conf/log.conf.d/httpd.collector.conf.example
+++ b/conf/log.conf.d/httpd.collector.conf.example
@@ -6,7 +6,7 @@ log4perl.rootLogger = INFO, HTTPD_COLLECTOR
 #log4perl.category.pf.SNMP = WARN
 
 ### Logging for httpd.collector
-log4perl.appender.HTTPD_COLLECTOR                              = Log::Log4perl::Appender::File
+log4perl.appender.HTTPD_COLLECTOR                              = pf::log::FileAppender
 log4perl.appender.HTTPD_COLLECTOR.filename                     = /usr/local/pf/logs/httpd.collector.log
 log4perl.appender.HTTPD_COLLECTOR.syswrite                     = 1
 log4perl.appender.HTTPD_COLLECTOR.mode                         = append

--- a/conf/log.conf.d/httpd.portal.conf.example
+++ b/conf/log.conf.d/httpd.portal.conf.example
@@ -19,7 +19,7 @@ log4perl.additivity.fingerbank = 0
 #log4perl.category.pf.SNMP = WARN
 
 ### Logging for httpd.portal
-log4perl.appender.HTTPD_PORTAL                              = Log::Log4perl::Appender::File
+log4perl.appender.HTTPD_PORTAL                              = pf::log::FileAppender
 # Replace /usr/local/pf/logs/packetfence.log by /usr/local/pf/logs/httpd.portal.log to allow
 # httpd.portal to log in its own log file.
 log4perl.appender.HTTPD_PORTAL.filename                     = /usr/local/pf/logs/packetfence.log
@@ -34,7 +34,7 @@ log4perl.appender.HTTPD_PORTAL.binmode                      = utf8
 
 
 ### General Catalyst (pfappserver) log facility configuration ###
-log4perl.appender.CATALYST                                 = Log::Log4perl::Appender::File
+log4perl.appender.CATALYST                                 = pf::log::FileAppender
 log4perl.appender.CATALYST.filename                        = /usr/local/pf/logs/httpd.portal.catalyst
 log4perl.appender.CATALYST.mode                            = append
 log4perl.appender.CATALYST.layout                          = PatternLayout
@@ -45,7 +45,7 @@ log4perl.appender.CATALYST.group                           = pf
 log4perl.appender.CATALYST.binmode                         = utf8
 
 ### General Fingerbank log facility configuration ###
-log4perl.appender.FINGERBANK                               = Log::Log4perl::Appender::File
+log4perl.appender.FINGERBANK                               = pf::log::FileAppender
 log4perl.appender.FINGERBANK.filename                      = /usr/local/fingerbank/logs/fingerbank.log
 log4perl.appender.FINGERBANK.mode                          = append
 log4perl.appender.FINGERBANK.layout                        = PatternLayout

--- a/conf/log.conf.d/httpd.proxy.conf.example
+++ b/conf/log.conf.d/httpd.proxy.conf.example
@@ -6,7 +6,7 @@ log4perl.rootLogger = INFO, HTTPD_PROXY
 #log4perl.category.pf.SNMP = WARN
 
 ### Logging for httpd.proxy
-log4perl.appender.HTTPD_PROXY                              = Log::Log4perl::Appender::File
+log4perl.appender.HTTPD_PROXY                              = pf::log::FileAppender
 log4perl.appender.HTTPD_PROXY.filename                     = /usr/local/pf/logs/httpd.proxy.log
 log4perl.appender.HTTPD_PROXY.syswrite                     = 1
 log4perl.appender.HTTPD_PROXY.mode                         = append

--- a/conf/log.conf.d/httpd.webservices.conf.example
+++ b/conf/log.conf.d/httpd.webservices.conf.example
@@ -18,7 +18,7 @@ log4perl.category.pf.dhcp = INFO, DHCP_PROCESSING
 log4perl.additivity.pf.dhcp = 0
 
 ### Logging for httpd.webservices
-log4perl.appender.HTTPD_WEBSERVICES                              = Log::Log4perl::Appender::File
+log4perl.appender.HTTPD_WEBSERVICES                              = pf::log::FileAppender
 # Replace /usr/local/pf/logs/packetfence.log by /usr/local/pf/logs/httpd.webservices.log to allow
 # httpd.webservices to log in its own log file.
 log4perl.appender.HTTPD_WEBSERVICES.filename                     = /usr/local/pf/logs/packetfence.log
@@ -32,7 +32,7 @@ log4perl.appender.HTTPD_WEBSERVICES.group                        = pf
 log4perl.appender.HTTPD_WEBSERVICES.binmode                      = utf8
 
 ### General Fingerbank log facility configuration ###
-log4perl.appender.FINGERBANK                               = Log::Log4perl::Appender::File
+log4perl.appender.FINGERBANK                               = pf::log::FileAppender
 log4perl.appender.FINGERBANK.filename                      = /usr/local/fingerbank/logs/fingerbank.log
 log4perl.appender.FINGERBANK.mode                          = append
 log4perl.appender.FINGERBANK.layout                        = PatternLayout
@@ -43,7 +43,7 @@ log4perl.appender.FINGERBANK.group                         = fingerbank
 log4perl.appender.FINGERBANK.binmode                       = utf8
 
 ### DHCP processing log facility configuration ###
-log4perl.appender.DHCP_PROCESSING                               = Log::Log4perl::Appender::File
+log4perl.appender.DHCP_PROCESSING                               = pf::log::FileAppender
 log4perl.appender.DHCP_PROCESSING.filename                      = /usr/local/pf/logs/pfdhcplistener.log
 log4perl.appender.DHCP_PROCESSING.mode                          = append
 log4perl.appender.DHCP_PROCESSING.layout                        = PatternLayout

--- a/conf/log.conf.d/pfbandwidthd.conf.example
+++ b/conf/log.conf.d/pfbandwidthd.conf.example
@@ -6,7 +6,7 @@ log4perl.rootLogger = INFO, PFBANDWIDTHD
 #log4perl.category.pf.SNMP = WARN
 
 ### Logging for pfbandwidthd
-log4perl.appender.PFBANDWIDTHD                              = Log::Log4perl::Appender::File
+log4perl.appender.PFBANDWIDTHD                              = pf::log::FileAppender
 log4perl.appender.PFBANDWIDTHD.filename                     = /usr/local/pf/logs/pfbandwidthd.log
 log4perl.appender.PFBANDWIDTHD.syswrite                     = 1
 log4perl.appender.PFBANDWIDTHD.mode                         = append

--- a/conf/log.conf.d/pfconfig.conf.example
+++ b/conf/log.conf.d/pfconfig.conf.example
@@ -6,7 +6,7 @@ log4perl.rootLogger = ERROR, PFCONFIG
 #log4perl.category.pf.SNMP = WARN
 
 ### Logging for pfdns
-log4perl.appender.PFCONFIG                              = Log::Log4perl::Appender::File
+log4perl.appender.PFCONFIG                              = pf::log::FileAppender
 log4perl.appender.PFCONFIG.filename                     = /usr/local/pf/logs/pfconfig.log
 log4perl.appender.PFCONFIG.syswrite                     = 1
 log4perl.appender.PFCONFIG.mode                         = append

--- a/conf/log.conf.d/pfdetect.conf.example
+++ b/conf/log.conf.d/pfdetect.conf.example
@@ -6,7 +6,7 @@ log4perl.rootLogger = INFO, PFDETECT
 #log4perl.category.pf.SNMP = WARN
 
 ### Logging for pfdetect
-log4perl.appender.PFDETECT                              = Log::Log4perl::Appender::File
+log4perl.appender.PFDETECT                              = pf::log::FileAppender
 log4perl.appender.PFDETECT.filename                     = /usr/local/pf/logs/pfdetect.log
 log4perl.appender.PFDETECT.syswrite                     = 1
 log4perl.appender.PFDETECT.mode                         = append

--- a/conf/log.conf.d/pfdhcplistener.conf.example
+++ b/conf/log.conf.d/pfdhcplistener.conf.example
@@ -6,7 +6,7 @@ log4perl.rootLogger = INFO, PFDHCPLISTENER
 #log4perl.category.pf.SNMP = WARN
 
 ### Logging for pfdhcplistener
-log4perl.appender.PFDHCPLISTENER                              = Log::Log4perl::Appender::File
+log4perl.appender.PFDHCPLISTENER                              = pf::log::FileAppender
 log4perl.appender.PFDHCPLISTENER.filename                     = /usr/local/pf/logs/pfdhcplistener.log
 log4perl.appender.PFDHCPLISTENER.syswrite                     = 1
 log4perl.appender.PFDHCPLISTENER.mode                         = append

--- a/conf/log.conf.d/pfdns.conf.example
+++ b/conf/log.conf.d/pfdns.conf.example
@@ -6,7 +6,7 @@ log4perl.rootLogger = INFO, PFDNS
 #log4perl.category.pf.SNMP = WARN
 
 ### Logging for pfdns
-log4perl.appender.PFDNS                              = Log::Log4perl::Appender::File
+log4perl.appender.PFDNS                              = pf::log::FileAppender
 log4perl.appender.PFDNS.filename                     = /usr/local/pf/logs/pfdns.log
 log4perl.appender.PFDNS.syswrite                     = 1
 log4perl.appender.PFDNS.mode                         = append

--- a/conf/log.conf.d/pfmon.conf.example
+++ b/conf/log.conf.d/pfmon.conf.example
@@ -6,7 +6,7 @@ log4perl.rootLogger = INFO, PFMON
 #log4perl.category.pf.SNMP = WARN
 
 ### Logging for pfmon
-log4perl.appender.PFMON                              = Log::Log4perl::Appender::File
+log4perl.appender.PFMON                              = pf::log::FileAppender
 log4perl.appender.PFMON.filename                     = /usr/local/pf/logs/pfmon.log
 log4perl.appender.PFMON.syswrite                     = 1
 log4perl.appender.PFMON.mode                         = append

--- a/conf/log.conf.d/pfqueue.conf.example
+++ b/conf/log.conf.d/pfqueue.conf.example
@@ -18,7 +18,7 @@ log4perl.category.pf.dhcp = INFO, DHCP_PROCESSING
 log4perl.additivity.pf.dhcp = 0
 
 ### Logging for pfqueue
-log4perl.appender.PFQUEUE                              = Log::Log4perl::Appender::File
+log4perl.appender.PFQUEUE                              = pf::log::FileAppender
 log4perl.appender.PFQUEUE.filename                     = /usr/local/pf/logs/pfqueue.log
 log4perl.appender.PFQUEUE.syswrite                     = 1
 log4perl.appender.PFQUEUE.mode                         = append
@@ -30,7 +30,7 @@ log4perl.appender.PFQUEUE.group                        = pf
 log4perl.appender.PFQUEUE.binmode                      = utf8
 
 ### General Fingerbank log facility configuration ###
-log4perl.appender.FINGERBANK                           = Log::Log4perl::Appender::File
+log4perl.appender.FINGERBANK                           = pf::log::FileAppender
 log4perl.appender.FINGERBANK.filename                  = /usr/local/fingerbank/logs/fingerbank.log
 log4perl.appender.FINGERBANK.mode                      = append
 log4perl.appender.FINGERBANK.layout                    = PatternLayout
@@ -41,7 +41,7 @@ log4perl.appender.FINGERBANK.group                     = fingerbank
 log4perl.appender.FINGERBANK.binmode                   = utf8
 #
 ### DHCP processing log facility configuration ###
-log4perl.appender.DHCP_PROCESSING                               = Log::Log4perl::Appender::File
+log4perl.appender.DHCP_PROCESSING                               = pf::log::FileAppender
 log4perl.appender.DHCP_PROCESSING.filename                      = /usr/local/pf/logs/pfdhcplistener.log
 log4perl.appender.DHCP_PROCESSING.mode                          = append
 log4perl.appender.DHCP_PROCESSING.layout                        = PatternLayout

--- a/conf/log.conf.d/pfsetvlan.conf.example
+++ b/conf/log.conf.d/pfsetvlan.conf.example
@@ -6,7 +6,7 @@ log4perl.rootLogger = INFO, PFSETVLAN
 #log4perl.category.pf.SNMP = WARN
 
 ### Logging for pfsetvlan
-log4perl.appender.PFSETVLAN                              = Log::Log4perl::Appender::File
+log4perl.appender.PFSETVLAN                              = pf::log::FileAppender
 # Replace /usr/local/pf/logs/packetfence.log by /usr/local/pf/logs/pfsetvlan.log to allow
 # pfsetvlan to log in its own log file.
 log4perl.appender.PFSETVLAN.filename                     = /usr/local/pf/logs/packetfence.log

--- a/lib/pf/log/FileAppender.pm
+++ b/lib/pf/log/FileAppender.pm
@@ -1,0 +1,15 @@
+package pf::log::FileAppender;
+use base qw( Log::Log4perl::Appender::File );
+use strict;
+use warnings;
+
+sub log {
+     my($self, @args) = @_;
+
+     local $Log::Log4perl::caller_depth =
+           $Log::Log4perl::caller_depth + 1;
+
+     eval { $self->SUPER::log(@args) };
+}
+
+1;

--- a/lib/pf/log/FileAppender.pm
+++ b/lib/pf/log/FileAppender.pm
@@ -1,4 +1,17 @@
 package pf::log::FileAppender;
+
+=head1 NAME
+
+pf::log::FileAppender
+
+=cut
+
+=head1 DESCRIPTION
+
+Used to extend the Log4perl file appender so it doesn't die on failure.
+
+=cut
+
 use base qw( Log::Log4perl::Appender::File );
 use strict;
 use warnings;
@@ -12,4 +25,32 @@ sub log {
      eval { $self->SUPER::log(@args) };
 }
 
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2016 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
 1;
+


### PR DESCRIPTION
# Description
Don't die when logger fails to write line

# Impacts
Logging

# Issue
fixes #1734 

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* Prevent logging failure from making a process die (fixes #1734)

# UPGRADE file entries

In order to be sure all your logging facilities use the new logging backend which ensures the processes won't die in case of a logging failure, you must execute the following command:
```
# find conf/log.conf.d/ -type f -exec sed -i.bak "s/Log::Log4perl::Appender::File/pf::log::FileAppender/g" {} \; ; find conf/log.conf.d/ -name '*.bak' -delete
```