### PR TITLE
Feature/reboot port

### DIFF
--- a/html/pfappserver/lib/pfappserver/Model/Node.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Node.pm
@@ -457,6 +457,8 @@ sub reevaluate {
 
 =head2 restartSwitchport
 
+Restart the switchport for a MAC address.
+
 =cut
 
 sub restartSwitchport {
@@ -846,6 +848,8 @@ sub bulkApplyBypassRole {
 }
 
 =head2 bulkRestartSwitchport
+
+Restart the switchport for a list of MAC addresses
 
 =cut
 

--- a/html/pfappserver/lib/pfappserver/Model/Node.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Node.pm
@@ -845,6 +845,20 @@ sub bulkApplyBypassRole {
     return ($STATUS::OK, ["Bypass Role was changed for [_1] node(s)", $count]);
 }
 
+=head2 bulkRestartSwitchport
+
+=cut
+
+sub bulkRestartSwitchport {
+    my ($self, @macs) = @_;
+    my $count = 0;
+    foreach my $mac (@macs) {
+        my ($status, undef) = $self->restartSwitchport($mac);
+        $count ++ if(is_success($status));
+    }
+    return ($STATUS::OK, ["Switchport was restarted for [_1] node(s)", $count]);
+}
+
 =head2 bulkReevaluateAccess
 
 =cut

--- a/html/pfappserver/lib/pfappserver/PacketFence/Controller/Node.pm
+++ b/html/pfappserver/lib/pfappserver/PacketFence/Controller/Node.pm
@@ -368,6 +368,22 @@ sub reevaluate_access :Chained('object') :PathPart('reevaluate_access') :Args(0)
     $c->stash->{current_view} = 'JSON';
 }
 
+=head2 restart_switchport
+
+Restart the switchport for a device
+
+=cut
+
+sub restart_switchport :Chained('object') :PathPart('restart_switchport') :Args(0) :AdminRole('NODES_UPDATE') {
+    my ( $self, $c ) = @_;
+
+    my ($status, $message) = $c->model('Node')->restartSwitchport($c->stash->{mac});
+    $self->audit_current_action($c, status => $status, mac => $c->stash->{mac});
+    $c->response->status($status);
+    $c->stash->{status_msg} = $message; # TODO: localize error message
+    $c->stash->{current_view} = 'JSON';
+}
+
 =head2 violations
 
 =cut

--- a/html/pfappserver/lib/pfappserver/PacketFence/Controller/Node.pm
+++ b/html/pfappserver/lib/pfappserver/PacketFence/Controller/Node.pm
@@ -35,7 +35,8 @@ __PACKAGE__->config(
         bulk_deregister      => { AdminRole => 'NODES_UPDATE' },
         bulk_apply_role      => { AdminRole => 'NODES_UPDATE' },
         bulk_apply_violation => { AdminRole => 'NODES_UPDATE' },
-        bulk_reevaluate_access => { AdminRole => 'NODES_UPDATE' },
+        bulk_restart_switchport => { AdminRole => 'NODES_UPDATE' },
+        bulk_reevaluate_access  => { AdminRole => 'NODES_UPDATE' },
     },
     action_args => {
         '*' => { model => 'Node' },

--- a/html/pfappserver/lib/pfappserver/Role/Controller/BulkActions.pm
+++ b/html/pfappserver/lib/pfappserver/Role/Controller/BulkActions.pm
@@ -127,6 +127,28 @@ sub bulk_apply_violation : Local : Args(1) {
     $c->stash->{status_msg} = $status_msg;
 }
 
+=head2 bulk_restart_switchport
+
+=cut
+
+sub bulk_restart_switchport : Local {
+    my ( $self, $c ) = @_;
+    $c->stash->{current_view} = 'JSON';
+    my ( $status, $status_msg );
+    my $request = $c->request;
+    if ($request->method eq 'POST') {
+        my @ids = $request->param('items');
+        ($status, $status_msg) = $self->getModel($c)->bulkRestartSwitchport(@ids);
+        $self->audit_current_action($c, status => $status, ids => \@ids);
+    }
+    else {
+        $status = HTTP_BAD_REQUEST;
+        $status_msg = "";
+    }
+    $c->response->status($status);
+    $c->stash->{status_msg} = $status_msg;
+}
+
 =head2 bulk_reevaluate_access
 
 =cut

--- a/html/pfappserver/lib/pfappserver/Role/Controller/BulkActions.pm
+++ b/html/pfappserver/lib/pfappserver/Role/Controller/BulkActions.pm
@@ -129,6 +129,8 @@ sub bulk_apply_violation : Local : Args(1) {
 
 =head2 bulk_restart_switchport
 
+Restart the switchport for a list of MAC addresses
+
 =cut
 
 sub bulk_restart_switchport : Local {

--- a/html/pfappserver/root/admin/bulk_actions.inc
+++ b/html/pfappserver/root/admin/bulk_actions.inc
@@ -9,6 +9,7 @@
     <li class="disabled"><a class="bulk_action" data-target="[% c.uri_for(c.controller.action_for('bulk_deregister'))  %]">[% l('Deregister') %]</a></li>
     [% IF bulk_type == 'node' %]
     <li class="disabled"><a class="bulk_action" data-target="[% c.uri_for(c.controller.action_for('bulk_reevaluate_access'))  %]">[% l('Reevaluate access') %]</a></li>
+    <li class="disabled"><a class="bulk_action" data-target="[% c.uri_for(c.controller.action_for('bulk_restart_switchport'))  %]">[% l('Restart Switchport') %]</a></li>
     [% END %]
     [% IF bulk_type == 'user' %]
     <li class="disabled"><a class="bulk_action" data-target="[% c.uri_for(c.controller.action_for('bulk_delete'))  %]">[% l('Delete') %]</a></li>

--- a/html/pfappserver/root/node/view.tt
+++ b/html/pfappserver/root/node/view.tt
@@ -155,6 +155,7 @@
 
         <div class="modal-footer">
           [% IF can_access("NODES_UPDATE") && !form.readonly %]<a href="[% c.uri_for(c.controller('Node').action_for('reevaluate_access'), [ node.mac ]) %]" id="reevaluateNode" class="btn btn-warning pull-left"> [% l('Reevaluate access') %]</a>[% END %]
+          [% IF can_access("NODES_UPDATE") && !form.readonly %]<a href="[% c.uri_for(c.controller('Node').action_for('restart_switchport'), [ node.mac ]) %]" id="restartSwitchport" class="btn btn-danger pull-left"> [% l('Restart Switchport') %]</a>[% END %]
           <a href="#" class="btn" data-dismiss="modal">[% l('Close') %]</a>
           [% IF can_access("NODES_UPDATE") && !form.readonly %]<button type="submit" class="btn btn-primary" data-loading-text="[% l('Saving') %]">[% l('Save') %]</button>[% END %]
         </div><!--modal-footer-->

--- a/html/pfappserver/root/static/js/node.js
+++ b/html/pfappserver/root/static/js/node.js
@@ -78,6 +78,8 @@ var NodeView = function(options) {
     this.proxyClick(body, '#modalNode [href*="/run/"]', this.runViolation);
 
     this.proxyClick(body, '#modalNode #reevaluateNode', this.reevaluateAccess);
+    
+    this.proxyClick(body, '#modalNode #restartSwitchport', this.restartSwitchport);
 
     this.proxyClick(body, '#modalNode #addViolation', this.triggerViolation);
 
@@ -396,6 +398,22 @@ NodeView.prototype.triggerViolation = function(e) {
 };
 
 NodeView.prototype.reevaluateAccess = function(e){
+    e.preventDefault();
+    
+    var modal = $('#modalNode');
+    var modal_body = modal.find('.modal-body');
+    var link = $(e.target);
+    var url = link.attr('href');
+    this.nodes.get({
+        url: url,
+        success: function(data) {
+            showSuccess(modal_body.children().first(), data.status_msg);
+        },
+        errorSibling: modal_body.children().first()
+    });
+}
+
+NodeView.prototype.restartSwitchport = function(e){
     e.preventDefault();
     
     var modal = $('#modalNode');

--- a/lib/pf/Connection.pm
+++ b/lib/pf/Connection.pm
@@ -81,6 +81,22 @@ sub _stringToAttributes {
     ( lc($type) =~ /^8021x/ ) ? $self->is8021X($TRUE) : $self->is8021X($FALSE);
 }
 
+sub backwardCompatibleToAttributes {
+    my ($self, $type) = @_;
+
+    # We set the transport type
+    ( lc($type) =~ /^wireless-802\.11/ ) ? $self->transport("Wireless") : $self->transport("Wired");
+
+    # We check if SNMP
+    ( (lc($type) =~ /^snmp/) ) ? $self->isSNMP($TRUE) : $self->isSNMP($FALSE);
+
+    # We check if mac authentication
+    ( lc($type) eq "wired_mac_auth" || lc($type) eq "Ethernet-NoEAP" ) ? $self->isMacAuth($TRUE) : $self->isMacAuth($FALSE);
+
+    # We check if EAP
+    ( lc($type) =~ /eap$/ && !lc($type) =~ /noeap$/ ) ? $self->isEAP($TRUE) : $self->isEAP($FALSE);
+}
+
 =head2 attributesToBackwardCompatible
 
 Only for backward compatibility while we introduce the new connection types.

--- a/lib/pf/Connection.pm
+++ b/lib/pf/Connection.pm
@@ -90,17 +90,32 @@ Go from a backward compatible string (L<%pf::config::connection_type>) to attrib
 sub backwardCompatibleToAttributes {
     my ($self, $type) = @_;
 
+    return if( lc($type) =~ /inline/ || !$type );
+
     # We set the transport type
     ( lc($type) =~ /^wireless-802\.11/ ) ? $self->transport("Wireless") : $self->transport("Wired");
 
-    # We check if SNMP
-    ( (lc($type) =~ /^snmp/) ) ? $self->isSNMP($TRUE) : $self->isSNMP($FALSE);
+    # We check if SNMP. If so, we return immediately while setting the flag
+    if ( (lc($type) =~ /^snmp/) ) { 
+        $self->isSNMP($TRUE);
+        return
+    }
+    else {
+        $self->isSNMP($FALSE);
+    }
 
     # We check if mac authentication
     ( lc($type) eq "wired_mac_auth" || lc($type) eq "Ethernet-NoEAP" ) ? $self->isMacAuth($TRUE) : $self->isMacAuth($FALSE);
 
     # We check if EAP
-    ( lc($type) =~ /eap$/ && !lc($type) =~ /noeap$/ ) ? $self->isEAP($TRUE) : $self->isEAP($FALSE);
+    if ( lc($type) =~ /eap$/ && lc($type) !~ /noeap$/ ) {
+        $self->isEAP($TRUE);
+        $self->is8021X($TRUE); 
+        $self->isMacAuth($FALSE);
+    }
+    else {
+        $self->isEAP($FALSE) ; $self->is8021X($FALSE) ; $self->isMacAuth($TRUE);
+    }
 }
 
 =head2 attributesToBackwardCompatible

--- a/lib/pf/Connection.pm
+++ b/lib/pf/Connection.pm
@@ -81,6 +81,12 @@ sub _stringToAttributes {
     ( lc($type) =~ /^8021x/ ) ? $self->is8021X($TRUE) : $self->is8021X($FALSE);
 }
 
+=head2 backwardCompatibleToAttributes
+
+Go from a backward compatible string (L<%pf::config::connection_type>) to attributes for this class
+
+=cut
+
 sub backwardCompatibleToAttributes {
     my ($self, $type) = @_;
 

--- a/t/unittest/Connection.t
+++ b/t/unittest/Connection.t
@@ -1,0 +1,120 @@
+#!/usr/bin/perl
+=head1 NAME
+
+Connection
+
+=cut
+
+=head1 DESCRIPTION
+
+tests for pf::Connection class
+
+=cut
+
+use strict;
+use warnings;
+
+use Test::More tests => 9;                      # last test to print
+
+use Test::NoWarnings;
+use diagnostics;
+use lib '/usr/local/pf/lib';
+BEGIN {
+    use lib '/usr/local/pf/t';
+    use setup_test_config;
+}
+
+use pf::config qw(
+    $WIRELESS_802_1X
+    $WIRELESS_MAC_AUTH
+    $WIRED_802_1X
+    $WIRED_MAC_AUTH
+    $WIRED_SNMP_TRAPS
+    $INLINE
+    $UNKNOWN
+);
+
+use_ok("pf::Connection");
+
+my $conn;
+
+my $type_tests = {
+    $pf::config::connection_type_to_str{$pf::config::WIRELESS_802_1X} => pf::Connection->new(
+        'transport' => 'Wireless',
+        'isMacAuth' => 0,
+        'isSNMP' => 0,
+        'isEAP' => 1,
+        'is8021X' => 1   
+      ),
+    $pf::config::connection_type_to_str{$pf::config::WIRELESS_MAC_AUTH} => pf::Connection->new(
+        'transport' => 'Wireless',
+        'isMacAuth' => 1,
+        'isSNMP' => 0,
+        'isEAP' => 0,
+        'is8021X' => 0   
+      ),
+    $pf::config::connection_type_to_str{$pf::config::WIRED_802_1X} => pf::Connection->new(
+        'transport' => 'Wired',
+        'isMacAuth' => 0,
+        'isSNMP' => 0,
+        'isEAP' => 1,
+        'is8021X' => 1   
+      ),
+    $pf::config::connection_type_to_str{$pf::config::WIRED_MAC_AUTH} => pf::Connection->new(
+        'transport' => 'Wired',
+        'isMacAuth' => 1,
+        'isSNMP' => 0,
+        'isEAP' => 0,
+        'is8021X' => 0   
+      ),
+    $pf::config::connection_type_to_str{$pf::config::WIRED_SNMP_TRAPS} => pf::Connection->new(
+        'transport' => 'Wired',
+        'isMacAuth' => 0,
+        'isSNMP' => 1,
+        'isEAP' => 0,
+        'is8021X' => 0   
+      ),
+    $pf::config::connection_type_to_str{$pf::config::INLINE} => pf::Connection->new(),
+    $pf::config::connection_type_to_str{$pf::config::UNKNOWN} => pf::Connection->new(),
+};
+
+while( my ($type, $expected) = each(%$type_tests) ) {
+    $conn = pf::Connection->new;
+    $conn->backwardCompatibleToAttributes($type);
+    is_deeply(
+        $conn,
+        $expected,
+        "Matched correctly $type"
+    );
+}
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2017 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;
+
+
+


### PR DESCRIPTION
# Description
Allows to restart a switchport from the administration interface
Also adds a way to instantiate a pf::Connection from its locationlog reprensented string

# Impacts
node view/list

# Delete branch after merge
YES

# NEWS file entries
## Enhancements
* Can now restart the switchport where a node is connected from the administration interface
