### PR TITLE
Make valid_from have a proper default value

### DIFF
--- a/db/pf-schema-X.Y.Z.sql
+++ b/db/pf-schema-X.Y.Z.sql
@@ -380,7 +380,7 @@ CREATE TABLE `configfile` (
 CREATE TABLE `password` (
   `pid` varchar(255) NOT NULL,
   `password` varchar(255) NOT NULL,
-  `valid_from` datetime default NULL,
+  `valid_from` datetime NOT NULL DEFAULT "0000-00-00 00:00:00",
   `expiration` datetime NOT NULL,
   `access_duration` varchar(255) default NULL,
   `access_level` varchar(255) DEFAULT 'NONE',

--- a/db/upgrade-X.X.X-X.Y.Z.sql
+++ b/db/upgrade-X.X.X-X.Y.Z.sql
@@ -11,6 +11,17 @@ SET @MINOR_VERSION = 4;
 SET @SUBMINOR_VERSION = 9;
 
 --
+-- Set passwords with NULL value to the new default value
+--
+UPDATE password set valid_from="0000-00-00 00:00:00" WHERE valid_from IS NULL;
+
+--
+-- Make valid_from default to 0000-00-00 00:00:00
+--
+
+ALTER TABLE password MODIFY valid_from DATETIME NOT NULL DEFAULT "0000-00-00 00:00:00";
+
+--
 -- The VERSION_INT to ensure proper ordering of the version in queries
 --
 


### PR DESCRIPTION
# Description
Make password.valid_from have a proper default value that fits with what the application expects

# Impacts
local accounts

# Issue
fixes #1920 

# Delete branch after merge
YES

# NEWS file entries
## Enhancements
* Changed password.valid_from default value to "0000-00-00 00:00:00" so its value is valid across the whole application (#1920)