### PR TITLE
filter out PacketFence-Authorization-Status from RADIUS replies

### DIFF
--- a/conf/radiusd/packetfence-tunnel.example
+++ b/conf/radiusd/packetfence-tunnel.example
@@ -244,9 +244,9 @@ session {
 post-auth {
 	rest
 	update {
-                &request:User-Password := "******"
-        }
-	if (&reply:PacketFence-Authorization-Status == "deny") {
+		&request:User-Password := "******"
+	}
+	if (&control:PacketFence-Authorization-Status == "deny") {
 		packetfence-audit-log-reject
 		reject
 	} else {
@@ -583,9 +583,9 @@ session {
 post-auth {
 	rest
 	update {
-                &request:User-Password := "******"
-        }
-	if (&reply:PacketFence-Authorization-Status == "deny") {
+		&request:User-Password := "******"
+	}
+	if (&control:PacketFence-Authorization-Status == "deny") {
 		packetfence-audit-log-reject
 		reject
 	} else {

--- a/conf/radiusd/packetfence.example
+++ b/conf/radiusd/packetfence.example
@@ -331,10 +331,10 @@ post-auth {
 	# send it to packetfence
 	if (! EAP-Type || (EAP-Type != TTLS  && EAP-Type != PEAP) ) {
 		rest
-                update {
-                       &request:User-Password := "******"
-                }
-		if (&reply:PacketFence-Authorization-Status == "deny") {
+		update {
+			&request:User-Password := "******"
+		}
+		if (&control:PacketFence-Authorization-Status == "deny") {
 			packetfence-audit-log-reject
 			reject
 		} else {
@@ -355,8 +355,8 @@ post-auth {
 	#
 	Post-Auth-Type REJECT {
 		update {
-                        &request:User-Password := "******"
-                }
+			&request:User-Password := "******"
+		}
 		if (! EAP-Type || (EAP-Type != TTLS  && EAP-Type != PEAP) ) {
 			packetfence-audit-log-reject
 		}

--- a/lib/pf/radius/rest.pm
+++ b/lib/pf/radius/rest.pm
@@ -37,15 +37,16 @@ sub format_response {
     while (my ($key, $value) = each %$radius_audit) {
         $audit{"control:$key"} = $value;
     }
+
     %mapped_object = ( %audit, %mapped_object);
 
     get_logger->trace(sub { use Data::Dumper ; "RADIUS REST object : ". Dumper(\%mapped_object) });
     $response = \%mapped_object;
 
-    $response->{'reply:PacketFence-Authorization-Status'} = 'allow';
+    $response->{'control:PacketFence-Authorization-Status'} = 'allow';
 
     if($radius_return == $RADIUS::RLM_MODULE_USERLOCK) {
-        $response->{'reply:PacketFence-Authorization-Status'} = 'deny';
+        $response->{'control:PacketFence-Authorization-Status'} = 'deny';
         $radius_return = $RADIUS::RLM_MODULE_OK
     }
 

--- a/raddb/mods-config/attr_filter/packetfence-post-auth
+++ b/raddb/mods-config/attr_filter/packetfence-post-auth
@@ -31,4 +31,5 @@ DEFAULT
     PacketFence-Domain                    !* ANY,
     PacketFence-Computer-Name             !* ANY,
     PacketFence-Handled                   !* ANY,
-    PacketFence-Request-Time              !* ANY
+    PacketFence-Request-Time              !* ANY,
+    PacketFence-Authorization-Status      !* ANY


### PR DESCRIPTION
# Description
Put PacketFence-Authorization-Status in the FreeRADIUS control instead of the reply

# Impacts
PacketFence REJECT role
All RADIUS replies

# Code / PR Dependencies
(OPTIONAL. REMOVE IF NOT NEEDED)
List the PRs or other factors on which this PR depends

# Issue
fixes #2085

# Delete branch after merge
YES

## Bug Fixes
* Removed PacketFence-Authorization-Status attribute from the RADIUS replies to prevent RADIUS replies from being discarded due to an unknown attribute (#2085)
