### PR TITLE
Use rotation parameters to deletion when rotation is disabled

### DIFF
--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1485,31 +1485,31 @@ type=toggle
 options=enabled|disabled
 description=<<EOT
 Enable or disable iplog rotation (moving iplog_history records to iplog_archive)
-If disabled, 'iplog_cleanup' will delete from the iplog_history table rather than the iplog_archive
+If disabled, 'iplog_cleanup' will delete from the iplog_history table rather than the iplog_archive using the iplog rotation window, interval, batch and timeout parameters.
 EOT
 
 [maintenance.iplog_rotation_window]
 type=time
 description=<<EOT
-How long to keep iplog history entry before rotating it to iplog archive
+How long to keep iplog history entry before rotating it to iplog archive (or deleting it if rotation is disabled).
 EOT
 
 [maintenance.iplog_rotation_interval]
 type=time
 description=<<EOT
-At which interval to run the iplog history rotation job
+At which interval to run the iplog history rotation job (or deletion job if rotation is disabled).
 EOT
 
 [maintenance.iplog_rotation_batch]
 type=numeric
 description=<<EOT
-How many iplog history entries to rotate in one job
+How many iplog history entries to rotate (or to delete if rotation is disabled) in one job.
 EOT
 
 [maintenance.iplog_rotation_timeout]
 type=time
 description=<<EOT
-How long a iplog history rotation job can take before being killed
+How long a iplog history rotation job (or deletion job if rotation is disabled) can take before being killed.
 EOT
 
 [maintenance.iplog_cleanup_window]

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -1139,27 +1139,27 @@ aaa_port=7070
 # maintenance.iplog_rotation
 #
 # Enable or disable iplog rotation (moving iplog_history records to iplog_archive)
-# If disabled, 'iplog_cleanup' will delete from the iplog_history table rather than the iplog_archive
+# If disabled, 'iplog_cleanup' will delete from the iplog_history table rather than the iplog_archive using the iplog rotation window, interval, batch and timeout parameters.
 iplog_rotation=disabled
 #
 # maintenance.iplog_rotation_window
 #
-# How long to keep iplog_history entry before rotating it to iplog_archive
+# How long to keep iplog history entry before rotating it to iplog archive (or deleting it if rotation is disabled).
 iplog_rotation_window=1W
 #
 # maintenance.iplog_rotation_interval
 #
-# At which interval to run the iplog_history rotation job
+# At which interval to run the iplog history rotation job (or deletion job if rotation is disabled).
 iplog_rotation_interval=60s
 #
 # maintenance.iplog_rotation_batch
 #
-# How many iplog_history entries to rotate in one job
+# How many iplog history entries to rotate (or to delete if rotation is disabled) in one job.
 iplog_rotation_batch=100
 #
 # maintenance.iplog_rotation_timeout
 #
-# How long a iplog_history rotation job can take before being killed
+# How long a iplog history rotation job (or deletion job if rotation is disabled) can take before being killed.
 iplog_rotation_timeout=10s
 #
 # maintenance.iplog_cleanup_window

--- a/sbin/pfmon
+++ b/sbin/pfmon
@@ -190,7 +190,7 @@ sub registertasks  {
             my $batch = ( isdisabled($Config{'maintenance'}{'iplog_rotation'}) ) ? $Config{maintenance}{iplog_rotation_batch} : $Config{maintenance}{iplog_cleanup_batch};
             my $timeout = ( isdisabled($Config{'maintenance'}{'iplog_rotation'}) ) ? $Config{maintenance}{iplog_rotation_timeout} : $Config{maintenance}{iplog_cleanup_timeout};
             my $table = ( isdisabled($Config{'maintenance'}{'iplog_rotation'}) ) ? 'iplog_history' : 'iplog_archive';
-            pf::iplog::cleanup( $Config{'maintenance'}{'iplog_cleanup_window'}, $Config{maintenance}{iplog_cleanup_batch}, $Config{maintenance}{iplog_cleanup_timeout}, $table );
+            pf::iplog::cleanup( $window, $batch, $timeout, $table ) if ( $Config{'maintenance'}{'iplog_cleanup_window'} );
         }
     ) if ( $Config{'maintenance'}{'iplog_cleanup_window'} );
 

--- a/sbin/pfmon
+++ b/sbin/pfmon
@@ -190,7 +190,7 @@ sub registertasks  {
             my $batch = ( isdisabled($Config{'maintenance'}{'iplog_rotation'}) ) ? $Config{maintenance}{iplog_rotation_batch} : $Config{maintenance}{iplog_cleanup_batch};
             my $timeout = ( isdisabled($Config{'maintenance'}{'iplog_rotation'}) ) ? $Config{maintenance}{iplog_rotation_timeout} : $Config{maintenance}{iplog_cleanup_timeout};
             my $table = ( isdisabled($Config{'maintenance'}{'iplog_rotation'}) ) ? 'iplog_history' : 'iplog_archive';
-            pf::iplog::cleanup( $window, $batch, $timeout, $table ) if ( $Config{'maintenance'}{'iplog_cleanup_window'} );
+            pf::iplog::cleanup( $window, $batch, $timeout, $table );
         }
     ) if ( $Config{'maintenance'}{'iplog_cleanup_window'} );
 

--- a/sbin/pfmon
+++ b/sbin/pfmon
@@ -184,8 +184,11 @@ sub registertasks  {
 
     register_task(
         'iplog cleanup',
-        'iplog_cleanup_interval',
+        ( isdisabled($Config{'maintenance'}{'iplog_rotation'}) ) ? 'iplog_rotation_interval' : 'iplog_cleanup_interval',
         sub {
+            my $window = ( isdisabled($Config{'maintenance'}{'iplog_rotation'}) ) ? $Config{'maintenance'}{'iplog_rotation_window'} : $Config{'maintenance'}{'iplog_cleanup_window'};
+            my $batch = ( isdisabled($Config{'maintenance'}{'iplog_rotation'}) ) ? $Config{maintenance}{iplog_rotation_batch} : $Config{maintenance}{iplog_cleanup_batch};
+            my $timeout = ( isdisabled($Config{'maintenance'}{'iplog_rotation'}) ) ? $Config{maintenance}{iplog_rotation_timeout} : $Config{maintenance}{iplog_cleanup_timeout};
             my $table = ( isdisabled($Config{'maintenance'}{'iplog_rotation'}) ) ? 'iplog_history' : 'iplog_archive';
             pf::iplog::cleanup( $Config{'maintenance'}{'iplog_cleanup_window'}, $Config{maintenance}{iplog_cleanup_batch}, $Config{maintenance}{iplog_cleanup_timeout}, $table );
         }


### PR DESCRIPTION
# Description
If you disable the iplog rotation, the table that gets cleaned is the iplog_history but it uses the retention parameter of the iplog_archive

We should either make documentation.conf clearer if thats the behavior we want or take the rotation parameter

# Impacts
* pfmon
* iplog cleanup
* iplog rotate

# Issue
fixes #1896

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* iplog rotation retention configuration is not always using the right param (#1896)