### PR TITLE
Feature/node last seen

### DIFF
--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1464,7 +1464,14 @@ EOT
 [maintenance.node_cleanup_window]
 type=time
 description=<<EOT
-How long to keep a node entry before deleting it
+How long can an unregistered node be inactive on the network before being deleted
+This shouldn't be used if you are using port-security
+EOT
+
+[maintenance.node_unreg_window]
+type=time
+description=<<EOT
+How long can a registered node be inactive on the network before it becomes unregistered
 EOT
 
 [maintenance.node_cleanup_interval]

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1464,7 +1464,7 @@ EOT
 [maintenance.node_cleanup_window]
 type=time
 description=<<EOT
-How long can an unregistered node be inactive on the network before being deleted
+How long can an unregistered node be inactive on the network before being deleted.
 This shouldn't be used if you are using port-security
 EOT
 

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -1131,8 +1131,13 @@ radius_audit_log_cleanup_timeout=10s
 #
 # maintenance.node_cleanup_window
 #
-# How long to keep a node entry before deleting it
+# How long can an unregistered node be inactive on the network before being deleted
 node_cleanup_window=0D
+#
+# maintenance.node_unreg_window
+#
+# How long can a registered node be inactive on the network before it becomes unregistered
+node_unreg_window=0D
 #
 # maintenance.node_cleanup_interval
 #

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -1131,7 +1131,8 @@ radius_audit_log_cleanup_timeout=10s
 #
 # maintenance.node_cleanup_window
 #
-# How long can an unregistered node be inactive on the network before being deleted
+# How long can an unregistered node be inactive on the network before being deleted.
+# This shouldn't be used if you are using port-security
 node_cleanup_window=0D
 #
 # maintenance.node_unreg_window

--- a/db/pf-schema-X.Y.Z.sql
+++ b/db/pf-schema-X.Y.Z.sql
@@ -167,6 +167,7 @@ CREATE TABLE node (
   sessionid varchar(30) default NULL,
   machine_account varchar(255) default NULL,
   bypass_role_id int default NULL,
+  last_seen DATETIME NOT NULL DEFAULT "0000-00-00 00:00:00",
   PRIMARY KEY (mac),
   KEY pid (pid),
   KEY category_id (category_id),

--- a/db/pf-schema-X.Y.Z.sql
+++ b/db/pf-schema-X.Y.Z.sql
@@ -173,6 +173,7 @@ CREATE TABLE node (
   KEY category_id (category_id),
   KEY `node_status` (`status`, `unregdate`),
   KEY `node_dhcpfingerprint` (`dhcp_fingerprint`),
+  KEY `node_last_seen` (`last_seen`),
   CONSTRAINT `0_57` FOREIGN KEY (`pid`) REFERENCES `person` (`pid`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `node_category_key` FOREIGN KEY (`category_id`) REFERENCES `node_category` (`category_id`)
 ) ENGINE=InnoDB;

--- a/db/upgrade-X.X.X-X.Y.Z.sql
+++ b/db/upgrade-X.X.X-X.Y.Z.sql
@@ -149,3 +149,9 @@ CREATE TABLE `chi_cache` (
   KEY chi_cache_expires_at (expires_at)
 );
 
+--
+-- Add last_seen column to node table
+--
+
+ALTER TABLE node ADD last_seen DATETIME NOT NULL DEFAULT "0000-00-00 00:00:00";
+

--- a/db/upgrade-X.X.X-X.Y.Z.sql
+++ b/db/upgrade-X.X.X-X.Y.Z.sql
@@ -155,3 +155,5 @@ CREATE TABLE `chi_cache` (
 
 ALTER TABLE node ADD last_seen DATETIME NOT NULL DEFAULT "0000-00-00 00:00:00";
 
+ALTER TABLE node ADD INDEX node_last_seen (last_seen);
+

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Root.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Root.pm
@@ -66,6 +66,8 @@ sub auto : Private {
 
 =head2 updateNodeLastSeen
 
+Update node.last_seen
+
 =cut
 
 sub updateNodeLastSeen :Private {

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Root.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Root.pm
@@ -59,6 +59,7 @@ sub auto : Private {
     $c->forward('setupDynamicRouting');
     $c->forward('checkReadonly');
     $c->forward('checkForParking');
+    ### record last-seen
 
     return 1;
 }

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Root.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Root.pm
@@ -59,9 +59,19 @@ sub auto : Private {
     $c->forward('setupDynamicRouting');
     $c->forward('checkReadonly');
     $c->forward('checkForParking');
-    ### record last-seen
+    $c->forward('updateNodeLastSeen');
 
     return 1;
+}
+
+=head2 updateNodeLastSeen
+
+=cut
+
+sub updateNodeLastSeen :Private {
+    my ($self, $c) = @_;
+    # update last_seen of MAC address as some activity from it has been seen
+    node_update_last_seen($c->portalSession->clientMac);
 }
 
 =head2 checkForParking

--- a/html/pfappserver/lib/pfappserver/Form/Node.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Node.pm
@@ -69,6 +69,11 @@ has_field 'unregdate' =>
    type => '+DateTimePicker',
    label => 'Unregistration',
   );
+has_field 'last_seen' =>
+  (
+   type => 'Uneditable',
+   label => 'Last Seen',
+  );
 has_field 'time_balance' =>
   (
    type => 'PosInteger',

--- a/html/pfappserver/lib/pfappserver/I18N/en.po
+++ b/html/pfappserver/lib/pfappserver/I18N/en.po
@@ -9518,6 +9518,10 @@ msgid "maintenance.node_cleanup_window"
 msgstr "Node Cleanup Window"
 
 # conf/documentation.conf
+msgid "maintenance.node_unreg_window"
+msgstr "Node Unregistration Window"
+
+# conf/documentation.conf
 msgid "maintenance.nodes_maintenance_interval"
 msgstr "Nodes Maintenance Interval"
 

--- a/html/pfappserver/lib/pfappserver/Model/Search/Node.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Search/Node.pm
@@ -100,6 +100,7 @@ sub make_builder {
             L_("IF(detect_date = '0000-00-00 00:00:00', '', detect_date)", 'detect_date'),
             L_("IF(regdate = '0000-00-00 00:00:00', '', regdate)", 'regdate'),
             L_("IF(unregdate = '0000-00-00 00:00:00', '', unregdate)", 'unregdate'),
+            L_("IF(last_seen = '0000-00-00 00:00:00', '', last_seen)", 'last_seen'),
             L_("IFNULL(node_category.name, '')", 'category'),
             L_("IFNULL(node_category_bypass_role.name, '')", 'bypass_role'),
             L_("IFNULL(device_class, ' ')", 'device_class'),

--- a/html/pfappserver/root/node/view.tt
+++ b/html/pfappserver/root/node/view.tt
@@ -32,6 +32,7 @@
             [% form.field('category_id').render | none %]
             [% form.field('regdate').render | none %]
             [% form.field('unregdate').render | none %]
+            [% form.field('last_seen').render | none %]
             <div class="control-group">
               <label class="control-label">[% l('Access Time Balance') %]</label>
               <div class="controls">[% form.field('time_balance').render_element | none %] [% l('seconds') %]</div>

--- a/lib/pf/dhcp/processor.pm
+++ b/lib/pf/dhcp/processor.pm
@@ -55,7 +55,6 @@ sub processFingerbank {
     pf::node::node_modify($fingerbank_args->{'mac'}, %{$fingerbank_args});
 }
 
-
 =head1 AUTHOR
 
 Inverse inc. <info@inverse.ca>

--- a/lib/pf/dhcp/processor_v4.pm
+++ b/lib/pf/dhcp/processor_v4.pm
@@ -685,7 +685,8 @@ sub update_iplog {
         return;
     }
 
-    ### record last-seen
+    # update last_seen of MAC address as some activity from it has been seen
+    node_update_last_seen($srcmac);
 
     # we have to check directly in the DB since the OMAPI already contains the current lease info
     my $oldip  = pf::ip4log::_mac2ip_sql($srcmac);

--- a/lib/pf/dhcp/processor_v4.pm
+++ b/lib/pf/dhcp/processor_v4.pm
@@ -685,6 +685,8 @@ sub update_iplog {
         return;
     }
 
+    ### record last-seen
+
     # we have to check directly in the DB since the OMAPI already contains the current lease info
     my $oldip  = pf::ip4log::_mac2ip_sql($srcmac);
     my $oldmac = pf::ip4log::_ip2mac_sql($srcip);

--- a/lib/pf/node.pm
+++ b/lib/pf/node.pm
@@ -159,7 +159,7 @@ sub node_db_prepare {
             IF(ISNULL(nr.name), '', nr.name) as bypass_role,
             detect_date, regdate, unregdate, lastskip, time_balance, bandwidth_balance,
             user_agent, computername, dhcp_fingerprint, dhcp_vendor, dhcp6_fingerprint, dhcp6_enterprise, device_type, device_class, device_version, device_score,
-            last_arp, last_dhcp,
+            last_arp, last_dhcp, last_seen,
             node.notes, autoreg, sessionid, machine_account
         FROM node
             LEFT JOIN node_category as nr on node.bypass_role_id = nr.category_id
@@ -175,7 +175,7 @@ sub node_db_prepare {
             IF(ISNULL(nr.name), '', nr.name) as bypass_role ,
             detect_date, regdate, unregdate, lastskip,
             user_agent, computername, device_class AS dhcp_fingerprint,
-            last_arp, last_dhcp,
+            last_arp, last_dhcp, last_seen,
             node.notes, autoreg, sessionid, machine_account
         FROM node
             LEFT JOIN node_category as nr on node.bypass_role_id = nr.category_id
@@ -216,7 +216,7 @@ sub node_db_prepare {
             IF(ISNULL(nr.name), '', nr.name) as bypass_role ,
             node.detect_date, node.regdate, node.unregdate, node.lastskip, node.time_balance, node.bandwidth_balance,
             node.user_agent, node.computername, node.dhcp_fingerprint, node.dhcp_vendor, node.dhcp6_fingerprint, node.dhcp6_enterprise, node.device_type, node.device_class, node.device_version, node.device_score,
-            node.last_arp, node.last_dhcp,
+            node.last_arp, node.last_dhcp, node.last_seen,
             node.notes, node.autoreg, node.sessionid, node.machine_account,
             UNIX_TIMESTAMP(node.regdate) AS regdate_timestamp,
             UNIX_TIMESTAMP(node.unregdate) AS unregdate_timestamp
@@ -282,7 +282,7 @@ sub node_db_prepare {
             IF(node.unregdate = '0000-00-00 00:00:00', '', node.unregdate) as unregdate,
             IF(node.lastskip = '0000-00-00 00:00:00', '', node.lastskip) as lastskip,
             node.user_agent, node.computername, device_class AS dhcp_fingerprint,
-            node.last_arp, node.last_dhcp,
+            node.last_arp, node.last_dhcp, node.last_seen,
             locationlog.switch as last_switch, locationlog.port as last_port, locationlog.vlan as last_vlan,
             IF(ISNULL(locationlog.connection_type), '', locationlog.connection_type) as last_connection_type,
             locationlog.dot1x_username as last_dot1x_username, locationlog.ssid as last_ssid,

--- a/lib/pf/node.pm
+++ b/lib/pf/node.pm
@@ -1439,6 +1439,7 @@ sub node_update_last_seen {
     my ($mac) = @_;
     $mac = clean_mac($mac);
     if($mac) {
+        get_logger->debug("Updating last_seen for $mac");
         db_query_execute(NODE, $node_statements, 'node_update_last_seen_sql', $mac);
         node_remove_from_cache($mac);
     }

--- a/lib/pf/node.pm
+++ b/lib/pf/node.pm
@@ -1153,25 +1153,43 @@ sub node_expire_lastseen {
     return db_data(NODE, $node_statements, 'node_expire_lastseen_sql', $time);
 }
 
+sub node_inactive_lastseen {
+    my ($time) = @_;
+    return db_data(NODE, $node_statements, 'node_inactive_lastseen_sql', $time);
+}
+
 sub node_cleanup {
     my $timer = pf::StatsD::Timer->new;
-    my ($time) = @_;
+    my ($delete_time, $unreg_time) = @_;
     my $logger = get_logger();
-    $logger->debug("calling node_cleanup with time=$time");
+    $logger->debug("calling node_cleanup with delete_time=$delete_time unreg_time=$unreg_time");
     
-    if($time eq "0") {
-        $logger->debug("Not deleting because the window is 0");
-        return;
-    }
-
-    foreach my $rowVlan ( node_expire_lastseen($time) ) {
-        my $mac = $rowVlan->{'mac'};
-        require pf::locationlog;
-        if (pf::locationlog::locationlog_update_end_mac($mac)) {
-            $logger->info("mac $mac not seen for $time seconds, deleting");
-           node_delete($mac);
+    if($delete_time ne "0") {
+        foreach my $row ( node_expire_lastseen($delete_time) ) {
+            my $mac = $row->{'mac'};
+            require pf::locationlog;
+            if (pf::locationlog::locationlog_update_end_mac($mac)) {
+                $logger->info("mac $mac not seen for $delete_time seconds, deleting");
+               node_delete($mac);
+            }
         }
     }
+    else {
+        $logger->debug("Not deleting because the window is 0");
+    }
+
+    if($unreg_time ne "0") {
+        foreach my $row ( node_inactive_lastseen($unreg_time) ) {
+            my $mac = $row->{'mac'};
+            $logger->info("mac $mac not seen for $unreg_time seconds, unregistering");
+            node_deregister($mac);
+            # not reevaluating access since the node is be inactive
+        }
+    }
+    else {
+        $logger->debug("Not unregistering because the window is 0");
+    }
+
     return (0);
 }
 

--- a/lib/pf/node.pm
+++ b/lib/pf/node.pm
@@ -1437,8 +1437,11 @@ Update the last_seen attribute of a node to now
 
 sub node_update_last_seen {
     my ($mac) = @_;
-    db_query_execute(NODE, $node_statements, 'node_update_last_seen_sql', $mac);
-    node_remove_from_cache($mac);
+    $mac = clean_mac($mac);
+    if($mac) {
+        db_query_execute(NODE, $node_statements, 'node_update_last_seen_sql', $mac);
+        node_remove_from_cache($mac);
+    }
 }
 
 =back

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -161,6 +161,8 @@ sub authorize {
         radius_request => $radius_request,
     };
 
+    ### record last-seen
+
     $logger->trace( sub { "received a radius authorization request with parameters: ".
         "nas port type => $args->{nas_port_type}, switch_ip => ($switch_ip), EAP-Type => $args->{eap_type}, ".
         "mac => [$mac], port => $port, username => \"$user_name\"" });
@@ -340,6 +342,8 @@ sub accounting {
     }
 
     my ($nas_port_type, $eap_type, $mac, $port, $user_name, $nas_port_id, $session_id) = $switch->parseRequest($radius_request);
+
+    ## record last-seen
 
     my $isStart   = $radius_request->{'Acct-Status-Type'}  == $ACCOUNTING::START;
     my $isStop   = $radius_request->{'Acct-Status-Type'}  == $ACCOUNTING::STOP;

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -161,7 +161,8 @@ sub authorize {
         radius_request => $radius_request,
     };
 
-    ### record last-seen
+    # update last_seen of MAC address as some activity from it has been seen
+    node_update_last_seen($mac);
 
     $logger->trace( sub { "received a radius authorization request with parameters: ".
         "nas port type => $args->{nas_port_type}, switch_ip => ($switch_ip), EAP-Type => $args->{eap_type}, ".
@@ -343,7 +344,8 @@ sub accounting {
 
     my ($nas_port_type, $eap_type, $mac, $port, $user_name, $nas_port_id, $session_id) = $switch->parseRequest($radius_request);
 
-    ## record last-seen
+    # update last_seen of MAC address as some activity from it has been seen
+    node_update_last_seen($mac);
 
     my $isStart   = $radius_request->{'Acct-Status-Type'}  == $ACCOUNTING::START;
     my $isStop   = $radius_request->{'Acct-Status-Type'}  == $ACCOUNTING::STOP;

--- a/sbin/pfmon
+++ b/sbin/pfmon
@@ -223,9 +223,9 @@ sub registertasks  {
         'node cleanup',
         'node_cleanup_interval',
         sub {
-            node_cleanup( $Config{'maintenance'}{'node_cleanup_window'} );
+            node_cleanup( $Config{'maintenance'}{'node_cleanup_window'}, $Config{'maintenance'}{'node_unreg_window'} );
         }
-    ) if ( $Config{'maintenance'}{'node_cleanup_window'} );
+    ) if ( $Config{'maintenance'}{'node_cleanup_window'} || $Config{'maintenance'}{'node_unreg_window'} );
 
     register_task(
         'person cleanup',

--- a/sbin/pfsetvlan
+++ b/sbin/pfsetvlan
@@ -747,9 +747,6 @@ sub parseTrap {
                     $trapConnectionType = $trapHashRef->{'trapConnectionType'};
                 }
 
-                # update last_seen of MAC address as some activity from it has been seen
-                node_update_last_seen($trapMac);
-
                 return "$switch_id|$switch_port|$trapType|$trapVlan|$trapOperation|$trapMac|$trapSSID|$trapClientUserName|$trapIfIndex|$trapConnectionType";
             } else {
                 $logger->debug("ignoring unknown trap: $trapLine");
@@ -949,6 +946,10 @@ sub handleTrap {
     my $role_obj = new pf::role::custom();
 
     # }}}2
+
+    # update last_seen of MAC address as some activity from it has been seen
+    node_update_last_seen($trapMac);
+
 
     # test if act on this trap {{{2
     my $switch = getSwitch($switch_id);

--- a/sbin/pfsetvlan
+++ b/sbin/pfsetvlan
@@ -747,6 +747,8 @@ sub parseTrap {
                     $trapConnectionType = $trapHashRef->{'trapConnectionType'};
                 }
 
+                ### record last-seen
+
                 return "$switch_id|$switch_port|$trapType|$trapVlan|$trapOperation|$trapMac|$trapSSID|$trapClientUserName|$trapIfIndex|$trapConnectionType";
             } else {
                 $logger->debug("ignoring unknown trap: $trapLine");

--- a/sbin/pfsetvlan
+++ b/sbin/pfsetvlan
@@ -747,7 +747,8 @@ sub parseTrap {
                     $trapConnectionType = $trapHashRef->{'trapConnectionType'};
                 }
 
-                ### record last-seen
+                # update last_seen of MAC address as some activity from it has been seen
+                node_update_last_seen($trapMac);
 
                 return "$switch_id|$switch_port|$trapType|$trapVlan|$trapOperation|$trapMac|$trapSSID|$trapClientUserName|$trapIfIndex|$trapConnectionType";
             } else {


### PR DESCRIPTION
# Description
Add a new way to track when a node was last seen active via a dedicated column in the node table.
At the same time, add a way to unregister a device that was inactive for x time
Also cleanup nodes based on this new column instead of last_dhcp

last_seen is updated on:
 * DHCP packet that generates a call to pf.dhcp.processor.update_iplog
 * RADIUS authentication + accounting
 * Port-security trap
 * Captive portal hit

# Impacts
Node cleanup

# Delete branch after merge
YES

# NEWS file entries
## New Features
* Added way to unregister devices that were inactive for a certain amount of time (maintenance.node_unreg_window)

## Enhancements
* Added a new last_seen column to nodes to track their last activity (Authentication, HTTP portal, DHCP)
* Delete nodes based on the new last_seen column instead of looking at the last DHCP packet
