### PR TITLE
Keep UID and GID on uninstallation time

### DIFF
--- a/addons/packages/packetfence.spec
+++ b/addons/packages/packetfence.spec
@@ -829,37 +829,6 @@ if [ $1 -eq 0 ] ; then
 %endif
 fi
 
-%postun -n %{real_name}
-if [ $1 -eq 0 ]; then
-        if /usr/bin/id pf &>/dev/null; then
-               /usr/sbin/userdel pf || %logmsg "User \"pf\" could not be deleted."
-#               /usr/sbin/groupdel pf || %logmsg "Group \"pf\" could not be deleted."
-#        else
-#               /sbin/service pf condrestart &>/dev/null || :
-        fi
-fi
-
-%postun -n %{real_name}-remote-snort-sensor
-if [ $1 -eq 0 ]; then
-        if /usr/bin/id pf &>/dev/null; then
-                /usr/sbin/userdel pf || %logmsg "User \"pf\" could not be deleted."
-        fi
-fi
-
-%postun -n %{real_name}-remote-arp-sensor
-if [ $1 -eq 0 ]; then
-        if /usr/bin/id pf &>/dev/null; then
-                /usr/sbin/userdel pf || %logmsg "User \"pf\" could not be deleted."
-        fi
-fi
-
-%postun -n %{real_name}-config
-if [ $1 -eq 0 ]; then
-        if /usr/bin/id pf &>/dev/null; then
-                /usr/sbin/userdel pf || %logmsg "User \"pf\" could not be deleted."
-        fi
-fi
-
 # TODO we should simplify this file manifest to the maximum keeping treating 
 # only special attributes explicitly 
 # "To make this situation a bit easier, if the %files list contains a path 

--- a/addons/packages/packetfence.spec
+++ b/addons/packages/packetfence.spec
@@ -585,8 +585,13 @@ rm -rf $RPM_BUILD_ROOT
 %pre -n %{real_name}
 
 if ! /usr/bin/id pf &>/dev/null; then
+    if ! /usr/bin/id -g pf &>/dev/null; then
         /usr/sbin/useradd -r -d "/usr/local/pf" -s /bin/sh -c "PacketFence" -M pf || \
                 echo Unexpected error adding user "pf" && exit
+    else
+        /usr/sbin/useradd -r -d "/usr/local/pf" -s /bin/sh -c "PacketFence" -M pf -g pf || \
+                echo Unexpected error adding user "pf" && exit
+    fi
 fi
 /usr/sbin/usermod -aG wbpriv,fingerbank,apache,carbon pf
 
@@ -608,22 +613,37 @@ fi
 %pre -n %{real_name}-remote-snort-sensor
 
 if ! /usr/bin/id pf &>/dev/null; then
+    if ! /usr/bin/id -g pf &>/dev/null; then
         /usr/sbin/useradd -r -d "/usr/local/pf" -s /bin/sh -c "PacketFence" -M pf || \
                 echo Unexpected error adding user "pf" && exit
+    else
+        /usr/sbin/useradd -r -d "/usr/local/pf" -s /bin/sh -c "PacketFence" -M pf -g pf || \
+                echo Unexpected error adding user "pf" && exit
+    fi
 fi
 
 %pre -n %{real_name}-remote-arp-sensor
 
 if ! /usr/bin/id pf &>/dev/null; then
+    if ! /usr/bin/id -g pf &>/dev/null; then
         /usr/sbin/useradd -r -d "/usr/local/pf" -s /bin/sh -c "PacketFence" -M pf || \
                 echo Unexpected error adding user "pf" && exit
+    else
+        /usr/sbin/useradd -r -d "/usr/local/pf" -s /bin/sh -c "PacketFence" -M pf -g pf || \
+                echo Unexpected error adding user "pf" && exit
+    fi
 fi
 
 %pre -n %{real_name}-config
 
 if ! /usr/bin/id pf &>/dev/null; then
+    if ! /usr/bin/id -g pf &>/dev/null; then
         /usr/sbin/useradd -r -d "/usr/local/pf" -s /bin/sh -c "PacketFence" -M pf || \
                 echo Unexpected error adding user "pf" && exit
+    else
+        /usr/sbin/useradd -r -d "/usr/local/pf" -s /bin/sh -c "PacketFence" -M pf -g pf || \
+                echo Unexpected error adding user "pf" && exit
+    fi
 fi
 
 

--- a/debian/packetfence-config.preinst
+++ b/debian/packetfence-config.preinst
@@ -27,8 +27,12 @@ case "$1" in
         if grep -E "^pf:" /etc/passwd > /dev/null ; then
                 echo "pf user already exist"
         else
+            if ! /usr/bin/id -g pf &>/dev/null; then
                 useradd -r -d "/usr/local/pf" -s /bin/sh -c "PacketFence" -M pf
-                echo "create pf user"
+            else
+                useradd -r -d "/usr/local/pf" -s /bin/sh -c "PacketFence" -M pf -g pf
+            fi
+            echo "create pf user"
         fi
         exit 0
     ;;

--- a/debian/packetfence-redis-cache.preinst
+++ b/debian/packetfence-redis-cache.preinst
@@ -27,8 +27,12 @@ case "$1" in
         if grep -E "^pf:" /etc/passwd > /dev/null ; then
                 echo "pf user already exist"
         else
+            if ! /usr/bin/id -g pf &>/dev/null; then
                 useradd -r -d "/usr/local/pf" -s /bin/sh -c "PacketFence" -M pf
-                echo "create pf user"
+            else
+                useradd -r -d "/usr/local/pf" -s /bin/sh -c "PacketFence" -M pf -g pf
+            fi
+            echo "create pf user"
         fi
         exit 0
     ;;

--- a/debian/packetfence-remote-arp-sensor.preinst
+++ b/debian/packetfence-remote-arp-sensor.preinst
@@ -19,8 +19,12 @@ case "$1" in
         if grep -E "^pf:" /etc/passwd > /dev/null ; then
                 echo "pf user already exist"
         else
+            if ! /usr/bin/id -g pf &>/dev/null; then
                 useradd -r -d "/usr/local/pf" -s /bin/sh -c "PacketFence" -M pf
-                echo "create pf user"
+            else
+                useradd -r -d "/usr/local/pf" -s /bin/sh -c "PacketFence" -M pf -g pf
+            fi
+            echo "create pf user"
         fi
         exit 0
     ;;

--- a/debian/packetfence-remote-snort-sensor.preinst
+++ b/debian/packetfence-remote-snort-sensor.preinst
@@ -19,8 +19,12 @@ case "$1" in
         if grep -E "^pf:" /etc/passwd > /dev/null ; then
                 echo "pf user already exist"
         else
+            if ! /usr/bin/id -g pf &>/dev/null; then
                 useradd -r -d "/usr/local/pf" -s /bin/sh -c "PacketFence" -M pf
-                echo "create pf user"
+            else
+                useradd -r -d "/usr/local/pf" -s /bin/sh -c "PacketFence" -M pf -g pf
+            fi
+            echo "create pf user"
         fi
         exit 0
     ;;

--- a/debian/packetfence.postrm
+++ b/debian/packetfence.postrm
@@ -33,7 +33,6 @@ case "$1" in
     ;;
 
     remove)
-        #remove user and group pf
         if [ ${DIST} = "wheezy" ] || [ ${DIST} = "precise" ]; then
             if [ -x /etc/init.d/packetfence ]; then
                 invoke-rc.d packetfence stop
@@ -42,18 +41,6 @@ case "$1" in
         if [ ${DIST} = "jessie" ] ; then
             systemctl stop packetfence
         fi
-        set +e
-        userdel pf
-        if [ $? -ne 0 ]; then
-            echo "Unable to remove pf user"
-        fi
-        if [ -e /etc/lsb-release ]; then
-            groupdel pf
-            if [ $? -ne 0 ]; then
-                echo "Unable to remove pf group"
-            fi
-        fi
-        set -e
         if [ ${DIST} = "wheezy" ] || [ ${DIST} = "precise" ]; then
             # removing init scripts
             if [ -e /etc/lsb-release ]; then

--- a/debian/packetfence.preinst
+++ b/debian/packetfence.preinst
@@ -43,8 +43,12 @@ case "$1" in
     install)
         stop_service_if_exists packetfence
         if [ -z "$(getent passwd pf)" ]; then
+            if ! /usr/bin/id -g pf &>/dev/null; then
                 useradd -U -r -d "/usr/local/pf" -s /bin/sh -c "PacketFence" -M pf
-                echo "create pf user"
+            else
+                useradd -r -d "/usr/local/pf" -s /bin/sh -c "PacketFence" -M pf -g pf
+            fi
+            echo "create pf user"
         else
                 echo "pf user already exist"
         fi


### PR DESCRIPTION
# Description
Do not remove UID / GID when uninstalling. Handling existing UID/GID on re-installation time.

# Impacts
Packaging (RHEL / CentOS and Debian)
* Install
* Uninstall
* Upgrade
* Reinstall

# Issue
fixes #1944 

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* packaging: Do not delete UID / GID on uninstall time. (#1944)