### PR TITLE
Ability to provide a CN format in PKI providers

### DIFF
--- a/html/pfappserver/lib/pfappserver/Form/Config/PKI_Provider/packetfence_pki.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/PKI_Provider/packetfence_pki.pm
@@ -144,7 +144,7 @@ has_field 'cn_format' => (
     default => '%s',
     tags    => {
         after_element   => \&help,
-        help            => 'Defines how the common name will be formated. %s will expand the defined Common Name Attribute value',
+        help            => 'Defines how the common name will be formated. %s will expand to the defined Common Name Attribute value',
     },
 );
 

--- a/html/pfappserver/lib/pfappserver/Form/Config/PKI_Provider/packetfence_pki.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/PKI_Provider/packetfence_pki.pm
@@ -138,6 +138,16 @@ has_field 'cn_attribute' => (
     },
 );
 
+has_field 'cn_format' => (
+    type    => 'Text',
+    label   => 'Common Name Format',
+    default => '%s',
+    tags    => {
+        after_element   => \&help,
+        help            => 'Defines how the common name will be formated. %s will expand the defined Common Name Attribute value',
+    },
+);
+
 has_field 'server_cert_path' => (
     type        => 'Path',
     label       => 'Server cert path',
@@ -159,7 +169,7 @@ has_field 'revoke_on_unregistration' => (
 );
 
 has_block 'definition' => (
-    render_list => [ qw(type proto host port username password profile country state organization cn_attribute revoke_on_unregistration ca_cert_path server_cert_path) ],
+    render_list => [ qw(type proto host port username password profile country state organization cn_attribute cn_format revoke_on_unregistration ca_cert_path server_cert_path) ],
 );
 
 =head1 AUTHOR

--- a/html/pfappserver/lib/pfappserver/Form/Config/PKI_Provider/scep.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/PKI_Provider/scep.pm
@@ -126,7 +126,7 @@ has_field 'cn_format' => (
     default => '%s',
     tags    => {
         after_element   => \&help,
-        help            => 'Defines how the common name will be formated. %s will expand the defined Common Name Attribute value',
+        help            => 'Defines how the common name will be formated. %s will expand to the defined Common Name Attribute value',
     },
 );
 

--- a/html/pfappserver/lib/pfappserver/Form/Config/PKI_Provider/scep.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/PKI_Provider/scep.pm
@@ -120,9 +120,19 @@ has_field 'cn_attribute' =>
              help => 'Defines what attribute of the node to use as the common name during the certificate generation.' },
   );
 
+has_field 'cn_format' => (
+    type    => 'Text',
+    label   => 'Common Name Format',
+    default => '%s',
+    tags    => {
+        after_element   => \&help,
+        help            => 'Defines how the common name will be formated. %s will expand the defined Common Name Attribute value',
+    },
+);
+
 has_block definition =>
   (
-    render_list => [qw(type url username password country state locality organization organizational_unit cn_attribute ca_cert_path server_cert_path)],
+    render_list => [qw(type url username password country state locality organization organizational_unit cn_attribute cn_format ca_cert_path server_cert_path)],
   );
 
 =head1 COPYRIGHT

--- a/lib/pf/pki_provider.pm
+++ b/lib/pf/pki_provider.pm
@@ -29,6 +29,8 @@ has server_cert => (is => 'ro' , builder => 1, lazy => 1);
 
 has cn_attribute => (is => 'rw');
 
+has cn_format => (is => 'rw', default => '%s');
+
 has revoke_on_unregistration => (is => 'rw', default => 'N');
 
 =head2 country
@@ -199,7 +201,7 @@ sub ca_cn {
 
 sub user_cn {
     my ($self, $node_info) = @_;
-    my $cn = $node_info->{$self->cn_attribute};
+    my $cn = sprintf($self->cn_format, $node_info->{$self->cn_attribute});
     if( defined($cn) ) {
         return $cn;
     }


### PR DESCRIPTION
# Description
Title says it all

# Impacts
Client generated certs for EAP-TLS

# Issue
fixes #2116 

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* pki: Add the ability to "format" the CN (#2116)
