### PR TITLE
Maintain Captive Portal Interface Seperation

### DIFF
--- a/NEWS.asciidoc
+++ b/NEWS.asciidoc
@@ -11,6 +11,17 @@ This is a list of noteworthy changes across releases.
 For more details and developer visible changes see the ChangeLog file.
 For a list of compatibility related changes see the UPGRADE.asciidoc file.
 
+Version 6.5.1 released on XXXX-XX-XX
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Bug Fixes
++++++++++
+ * Fix incorrect node cleanup job handling.
+ * Fix multiple firewall SSO not working when cached updates were enabled.
+ * Removed usage of pf_memoize which could create a race condition when adding a node.
+ * Fix incorrect locationlog informations because of a null role.
+ * Fixed syntax error in generated Suricata rules
+
 Version 6.5.0 released on 2016-01-30
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/NEWS.asciidoc
+++ b/NEWS.asciidoc
@@ -11,7 +11,7 @@ This is a list of noteworthy changes across releases.
 For more details and developer visible changes see the ChangeLog file.
 For a list of compatibility related changes see the UPGRADE.asciidoc file.
 
-Version 6.5.1 released on XXXX-XX-XX
+Version 6.5.1 released on 2017-02-23
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Bug Fixes

--- a/NEWS.asciidoc
+++ b/NEWS.asciidoc
@@ -21,6 +21,8 @@ Bug Fixes
  * Removed usage of pf_memoize which could create a race condition when adding a node.
  * Fix incorrect locationlog informations because of a null role.
  * Fixed syntax error in generated Suricata rules
+ * Fixed the Portal preview through the admin
+ * Fixed issue extracting the SSID from the switch HP::Controller_MSM710
 
 Version 6.5.0 released on 2016-01-30
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/UPGRADE.asciidoc
+++ b/UPGRADE.asciidoc
@@ -119,6 +119,19 @@ The "configfile" and "traplog" database tables are now deprecated. If you wish t
 
 Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 6.5.0).
 
+pfdetect.conf
+^^^^^^^^^^^^
+
+New parameters have been introduced in conf/pfdetect.conf
+Run the following script to add these parameters to pfdetect.conf
+
+   /usr/local/pf/addons/upgrade/to-6.5-pfdetect-conf.pl
+
+Default RoleMap for the switches
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you were using the default 'RoleMap = Y' in the conf/switches.conf it's disabled by default now. You will need to put 'RoleMap = Y' under your switches or switch group configuration.
+
 Upgrading from a version prior to 6.4.0
 ---------------------------------------
 

--- a/addons/packages/packetfence.spec
+++ b/addons/packages/packetfence.spec
@@ -1393,6 +1393,9 @@ fi
 %exclude                /usr/local/pf/addons/pfconfig/pfconfig.init
 
 %changelog
+* Thu Feb 23 2017 Inverse <info@inverse.ca> - 6.5.1-1
+- New release 6.5.1
+
 * Mon Jan 30 2017 Inverse <info@inverse.ca> - 6.5.0-1
 - New release 6.5.0
 

--- a/conf/httpd.conf.d/httpd.portal.tt.example
+++ b/conf/httpd.conf.d/httpd.portal.tt.example
@@ -327,6 +327,7 @@ NameVirtualHost [% vhost %]:443
      [% IF captive_portal.secure_redirect %]
      RewriteEngine On
      RewriteCond %{HTTP:X-Forwarded-Proto} !=https
+     RewriteCond %{HTTP:X-Forwarded-For-PacketFence} =""
      RewriteCond %{HTTPS} !=on
      RewriteRule ^/?(.*) https://%{SERVER_NAME}/$1 [R,L]
      [% END %]

--- a/conf/pf-release
+++ b/conf/pf-release
@@ -1,1 +1,1 @@
-PacketFence 6.5.0
+PacketFence 6.5.1

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+packetfence (6.5.1) unstable; urgency=low
+
+  * Version 6.5.1
+
+ -- Inverse <info@inverse.ca>  Thu, 23 Feb 2017 12:00:00 -0400
+
 packetfence (6.5.0) unstable; urgency=low
 
   * Version 6.5.0

--- a/docs/PacketFence_MSPKI_Quick_Install_Guide.asciidoc
+++ b/docs/PacketFence_MSPKI_Quick_Install_Guide.asciidoc
@@ -276,7 +276,7 @@ Configuring this has to be done in the 'Signing' tab in the "Apple devices".
 image::docs/images/packetfence-pki-eaptls-sign-example.png[scaledwidth="100%",alt="Signing provisioner"]
 
 Fill out the fields with the contents of the Base64 encoded certificates.
-To extract this information from a pem formatted certificate, copy the file content included between the begin and end tag, not including the delimiters themselves.
+To extract this information from a pem formatted certificate, copy the file content.
 
 Certificate file example:
 
@@ -287,7 +287,7 @@ zxcvbnmqwertyuiop78
 ----- END CERTIFICATE -----
 ----
 
-Copy everything between the BEGIN and END lines, but not the lines themselves.
+Copy everything from the BEGIN to END lines.
 Repeat this operation for the certificate key and intermediate certificate.
 
 ----

--- a/lib/pf/CHI/Request.pm
+++ b/lib/pf/CHI/Request.pm
@@ -38,7 +38,7 @@ __PACKAGE__->config({
         },
     },
     namespace => {
-       'pf::node::node_exist' => {
+       'pf::node::_node_exist' => {
            storage => 'raw_memory',
        },
     },

--- a/lib/pf/Portal/ProfileFactory.pm
+++ b/lib/pf/Portal/ProfileFactory.pm
@@ -28,7 +28,6 @@ use pf::factory::condition::profile;
 use pfconfig::cached_scalar;
 use List::Util qw(first);
 use pf::StatsD::Timer;
-use pf::CHI::Request qw(pf_memoize);
 
 =head1 SUBROUTINES
 

--- a/lib/pf/Report.pm
+++ b/lib/pf/Report.pm
@@ -105,15 +105,25 @@ sub generate_sql_query {
         );
     }
 
+
+    # NOTE: when counting, we shouldn't group but instead count distinct so it is ignored in that case even when specified
     my %group_by;
-    if($self->group_field) {
+    if($self->group_field && !$infos{count_only}) {
         %group_by = (
             -group_by => [$self->group_field],
         );
     }
 
+    my $columns;
+    if($infos{count_only}) {
+        $columns = $self->group_field ? 'count(distinct('.$self->group_field.')) as count' : 'count(*) as count';
+    }
+    else {
+        $columns = $self->columns;
+    }
+
     my ($sql, @params) = $sqla->select(
-        -columns => $infos{count_only} ? 'count(*) as count' : $self->columns, 
+        -columns => $columns,
         -from => [
             -join => ($self->base_table, split(" ", join(" ", @{$self->joins}))),
         ],

--- a/lib/pf/Switch/HP/Controller_MSM710.pm
+++ b/lib/pf/Switch/HP/Controller_MSM710.pm
@@ -161,14 +161,15 @@ sub extractSsid {
     my $logger = $self->logger;
 
     if (defined($radius_request->{'Colubris-AVPair'})) {
+        my $pairs = listify($radius_request->{'Colubris-AVPair'});
         # With HP Procurve AP Ccontroller, we receive an array of settings in Colubris-AVPair:
         # Colubris-AVPair = ssid=Inv_Controller
         # Colubris-AVPair = group=Default Group
         # Colubris-AVPair = phytype=IEEE802dot11g
-        foreach (@{$radius_request->{'Colubris-AVPair'}}) {
+        foreach (@$pairs) {
             if (/^ssid=(.*)$/) { return $1; }
         }
-        $logger->info("Unable to extract SSID of Colubris-AVPair: ".@{$radius_request->{'Colubris-AVPair'}});
+        $logger->info("Unable to extract SSID of Colubris-AVPair: ". join(", ", @$pairs));
     }
 
     $logger->warn(

--- a/lib/pf/SwitchFactory.pm
+++ b/lib/pf/SwitchFactory.pm
@@ -30,7 +30,6 @@ use pfconfig::cached_array;
 use NetAddr::IP;
 use pf::StatsD::Timer;
 use pf::util::statsd qw(called);
-use pf::CHI::Request qw(pf_memoize);
 
 our %SwitchConfig;
 tie %SwitchConfig, 'pfconfig::cached_hash', 'config::Switch';
@@ -175,8 +174,6 @@ sub instantiate {
 
     return $result;
 }
-
-pf_memoize("pf::SwitchFactory::instantiate");
 
 sub config {
     my %temp = %SwitchConfig;

--- a/lib/pf/api.pm
+++ b/lib/pf/api.pm
@@ -290,7 +290,7 @@ sub firewallsso : Public : Fork {
                 my $cache = pf::CHI->new( namespace => 'firewall_sso' );
                 my $cache_timeout = $pf::config::ConfigFirewallSSO{$firewall_id}{cache_timeout} || $postdata{timeout} / 2;
                 my $cache_key = "$firewall_id - $postdata{ip}";
-                return $cache->compute($cache_key, { expires_in => $cache_timeout },
+                $cache->compute($cache_key, { expires_in => $cache_timeout },
                     sub {
                         $logger->debug("Doing cached firewall SSO for '$cache_key' with expiration of $cache_timeout");
                         $firewall->action($firewall_id,'Start',$postdata{'mac'},$postdata{'ip'},$postdata{'timeout'});

--- a/lib/pf/auth_log.pm
+++ b/lib/pf/auth_log.pm
@@ -150,6 +150,12 @@ sub cleanup {
     my ($expire_seconds, $batch, $time_limit) = @_;
     my $logger = get_logger();
     $logger->debug("calling cleanup with time=$expire_seconds batch=$batch timelimit=$time_limit");
+
+    if($expire_seconds eq "0") {
+        $logger->debug("Not deleting because the window is 0");
+        return;
+    }
+
     my $now = db_now();
     my $start_time = time;
     my $end_time;

--- a/lib/pf/iplog.pm
+++ b/lib/pf/iplog.pm
@@ -810,8 +810,13 @@ sub cleanup {
     my $timer = pf::StatsD::Timer->new({sample_rate => 0.2});
     my ( $window_seconds, $batch, $time_limit, $table ) = @_;
     my $logger = pf::log::get_logger();
-
     $logger->debug("Calling cleanup with window='$window_seconds' seconds, batch='$batch', timelimit='$time_limit'");
+
+    if($window_seconds eq "0") {
+        $logger->debug("Not deleting because the window is 0");
+        return;
+    }
+
     my $now = db_now();
     my $start_time = time;
     my $end_time;

--- a/lib/pf/locationlog.pm
+++ b/lib/pf/locationlog.pm
@@ -341,9 +341,6 @@ sub locationlog_insert_start {
     if (!(defined($vlan)) && defined($locationlog_mac->{'vlan'})) {
         $vlan = $locationlog_mac->{'vlan'};
     }
-    if (!(defined($role)) && defined($locationlog_mac->{'role'})) {
-        $role = $locationlog_mac->{'role'};
-    }
     if ( defined($mac) ) {
         db_query_execute(LOCATIONLOG, $locationlog_statements, 'locationlog_insert_start_with_mac_sql',
             lc($mac), $switch, $switch_ip, $switch_mac, $ifIndex, $vlan, $role, $conn_type, $connection_sub_type, $user_name, $ssid, $stripped_user_name, $realm)
@@ -546,11 +543,15 @@ sub _is_locationlog_accurate {
     my $conn_typeChanged = ($locationlog_mac->{connection_type} ne connection_type_to_str($connection_type));
     my $userChanged = ($locationlog_mac->{'dot1x_username'} ne $user_name);
     my $ssidChanged = ($locationlog_mac->{'ssid'} ne $ssid);
+    
     my $roleChanged = '0';
-    if (defined($role)) {
-        my $old_role = $locationlog_mac->{'role'};
-        $roleChanged = ( defined ($old_role) && $old_role ne $role);
-    }
+    my $old_role = $locationlog_mac->{'role'};
+    $roleChanged = ( 
+        (!defined($old_role) && defined($role))
+        || (defined($old_role) && !defined($role))
+        || (defined($old_role) && defined($role) && $old_role ne $role)
+    );
+
     # ifIndex on wireless is not important
     my $ifIndexChanged = 0;
     if (($connection_type & $WIRED) == $WIRED) {

--- a/lib/pf/locationlog.pm
+++ b/lib/pf/locationlog.pm
@@ -497,6 +497,12 @@ sub locationlog_cleanup {
     my ($expire_seconds, $batch, $time_limit) = @_;
     my $logger = get_logger();
     $logger->debug("calling locationlog_cleanup with time=$expire_seconds batch=$batch timelimit=$time_limit");
+
+    if($expire_seconds eq "0") {
+        $logger->debug("Not deleting because the window is 0");
+        return;
+    }
+
     my $now = db_now();
     my $start_time = time;
     my $end_time;

--- a/lib/pf/locationlog.pm
+++ b/lib/pf/locationlog.pm
@@ -345,7 +345,6 @@ sub locationlog_insert_start {
         db_query_execute(LOCATIONLOG, $locationlog_statements, 'locationlog_insert_start_with_mac_sql',
             lc($mac), $switch, $switch_ip, $switch_mac, $ifIndex, $vlan, $role, $conn_type, $connection_sub_type, $user_name, $ssid, $stripped_user_name, $realm)
             || return (0);
-        node_remove_from_cache($mac);
     } else {
         db_query_execute(LOCATIONLOG, $locationlog_statements, 'locationlog_insert_start_no_mac_sql',
             $switch, $switch_ip, $switch_mac, $ifIndex, $vlan, $role, $conn_type, $connection_sub_type, $user_name, $ssid, $stripped_user_name, $realm)
@@ -393,7 +392,6 @@ sub locationlog_update_end_mac {
 
     db_query_execute(LOCATIONLOG, $locationlog_statements, 'locationlog_update_end_mac_sql', $mac)
         || return (0);
-    node_remove_from_cache($mac);
     return (1);
 }
 

--- a/lib/pf/node.pm
+++ b/lib/pf/node.pm
@@ -26,7 +26,6 @@ use pf::util::statsd qw(called);
 use pf::error qw(is_success);
 use pf::constants::parking qw($PARKING_VID);
 use CHI::Memoize qw(memoized);
-use pf::CHI::Request qw(pf_memoize);
 
 use constant NODE => 'node';
 
@@ -80,7 +79,6 @@ BEGIN {
         node_search
         $STATUS_REGISTERED
         node_last_reg
-        node_remove_from_cache
     );
 }
 
@@ -409,8 +407,6 @@ sub _node_exist {
     return ($val);
 }
 
-pf_memoize("pf::node::_node_exist");
-
 #
 # return mac if the node exists
 #
@@ -685,9 +681,6 @@ sub _node_view {
     return ($node_info_ref);
 }
 
-pf_memoize("pf::node::_node_view");
-
-
 =item node_view
 
 Returning lots of information about a given MAC address (node).
@@ -952,7 +945,6 @@ sub node_modify {
         $mac
     );
     if($sth) {
-        node_remove_from_cache($new_mac);
         return ( $sth->rows );
     }
     $logger->error("Unable to modify node '" . $mac // 'undef' . "'");
@@ -1408,27 +1400,6 @@ sub fingerbank_info {
     $info ={ (%$info, %$device_info) };
 
     return $info;
-}
-
-=item node_remove_from_cache
-
-Remove node from the cache
-
-=cut
-
-sub node_remove_from_cache {
-    my ($mac) = @_;
-    $mac = clean_mac($mac);
-    if ($mac) {
-        my $cache = memoized("pf::node::_node_view")->cache;
-        if ($cache) {
-            $cache->remove($mac);
-        }
-        else {
-            my $logger = get_logger();
-            $logger->error("Cannot get the cache for pf::node::_node_view");
-        }
-    }
 }
 
 =back

--- a/lib/pf/node.pm
+++ b/lib/pf/node.pm
@@ -1146,6 +1146,11 @@ sub node_cleanup {
     my ($time) = @_;
     my $logger = get_logger();
     $logger->debug("calling node_cleanup with time=$time");
+    
+    if($time eq "0") {
+        $logger->debug("Not deleting because the window is 0");
+        return;
+    }
 
     foreach my $rowVlan ( node_expire_lastdhcp($time) ) {
         my $mac = $rowVlan->{'mac'};

--- a/lib/pf/provisioner/mobileconfig.pm
+++ b/lib/pf/provisioner/mobileconfig.pm
@@ -223,7 +223,7 @@ sub sign_profile {
     if($self->cert_chain) {
         $smime->setPublicKey($self->cert_chain);
     }
-    return decode_base64($smime->signonly_attached($content));
+    return decode_base64($smime->signonly($content));
 }
 
 =head2 _build_profile_template

--- a/lib/pf/radius_audit_log.pm
+++ b/lib/pf/radius_audit_log.pm
@@ -238,6 +238,12 @@ sub radius_audit_log_cleanup {
     my ($expire_seconds, $batch, $time_limit) = @_;
     my $logger = get_logger();
     $logger->debug(sub { "calling radius_audit_log_cleanup with time=$expire_seconds batch=$batch timelimit=$time_limit" });
+    
+    if($expire_seconds eq "0") {
+        $logger->debug("Not deleting because the window is 0");
+        return;
+    }
+
     my $now = db_now();
     my $start_time = time;
     my $end_time;

--- a/lib/pf/services/manager/p0f.pm
+++ b/lib/pf/services/manager/p0f.pm
@@ -35,7 +35,7 @@ has '+launcher' => (
         my $pid_file = $self->pidFile;
         my $name = $self->name;
         my $p0f_cmdline;
-        if (@ha_ints)
+        if ($cluster_enabled)
         {
             my $p0f_bpf_filter = bpf_filter();
             $p0f_cmdline="sudo %1\$s -d -i any -p -f $p0f_map -s $p0f_sock" . " '$p0f_bpf_filter' " . " > /dev/null && pidof $name > $pid_file";

--- a/lib/pf/services/manager/suricata.pm
+++ b/lib/pf/services/manager/suricata.pm
@@ -49,7 +49,7 @@ sub generateConfig {
 
             #append install_dir if the path doesn't start with /
             $rule = " - $rule" if ( $rule !~ /^\// );
-            push @rules, " - $rule";
+            push @rules, "$rule";
         }
     }
     $tags{'suricata_rules'} = join( "\n", @rules );

--- a/lib/pf/web/dispatcher.pm
+++ b/lib/pf/web/dispatcher.pm
@@ -186,6 +186,19 @@ sub html_redirect {
     }
 
     my $captive_portal_domain = $Config{'general'}{'hostname'}.".".$Config{'general'}{'domain'};
+   
+	# Look up the hostname of the incoming request and use it for the captive portal 
+	foreach my $key (keys %Config) {
+        if ($key =~ /interface/) {
+            if ($Config{$key}{'ip'} eq $r->connection->local_ip) {
+                if (exists $Config{$key}{'hostname'}) {
+                    $captive_portal_domain = $Config{$key}{'hostname'};
+                    last;
+                }
+            }
+        }
+    }
+    
     my $ip = defined($r->headers_in->{'X-Forwarded-For'}) ? $r->headers_in->{'X-Forwarded-For'} : $r->connection->remote_ip;
     $ip = new NetAddr::IP::Lite clean_ip($ip);
     my $user_agent = $r->headers_in->{'User-Agent'};

--- a/lib/pfconfig/cached.pm
+++ b/lib/pfconfig/cached.pm
@@ -240,7 +240,7 @@ sub is_valid {
         return 0;
     }
 
-    my $memory_timestamp = $self->{memorized_at} || time;
+    my $memory_timestamp = $self->{memorized_at} // 0;
 
 #$logger->trace("Control file has timestamp $file_timestamp and memory has timestamp $memory_timestamp for key $what");
 # if the timestamp of the file is after the one we have in memory


### PR DESCRIPTION
# Description
One of the problems with the captive portal is that on a html redirect to the captive portal the hostname of the management interface is used. This is fine if the user subnet has access to the management interface, but poses a problem when it does not. An use case for this is our guest network resides in a L3VPN, and doesn't have access to the management interface, but shares the same DNS server with the rest of campus preventing the use of different DNS entries.

This enhancement adds a hostname variable to the interface sections of the pf.conf file. When a request comes in to httpd.portal the pf::web::dispatcher does a lookup of the incoming server IP address, and uses the hostname variable for the $captive_portal_domain if it exists. This in turn returns the correct hostname for isolated networks.

# Impacts
This code makes changes to the pf::web::dispatcher::html_redirect subroutine adding a lookup to code to redirect the incoming request to the appropriate interface.

# Code / PR Dependencies
See diff.

# NEW Package(s) required
None.

# Issue
None.

# Delete branch after merge
YES

# NEWS file entries
(REQUIRED, but may be optional...)
* Ability to redirect captive portals to incoming interface
