### PR TITLE
Feature/twilio

### DIFF
--- a/addons/packages/packetfence.spec
+++ b/addons/packages/packetfence.spec
@@ -212,6 +212,7 @@ Requires: perl(URI::Escape::XS)
 Requires: perl(Apache::Htpasswd)
 Requires: perl(Authen::Radius) >= 0.24
 Requires: perl(Authen::Krb5::Simple)
+Requires: perl(WWW::Twilio::API)
 # Required for importation feature
 Requires: perl(Text::CSV)
 Requires: perl(Text::CSV_XS)

--- a/conf/portal_modules.conf.defaults
+++ b/conf/portal_modules.conf.defaults
@@ -20,7 +20,7 @@ type=Authentication::Login
 [default_guest_policy]
 description=Guest signup
 type=Authentication::Choice
-multi_source_object_classes=pf::Authentication::Source::EmailSource,pf::Authentication::Source::SMSSource,pf::Authentication::Source::SponsorEmailSource,pf::Authentication::Source::NullSource
+multi_source_object_classes=pf::Authentication::Source::EmailSource,pf::Authentication::Source::SMSSource,pf::Authentication::Source::TwilioSource,pf::Authentication::Source::SponsorEmailSource,pf::Authentication::Source::NullSource
 
 [default_oauth_policy]
 description=OAuth login

--- a/debian/control
+++ b/debian/control
@@ -71,7 +71,7 @@ Depends: ${misc:Depends}, vlan,
  libcrypt-openssl-pkcs12-perl,libcrypt-openssl-x509-perl,libconst-fast-perl,
  libtime-period-perl, libtime-piece-perl, libsereal-encoder-perl, libsereal-decoder-perl, libdata-serializer-sereal-perl (>= 1.04), libphp-serialization-perl,
  libnet-ip-perl, libdigest-hmac-perl, libcrypt-openssl-pkcs10-perl, libcrypt-openssl-rsa-perl, libfile-tempdir-perl,
- liburi-escape-xs-perl, libsql-abstract-more-perl, libio-socket-timeout-perl, liblinux-distribution-perl,
+ liburi-escape-xs-perl, libsql-abstract-more-perl, libio-socket-timeout-perl, liblinux-distribution-perl, libwww-twilio-api-perl,
 # hard-coded to specific version because v3 broke the API and we haven't ported to it yet
 # see #1313: Port our Net-Appliance-Session to the version 3 API
 # http://packetfence.org/bugs/view.php?id=1313

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/SMS.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/SMS.pm
@@ -91,10 +91,14 @@ Prompt fields with source specific SMS carriers
 sub prompt_fields {
     my ($self) = @_;
 
-    my @carriers = map { { label => $_->{name}, value => $_->{id} } } @{sms_carrier_view_all($self->source)};
-    $self->SUPER::prompt_fields({
-        sms_carriers => \@carriers, 
-    });
+    unless ( $self->source->type eq "Twilio" ) {
+        my @carriers = map { { label => $_->{name}, value => $_->{id} } } @{sms_carrier_view_all($self->source)};
+        $self->SUPER::prompt_fields({
+            sms_carriers => \@carriers, 
+        });
+    } else {
+        $self->SUPER::prompt_fields();
+    }
 }
 
 =head2 prompt_pin
@@ -128,7 +132,7 @@ sub validate_info {
     }
 
     $self->update_person_from_fields();
-    pf::activation::sms_activation_create_send( $self->current_mac, $pid, $telephone, $self->app->profile->getName, $mobileprovider );
+    pf::activation::sms_activation_create_send( $self->current_mac, $pid, $telephone, $self->app->profile->getName, $mobileprovider, $self->source );
 
     pf::auth_log::record_guest_attempt($self->source->id, $self->current_mac, $pid);
 

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/SMS.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/SMS.pm
@@ -23,7 +23,7 @@ use pf::auth_log;
 
 has '+pid_field' => (default => sub { "telephone" });
 
-has '+source' => (isa => 'pf::Authentication::Source::SMSSource');
+has '+source' => (isa => 'pf::Authentication::Source::SMSSource|pf::Authentication::Source::TwilioSource');
 
 =head2 allowed_urls_auth_module
 

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/SMS.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/SMS.pm
@@ -132,7 +132,12 @@ sub validate_info {
     }
 
     $self->update_person_from_fields();
-    pf::activation::sms_activation_create_send( $self->current_mac, $pid, $telephone, $self->app->profile->getName, $mobileprovider, $self->source );
+    my ( $status, $message ) = pf::activation::sms_activation_create_send( $self->current_mac, $pid, $telephone, $self->app->profile->getName, $mobileprovider, $self->source );
+    unless ( $status ) {
+        $self->app->flash->{error} = $message;
+        $self->prompt_fields();
+        return;
+    };
 
     pf::auth_log::record_guest_attempt($self->source->id, $self->current_mac, $pid);
 

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/SMS.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/SMS.pm
@@ -217,7 +217,7 @@ Inverse inc. <info@inverse.ca>
 
 =head1 COPYRIGHT
 
-Copyright (C) 2005-2016 Inverse inc.
+Copyright (C) 2005-2017 Inverse inc.
 
 =head1 LICENSE
 

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/SMS.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/SMS.pm
@@ -91,7 +91,7 @@ Prompt fields with source specific SMS carriers
 sub prompt_fields {
     my ($self) = @_;
 
-    unless ( $self->source->type eq "Twilio" ) {
+    if ( $self->source->meta->get_attribute('sms_carriers') ) {
         my @carriers = map { { label => $_->{name}, value => $_->{id} } } @{sms_carrier_view_all($self->source)};
         $self->SUPER::prompt_fields({
             sms_carriers => \@carriers, 

--- a/html/pfappserver/lib/pfappserver/Form/Config/Authentication/Source/Twilio.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Authentication/Source/Twilio.pm
@@ -46,7 +46,7 @@ has_field 'twilio_phone_number' => (
     required        => 1,
     tags            => {
         after_element   => \&help,
-        help            => 'Twilio provided phone number which will be used as a From',
+        help            => 'Twilio provided phone number which will show as the sender',
     },
     element_attr    => {
         placeholder     => pf::Authentication::Source::TwilioSource->meta->get_attribute('twilio_phone_number')->default,

--- a/html/pfappserver/lib/pfappserver/Form/Config/Authentication/Source/Twilio.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Authentication/Source/Twilio.pm
@@ -23,7 +23,6 @@ with 'pfappserver::Base::Form::Role::Help';
 has_field 'api_url' => (
     type        => 'Text',
     label       => 'API URL',
-    required    => 1,
     tags        => {
         after_element   => \&help,
         help            => 'POST URL of the Twilio API',
@@ -57,6 +56,7 @@ has_field 'auth_token' => (
 has_field 'twilio_phone_number' => (
     type            => 'Text',
     label           => 'Phone Number (From)',
+    required        => 1,
     tags            => {
         after_element   => \&help,
         help            => 'Twilio provided phone number which will be used as a From',

--- a/html/pfappserver/lib/pfappserver/Form/Config/Authentication/Source/Twilio.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Authentication/Source/Twilio.pm
@@ -1,0 +1,99 @@
+package pfappserver::Form::Config::Authentication::Source::Twilio;
+
+=head1 NAME
+
+pfappserver::Form::Config::Authentication::Source::Twilio
+
+=cut
+
+=head1 DESCRIPTION
+
+Form definition to create or update a Twilio authentication source.
+
+=cut
+
+use strict;
+use warnings;
+
+use HTML::FormHandler::Moose;
+
+extends 'pfappserver::Form::Config::Authentication::Source';
+with 'pfappserver::Base::Form::Role::Help';
+
+has_field 'api_url' => (
+    type        => 'Text',
+    label       => 'API URL',
+    required    => 1,
+    tags        => {
+        after_element   => \&help,
+        help            => 'POST URL of the Twilio API',
+    },
+    element_attr    => {
+        placeholder     => pf::Authentication::Source::TwilioSource->meta->get_attribute('api_url')->default,
+    },
+    default         => pf::Authentication::Source::TwilioSource->meta->get_attribute('api_url')->default,
+);
+
+has_field 'account_sid' => (
+    type        => 'Text',
+    label       => 'Account SID',
+    required    => 1,
+    tags        => {
+        after_element   => \&help,
+        help            => 'Twilio Account SID',
+    },
+);
+
+has_field 'auth_token' => (
+    type        => 'Text',
+    label       => 'Auth Token',
+    required    => 1,
+    tags        => {
+        after_element   => \&help,
+        help            => 'Twilio Auth Token',
+    },
+);
+
+has_field 'twilio_phone_number' => (
+    type            => 'Text',
+    label           => 'Phone Number (From)',
+    tags            => {
+        after_element   => \&help,
+        help            => 'Twilio provided phone number which will be used as a From',
+    },
+    element_attr    => {
+        placeholder     => pf::Authentication::Source::TwilioSource->meta->get_attribute('twilio_phone_number')->default,
+    },
+    default         => pf::Authentication::Source::TwilioSource->meta->get_attribute('twilio_phone_number')->default,
+);
+
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2016 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;
+

--- a/html/pfappserver/lib/pfappserver/Form/Config/Authentication/Source/Twilio.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Authentication/Source/Twilio.pm
@@ -20,19 +20,6 @@ use HTML::FormHandler::Moose;
 extends 'pfappserver::Form::Config::Authentication::Source';
 with 'pfappserver::Base::Form::Role::Help';
 
-has_field 'api_url' => (
-    type        => 'Text',
-    label       => 'API URL',
-    tags        => {
-        after_element   => \&help,
-        help            => 'POST URL of the Twilio API',
-    },
-    element_attr    => {
-        placeholder     => pf::Authentication::Source::TwilioSource->meta->get_attribute('api_url')->default,
-    },
-    default         => pf::Authentication::Source::TwilioSource->meta->get_attribute('api_url')->default,
-);
-
 has_field 'account_sid' => (
     type        => 'Text',
     label       => 'Account SID',

--- a/html/pfappserver/lib/pfappserver/Form/Config/Authentication/Source/Twilio.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Authentication/Source/Twilio.pm
@@ -74,7 +74,7 @@ Inverse inc. <info@inverse.ca>
 
 =head1 COPYRIGHT
 
-Copyright (C) 2005-2016 Inverse inc.
+Copyright (C) 2005-2017 Inverse inc.
 
 =head1 LICENSE
 

--- a/html/pfappserver/root/authentication/source/type/Twilio.tt
+++ b/html/pfappserver/root/authentication/source/type/Twilio.tt
@@ -1,0 +1,4 @@
+[% form.field('api_url').render | none %]
+[% form.field('account_sid').render | none %]
+[% form.field('auth_token').render | none %]
+[% form.field('twilio_phone_number').render | none %]

--- a/html/pfappserver/root/authentication/source/type/Twilio.tt
+++ b/html/pfappserver/root/authentication/source/type/Twilio.tt
@@ -1,4 +1,3 @@
-[% form.field('api_url').render | none %]
 [% form.field('account_sid').render | none %]
 [% form.field('auth_token').render | none %]
 [% form.field('twilio_phone_number').render | none %]

--- a/lib/pf/Authentication/Source/SMSSource.pm
+++ b/lib/pf/Authentication/Source/SMSSource.pm
@@ -15,9 +15,10 @@ use Moose;
 extends 'pf::Authentication::Source';
 with 'pf::Authentication::CreateLocalAccountRole';
 
-has '+class' => (default => 'external');
-has '+type' => (default => 'SMS');
-has 'sms_carriers' => (isa => 'ArrayRef', is => 'rw', default => sub {[]});
+has '+class'        => (default => 'external');
+has '+type'         => (default => 'SMS');
+has 'can_send_sms'  => (isa => 'Bool', is => 'ro', default => $FALSE);
+has 'sms_carriers'  => (isa => 'ArrayRef', is => 'rw', default => sub {[]});
 
 =head1 METHODS
 

--- a/lib/pf/Authentication/Source/SMSSource.pm
+++ b/lib/pf/Authentication/Source/SMSSource.pm
@@ -17,7 +17,7 @@ with 'pf::Authentication::CreateLocalAccountRole';
 
 has '+class'        => (default => 'external');
 has '+type'         => (default => 'SMS');
-has 'can_send_sms'  => (isa => 'Bool', is => 'ro', default => $FALSE);
+has 'can_send_sms'  => (isa => 'Bool', is => 'rw', default => $FALSE);
 has 'sms_carriers'  => (isa => 'ArrayRef', is => 'rw', default => sub {[]});
 
 =head1 METHODS
@@ -108,7 +108,7 @@ Inverse inc. <info@inverse.ca>
 
 =head1 COPYRIGHT
 
-Copyright (C) 2005-2016 Inverse inc.
+Copyright (C) 2005-2017 Inverse inc.
 
 =head1 LICENSE
 

--- a/lib/pf/Authentication/Source/TwilioSource.pm
+++ b/lib/pf/Authentication/Source/TwilioSource.pm
@@ -21,7 +21,7 @@ extends 'pf::Authentication::Source';
 has '+type'                     => (default => 'Twilio');
 has '+class'                    => (isa => 'Str', is => 'ro', default => 'external');
 has '+dynamic_routing_module'   => (is => 'rw', default => 'Authentication::SMS');
-has 'can_send_sms'              => (isa => 'Bool', is => 'ro', default => $TRUE);
+has 'can_send_sms'              => (isa => 'Bool', is => 'rw', default => $TRUE);
 has 'api_url'                   => (isa => 'Maybe[Str]', is => 'rw', default => 'https://api.twilio.com/2010-04-01/Accounts/$account_sid/Messages.json');
 has 'account_sid'               => (isa => 'Str', is => 'rw');
 has 'auth_token'                => (isa => 'Str', is => 'rw');
@@ -130,7 +130,7 @@ Inverse inc. <info@inverse.ca>
 
 =head1 COPYRIGHT
 
-Copyright (C) 2005-2016 Inverse inc.
+Copyright (C) 2005-2017 Inverse inc.
 
 =head1 LICENSE
 

--- a/lib/pf/Authentication/Source/TwilioSource.pm
+++ b/lib/pf/Authentication/Source/TwilioSource.pm
@@ -18,6 +18,7 @@ extends 'pf::Authentication::Source';
 has '+type'                     => (default => 'Twilio');
 has '+class'                    => (isa => 'Str', is => 'ro', default => 'external');
 has '+dynamic_routing_module'   => (is => 'rw', default => 'Authentication::SMS');
+has 'can_send_sms'              => (isa => 'Bool', is => 'ro', default => $TRUE);
 has 'api_url'                   => (isa=> 'Maybe[Str]', is => 'rw', default => 'https://api.twilio.com/2010-04-01/Accounts/$account_sid/Messages.json');
 has 'account_sid'               => (isa => 'Str', is => 'rw');
 has 'auth_token'                => (isa => 'Str', is => 'rw');

--- a/lib/pf/Authentication/Source/TwilioSource.pm
+++ b/lib/pf/Authentication/Source/TwilioSource.pm
@@ -1,0 +1,119 @@
+package pf::Authentication::Source::TwilioSource;
+
+=head1 NAME
+
+pf::Authentication::Source::TwilioSource
+
+=head1 DESCRIPTION
+
+=cut
+
+use pf::Authentication::constants;
+use pf::constants qw($TRUE $FALSE);
+use pf::log;
+
+use Moose;
+extends 'pf::Authentication::Source';
+
+has '+type'                     => (default => 'Twilio');
+has '+class'                    => (isa => 'Str', is => 'ro', default => 'external');
+has '+dynamic_routing_module'   => (is => 'rw', default => 'Authentication::SMS');
+has 'api_url'                   => (isa=> 'Maybe[Str]', is => 'rw', default => 'https://api.twilio.com/2010-04-01/Accounts/$account_sid/Messages.json');
+has 'account_sid'               => (isa => 'Str', is => 'rw');
+has 'auth_token'                => (isa => 'Str', is => 'rw');
+has 'twilio_phone_number'       => (isa => 'Str', is => 'rw', default => '+15555551234');
+
+
+=head2 available_rule_classes
+
+Only allow 'authentication' rules
+
+=cut
+
+sub available_rule_classes {
+    return [ grep { $_ ne $Rules::ADMIN } @Rules::CLASSES ];
+}
+
+
+=head2 available_actions
+
+Only allow 'authentication' actions
+
+=cut
+
+sub available_actions {
+    my @actions = map( { @$_ } $Actions::ACTIONS{$Rules::AUTH});
+    return \@actions;
+}
+
+
+=head2 available_attributes
+
+Allow to make a condition on the provided phone number
+
+=cut
+
+sub available_attributes {
+  my $self = shift;
+
+  my $super_attributes = $self->SUPER::available_attributes;
+  my $own_attributes = [{ value => "phonenumber", type => $Conditions::SUBSTRING }];
+
+  return [@$super_attributes, @$own_attributes];
+}
+
+
+=head2 mandatoryFields
+
+List of mandatory fields for this source
+
+=cut
+
+sub mandatoryFields {
+    return qw(telephone);
+}
+
+
+=head2 match_in_subclass
+
+=cut
+
+sub match_in_subclass {
+    my ($self, $params, $rule, $own_conditions, $matching_conditions) = @_;
+    return $params->{'username'};
+}
+
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2016 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+__PACKAGE__->meta->make_immutable;
+1;
+
+# vim: set shiftwidth=4:
+# vim: set expandtab:
+# vim: set backspace=indent,eol,start:

--- a/lib/pf/Authentication/Source/TwilioSource.pm
+++ b/lib/pf/Authentication/Source/TwilioSource.pm
@@ -19,7 +19,7 @@ has '+type'                     => (default => 'Twilio');
 has '+class'                    => (isa => 'Str', is => 'ro', default => 'external');
 has '+dynamic_routing_module'   => (is => 'rw', default => 'Authentication::SMS');
 has 'can_send_sms'              => (isa => 'Bool', is => 'ro', default => $TRUE);
-has 'api_url'                   => (isa=> 'Maybe[Str]', is => 'rw', default => 'https://api.twilio.com/2010-04-01/Accounts/$account_sid/Messages.json');
+has 'api_url'                   => (isa => 'Maybe[Str]', is => 'rw', default => 'https://api.twilio.com/2010-04-01/Accounts/$account_sid/Messages.json');
 has 'account_sid'               => (isa => 'Str', is => 'rw');
 has 'auth_token'                => (isa => 'Str', is => 'rw');
 has 'twilio_phone_number'       => (isa => 'Str', is => 'rw', default => '+15555551234');

--- a/lib/pf/Authentication/Source/TwilioSource.pm
+++ b/lib/pf/Authentication/Source/TwilioSource.pm
@@ -22,7 +22,6 @@ has '+type'                     => (default => 'Twilio');
 has '+class'                    => (isa => 'Str', is => 'ro', default => 'external');
 has '+dynamic_routing_module'   => (is => 'rw', default => 'Authentication::SMS');
 has 'can_send_sms'              => (isa => 'Bool', is => 'rw', default => $TRUE);
-has 'api_url'                   => (isa => 'Maybe[Str]', is => 'rw', default => 'https://api.twilio.com/2010-04-01/Accounts/$account_sid/Messages.json');
 has 'account_sid'               => (isa => 'Str', is => 'rw');
 has 'auth_token'                => (isa => 'Str', is => 'rw');
 has 'twilio_phone_number'       => (isa => 'Str', is => 'rw', default => '+15555551234');

--- a/lib/pf/activation.pm
+++ b/lib/pf/activation.pm
@@ -608,12 +608,14 @@ sub sms_activation_create_send {
     if (defined($activation_code)) {
         if ( $authentication_source->can_send_sms ) {
             unless ($authentication_source->sendSMS($activation_code)) {
-                ($success, $err) = ($FALSE, $GUEST::ERROR_CONFIRMATION_SMS);
+                ($success, $err) = ($FALSE, $GUEST::ERRORS{$GUEST::ERROR_CONFIRMATION_SMS});
+                invalidate_codes($args{'mac'}, $args{'pid'}, $args{'pending'});
             }
         }
         else {
             unless (send_sms($activation_code)) {
-                ($success, $err) = ($FALSE, $GUEST::ERROR_CONFIRMATION_SMS);
+                ($success, $err) = ($FALSE, $GUEST::ERRORS{$GUEST::ERROR_CONFIRMATION_SMS});
+                invalidate_codes($args{'mac'}, $args{'pid'}, $args{'pending'});
             }
         }
     }

--- a/lib/pf/activation.pm
+++ b/lib/pf/activation.pm
@@ -684,7 +684,7 @@ Inverse inc. <info@inverse.ca>
 
 =head1 COPYRIGHT
 
-Copyright (C) 2005-2016 Inverse inc.
+Copyright (C) 2005-2017 Inverse inc.
 
 =head1 LICENSE
 

--- a/lib/pf/activation.pm
+++ b/lib/pf/activation.pm
@@ -630,9 +630,10 @@ Send SMS with activation code
 =cut
 
 sub send_sms {
-    my ($activation_code, %info) = @_;
+    my ($activation_code) = @_;
     my $logger = get_logger();
 
+    my %info;
     my $smtpserver = $Config{'alerting'}{'smtpserver'};
     $info{'from'} = $Config{'alerting'}{'fromaddr'} || 'root@' . $fqdn;
     $info{'currentdate'} = POSIX::strftime( "%m/%d/%y %H:%M:%S", localtime );

--- a/lib/pf/activation.pm
+++ b/lib/pf/activation.pm
@@ -587,10 +587,8 @@ Create and send PIN code
 
 =cut
 
-#The attribute %info is only meant to be used for debugging purposes.
-
 sub sms_activation_create_send {
-    my ($mac, $pid, $phone_number, $portal, $provider_id, %info) = @_;
+    my ($mac, $pid, $phone_number, $portal, $provider_id, $authentication_source) = @_;
     my $logger = get_logger();
 
     # Strip non-digits
@@ -608,9 +606,16 @@ sub sms_activation_create_send {
 
     my $activation_code = create(\%args);
     if (defined($activation_code)) {
-      unless (send_sms($activation_code, %info)) {
-        ($success, $err) = ($FALSE, $GUEST::ERROR_CONFIRMATION_SMS);
-      }
+        if ( $authentication_source->can_send_sms ) {
+            unless ($authentication_source->sendSMS($activation_code)) {
+                ($success, $err) = ($FALSE, $GUEST::ERROR_CONFIRMATION_SMS);
+            }
+        }
+        else {
+            unless (send_sms($activation_code)) {
+                ($success, $err) = ($FALSE, $GUEST::ERROR_CONFIRMATION_SMS);
+            }
+        }
     }
 
     return ($success, $err, $activation_code);


### PR DESCRIPTION
# Description
Add a Twilio authentication source to send SMS through Twilio SMS gateway service

# Impacts
* Authentication sources
* SMS registration

# NEW Package(s) required
perl-WWW-Twilio-API from epel

# Delete branch after merge
YES

# NEWS file entries
## New Features
* Added Twilio as an authentication source to send SMS through their SMS gateway service