### PR TITLE
Disable the default role in switch config

### DIFF
--- a/conf/switches.conf.defaults
+++ b/conf/switches.conf.defaults
@@ -26,7 +26,7 @@ inlineRole = inline
 VoIPEnabled = N
 cliAccess = N
 VlanMap = Y
-RoleMap = Y
+RoleMap = N
 ExternalPortalEnforcement = N
 
 mode = testing


### PR DESCRIPTION
# Description
Disable the default role mapping under the switch configuration. It priorities the VLAN ID configuration.

# Impacts
Switches configuration

# Delete branch after merge
YES 

# NEWS file entries
Disable the default role mapping configuration

# UPGRADE file entries
Default RoleMap for the switches:
If you were using the default 'RoleMap = Y' in the conf/switches.conf it's disabled by default now. You will need to put 'RoleMap = Y' under your switches or switch group configuration.