### PR TITLE
typo correction. perl library is libnet-syslog-perl

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -129,7 +129,7 @@ Depends: ${misc:Depends}, vlan,
 # SAML
  liblasso-perl,
 # PaloAlto syslog SSO
- libnet-syslogd-perl,
+ libnet-syslog-perl,
 # for packaging
  dpkg-distribution,
 # Distribution specific


### PR DESCRIPTION
# Description
typo correction ofr packetfence package dependencies.
Will delete libnet-syslogd-perl packages in repos

# Impacts
(REQUIRED)
none

# NEW Package(s) required
libnet-syslog-perl

# Issue
https://github.com/inverse-inc/packetfence/issues/1984

# Delete branch after merge
YES 


