### PR TITLE
Fixed "autoreg" field not set in db.

### DIFF
--- a/lib/pf/node.pm
+++ b/lib/pf/node.pm
@@ -867,13 +867,6 @@ sub node_modify {
         return (0);
     }
 
-    # hack to support an additional autoreg param to the sub without changing the hash to a reference everywhere
-    my $auto_registered = 0;
-    if (defined($data{'auto_registered'})) {
-        $auto_registered = 1;
-        delete($data{'auto_registered'});
-    }
-
     if ( !node_exist($mac) ) {
         if ( node_add_simple($mac) ) {
             $logger->info(
@@ -919,9 +912,7 @@ sub node_modify {
     pf::ipset::iptables_update_set($mac, $old_role_id, $new_role_id) if (defined($node_info->{'last_connection_type'}) && $node_info->{'last_connection_type'} eq $connection_type_to_str{$INLINE});
 
     # Autoregistration handling
-    if (!defined($data{'autoreg'}) && (!defined($existing->{autoreg}) || $existing->{autoreg} ne 'yes' )) {
-        $existing->{autoreg} = 'no';
-    }
+    if (defined($data{'autoreg'})) {  $existing->{autoreg} = $data{'autoreg'}; }
 
     _cleanup_attributes($existing);
 
@@ -1061,6 +1052,7 @@ sub node_deregister {
     $info{'regdate'}   = 0;
     $info{'unregdate'} = 0;
     $info{'lastskip'}  = 0;
+    $info{'autoreg'}   = 'no';
 
     my $profile = pf::Portal::ProfileFactory->instantiate($mac);
     if(my $provisioner = $profile->findProvisioner($mac)){

--- a/lib/pf/role.pm
+++ b/lib/pf/role.pm
@@ -126,12 +126,6 @@ sub fetchRoleForNode {
     # there were no violation, now onto registration handling
     $answer = $self->getRegistrationRole($args);
     if (defined($answer->{role}) && $answer->{role} ne "0") {
-        if ( $args->{'connection_type'} && ($args->{'connection_type'} & $WIRELESS_MAC_AUTH) == $WIRELESS_MAC_AUTH ) {
-            if (isenabled($node_info->{'autoreg'})) {
-                $logger->info("Connection type is WIRELESS_MAC_AUTH and the device was coming from a secure SSID with auto registration");
-                node_modify($args->{'mac'}, ('autoreg' => 'no'));
-            }
-        }
         return $answer;
     }
 
@@ -451,7 +445,6 @@ sub getRegisteredRole {
             pf::lookup::person::async_lookup_person($args->{'user_name'}, $source) if !($args->{'autoreg'});
             $portal = $profile->getName;
             my %info = (
-                'autoreg' => 'no',
                 'pid' => $args->{'user_name'},
             );
             if (defined $unregdate) {


### PR DESCRIPTION
# Description
fetchRoleForNode overwrites the autoreg field in the database.
Therefore the field is never set to "yes" and any filter that relies upon it will never match.
This fixes that.

# Impacts
autoreg should equal 'yes' in the node table when a device has been autoregistered
Conversely, when the device has been unregistered, or not autoregistered the field should be equal to 'no'.

# Issue
fixes #1883

# Delete branch after merge
YES 

# NEWS file entries

## Bug Fixes
* autoreg flag is now set correctly (#1883)


