### PR TITLE
use MAC based SID in pf::Portal::Session when possible

### DIFF
--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Root.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Root.pm
@@ -115,7 +115,7 @@ sub handle_web_form_release {
             $switch = pf::SwitchFactory->instantiate($last_switch_id);
         }
     }
-    my $session = new pf::Portal::Session()->session;
+    my $session = new pf::Portal::Session(client_mac => $self->current_mac)->session;
     if(defined($switch) && $switch && $switch->supportsWebFormRegistration && defined($session->param('is_external_portal')) && $session->param('is_external_portal')){
         get_logger->info("(" . $switch->{_id} . ") supports web form release. Will use this method to authenticate");
         $self->render('webFormRelease.html', {

--- a/html/captive-portal/lib/captiveportal/PacketFence/Model/Portal/Session.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Model/Portal/Session.pm
@@ -251,9 +251,18 @@ sub _build_profile {
 
 sub _build_dispatcherSession {
     my ($self) = @_;
-    my $session = new pf::Portal::Session()->session;
-    my %session_data;
     my $logger = get_logger();
+
+    # Restore with a dummy MAC since we don't care about what contains the session if it can't be restored from the session ID
+    my $dummy_mac = "ff:ff:ff:ff:ff:ff";
+    my $session = new pf::Portal::Session(client_mac => $dummy_mac)->session;
+
+    if($session->param('_client_mac') eq $dummy_mac) {
+        $logger->debug("Ignoring dispatcher session as it wasn't restored from a valid session ID");
+        return {};
+    }
+
+    my %session_data;
     foreach my $key ($session->param) {
         my $value = $session->param($key);
         $logger->debug( sub { "Adding session parameter from dispatcher session to Catalyst session : $key : " . ($value // 'undef') });

--- a/html/captive-portal/lib/captiveportal/PacketFence/Model/Portal/Session.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Model/Portal/Session.pm
@@ -27,6 +27,7 @@ use URI::URL;
 use URI::Escape::XS qw(uri_escape uri_unescape);
 use HTML::Entities;
 use List::MoreUtils qw(any);
+use pf::constants::Portal::Session qw($DUMMY_MAC);
 
 =head1 NAME
 
@@ -254,9 +255,7 @@ sub _build_dispatcherSession {
     my $logger = get_logger();
 
     # Restore with a dummy MAC since we don't care about what contains the session if it can't be restored from the session ID
-    my $dummy_mac = "ff:ff:ff:ff:ff:ff";
-    
-    my $portal_session = new pf::Portal::Session(client_mac => $dummy_mac);
+    my $portal_session = new pf::Portal::Session(client_mac => $DUMMY_MAC);
 
     if($portal_session->{_dummy_session}) {
         $logger->debug("Ignoring dispatcher session as it wasn't restored from a valid session ID");

--- a/html/captive-portal/lib/captiveportal/PacketFence/Model/Portal/Session.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Model/Portal/Session.pm
@@ -255,12 +255,15 @@ sub _build_dispatcherSession {
 
     # Restore with a dummy MAC since we don't care about what contains the session if it can't be restored from the session ID
     my $dummy_mac = "ff:ff:ff:ff:ff:ff";
-    my $session = new pf::Portal::Session(client_mac => $dummy_mac)->session;
+    
+    my $portal_session = new pf::Portal::Session(client_mac => $dummy_mac);
 
-    if($session->param('_client_mac') eq $dummy_mac) {
+    if($portal_session->{_dummy_session}) {
         $logger->debug("Ignoring dispatcher session as it wasn't restored from a valid session ID");
         return {};
     }
+
+    my $session = $portal_session->session;
 
     my %session_data;
     foreach my $key ($session->param) {

--- a/lib/pf/Portal/Session.pm
+++ b/lib/pf/Portal/Session.pm
@@ -109,6 +109,8 @@ sub _initialize {
         }
     );
 
+    $self->{_dummy_session} = (defined($mac) && $mac eq "ff:ff:ff:ff:ff:ff");
+
     # Don't assign $mac if the dummy MAC was used for restoring the session
     $self->{'_client_mac'} = ((defined($mac) && $mac ne "ff:ff:ff:ff:ff:ff") ? $mac : undef) || $self->session->param("_client_mac") || $self->_restoreFromSession("_client_mac",sub {
             return $self->getClientMac;

--- a/lib/pf/Portal/Session.pm
+++ b/lib/pf/Portal/Session.pm
@@ -109,7 +109,8 @@ sub _initialize {
         }
     );
 
-    $self->{'_client_mac'} = $mac || $self->session->param("_client_mac") || $self->_restoreFromSession("_client_mac",sub {
+    # Don't assign $mac if the dummy MAC was used for restoring the session
+    $self->{'_client_mac'} = ((defined($mac) && $mac ne "ff:ff:ff:ff:ff:ff") ? $mac : undef) || $self->session->param("_client_mac") || $self->_restoreFromSession("_client_mac",sub {
             return $self->getClientMac;
         }
     );

--- a/lib/pf/Portal/Session.pm
+++ b/lib/pf/Portal/Session.pm
@@ -45,6 +45,7 @@ use pf::web::constants;
 use pf::web::util;
 use pf::web::constants;
 use pf::activation qw(view_by_code);
+use pf::constants::Portal::Session qw($DUMMY_MAC);
 
 =head1 CONSTANTS
 
@@ -109,10 +110,10 @@ sub _initialize {
         }
     );
 
-    $self->{_dummy_session} = (defined($mac) && $mac eq "ff:ff:ff:ff:ff:ff");
+    $self->{_dummy_session} = (defined($mac) && $mac eq $DUMMY_MAC);
 
     # Don't assign $mac if the dummy MAC was used for restoring the session
-    $self->{'_client_mac'} = ((defined($mac) && $mac ne "ff:ff:ff:ff:ff:ff") ? $mac : undef) || $self->session->param("_client_mac") || $self->_restoreFromSession("_client_mac",sub {
+    $self->{'_client_mac'} = ((defined($mac) && $mac ne $DUMMY_MAC) ? $mac : undef) || $self->session->param("_client_mac") || $self->_restoreFromSession("_client_mac",sub {
             return $self->getClientMac;
         }
     );

--- a/lib/pf/constants/Portal/Session.pm
+++ b/lib/pf/constants/Portal/Session.pm
@@ -1,0 +1,54 @@
+package pf::constants::Portal::Session;
+
+=head1 NAME
+
+pf::constants::Portal::Session
+
+=cut
+
+=head1 DESCRIPTION
+
+constants for pf::Portal::Session
+
+=cut
+
+use strict;
+use warnings;
+use base qw(Exporter);
+
+our @EXPORT_OK = qw(
+    $DUMMY_MAC
+);
+
+our $DUMMY_MAC = "ff:ff:ff:ff:ff:ff";
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2017 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;
+
+


### PR DESCRIPTION
# Description
Use a MAC based session for pf::Portal::Session when possible to prevent an endpoint creating thousands of useless sessions by not reusing the session ID

# Impacts
All web-authentication and wispr

# Delete branch after merge
YES

# Issue
fixes #2352 


# NEWS file entries
## Enhancements
* Limit the amount of portal sessions an endpoint can create when using web authentication