### PR TITLE
Fix bad memory cache update of portal profile sources when editing an auth source

### DIFF
--- a/lib/pf/Connection/Profile.pm
+++ b/lib/pf/Connection/Profile.pm
@@ -38,7 +38,7 @@ use pf::config qw(
 use pfconfig::memory_cached;
 
 # a memory cache tied to the config::Profiles namepace
-our $SOURCES_CACHE = pfconfig::memory_cached->new('config::Profiles');
+our $SOURCES_CACHE = pfconfig::memory_cached->new('config::Profiles', 'config::Authentication');
 
 =head1 METHODS
 

--- a/lib/pfconfig/memory_cached.pm
+++ b/lib/pfconfig/memory_cached.pm
@@ -34,13 +34,32 @@ Constructor
 =cut
 
 sub init {
-    my ( $self, $namespace ) = @_;
+    my ( $self, @namespaces ) = @_;
 
-    $self->{"_namespace"} = $namespace;
-    $self->{"_control_file_path"} = pfconfig::util::control_file_path($namespace);
+    $self->{"_namespaces"} = \@namespaces;
 
     return $self;
 }
+
+=head2 is_valid
+
+Method that is used to determine if the object has been refreshed in pfconfig
+Uses the control files in var/control and the memorized_at hash to know if a namespace has expired
+
+This is overriden for the support of the mutli-namespace
+
+=cut
+
+sub is_valid {
+    my ($self)         = @_;
+    foreach my $namespace (@{$self->{namespaces}}) {
+        $self->{_namespace} = $namespace;
+        $self->{"_control_file_path"} = pfconfig::util::control_file_path($namespace);
+        return 0 unless($self->SUPER::is_valid());
+    }
+    return 1;
+}
+
 
 =head1 AUTHOR
 

--- a/lib/pfconfig/memory_cached.pm
+++ b/lib/pfconfig/memory_cached.pm
@@ -52,7 +52,7 @@ This is overriden for the support of the mutli-namespace
 
 sub is_valid {
     my ($self)         = @_;
-    foreach my $namespace (@{$self->{namespaces}}) {
+    foreach my $namespace (@{$self->{_namespaces}}) {
         $self->{_namespace} = $namespace;
         $self->{"_control_file_path"} = pfconfig::util::control_file_path($namespace);
         return 0 unless($self->SUPER::is_valid());

--- a/t/unittest/pfconfig/memory_cached.t
+++ b/t/unittest/pfconfig/memory_cached.t
@@ -49,6 +49,30 @@ $result = $mem->compute_from_subcache($testkey, sub {"value changed !"});
 is($result, "value changed !", 
     "Value is properly recompute_from_subcached when namespace expired.");
 
+my $testns2 = "testns2";
+$mem = pfconfig::memory_cached->new($testns, $testns2);
+
+$result = $mem->compute_from_subcache($testkey, sub {"dinde"});
+is($result, "dinde", 
+    "Computing should return proper value");
+
+$result = $mem->compute_from_subcache($testkey, sub {"that-would-be-bad"});
+is($result, "dinde", 
+    "Computing should return cached value if no namespace has expired in the namespace list");
+
+$manager->touch_cache($testns);
+
+$result = $mem->compute_from_subcache($testkey, sub {"value changed !"});
+is($result, "value changed !", 
+    "Value is properly recompute_from_subcached when one of the namespaces expired.");
+
+$manager->touch_cache($testns2);
+
+$result = $mem->compute_from_subcache($testkey, sub {"value changed again !"});
+is($result, "value changed !", 
+    "Value is properly recompute_from_subcached when on of the namespaces expired.");
+
+
 =head1 AUTHOR
 
 Inverse inc. <info@inverse.ca>


### PR DESCRIPTION
# Description
Fix bad memory cache update of portal profile sources when editing an auth source

# Impacts
Portal profile sources

# Issue
fixes #1933 

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* Fixed bad memory cache refresh of the Portal Profile sources (#1933)

