### PR TITLE
allow to use git in pf-maint (for ignoring files)

### DIFF
--- a/addons/pf-maint.pl
+++ b/addons/pf-maint.pl
@@ -52,10 +52,13 @@ our $test;
 # Files that should be excluded from patching
 # Will only work when using git to patch a server
 our @excludes = (
+    # Files
     ".gitattributes",
     ".gitconfig",
     ".gitignore",
+    "addons/logrotate"
     "packetfence.logrotate",
+    # Directories
     ".github/*",
     ".tx/*",
     "debian/*",

--- a/addons/pf-maint.pl
+++ b/addons/pf-maint.pl
@@ -81,7 +81,11 @@ pod2usage(1) if $help;
 
 die "$PATCH_BIN does not exists or is not executable please install or make it executable" unless patch_bin_exists();
 
-print STDERR "$GIT_BIN does not exist, it is advised to install git to improve the patching process\n" unless(git_bin_exists());
+unless(git_bin_exists()) {
+    print STDERR "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n";
+    print STDERR "$GIT_BIN does not exist, it is advised to install git to improve the patching process\n";
+    print STDERR "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n";
+}
 
 our $PATCHES_DIR = catdir( $PF_DIR, '.patches' );
 mkdir $PATCHES_DIR or die "cannot create $PATCHES_DIR" unless -d $PATCHES_DIR;

--- a/addons/pf-maint.pl
+++ b/addons/pf-maint.pl
@@ -81,7 +81,7 @@ pod2usage(1) if $help;
 
 die "$PATCH_BIN does not exists or is not executable please install or make it executable" unless patch_bin_exists();
 
-unless(git_bin_exists()) {
+unless(git_bin_exists()) {
     print STDERR "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n";
     print STDERR "$GIT_BIN does not exist, it is advised to install git to improve the patching process\n";
     print STDERR "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n";

--- a/addons/pf-maint.pl
+++ b/addons/pf-maint.pl
@@ -56,7 +56,7 @@ our @excludes = (
     ".gitattributes",
     ".gitconfig",
     ".gitignore",
-    "addons/logrotate"
+    "addons/logrotate",
     "packetfence.logrotate",
     # Directories
     ".github/*",

--- a/addons/pf-maint.pl
+++ b/addons/pf-maint.pl
@@ -173,7 +173,7 @@ sub apply_patch {
     my $file = make_patch_filename( $base, $head );
     chdir $PF_DIR or die "cannot change directory $PF_DIR\n";
     if(git_bin_exists()) {
-        system "$GIT_BIN apply --verbose ".join(' ', map{"--exclude=$_"} @excludes)." < $file";
+        system "$GIT_BIN apply --reject --verbose ".join(' ', map{"--exclude=$_"} @excludes)." < $file";
     }
     else {
         system "$PATCH_BIN -b -p1 < $file";

--- a/addons/pf-maint.pl
+++ b/addons/pf-maint.pl
@@ -85,9 +85,9 @@ pod2usage(1) if $help;
 die "$PATCH_BIN does not exists or is not executable please install or make it executable" unless patch_bin_exists();
 
 unless(git_bin_exists()) {
-    print STDERR "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n";
+    print STDERR "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n";
     print STDERR "$GIT_BIN does not exist, it is advised to install git to improve the patching process\n";
-    print STDERR "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n";
+    print STDERR "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n";
 }
 
 our $PATCHES_DIR = catdir( $PF_DIR, '.patches' );


### PR DESCRIPTION
# Description
Allow to use git in pf-maint.pl so un-patchable files (like the ones in debian/) don't attempt to be patched and make users insecure with meaningless warnings

# Impacts
pf-maint.pl

# Issue
fixes #807 

# Delete branch after merge
YES

# NEWS file entries
## Enhancements
* Maintenance patching can now use git in order to ignore files that shouldn't be patched via the maintenance script (#807)
