### PR TITLE
Added a way to override switch configuration based on the request parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ conf/redis_ntlm_cache.conf
 conf/realm.conf
 conf/domain.conf
 conf/radius_filters.conf
+conf/switch_filters.conf
 conf/scan.conf
 conf/pfqueue.conf
 conf/pfmon.conf

--- a/addons/packages/packetfence.spec
+++ b/addons/packages/packetfence.spec
@@ -1013,6 +1013,8 @@ fi
 %config(noreplace)      /usr/local/pf/conf/switches.conf
 %config                 /usr/local/pf/conf/switches.conf.defaults
                         /usr/local/pf/conf/switches.conf.example
+%config(noreplace)      /usr/local/pf/conf/switch_filters.conf
+                        /usr/local/pf/conf/switch_filters.conf.example
 %config(noreplace)      /usr/local/pf/conf/vlan_filters.conf
                         /usr/local/pf/conf/vlan_filters.conf.example
 %config                 /usr/local/pf/conf/vlan_filters.conf.defaults

--- a/conf/switch_filters.conf.example
+++ b/conf/switch_filters.conf.example
@@ -1,0 +1,216 @@
+# SWITCH FILTERS configuration
+# ============================
+#
+# Scopes
+# ------
+# It is possible to trigger rules / actions within the following specific connection flow scopes
+# - radius_authorize: Used when PacketFence receive a radius request
+# - external_portal: Used when an endpoint hit the captive portal for web authentication
+#
+#
+# A "SWITCH Filter" configuration is mainly constituted of two (2) parts; rules(s)/condition(s) and action(s)
+# Some working examples covering useful use cases can be found at the bottom of this file
+#
+#
+#
+# Rule(s)/Condition(s)
+# --------------------
+# Structure example of a rule/condition
+# [NAMEOFRULE]
+# filter = FILTER
+# operator = OPERATOR
+# value = VALUE
+#
+# Filter can be:
+#     node_info.autoreg
+#     node_info.status
+#     node_info.bypass_vlan
+#     node_info.bandwidth_balance
+#     node_info.regdate
+#     node_info.bypass_role
+#     node_info.device_class
+#     node_info.device_type
+#     node_info.device_version
+#     node_info.device_score
+#     node_info.pid
+#     node_info.machine_account
+#     node_info.category
+#     node_info.mac
+#     node_info.last_arp
+#     node_info.lastskip
+#     node_info.last_dhcp
+#     node_info.user_agent
+#     node_info.computername
+#     node_info.dhcp_fingerprint
+#     node_info.detect_date
+#     node_info.voip
+#     node_info.notes
+#     node_info.time_balance
+#     node_info.sessionid
+#     node_info.dhcp_vendor
+#     node_info.unregdate
+#     fingerbank_info.device_fq
+#     fingerbank_info.device_hierarchy_names
+#     fingerbank_info.device_hierarchy_ids
+#     fingerbank_info.score
+#     fingerbank_info.version
+#     fingerbank_info.mobile
+#     switch._switchIp
+#     switch._ip
+#     switch._portalURL
+#     switch._switchMac
+#     switch._ip
+#     ifIndex
+#     mac
+#     connection_type
+#     user_name
+#     ssid
+#     time
+#     owner.pid
+#     owner.firstname
+#     owner.lastname
+#     owner.email
+#     owner.telephone
+#     owner.company
+#     owner.address
+#     owner.notes
+#     owner.sponsor
+#     owner.anniversary
+#     owner.birthday
+#     owner.gender
+#     owner.lang
+#     owner.nickname
+#     owner.cell_phone
+#     owner.work_phone
+#     owner.title
+#     owner.building_number
+#     owner.apartment_number
+#     owner.room_number
+#     owner.custom_field_1
+#     owner.custom_field_2
+#     owner.custom_field_3
+#     owner.custom_field_4
+#     owner.custom_field_5
+#     owner.custom_field_6
+#     owner.custom_field_7
+#     owner.custom_field_8
+#     owner.custom_field_9
+#     owner.portal
+#     owner.source
+#     owner.nodes
+#     owner.password
+#     owner.valid_from
+#     owner.expiration
+#     owner.access_duration
+#     owner.access_level
+#     owner.can_sponsor
+#     owner.unregdate
+#     owner.category
+#     radius_request
+#     params
+# 
+# Operator can be:
+#     is
+#     is_not
+#     match
+#     match_not
+#     defined
+#     not_defined
+#     regex
+#     date_is_before
+#     date_is_after
+#
+# Attribute can be:
+# - for connection_type
+#     Wireless-802.11-EAP
+#     Wireless-802.11-NoEAP
+#     Ethernet-EAP
+#     Ethernet-NoEAP
+#     SNMP-Traps
+#     Inline
+#     WIRED_MAC_AUTH
+# - for the radius_request
+#     All the attributes you can have in the RADIUS request (run FreeRADIUS in debug mode to see these attributes)
+#
+# - for the params
+#     It correspond of the attributes in the uri when the device hit the portal
+#
+# Actions
+# -------
+# Structure example of an action
+# [NAMEOFTHEACTION:RULE1&RULE2&RULE3]
+# scope = SCOPE
+# param1 = SWITCH_PARAMETER => VALUE
+# param2 = SWITCH_PARAMETER => VALUE
+# paramx = SWITCH_PARAMETER => VALUE
+# switch = SWITCH_MODULE
+#
+# Scope can be:
+# - see beginning of this file for possible scope. They are usually extensions points of endpoint connection flow
+#
+#
+# Param(x) can be:
+# - any switch configuration parameter to override (Only available for radius_authorize scope)
+#
+# Switch can be:
+# - any switch module
+#
+# -------------------------
+#
+#
+# EXAMPLES
+# --------
+# - If the ssid is test then override ExternalPortalEnforcement and VlanMap value
+#
+#[SSID]
+#filter = ssid
+#operator = is
+#value = Test
+#
+#[1:SSID]
+#scope = radius_authorize
+#param1 = ExternalPortalEnforcement => N
+#param2 = VlanMap => Y
+#
+#[status]
+#filter = node_info.status
+#operator = is
+#value = reg
+#
+#[2:!SSID&status]
+#scope = radius_authorize
+#param1 = ExternalPortalEnforcement => N
+#
+# - If the device hit the portal with theses parameters in the uri then use the Fortinet::FortiGate switch module
+#
+#[login]
+#filter = params.login
+#operator = defined
+#
+#[post]
+#filter = params.post
+#operator = defined
+#
+#[magic]
+#filter = params.magic
+#operator = defined
+#
+#[usermac]
+#filter = params.usermac
+#operator = defined
+#
+#[apmac]
+#filter = params.apmac
+#operator = defined
+#
+#[apip]
+#filter = params.apip
+#operator = defined
+#
+#[userip]
+#filter = params.userip
+#operator = defined
+#
+#[1:login&post&magic&usermac&apmac&apip&userip]
+#scope = external_portal
+#switch = Fortinet::FortiGate

--- a/debian/packetfence.conffiles
+++ b/debian/packetfence.conffiles
@@ -70,6 +70,7 @@
 /usr/local/pf/conf/radiusd/eduroam
 /usr/local/pf/conf/radiusd/eduroam-cluster
 /usr/local/pf/conf/radiusd/eduroam.conf
+/usr/local/pf/conf/switch_filters.conf
 /usr/local/pf/conf/snmptrapd.conf
 /usr/local/pf/conf/ui.conf
 /usr/local/pf/conf/ui.conf.es_ES

--- a/html/pfappserver/root/config/filters/index.tt
+++ b/html/pfappserver/root/config/filters/index.tt
@@ -20,6 +20,9 @@
     <li [% IF tab == 'dns-filters' %]class="active"[% END %]>
       <a href="#config/filters/dns-filters">[% l('DNS filters') %]</a>
     </li>
+    <li [% IF tab == 'switch-filters' %]class="active"[% END %]>
+      <a href="#config/filters/switch-filters">[% l('Switch filters') %]</a>
+    </li>
   </ul>
 
   [%- IF can_access("FILTERS_UPDATE") %]

--- a/lib/pf/ConfigStore/SwitchFilters.pm
+++ b/lib/pf/ConfigStore/SwitchFilters.pm
@@ -1,0 +1,53 @@
+package pf::ConfigStore::SwitchFilters;
+=head1 NAME
+
+pf::ConfigStore::SwitchFilters add documentation
+
+=cut
+
+=head1 DESCRIPTION
+
+pf::ConfigStore::SwitchFilters
+
+=cut
+
+use strict;
+use warnings;
+use Moo;
+use pf::file_paths qw($switch_filters_config_file);
+extends 'pf::ConfigStore';
+
+sub configFile { $switch_filters_config_file };
+
+sub pfconfigNamespace {'config::SwitchFilters'}
+
+__PACKAGE__->meta->make_immutable;
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2016 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;

--- a/lib/pf/access_filter/switch.pm
+++ b/lib/pf/access_filter/switch.pm
@@ -13,6 +13,8 @@ pf::access_filter::switch
 use strict;
 use warnings;
 
+use Scalar::Util qw(reftype);
+
 use base qw(pf::access_filter);
 tie our %ConfigSwitchFilters, 'pfconfig::cached_hash', 'config::SwitchFilters';
 tie our %SwitchFilterEngineScopes, 'pfconfig::cached_hash', 'FilterEngine::SwitchScopes';
@@ -25,13 +27,82 @@ tie our %SwitchFilterEngineScopes, 'pfconfig::cached_hash', 'FilterEngine::Switc
 
 sub filterRule {
     my ($self, $rule, $args) = @_;
+    my $logger = $self->logger;
+    my $switch_params = {};
     if(defined $rule) {
         if (defined($rule->{'switch'}) && $rule->{'switch'} ne '') {
             my $switch = $rule->{'switch'};
             return $switch;
+        } elsif ($rule->{'scope'} eq 'radius_authorize') {
+            my $i = 1;
+            $logger->info(evalParam($rule->{'log'},$args)) if defined($rule->{'log'});
+            while (1) {
+                if (defined($rule->{"param$i"}) && $rule->{"param$i"} ne '') {
+                    my @answer = $rule->{"param$i"} =~ /([a-zA-Z_-]*)\s*=>\s*(.*)/;
+                    evalAnswer(\@answer,$args,\$switch_params);
+                } else {
+                    last;
+                }
+                $i++;
+            }
+            return ($switch_params);
         }
     }
     return undef;
+}
+
+=head2 evalAnswer
+
+evaluate the radius answer
+
+=cut
+
+sub evalAnswer {
+    my ($answer,$args,$switch_params) = @_;
+
+    my $return = evalParam(@{$answer}[1],$args);
+    my @multi_value = split(';',$return);
+    @{$answer}[0] =~ s/\s//g;
+    if (scalar @multi_value > 1) {
+        $$switch_params->{'_'.@{$answer}[0]} = \@multi_value;
+    } else {
+        $$switch_params->{'_'.@{$answer}[0]} = $return;
+    }
+
+}
+
+=head2 evalParam
+
+evaluate all the variables
+
+=cut
+
+sub evalParam {
+    my ($answer, $args) = @_;
+    $answer =~ s/\$([a-zA-Z_0-9]+)/$args->{$1} \/\/ ''/ge;
+    $answer =~ s/\${([a-zA-Z0-9_\-]+(?:\.[a-zA-Z0-9_\-]+)*)}/&_replaceParamsDeep($1,$args)/ge;
+    return $answer;
+}
+
+=head2 _replaceParamsDeep
+
+evaluate all the variables deeply
+
+=cut
+
+sub _replaceParamsDeep {
+    my ($param_string, $args) = @_;
+    my @params = split /\./, $param_string;
+    my $param  = pop @params;
+    my $hash   = $args;
+    foreach my $key (@params) {
+        if (exists $hash->{$key} && reftype($hash->{$key}) eq 'HASH') {
+            $hash = $hash->{$key};
+            next;
+        }
+        return '';
+    }
+    return $hash->{$param} // '';
 }
 
 =head2 getEngineForScope

--- a/lib/pf/access_filter/switch.pm
+++ b/lib/pf/access_filter/switch.pm
@@ -14,8 +14,8 @@ use strict;
 use warnings;
 
 use base qw(pf::access_filter);
-tie our %ConfigSwitchFilters, 'pfconfig::cached_hash', 'config::PortalFilters';
-tie our %PortalFilterEngineScopes, 'pfconfig::cached_hash', 'FilterEngine::PortalScopes';
+tie our %ConfigSwitchFilters, 'pfconfig::cached_hash', 'config::SwitchFilters';
+tie our %SwitchFilterEngineScopes, 'pfconfig::cached_hash', 'FilterEngine::SwitchScopes';
 
 =head2 filterRule
 

--- a/lib/pf/access_filter/switch.pm
+++ b/lib/pf/access_filter/switch.pm
@@ -1,0 +1,79 @@
+package pf::access_filter::switch;
+
+=head1 NAME
+
+pf::access_filter::switch -
+
+=head1 DESCRIPTION
+
+pf::access_filter::switch
+
+=cut
+
+use strict;
+use warnings;
+
+use base qw(pf::access_filter);
+tie our %ConfigSwitchFilters, 'pfconfig::cached_hash', 'config::PortalFilters';
+tie our %PortalFilterEngineScopes, 'pfconfig::cached_hash', 'FilterEngine::PortalScopes';
+
+=head2 filterRule
+
+    Handle the role update
+
+=cut
+
+sub filterRule {
+    my ($self, $rule, $args) = @_;
+    if(defined $rule) {
+        if (defined($rule->{'switch'}) && $rule->{'switch'} ne '') {
+            my $portal = $rule->{'switch'};
+            return $portal;
+        }
+    }
+    return undef;
+}
+
+=head2 getEngineForScope
+
+ gets the engine for the scope
+
+=cut
+
+sub getEngineForScope {
+    my ($self, $scope) = @_;
+    if (exists $SwitchFilterEngineScopes{$scope}) {
+        return $SwitchFilterEngineScopes{$scope};
+    }
+    return undef;
+}
+
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2016 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;

--- a/lib/pf/access_filter/switch.pm
+++ b/lib/pf/access_filter/switch.pm
@@ -27,8 +27,8 @@ sub filterRule {
     my ($self, $rule, $args) = @_;
     if(defined $rule) {
         if (defined($rule->{'switch'}) && $rule->{'switch'} ne '') {
-            my $portal = $rule->{'switch'};
-            return $portal;
+            my $switch = $rule->{'switch'};
+            return $switch;
         }
     }
     return undef;

--- a/lib/pf/access_filter/switch.pm
+++ b/lib/pf/access_filter/switch.pm
@@ -21,7 +21,7 @@ tie our %SwitchFilterEngineScopes, 'pfconfig::cached_hash', 'FilterEngine::Switc
 
 =head2 filterRule
 
-    Handle the role update
+    Handle the switch update
 
 =cut
 
@@ -126,7 +126,7 @@ Inverse inc. <info@inverse.ca>
 
 =head1 COPYRIGHT
 
-Copyright (C) 2005-2016 Inverse inc.
+Copyright (C) 2005-2017 Inverse inc.
 
 =head1 LICENSE
 

--- a/lib/pf/constants/filters.pm
+++ b/lib/pf/constants/filters.pm
@@ -22,6 +22,7 @@ use pf::ConfigStore::RadiusFilters;
 use pf::ConfigStore::DhcpFilters;
 use pf::ConfigStore::ApacheFilters;
 use pf::ConfigStore::DNS_Filters;
+use pf::ConfigStore::SwitchFilters;
 
 our @EXPORT_OK = qw(%FILTERS_IDENTIFIERS %CONFIGSTORE_MAP %ENGINE_MAP);
 
@@ -31,6 +32,7 @@ our %FILTERS_IDENTIFIERS = (
     DHCP_FILTERS   => "dhcp-filters",
     APACHE_FILTERS => "apache-filters",
     DNS_FILTERS    => "dns-filters",
+    SWITCH_FILTERS => "switch-filters",
 );
 
 our %CONFIGSTORE_MAP = (
@@ -38,7 +40,8 @@ our %CONFIGSTORE_MAP = (
     $FILTERS_IDENTIFIERS{RADIUS_FILTERS} => pf::ConfigStore::RadiusFilters->new,
     $FILTERS_IDENTIFIERS{DHCP_FILTERS}   => pf::ConfigStore::DhcpFilters->new,
     $FILTERS_IDENTIFIERS{APACHE_FILTERS} => pf::ConfigStore::ApacheFilters->new,
-    $FILTERS_IDENTIFIERS{DNS_FILTERS} => pf::ConfigStore::DNS_Filters->new,
+    $FILTERS_IDENTIFIERS{DNS_FILTERS}    => pf::ConfigStore::DNS_Filters->new,
+    $FILTERS_IDENTIFIERS{SWITCH_FILTERS}    => pf::ConfigStore::SwitchFilters->new,
 );
 
 our %ENGINE_MAP = (
@@ -46,7 +49,8 @@ our %ENGINE_MAP = (
     $FILTERS_IDENTIFIERS{RADIUS_FILTERS} => "FilterEngine::RadiusScopes",
     $FILTERS_IDENTIFIERS{DHCP_FILTERS}   => "FilterEngine::DhcpScopes",
     $FILTERS_IDENTIFIERS{APACHE_FILTERS} => $CONFIGSTORE_MAP{"apache-filters"}->pfconfigNamespace,
-    $FILTERS_IDENTIFIERS{DNS_FILTERS}   => "FilterEngine::DNS_Scopes",
+    $FILTERS_IDENTIFIERS{DNS_FILTERS}    => "FilterEngine::DNS_Scopes",
+    $FILTERS_IDENTIFIERS{SWITCH_FILTERS}    => "FilterEngine::SwitchScopes",
 );
 
 =head1 AUTHOR

--- a/lib/pf/file_paths.pm
+++ b/lib/pf/file_paths.pm
@@ -96,6 +96,7 @@ our (
     $control_dir,
     $switch_control_dir,
     $pfmon_config_file, $pfmon_default_config_file,
+    $switch_filters_config_file,
 );
 
 BEGIN {
@@ -166,6 +167,7 @@ BEGIN {
         $control_dir
         $switch_control_dir
         $pfmon_config_file $pfmon_default_config_file
+        $switch_filters_config_file
     );
 }
 
@@ -257,6 +259,7 @@ $portal_modules_config_file = catfile($conf_dir,"portal_modules.conf");
 $portal_modules_default_config_file = catfile($conf_dir,"portal_modules.conf.defaults");
 $pfmon_config_file = catfile($conf_dir,"pfmon.conf");
 $pfmon_default_config_file = catfile($conf_dir,"pfmon.conf.defaults");
+$switch_filters_config_file = catfile($conf_dir,"switch_filters.conf"); 
 
 $oui_url               = 'http://standards.ieee.org/regauth/oui/oui.txt';
 $dhcp_fingerprints_url = 'http://www.packetfence.org/dhcp_fingerprints.conf';
@@ -296,6 +299,7 @@ $captiveportal_default_profile_templates_path = catdir ($captiveportal_profile_t
     $roles_config_file,
     $dns_filters_config_file,
     $pfmon_config_file,
+    $switch_filters_config_file,
 );
 
 $pffilter_socket_path = catfile($var_dir, "run/pffilter.sock");

--- a/lib/pf/pfcmd/checkup.pm
+++ b/lib/pf/pfcmd/checkup.pm
@@ -1050,7 +1050,7 @@ sub vlan_filter_rules {
             add_problem ( $WARN, "Missing operator attribute in $rule vlan filter rule")
                 if (!defined($ConfigVlanFilters{$rule}->{'operator'}));
             add_problem ( $WARN, "Missing value attribute in $rule vlan filter rule")
-                if (!defined($ConfigVlanFilters{$rule}->{'value'}));
+                if (!defined($ConfigVlanFilters{$rule}->{'value'}) && $ConfigVlanFilters{$rule}->{'operator'} ne 'defined' && $ConfigVlanFilters{$rule}->{'operator'} ne 'not_defined');
         }
     }
 }

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -62,6 +62,7 @@ use pf::cluster;
 use pf::api::queue;
 use pf::access_filter::radius;
 use pf::registration;
+use pf::access_filter::switch;
 
 our $VERSION = 1.03;
 
@@ -299,6 +300,10 @@ sub authorize {
         # When the _setVlan of a switch who can't do RADIUS VLAN assignment uses the lock we will need to re-evaluate
         $switch->_setVlan( $port, $vlan, undef, {} );
     }
+
+    my $filter = pf::access_filter::switch->new;
+    my %switch_params = $filter->filter('radius_authorize', $args);
+
     $RAD_REPLY_REF = $switch->returnRadiusAccessAccept($args);
 
 CLEANUP:

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -302,7 +302,13 @@ sub authorize {
     }
 
     my $filter = pf::access_filter::switch->new;
-    my %switch_params = $filter->filter('radius_authorize', $args);
+    my $switch_params = $filter->filter('radius_authorize', $args);
+
+    if (defined($switch_params)) {
+        foreach my $key (keys %{$switch_params}) {
+            $switch->{$key} = $switch_params->{$key};
+        }
+    }
 
     $RAD_REPLY_REF = $switch->returnRadiusAccessAccept($args);
 

--- a/lib/pf/web/externalportal.pm
+++ b/lib/pf/web/externalportal.pm
@@ -74,11 +74,13 @@ sub handle {
     my $req = Apache2::Request->new($r);
     my $uri = $r->uri;
 
-    my $table = $req->param;
+    my $params = $req->param;
+    my $headers_in = $r->headers_in();
 
     my $args = {
         uri => $uri,
-        request => { %$table },
+        params => { %$params },
+        headers => { %$headers_in },
     };
 
     my $filter = pf::access_filter::switch->new;

--- a/lib/pf/web/externalportal.pm
+++ b/lib/pf/web/externalportal.pm
@@ -34,6 +34,7 @@ use pf::util;
 use pf::web::constants;
 use pf::web::util;
 use pf::constants;
+use pf::access_filter::switch;
 
 # Some vendors don't support some charatcters in their redirect URL
 # This here below allows to map some URLs to a specific switch module
@@ -70,6 +71,14 @@ sub handle {
 
     my $req = Apache2::Request->new($r);
     my $uri = $r->uri;
+
+    my $args = {
+        uri => $uri,
+        request => { %$table },
+    };
+
+    my $filter = pf::access_filter::switch->new;
+    my $type_switch = $filter->filter('external_portal', $args);
 
     # Discarding non external portal requests
     unless ( $uri =~ /$WEB::EXTERNAL_PORTAL_URL/o ) {

--- a/lib/pf/web/externalportal.pm
+++ b/lib/pf/web/externalportal.pm
@@ -74,6 +74,8 @@ sub handle {
     my $req = Apache2::Request->new($r);
     my $uri = $r->uri;
 
+    my $table = $req->param;
+
     my $args = {
         uri => $uri,
         request => { %$table },

--- a/lib/pf/web/externalportal.pm
+++ b/lib/pf/web/externalportal.pm
@@ -100,7 +100,7 @@ sub handle {
         # - sid424242 is the optional PacketFence session ID to track the session when working by session ID and not by URI parameters
         $logger->info("URI '$uri' is detected as an external captive portal URI");
         $uri =~ /\/([^\/]*)/;
-        my $switch_type = $1;
+        $switch_type = $1;
         if(exists($SWITCH_REWRITE_MAP->{$switch_type})) {
             my $new_switch_type = $SWITCH_REWRITE_MAP->{$switch_type};
             $logger->debug("Rewriting switch type $switch_type to $new_switch_type");

--- a/lib/pf/web/externalportal.pm
+++ b/lib/pf/web/externalportal.pm
@@ -80,26 +80,30 @@ sub handle {
     my $filter = pf::access_filter::switch->new;
     my $type_switch = $filter->filter('external_portal', $args);
 
-    # Discarding non external portal requests
-    unless ( $uri =~ /$WEB::EXTERNAL_PORTAL_URL/o ) {
-        $logger->debug("Tested URI '$uri' against external portal mechanism and does not appear to be one.");
-        return $FALSE;
+    if (!$type_switch) {
+        # Discarding non external portal requests
+        unless ( $uri =~ /$WEB::EXTERNAL_PORTAL_URL/o ) {
+            $logger->debug("Tested URI '$uri' against external portal mechanism and does not appear to be one.");
+            return $FALSE;
+        }
+
+        # Parsing external portal URL information for switch handling
+        # URI will usually be in the form (/Switch::Type/sid424242), where:
+        # - Switch::Type will be the switch type to instantiate (mandatory)
+        # - sid424242 is the optional PacketFence session ID to track the session when working by session ID and not by URI parameters
+        $logger->info("URI '$uri' is detected as an external captive portal URI");
+        $uri =~ /\/([^\/]*)/;
+        my $switch_type = $1;
+        if(exists($SWITCH_REWRITE_MAP->{$switch_type})) {
+            my $new_switch_type = $SWITCH_REWRITE_MAP->{$switch_type};
+            $logger->debug("Rewriting switch type $switch_type to $new_switch_type");
+            $switch_type = $new_switch_type;
+        }
+        $switch_type = "pf::Switch::$switch_type";
+    } else {
+        $switch_type = "pf::Switch::$type_switch";
     }
 
-    # Parsing external portal URL information for switch handling
-    # URI will usually be in the form (/Switch::Type/sid424242), where:
-    # - Switch::Type will be the switch type to instantiate (mandatory)
-    # - sid424242 is the optional PacketFence session ID to track the session when working by session ID and not by URI parameters
-    $logger->info("URI '$uri' is detected as an external captive portal URI");
-    $uri =~ /\/([^\/]*)/;
-    my $switch_type = $1;
-    if(exists($SWITCH_REWRITE_MAP->{$switch_type})) {
-        my $new_switch_type = $SWITCH_REWRITE_MAP->{$switch_type};
-        $logger->debug("Rewriting switch type $switch_type to $new_switch_type");
-        $switch_type = $new_switch_type;
-    }
-
-    $switch_type = "pf::Switch::$switch_type";
     if ( !(eval "$switch_type->require()") ) {
         $logger->error("Cannot load perl module for switch type '$switch_type'. Either switch type is unknown or switch type perl module have compilation errors. " .
         "See the following message for details: $@");

--- a/lib/pf/web/externalportal.pm
+++ b/lib/pf/web/externalportal.pm
@@ -69,6 +69,8 @@ sub handle {
     my ( $self, $r ) = @_;
     my $logger = get_logger;
 
+    my $switch_type;
+
     my $req = Apache2::Request->new($r);
     my $uri = $r->uri;
 

--- a/lib/pf/web/externalportal.pm
+++ b/lib/pf/web/externalportal.pm
@@ -77,10 +77,11 @@ sub handle {
     my $params = $req->param;
     my $headers_in = $r->headers_in();
 
+
     my $args = {
         uri => $uri,
-        params => { %$params },
-        headers => { %$headers_in },
+        (defined $params ? (params => { %$params }) : ()),
+        (defined $headers_in ? (headers => { %$headers_in }) : ()),
     };
 
     my $filter = pf::access_filter::switch->new;

--- a/lib/pfconfig/namespaces/FilterEngine/SwitchScopes.pm
+++ b/lib/pfconfig/namespaces/FilterEngine/SwitchScopes.pm
@@ -1,0 +1,55 @@
+package pfconfig::namespaces::FilterEngine::SwitchScopes;
+
+=head1 NAME
+
+pfconfig::namespaces::FilterEngine::SwitchScopes
+
+=cut
+
+=head1 DESCRIPTION
+
+pfconfig::namespaces::FilterEngine::SwitchScopes
+
+=cut
+
+use strict;
+use warnings;
+use pf::log;
+use pfconfig::namespaces::config;
+use pfconfig::namespaces::config::SwitchFilters;
+
+use base 'pfconfig::namespaces::FilterEngine::AccessScopes';
+
+sub parentConfig {
+    my ($self) = @_;
+    return pfconfig::namespaces::config::SwitchFilters->new($self->{cache});
+}
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2016 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;

--- a/lib/pfconfig/namespaces/config/SwitchFilters.pm
+++ b/lib/pfconfig/namespaces/config/SwitchFilters.pm
@@ -1,0 +1,75 @@
+package pfconfig::namespaces::config::SwitchFilters;
+
+=head1 NAME
+
+pfconfig::namespaces::config::template
+
+=cut
+
+=head1 DESCRIPTION
+
+pfconfig::namespaces::config::template
+
+This module creates the configuration hash associated to somefile.conf
+
+=cut
+
+use strict;
+use warnings;
+
+use pfconfig::namespaces::config;
+use pf::file_paths qw(
+    $switch_filters_config_file
+);
+
+use base 'pfconfig::namespaces::config';
+
+sub init {
+    my ($self) = @_;
+    $self->{file} = $switch_filters_config_file;
+    $self->{child_resources} = [ 'FilterEngine::SwitchScopes'];
+
+}
+
+sub build_child {
+    my ($self) = @_;
+    my %tmp_cfg = %{ $self->{cfg} };
+
+    $self->cleanup_whitespaces( \%tmp_cfg );
+
+    return \%tmp_cfg;
+
+}
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2016 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;
+
+# vim: set shiftwidth=4:
+# vim: set expandtab:
+# vim: set backspace=indent,eol,start:


### PR DESCRIPTION
# Description
Override switch configuration based on the request parameter.
Like you want to enable externalportal for a specific ssid and not for another one for the same AP or select a different switch module based on uri parameters.

# Impacts
- RADIUS authorize workflow
- External Protal workflow

# Delete branch after merge
YES

# NEWS file entries
## New Features
* Switch filter to allow to averride switch configuration based on the request
