### PR TITLE
Feature/caddy sdnotify

### DIFF
--- a/conf/systemd/packetfence-httpd.dispatcher.service
+++ b/conf/systemd/packetfence-httpd.dispatcher.service
@@ -5,6 +5,8 @@ After=packetfence-base.target packetfence-config.service packetfence-iptables.se
 Before=packetfence-httpd.portal.service
 
 [Service]
+Type=notify
+LimitNOFILE=8192
 ExecStart=/usr/local/pf/bin/pfhttpd -conf /usr/local/pf/conf/caddy-services/httpdispatcher.conf
 Restart=on-failure
 Slice=packetfence.slice

--- a/conf/systemd/packetfence-pfsso.service
+++ b/conf/systemd/packetfence-pfsso.service
@@ -5,6 +5,8 @@ After=packetfence-base.target packetfence-config.service packetfence-iptables.se
 Before=packetfence-httpd.portal.service
 
 [Service]
+Type=notify
+LimitNOFILE=8192
 ExecStart=/usr/local/pf/bin/pfhttpd -conf /usr/local/pf/conf/caddy-services/pfsso.conf
 Restart=on-failure
 Slice=packetfence.slice

--- a/go/caddy/caddy/caddy.go
+++ b/go/caddy/caddy/caddy.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/coreos/go-systemd/daemon"
 	"github.com/inverse-inc/packetfence/go/caddy/caddy/caddyfile"
 )
 
@@ -140,6 +141,14 @@ func (i *Instance) ShutdownCallbacks() []error {
 // instance to replace i. Upon failure, i will not be replaced.
 func (i *Instance) Restart(newCaddyfile Input) (*Instance, error) {
 	log.Println("[INFO] Reloading")
+	daemon.SdNotify(true, "RELOADING=1")
+	defer func() {
+		// notify systemd that startup is complete
+		_, err := daemon.SdNotify(true, "READY=1")
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "Error sending systemd ready notification %s", err.Error())
+		}
+	}()
 
 	i.wg.Add(1)
 	defer i.wg.Done()
@@ -422,6 +431,13 @@ func (i *Instance) Caddyfile() Input {
 //
 // This function blocks until all the servers are listening.
 func Start(cdyfile Input) (*Instance, error) {
+	defer func() {
+		// notify systemd that startup is complete
+		_, err := daemon.SdNotify(true, "READY=1")
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "Error sending systemd ready notification %s", err.Error())
+		}
+	}()
 	writePidFile()
 	inst := &Instance{serverType: cdyfile.ServerType(), wg: new(sync.WaitGroup)}
 	return inst, startWithListenerFds(cdyfile, inst, nil)

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -9,6 +9,12 @@
 			"revisionTime": "2017-02-13T16:13:28Z"
 		},
 		{
+			"checksumSHA1": "+Zz+leZHHC9C0rx8DoRuffSRPso=",
+			"path": "github.com/coreos/go-systemd/daemon",
+			"revision": "1f9909e51b2dab2487c26d64c8f2e7e580e4c9f5",
+			"revisionTime": "2017-03-24T09:58:19Z"
+		},
+		{
 			"checksumSHA1": "dvabztWVQX8f6oMLRyv4dLH+TGY=",
 			"path": "github.com/davecgh/go-spew/spew",
 			"revision": "346938d642f2ec3594ed81d874461961cd0faa76",
@@ -385,6 +391,30 @@
 			"path": "golang.org/x/net/publicsuffix",
 			"revision": "61557ac0112b576429a0df080e1c2cef5dfbb642",
 			"revisionTime": "2017-01-26T11:54:58Z"
+		},
+		{
+			"checksumSHA1": "faFDXp++cLjLBlvsr+izZ+go1WU=",
+			"path": "golang.org/x/text/secure/bidirule",
+			"revision": "5a42fa2464759cbb7ee0af9de00b54d69f09a29c",
+			"revisionTime": "2016-10-16T16:34:30Z"
+		},
+		{
+			"checksumSHA1": "ziMb9+ANGRJSSIuxYdRbA+cDRBQ=",
+			"path": "golang.org/x/text/transform",
+			"revision": "5a42fa2464759cbb7ee0af9de00b54d69f09a29c",
+			"revisionTime": "2016-10-16T16:34:30Z"
+		},
+		{
+			"checksumSHA1": "VoN1N+QSzZGXJuTX2mVH7fAUXNM=",
+			"path": "golang.org/x/text/unicode/bidi",
+			"revision": "5a42fa2464759cbb7ee0af9de00b54d69f09a29c",
+			"revisionTime": "2016-10-16T16:34:30Z"
+		},
+		{
+			"checksumSHA1": "Aj3JSVO324FCjEAGm4ZwmC79bbo=",
+			"path": "golang.org/x/text/unicode/norm",
+			"revision": "5a42fa2464759cbb7ee0af9de00b54d69f09a29c",
+			"revisionTime": "2016-10-16T16:34:30Z"
 		},
 		{
 			"checksumSHA1": "o5Skl9YjZqmvEEqWie3f3oY0Kow=",


### PR DESCRIPTION
# Description
Adds support for systemd sd_notify READY and RELOAD notifications to caddy.

# Impacts
Affects pfsso and httpd.dispatcher.
These services should now be of Type=notify.

# Delete branch after merge
YES 

# NEWS file entries

## Enhancements
* caddy based services now support systemd notifications.
