### PR TITLE
Reject a EAP radius request if the previous request failed.

### DIFF
--- a/conf/radiusd/packetfence-tunnel.example
+++ b/conf/radiusd/packetfence-tunnel.example
@@ -36,6 +36,16 @@ authorize {
 	#  the MS-CHAP-Challenge attribute, and add 'Auth-Type := MS-CHAP'
 	#  to the request, which will cause the server to then use
 	#  the mschap module for authentication.
+        update control {
+            Cache-Status-Only = 'yes'
+        }
+        cache_ntlm
+        if (ok) {
+            cache_ntlm
+            if (&request:Tmp-Integer-9 > 1) {
+                reject
+            }
+        }
 	mschap
 
 	#
@@ -288,6 +298,7 @@ post-auth {
 	#  'edir_account_policy_check = yes' in the ldap module configuration
 	#
 	Post-Auth-Type REJECT {
+                packetfence-cache-ntlm-hit
 		update {
 			&request:User-Password := "******"
 		}

--- a/conf/radiusd/packetfence-tunnel.example
+++ b/conf/radiusd/packetfence-tunnel.example
@@ -36,16 +36,10 @@ authorize {
 	#  the MS-CHAP-Challenge attribute, and add 'Auth-Type := MS-CHAP'
 	#  to the request, which will cause the server to then use
 	#  the mschap module for authentication.
-        update control {
-            Cache-Status-Only = 'yes'
-        }
-        cache_ntlm
-        if (ok) {
-            cache_ntlm
-            if (&request:Tmp-Integer-9 > 1) {
-                reject
-            }
-        }
+
+	# Uncomment if you need to reject user who already failed ntlm_auth (see packetfence-cache-ntlm-hit too)
+	# packetfence-control-ntlm-failure
+
 	mschap
 
 	#
@@ -298,7 +292,8 @@ post-auth {
 	#  'edir_account_policy_check = yes' in the ldap module configuration
 	#
 	Post-Auth-Type REJECT {
-                packetfence-cache-ntlm-hit
+		# Uncomment if you need to limit failed ntlm authentication (see packetfence-control-ntlm-failure too)
+		# packetfence-cache-ntlm-hit
 		update {
 			&request:User-Password := "******"
 		}

--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -1239,8 +1239,8 @@ Restart the radiusd service in order to apply the change.
 
 CAUTION: You will need to disable password hashing in the database for local authentication to work. In the administration interface, go in 'Configuration -> System Configuration -> Main Configuration ->Advanced' and set 'Database passwords hashing method' to `plaintext` or `ntlm`. Don't use `bcrypt`.
 
-Option 6: Limit brute force EAP authentication
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Limit brute force EAP authentication
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This section will allow you to limit a brute force attack and prevent the locking of Active Directory accounts.
 

--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -1239,6 +1239,22 @@ Restart the radiusd service in order to apply the change.
 
 CAUTION: You will need to disable password hashing in the database for local authentication to work. In the administration interface, go in 'Configuration -> System Configuration -> Main Configuration ->Advanced' and set 'Database passwords hashing method' to `plaintext` or `ntlm`. Don't use `bcrypt`.
 
+Option 6: Limit brute force EAP authentication
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This section will allow you to limit a brute force attack and prevent the locking of Active Directory accounts.
+
+Edit `/usr/local/pf/conf/radiusd/packetfence-tunnel`
+
+----
+# Uncomment the following lines to enable this feature
+packetfence-control-ntlm-failure
+packetfence-cache-ntlm-hit
+----
+
+By default it will reject for 5 minutes a device that has been rejected twice in the last 5 minutes.
+Fell free to change the default values in `raddb/policy.d/packetfence` and in `raddb/mods-enabled/cache_ntlm`
+
 Tests
 ^^^^^
 

--- a/raddb/mods-enabled/cache_ntlm
+++ b/raddb/mods-enabled/cache_ntlm
@@ -1,0 +1,16 @@
+cache cache_ntlm {
+
+        driver = "rlm_cache_rbtree"
+        key = "%{User-Name}%{Calling-Station-Id}"
+        ttl = 300
+        add_stats = no
+        update {
+                &request:Tmp-Integer-9 += &request:Tmp-Integer-9
+
+                # Add our own to show when the cache was last updated
+                &reply:Reply-Message += "Cache last updated at %t"
+
+                &reply:Class := "%{randstr:ssssssssssssssssssssssssssssssss}"
+        }
+}
+

--- a/raddb/mods-enabled/cache_ntlm
+++ b/raddb/mods-enabled/cache_ntlm
@@ -2,6 +2,7 @@ cache cache_ntlm {
 
         driver = "rlm_cache_rbtree"
         key = "%{User-Name}%{Calling-Station-Id}"
+        # Cache for 5 minutes
         ttl = 300
         add_stats = no
         update {
@@ -9,8 +10,6 @@ cache cache_ntlm {
 
                 # Add our own to show when the cache was last updated
                 &reply:Reply-Message += "Cache last updated at %t"
-
-                &reply:Class := "%{randstr:ssssssssssssssssssssssssssssssss}"
         }
 }
 

--- a/raddb/policy.d/packetfence
+++ b/raddb/policy.d/packetfence
@@ -104,3 +104,31 @@ packetfence-mschap-authenticate {
       }
     }
 }
+
+
+packetfence-cache-ntlm-hit {
+  update control {
+    Cache-Status-Only = 'yes'
+  }
+  cache_ntlm
+  if (ok) {
+    cache_ntlm
+    update {
+      &request:Tmp-Integer-9 := "%{expr: 1 + %{&request:Tmp-Integer-9}}"
+    }
+    update control {
+      Cache-TTL = 0
+    }
+    cache_ntlm
+    update control {
+      Cache-TTL = 300
+    }
+    cache_ntlm
+  }
+  else {
+    update {
+      &request:Tmp-Integer-9 := 0
+    }
+    cache_ntlm
+  }
+}

--- a/raddb/policy.d/packetfence
+++ b/raddb/policy.d/packetfence
@@ -132,3 +132,16 @@ packetfence-cache-ntlm-hit {
     cache_ntlm
   }
 }
+
+packetfence-control-ntlm-failure {
+  update control {
+    Cache-Status-Only = 'yes'
+  }
+  cache_ntlm
+  if (ok) {
+    cache_ntlm
+    if (&request:Tmp-Integer-9 > 1) {
+      reject
+    }
+  }
+}

--- a/raddb/policy.d/packetfence
+++ b/raddb/policy.d/packetfence
@@ -121,6 +121,7 @@ packetfence-cache-ntlm-hit {
     }
     cache_ntlm
     update control {
+      #Default TTL to 5 minutes
       Cache-TTL = 300
     }
     cache_ntlm
@@ -140,6 +141,7 @@ packetfence-control-ntlm-failure {
   cache_ntlm
   if (ok) {
     cache_ntlm
+    # raise the value if you want to permit more ntlm_auth failure before rejecting the request
     if (&request:Tmp-Integer-9 > 1) {
       reject
     }


### PR DESCRIPTION
# Description
Allow to reject eap radius request if the previous authentication failed (default bloc for 5 minutes and after one failed authentication)

# Impacts
Freeradius configuration
RADIUS EAP flow

# Delete branch after merge
YES

# NEWS file entries
## New Features
* Allow to reject a EAP authentication if the previous authentications (default to 1) failed. It will prevent for brute force attack and password locking on the Active Directory
