### PR TITLE
Because sometimes we need a different port for the coa and disconnect

### DIFF
--- a/html/pfappserver/lib/pfappserver/Form/Config/Switch.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Switch.pm
@@ -300,7 +300,7 @@ has_field macSearchesSleepInterval  =>
 
 has_block definition =>
   (
-   render_list => [ qw(description type mode group deauthMethod useCoA cliAccess ExternalPortalEnforcement VoIPEnabled VoIPLLDPDetect VoIPCDPDetect VoIPDHCPDetect uplink_dynamic uplink controllerIp controllerPort) ],
+   render_list => [ qw(description type mode group deauthMethod useCoA cliAccess ExternalPortalEnforcement VoIPEnabled VoIPLLDPDetect VoIPCDPDetect VoIPDHCPDetect uplink_dynamic uplink controllerIp controllerPort coaPort) ],
   );
 has_field 'SNMPVersion' =>
   (
@@ -485,7 +485,17 @@ has_field controllerIp =>
 has_field controllerPort =>
   (
     type => 'PosInteger',
-    label => 'Controller Port',
+    label => 'Disconnect Port',
+    tags => {
+        after_element => \&help_list,
+        help => 'For Disconnect request, if we have to send to another port'
+    },
+  );
+
+has_field coaPort =>
+  (
+    type => 'PosInteger',
+    label => 'CoA Port',
     tags => {
         after_element => \&help_list,
         help => 'For CoA request, if we have to send to another port'

--- a/html/pfappserver/lib/pfappserver/Form/Config/Switch.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Switch.pm
@@ -300,7 +300,7 @@ has_field macSearchesSleepInterval  =>
 
 has_block definition =>
   (
-   render_list => [ qw(description type mode group deauthMethod useCoA cliAccess ExternalPortalEnforcement VoIPEnabled VoIPLLDPDetect VoIPCDPDetect VoIPDHCPDetect uplink_dynamic uplink controllerIp controllerPort coaPort) ],
+   render_list => [ qw(description type mode group deauthMethod useCoA cliAccess ExternalPortalEnforcement VoIPEnabled VoIPLLDPDetect VoIPCDPDetect VoIPDHCPDetect uplink_dynamic uplink controllerIp disconnectPort coaPort) ],
   );
 has_field 'SNMPVersion' =>
   (
@@ -482,7 +482,7 @@ has_field controllerIp =>
     },
   );
 
-has_field controllerPort =>
+has_field disconnectPort =>
   (
     type => 'PosInteger',
     label => 'Disconnect Port',

--- a/lib/pf/Switch.pm
+++ b/lib/pf/Switch.pm
@@ -311,6 +311,7 @@ sub new {
         '_radiusSecret'                 => undef,
         '_controllerIp'                 => undef,
         '_controllerPort'               => undef,
+        '_coaPort'                      => undef,
         '_uplink'                       => undef,
         '_vlans'                        => undef,
         '_ExternalPortalEnforcement'    => 'disabled',    

--- a/lib/pf/Switch.pm
+++ b/lib/pf/Switch.pm
@@ -310,7 +310,7 @@ sub new {
         '_wsTransport'                  => undef,
         '_radiusSecret'                 => undef,
         '_controllerIp'                 => undef,
-        '_controllerPort'               => undef,
+        '_disconnectPort'               => undef,
         '_coaPort'                      => undef,
         '_uplink'                       => undef,
         '_vlans'                        => undef,
@@ -542,7 +542,7 @@ Establishes an SNMP write connection to the controller of the network device as 
 
 sub connectWriteToController {
     my $self   = shift;
-    return $self->connectWriteTo($self->{_controllerIp}, '_sessionControllerWrite',$self->{_controllerPort});
+    return $self->connectWriteTo($self->{_controllerIp}, '_sessionControllerWrite',$self->{_disconnectPort});
 }
 
 =item disconnectWriteTo
@@ -2754,8 +2754,8 @@ sub radiusDisconnect {
             LocalAddr => $self->deauth_source_ip(),
         };
 
-        if (defined($self->{'_controllerPort'}) && $self->{'_controllerPort'} ne '') {
-            $connection_info->{'nas_port'} = $self->{'_controllerPort'};
+        if (defined($self->{'_disconnectPort'}) && $self->{'_disconnectPort'} ne '') {
+            $connection_info->{'nas_port'} = $self->{'_disconnectPort'};
         }
 
         # transforming MAC to the expected format 00-11-22-33-CA-FE

--- a/lib/pf/Switch/Cisco/WLC.pm
+++ b/lib/pf/Switch/Cisco/WLC.pm
@@ -476,7 +476,7 @@ sub radiusDisconnect {
         $send_disconnect_to = $self->{'_controllerIp'};
     }
     # On which port we have to send the CoA-Request ?
-    my $nas_port = $self->{'_controllerPort'} || '3799';
+    my $nas_port = $self->{'_disconnectPort'} || '3799';
     my $coa_port = $self->{'_coaPort'} || '1700';
     # allowing client code to override where we connect with NAS-IP-Address
     $send_disconnect_to = $add_attributes_ref->{'NAS-IP-Address'}
@@ -548,7 +548,7 @@ sub radiusDisconnect {
     } catch {
         chomp;
         $logger->warn("Unable to perform RADIUS CoA-Request on (".$self->{'_id'}."): $_");
-        $logger->error("Wrong RADIUS secret or unreachable network device (".$self->{'_id'}.")... On some Cisco Wireless Controllers you might have to set controllerPort=1700 as some versions ignore the CoA requests on port 3799") if ($_ =~ /^Timeout/);
+        $logger->error("Wrong RADIUS secret or unreachable network device (".$self->{'_id'}.")... On some Cisco Wireless Controllers you might have to set disconnectPort=1700 as some versions ignore the CoA requests on port 3799") if ($_ =~ /^Timeout/);
     };
     return if (!defined($response));
 

--- a/lib/pf/Switch/Cisco/WLC.pm
+++ b/lib/pf/Switch/Cisco/WLC.pm
@@ -477,6 +477,7 @@ sub radiusDisconnect {
     }
     # On which port we have to send the CoA-Request ?
     my $nas_port = $self->{'_controllerPort'} || '3799';
+    my $coa_port = $self->{'_coaPort'} || '1700';
     # allowing client code to override where we connect with NAS-IP-Address
     $send_disconnect_to = $add_attributes_ref->{'NAS-IP-Address'}
         if (defined($add_attributes_ref->{'NAS-IP-Address'}));
@@ -487,7 +488,7 @@ sub radiusDisconnect {
             nas_ip => $send_disconnect_to,
             secret => $self->{'_radiusSecret'},
             LocalAddr => $self->deauth_source_ip(),
-            nas_port => $nas_port,
+            nas_port => $coa_port,
         };
 
         $logger->debug("network device (".$self->{'_id'}.") supports roles. Evaluating role to be returned");

--- a/lib/pf/Switch/HP/Controller_MSM710.pm
+++ b/lib/pf/Switch/HP/Controller_MSM710.pm
@@ -189,10 +189,10 @@ sub _deauthenticateMacWithSSH {
     my $logger = $self->logger;
     my $session;
     my @addition_ops;
-    if (defined $self->{_controllerPort} && $self->{_cliTransport} eq 'SSH' ) {
+    if (defined $self->{_disconnectPort} && $self->{_cliTransport} eq 'SSH' ) {
         @addition_ops = (
             connect_options => {
-                ops => [ '-p' => $self->{_controllerPort}  ]
+                ops => [ '-p' => $self->{_disconnectPort}  ]
             }
         );
     }

--- a/lib/pf/Switch/HP/MSM.pm
+++ b/lib/pf/Switch/HP/MSM.pm
@@ -45,10 +45,10 @@ sub _deauthenticateMacWithSSH {
     my $logger = $self->logger;
     my $session;
     my @addition_ops;
-    if (defined $self->{_controllerPort} && $self->{_cliTransport} eq 'SSH' ) {
+    if (defined $self->{_disconnectPort} && $self->{_cliTransport} eq 'SSH' ) {
         @addition_ops = (
             connect_options => {
-                ops => [ '-p' => $self->{_controllerPort}  ]
+                ops => [ '-p' => $self->{_disconnectPort}  ]
             }
         );
     }

--- a/lib/pf/Switch/Meraki/MR_v2.pm
+++ b/lib/pf/Switch/Meraki/MR_v2.pm
@@ -80,7 +80,7 @@ sub radiusDisconnect {
         $send_disconnect_to = $self->{'_controllerIp'};
     }
     # On which port we have to send the CoA-Request ?
-    my $nas_port = $self->{'_controllerPort'} || '3799';
+    my $nas_port = $self->{'_disconnectPort'} || '3799';
     # allowing client code to override where we connect with NAS-IP-Address
     $send_disconnect_to = $add_attributes_ref->{'NAS-IP-Address'}
         if (defined($add_attributes_ref->{'NAS-IP-Address'}));

--- a/lib/pf/Switch/Mojo.pm
+++ b/lib/pf/Switch/Mojo.pm
@@ -126,7 +126,7 @@ sub radiusDisconnect {
         $send_disconnect_to = $self->{'_controllerIp'};
     }
     # On which port we have to send the CoA-Request ?
-    my $nas_port = $self->{'_controllerPort'} || '3799';
+    my $nas_port = $self->{'_disconnectPort'} || '3799';
     # allowing client code to override where we connect with NAS-IP-Address
     $send_disconnect_to = $add_attributes_ref->{'NAS-IP-Address'}
         if (defined($add_attributes_ref->{'NAS-IP-Address'}));


### PR DESCRIPTION
# Description
Some wlc use the 2 port , one for disconect and the other one for coa.
Added an option to define both.

# Impacts
Cisco WLC

# Delete branch after merge
YES

# NEWS file entries

## Enhancements
* Added a way to define 2 differents port for dicsonnect and coa

# UPGRADE file entries
Update controllerPort to disconnectPort in switches.conf (find . -name "switches.conf" -exec sed -i "s/controllerPort/disconnectPort/g" '{}' \;)
