### PR TITLE
Added dependencies on sd_notify version of FreeRADIUS.

### DIFF
--- a/addons/packages/packetfence.spec
+++ b/addons/packages/packetfence.spec
@@ -92,7 +92,7 @@ Requires: mod_perl, mod_proxy_html
 requires: libapreq2
 Requires: dhcp
 Requires: redis
-Requires: freeradius >= 3.0.13-19, freeradius-mysql, freeradius-perl, freeradius-ldap, freeradius-utils, freeradius-redis, freeradius-rest, freeradius-radsniff >= 3.0.13-19
+Requires: freeradius >= 3.0.14-2, freeradius-mysql, freeradius-perl, freeradius-ldap, freeradius-utils, freeradius-redis, freeradius-rest, freeradius-radsniff >= 3.0.14-2
 Requires: make
 Requires: net-tools
 Requires: sscep
@@ -727,6 +727,9 @@ sed -i 's/\%.*$//g' /etc/resolv.conf
 echo "# ip forwarding enabled by packetfence" > /etc/sysctl.d/99-ip_forward.conf
 echo "net.ipv4.ip_forward = 1" >> /etc/sysctl.d/99-ip_forward.conf
 sysctl -p /etc/sysctl.d/99-ip_forward.conf
+
+# reloading systemd unit files
+/bin/systemctl daemon-reload
 
 #Starting PacketFence.
 echo "Starting PacketFence Administration GUI..."

--- a/conf/systemd/packetfence-radiusd-acct.service
+++ b/conf/systemd/packetfence-radiusd-acct.service
@@ -8,6 +8,7 @@ Wants=packetfence-base.target packetfence-config.service packetfence-iptables.se
 After=packetfence-base.target packetfence-config.service packetfence-iptables.service 
 
 [Service]
+Type=notify
 StartLimitBurst=3
 StartLimitInterval=60
 PIDFile=/usr/local/pf/var/run/radiusd-acct.pid

--- a/conf/systemd/packetfence-radiusd-auth.service
+++ b/conf/systemd/packetfence-radiusd-auth.service
@@ -7,6 +7,7 @@ Wants=packetfence-base.target packetfence-config.service packetfence-iptables.se
 After=packetfence-base.target packetfence-config.service packetfence-iptables.service 
 
 [Service]
+Type=notify
 StartLimitBurst=3
 StartLimitInterval=60
 PIDFile=/usr/local/pf/var/run/radiusd-auth.pid

--- a/conf/systemd/packetfence-radiusd-cli.service
+++ b/conf/systemd/packetfence-radiusd-cli.service
@@ -8,6 +8,7 @@ Wants=packetfence-base.target packetfence-config.service packetfence-iptables.se
 After=packetfence-base.target packetfence-config.service packetfence-iptables.service
 
 [Service]
+Type=notify
 StartLimitBurst=3
 StartLimitInterval=60
 PIDFile=/usr/local/pf/var/run/radiusd-cli.pid

--- a/conf/systemd/packetfence-radiusd-eduroam.service
+++ b/conf/systemd/packetfence-radiusd-eduroam.service
@@ -7,6 +7,7 @@ Wants=packetfence-base.target packetfence-config.service packetfence-iptables.se
 After=packetfence-base.target packetfence-config.service packetfence-iptables.service 
 
 [Service]
+Type=notify
 StartLimitBurst=3
 StartLimitInterval=60
 PIDFile=/usr/local/pf/var/run/radiusd-eduroam.pid

--- a/conf/systemd/packetfence-radiusd-load_balancer.service
+++ b/conf/systemd/packetfence-radiusd-load_balancer.service
@@ -7,6 +7,7 @@ Wants=packetfence-base.target packetfence-config.service packetfence-iptables.se
 After=packetfence-base.target packetfence-config.service packetfence-iptables.service
 
 [Service]
+Type=notify
 StartLimitBurst=3
 StartLimitInterval=60
 PIDFile=/usr/local/pf/var/run/radiusd-load_balancer.pid

--- a/debian/control
+++ b/debian/control
@@ -28,7 +28,7 @@ Depends: ${misc:Depends}, vlan,
  libapache2-request-perl, libtie-dxhash-perl, libapache-session-perl,
  libapache-ssllookup-perl,
 # freeradius
- freeradius (>= 3.0.13.9), freeradius-ldap, 
+ freeradius (>= 3.0.14.2), freeradius-ldap, 
  freeradius-mysql, freeradius-utils, freeradius-rest, freeradius-redis,
 # binary
  make,


### PR DESCRIPTION
# Description
Adds package dependencies on sd_notify compliant versions of FreeRADIUS.

# Impacts
Packaging: packetfence.spec, and debian/control

# NEW Package(s) required
Depends on the correct versions of the packages being available, which they should be by now, i.e. freeradius 3.0.14.2 and upwards.


# Delete branch after merge
YES 

## Enhancements
* Adds support for sd_notify in FreeRADIUS