### PR TITLE
Guest pass printing improvement

### DIFF
--- a/html/pfappserver/root/user/print.tt
+++ b/html/pfappserver/root/user/print.tt
@@ -1,85 +1,116 @@
 <style type="text/css">
 h3, .aup {
-        display: none;
+  display: none;
 }
 </style>
 
 <style type="text/css" media="print">
 .row-fluid .offset2:first-child {
-        margin-left: 0;
+  margin-left: 0;
 }
 .row-fluid .span8 {
-        width: auto;
+  width: auto;
 }
 hr {
   border: 0;
   border-bottom: 1px dashed #000;
 }
-h1, #navbar, .alert {
-        display: none;
+h1, #navbar, .alert, .print-menu {
+  display: none;
 }
 h3, .aup {
-        display: block;
+  display: block;
 }
 dd.aup {
-        font-size: 9pt;
-        line-height: 9pt;
+  font-size: 9pt;
+  line-height: 9pt;
 }
 .dl-horizontal dt {
-        float: none;
-        text-align: left;
-        width: auto;
+  float: none;
+  text-align: left;
+  width: auto;
 }
 .dl-horizontal dd {
-        margin-left: 0;
+  margin-left: 0;
 }
 .page-break {
-        display:block;
-        page-break-before:always;
+  display:block;
+  page-break-before:always;
+}
+.ignore {
+  display:none !important;
+  page-break-before:auto !important;
 }
 .spacer {
-        display:block;
-        height:0.5in;
+  display:block;
+  height:0.5in;
 }
 @page {
-        margin-left: 1.5in;
-        margin-right: 1.5in;
+  margin:0;
+}
+body {
+  margin-left: 1.5in;
+  margin-right: 1.5in;
 }
 </style>
-    <div class="container-fluid">
-      <div class="row-fluid">
-        <div class="span8 offset2">
-          <h1>[% l('Access Code') %]</h1>
-          <div class="alert alert-warn">
-            <button class="close" data-dismiss="alert">&times;</button>
-            <h4>[% l('Warning!') %]</h4>
-            <p>[% l('Each account will be printed on a single page with the acceptable user policy.') %]</p>
-            <p><a class="btn btn-warning" onClick="window.print()">[% l('Print') %]</a></p>
-          </div>
-          [% FOREACH user IN users %]
-          <h3>[% l('Access Code') %]</h3>
-          <hr/>
-          <dl class="dl-horizontal">
-            <dt>[% l('Username') %]</dt>
-            <dd>[% user.pid | html %]</dd>
-            <dt>[% l('Password') %]</dt>
-            <dd>[% user.password | html %]</dd>
-            [% IF user.email -%]
-            <dt>[% l('Email address') %]</dt>
-            <dd>[% user.email | html %]</dd>
-            [% END -%]
-            [% IF user.txt_valid_from -%]
-            <dt>[% l('Activation') %]</dt>
-            <dd>[% user.txt_valid_from | html %]</dd>
-            [% END -%]
-            [% IF user.txt_duration -%]
-            <dt>[% l('Expiration') %]</dt>
-            <dd>[% user.txt_duration | html %]</dd>
-            [% END -%]
-            <dd class="aup">[% aup | none %]</dd>
-          </dl>
-          [% UNLESS loop.last %]<div class="page-break"></div><div class="spacer"></div>[% END %]
-          [% END -%]
-        </div><!--/span-->
-      </div><!--/row-->
-    </div><!--/.fluid-container-->
+<div class="container-fluid">
+  <div class="row-fluid">
+    <div class="span8 offset2">
+      <div class="print-menu">
+        <h1>[% l('Access Code') %]</h1>
+        <div>
+          <label>Print with AUP: <input autocomplete="off" type="checkbox" name="with-aup" value="yes" checked="checked"></label>
+        </div>
+        <div class="alert alert-warn">
+          <button class="close" data-dismiss="alert">&times;</button>
+          <h4>[% l('Warning!') %]</h4>
+          <p>[% l('Each account will be printed on a single page with the acceptable user policy.') %]</p>
+          <p><a class="btn btn-warning" onClick="window.print()">[% l('Print') %]</a></p>
+        </div>
+        </div>
+      [% FOREACH user IN users %]
+      <h3>[% l('Access Code') %]</h3>
+      <hr/>
+      <dl class="dl-horizontal">
+        <dt>[% l('Username') %]</dt>
+        <dd>[% user.pid | html %]</dd>
+        <dt>[% l('Password') %]</dt>
+        <dd>[% user.password | html %]</dd>
+        [% IF user.email -%]
+        <dt>[% l('Email address') %]</dt>
+        <dd>[% user.email | html %]</dd>
+        [% END -%]
+        [% IF user.txt_valid_from -%]
+        <dt>[% l('Activation') %]</dt>
+        <dd>[% user.txt_valid_from | html %]</dd>
+        [% END -%]
+        [% IF user.txt_duration -%]
+        <dt>[% l('Expiration') %]</dt>
+        <dd>[% user.txt_duration | html %]</dd>
+        [% END -%]
+        <dd class="aup">[% aup | none %]</dd>
+      </dl>
+      [% UNLESS loop.last %]<div data-index="[% loop.count - 1 %]" class="page-break"><div class="spacer"></div></div>[% END %]
+      [% END -%]
+    </div><!--/span-->
+  </div><!--/row-->
+</div><!--/.fluid-container-->
+
+<script type="text/javascript" src="/static/app/jquery.js"></script>
+<script>
+  $('[name="with-aup"]').change(function(){
+    if($(this).prop('checked')) {
+      $('.page-break').removeClass('ignore');
+      $('dd.aup').removeClass('ignore');
+    }
+    else {
+      $('.page-break').each(function(){
+        if(parseInt($(this).data('index')) % 4 != 3) {
+          $(this).addClass('ignore');
+          $('dd.aup').addClass('ignore');
+        }
+      });
+    }
+  });
+
+</script>

--- a/html/pfappserver/root/user/print.tt
+++ b/html/pfappserver/root/user/print.tt
@@ -2,6 +2,13 @@
 h3, .aup {
   display: none;
 }
+
+.print-with-aup {
+  float:right;
+  position:relative;
+  right:20px;
+  top:5px;
+}
 </style>
 
 <style type="text/css" media="print">
@@ -57,10 +64,12 @@ body {
   <div class="row-fluid">
     <div class="span8 offset2">
       <div class="print-menu">
-        <h1>[% l('Access Code') %]</h1>
-        <div>
-          <label>Print with AUP: <input autocomplete="off" type="checkbox" name="with-aup" value="yes" checked="checked"></label>
-        </div>
+        <h1>
+          <span>[% l('Access Code') %]</span>
+          <span class="print-with-aup" style="display:inline-block;">
+            <label>Print with AUP: <input autocomplete="off" type="checkbox" name="with-aup" value="yes" checked="checked"></label>
+          </span>
+        </h1>
         <div class="alert alert-warn">
           <button class="close" data-dismiss="alert">&times;</button>
           <h4>[% l('Warning!') %]</h4>

--- a/html/pfappserver/root/user/print.tt
+++ b/html/pfappserver/root/user/print.tt
@@ -64,7 +64,7 @@ body {
         <div class="alert alert-warn">
           <button class="close" data-dismiss="alert">&times;</button>
           <h4>[% l('Warning!') %]</h4>
-          <p>[% l('Each account will be printed on a single page with the acceptable user policy.') %]</p>
+          <p>[% l('Unless specified otherwise, each account will be printed on a single page with the acceptable user policy.') %]</p>
           <p><a class="btn btn-warning" onClick="window.print()">[% l('Print') %]</a></p>
         </div>
         </div>

--- a/html/pfappserver/root/user/print.tt
+++ b/html/pfappserver/root/user/print.tt
@@ -8,6 +8,7 @@ h3, .aup {
   position:relative;
   right:20px;
   top:5px;
+  display:inline-block;
 }
 </style>
 
@@ -69,7 +70,7 @@ body {
       <div class="print-menu">
         <h1>
           <span>[% l('Access Code') %]</span>
-          <span class="print-with-aup" style="display:inline-block;">
+          <span class="print-with-aup">
             <label>Print with AUP: <input autocomplete="off" type="checkbox" name="with-aup" value="yes" checked="checked"></label>
           </span>
         </h1>

--- a/html/pfappserver/root/user/print.tt
+++ b/html/pfappserver/root/user/print.tt
@@ -71,7 +71,7 @@ body {
         <h1>
           <span>[% l('Access Code') %]</span>
           <span class="print-with-aup">
-            <label>Print with AUP: <input autocomplete="off" type="checkbox" name="with-aup" value="yes" checked="checked"></label>
+            <label>[% l('Print with AUP') %]: <input autocomplete="off" type="checkbox" name="with-aup" value="yes" checked="checked"></label>
           </span>
         </h1>
         <div class="alert alert-warn">

--- a/html/pfappserver/root/user/print.tt
+++ b/html/pfappserver/root/user/print.tt
@@ -59,6 +59,9 @@ body {
   margin-left: 1.5in;
   margin-right: 1.5in;
 }
+.title-underline {
+  border-bottom:3px dotted black;
+}
 </style>
 <div class="container-fluid">
   <div class="row-fluid">
@@ -79,7 +82,7 @@ body {
         </div>
       [% FOREACH user IN users %]
       <h3>[% l('Access Code') %]</h3>
-      <hr/>
+      <div class="title-underline"></div>
       <dl class="dl-horizontal">
         <dt>[% l('Username') %]</dt>
         <dd>[% user.pid | html %]</dd>

--- a/html/pfappserver/root/user/print.tt
+++ b/html/pfappserver/root/user/print.tt
@@ -53,7 +53,7 @@ dd.aup {
   height:0.5in;
 }
 @page {
-  margin:0;
+  margin:0 !important;
 }
 body {
   margin-left: 1.5in;


### PR DESCRIPTION
# Description
Allow to print a guest pass (local account) without the AUP while having multiple per page
Also improves the general layout of printing those passes

# Impacts
Printing guest passes

# Issue
fixes #1409 

# Delete branch after merge
YES

# NEWS file entries
## Enhancements
* Can now print multiple guest passes per page without the AUP in the administration interface (#1409)
