### PR TITLE
Set GOPATH while setting up go environment

### DIFF
--- a/addons/dev-helpers/setup-go-env.sh
+++ b/addons/dev-helpers/setup-go-env.sh
@@ -11,9 +11,12 @@ else
   tar -C /usr/local -xzf /tmp/$GOVERSION.linux-amd64.tar.gz
   rm /tmp/$GOVERSION.linux-amd64.tar.gz
 
-  echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc
-  echo 'export GOPATH=~/gospace' >> ~/.bashrc
-  echo 'export PATH=~/gospace/bin:$PATH' >> ~/.bashrc
+  SETUP='
+export PATH=$PATH:/usr/local/go/bin
+export GOPATH=~/gospace
+export PATH=~/gospace/bin:$PATH'
+  echo "$SETUP" >> ~/.bashrc
+  eval "$SETUP"
 
   mkdir -p $GOPATH/src/github.com/inverse-inc/packetfence
   


### PR DESCRIPTION
# Description
Fix a bug when setting up the go environment for the first time.

# Impacts
The script run by `make go-env` currently creates the symlink under `/` instead of `~/gospace`.

# NEWS file entries
## Bug Fixes
* Set up variable GOPATH correctly while setting up developer environment for go.