### PR TITLE
eduroam authentication source match

### DIFF
--- a/lib/pf/Authentication/Source/EduroamSource.pm
+++ b/lib/pf/Authentication/Source/EduroamSource.pm
@@ -47,6 +47,44 @@ sub available_actions {
 }
 
 
+=head2 available_attributes
+
+Allow to make a condition on the user's username.
+
+=cut
+
+sub available_attributes {
+  my $self = shift;
+
+  my $super_attributes = $self->SUPER::available_attributes;
+  my $own_attributes = [{ value => "username", type => $Conditions::SUBSTRING }];
+
+  return [@$super_attributes, @$own_attributes];
+}
+
+
+=head2 match_in_subclass
+
+Should always "match" and allow specific conditions
+
+=cut
+
+sub match_in_subclass {
+    my ( $self, $params, $rule, $own_conditions, $matching_conditions ) = @_;
+    my $username = $params->{'username'};
+
+    foreach my $condition ( @{ $own_conditions } ) {
+        if ( $condition->{'attribute'} eq "username" ) {
+            if ( $condition->matches("username", $username) ) {
+                push(@{ $matching_conditions }, $condition);
+            }
+        }
+    }
+
+    return $username;
+}
+
+
 =head1 AUTHOR
 
 Inverse inc. <info@inverse.ca>

--- a/lib/pf/Authentication/Source/EduroamSource.pm
+++ b/lib/pf/Authentication/Source/EduroamSource.pm
@@ -16,7 +16,7 @@ use Moose;
 extends 'pf::Authentication::Source';
 
 has '+type'                 => (default => 'Eduroam');
-has '+class'                => (isa => 'Str', is => 'ro', default => 'external');
+has '+class'                => (isa => 'Str', is => 'ro', default => 'exclusive');
 has '+unique'               => (isa => 'Bool', is => 'ro', default => $TRUE);
 has 'server1_address'       => (isa => 'Str', is => 'rw');
 has 'server2_address'       => (isa => 'Str', is => 'rw');
@@ -33,6 +33,7 @@ Eduroam source only allow 'authentication' rules
 sub available_rule_classes {
     return [ grep { $_ ne $Rules::ADMIN } @Rules::CLASSES ];
 }
+
 
 =head2 available_actions
 


### PR DESCRIPTION
# Description
Ability to match rules in an eduroam source

# Impacts
* eduroam authentication sources
* RADIUS instances

# Delete branch after merge
YES

# NEWS file entries
## Enhancements
* eduroam authentication source can now match rules.

# UPGRADE file entries
* eduroam authentication source is now an "exclusive" authentication source rather than an "external" one. That being said, make sure to adjust portal profile accordingly (an "exclusive" authentication source can be the only one configured in a portal profile)
