### PR TITLE
Added requirements for sd_notify support in apache.

### DIFF
--- a/conf/httpd.conf.d/httpd.admin.tt.example
+++ b/conf/httpd.conf.d/httpd.admin.tt.example
@@ -64,6 +64,9 @@
   <IfModule !mod_headers.c>
     LoadModule headers_module /usr/lib/apache2/modules/mod_headers.so
   </IfModule>
+  <IfModule !mod_systemd.c>
+    LoadModule systemd_module     /usr/lib/apache2/modules/mod_systemd.so
+  </IfModule>
 </IfDefine>
 
 #RHEL specific
@@ -127,7 +130,9 @@
   <IfModule !mod_headers.c>
       LoadModule headers_module modules/mod_headers.so
   </IfModule>
-
+  <IfModule !mod_systemd.c>
+    LoadModule systemd_module   modules/mod_systemd.so
+  </IfModule>
 </IfDefine>
 [% IF apache_version == "2.4" %]
 Mutex posixsem default

--- a/conf/httpd.conf.d/httpd.collector.tt.example
+++ b/conf/httpd.conf.d/httpd.collector.tt.example
@@ -49,7 +49,9 @@
   <IfModule !mod_setenvif.c>
     LoadModule setenvif_module /usr/lib/apache2/modules/mod_setenvif.so
   </IfModule>
-
+  <IfModule !mod_systemd.c>
+    LoadModule systemd_module     /usr/lib/apache2/modules/mod_systemd.so
+  </IfModule>
 </IfDefine>
 
 #RHEL Specific
@@ -100,6 +102,9 @@
   </IfModule>
   <IfModule !mod_setenvif.c>
     LoadModule setenvif_module modules/mod_setenvif.so
+  </IfModule>
+  <IfModule !mod_systemd.c>
+    LoadModule systemd_module   modules/mod_systemd.so
   </IfModule>
 </IfDefine>
 

--- a/conf/httpd.conf.d/httpd.graphite.tt.example
+++ b/conf/httpd.conf.d/httpd.graphite.tt.example
@@ -40,6 +40,9 @@
   <IfModule !mod_mime.c>
     LoadModule mime_module /usr/lib/apache2/modules/mod_mime.so
   </IfModule>
+  <IfModule !mod_systemd.c>
+    LoadModule systemd_module     /usr/lib/apache2/modules/mod_systemd.so
+  </IfModule>
 </IfDefine>
 
 #RHEL specific
@@ -84,6 +87,9 @@
   </IfModule>
   <IfModule !mod_mime.c>
     LoadModule mime_module modules/mod_mime.so
+  </IfModule>
+  <IfModule !mod_systemd.c>
+    LoadModule systemd_module   modules/mod_systemd.so
   </IfModule>
 </IfDefine>
 

--- a/conf/httpd.conf.d/httpd.parking.tt.example
+++ b/conf/httpd.conf.d/httpd.parking.tt.example
@@ -43,6 +43,9 @@
   <IfModule !mod_rewrite.c>
     LoadModule rewrite_module /usr/lib/apache2/modules/mod_rewrite.so
   </IfModule>
+  <IfModule !mod_systemd.c>
+    LoadModule systemd_module     /usr/lib/apache2/modules/mod_systemd.so
+  </IfModule>
 </IfDefine>
 
 #RHEL specific
@@ -87,6 +90,9 @@
   </IfModule>
   <IfModule !mod_rewrite.c>
     LoadModule rewrite_module modules/mod_rewrite.so
+  </IfModule>
+  <IfModule !mod_systemd.c>
+    LoadModule systemd_module modules/mod_systemd.so
   </IfModule>
 </IfDefine>
 

--- a/conf/httpd.conf.d/httpd.portal.tt.example
+++ b/conf/httpd.conf.d/httpd.portal.tt.example
@@ -53,6 +53,9 @@
   <IfModule !mod_status.c>
     LoadModule status_module /usr/lib/apache2/modules/mod_status.so
   </IfModule>
+  <IfModule !mod_systemd.c>
+    LoadModule systemd_module     /usr/lib/apache2/modules/mod_systemd.so
+  </IfModule>
 </IfDefine>
 
 #RHEL specific
@@ -109,6 +112,9 @@
   </IfModule>
   <IfModule !mod_status.c>
     LoadModule status_module modules/mod_status.so
+  </IfModule>
+  <IfModule !mod_systemd.c>
+    LoadModule systemd_module modules/mod_systemd.so
   </IfModule>
 </IfDefine>
 

--- a/conf/httpd.conf.d/httpd.proxy.tt.example
+++ b/conf/httpd.conf.d/httpd.proxy.tt.example
@@ -46,6 +46,9 @@
   <IfModule !mod_headers.c>
     LoadModule headers_module /usr/lib/apache2/modules/mod_headers.so
   </IfModule>
+  <IfModule !mod_systemd.c>
+    LoadModule systemd_module     /usr/lib/apache2/modules/mod_systemd.so
+  </IfModule>
 </IfDefine>
 
 #RHEL specific
@@ -93,6 +96,9 @@
   </IfModule>
   <IfModule !mod_headers.c>
     LoadModule headers_module modules/mod_headers.so
+  </IfModule>
+  <IfModule !mod_systemd.c>
+    LoadModule systemd_module modules/mod_systemd.so
   </IfModule>
 </IfDefine>
 

--- a/conf/httpd.conf.d/httpd.webservices.tt.example
+++ b/conf/httpd.conf.d/httpd.webservices.tt.example
@@ -52,6 +52,9 @@
   <IfModule !mod_setenvif.c>
     LoadModule setenvif_module /usr/lib/apache2/modules/mod_setenvif.so
   </IfModule>
+  <IfModule !mod_systemd.c>
+    LoadModule systemd_module     /usr/lib/apache2/modules/mod_systemd.so
+  </IfModule>
 
 </IfDefine>
 
@@ -106,6 +109,9 @@
   </IfModule>
   <IfModule !mod_setenvif.c>
     LoadModule setenvif_module modules/mod_setenvif.so
+  </IfModule>
+  <IfModule !mod_systemd.c>
+    LoadModule systemd_module modules/mod_systemd.so
   </IfModule>
 </IfDefine>
 

--- a/conf/systemd/packetfence-httpd.aaa.service
+++ b/conf/systemd/packetfence-httpd.aaa.service
@@ -9,7 +9,7 @@ Before=packetfence-radiusd-auth.service packetfence-radiusd-acct.service packetf
 [Service]
 StartLimitBurst=3
 StartLimitInterval=60
-Type=simple
+Type=notify
 PIDFile=/usr/local/pf/var/run/httpd.aaa.pid
 ExecStartPre=/usr/local/pf/bin/pfcmd service httpd.aaa generateconfig
 ExecStart=/usr/sbin/httpd -f /usr/local/pf/var/conf/httpd.conf.d/httpd.aaa -DFOREGROUND  -Drhel

--- a/conf/systemd/packetfence-httpd.admin.service
+++ b/conf/systemd/packetfence-httpd.admin.service
@@ -8,7 +8,7 @@ After=packetfence-base.target packetfence-config.service packetfence-haproxy.ser
 [Service]
 StartLimitBurst=3
 StartLimitInterval=60
-Type=simple
+Type=notify
 PIDFile=/usr/local/pf/var/run/httpd.admin.pid
 Environment=X_PORTAL=default
 ExecStartPre=/usr/local/pf/bin/pfcmd service httpd.admin generateconfig

--- a/conf/systemd/packetfence-httpd.collector.service
+++ b/conf/systemd/packetfence-httpd.collector.service
@@ -8,7 +8,7 @@ After=packetfence-base.target packetfence-config.service packetfence-iptables.se
 [Service]
 StartLimitBurst=3
 StartLimitInterval=60
-Type=simple
+Type=notify
 PIDFile=/usr/local/pf/var/run/httpd.collector.pid
 ExecStartPre=/usr/local/pf/bin/pfcmd service httpd.collector generateconfig
 ExecStart=/usr/sbin/httpd -f /usr/local/pf/var/conf/httpd.conf.d/httpd.collector -DFOREGROUND  -Drhel

--- a/conf/systemd/packetfence-httpd.graphite.service
+++ b/conf/systemd/packetfence-httpd.graphite.service
@@ -8,7 +8,7 @@ After=packetfence-base.target packetfence-config.service packetfence-iptables.se
 [Service]
 StartLimitBurst=3
 StartLimitInterval=60
-Type=simple
+Type=notify
 PIDFile=/usr/local/pf/var/run/httpd.graphite.pid
 ExecStartPre=/usr/local/pf/bin/pfcmd service httpd.graphite generateconfig
 ExecStart=/usr/sbin/httpd -f /usr/local/pf/var/conf/httpd.conf.d/httpd.graphite -DFOREGROUND  -Drhel

--- a/conf/systemd/packetfence-httpd.parking.service
+++ b/conf/systemd/packetfence-httpd.parking.service
@@ -8,7 +8,7 @@ After=packetfence-base.target packetfence-config.service packetfence-iptables.se
 [Service]
 StartLimitBurst=3
 StartLimitInterval=60
-Type=simple
+Type=notify
 ExecStartPre=/usr/local/pf/bin/pfcmd service httpd.parking generateconfig
 ExecStart=/usr/sbin/httpd -f /usr/local/pf/var/conf/httpd.conf.d/httpd.parking -DFOREGROUND  -Drhel
 ExecReload=/bin/kill -USR1 ${MAINPID}

--- a/conf/systemd/packetfence-httpd.portal.service
+++ b/conf/systemd/packetfence-httpd.portal.service
@@ -8,7 +8,7 @@ After=packetfence-base.target packetfence-config.service packetfence-iptables.se
 [Service]
 StartLimitBurst=3
 StartLimitInterval=60
-Type=simple
+Type=notify
 PIDFile=/usr/local/pf/var/run/httpd.portal.pid
 ExecStartPre=/usr/local/pf/bin/pfcmd service httpd.portal generateconfig
 ExecStart=/usr/sbin/httpd -f /usr/local/pf/var/conf/httpd.conf.d/httpd.portal -DFOREGROUND  -Drhel

--- a/conf/systemd/packetfence-httpd.proxy.service
+++ b/conf/systemd/packetfence-httpd.proxy.service
@@ -8,7 +8,7 @@ After=packetfence-base.target packetfence-config.service packetfence-iptables.se
 [Service]
 StartLimitBurst=3
 StartLimitInterval=60
-Type=simple
+Type=notify
 PIDFile=/usr/local/pf/var/run/httpd.proxy.pid
 ExecStartPre=/usr/local/pf/bin/pfcmd service httpd.proxy generateconfig
 ExecStart=/usr/sbin/httpd -f /usr/local/pf/var/conf/httpd.conf.d/httpd.proxy -DFOREGROUND  -Drhel

--- a/conf/systemd/packetfence-httpd.webservices.service
+++ b/conf/systemd/packetfence-httpd.webservices.service
@@ -8,7 +8,7 @@ After=packetfence-base.target packetfence-config.service packetfence-iptables.se
 [Service]
 StartLimitBurst=3
 StartLimitInterval=60
-Type=simple
+Type=notify
 PIDFile=/usr/local/pf/var/run/httpd.webservices.pid
 ExecStartPre=/usr/local/pf/bin/pfcmd service httpd.webservices generateconfig
 ExecStart=/usr/sbin/httpd -f /usr/local/pf/var/conf/httpd.conf.d/httpd.webservices -DFOREGROUND  -Drhel

--- a/debian/control
+++ b/debian/control
@@ -26,7 +26,7 @@ Depends: ${misc:Depends}, vlan,
  apache2, apache2-utils, libapache2-mod-proxy-html,
  apache2-mpm-prefork, libapache2-mod-apreq2, libapache2-mod-perl2,
  libapache2-request-perl, libtie-dxhash-perl, libapache-session-perl,
- libapache-ssllookup-perl,
+ libapache-ssllookup-perl, libapache2-mod-systemd,
 # freeradius
  freeradius (>= 3.0.14.2), freeradius-ldap, 
  freeradius-mysql, freeradius-utils, freeradius-rest, freeradius-redis,


### PR DESCRIPTION
# Description
This provides for sd_notify "READY" notification support in all PF httpd services.
Support is provided for Debian and Red Hat.

# Impacts
systemd should now wait to receive the "READY" notification before considering an apache based service to be started.

# NEW Package(s) required
mod_systemd is already included in httpd on Red Hat.
libapache2-mod-systemd is required on Debian.


# Delete branch after merge
YES 

# NEWS file entries

## Enhancements
* Apache based services now support systemd sd_notify