### PR TITLE
So that PF upgrades do not create duplicate ip_forward entries.

### DIFF
--- a/addons/packages/packetfence.spec
+++ b/addons/packages/packetfence.spec
@@ -758,8 +758,9 @@ sed -i 's/^SELINUX=.*/SELINUX=disabled/g' /etc/selinux/config
 sed -i 's/\%.*$//g' /etc/resolv.conf
 
 # Enabling ip forwarding
-echo "net.ipv4.ip_forward = 1" >> /etc/sysctl.conf
-sysctl -p /etc/sysctl.conf
+echo "# ip forwarding enabled by packetfence" > /etc/sysctl.d/99-ip_forward.conf
+echo "net.ipv4.ip_forward = 1" >> /etc/sysctl.d/99-ip_forward.conf
+sysctl -p /etc/sysctl.d/99-ip_forward.conf
 
 #Starting PacketFence.
 echo "Starting PacketFence Administration GUI..."

--- a/debian/packetfence.postinst
+++ b/debian/packetfence.postinst
@@ -144,10 +144,10 @@ case "$1" in
 
         /sbin/ldconfig
         # Enabling ip forwarding
-        echo "# ip forwarding enabled by packetfence" >> /etc/sysctl.conf
-        echo "net.ipv4.ip_forward = 1" >> /etc/sysctl.conf
-        sysctl -p /etc/sysctl.conf
-
+        echo "# ip forwarding enabled by packetfence" > /etc/sysctl.d/99-ip_forward.conf
+        echo "net.ipv4.ip_forward = 1" >> /etc/sysctl.d/99-ip_forward.conf
+        sysctl -p /etc/sysctl.d/99-ip_forward.conf
+ 
         #Starting PacketFence.
         echo "Starting PacketFence Administration GUI..."
         #removing old cache


### PR DESCRIPTION
# Description
Title says it all.

If ip_forward is also existing in /etc/sysctl.conf (PF 6.x installed on CentOS7), it will still duplicate. Each new upgrade will overwrite its /etc/sysctl.d/99-ip_forward.conf file.

# Impacts
none 

# Delete branch after merge
YES

fixes #2145 

# News
ip forwarding is now activated by default per packetfence package installation.