### PR TITLE
Fix/1971 ruckus deauth

### DIFF
--- a/lib/pf/Switch/Ruckus.pm
+++ b/lib/pf/Switch/Ruckus.pm
@@ -146,7 +146,7 @@ sub deauthenticateMacDefault {
 
     $logger->debug("deauthenticate $mac using RADIUS Disconnect-Request deauth method");
     return $self->radiusDisconnect(
-        $mac, { 'Acct-Session-Id' => $dynauth->{'acctsessionid'}, 'User-Name' => $dynauth->{'username'} },
+        $mac, { 'User-Name' => $dynauth->{'username'} },
     );
 }
 

--- a/lib/pf/Switch/Ruckus/Legacy.pm
+++ b/lib/pf/Switch/Ruckus/Legacy.pm
@@ -1,8 +1,8 @@
-package pf::Switch::Ruckus::Ruckus_Legacy;
+package pf::Switch::Ruckus::Legacy;
 
 =head1 NAME
 
-pf::Switch::Ruckus::Ruckus_Legacy
+pf::Switch::Ruckus::Legacy
 
 =head1 SYNOPSIS
 

--- a/lib/pf/Switch/Ruckus/Ruckus_Legacy.pm
+++ b/lib/pf/Switch/Ruckus/Ruckus_Legacy.pm
@@ -1,0 +1,80 @@
+package pf::Switch::Ruckus::Ruckus_Legacy;
+
+=head1 NAME
+
+pf::Switch::Ruckus::Ruckus_Legacy
+
+=head1 SYNOPSIS
+
+Override base methods to comply with legacy hardware
+
+=cut
+
+use strict;
+use warnings;
+
+use base ('pf::Switch::Ruckus');
+
+use pf::accounting qw(node_accounting_dynauth_attr);
+use pf::constants;
+use pf::util;
+
+sub description { 'Ruckus Wireless Controllers - Legacy' }
+
+=over
+
+=item deauthenticateMacDefault
+
+Overrides base method to send Acct-Session-Id withing the RADIUS disconnect request
+
+=cut
+
+sub deauthenticateMacDefault {
+    my ( $self, $mac, $is_dot1x ) = @_;
+    my $logger = $self->logger;
+
+    if ( !$self->isProductionMode() ) {
+        $logger->info("not in production mode... we won't perform deauthentication");
+        return 1;
+    }
+
+    #Fetching the acct-session-id
+    my $dynauth = node_accounting_dynauth_attr($mac);
+
+    $logger->debug("deauthenticate $mac using RADIUS Disconnect-Request deauth method");
+    return $self->radiusDisconnect(
+        $mac, { 'Acct-Session-Id' => $dynauth->{'acctsessionid'}, 'User-Name' => $dynauth->{'username'} },
+    );
+}
+
+
+=back
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2017 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;


### PR DESCRIPTION
# Description
Introduced a legacy class for old Ruckus equipment and modify the RADIUS Disconnect message behavior

# Impacts
Ruckus network equipment

# Issue
fixes #1971 

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* Radius disconnect doesn't work on the Ruckus switch module (#1971)

# UPGRADE file entries
* Ruckus RADIUS Disconnect message on newer version does not support the Accounting-Session-Id parameter to be sent anymore. That parameter have been removed. To make sure continuing supporting "legacy" equipment, please use the new "Ruckus Wireless Controller - Legacy" switch module if your Ruckus Wireless Controller needs that attribute.