### PR TITLE
Feature/registration role violation

### DIFF
--- a/html/pfappserver/lib/pfappserver/Form/Violation.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Violation.pm
@@ -106,7 +106,7 @@ has_field 'whitelisted_roles' =>
    type => 'Select',
    multiple => 1,
    label => 'Whitelisted Roles',
-   options_method => \&options_roles,
+   options_method => \&options_whitelisted_roles,
    element_class => ['chzn-select', 'input-xxlarge'],
    element_attr => {'data-placeholder' => 'Click to add a role'},
    tags => { after_element => \&help,
@@ -275,6 +275,31 @@ sub options_vclose {
     my @violations = map { $_->{id} => $_->{desc} || $_->{id} } @{$self->form->violations} if ($self->form->violations);
 
     return ('' => '', @violations);
+}
+
+=head2 options_whitelisted_roles
+
+The options for whitelisted roles
+
+=cut
+
+sub options_whitelisted_roles {
+    my ($self) = @_;
+    # NOTE: options_roles is a method on form but that receives the field as the first argument
+    my %roles = options_roles($self);
+    # Roles that aren't technically roles (non-db), except for registration which matches unregistered devices
+    my %skip_roles = (
+        isolation => 1,
+        macDetection => 1,
+        voice => 1,
+        inline => 1,
+    );
+    my %whitelisted_roles;
+    foreach my $role (keys(%roles)) {
+        next if(exists($skip_roles{$role}));
+        $whitelisted_roles{$role} = $role;
+    }
+    return %whitelisted_roles;
 }
 
 =head2 options_roles

--- a/html/pfappserver/lib/pfappserver/Form/Violation.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Violation.pm
@@ -18,7 +18,7 @@ use HTTP::Status qw(:constants is_success);
 
 use pf::action;
 use pf::log;
-use pf::constants::violation qw($MAX_VID);
+use pf::constants::violation qw($MAX_VID %NON_WHITELISTABLE_ROLES);
 
 has '+field_name_space' => ( default => 'pfappserver::Form::Field' );
 has '+widget_name_space' => ( default => 'pfappserver::Form::Widget' );
@@ -288,15 +288,9 @@ sub options_whitelisted_roles {
     # NOTE: options_roles is a method on form but that receives the field as the first argument
     my %roles = options_roles($self);
     # Roles that aren't technically roles (non-db), except for registration which matches unregistered devices
-    my %skip_roles = (
-        isolation => 1,
-        macDetection => 1,
-        voice => 1,
-        inline => 1,
-    );
     my %whitelisted_roles;
     foreach my $role (keys(%roles)) {
-        next if(exists($skip_roles{$role}));
+        next if(exists($NON_WHITELISTABLE_ROLES{$role}));
         $whitelisted_roles{$role} = $role;
     }
     return %whitelisted_roles;

--- a/lib/pf/constants/violation.pm
+++ b/lib/pf/constants/violation.pm
@@ -16,10 +16,19 @@ use strict;
 use warnings;
 use base qw(Exporter);
 use Readonly;
+use pf::constants;
+use pf::constants::role qw($ISOLATION_ROLE $MAC_DETECTION_ROLE $VOICE_ROLE $INLINE_ROLE);
 
-our @EXPORT_OK = qw($MAX_VID);
+our @EXPORT_OK = qw($MAX_VID %NON_WHITELISTABLE_ROLES);
 
 Readonly our $MAX_VID => 2000000000;
+
+Readonly our %NON_WHITELISTABLE_ROLES => (
+    $ISOLATION_ROLE     => $TRUE,
+    $MAC_DETECTION_ROLE => $TRUE,
+    $VOICE_ROLE         => $TRUE,
+    $INLINE_ROLE        => $TRUE,
+);
 
 =head1 AUTHOR
 

--- a/lib/pf/violation.pm
+++ b/lib/pf/violation.pm
@@ -118,6 +118,7 @@ use pf::constants qw(
 use pf::enforcement;
 use pf::db;
 use pf::constants::scan qw($SCAN_VID $POST_SCAN_VID $PRE_SCAN_VID);
+use pf::constants::role qw($REGISTRATION_ROLE);
 use pf::util;
 use pf::config::util;
 use pf::client;
@@ -888,7 +889,7 @@ sub _is_node_category_whitelisted {
     my $node_role = $node_info->{category};
     # matching registration role for unregistered devices
     if($node_info->{status} eq $pf::node::STATUS_UNREGISTERED) {
-        $node_role = "registration";
+        $node_role = $REGISTRATION_ROLE;
     }
 
     # trying to match node's category on whitelisted categories

--- a/lib/pf/violation.pm
+++ b/lib/pf/violation.pm
@@ -885,11 +885,17 @@ sub _is_node_category_whitelisted {
         return 0;
     }
 
+    my $node_role = $node_info->{category};
+    # matching registration role for unregistered devices
+    if($node_info->{status} eq $pf::node::STATUS_UNREGISTERED) {
+        $node_role = "registration";
+    }
+
     # trying to match node's category on whitelisted categories
     my $role_found = 0;
     # whitelisted_roles is of the form "cat1,cat2,cat3,etc."
     foreach my $role (@{$class->{'whitelisted_roles'}}) {
-        if (lc($role) eq lc($node_info->{'category'})) {
+        if (lc($role) eq lc($node_role)) {
             $role_found = 1;
         }
     }


### PR DESCRIPTION
# Description
Allow to define the 'registration' role in violation whitelistable roles so it matches unregistered devices
Also prevents user from selecting whitelistable roles that can never match (macDetection,voice,inline,isolation)

# Impacts
Violation role whitelisting

# Issue
fixes #1278 

# Delete branch after merge
YES

# NEWS file entries
## Enhancements
* Allow to whitelist unregistered devices from violations

# UPGRADE file entries

When whitelisting roles in a violation, the registration role will now match unregistered devices where before it would never match. Make sure to go through violations that may include this role to make sure it is relevant.
