### PR TITLE
Allow arrays to be submitted in form data

### DIFF
--- a/lib/pf/person.pm
+++ b/lib/pf/person.pm
@@ -355,6 +355,13 @@ sub person_modify {
     my ( $pid, %data ) = @_;
 
     my $logger = get_logger();
+
+    foreach my $item ( keys(%data) ){
+        if(ref($data{$item}) eq "ARRAY"){
+           $data{$item} = join(',',(@{$data{$item}}));
+        }
+    }
+
     if ( !person_exist($pid) ) {
         if ( person_add( $pid, %data ) ) {
             $logger->warn(


### PR DESCRIPTION
As per historical discussion here: https://sourceforge.net/p/packetfence/mailman/message/34115496/ (from 2015), I need to push arrays of data into form fields for portal registrations. This works on packetfence 7.0.0 live code.

# Description
This code handles array data submitted from forms, and removes the assumption that all form data is strings.

# Impacts
The forloop looks at all form data submitted through portal code - this is probably excessive.

# Delete branch after merge
YES