### PR TITLE
support for sd_notify in pfdns. 

### DIFF
--- a/addons/packages/packetfence.spec
+++ b/addons/packages/packetfence.spec
@@ -168,6 +168,8 @@ Requires: perl(Net::Pcap) >= 0.16
 Requires: perl(NetPacket) >= 1.2.0
 # pfdns
 Requires: perl(Net::DNS), perl(Net::DNS::Nameserver), perl(Module::Metadata)
+# systemd sd_notify support
+Requires: perl(Systemd::Daemon)
 # RADIUS CoA support
 Requires: perl(Net::Radius::Dictionary), perl(Net::Radius::Packet)
 # SNMP to network hardware

--- a/conf/systemd/packetfence-pfdns.service
+++ b/conf/systemd/packetfence-pfdns.service
@@ -5,6 +5,7 @@ After=packetfence-base.target packetfence-config.service packetfence-iptables.se
 Before=packetfence-httpd.portal.service
 
 [Service]
+Type=notify
 StartLimitBurst=3
 StartLimitInterval=60
 PIDFile=/usr/local/pf/var/run/pfdns.pid

--- a/debian/control
+++ b/debian/control
@@ -30,6 +30,8 @@ Depends: ${misc:Depends}, vlan,
 # freeradius
  freeradius (>= 3.0.15.6), freeradius-ldap, 
  freeradius-mysql, freeradius-utils, freeradius-rest, freeradius-redis,
+# systemd sd_notify support
+ libsystemd-daemon-perl,
 # binary
  make,
  samba,

--- a/sbin/pfdns
+++ b/sbin/pfdns
@@ -26,6 +26,7 @@ use Try::Tiny;
 use Net::DNS::Nameserver;
 use NetAddr::IP;
 use Net::DNS::Resolver;
+use Systemd::Daemon qw{ -soft -notify };
 
 BEGIN {
     # log4perl init
@@ -190,6 +191,7 @@ my $ns = new Net::DNS::Nameserver(
 daemonize($PROGRAM_NAME) if ($daemonize);
 our $PARENT_PID = $$;
 $started_successfully = 1;
+&Systemd::Daemon::notify( READY => 1, STATUS => "Ready", unset => 1 );
 
 sub _run_worker {
     my ($id) = @_;
@@ -204,6 +206,7 @@ END {
         if(!$IS_CHILD && $started_successfully) {
             deletepid("pfdns");
             $logger->info("stopping pfdns");
+            &Systemd::Daemon::notify( STOPPING => 1 );
         }
     }
 }


### PR DESCRIPTION
# Description
Adds support for systemd sd_notify in pfdns and changes the service type to "notify".

# Impacts
systemd should now wait for a "READY" notification before considering the service started.


# NEW Package(s) required
perl-Systemd-Daemon (RHEL)
libsystemd-daemon-perl (Debian)

# Delete branch after merge
YES 

# NEWS file entries


## Enhancements
* pfdns now supports systemd's sd_notify 
