### PR TITLE
Do not strip non-digit characters from phone number

### DIFF
--- a/lib/pf/activation.pm
+++ b/lib/pf/activation.pm
@@ -609,9 +609,6 @@ sub sms_activation_create_send {
     my ($mac, $pid, $phone_number, $portal, $provider_id, $authentication_source) = @_;
     my $logger = get_logger();
 
-    # Strip non-digits
-    $phone_number =~ s/\D//g;
-
     my ( $success, $err ) = ( $TRUE, 0 );
     my %args = (
         mac         => $mac,


### PR DESCRIPTION
# Description
Title says it all !

# Impacts
SMS registration

# Issue
fixes #2296

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* Twilio: "To" phone number is being stripped of any "+" sign (#2296)