### PR TITLE
Enforces block behavior when a browser detects an XSS attempt targeting PF

### DIFF
--- a/conf/httpd.conf.d/httpd.admin.tt.example
+++ b/conf/httpd.conf.d/httpd.admin.tt.example
@@ -178,7 +178,7 @@ SSLCipherSuite ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-R
 [% END %]
 
 SSLHonorCipherOrder  on
-X-XSS-Protection: 1; mode=block
+Header set X-XSS-Protection "1; mode=block"
 
 ErrorLog  [% install_dir %]/logs/[% name %].error
 

--- a/conf/httpd.conf.d/httpd.admin.tt.example
+++ b/conf/httpd.conf.d/httpd.admin.tt.example
@@ -178,6 +178,8 @@ SSLCipherSuite ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-R
 [% END %]
 
 SSLHonorCipherOrder  on
+X-XSS-Protection: 1; mode=block
+
 ErrorLog  [% install_dir %]/logs/[% name %].error
 
 ServerAdmin [% server_admin %]

--- a/conf/httpd.conf.d/httpd.graphite.tt.example
+++ b/conf/httpd.conf.d/httpd.graphite.tt.example
@@ -117,6 +117,7 @@ MaxSpareServers 1
 HostnameLookups off
 MaxRequestsPerChild 1000
 
+Header set X-XSS-Protection "1; mode=block"
 ErrorLog  [% install_dir %]/logs/[% name %].error
 
 ServerAdmin [% server_admin %]

--- a/conf/httpd.conf.d/httpd.parking.tt.example
+++ b/conf/httpd.conf.d/httpd.parking.tt.example
@@ -123,6 +123,7 @@ DocumentRoot [% install_dir %]/html/parking
 
 DirectoryIndex index.html
 
+Header set X-XSS-Protection "1; mode=block"
 ErrorLog [% install_dir %]/logs/[% name %].error
 
 LogLevel warn

--- a/conf/httpd.conf.d/httpd.portal.tt.example
+++ b/conf/httpd.conf.d/httpd.portal.tt.example
@@ -209,7 +209,7 @@ SSLCipherSuite ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-R
 [% END %]
 
 SSLHonorCipherOrder on
-X-XSS-Protection: 1; mode=block
+Header set X-XSS-Protection "1; mode=block"
 
 ErrorLog [% install_dir %]/logs/[% name %].error
 

--- a/conf/httpd.conf.d/httpd.portal.tt.example
+++ b/conf/httpd.conf.d/httpd.portal.tt.example
@@ -209,6 +209,7 @@ SSLCipherSuite ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-R
 [% END %]
 
 SSLHonorCipherOrder on
+X-XSS-Protection: 1; mode=block
 
 ErrorLog [% install_dir %]/logs/[% name %].error
 


### PR DESCRIPTION
# Description
IE, Chrome and Safari enforces X-XSS filter. 

Rather than sanitize the page, when a XSS attack is detected, the browser is instructed to prevent rendering of the page completely and serves an empty page instead.

# Impacts
None

# Delete branch after merge
YES

# News
Cross-site scripting (XSS) filtering is now requested from your browser.