### PR TITLE
Update api.pm, return number of nodes unregistered instead of static 1.

### DIFF
--- a/lib/pf/api.pm
+++ b/lib/pf/api.pm
@@ -267,7 +267,7 @@ sub unreg_node_for_pid : Public:AllowedAsAction(pid, $pid) {
         pf::node::node_deregister($node_info->{'mac'});
     }
 
-    return 1;
+    return scalar(@node_infos);
 }
 
 sub synchronize_locationlog : Public {


### PR DESCRIPTION
# Description
API function unreg_node_for_pid returns number of nodes unregistered instead of static 1.

# Impacts
Is there a component always expecting return value 1 for this function? If not, there should be no impact.

# Delete branch after merge
YES

# NEWS file entries
## Enhancements
* api function unreg_node_for_pid has now usable return values

