### PR TITLE
CentOS repository package signing

### DIFF
--- a/addons/packages/packetfence-release.spec
+++ b/addons/packages/packetfence-release.spec
@@ -53,12 +53,14 @@ for the PacketFence RPM repository.
 [packetfence]
 name=PacketFence Repository
 baseurl=http://inverse.ca/downloads/PacketFence/RHEL$releasever/$basearch
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-PACKETFENCE-CENTOS
 gpgcheck=1
 enabled=0
 
 [packetfence-devel]
 name=PacketFence Devel Repository
 baseurl=http://inverse.ca/downloads/PacketFence/RHEL$releasever/devel/$basearch
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-PACKETFENCE-CENTOS
 gpgcheck=1
 enabled=0
 

--- a/addons/packages/packetfence-release.spec
+++ b/addons/packages/packetfence-release.spec
@@ -53,21 +53,21 @@ for the PacketFence RPM repository.
 ## PacketFence RPM Repository for RHEL/Centos
 [packetfence]
 name=PacketFence Repository
-baseurl=http://inverse.ca/downloads/PacketFence/RHEL$releasever/$basearch
+baseurl=http://inverse.ca/downloads/PacketFence/RHEL\$releasever/\$basearch
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-PACKETFENCE-CENTOS
 gpgcheck=1
 enabled=0
 
 [packetfence-devel]
 name=PacketFence Devel Repository
-baseurl=http://inverse.ca/downloads/PacketFence/RHEL$releasever/devel/$basearch
+baseurl=http://inverse.ca/downloads/PacketFence/RHEL\$releasever/devel/\$basearch
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-PACKETFENCE-CENTOS
 gpgcheck=1
 enabled=0
 
 [packetfence-extra]
 name=PacketFence Extra Repository
-baseurl=http://inverse.ca/downloads/PacketFence/RHEL$releasever/extra/\$basearch
+baseurl=http://inverse.ca/downloads/PacketFence/RHEL\$releasever/extra/\$basearch
 gpgcheck=0
 enabled=0
 
@@ -111,6 +111,7 @@ EOF
 %install
 rm -rf %{buildroot}
 mkdir -p %{buildroot}/etc/yum.repos.d/
+mkdir -p %{buildroot}/etc/pki/rpm-gpg/
 cp /etc/yum.repos.d/packetfence.repo $RPM_BUILD_ROOT/etc/yum.repos.d/packetfence.repo
 cp /etc/pki/rpm-gpg/RPM-GPG-KEY-PACKETFENCE-CENTOS $RPM_BUILD_ROOT%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-PACKETFENCE-CENTOS
 %clean
@@ -123,11 +124,13 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
-* Thu Jan 05 2017 Inverse inc. <support@inverse.ca>
+* Thu Jan 05 2017 Inverse inc. <support@inverse.ca> - 1.2-6
 - Merged changes from the build system for dynamic versioning
 - Added GPG key
 - Activated gpgcheck
+
 * Thu May 01 2014 Inverse inc. <support@inverse.ca>
 - fixed variable issue
+
 * Fri Apr 25 2014 Inverse inc. <support@inverse.ca>
 - Release file created.

--- a/addons/packages/packetfence-release.spec
+++ b/addons/packages/packetfence-release.spec
@@ -124,13 +124,13 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
-* Thu Jan 05 2017 Inverse inc. <support@inverse.ca> - 1.2-6
+* Thu Jan 05 2017 Inverse inc. <info@inverse.ca> - 1.2-6
 - Merged changes from the build system for dynamic versioning
 - Added GPG key
 - Activated gpgcheck
 
-* Thu May 01 2014 Inverse inc. <support@inverse.ca>
+* Thu May 01 2014 Inverse inc. <info@inverse.ca>
 - fixed variable issue
 
-* Fri Apr 25 2014 Inverse inc. <support@inverse.ca>
+* Fri Apr 25 2014 Inverse inc. <info@inverse.ca>
 - Release file created.

--- a/addons/packages/packetfence-release.spec
+++ b/addons/packages/packetfence-release.spec
@@ -3,9 +3,9 @@
 # NEW (since git migration):
 #
 #   Expecting a standard tarball with packetfence-<version>/...
-#
+# 
 # BUILDING FOR RELEASE
-#
+# 
 # - Build
 #  - define ver <version>
 #  - define dist based on target distro (for centos/rhel => .el5)
@@ -35,7 +35,6 @@ License: GPL
 Group: System Environment/Base
 URL: http://www.packetfence.org
 BuildRoot: %{_tmppath}/%{real_name}-%{version}-%{rev}-root
-BuildArch: noarch
 # disables the creation of the debug package for our setuid C wrapper
 %define debug_package %{nil}
 
@@ -44,40 +43,87 @@ Vendor: PacketFence, http://www.packetfence.org
 
 %description
 
-PacketFence release file. This package contains the yum configuration
+PacketFence release file. This package contains yum configuration
 for the PacketFence RPM repository.
 
 %prep
 
 %{__cat} <<EOF >/etc/yum.repos.d/packetfence.repo
-## PacketFence RPM Repository for RHEL/Centos 6
+## PacketFence RPM Repository for RHEL/Centos
 [packetfence]
 name=PacketFence Repository
-baseurl=http://inverse.ca/downloads/PacketFence/RHEL6/\$basearch
-gpgcheck=0
+baseurl=http://inverse.ca/downloads/PacketFence/RHEL$releasever/$basearch
+gpgcheck=1
 enabled=0
 
 [packetfence-devel]
 name=PacketFence Devel Repository
-baseurl=http://inverse.ca/downloads/PacketFence/RHEL6/devel/\$basearch
-gpgcheck=0
+baseurl=http://inverse.ca/downloads/PacketFence/RHEL$releasever/devel/$basearch
+gpgcheck=1
 enabled=0
+
+[packetfence-extra]
+name=PacketFence Extra Repository
+baseurl=http://inverse.ca/downloads/PacketFence/RHEL$releasever/extra/\$basearch
+gpgcheck=1
+enabled=0
+
 EOF
+
+%{__cat} <<EOF > /etc/pki/rpm-gpg/RPM-GPG-KEY-PACKETFENCE-CENTOS
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+Version: GnuPG v1.4.12 (GNU/Linux)
+
+mQINBFboV/kBEAD0lENE/obEKUnHhRJzr/y+27BVHI0KUia4CbXESHBYla/+ZMS/
+Kr91b8JFgfhw52BMDeB/73vN1HKoPvO8THzimOJA3CoN8C9I/0eqyE32SsqGA/c2
+6FL9a1zTRff7BVkQTsiq3gPjLfykERzIpmfWB/FML0S+guGmS6BY04P15MOhGCwH
+1emW931uwZyMv7VpNffnaUoxoMjkh4PPo7ferNRpU+cCaiokmvVS+1l+ZWeehq9N
+YrNJzupQao5HdG2t2tj1n+IJChrCo5qDBZ6YlnjYxaNSaaa8bK4nPmbdmjm/3YFK
+On2DIriAU0CRaJVYkWgvhEQznHwGzKeXm6x8K7Px+uvNx/OAfiwBti43WMlxbyw4
+Z5fkKfRErm1BBlHI7FQkOi0sY+g7yCrlTx6+4evJC6kJ+xPyk5wFgwrs+A9iEpj2
+kXkvYOPuZttA5XsqKo1tsC85j2zRnC5X53WV4ccPWiRM6cpsvDZrpi32pP6I4WE2
+oE9Dt25RVA4VTovaYZKXq0H7FIIVtCTxyHXNevAmPpZKmdAnSi9vb3Yj329p5JFf
+3BHtZH8li+bg5dSUSUyxS2Kdb+4q63n4NAYz52wex0t7evutEo1rzpTjNQuSp/aa
+Y9mspj9xV/LdlMce9v822wGUKtvaXFUhhor0XV5icYsv93NEl3NBSnpnfQARAQAB
+tDpJbnZlcnNlIFN1cHBvcnQgKFJQTSBwYWNrYWdlIHNpZ25pbmcpIDxzdXBwb3J0
+QGludmVyc2UuY2E+iQI4BBMBAgAiBQJW6Ff5AhsDBgsJCAcDAgYVCAIJCgsEFgID
+AQIeAQIXgAAKCRDLLToqoAMOLFyKEADV1/4XeP7maHYqRdzEfovd8dSqRTgnQKxb
+gErvBdpna1vR7QNGY19zMKduSQKTIOI704s8jrtGmORrtlM5OJgrfYA1HDiTIkRp
+1L6yps7Vz7qBSxGhKaT5sDsolYHX9MlgJBIQ4rs5lxZ0oQFLbaNUgRf333v+SyJC
+Y720OohUa9qtur6uK2VDrJqgzl1huWctZ3FdxcbKrMwn93//W27VNdPCaRxcpbeO
+qy8hJ74F+Iom9Kqw5YBPAABdSlJ2DEwxN+ItyiMExYqkTidcQmk+LdNkP2eN4OIM
+d59Lp2iWP2zIqaJ9hKURwdUKYajrsFpAS7eubUprN436sK/dFpv4NL7grnoD4seB
+wvk8eqxIyzONZqgZH5nhilf6QJ340SYHglQ2gChkAC5MENsUk2Cr8+R72GRtOvAP
+N2GTU+v7KWtudl2jpWorlxNWRSqpFynHIUbnDdn6t0VQWnpNJWhgZBGhzA0eIYgl
+7rtqJ/hlU7Cu7CzWtM3XluWhrNw4/K3lmngj2UNJkIxbZKi3K/UKsuHtvHAt6B1H
+LOoD07gvX25E1Kx14KxW6oq4lsnjg/vdUwKYDdmGZCDCSsUCMdHcMQPNbLhEoBNl
+B2RzxDpxO81bCL692Wxx50JFFhspOLR1a09ljrwAHtWrX5zV3Pb4qrTeiQpMgeZq
+yglRDT063w==
+=sdaP
+-----END PGP PUBLIC KEY BLOCK-----
+EOF
+
 
 %build
 %install
 rm -rf %{buildroot}
 mkdir -p %{buildroot}/etc/yum.repos.d/
 cp /etc/yum.repos.d/packetfence.repo $RPM_BUILD_ROOT/etc/yum.repos.d/packetfence.repo
+cp /etc/pki/rpm-gpg/RPM-GPG-KEY-PACKETFENCE-CENTOS $RPM_BUILD_ROOT%{_sysconfdir}/pki/rpm-gpg/RPM-GPG-KEY-PACKETFENCE-CENTOS
 %clean
 rm -rf $RPM_BUILD_ROOT
 
 %files -n %{real_name}
 %defattr(0755, root, root)
 %config /etc/yum.repos.d/packetfence.repo
+/etc/pki/rpm-gpg/RPM-GPG-KEY-PACKETFENCE-CENTOS
 
 
 %changelog
+* Thu Jan 05 2017 Inverse inc. <support@inverse.ca>
+- Merged changes from the build system for dynamic versioning
+- Added GPG key
+- Activated gpgcheck
 * Thu May 01 2014 Inverse inc. <support@inverse.ca>
 - fixed variable issue
 * Fri Apr 25 2014 Inverse inc. <support@inverse.ca>

--- a/addons/packages/packetfence-release.spec
+++ b/addons/packages/packetfence-release.spec
@@ -35,6 +35,7 @@ License: GPL
 Group: System Environment/Base
 URL: http://www.packetfence.org
 BuildRoot: %{_tmppath}/%{real_name}-%{version}-%{rev}-root
+BuildArch: noarch
 # disables the creation of the debug package for our setuid C wrapper
 %define debug_package %{nil}
 

--- a/addons/packages/packetfence-release.spec
+++ b/addons/packages/packetfence-release.spec
@@ -70,12 +70,6 @@ baseurl=http://inverse.ca/downloads/PacketFence/RHEL$releasever/extra/\$basearch
 gpgcheck=0
 enabled=0
 
-[packetfence-extra]
-name=PacketFence Extra Repository
-baseurl=http://inverse.ca/downloads/PacketFence/RHEL$releasever/extra/\$basearch
-gpgcheck=1
-enabled=0
-
 EOF
 
 %{__cat} <<EOF > /etc/pki/rpm-gpg/RPM-GPG-KEY-PACKETFENCE-CENTOS

--- a/addons/packages/packetfence-release.spec
+++ b/addons/packages/packetfence-release.spec
@@ -12,7 +12,7 @@
 #  - define rev based on package revision (must be > 0 for proprer upgrade from snapshots)
 # ex:
 # cd /usr/src/redhat/
-# rpmbuild -ba --define 'version 3.3.0' --define 'dist .el5' --define 'rev 1' SPECS/packetfence.spec
+# rpmbuild -ba --define 'ver 3.3.0' --define 'dist .el5' --define 'rev 1' SPECS/packetfence.spec
 #
 #
 # BUILDING FOR A SNAPSHOT (PRE-RELEASE)
@@ -24,7 +24,7 @@
 #  - define rev to 0.<date> this way one can upgrade from snapshot to release
 # ex:
 # cd /usr/src/redhat/
-# rpmbuild -ba --define 'version 3.3.0' --define 'snapshot 1' --define 'dist .el5' --define 'rev 0.20100506' SPECS/packetfence.spec
+# rpmbuild -ba --define 'ver 3.3.0' --define 'snapshot 1' --define 'dist .el5' --define 'rev 0.20100506' SPECS/packetfence.spec
 #
 Summary: PacketFence release file and RPM repository configuration
 %global real_name packetfence-release

--- a/addons/packages/packetfence-release.spec
+++ b/addons/packages/packetfence-release.spec
@@ -65,7 +65,7 @@ enabled=0
 [packetfence-extra]
 name=PacketFence Extra Repository
 baseurl=http://inverse.ca/downloads/PacketFence/RHEL$releasever/extra/\$basearch
-gpgcheck=1
+gpgcheck=0
 enabled=0
 
 EOF

--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -261,7 +261,7 @@ RHEL / CentOS
 
 In order to use the PacketFence repository :
 
-  # yum localinstall http://packetfence.org/downloads/PacketFence/RHEL7/`uname -i`/RPMS/packetfence-release-1.2-6.el7.noarch.rpm
+  # yum localinstall http://packetfence.org/downloads/PacketFence/RHEL7/`uname -i`/RPMS/packetfence-release-1.2-6.el7.centos.noarch.rpm
 
 Once the repository is defined, you can install PacketFence with all its
 dependencies, and the required external services (Database

--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -261,7 +261,7 @@ RHEL / CentOS
 
 In order to use the PacketFence repository :
 
-  # yum localinstall http://packetfence.org/downloads/PacketFence/RHEL6/`uname -i`/RPMS/packetfence-release-1.2-6.el7.noarch.rpm
+  # yum localinstall http://packetfence.org/downloads/PacketFence/RHEL7/`uname -i`/RPMS/packetfence-release-1.2-6.el7.noarch.rpm
 
 Once the repository is defined, you can install PacketFence with all its
 dependencies, and the required external services (Database

--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -261,7 +261,7 @@ RHEL / CentOS
 
 In order to use the PacketFence repository :
 
-  # yum localinstall http://packetfence.org/downloads/PacketFence/RHEL6/`uname -i`/RPMS/packetfence-release-1.2-5.1.noarch.rpm
+  # yum localinstall http://packetfence.org/downloads/PacketFence/RHEL6/`uname -i`/RPMS/packetfence-release-1.2-6.el7.noarch.rpm
 
 Once the repository is defined, you can install PacketFence with all its
 dependencies, and the required external services (Database


### PR DESCRIPTION
# Description
Build server now signs all packages prior to moving them to their final location. This doesn't impact anyone before packetfence-release is installed from RHEL7 repo, which enforces package signature validation.

Changes:
- packetfence-release.spec was merged with buildserver's version to be CENTO6/7 compliant, and add extra repository)
- CentOS6 packages are also signed.
- GPG public key added to validate package signing.
- GPG signature validation activated for main devel and extra repositories.
- pfbuilder scripts got modified to sign  packages with the same key used to sign Sogo RPM packages on the nightly and release.
 
# Impacts
Yum configuration file will be overwritten. (no noreplace)

# Delete branch after merge
YES 

# NEWS file entries
## New Features
* CentOS repositories (packetfence and packetfence-devel) packages are now signed. Please upgrade package-release in CentOS7!
