### PR TITLE
Updated procedure in order to detect Interim update just after stop

### DIFF
--- a/addons/database-backup-and-maintenance.sh
+++ b/addons/database-backup-and-maintenance.sh
@@ -75,8 +75,7 @@ fi
 # Is the database run on the current server?
 if [ -f /var/run/mysqld/mysqld.pid ] || [ -f /var/run/mariadb/mariadb.pid ]; then
 
-    # Close radacct entries that are open more than one time
-    mysql -u $DB_USER -p$DB_PWD -D $DB_NAME -e "update radacct a JOIN (select callingstationid,count(*) as cnt, max(acctupdatetime) as acctupdatetime from radacct where acctstoptime is null group by callingstationid having cnt > 1) as b ON a.callingstationid=b.callingstationid and a.acctupdatetime<>b.acctupdatetime and a.acctstoptime is null set acctstoptime=now();"
+    /usr/local/pf/addons/database-cleaner.pl --table=radacct --date-field=acctupdatetime --older-than="1 WEEK" --additionnal-condition="acctstoptime IS NOT NULL" --update --update-field=acctstoptime
 
     /usr/local/pf/addons/database-cleaner.pl --table=radacct --date-field=acctstarttime --older-than="1 WEEK" --additionnal-condition="acctstoptime IS NOT NULL"
     

--- a/addons/database-backup-and-maintenance.sh
+++ b/addons/database-backup-and-maintenance.sh
@@ -75,6 +75,9 @@ fi
 # Is the database run on the current server?
 if [ -f /var/run/mysqld/mysqld.pid ] || [ -f /var/run/mariadb/mariadb.pid ]; then
 
+    # Close radacct entries that are open more than one time
+    mysql -u $DB_USER -p$DB_PWD -D $DB_NAME -e "update radacct a JOIN (select callingstationid,count(*) as cnt, max(acctupdatetime) as acctupdatetime from radacct where acctstoptime is null group by callingstationid having cnt > 1) as b ON a.callingstationid=b.callingstationid and a.acctupdatetime<>b.acctupdatetime and a.acctstoptime is null set acctstoptime=now();"
+
     /usr/local/pf/addons/database-cleaner.pl --table=radacct --date-field=acctstarttime --older-than="1 WEEK" --additionnal-condition="acctstoptime IS NOT NULL"
     
     /usr/local/pf/addons/database-cleaner.pl --table=radacct_log --date-field=timestamp --older-than="1 WEEK"

--- a/conf/radiusd/packetfence.example
+++ b/conf/radiusd/packetfence.example
@@ -196,6 +196,8 @@ authenticate {
 #
 preacct {
 	preprocess
+	set_calling_station_id
+	rewrite_calling_station_id
 	rewrite_called_station_id
 
 	#
@@ -249,9 +251,6 @@ preacct {
 #  Accounting.  Log the accounting data.
 #
 accounting {
-	set_calling_station_id
-	rewrite_calling_station_id
-	rewrite_called_station_id
 	# Add in PacketFence specific configuration
 	update {
 		&request:FreeRADIUS-Client-IP-Address := "%{Packet-Src-IP-Address}"

--- a/db/pf-schema-X.Y.Z.sql
+++ b/db/pf-schema-X.Y.Z.sql
@@ -849,7 +849,7 @@ BEGIN
   DECLARE Opened_Sessions int(12);
   DECLARE Latest_acctstarttime datetime;
   DECLARE cnt int(12);
-  DECLARE counte int(12);
+  DECLARE countmac int(12);
   SELECT count(acctuniqueid), max(acctstarttime)
   INTO Opened_Sessions, Latest_acctstarttime
   FROM radacct
@@ -887,12 +887,12 @@ BEGIN
 
   #Detect if there is an radacct entry open
   SELECT count(callingstationid), acctinputoctets, acctoutputoctets, acctsessiontime, acctupdatetime
-    INTO counte, Previous_Input_Octets, Previous_Output_Octets, Previous_Session_Time, Previous_AcctUpdate_Time
+    INTO countmac, Previous_Input_Octets, Previous_Output_Octets, Previous_Session_Time, Previous_AcctUpdate_Time
     FROM radacct
     WHERE (acctuniqueid = p_acctuniqueid) 
     AND (acctstoptime IS NULL OR acctstoptime = 0) LIMIT 1;
 
-  IF (counte = 1) THEN
+  IF (countmac = 1) THEN
     # Update record with new traffic
     UPDATE radacct SET
         framedipaddress = p_framedipaddress,

--- a/db/upgrade-X.X.X-X.Y.Z.sql
+++ b/db/upgrade-X.X.X-X.Y.Z.sql
@@ -169,3 +169,138 @@ ALTER table locationlog_archive ADD column ifDesc VARCHAR(255) DEFAULT NULL;
 -- Add unicity index to node_category.name
 --
 ALTER TABLE node_category ADD UNIQUE INDEX node_category_name (name);
+
+--
+-- Change acct_update procedure
+--
+
+DROP PROCEDURE IF EXISTS acct_update;
+DELIMITER /
+CREATE PROCEDURE acct_update(
+  IN p_timestamp datetime,
+  IN p_framedipaddress varchar(15),
+  IN p_acctsessiontime int(12),
+  IN p_acctinputoctets bigint(20),
+  IN p_acctoutputoctets bigint(20),
+  IN p_acctuniqueid varchar(32),
+  IN p_acctsessionid varchar(64),
+  IN p_username varchar(64),
+  IN p_realm varchar(64),
+  IN p_nasipaddress varchar(15),
+  IN p_nasportid varchar(32),
+  IN p_nasporttype varchar(32),
+  IN p_acctauthentic varchar(32),
+  IN p_connectinfo_start varchar(50),
+  IN p_calledstationid varchar(50),
+  IN p_callingstationid varchar(50),
+  IN p_servicetype varchar(32),
+  IN p_framedprotocol varchar(32),
+  IN p_acctstatustype varchar(25)
+)
+BEGIN
+  DECLARE Previous_Input_Octets bigint(20);
+  DECLARE Previous_Output_Octets bigint(20);
+  DECLARE Previous_Session_Time int(12);
+  DECLARE Previous_AcctUpdate_Time datetime;
+
+  DECLARE Opened_Sessions int(12);
+  DECLARE Latest_acctstarttime datetime;
+  DECLARE cnt int(12);
+  DECLARE counte int(12);
+  SELECT count(acctuniqueid), max(acctstarttime)
+  INTO Opened_Sessions, Latest_acctstarttime
+  FROM radacct
+  WHERE acctuniqueid = p_acctuniqueid
+  AND (acctstoptime IS NULL OR acctstoptime = 0);
+
+  IF (Opened_Sessions > 1) THEN
+      UPDATE radacct SET
+        acctstoptime = NOW(),
+        acctterminatecause = 'UNKNOWN'
+        WHERE acctuniqueid = p_acctuniqueid
+        AND acctstarttime < Latest_acctstarttime
+        AND (acctstoptime IS NULL OR acctstoptime = 0);
+  END IF;
+
+
+  # Detect if we receive in the same time a stop before the interim update
+  SELECT COUNT(*)
+  INTO cnt
+  FROM radacct
+  WHERE acctuniqueid = p_acctuniqueid
+  AND (acctstoptime = p_timestamp);
+
+  # If there is an old closed entry then update it
+  IF (cnt = 1) THEN
+    UPDATE radacct SET
+        framedipaddress = p_framedipaddress,
+        acctsessiontime = p_acctsessiontime,
+        acctinputoctets = p_acctinputoctets,
+        acctoutputoctets = p_acctoutputoctets,
+        acctupdatetime = p_timestamp
+    WHERE acctuniqueid = p_acctuniqueid
+    AND (acctstoptime = p_timestamp);
+  END IF;
+
+  #Detect if there is an radacct entry open
+  SELECT count(callingstationid), acctinputoctets, acctoutputoctets, acctsessiontime, acctupdatetime
+    INTO counte, Previous_Input_Octets, Previous_Output_Octets, Previous_Session_Time, Previous_AcctUpdate_Time
+    FROM radacct
+    WHERE (acctuniqueid = p_acctuniqueid) 
+    AND (acctstoptime IS NULL OR acctstoptime = 0) LIMIT 1;
+
+  IF (counte = 1) THEN
+    # Update record with new traffic
+    UPDATE radacct SET
+        framedipaddress = p_framedipaddress,
+        acctsessiontime = p_acctsessiontime,
+        acctinputoctets = p_acctinputoctets,
+        acctoutputoctets = p_acctoutputoctets,
+        acctupdatetime = p_timestamp,
+        acctinterval = timestampdiff( second, Previous_AcctUpdate_Time,  p_timestamp  )
+    WHERE acctuniqueid = p_acctuniqueid 
+    AND (acctstoptime IS NULL OR acctstoptime = 0);
+  ELSE
+    IF (cnt = 0) THEN
+      # If there is no open session for this, open one.
+      # Set values to 0 when no previous records
+      SET Previous_Session_Time = 0;
+      SET Previous_Input_Octets = 0;
+      SET Previous_Output_Octets = 0;
+      SET Previous_AcctUpdate_Time = p_timestamp;
+      INSERT INTO radacct
+             (
+              acctsessionid,acctuniqueid,username,
+              realm,nasipaddress,nasportid,
+              nasporttype,acctstarttime,
+              acctupdatetime,acctsessiontime,acctauthentic,
+              connectinfo_start,acctinputoctets,
+              acctoutputoctets,calledstationid,callingstationid,
+              servicetype,framedprotocol,
+              framedipaddress
+             )
+      VALUES
+          (
+              p_acctsessionid,p_acctuniqueid,p_username,
+              p_realm,p_nasipaddress,p_nasportid,
+              p_nasporttype,date_sub(p_timestamp, INTERVAL p_acctsessiontime SECOND ),
+              p_timestamp,p_acctsessiontime,p_acctauthentic,
+              p_connectinfo_start,p_acctinputoctets,
+              p_acctoutputoctets,p_calledstationid,p_callingstationid,
+              p_servicetype,p_framedprotocol,
+              p_framedipaddress
+          );
+     END IF;
+   END IF;
+
+ 
+  # Create new record in the log table
+  INSERT INTO radacct_log
+   (acctsessionid, username, nasipaddress,
+    timestamp, acctstatustype, acctinputoctets, acctoutputoctets, acctsessiontime, acctuniqueid)
+  VALUES
+   (p_acctsessionid, p_username, p_nasipaddress,
+    p_timestamp, p_acctstatustype, (p_acctinputoctets - Previous_Input_Octets), (p_acctoutputoctets - Previous_Output_Octets),
+    (p_acctsessiontime - Previous_Session_Time), p_acctuniqueid);
+END /
+DELIMITER ;

--- a/db/upgrade-X.X.X-X.Y.Z.sql
+++ b/db/upgrade-X.X.X-X.Y.Z.sql
@@ -206,7 +206,7 @@ BEGIN
   DECLARE Opened_Sessions int(12);
   DECLARE Latest_acctstarttime datetime;
   DECLARE cnt int(12);
-  DECLARE counte int(12);
+  DECLARE countmac int(12);
   SELECT count(acctuniqueid), max(acctstarttime)
   INTO Opened_Sessions, Latest_acctstarttime
   FROM radacct
@@ -244,12 +244,12 @@ BEGIN
 
   #Detect if there is an radacct entry open
   SELECT count(callingstationid), acctinputoctets, acctoutputoctets, acctsessiontime, acctupdatetime
-    INTO counte, Previous_Input_Octets, Previous_Output_Octets, Previous_Session_Time, Previous_AcctUpdate_Time
+    INTO countmac, Previous_Input_Octets, Previous_Output_Octets, Previous_Session_Time, Previous_AcctUpdate_Time
     FROM radacct
     WHERE (acctuniqueid = p_acctuniqueid) 
     AND (acctstoptime IS NULL OR acctstoptime = 0) LIMIT 1;
 
-  IF (counte = 1) THEN
+  IF (countmac = 1) THEN
     # Update record with new traffic
     UPDATE radacct SET
         framedipaddress = p_framedipaddress,


### PR DESCRIPTION

# Description
Some NAS send an interim update just after a stop for the same session, it occur that we open a new radacct entry with wrong accounting values. In order to fix it we try to detect if a stop match the interim update before trying to open a new radacct entry.

# Impacts
RADIUS accounting workflow

# Delete branch after merge
YES

# NEWS file entries

## Bug Fixes
* Avoid opening a double entry with wrong accounting values

