### PR TITLE
Replacement of the Windows DHCP sensor section (UDP-Reflector) with DHCP-Forwarder.

### DIFF
--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -3755,7 +3755,7 @@ It will install WinPCAP, nssm, launch a configurator to ask for interface, IP an
 
 When you will be asked for a host IP and port, specify PacketFence management IP and 767 as the UDP port.
 
-The projet page is https://github.com/inverse-inc/packetfence-dhcp-forwarder[here].
+The project page can be found https://github.com/inverse-inc/packetfence-dhcp-forwarder[here].
 
 Linux based sensor
 ^^^^^^^^^^^^^^^^^^

--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -3749,13 +3749,13 @@ Microsoft DHCP sensor
 ^^^^^^^^^^^^^^^^^^^^^
 DHCP-Forwarder is an optimized version of precedent udp-reflector, which installs easily and only copy DHCPREQUESTS and DHCPACK packets to the destination. 
 
-[Download the installer here.](https://inverse.ca/downloads/PacketFence/windows-dhcp-forwarder/DHCP%20Forwarder%20Installer.exe)
+https://inverse.ca/downloads/PacketFence/windows-dhcp-forwarder/DHCP%20Forwarder%20Installer.exe[Download the installer here.]
 
 It will install WinPCAP, nssm, launch a configurator to ask for interface, IP and port, save the configuration, install and launch DHCP-Forwarder service.
 
 When you will be asked for a host IP and port, specify PacketFence management IP and 667 as the UDP port.
 
-The projet page is [here](https://github.com/inverse-inc/packetfence-dhcp-forwarder).
+The projet page is https://github.com/inverse-inc/packetfence-dhcp-forwarder[here].
 
 Linux based sensor
 ^^^^^^^^^^^^^^^^^^

--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -3747,45 +3747,15 @@ These sensors work by capturing the packets at the lowest level possible on your
 
 Microsoft DHCP sensor
 ^^^^^^^^^^^^^^^^^^^^^
+DHCP-Forwarder is an optimized version of precedent udp-reflector, which installs easily and only copy DHCPREQUESTS and DHCPACK packets to the destination. 
 
-You will first need to download and install 'WinPcap' available from http://www.winpcap.org/install/
+[Download the installer here.](https://inverse.ca/downloads/PacketFence/windows-dhcp-forwarder/DHCP%20Forwarder%20Installer.exe)
 
-You will also need to download and install 'Microsoft Visual C++ 2010 Redistributable' available from http://www.microsoft.com/download/details.aspx?id=5555
+It will install WinPCAP, nssm, launch a configurator to ask for interface, IP and port, save the configuration, install and launch DHCP-Forwarder service.
 
-NOTE: You absolutely need to install the 32-bit version of 'Microsoft Visual C++ 2010 Redistributable' even if you are using a 64-bit operating system.
+When you will be asked for a host IP and port, specify PacketFence management IP and 667 as the UDP port.
 
-Then get the remote sensor from Inverse's download website http://inverse.ca/downloads/PacketFence/udp-reflector/udp_reflector.exe
-
-Create the directory `C:\udp-reflector` and move the downloaded file inside.
-
-Now we will create a service so the reflector starts on boot.
-
-First download and unzip nssm from https://nssm.cc/download
-
-Next create a batch file `udpreflector.bat` in `C:\udp-reflector` that contain:
-`C:\udp-reflector\udp_reflector.exe -s pcap0:67 -d 192.168.1.5:767 -b 25000`
-
-Where `pcap0` is the interface where your DHCP is listening (use `C:\udp-reflector\udp_reflector.exe -l` to list interfaces)
-
-Then run `nssm install udpreflector`
-
-In Application:
-[options="compact"]
-* In 'Path' set it to `C:\udp-reflector\udpreflector.bat`
-* In 'Startup directory' set it to `C:\udp-reflector\`
-* In 'Arguments' set it to nothing
-
-In Details:
-[options="compact"]
-* In 'Startup type' select Automatic
-
-In Log on:
-[options="compact"]
-* In 'Log on as' select Local System account
-
-Then press 'Install service'
-
-The DHCP traffic should now be reflected on your PacketFence server.
+The projet page is [here](https://github.com/inverse-inc/packetfence-dhcp-forwarder).
 
 Linux based sensor
 ^^^^^^^^^^^^^^^^^^

--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -3753,7 +3753,7 @@ https://inverse.ca/downloads/PacketFence/windows-dhcp-forwarder/DHCP%20Forwarder
 
 It will install WinPCAP, nssm, launch a configurator to ask for interface, IP and port, save the configuration, install and launch DHCP-Forwarder service.
 
-When you will be asked for a host IP and port, specify PacketFence management IP and 667 as the UDP port.
+When you will be asked for a host IP and port, specify PacketFence management IP and 767 as the UDP port.
 
 The projet page is https://github.com/inverse-inc/packetfence-dhcp-forwarder[here].
 


### PR DESCRIPTION
# Description
Replaces udp-reflector documentation and launches DHCP-Forwarder.

# Delete branch after merge
YES

# NEWS file entries
* DHCP-Forwarder Installer replaces complicated udp-reflector deployement. IP helpers no more?

## Enhancements
* We could receive only 18% of the DHCP traffic we currently receive, thanks to DHCP-Forwarder. (see dhcp-forwarder/TESTING.md)

# UPGRADE file entries
* Should we create a uninstall guide for udp-reflector?
