### PR TITLE
feature/pfdhcplistener-process-readonly-mode

### DIFF
--- a/lib/pf/dhcp/processor.pm
+++ b/lib/pf/dhcp/processor.pm
@@ -150,6 +150,10 @@ Process a packet
 sub process_packet {
     my $timer = pf::StatsD::Timer->new();
     my ( $self ) = @_;
+    if (db_check_readonly()) {
+        $logger->trace("The database is in readonly mode skipping processing the database");
+        return;
+    }
 
     my $dhcp = $self->{dhcp};
 


### PR DESCRIPTION
Description
-----------
Do not process dhcp packets when the database is in readonly

Impacts
-----------
dhcp processing

NEWS file entries
-------

New Features
++++++++++++
* Do not process dhcp packets when the database is in readonly

Delete branch after merge
-------------------------
NO