### PR TITLE
Feature/add brands icons

### DIFF
--- a/html/pfappserver/root/authentication/source/read.tt
+++ b/html/pfappserver/root/authentication/source/read.tt
@@ -12,7 +12,7 @@
 
 <div class="card">
 <div class="card-title">
-<h3><i class="icon-2x icon-[% source.type | html | lower %]"></i>[% heading | html %] <small>[% source.type | html %]</small></i></h3>
+<h3><i class="icon-2x icon-[% source.type | html | lower %]"></i>&nbsp[% heading | html %] <small>[% source.type | html %]</small></i></h3>
 </div>
 
     [% IF message %]<div class="alert alert-success">

--- a/html/pfappserver/root/authentication/source/read.tt
+++ b/html/pfappserver/root/authentication/source/read.tt
@@ -12,7 +12,7 @@
 
 <div class="card">
 <div class="card-title">
-<h3>[% heading | html %] <small>[% source.type | html %]</small></h3>
+<h3><i class="icon-2x icon-[% source.type | html | lower %]"></i>[% heading | html %] <small>[% source.type | html %]</small></i></h3>
 </div>
 
     [% IF message %]<div class="alert alert-success">

--- a/html/pfappserver/root/config/authentication.tt
+++ b/html/pfappserver/root/config/authentication.tt
@@ -77,9 +77,9 @@
       [% IF source.field('class').value == 'external' %]
       <tr>
           <td class="hidden-phone"></td>
-        <td>[% source.field('id').render_element | none %]<a href="[% c.pf_hash_for(c.controller('Config::Authentication::Source').action_for('read'), [ source.field('id').value ]) %]">[% source.field('id').value | html %]</a></td>
+        <td>[% source.field('id').render_element | none %]<a href="[% c.pf_hash_for(c.controller('Config::Authentication::Source').action_for('read'), [ source.field('id').value ]) %]">[% source.field('id').value | html %]</a>&nbsp<i class="icon-[% source.field('type').value | lower %]"</i></td>
         <td class="hidden-phone">[% source.field('description').value | html %]</td>
-        <td>[% l(source.field('type').value) %]<i class="icon-[% source.field('type') | lower %]"></i></td>
+        <td>[% l(source.field('type').value) %]</td>
         <td>
           [%- IF can_access("USERS_SOURCES_DELETE") %]
           <a class="btn btn-mini btn-danger" href="[% c.uri_for(c.controller('Config::Authentication::Source').action_for('delete'), [ source.field('id').value ]) %]">[% l('Delete') %]</a>
@@ -133,7 +133,7 @@
       [% IF source.field('class').value == 'billing' %]
       <tr>
           <td class="hidden-phone"></td>
-        <td>[% source.field('id').render_element | none %]<a href="[% c.pf_hash_for(c.controller('Config::Authentication::Source').action_for('read'), [ source.field('id').value ]) %]">[% source.field('id').value | html %]</a></td>
+        <td>[% source.field('id').render_element | none %]<a href="[% c.pf_hash_for(c.controller('Config::Authentication::Source').action_for('read'), [ source.field('id').value ]) %]">[% source.field('id').value | html %]</a>&nbsp<i class="icon-[% source.field('type').value | lower %]"</i></td>
         <td class="hidden-phone">[% source.field('description').value | html %]</td>
         <td>[% l(source.field('type').value) %]</td>
         <td><a class="btn btn-mini btn-danger" href="[% c.uri_for(c.controller('Config::Authentication::Source').action_for('delete'), [ source.field('id').value ]) %]">[% l('Delete') %]</a></td>

--- a/html/pfappserver/root/config/authentication.tt
+++ b/html/pfappserver/root/config/authentication.tt
@@ -79,7 +79,7 @@
           <td class="hidden-phone"></td>
         <td>[% source.field('id').render_element | none %]<a href="[% c.pf_hash_for(c.controller('Config::Authentication::Source').action_for('read'), [ source.field('id').value ]) %]">[% source.field('id').value | html %]</a></td>
         <td class="hidden-phone">[% source.field('description').value | html %]</td>
-        <td>[% l(source.field('type').value) %]</td>
+        <td>[% l(source.field('type').value) %]<i class="icon-[% source.field('type') | lower %]"></i></td>
         <td>
           [%- IF can_access("USERS_SOURCES_DELETE") %]
           <a class="btn btn-mini btn-danger" href="[% c.uri_for(c.controller('Config::Authentication::Source').action_for('delete'), [ source.field('id').value ]) %]">[% l('Delete') %]</a>

--- a/html/pfappserver/root/config/authentication.tt
+++ b/html/pfappserver/root/config/authentication.tt
@@ -77,7 +77,7 @@
       [% IF source.field('class').value == 'external' %]
       <tr>
           <td class="hidden-phone"></td>
-        <td>[% source.field('id').render_element | none %]<a href="[% c.pf_hash_for(c.controller('Config::Authentication::Source').action_for('read'), [ source.field('id').value ]) %]">[% source.field('id').value | html %]</a>&nbsp<i class="icon-[% source.field('type').value | lower %]"</i></td>
+        <td><i class="icon-[% source.field('type').value | lower %]"></i>&nbsp[% source.field('id').render_element | none %]<a href="[% c.pf_hash_for(c.controller('Config::Authentication::Source').action_for('read'), [ source.field('id').value ]) %]">[% source.field('id').value | html %]</a></td>
         <td class="hidden-phone">[% source.field('description').value | html %]</td>
         <td>[% l(source.field('type').value) %]</td>
         <td>
@@ -133,7 +133,7 @@
       [% IF source.field('class').value == 'billing' %]
       <tr>
           <td class="hidden-phone"></td>
-        <td>[% source.field('id').render_element | none %]<a href="[% c.pf_hash_for(c.controller('Config::Authentication::Source').action_for('read'), [ source.field('id').value ]) %]">[% source.field('id').value | html %]</a>&nbsp<i class="icon-[% source.field('type').value | lower %]"</i></td>
+        <td><i class="icon-[% source.field('type').value | lower %]"></i>&nbsp[% source.field('id').render_element | none %]<a href="[% c.pf_hash_for(c.controller('Config::Authentication::Source').action_for('read'), [ source.field('id').value ]) %]">[% source.field('id').value | html %]</a></td>
         <td class="hidden-phone">[% source.field('description').value | html %]</td>
         <td>[% l(source.field('type').value) %]</td>
         <td><a class="btn btn-mini btn-danger" href="[% c.uri_for(c.controller('Config::Authentication::Source').action_for('delete'), [ source.field('id').value ]) %]">[% l('Delete') %]</a></td>

--- a/html/pfappserver/root/static/scss/_icon.scss
+++ b/html/pfappserver/root/static/scss/_icon.scss
@@ -30,3 +30,10 @@ $fa-line-height-base: 1;
   font-size: 50%;
   vertical-align: super;
 }
+
+/**
+ * Alias for Windows Live oauth source
+ */
+.icon-windowslive {
+  @extend .icon-windows;
+}


### PR DESCRIPTION
# Description
Adding brands icons next to sources name and in creation of a source. Available only if the icons is existing in http://fontawesome.io/icons/

# Impacts
Authentication sources list, and source edit.

# Issue
fixes #2228 

# Delete branch after merge
YES 

# NEWS file entries
## Enhancements
* Adding brands icons to authentication source (i.e Twitter, PayPal etc ..) in the administration interface
