### PR TITLE
Fix/reg after status

### DIFF
--- a/conf/profiles.conf.defaults
+++ b/conf/profiles.conf.defaults
@@ -26,3 +26,4 @@ scans=
 reuse_dot1x_credentials=0
 sources=
 provisioners=
+access_registration_when_registered=disabled

--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -1831,6 +1831,11 @@ Where :
 
 Now everytime a user unsubscribes from a plan, PacketFence will be notified and will unregister that device from your network.
 
+Extending access before it ends
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+PacketFence allows users to extend their access before it has ended. In order to do so, you need to enable 'Allow access to registration portal when registered' accessible via the 'Captive Portal' tab of the 'Portal Profiles'. Once this is activated, the users can reach https://YOUR_PORTAL_IP/status and select 'Extend your access' in order to be able to access the billing section after they have registered.
+
 Devices Registration
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Status.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Status.pm
@@ -49,6 +49,7 @@ sub index : Path : Args(0) {
         title => "State - Network Access",
         template => 'status.html',
         billing  => $c->profile->hasBilling(),
+        access_registration_when_registered => $c->profile->canAccessRegistrationWhenRegistered(),
     );
 }
 

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Root.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Root.pm
@@ -209,7 +209,10 @@ sub execute_child {
     # HACK alert : E-mail registration has the user registered but still going in the portal
     # release_bypass is there for that. If it is set, it will keep the user in the portal
     my $node = node_view($self->current_mac);
-    if(defined($node->{status}) && $node->{status} eq "reg" && !$self->app->session->{release_bypass}){
+    if($self->app->profile->canAccessRegistrationWhenRegistered() && $self->app->session->{release_bypass}) {
+        get_logger->info("Allowing user through portal even though he is registered as the release bypass is set and the portal profile is configured to let registered users use the registration module of the portal.");
+    }
+    elsif(defined($node->{status}) && $node->{status} eq "reg"){
         return $self->unknown_state();
     }
     $self->SUPER::execute_child();

--- a/html/captive-portal/templates/status.html
+++ b/html/captive-portal/templates/status.html
@@ -161,8 +161,8 @@ $(document).ready(function() {
         </div>
       </button>
 
-      [%- IF billing %]
-      <a href="[% URL_STATUS_BILLING %]" class="btn btn--full btn--light u-mt">
+      [%- IF billing && access_registration_when_registered %]
+      <a href="/status/billing" class="btn btn--full btn--light u-mt">
         <div class="flag">
           <div class="flag__img">[% svgIcon(id='ic_credit_card_black_24px',size='small') %]</div>
           <p class="flag__body">[% i18n("Extend your access") %]</p>

--- a/html/pfappserver/lib/pfappserver/Form/Config/ProfileCommon.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/ProfileCommon.pm
@@ -48,7 +48,7 @@ The captival portal block
 
 has_block 'captive_portal' =>
   (
-    render_list => [qw(logo redirecturl always_use_redirecturl nbregpages block_interval sms_pin_retry_limit sms_request_limit login_attempt_limit)],
+    render_list => [qw(logo redirecturl always_use_redirecturl nbregpages block_interval sms_pin_retry_limit sms_request_limit login_attempt_limit access_registration_when_registered)],
   );
 
 =head1 Fields
@@ -402,6 +402,22 @@ has_field 'scans.contains' =>
     type => 'Select',
     options_method => \&options_scan,
     widget_wrapper => 'DynamicTableRow',
+  );
+
+=head2 preregistration
+
+Controls whether or not this portal profile is used for preregistration
+
+=cut
+
+has_field 'access_registration_when_registered' =>
+  (
+   type => 'Toggle',
+   label => 'Allow access to registration portal when registered',
+   checkbox_value => 'enabled',
+   unchecked_value => 'disabled',
+   tags => { after_element => \&help,
+             help => 'This allows already registered users to be able to re-register their device by first accessing the status page and then accessing the portal. This is useful to allow users to extend their access even though they are already registered.' },
   );
 
 

--- a/lib/pf/Portal/Profile.pm
+++ b/lib/pf/Portal/Profile.pm
@@ -591,6 +591,17 @@ sub getLocalizedTemplate {
     return $base_template;
 }
 
+=item canAccessRegistrationWhenRegistered
+
+Should the user be able to access the registration part of the portal even if he is registered
+
+=cut
+
+sub canAccessRegistrationWhenRegistered {
+    my ($self) = @_;
+    return isenabled($self->{_access_registration_when_registered});
+}
+
 =back
 
 =head1 AUTHOR

--- a/lib/pf/pfcmd/checkup.pm
+++ b/lib/pf/pfcmd/checkup.pm
@@ -1030,7 +1030,7 @@ sub portal_profiles {
         billing_tiers|description|sources|redirecturl|always_use_redirecturl|
         nbregpages|allowed_devices|allow_android_devices|
         reuse_dot1x_credentials|provisioners|filter_match_style|sms_pin_retry_limit|
-        sms_request_limit|login_attempt_limit|block_interval|dot1x_recompute_role_from_portal|scan|root_module|preregistration|autoregister)/x;
+        sms_request_limit|login_attempt_limit|block_interval|dot1x_recompute_role_from_portal|scan|root_module|preregistration|autoregister|access_registration_when_registered)/x;
     my $validator = pf::validation::profile_filters->new;
 
     foreach my $portal_profile ( keys %Profiles_Config ) {


### PR DESCRIPTION
# Description
This will prevent access to the registration portal after reaching the status page unless explicitly allowed by the administrator on a portal profile basis

# Impacts
Status page flow

# Issue
fixes #1877 

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* Fix devices gaining access to registration section of the portal even though they were already registered (#1877)

# UPGRADE notes

PacketFence will not allow access to the registration section of the portal (signup/billing/login) when a device is registered unless access_registration_when_registered is enabled in the portal profile. That means if you have users that need to be able to register on the portal even when they are already registered (like when renewing paid access), make sure you activate this parameter on your portal profile.
