### PR TITLE
Reduce p0f cpu usage

### DIFF
--- a/addons/packages/packetfence.spec
+++ b/addons/packages/packetfence.spec
@@ -274,6 +274,7 @@ Requires: perl(IO::Interface)
 Requires: perl(Time::Period)
 Requires: perl(Time::Piece)
 Requires: perl(Number::Range)
+Requires: perl(Algorithm::Combinatorics)
 Requires: iproute >= 3.0.0, krb5-workstation
 %{?el6:Requires: samba <= 3.9.9}
 %{?el7:Requires: samba >= 4}

--- a/debian/control
+++ b/debian/control
@@ -83,6 +83,7 @@ Depends: ${misc:Depends}, vlan,
  libsoap-lite-perl (>= 1.0), libnet-frame-perl, libthread-pool-perl,
  libwww-curl-perl, libposix-2008-perl, libdata-messagepack-stream-perl, libdata-messagepack-perl,
  libnet-nessus-xmlrpc-perl (>= 0.4), libnet-nessus-rest-perl (>= 0.2), libfile-slurp-perl,
+ libalgorithm-combinatronivs-perl,
 # required for ipset
  libnetaddr-ip-perl, libfile-which-perl,
 # FIXME track what requires the conveyor stuff and identify it. If we can, get rid of it.

--- a/debian/control
+++ b/debian/control
@@ -83,7 +83,7 @@ Depends: ${misc:Depends}, vlan,
  libsoap-lite-perl (>= 1.0), libnet-frame-perl, libthread-pool-perl,
  libwww-curl-perl, libposix-2008-perl, libdata-messagepack-stream-perl, libdata-messagepack-perl,
  libnet-nessus-xmlrpc-perl (>= 0.4), libnet-nessus-rest-perl (>= 0.2), libfile-slurp-perl,
- libalgorithm-combinatronivs-perl,
+ libalgorithm-combinatorics-perl,
 # required for ipset
  libnetaddr-ip-perl, libfile-which-perl,
 # FIXME track what requires the conveyor stuff and identify it. If we can, get rid of it.


### PR DESCRIPTION
# Description
P0f doen't allow to listen on multiples interfaces (-i eth0 -i eth1 ...), so in order to reduce the number of packets it has to process this code generate a bpf filter to remove traffic between each packetfence's server (cluster) and remove all the 'lo' traffic (net 127.0.0.0/8 and 0:0:0:0:0:0:0:1 ipv6 address).

# Impacts
Reduce cpu usage

# NEW Package(s) required
Algorithm::Combinatorics (http://search.cpan.org/~fxn/Algorithm-Combinatorics-0.27/Combinatorics.pm)

# Delete branch after merge
YES

# NEWS file entries

## Enhancements
* Reduce p0f cpu usage
