### PR TITLE
Fix/portal module source order

### DIFF
--- a/html/pfappserver/lib/pfappserver/Base/Form/Role/WithSource.pm
+++ b/html/pfappserver/lib/pfappserver/Base/Form/Role/WithSource.pm
@@ -14,17 +14,20 @@ use HTML::FormHandler::Moose::Role;
 with 'pfappserver::Base::Form::Role::Help';
 
 use pf::log;
+use pf::constants;
 
 after 'setup' => sub {
     my ($self) = @_;
 
     if($self->for_module->does('captiveportal::Role::MultiSource')){
-        $self->field('source_id')->multiple(1);
-        $self->field('source_id')->options([$self->options_sources(multiple => 1)]);
+        $self->field('multi_source_ids.contains')->options([$self->options_sources(multiple => 1)]);
+        $self->field('multi_source_ids')->inactive($FALSE);
     }
     else {
         $self->field('source_id')->options([$self->options_sources(multiple => 0)]);
+        $self->field('multi_source_ids')->inactive($TRUE);
     }
+
 };
 
 after 'process' => sub {
@@ -37,6 +40,25 @@ after 'process' => sub {
     }
 };
 
+sub source_fields {
+    my ($self) = @_;
+    return $self->for_module->does('captiveportal::Role::MultiSource') ? qw() : qw(source_id);
+}
+
+has_field 'multi_source_ids' =>
+  (
+    'type' => 'DynamicTable',
+    'sortable' => 1,
+    'do_label' => 0,
+  );
+
+has_field 'multi_source_ids.contains' =>
+  (
+    type => 'Select',
+    widget_wrapper => 'DynamicTableRow',
+  );
+
+
 has_field 'source_id' =>
   (
    type => 'Select',
@@ -47,6 +69,15 @@ has_field 'source_id' =>
    tags => { after_element => \&help,
              help => 'The sources to use in the module. If no sources are specified, all the sources on the Connection Profile will be used' },
   );
+
+#sub field_list {
+#    my ($self) = @_;
+#    use Data::Dumper; get_logger->info(Dumper(\@_));
+#    my $class = ref($self);
+#    get_logger->info("yes hello i'm zayme president of zaymebabwe ". $class);
+#    require $class;
+#    return $class::field_list($self);
+#}
 
 
 sub options_sources {

--- a/html/pfappserver/lib/pfappserver/Base/Form/Role/WithSource.pm
+++ b/html/pfappserver/lib/pfappserver/Base/Form/Role/WithSource.pm
@@ -25,6 +25,8 @@ after 'setup' => sub {
     }
     else {
         $self->field('source_id')->options([$self->options_sources(multiple => 0)]);
+
+        # The multi-source field should be set to inactive so it doesn't display
         $self->field('multi_source_ids')->inactive($TRUE);
     }
 
@@ -40,8 +42,15 @@ after 'process' => sub {
     }
 };
 
+=head2 source_fields
+
+The fields that need to be used to display the source(s) selection
+
+=cut
+
 sub source_fields {
     my ($self) = @_;
+    # No need to add the multi_source_ids fields as it will be taken when looking at all the dynamic tables
     return $self->for_module->does('captiveportal::Role::MultiSource') ? qw() : qw(source_id);
 }
 
@@ -69,16 +78,6 @@ has_field 'source_id' =>
    tags => { after_element => \&help,
              help => 'The sources to use in the module. If no sources are specified, all the sources on the Connection Profile will be used' },
   );
-
-#sub field_list {
-#    my ($self) = @_;
-#    use Data::Dumper; get_logger->info(Dumper(\@_));
-#    my $class = ref($self);
-#    get_logger->info("yes hello i'm zayme president of zaymebabwe ". $class);
-#    require $class;
-#    return $class::field_list($self);
-#}
-
 
 sub options_sources {
     my ($self, %options) = @_;

--- a/html/pfappserver/lib/pfappserver/Base/Form/Role/WithSource.pm
+++ b/html/pfappserver/lib/pfappserver/Base/Form/Role/WithSource.pm
@@ -20,11 +20,11 @@ after 'setup' => sub {
     my ($self) = @_;
 
     if($self->for_module->does('captiveportal::Role::MultiSource')){
-        $self->field('multi_source_ids.contains')->options([$self->options_sources(multiple => 1)]);
+        $self->field('multi_source_ids.contains')->options([$self->options_sources(multiple => $TRUE)]);
         $self->field('multi_source_ids')->inactive($FALSE);
     }
     else {
-        $self->field('source_id')->options([$self->options_sources(multiple => 0)]);
+        $self->field('source_id')->options([$self->options_sources(multiple => $FALSE)]);
 
         # The multi-source field should be set to inactive so it doesn't display
         $self->field('multi_source_ids')->inactive($TRUE);
@@ -57,8 +57,8 @@ sub source_fields {
 has_field 'multi_source_ids' =>
   (
     'type' => 'DynamicTable',
-    'sortable' => 1,
-    'do_label' => 0,
+    'sortable' => $TRUE,
+    'do_label' => $FALSE,
   );
 
 has_field 'multi_source_ids.contains' =>

--- a/html/pfappserver/lib/pfappserver/Form/Config/PortalModule.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/PortalModule.pm
@@ -130,7 +130,7 @@ sub dynamic_tables {
     my ($self) = @_;
     my @fields;
     foreach my $field ($self->all_fields){
-        if($field->type eq "DynamicTable") {
+        if($field->type eq "DynamicTable" && $field->is_active) {
             push @fields, $field->name;
         }
     }

--- a/html/pfappserver/lib/pfappserver/Form/Config/PortalModule/Authentication.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/PortalModule/Authentication.pm
@@ -66,7 +66,7 @@ The fields to display
 
 sub child_definition {
     my ($self) = @_;
-    return (qw(source_id pid_field custom_fields with_aup aup_template signup_template), $self->auth_module_definition());
+    return ($self->source_fields, qw(pid_field custom_fields with_aup aup_template signup_template), $self->auth_module_definition());
 }
 
 =head2 BUILD

--- a/html/pfappserver/lib/pfappserver/Form/Config/PortalModule/Authentication/Choice.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/PortalModule/Authentication/Choice.pm
@@ -24,7 +24,7 @@ sub for_module {'captiveportal::PacketFence::DynamicRouting::Module::Authenticat
 
 sub child_definition {
     my ($self) = @_;
-    return qw(source_id custom_fields template);
+    return ($self->source_fields, qw(custom_fields template));
 }
 
 =over

--- a/html/pfappserver/lib/pfappserver/I18N/en.po
+++ b/html/pfappserver/lib/pfappserver/I18N/en.po
@@ -10792,3 +10792,6 @@ msgstr ""
 msgid "{percent}% of {total_size}"
 msgstr ""
 
+msgid "multi_source_ids"
+msgstr "sources"
+

--- a/html/pfappserver/root/config/portal_module/view.tt
+++ b/html/pfappserver/root/config/portal_module/view.tt
@@ -54,7 +54,7 @@
         <div id="[% field %]Empty" class="unwell unwell-horizontal[% ' hidden' IF form.field(field).index > 1 %]">
           <p>
             <i class="icon-cog icon-large"></i>
-            [% l('No ' _ field _ ' selected') %]
+            [% l('No ' _ l(field) _ ' selected') %]
             <a href="#add">[% l('Add one.') %]</a>
           </p>
           <p>[% form.field(field).tags.when_empty %]</p>

--- a/lib/pf/ConfigStore/PortalModule.pm
+++ b/lib/pf/ConfigStore/PortalModule.pm
@@ -59,7 +59,7 @@ sub cleanupBeforeCommit {
     my ($self, $id, $object) = @_;
     
     # portal_modules.conf always stores sources in source_id whether they are multiple or single, so we take multi_source_ids and put it in source_id
-    if (scalar(@{$object->{multi_source_ids}}) > 0) {
+    if (defined($object->{multi_source_ids}) && scalar(@{$object->{multi_source_ids}}) > 0) {
         get_logger->debug("Multiple sources were defined for this object, taking the content of multi_source_ids to put it in source_id");
         $object->{source_id} = delete $object->{multi_source_ids};
     } else {

--- a/lib/pf/ConfigStore/PortalModule.pm
+++ b/lib/pf/ConfigStore/PortalModule.pm
@@ -42,6 +42,9 @@ sub cleanupAfterRead {
     if($object->{type} eq "Message" && ref($object->{message}) eq 'ARRAY'){
         $object->{message} = join("\n", @{$object->{message}});
     }
+
+    # Multiple sources are stored in this special field to the admin forms can display it differently
+    $object->{multi_source_ids} = $object->{source_id}; 
 }
 
 =head2 cleanupBeforeCommit
@@ -52,6 +55,14 @@ Clean data before update or creating
 
 sub cleanupBeforeCommit {
     my ($self, $id, $object) = @_;
+    
+    # portal_modules.conf always stores sources in source_id whether they are multiple or single, so we take multi_source_ids and put it in source_id
+    if (scalar(@{$object->{multi_source_ids}}) > 0) {
+        $object->{source_id} = delete $object->{multi_source_ids};
+    } else {
+        delete $object->{multi_source_ids};
+    }
+
     $self->flatten_list($object, $self->_fields_expanded);
     $self->join_lines($object, $self->_fields_line_expanded);
 }
@@ -64,6 +75,7 @@ sub _fields_expanded {
     return qw(
     modules
     source_id
+    multi_source_ids
     custom_fields
     actions
     );

--- a/lib/pf/ConfigStore/PortalModule.pm
+++ b/lib/pf/ConfigStore/PortalModule.pm
@@ -21,6 +21,8 @@ use pf::file_paths qw(
 );
 extends 'pf::ConfigStore';
 
+use pf::log;
+
 sub configFile { $portal_modules_config_file};
 
 sub importConfigFile { $portal_modules_default_config_file }
@@ -58,6 +60,7 @@ sub cleanupBeforeCommit {
     
     # portal_modules.conf always stores sources in source_id whether they are multiple or single, so we take multi_source_ids and put it in source_id
     if (scalar(@{$object->{multi_source_ids}}) > 0) {
+        get_logger->debug("Multiple sources were defined for this object, taking the content of multi_source_ids to put it in source_id");
         $object->{source_id} = delete $object->{multi_source_ids};
     } else {
         delete $object->{multi_source_ids};


### PR DESCRIPTION
## Need to discuss whether or not we backport this in maintenance. If so, it should be tested thoroughly given its high impact on the captive portal

# Description
Ensure that authentication sources are properly ordered for portal modules when using the admin interface

# Impacts
Portal modules / the whole captive portal

# Issue
fixes #2323 

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* Fix authentication sources ordering issue for portal modules when using the administration interface (#2323)
