### PR TITLE
Do not log weak authentication methods passwords (ex. PAP) in CLI audit logs.

### DIFF
--- a/conf/radiusd/load_balancer.conf.example
+++ b/conf/radiusd/load_balancer.conf.example
@@ -127,8 +127,8 @@ log {
 	#
 	#  allowed values: {no, yes}
 	#
-	auth_badpass = yes
-	auth_goodpass = yes
+	auth_badpass = no
+	auth_goodpass = no
 
 	#  Log additional text at the end of the "Login OK" messages.
 	#  for these to work, the "auth" and "auth_goodpass" or "auth_badpass"

--- a/conf/radiusd/packetfence-cli.example
+++ b/conf/radiusd/packetfence-cli.example
@@ -307,6 +307,7 @@ post-auth {
 		&control:PacketFence-RPC-User = ${rpc_user}
 		&control:PacketFence-RPC-Pass = ${rpc_pass}
 		&control:PacketFence-RPC-Proto = ${rpc_proto}
+		&request:User-Password := "******"
 	}
 	#
 	#  For EAP-TTLS and PEAP, add the cached attributes to the reply.
@@ -337,6 +338,9 @@ post-auth {
 	#  The "session-state" attributes are not available here.
 	#
 	Post-Auth-Type REJECT {
+		update {
+			&request:User-Password := "******"
+		}
 		if (! EAP-Type || (EAP-Type != TTLS  && EAP-Type != PEAP) ) {
 			packetfence-audit-log-reject
 		}

--- a/conf/radiusd/packetfence-tunnel.example
+++ b/conf/radiusd/packetfence-tunnel.example
@@ -238,10 +238,10 @@ session {
 #  the ONLY safe way is to set "use_tunneled_reply = yes", and
 #  then update the inner-tunnel reply.
 post-auth {
-	update {
-		&request:User-Password := "******"
-	}
 	rest
+	update {
+                &request:User-Password := "******"
+        }
 	if (&reply:PacketFence-Authorization-Status == "deny") {
 		packetfence-audit-log-reject
 		reject

--- a/conf/radiusd/packetfence-tunnel.example
+++ b/conf/radiusd/packetfence-tunnel.example
@@ -238,7 +238,9 @@ session {
 #  the ONLY safe way is to set "use_tunneled_reply = yes", and
 #  then update the inner-tunnel reply.
 post-auth {
-	#
+	update {
+		&request:User-Password := "******"
+	}
 	rest
 	if (&reply:PacketFence-Authorization-Status == "deny") {
 		packetfence-audit-log-reject
@@ -282,6 +284,9 @@ post-auth {
 	#  'edir_account_policy_check = yes' in the ldap module configuration
 	#
 	Post-Auth-Type REJECT {
+		update {
+			&request:User-Password := "******"
+		}
 		packetfence-audit-log-reject
 		attr_filter.access_reject
 

--- a/conf/radiusd/packetfence.example
+++ b/conf/radiusd/packetfence.example
@@ -331,6 +331,9 @@ post-auth {
 	# send it to packetfence
 	if (! EAP-Type || (EAP-Type != TTLS  && EAP-Type != PEAP) ) {
 		rest
+                update {
+                       &request:User-Password := "******"
+                }
 		if (&reply:PacketFence-Authorization-Status == "deny") {
 			packetfence-audit-log-reject
 			reject
@@ -351,6 +354,9 @@ post-auth {
 	#  The "session-state" attributes are not available here.
 	#
 	Post-Auth-Type REJECT {
+		update {
+                        &request:User-Password := "******"
+                }
 		if (! EAP-Type || (EAP-Type != TTLS  && EAP-Type != PEAP) ) {
 			packetfence-audit-log-reject
 		}


### PR DESCRIPTION
To generalize?

# Description
Modify RADIUS Packetfence-CLI so that even weak password authentication methods do not result in password leaks in PacketFence audit logs.

# Impacts
RADIUS audit logs.

# Delete branch after merge
YES

## Enhancements

# UPGRADE file entries
How should we proceed?