### PR TITLE
validate date cannot exceed 2038-01-18 in admin interface

### DIFF
--- a/html/pfappserver/lib/pfappserver/Form/Config/Authentication/Rule.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Authentication/Rule.pm
@@ -16,6 +16,7 @@ extends 'pfappserver::Base::Form::Authentication::Action';
 
 use pf::config qw(%connection_group %connection_type);
 use pf::Authentication::constants;
+use pf::util;
 
 # Form select options
 has 'attrs' => ( is => 'ro' );
@@ -337,6 +338,16 @@ sub validate {
         @actions = grep { $_->{type} eq $Actions::SET_UNREG_DATE } @{$self->value->{actions}};
         if (scalar @actions > 0) {
             $self->field('actions')->add_error("You can't define an access duration and an unregistration date at the same time.");
+        }
+    }
+    
+    @actions = grep { $_->{type} eq $Actions::SET_UNREG_DATE } @{$self->value->{actions}};
+    foreach my $action (@actions) {
+        use pf::log;
+        use Data::Dumper;
+        get_logger->info(Dumper($action));
+        if(!validate_date($action->{value})) {
+            $self->field('actions')->add_error("Unregistration date must not exceed 2038-01-18");
         }
     }
 

--- a/html/pfappserver/lib/pfappserver/Form/Config/Authentication/Rule.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Authentication/Rule.pm
@@ -343,9 +343,6 @@ sub validate {
     
     @actions = grep { $_->{type} eq $Actions::SET_UNREG_DATE } @{$self->value->{actions}};
     foreach my $action (@actions) {
-        use pf::log;
-        use Data::Dumper;
-        get_logger->info(Dumper($action));
         if(!validate_date($action->{value})) {
             $self->field('actions')->add_error("Unregistration date must not exceed 2038-01-18");
         }

--- a/html/pfappserver/lib/pfappserver/Form/Field/DatePicker.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Field/DatePicker.pm
@@ -15,9 +15,17 @@ This field is simply a text field to be formatted by a theme
 use Moose;
 extends 'HTML::FormHandler::Field::Text';
 use namespace::autoclean;
+use pf::util;
 
 has 'start' => ( is => 'rw', default => undef );
 has 'end' => ( is => 'rw', default => undef );
+
+sub validate {
+    my ($self) = @_;
+    if (!validate_date($self->value)) {
+        $self->add_error("Date shouldn't exceed 2038-01-18");
+    }
+}
 
 =head1 COPYRIGHT
 

--- a/html/pfappserver/lib/pfappserver/Form/Field/DatePicker.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Field/DatePicker.pm
@@ -20,6 +20,12 @@ use pf::util;
 has 'start' => ( is => 'rw', default => undef );
 has 'end' => ( is => 'rw', default => undef );
 
+=head2 validate
+
+Validate all dates cannot exceed 2038-01-38
+
+=cut
+
 sub validate {
     my ($self) = @_;
     if (!validate_date($self->value)) {

--- a/lib/pf/util.pm
+++ b/lib/pf/util.pm
@@ -81,6 +81,7 @@ BEGIN {
         pf_make_dir
         empty_dir
         is_in_list
+        validate_date
     );
 }
 
@@ -91,6 +92,7 @@ use pf::constants::config;
 use pf::constants::user;
 #use pf::config;
 use pf::log;
+use Time::Piece;
 
 =head1 SUBROUTINES
 
@@ -1229,6 +1231,24 @@ sub is_in_list {
     return $FALSE;
 }
 
+=item validate_date
+
+Validates a date to ensure it doesn't exceed 2038-01-18
+
+=cut
+
+sub validate_date {
+    my ($date) = @_;
+    my $t = Time::Piece->strptime($date, "%Y-%m-%d");
+    if(
+        $t->year > 2038
+        || $t->year == 2038 && $t->mon > 1
+        || $t->year == 2038 && $t->mon == 1 && $t->mday > 18
+    ) {
+        return $FALSE;
+    }
+    return $TRUE;
+}
 
 =back
 


### PR DESCRIPTION
# Description
Limit the date inputs to 2038-01-18

# Impacts
Admin interface date editing

# Issue
fixes #1126 

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
If an issue exists on Github, please refer to it (name) along with it's number...
* Now limiting dates to 2038-01-18 in admin interface (#1126)
