### PR TITLE
Use only internal authentication sources if none specified

### DIFF
--- a/lib/pf/authentication.pm
+++ b/lib/pf/authentication.pm
@@ -221,7 +221,7 @@ sub authenticate {
 
     # If no source(s) provided, all (except 'exclusive' ones) configured sources are used
     unless (@sources) {
-        @sources = grep { $_->class ne 'exclusive'  } @authentication_sources;
+        @sources = @{pf::authentication::getInternalAuthenticationSources()};
     }
     my $display_username = (defined $username) ? $username : "(anonymous)";
 

--- a/lib/pf/authentication.pm
+++ b/lib/pf/authentication.pm
@@ -219,7 +219,7 @@ sub authenticate {
     my $username = $params->{'username'};
     my $password = $params->{'password'};
 
-    # If no source(s) provided, all (except 'exclusive' ones) configured sources are used
+    # If no source(s) provided, all 'internal' configured sources are used
     unless (@sources) {
         @sources = @{pf::authentication::getInternalAuthenticationSources()};
     }


### PR DESCRIPTION
# Description
`pf::authentication::authenticate` uses only "internal" authentication sources if none are specified

# Impacts
- httpd.portal
- WISPr

# Issue
fixes #2338 
fixes #1784 

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* authentication: Too large scoping of authentication sources (#2338)
* device-registration: 'Null' source type should not be used (#1784)