### PR TITLE
Transparently proxy the graphite requests through the admin.

### DIFF
--- a/conf/httpd.conf.d/httpd.admin.tt.example
+++ b/conf/httpd.conf.d/httpd.admin.tt.example
@@ -280,6 +280,15 @@ ProxyHTMLLinks  script      src for
 
           Header add Set-Cookie "PF_PORTAL=%{X_PORTAL}e; Path=/portal_preview" env=X_PORTAL
       </Location>
+
+      <Location /metrics >
+          RequestHeader unset Accept-Encoding
+          RequestHeader append X-Forwarded-For-PacketFence "127.0.0.1"
+
+          ProxyPass  http://[% graphite_url %]/
+          ProxyPassReverse http://[% graphite_url %]/
+      </Location>
+
       Alias /static [% install_dir %]/html/pfappserver/root/static
       <Location / >
            SetHandler modperl

--- a/conf/httpd.conf.d/httpd.admin.tt.example
+++ b/conf/httpd.conf.d/httpd.admin.tt.example
@@ -281,7 +281,7 @@ ProxyHTMLLinks  script      src for
           Header add Set-Cookie "PF_PORTAL=%{X_PORTAL}e; Path=/portal_preview" env=X_PORTAL
       </Location>
 
-      <Location /metrics >
+      <Location /admin/metrics >
           RequestHeader unset Accept-Encoding
           RequestHeader append X-Forwarded-For-PacketFence "127.0.0.1"
 

--- a/conf/httpd.conf.d/httpd.graphite.tt.example
+++ b/conf/httpd.conf.d/httpd.graphite.tt.example
@@ -143,7 +143,7 @@ TraceEnable Off
       ServerName [% server_name %]
       DocumentRoot  [% install_dir %]/html/pfappserver/lib
       ErrorLog "| /usr/bin/logger -thttpd_graphite_err -plocal5.err"
-      CustomLog  "| /usr/bin/logger -thttpd_graphite -plocal5.info" combined
+      CustomLog  "| /usr/bin/logger -thttpd_graphite -plocal5.info" loadbalanced_combined
       WSGIScriptAlias  / [% install_dir %]/conf/httpd.conf.d/graphite-web.wsgi
       WSGIImportScript [% install_dir %]/conf/httpd.conf.d/graphite-web.wsgi process-group=%{GLOBAL} application-group=%{GLOBAL}
       Header           set Access-Control-Allow-Origin "*"

--- a/html/pfappserver/lib/pfappserver/PacketFence/Controller/Graph.pm
+++ b/html/pfappserver/lib/pfappserver/PacketFence/Controller/Graph.pm
@@ -296,12 +296,6 @@ sub _buildGraphiteURL :Private {
       ? $management_network->tag('vip')
       : $management_network->tag('ip');
 
-    my $options =
-      {
-       graphite_host => $c->req->uri->host,
-       graphite_port => $Config{'ports'}{'admin'},
-      };
-
     if (!$width) {
         $width = 1170;
     }
@@ -342,9 +336,7 @@ sub _buildGraphiteURL :Private {
     $params->{hideAxes} = 'false';
     $params->{colorList} = '#1f77b4,#ff7f0e,#2ca02c,#d62728,#9467bd,#8c564b,#e377c2,#7f7f7f,#bcbd22,#17becf';
 
-    my $url = sprintf('https://%s:%s/metrics/render?%s',
-                      $options->{graphite_host},
-                      $options->{graphite_port},
+    my $url = sprintf('./metrics/render?%s',
                       join('&', map { $_ . '=' . uri_escape($params->{$_}) }
                           grep { $_ ne "target" } grep { $_ ne "description" } keys(%$params))); # we don't map the target here. It can be an arrayref
 

--- a/html/pfappserver/lib/pfappserver/PacketFence/Controller/Graph.pm
+++ b/html/pfappserver/lib/pfappserver/PacketFence/Controller/Graph.pm
@@ -299,7 +299,7 @@ sub _buildGraphiteURL :Private {
     my $options =
       {
        graphite_host => $c->req->uri->host,
-       graphite_port => '9000'
+       graphite_port => $Config{'ports'}{'admin'},
       };
 
     if (!$width) {
@@ -342,7 +342,7 @@ sub _buildGraphiteURL :Private {
     $params->{hideAxes} = 'false';
     $params->{colorList} = '#1f77b4,#ff7f0e,#2ca02c,#d62728,#9467bd,#8c564b,#e377c2,#7f7f7f,#bcbd22,#17becf';
 
-    my $url = sprintf('http://%s:%s/render?%s',
+    my $url = sprintf('https://%s:%s/metrics/render?%s',
                       $options->{graphite_host},
                       $options->{graphite_port},
                       join('&', map { $_ . '=' . uri_escape($params->{$_}) }

--- a/lib/pf/services/manager/httpd_admin.pm
+++ b/lib/pf/services/manager/httpd_admin.pm
@@ -67,7 +67,10 @@ sub vhosts {
 
 sub additionalVars {
     my ($self) = @_;
-    return (preview_ip => $self->portal_preview_ip);
+    return (
+        preview_ip   => $self->portal_preview_ip,
+        graphite_url => "localhost:9000"
+    );
 }
 
 =head2 portal_preview_ip


### PR DESCRIPTION
# Description
Rewrites the URL for the graphite metrics on the dashboard so they point to the ip:port of the admin. They are now transparently proxied by the admin to the httpd.graphite.


# Impacts
All URLs on the admin dashboard should now be https.

# Issue
fixes #2272 

# Delete branch after merge
YES 

# NEWS file entries

## Bug Fixes
* Dashboard metrics are now fetched over https (#2272)
