### PR TITLE
fix wmi error when no IP is present

### DIFF
--- a/html/pfappserver/lib/pfappserver/Model/Node/Tab/WMI.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Node/Tab/WMI.pm
@@ -31,6 +31,7 @@ sub process_view {
     my ($status, @scans);
     ($status, my $node) = $c->model("Node")->view($mac);
     my $device_class = $node->{device_class};
+    my $host_ip = $node->{iplog}->{ip};
     my $scan_model = $c->model("Config::Scan");
     eval {
         my $profile = pf::Portal::ProfileFactory->instantiate($mac);
@@ -59,7 +60,7 @@ sub process_view {
     }
     
  
-    return ($STATUS::OK, {items => \@items, device_class => $device_class});
+    return ($STATUS::OK, {items => \@items, device_class => $device_class, host_ip => $host_ip});
 }
 
 =head2 process_tab

--- a/html/pfappserver/root/node/tab_WMI_view.tt
+++ b/html/pfappserver/root/node/tab_WMI_view.tt
@@ -1,4 +1,4 @@
-[% IF device_class == "Windows" && items.size > 0 %]
+[% IF device_class == "Windows" && items.size > 0 && host_ip.defined %]
     [% FOREACH item IN items %]
         <a href="#[% item.scan_id %]_[%item.rule_id%]" data-href="[% c.uri_for(c.controller.action_for('tab_process'), [mac], 'WMI', item.scan_id, item.rule_id) %]" id="node_tab_process" class="btn btn-mini">[% l("Run scan") %] for [% item.scan_id %] [% item.rule_id%]</a>
         <div id="[% item.scan_id %]_[% item.rule_id %]">


### PR DESCRIPTION
# Description
Fix an error on the template when no IP is known for the node which will be scanned

# Impacts
tab WMI in section node

# Issue
fixes issue #2025 

# Delete branch after merge
NO

# NEWS file entries
## Bug Fixes
* Issue with the template of WMI node tab which would not display properly when no IP exists for the node #2025