### PR TITLE
Addition of systemd too early swapoff workaround

### DIFF
--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -3770,6 +3770,7 @@ Workaround
 ++++++++++
 
  * Obtain the list of swap items that should be considered by systemd for it to enforce a correct ordering:
+
 ---
 #grep swap /var/log/dmesg |grep "dead -> active"
 ---

--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -3794,7 +3794,7 @@ After=dev-disk-by\x2duuid-6509e6e1\x2daf2d\x2d4d23\x2d9ebd\x2da9aa8801e658.swap 
 ```
 
 Operating System Best Practices
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------
 
 IPTables
 ~~~~~~~~

--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -3755,8 +3755,42 @@ Trigger a violation when discovering a node
 
 PacketFence is able to trigger a violation when a node is discovered on your network. It will send the trigger internal::node_discovered which is already part of violation 1300004. You can enable this violation with the default values and it will send a short report for every new device discovered by PacketFence. You can also execute any typical violation actions on during this process.
 
-Operating System Best Practices
--------------------------------
+Best Practices
+--------------
+
+RHEL7 systemd early swapoff bug mitigation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A https://bugzilla.redhat.com/show_bug.cgi?id=1031158[known bug] is still present in systemd-219-30.el7_3.7.x86_64 shipped with CentOS. (Debian fixed it in 228-3).
+
+The bug arises because not all swap aliases are registered, which results in an incorrect dependence tree which results in swapoff being called way too early at shutdown.
+
+
+Workaround:
+
+Obtain the list of swap items that should be considered by systemd for it to enforce a correct ordering:
+---
+#grep swap /var/log/dmesg |grep "dead -> active"
+---
+
+In our example, that gave the following output:
+
+```
+[    1.995413] systemd[1]: dev-dm\x2d1.swap changed dead -> active
+[    1.995495] systemd[1]: dev-cl-swap.swap changed dead -> active
+[    1.995550] systemd[1]: dev-disk-by\x2did-dm\x2dname\x2dcl\x2dswap.swap changed dead -> active
+[    1.995616] systemd[1]: dev-disk-by\x2did-dm\x2duuid\x2dLVM\x2dXOAK7DHxMdmQCrNdwWE3Pt836Q9pHYSGyrO9ycCGeIYavzbamVWNKMaVUMLf1NWZ.swap changed dead -> active
+[    1.995678] systemd[1]: dev-disk-by\x2duuid-6509e6e1\x2daf2d\x2d4d23\x2d9ebd\x2da9aa8801e658.swap changed dead -> active
+```
+
+Create /etc/systemd/system/swap.target and fill it with all swap aliases obtained from the previous command:
+
+```
+[Unit]
+Description=Swap
+Documentation=man:systemd.special(7)
+After=dev-disk-by\x2duuid-6509e6e1\x2daf2d\x2d4d23\x2d9ebd\x2da9aa8801e658.swap dev-dm1.swap dev-disk-by\x2did-dm\x2duuid\x2dLVM\x2dXOAK7DHxMdmQCrNdwWE3Pt836Q9pHYSGyrO9ycCGeIYavzbamVWNKMaVUMLf1NWZ.swap dev-disk-by\x2did-dm\x2dname\x2dcl\x2dswap.swap dev-cl-swap.swap dev-dm\x2d1.swap
+```
 
 IPTables
 ~~~~~~~~

--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -3759,16 +3759,17 @@ Best Practices
 --------------
 
 RHEL7 systemd early swapoff bug mitigation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A https://bugzilla.redhat.com/show_bug.cgi?id=1031158[known bug] is still present in systemd-219-30.el7_3.7.x86_64 shipped with CentOS. (Debian fixed it in 228-3).
 
 The bug arises because not all swap aliases are registered, which results in an incorrect dependence tree which results in swapoff being called way too early at shutdown.
 
 
-Workaround:
+Workaround
+++++++++++
 
-Obtain the list of swap items that should be considered by systemd for it to enforce a correct ordering:
+ * Obtain the list of swap items that should be considered by systemd for it to enforce a correct ordering:
 ---
 #grep swap /var/log/dmesg |grep "dead -> active"
 ---
@@ -3783,7 +3784,7 @@ In our example, that gave the following output:
 [    1.995678] systemd[1]: dev-disk-by\x2duuid-6509e6e1\x2daf2d\x2d4d23\x2d9ebd\x2da9aa8801e658.swap changed dead -> active
 ```
 
-Create /etc/systemd/system/swap.target and fill it with all swap aliases obtained from the previous command:
+ * Create /etc/systemd/system/swap.target and fill it with all swap aliases obtained from the previous command:
 
 ```
 [Unit]
@@ -3791,6 +3792,9 @@ Description=Swap
 Documentation=man:systemd.special(7)
 After=dev-disk-by\x2duuid-6509e6e1\x2daf2d\x2d4d23\x2d9ebd\x2da9aa8801e658.swap dev-dm1.swap dev-disk-by\x2did-dm\x2duuid\x2dLVM\x2dXOAK7DHxMdmQCrNdwWE3Pt836Q9pHYSGyrO9ycCGeIYavzbamVWNKMaVUMLf1NWZ.swap dev-disk-by\x2did-dm\x2dname\x2dcl\x2dswap.swap dev-cl-swap.swap dev-dm\x2d1.swap
 ```
+
+Operating System Best Practices
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 IPTables
 ~~~~~~~~

--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -3771,9 +3771,9 @@ Workaround
 
  * Obtain the list of swap items that should be considered by systemd for it to enforce a correct ordering:
 
----
+----
 #grep swap /var/log/dmesg |grep "dead -> active"
----
+----
 
 In our example, that gave the following output:
 


### PR DESCRIPTION
# Description
- Added section: Best Practices
- Addition of systemd too early swapoff workaround.

@louismunro @dwlfrth @extrafu : Would you call that section by any other name then "Best Practices"?

# Delete branch after merge
YES

## Bug Fixes
fixes #2140 
