### PR TITLE
Use returned radius attributes in order to tests them in rules

### DIFF
--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1052,6 +1052,12 @@ description=<<EOT
 List of LDAP attributes that can be used in the sources configuration
 EOT
 
+[advanced.radius_attributes]
+type=merged_list
+description=<<EOT
+List of RADIUS attributes that can be used in the sources configuration
+EOT
+
 [advanced.pfdns_processes]
 type=text
 description=<<EOT

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -774,6 +774,11 @@ ntlm_redis_cache=disabled
 # List of LDAP attributes that can be used in the sources configuration
 ldap_attributes=uid,cn,department,displayName,distinguishedName,givenName,memberOf,sn,eduPersonPrimaryAffiliation,mail,postOfficeBox,description,groupMembership
 #
+# advanced.radius_attributes
+#
+# List of RADIUS attributes that can be used in the sources configuration
+radius_attributes=username,NAS-ID,Called-Station-Id,Calling-Station-Id
+#
 # advanced.pfdns_processes
 #
 # Amount of pfdns processes to start

--- a/html/captive-portal/lib/captiveportal/Base/Actions.pm
+++ b/html/captive-portal/lib/captiveportal/Base/Actions.pm
@@ -25,8 +25,8 @@ our %AUTHENTICATION_ACTIONS = (
     set_role => sub { $_[0]->new_node_info->{category} = $_[1]; },
     set_unregdate => sub { $_[0]->new_node_info->{unregdate} = $_[1] },
     set_access_duration => sub { $_[0]->new_node_info->{unregdate} = pf::config::access_duration($_[1]) },
-    unregdate_from_source => sub { $_[0]->new_node_info->{unregdate} = pf::authentication::match($_[0]->source->id, $_[0]->auth_source_params, $Actions::SET_UNREG_DATE); },
-    role_from_source => sub { $_[0]->new_node_info->{category} = pf::authentication::match($_[0]->source->id, $_[0]->auth_source_params, $Actions::SET_ROLE); },
+    unregdate_from_source => sub { $_[0]->new_node_info->{unregdate} = pf::authentication::match($_[0]->source->id, $_[0]->auth_source_params, $Actions::SET_UNREG_DATE, undef, $_[0]->session->{extra}); },
+    role_from_source => sub { $_[0]->new_node_info->{category} = pf::authentication::match($_[0]->source->id, $_[0]->auth_source_params, $Actions::SET_ROLE, undef, $_[0]->session->{extra}); },
     no_action => sub {},
 );
 

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Authenticate.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Authenticate.pm
@@ -124,7 +124,7 @@ sub authenticationLogin : Private {
         $c->user_session->{source_match} = \@sources;
     } else {
         # validate login and password
-        ( $return, $message, $source_id ) =
+        ( $return, $message, $source_id, $extra ) =
           pf::authentication::authenticate( { 'username' => $username, 'password' => $password, 'rule_class' => $Rules::AUTH }, @sources );
         if ( defined($return) && $return == 1 ) {
             pf::auth_log::record_auth($source_id, $portalSession->clientMac, $username, $pf::auth_log::COMPLETED);

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Authenticate.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Authenticate.pm
@@ -76,7 +76,7 @@ sub authenticationLogin : Private {
     my $profile = $c->profile;
     my $portalSession = $c->portalSession;
     my $mac           = $portalSession->clientMac;
-    my ( $return, $message, $source_id );
+    my ( $return, $message, $source_id, $extra );
     $logger->debug("authentication attempt");
 
     if ($request->{'match'} eq "status/login") {

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/DeviceRegistration.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/DeviceRegistration.pm
@@ -148,11 +148,11 @@ sub registerNode : Private {
                 $logger->debug("Device registration role is $role (from pf.conf)");
             } else {
                 # Use role of user
-                $role = pf::authentication::match( $source_id, $params , $Actions::SET_ROLE);
+                $role = pf::authentication::match( $source_id, $params , $Actions::SET_ROLE, undef, $self->session->{extra});
                 $logger->debug("Gaming devices role is $role (from username $pid)");
             }
 
-            my $unregdate = pf::authentication::match( $source_id, $params, $Actions::SET_UNREG_DATE);
+            my $unregdate = pf::authentication::match( $source_id, $params, $Actions::SET_UNREG_DATE, undef, $self->session->{extra});
             if ( defined $unregdate ) {
                 $logger->debug("Got unregdate $unregdate for username $pid");
                 $info{unregdate} = $unregdate;

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication.pm
@@ -252,7 +252,7 @@ sub create_local_account {
 
     # We create a "password" (also known as a user account) using the pid
     # with different parameters coming from the authentication source (ie.: expiration date)
-    $actions = $actions // pf::authentication::match( $self->source->id, $auth_params );
+    $actions = $actions // pf::authentication::match( $self->source->id, $auth_params, undef, $self->session->{extra} );
 
     my $login_amount = ($self->source->local_account_logins eq $LOCAL_ACCOUNT_UNLIMITED_LOGINS) ? undef : $self->source->local_account_logins;
     $password = pf::password::generate($self->app->session->{username}, $actions, $password, $login_amount);

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/Login.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/Login.pm
@@ -195,7 +195,7 @@ sub authenticate {
         $username = $self->clean_username($username);
 
         # validate login and password
-        my ( $return, $message, $source_id ) =
+        my ( $return, $message, $source_id, $extra ) =
           pf::authentication::authenticate( { 'username' => $username, 'password' => $password, 'rule_class' => $Rules::AUTH }, @sources );
         if (!defined $return || $return == $LOGIN_FAILURE) {
             pf::auth_log::record_auth(join(',',map { $_->id } @sources), $self->current_mac, $username, $pf::auth_log::FAILED);
@@ -204,6 +204,7 @@ sub authenticate {
             return;
 
         }
+        $self->session->{extra} = $extra if defined($extra);
         $self->username($username);
         $self->source(pf::authentication::getAuthenticationSource($source_id));
         if ( $return == $LOGIN_SUCCESS ) {

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/Null.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/Null.pm
@@ -65,7 +65,7 @@ sub authenticate {
         $pid = $self->request_fields->{$self->pid_field};
 
         get_logger->info("Validating e-mail for user $pid");
-        my ($return, $message, $source_id) = pf::authentication::authenticate({username => $pid, password => '', rule_class => $Rules::AUTH}, $self->source);
+        my ($return, $message, $source_id, $extra) = pf::authentication::authenticate({username => $pid, password => '', rule_class => $Rules::AUTH}, $self->source);
         if(defined($return) && $return == 1){
             pf::auth_log::record_auth($source_id, $self->current_mac, $pid, $pf::auth_log::COMPLETED);
         }

--- a/html/pfappserver/lib/pfappserver/Authentication/Credential/Proxy.pm
+++ b/html/pfappserver/lib/pfappserver/Authentication/Credential/Proxy.pm
@@ -49,7 +49,7 @@ sub authenticate {
     my $address = $request->address;
     my $headers = $request->headers;
     #Use the address headers as the username and password refactor this to just pass a hash instead authenticate({},@sources)
-    my ($result, $message, $source_id) = &pf::authentication::authenticate({username => $address, password => $headers, 'rule_class' => $Rules::ADMIN}, @sources);
+    my ($result, $message, $source_id, $extra) = &pf::authentication::authenticate({username => $address, password => $headers, 'rule_class' => $Rules::ADMIN}, @sources);
     unless ($result) {
         $c->log->debug(sub { "Unable to authenticate in realm " . $realm->name . " Error $message" });
         return;
@@ -61,7 +61,7 @@ sub authenticate {
         return;
     }
     my $group = $source->getGroupFromHeader($headers);
-    my $value = &pf::authentication::match($source_id, {username => $username, group_header => $group, 'rule_class' => $Rules::ADMIN}, $Actions::SET_ACCESS_LEVEL);
+    my $value = &pf::authentication::match($source_id, {username => $username, group_header => $group, 'rule_class' => $Rules::ADMIN}, $Actions::SET_ACCESS_LEVEL, undef, $extra);
     # No roles found cannot login
     return unless $value;
     my $roles = [split /\s*,\s*/,$value] if defined $value;

--- a/html/pfappserver/lib/pfappserver/Authentication/Store/PacketFence/User.pm
+++ b/html/pfappserver/lib/pfappserver/Authentication/Store/PacketFence/User.pm
@@ -52,10 +52,10 @@ sub check_password {
     $internal_sources = [$realm_source];
   }
   $self->{_user} = isenabled($realm_source->{'stripped_user_name'}) ? $stripped_username : $self->{_user};
-  my ($result, $message, $source_id) = pf::authentication::authenticate( { 'username' => $self->_user, 'password' => $password, 'rule_class' => $Rules::ADMIN }, @{$internal_sources});
+  my ($result, $message, $source_id, $extra) = pf::authentication::authenticate( { 'username' => $self->_user, 'password' => $password, 'rule_class' => $Rules::ADMIN }, @{$internal_sources});
 
   if ($result) {
-      my $value = pf::authentication::match($source_id, { username => $self->_user, 'rule_class' => $Rules::ADMIN }, $Actions::SET_ACCESS_LEVEL);
+      my $value = pf::authentication::match($source_id, { username => $self->_user, 'rule_class' => $Rules::ADMIN }, $Actions::SET_ACCESS_LEVEL, undef, $extra);
       $self->_roles([split /\s*,\s*/,$value]) if defined $value;
       if ($result == $LOGIN_CHALLENGE ) {
             $self->_challenge($message);

--- a/lib/pf/Authentication/Source.pm
+++ b/lib/pf/Authentication/Source.pm
@@ -158,7 +158,7 @@ Returns the actions of the first matched rule.
 =cut
 
 sub match {
-    my ($self, $params, $action) = @_;
+    my ($self, $params, $action, $extra) = @_;
 
     my $common_attributes = $self->common_attributes();
     my $available_attributes = $self->available_attributes();
@@ -209,7 +209,7 @@ sub match {
 
         # We always check if at least the returned value is defined. That means the username
         # has been found in the source.
-        if (defined $self->match_in_subclass($params, $rule, \@own_conditions, \@matching_conditions)) {
+        if (defined $self->match_in_subclass($params, $rule, \@own_conditions, \@matching_conditions, $extra)) {
           # We compare the matched conditions with how many we had
           if ($rule->match eq $Rules::ANY &&
               scalar @matching_conditions > 0) {

--- a/lib/pf/Authentication/Source/RADIUSSource.pm
+++ b/lib/pf/Authentication/Source/RADIUSSource.pm
@@ -190,7 +190,7 @@ sub match_in_subclass {
                 push(@{ $matching_conditions }, $condition);
             }
         }
-        if defined($extra->{attributes}) {
+        if (defined($extra)) {
             for my $attribute (@{ $extra->{attributes}} ) {
                 if ($condition->{'attribute'} eq $attribute->{'Name'} ) {
                     if ( $condition->matches($condition->{'attribute'}, $attribute->{'Value'}) ) {

--- a/lib/pf/Authentication/Source/RADIUSSource.pm
+++ b/lib/pf/Authentication/Source/RADIUSSource.pm
@@ -190,10 +190,12 @@ sub match_in_subclass {
                 push(@{ $matching_conditions }, $condition);
             }
         }
-        for my $attribute (@{ $extra->{attributes}} ) {
-            if ($condition->{'attribute'} eq $attribute->{'Name'} ) {
-                if ( $condition->matches($condition->{'attribute'}, $attribute->{'Value'}) ) {
-                    push(@{ $matching_conditions }, $condition);
+        if defined($extra->{attributes}) {
+            for my $attribute (@{ $extra->{attributes}} ) {
+                if ($condition->{'attribute'} eq $attribute->{'Name'} ) {
+                    if ( $condition->matches($condition->{'attribute'}, $attribute->{'Value'}) ) {
+                        push(@{ $matching_conditions }, $condition);
+                    }
                 }
             }
         }

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -729,9 +729,9 @@ sub switch_access {
         radius_request => $radius_request,
     };
 
-    my ( $return, $message, $source_id ) = pf::authentication::authenticate( { 'username' =>  $radius_request->{'User-Name'}, 'password' =>  $radius_request->{'User-Password'}, 'rule_class' => $Rules::ADMIN }, @{pf::authentication::getInternalAuthenticationSources()} );
+    my ( $return, $message, $source_id, $extra ) = pf::authentication::authenticate( { 'username' =>  $radius_request->{'User-Name'}, 'password' =>  $radius_request->{'User-Password'}, 'rule_class' => $Rules::ADMIN }, @{pf::authentication::getInternalAuthenticationSources()} );
     if ( defined($return) && $return == $TRUE ) {
-        my $matched = pf::authentication::match2($source_id, { username => $radius_request->{'User-Name'}, 'rule_class' => $Rules::ADMIN });
+        my $matched = pf::authentication::match2($source_id, { username => $radius_request->{'User-Name'}, 'rule_class' => $Rules::ADMIN }, $extra);
         my $value = $matched->{values}{$Actions::SET_ACCESS_LEVEL} if $matched;
         if ($value) {
             my @values = split(',', $value);

--- a/lib/pf/web.pm
+++ b/lib/pf/web.pm
@@ -257,7 +257,7 @@ sub web_user_authenticate {
     }
 
     # validate login and password
-    my ($return, $message, $source_id) = pf::authentication::authenticate( { 'username' => $username, 'password' => $password, 'rule_class' => $Rules::AUTH }, @sources);
+    my ($return, $message, $source_id, $extra) = pf::authentication::authenticate( { 'username' => $username, 'password' => $password, 'rule_class' => $Rules::AUTH }, @sources);
 
     if (defined($return) && $return == 1) {
         # save login into session

--- a/lib/pf/web/wispr.pm
+++ b/lib/pf/web/wispr.pm
@@ -80,7 +80,7 @@ sub handler {
     # Trace the user in the apache log
     $r->user($req->param("username"));
 
-    my ($return, $message, $source_id) = &pf::web::web_user_authenticate($portalSession,$req->param("username"),$req->param("password"));
+    my ($return, $message, $source_id, $extra) = &pf::web::web_user_authenticate($portalSession,$req->param("username"),$req->param("password"));
     if ($return) {
         $logger->info("Authentification success for wispr client");
         $stash = {
@@ -110,7 +110,7 @@ sub handler {
         $params->{connection_type} = $locationlog_entry->{'connection_type'};
         $params->{SSID} = $locationlog_entry->{'ssid'};
     }
-    my $matched = pf::authentication::match2($source_id, $params);
+    my $matched = pf::authentication::match2($source_id, $params, $extra);
     if ($matched) {
         my $values = $matched->{values};
         my $role = $values->{$Actions::SET_ROLE};


### PR DESCRIPTION
# Description
When you do radius authentication (radius source) you can use the radius attributes returned in the answer in order to use it to compute some rules.

# Impacts
Authentication flow

# Delete branch after merge
YES

# NEWS file entries

## Enhancements
* Use the attributes returned by a radius use source as attributes to compute the rules.
 