### PR TITLE
Correct errors in generated suricata.yaml

### DIFF
--- a/lib/pf/services/manager/suricata.pm
+++ b/lib/pf/services/manager/suricata.pm
@@ -49,7 +49,7 @@ sub generateConfig {
 
             #append install_dir if the path doesn't start with /
             $rule = " - $rule" if ( $rule !~ /^\// );
-            push @rules, " - $rule";
+            push @rules, "$rule";
         }
     }
     $tags{'suricata_rules'} = join( "\n", @rules );


### PR DESCRIPTION
This was causing rule files after local.rules not to load.

# Description
Changes the formatting of the generated rule-files section of the suricata.yaml config file to remove extra dashes and spaces, which was stopping the rules from being loaded.

Previously the section would look like this:
```
rule-files:
  - - local.rules
  - - emerging-attack_response.rules
  - - emerging-exploit.rules
```

Now it generates this:
```
rule-files:
 - local.rules
 - emerging-attack_response.rules
 - emerging-exploit.rules
```

# Impacts
Generated suricata.yaml

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* Issue with suricata.yaml not loading all rules files