### PR TITLE
mschap machine auth for not chrooted domains

### DIFF
--- a/raddb/mods-available/mschap
+++ b/raddb/mods-available/mschap
@@ -393,19 +393,12 @@ mschap chrooted_mschap_machine {
 }
 
 mschap mschap_machine {
-
         use_mppe = yes
-
         require_encryption = yes
-
-
         require_strong = yes
         ntlm_auth = "/usr/local/pf/bin/ntlm_auth_wrapper -- \
              --request-nt-key --username=%{mschap:User-Name:-None} --challenge=%{mschap:Challenge:-00} --nt-response=%{mschap:NT-Response:-00}"	
-
-
         allow_retry = no
-
 }
 
 

--- a/raddb/mods-available/mschap
+++ b/raddb/mods-available/mschap
@@ -392,6 +392,23 @@ mschap chrooted_mschap_machine {
 
 }
 
+mschap _mschap_machine {
+
+        use_mppe = yes
+
+        require_encryption = yes
+
+
+        require_strong = yes
+        ntlm_auth = "/usr/local/pf/bin/ntlm_auth_wrapper -- \
+             --request-nt-key --username=%{mschap:User-Name:-None} --challenge=%{mschap:Challenge:-00} --nt-response=%{mschap:NT-Response:-00}"	
+
+
+        allow_retry = no
+
+}
+
+
 mschap mschap_local {
         #
         #  If you are using /etc/smbpasswd, see the 'passwd'

--- a/raddb/mods-available/mschap
+++ b/raddb/mods-available/mschap
@@ -392,7 +392,7 @@ mschap chrooted_mschap_machine {
 
 }
 
-mschap _mschap_machine {
+mschap mschap_machine {
 
         use_mppe = yes
 

--- a/raddb/policy.d/packetfence
+++ b/raddb/policy.d/packetfence
@@ -92,6 +92,11 @@ packetfence-mschap-authenticate {
       }
     }
     else {
-            mschap
+      if ( "%{User-Name}" =~ /^host\/.*/) {
+        mschap_machine
+      }
+      else {
+        mschap
+      }
     }
 }


### PR DESCRIPTION
# Description
This is a fix to not stripped the user-name in case of machine authentication while domains are not in a chroot

# Impacts
RADIUS, mschap

# Delete branch after merge
NO

# NEWS file entries
## Enhancements
* Fix an issue where machine authentication would not work if domains are not in a chroot
