### PR TITLE
Added sd_notify support to most sbin/ daemons.

### DIFF
--- a/conf/systemd/packetfence-config.service
+++ b/conf/systemd/packetfence-config.service
@@ -4,9 +4,9 @@ After=network.target packetfence-redis-cache.service
 Wants=packetfence-redis-cache.service
 
 [Service]
+Type=notify
 StartLimitBurst=3
 StartLimitInterval=60
-Type=simple
 PIDFile=/usr/local/pf/var/run/pfconfig.pid
 ExecStart=/usr/local/pf/sbin/pfconfig 
 User=pf

--- a/conf/systemd/packetfence-mariadb.service
+++ b/conf/systemd/packetfence-mariadb.service
@@ -7,6 +7,11 @@ Wants=packetfence-config.service
 Conflicts=mysql.service mariadb.service
 
 [Service]
+Type=notify
+# Setting this to true can break replication and the Type=notify settings
+# See also bind-address mysqld option.
+PrivateNetwork=false
+
 StartLimitBurst=3
 StartLimitInterval=60
 Type=simple

--- a/conf/systemd/packetfence-pfbandwidthd.service
+++ b/conf/systemd/packetfence-pfbandwidthd.service
@@ -4,6 +4,7 @@ Wants=packetfence-base.target packetfence-config.service packetfence-iptables.se
 After=packetfence-base.target packetfence-config.service packetfence-iptables.service
 
 [Service]
+Type=notify
 StartLimitBurst=3
 StartLimitInterval=60
 PIDFile=/usr/local/pf/var/run/pfbandwidthd.pid

--- a/conf/systemd/packetfence-pfdetect.service
+++ b/conf/systemd/packetfence-pfdetect.service
@@ -4,6 +4,7 @@ Wants=packetfence-base.target packetfence-config.service packetfence-iptables.se
 After=packetfence-base.target packetfence-config.service packetfence-iptables.service
 
 [Service]
+Type=notify
 StartLimitBurst=3
 StartLimitInterval=60
 PIDFile=/usr/local/pf/var/run/pfdetect.pid

--- a/conf/systemd/packetfence-pfdhcplistener.service
+++ b/conf/systemd/packetfence-pfdhcplistener.service
@@ -6,9 +6,9 @@ Wants=packetfence-base.target packetfence-config.service packetfence-iptables.se
 After=packetfence-base.target packetfence-config.service packetfence-iptables.service packetfence-pfqueue.service
 
 [Service]
+Type=notify
 StartLimitBurst=3
 StartLimitInterval=60
-Type=simple
 PIDFile=/usr/local/pf/var/run/pfdhcplistener
 ExecStart=/usr/local/pf/sbin/pfdhcplistener
 Restart=on-failure

--- a/conf/systemd/packetfence-pffilter.service
+++ b/conf/systemd/packetfence-pffilter.service
@@ -4,6 +4,7 @@ Wants=packetfence-base.target packetfence-config.service packetfence-iptables.se
 After=packetfence-base.target packetfence-config.service packetfence-iptables.service packetfence-redis_queue.service
 
 [Service]
+Type=notify
 StartLimitBurst=3
 StartLimitInterval=60
 PIDFile=/usr/local/pf/var/run/pffilter.pid

--- a/conf/systemd/packetfence-pfmon.service
+++ b/conf/systemd/packetfence-pfmon.service
@@ -4,6 +4,7 @@ Wants=packetfence-base.target packetfence-config.service packetfence-iptables.se
 After=packetfence-base.target packetfence-config.service packetfence-iptables.service
 
 [Service]
+Type=notify
 StartLimitBurst=3
 StartLimitInterval=60
 PIDFile=/usr/local/pf/var/run/pfmon.pid

--- a/conf/systemd/packetfence-pfqueue.service
+++ b/conf/systemd/packetfence-pfqueue.service
@@ -6,6 +6,7 @@ Wants=packetfence-base.target packetfence-config.service packetfence-iptables.se
 After=packetfence-base.target packetfence-config.service packetfence-iptables.service
 
 [Service]
+Type=notify
 StartLimitBurst=3
 StartLimitInterval=60
 PIDFile=/usr/local/pf/var/run/pfqueue.pid

--- a/conf/systemd/packetfence-pfsetvlan.service
+++ b/conf/systemd/packetfence-pfsetvlan.service
@@ -6,6 +6,7 @@ Wants=packetfence-snmptrapd.service
 Wants=packetfence-base.target packetfence-config.service packetfence-iptables.service
 
 [Service]
+Type=notify
 StartLimitBurst=3
 StartLimitInterval=60
 PIDFile=/usr/local/pf/var/run/pfsetvlan.pid

--- a/conf/systemd/packetfence-winbindd.service
+++ b/conf/systemd/packetfence-winbindd.service
@@ -5,6 +5,7 @@ After=packetfence-base.target packetfence-config.service packetfence-iptables.se
 Before=packetfence-radiusd-auth.service
 
 [Service]
+Type=notify
 StartLimitBurst=3
 StartLimitInterval=60
 ExecStartPre=/usr/local/pf/bin/pfcmd service winbindd generateconfig

--- a/sbin/pfbandwidthd
+++ b/sbin/pfbandwidthd
@@ -25,7 +25,7 @@ use NetPacket::Ethernet;
 use NetPacket::IP;
 use IO::Select;
 use Socket;
-use Systemd::Daemon qw{ -soft -notify };
+use Systemd::Daemon qw{ -soft };
 
 BEGIN {
     # log4perl init

--- a/sbin/pfbandwidthd
+++ b/sbin/pfbandwidthd
@@ -25,7 +25,7 @@ use NetPacket::Ethernet;
 use NetPacket::IP;
 use IO::Select;
 use Socket;
-use Systemd::Daemon();
+use Systemd::Daemon qw{ -soft -notify };
 
 BEGIN {
     # log4perl init

--- a/sbin/pfbandwidthd
+++ b/sbin/pfbandwidthd
@@ -155,7 +155,7 @@ foreach my $pcap (@devs) {
 
 # Change user to pf
 dropprivs("pf", "pf");
-&Systemd::Daemon::notify( READY => 1, STATUS => "Ready", unset => 1 );
+Systemd::Daemon::notify( READY => 1, STATUS => "Ready", unset => 1 );
 
 while ($RUNNING) {
     my @select_set = $read_set->can_read;
@@ -285,7 +285,7 @@ sub dropprivs {
 
 sub normal_sighandler {
     $RUNNING = 0;
-    &Systemd::Daemon::notify( STOPPING => 1 );
+    Systemd::Daemon::notify( STOPPING => 1 );
     deletepid("pfbandwidthd");
     if ( threads->self->tid() == 0 ) {
         $logger->logdie(

--- a/sbin/pfbandwidthd
+++ b/sbin/pfbandwidthd
@@ -285,11 +285,11 @@ sub dropprivs {
 
 sub normal_sighandler {
     $RUNNING = 0;
+    &Systemd::Daemon::notify( STOPPING => 1 );
     deletepid("pfbandwidthd");
     if ( threads->self->tid() == 0 ) {
         $logger->logdie(
             "pfbandwidthd: caught SIG" . $_[0] . " - terminating" );
-            &Systemd::Daemon::notify( STOPPING => 1 );
     }
 }
 

--- a/sbin/pfbandwidthd
+++ b/sbin/pfbandwidthd
@@ -25,7 +25,7 @@ use NetPacket::Ethernet;
 use NetPacket::IP;
 use IO::Select;
 use Socket;
-use Systemd::Daemon qw{ -soft -notify };
+use Systemd::Daemon();
 
 BEGIN {
     # log4perl init

--- a/sbin/pfbandwidthd
+++ b/sbin/pfbandwidthd
@@ -25,6 +25,7 @@ use NetPacket::Ethernet;
 use NetPacket::IP;
 use IO::Select;
 use Socket;
+use Systemd::Daemon qw{ -soft -notify };
 
 BEGIN {
     # log4perl init
@@ -154,6 +155,7 @@ foreach my $pcap (@devs) {
 
 # Change user to pf
 dropprivs("pf", "pf");
+&Systemd::Daemon::notify( READY => 1, STATUS => "Ready", unset => 1 );
 
 while ($RUNNING) {
     my @select_set = $read_set->can_read;
@@ -287,6 +289,7 @@ sub normal_sighandler {
     if ( threads->self->tid() == 0 ) {
         $logger->logdie(
             "pfbandwidthd: caught SIG" . $_[0] . " - terminating" );
+            &Systemd::Daemon::notify( STOPPING => 1 );
     }
 }
 

--- a/sbin/pfconfig
+++ b/sbin/pfconfig
@@ -49,7 +49,7 @@ use pf::Sereal qw($ENCODER);
 use Errno qw(EINTR EAGAIN);
 use bytes;
 use pf::util::networking qw(send_data_with_length);
-use Systemd::Daemon qw{ -soft -notify };
+use Systemd::Daemon qw{ -soft };
 our $RUNNING = 1;
 
 ## All pfconfig objects implementing TO_JSON must be imported here
@@ -138,7 +138,7 @@ our %DISPATCH = (
     'sleep'              => \&server_sleep,
 );
 
-&Systemd::Daemon::notify( READY => 1, STATUS => "Ready", unset => 1 );
+#&Systemd::Daemon::notify( READY => 1, STATUS => "Ready", unset => 1 );
 # Used to set the current prefered encoding
 my $encoding;
 
@@ -188,7 +188,7 @@ $logger->info("Stop running\n");
 
 END {
     if (!$args{h} && $FILE_LOCK ) {
-        &Systemd::Daemon::notify( STOPPING => 1 );
+        Systemd::Daemon::notify( STOPPING => 1 );
         deletepid($PROGRAM_NAME, $PID_FILE);
     }
 }

--- a/sbin/pfconfig
+++ b/sbin/pfconfig
@@ -138,7 +138,7 @@ our %DISPATCH = (
     'sleep'              => \&server_sleep,
 );
 
-#&Systemd::Daemon::notify( READY => 1, STATUS => "Ready", unset => 1 );
+#Systemd::Daemon::notify( READY => 1, STATUS => "Ready", unset => 1 );
 # Used to set the current prefered encoding
 my $encoding;
 

--- a/sbin/pfconfig
+++ b/sbin/pfconfig
@@ -138,7 +138,7 @@ our %DISPATCH = (
     'sleep'              => \&server_sleep,
 );
 
-#Systemd::Daemon::notify( READY => 1, STATUS => "Ready", unset => 1 );
+Systemd::Daemon::notify( READY => 1, STATUS => "Ready", unset => 1 );
 # Used to set the current prefered encoding
 my $encoding;
 

--- a/sbin/pfconfig
+++ b/sbin/pfconfig
@@ -187,8 +187,8 @@ while($RUNNING) {
 $logger->info("Stop running\n");
 
 END {
-    &Systemd::Daemon::notify( STOPPING => 1 );
     if (!$args{h} && $FILE_LOCK ) {
+        &Systemd::Daemon::notify( STOPPING => 1 );
         deletepid($PROGRAM_NAME, $PID_FILE);
     }
 }

--- a/sbin/pfconfig
+++ b/sbin/pfconfig
@@ -49,7 +49,7 @@ use pf::Sereal qw($ENCODER);
 use Errno qw(EINTR EAGAIN);
 use bytes;
 use pf::util::networking qw(send_data_with_length);
-use Systemd::Daemon();
+use Systemd::Daemon qw{ -soft -notify };
 our $RUNNING = 1;
 
 ## All pfconfig objects implementing TO_JSON must be imported here

--- a/sbin/pfconfig
+++ b/sbin/pfconfig
@@ -49,7 +49,7 @@ use pf::Sereal qw($ENCODER);
 use Errno qw(EINTR EAGAIN);
 use bytes;
 use pf::util::networking qw(send_data_with_length);
-use Systemd::Daemon qw{ -soft -notify };
+use Systemd::Daemon();
 our $RUNNING = 1;
 
 ## All pfconfig objects implementing TO_JSON must be imported here

--- a/sbin/pfconfig
+++ b/sbin/pfconfig
@@ -49,6 +49,7 @@ use pf::Sereal qw($ENCODER);
 use Errno qw(EINTR EAGAIN);
 use bytes;
 use pf::util::networking qw(send_data_with_length);
+use Systemd::Daemon qw{ -soft -notify };
 our $RUNNING = 1;
 
 ## All pfconfig objects implementing TO_JSON must be imported here
@@ -137,6 +138,7 @@ our %DISPATCH = (
     'sleep'              => \&server_sleep,
 );
 
+&Systemd::Daemon::notify( READY => 1, STATUS => "Ready", unset => 1 );
 # Used to set the current prefered encoding
 my $encoding;
 
@@ -185,6 +187,7 @@ while($RUNNING) {
 $logger->info("Stop running\n");
 
 END {
+    &Systemd::Daemon::notify( STOPPING => 1 );
     if (!$args{h} && $FILE_LOCK ) {
         deletepid($PROGRAM_NAME, $PID_FILE);
     }

--- a/sbin/pfdetect
+++ b/sbin/pfdetect
@@ -45,7 +45,7 @@ use pf::factory::detect::parser;
 use pf::client;
 use pfconfig::cached_hash;
 use pf::CHI::Request;
-use Systemd::Daemon();
+use Systemd::Daemon qw{ -soft -notify };
 
 # initialization
 # --------------

--- a/sbin/pfdetect
+++ b/sbin/pfdetect
@@ -98,7 +98,7 @@ my $IS_CHILD = 0;
 my $running = 1;
 
 sub start_detectors {
-    &Systemd::Daemon::notify( READY => 1, STATUS => "Ready", unset => 1 );
+    Systemd::Daemon::notify( READY => 1, STATUS => "Ready", unset => 1 );
     foreach my $id (keys %ConfigDetect) {
         next unless isenabled($ConfigDetect{$id}{status});
         run_detector($id);
@@ -203,7 +203,7 @@ while($running){
 
 
 END {
-    &Systemd::Daemon::notify( STOPPING => 1 );
+    Systemd::Daemon::notify( STOPPING => 1 );
     deletepid();
 }
 

--- a/sbin/pfdetect
+++ b/sbin/pfdetect
@@ -45,7 +45,7 @@ use pf::factory::detect::parser;
 use pf::client;
 use pfconfig::cached_hash;
 use pf::CHI::Request;
-use Systemd::Daemon qw{ -soft -notify };
+use Systemd::Daemon();
 
 # initialization
 # --------------

--- a/sbin/pfdetect
+++ b/sbin/pfdetect
@@ -45,6 +45,7 @@ use pf::factory::detect::parser;
 use pf::client;
 use pfconfig::cached_hash;
 use pf::CHI::Request;
+use Systemd::Daemon qw{ -soft -notify };
 
 # initialization
 # --------------
@@ -97,6 +98,7 @@ my $IS_CHILD = 0;
 my $running = 1;
 
 sub start_detectors {
+    &Systemd::Daemon::notify( READY => 1, STATUS => "Ready", unset => 1 );
     foreach my $id (keys %ConfigDetect) {
         next unless isenabled($ConfigDetect{$id}{status});
         run_detector($id);
@@ -201,6 +203,7 @@ while($running){
 
 
 END {
+    &Systemd::Daemon::notify( STOPPING => 1 );
     deletepid();
 }
 

--- a/sbin/pfdetect
+++ b/sbin/pfdetect
@@ -45,7 +45,7 @@ use pf::factory::detect::parser;
 use pf::client;
 use pfconfig::cached_hash;
 use pf::CHI::Request;
-use Systemd::Daemon qw{ -soft -notify };
+use Systemd::Daemon qw{ -soft };
 
 # initialization
 # --------------

--- a/sbin/pfdhcplistener
+++ b/sbin/pfdhcplistener
@@ -142,9 +142,9 @@ if ( isenabled( $Config{'network'}{'dhcpdetector'} ) ) {
 }
 
 END {
-    &Systemd::Daemon::notify( STOPPING => 1 );
     if (!$args{h} && $HAS_LOCK) {
         unless ($IS_CHILD) {
+            &Systemd::Daemon::notify( STOPPING => 1 );
             deletepid();
             $logger->info("stopping pfdhcplistener");
         }

--- a/sbin/pfdhcplistener
+++ b/sbin/pfdhcplistener
@@ -22,7 +22,7 @@ use Net::Pcap 0.16;
 use Pod::Usage;
 use POSIX qw(:signal_h pause :sys_wait_h SIG_BLOCK SIG_UNBLOCK);
 use Fcntl qw(:flock);
-use Systemd::Daemon();
+use Systemd::Daemon qw{ -soft -notify };
 
 BEGIN {
     # log4perl init

--- a/sbin/pfdhcplistener
+++ b/sbin/pfdhcplistener
@@ -22,7 +22,7 @@ use Net::Pcap 0.16;
 use Pod::Usage;
 use POSIX qw(:signal_h pause :sys_wait_h SIG_BLOCK SIG_UNBLOCK);
 use Fcntl qw(:flock);
-use Systemd::Daemon qw{ -soft -notify };
+use Systemd::Daemon qw{ -soft };
 
 BEGIN {
     # log4perl init

--- a/sbin/pfdhcplistener
+++ b/sbin/pfdhcplistener
@@ -22,7 +22,7 @@ use Net::Pcap 0.16;
 use Pod::Usage;
 use POSIX qw(:signal_h pause :sys_wait_h SIG_BLOCK SIG_UNBLOCK);
 use Fcntl qw(:flock);
-use Systemd::Daemon qw{ -soft -notify };
+use Systemd::Daemon();
 
 BEGIN {
     # log4perl init

--- a/sbin/pfdhcplistener
+++ b/sbin/pfdhcplistener
@@ -22,6 +22,7 @@ use Net::Pcap 0.16;
 use Pod::Usage;
 use POSIX qw(:signal_h pause :sys_wait_h SIG_BLOCK SIG_UNBLOCK);
 use Fcntl qw(:flock);
+use Systemd::Daemon qw{ -soft -notify };
 
 BEGIN {
     # log4perl init
@@ -135,11 +136,13 @@ my $net_addr;
 
 # start dhcp monitor
 if ( isenabled( $Config{'network'}{'dhcpdetector'} ) ) {
+    &Systemd::Daemon::notify( READY => 1, STATUS => "Ready", unset => 1 );
     start();
     cleanup();
 }
 
 END {
+    &Systemd::Daemon::notify( STOPPING => 1 );
     if (!$args{h} && $HAS_LOCK) {
         unless ($IS_CHILD) {
             deletepid();

--- a/sbin/pfdhcplistener
+++ b/sbin/pfdhcplistener
@@ -136,7 +136,7 @@ my $net_addr;
 
 # start dhcp monitor
 if ( isenabled( $Config{'network'}{'dhcpdetector'} ) ) {
-    &Systemd::Daemon::notify( READY => 1, STATUS => "Ready", unset => 1 );
+    Systemd::Daemon::notify( READY => 1, STATUS => "Ready", unset => 1 );
     start();
     cleanup();
 }
@@ -144,7 +144,7 @@ if ( isenabled( $Config{'network'}{'dhcpdetector'} ) ) {
 END {
     if (!$args{h} && $HAS_LOCK) {
         unless ($IS_CHILD) {
-            &Systemd::Daemon::notify( STOPPING => 1 );
+            Systemd::Daemon::notify( STOPPING => 1 );
             deletepid();
             $logger->info("stopping pfdhcplistener");
         }

--- a/sbin/pfdns
+++ b/sbin/pfdns
@@ -191,7 +191,7 @@ my $ns = new Net::DNS::Nameserver(
 daemonize($PROGRAM_NAME) if ($daemonize);
 our $PARENT_PID = $$;
 $started_successfully = 1;
-&Systemd::Daemon::notify( READY => 1, STATUS => "Ready", unset => 1 );
+Systemd::Daemon::notify( READY => 1, STATUS => "Ready", unset => 1 );
 
 sub _run_worker {
     my ($id) = @_;
@@ -204,7 +204,7 @@ sub _run_worker {
 END {
     if ( !$args{h} ) {
         if(!$IS_CHILD && $started_successfully) {
-            &Systemd::Daemon::notify( STOPPING => 1 );
+            Systemd::Daemon::notify( STOPPING => 1 );
             deletepid("pfdns");
             $logger->info("stopping pfdns");
         }

--- a/sbin/pfdns
+++ b/sbin/pfdns
@@ -26,7 +26,7 @@ use Try::Tiny;
 use Net::DNS::Nameserver;
 use NetAddr::IP;
 use Net::DNS::Resolver;
-use Systemd::Daemon qw{ -soft -notify };
+use Systemd::Daemon qw{ -soft };
 
 BEGIN {
     # log4perl init

--- a/sbin/pfdns
+++ b/sbin/pfdns
@@ -204,9 +204,9 @@ sub _run_worker {
 END {
     if ( !$args{h} ) {
         if(!$IS_CHILD && $started_successfully) {
+            &Systemd::Daemon::notify( STOPPING => 1 );
             deletepid("pfdns");
             $logger->info("stopping pfdns");
-            &Systemd::Daemon::notify( STOPPING => 1 );
         }
     }
 }

--- a/sbin/pfdns
+++ b/sbin/pfdns
@@ -26,7 +26,7 @@ use Try::Tiny;
 use Net::DNS::Nameserver;
 use NetAddr::IP;
 use Net::DNS::Resolver;
-use Systemd::Daemon qw{ -soft -notify };
+use Systemd::Daemon();
 
 BEGIN {
     # log4perl init

--- a/sbin/pfdns
+++ b/sbin/pfdns
@@ -26,7 +26,7 @@ use Try::Tiny;
 use Net::DNS::Nameserver;
 use NetAddr::IP;
 use Net::DNS::Resolver;
-use Systemd::Daemon();
+use Systemd::Daemon qw{ -soft -notify };
 
 BEGIN {
     # log4perl init

--- a/sbin/pffilter
+++ b/sbin/pffilter
@@ -125,9 +125,9 @@ start();
 cleanup();
 
 END {
-    &Systemd::Daemon::notify( STOPPING => 1 );
     if (!$args{h} && $HAS_LOCK) {
         unless ($IS_CHILD) {
+            &Systemd::Daemon::notify( STOPPING => 1 );
             deletepid();
             $logger->info("stopping pffilter");
         }

--- a/sbin/pffilter
+++ b/sbin/pffilter
@@ -23,6 +23,7 @@ use File::Basename qw(basename);
 use POSIX qw(:signal_h pause :sys_wait_h SIG_BLOCK SIG_UNBLOCK);
 use Pod::Usage;
 use Fcntl qw(:flock);
+use Systemd::Daemon qw{ -soft -notify };
 
 #pf::log must always be initilized first
 BEGIN {
@@ -124,6 +125,7 @@ start();
 cleanup();
 
 END {
+    &Systemd::Daemon::notify( STOPPING => 1 );
     if (!$args{h} && $HAS_LOCK) {
         unless ($IS_CHILD) {
             deletepid();
@@ -144,6 +146,7 @@ start
 
 sub start {
     registertasks();
+    &Systemd::Daemon::notify( READY => 1, STATUS => "Ready", unset => 1 );
     runtasks();
     waitforit();
 }

--- a/sbin/pffilter
+++ b/sbin/pffilter
@@ -23,7 +23,7 @@ use File::Basename qw(basename);
 use POSIX qw(:signal_h pause :sys_wait_h SIG_BLOCK SIG_UNBLOCK);
 use Pod::Usage;
 use Fcntl qw(:flock);
-use Systemd::Daemon qw{ -soft -notify };
+use Systemd::Daemon();
 
 #pf::log must always be initilized first
 BEGIN {

--- a/sbin/pffilter
+++ b/sbin/pffilter
@@ -23,7 +23,7 @@ use File::Basename qw(basename);
 use POSIX qw(:signal_h pause :sys_wait_h SIG_BLOCK SIG_UNBLOCK);
 use Pod::Usage;
 use Fcntl qw(:flock);
-use Systemd::Daemon qw{ -soft -notify };
+use Systemd::Daemon qw{ -soft };
 
 #pf::log must always be initilized first
 BEGIN {

--- a/sbin/pffilter
+++ b/sbin/pffilter
@@ -23,7 +23,7 @@ use File::Basename qw(basename);
 use POSIX qw(:signal_h pause :sys_wait_h SIG_BLOCK SIG_UNBLOCK);
 use Pod::Usage;
 use Fcntl qw(:flock);
-use Systemd::Daemon();
+use Systemd::Daemon qw{ -soft -notify };
 
 #pf::log must always be initilized first
 BEGIN {

--- a/sbin/pffilter
+++ b/sbin/pffilter
@@ -127,7 +127,7 @@ cleanup();
 END {
     if (!$args{h} && $HAS_LOCK) {
         unless ($IS_CHILD) {
-            &Systemd::Daemon::notify( STOPPING => 1 );
+            Systemd::Daemon::notify( STOPPING => 1 );
             deletepid();
             $logger->info("stopping pffilter");
         }
@@ -146,7 +146,7 @@ start
 
 sub start {
     registertasks();
-    &Systemd::Daemon::notify( READY => 1, STATUS => "Ready", unset => 1 );
+    Systemd::Daemon::notify( READY => 1, STATUS => "Ready", unset => 1 );
     runtasks();
     waitforit();
 }

--- a/sbin/pfmon
+++ b/sbin/pfmon
@@ -158,9 +158,9 @@ start();
 cleanup();
 
 END {
-    &Systemd::Daemon::notify( STOPPING => 1 );
     if ( !$args{h} && $HAS_LOCK ) {
         unless($IS_CHILD) {
+            &Systemd::Daemon::notify( STOPPING => 1 );
             deletepid();
             $logger->info("stopping pfmon");
         }

--- a/sbin/pfmon
+++ b/sbin/pfmon
@@ -23,7 +23,7 @@ use File::Basename qw(basename);
 use POSIX qw(:signal_h pause :sys_wait_h SIG_BLOCK SIG_UNBLOCK);
 use Pod::Usage;
 use Fcntl qw(:flock);
-use Systemd::Daemon qw{ -soft -notify };
+use Systemd::Daemon();
 
 #pf::log must always be initilized first
 BEGIN {

--- a/sbin/pfmon
+++ b/sbin/pfmon
@@ -23,7 +23,7 @@ use File::Basename qw(basename);
 use POSIX qw(:signal_h pause :sys_wait_h SIG_BLOCK SIG_UNBLOCK);
 use Pod::Usage;
 use Fcntl qw(:flock);
-use Systemd::Daemon qw{ -soft -notify };
+use Systemd::Daemon qw{ -soft };
 
 #pf::log must always be initilized first
 BEGIN {

--- a/sbin/pfmon
+++ b/sbin/pfmon
@@ -23,7 +23,7 @@ use File::Basename qw(basename);
 use POSIX qw(:signal_h pause :sys_wait_h SIG_BLOCK SIG_UNBLOCK);
 use Pod::Usage;
 use Fcntl qw(:flock);
-use Systemd::Daemon();
+use Systemd::Daemon qw{ -soft -notify };
 
 #pf::log must always be initilized first
 BEGIN {

--- a/sbin/pfmon
+++ b/sbin/pfmon
@@ -149,7 +149,7 @@ our $PARENT_PID = $$;
 sub start {
     reload_config();
     registertasks();
-    &Systemd::Daemon::notify( READY => 1, STATUS => "Ready", unset => 1 );
+    Systemd::Daemon::notify( READY => 1, STATUS => "Ready", unset => 1 );
     runtasks();
     waitforit();
 }
@@ -160,7 +160,7 @@ cleanup();
 END {
     if ( !$args{h} && $HAS_LOCK ) {
         unless($IS_CHILD) {
-            &Systemd::Daemon::notify( STOPPING => 1 );
+            Systemd::Daemon::notify( STOPPING => 1 );
             deletepid();
             $logger->info("stopping pfmon");
         }

--- a/sbin/pfmon
+++ b/sbin/pfmon
@@ -23,6 +23,7 @@ use File::Basename qw(basename);
 use POSIX qw(:signal_h pause :sys_wait_h SIG_BLOCK SIG_UNBLOCK);
 use Pod::Usage;
 use Fcntl qw(:flock);
+use Systemd::Daemon qw{ -soft -notify };
 
 #pf::log must always be initilized first
 BEGIN {
@@ -148,6 +149,7 @@ our $PARENT_PID = $$;
 sub start {
     reload_config();
     registertasks();
+    &Systemd::Daemon::notify( READY => 1, STATUS => "Ready", unset => 1 );
     runtasks();
     waitforit();
 }
@@ -156,6 +158,7 @@ start();
 cleanup();
 
 END {
+    &Systemd::Daemon::notify( STOPPING => 1 );
     if ( !$args{h} && $HAS_LOCK ) {
         unless($IS_CHILD) {
             deletepid();

--- a/sbin/pfqueue
+++ b/sbin/pfqueue
@@ -108,8 +108,8 @@ wait_for_it();
 cleanup();
 
 END {
-    &Systemd::Daemon::notify( STOPPING => 1 );
     if (!$args{h} && $HAS_LOCK && !$IS_CHILD) {
+        &Systemd::Daemon::notify( STOPPING => 1 );
         deletepid();
         $logger->info("stopping pfqueue");
     }

--- a/sbin/pfqueue
+++ b/sbin/pfqueue
@@ -24,7 +24,7 @@ use Pod::Usage;
 use Fcntl qw(:flock);
 use Scalar::Util qw(blessed);
 use Time::HiRes qw(usleep);
-use Systemd::Daemon qw{ -soft -notify };
+use Systemd::Daemon qw{ -soft };
 
 #pf::log must always be initilized first
 BEGIN {

--- a/sbin/pfqueue
+++ b/sbin/pfqueue
@@ -24,7 +24,7 @@ use Pod::Usage;
 use Fcntl qw(:flock);
 use Scalar::Util qw(blessed);
 use Time::HiRes qw(usleep);
-use Systemd::Daemon();
+use Systemd::Daemon qw{ -soft -notify };
 
 #pf::log must always be initilized first
 BEGIN {

--- a/sbin/pfqueue
+++ b/sbin/pfqueue
@@ -24,7 +24,7 @@ use Pod::Usage;
 use Fcntl qw(:flock);
 use Scalar::Util qw(blessed);
 use Time::HiRes qw(usleep);
-use Systemd::Daemon qw{ -soft -notify };
+use Systemd::Daemon();
 
 #pf::log must always be initilized first
 BEGIN {

--- a/sbin/pfqueue
+++ b/sbin/pfqueue
@@ -24,6 +24,7 @@ use Pod::Usage;
 use Fcntl qw(:flock);
 use Scalar::Util qw(blessed);
 use Time::HiRes qw(usleep);
+use Systemd::Daemon qw{ -soft -notify };
 
 #pf::log must always be initilized first
 BEGIN {
@@ -102,10 +103,12 @@ Log::Log4perl::MDC->put( 'tid', $$ );
 pf::SwitchFactory->preloadConfiguredModules();
 
 register_tasks();
+&Systemd::Daemon::notify( READY => 1, STATUS => "Ready", unset => 1 );
 wait_for_it();
 cleanup();
 
 END {
+    &Systemd::Daemon::notify( STOPPING => 1 );
     if (!$args{h} && $HAS_LOCK && !$IS_CHILD) {
         deletepid();
         $logger->info("stopping pfqueue");

--- a/sbin/pfqueue
+++ b/sbin/pfqueue
@@ -103,13 +103,13 @@ Log::Log4perl::MDC->put( 'tid', $$ );
 pf::SwitchFactory->preloadConfiguredModules();
 
 register_tasks();
-&Systemd::Daemon::notify( READY => 1, STATUS => "Ready", unset => 1 );
+Systemd::Daemon::notify( READY => 1, STATUS => "Ready", unset => 1 );
 wait_for_it();
 cleanup();
 
 END {
     if (!$args{h} && $HAS_LOCK && !$IS_CHILD) {
-        &Systemd::Daemon::notify( STOPPING => 1 );
+        Systemd::Daemon::notify( STOPPING => 1 );
         deletepid();
         $logger->info("stopping pfqueue");
     }

--- a/sbin/pfsetvlan
+++ b/sbin/pfsetvlan
@@ -45,7 +45,7 @@ use Getopt::Long;
 use Net::SMTP;
 use Pod::Usage;
 use POSIX;
-
+use Systemd::Daemon qw{ -soft -notify };
 
 use constant {
     PFCMD_FILE => INSTALL_DIR . "/bin/pfcmd"
@@ -217,6 +217,8 @@ sub add_new_threads_to_list {
 # }}}1
 
 # main program - read trap lines and addTrapLineToQueue($trapLine) {{{1
+
+&Systemd::Daemon::notify( READY => 1, STATUS => "Ready", unset => 1 );
 my $currentTrapLine = undef;
 my $completeTrapLine;
 my $inMultiLineTrap = 0;
@@ -2109,6 +2111,7 @@ sub add_to_switch_locker {
 }
 
 END {
+    &Systemd::Daemon::notify( STOPPING => 1 );
     if ( ( !$man ) && ( !$help ) ) {
         $logger->info("stopping pfsetvlan");
         deletepid();

--- a/sbin/pfsetvlan
+++ b/sbin/pfsetvlan
@@ -45,7 +45,7 @@ use Getopt::Long;
 use Net::SMTP;
 use Pod::Usage;
 use POSIX;
-use Systemd::Daemon qw{ -soft -notify };
+use Systemd::Daemon();
 
 use constant {
     PFCMD_FILE => INSTALL_DIR . "/bin/pfcmd"

--- a/sbin/pfsetvlan
+++ b/sbin/pfsetvlan
@@ -218,7 +218,7 @@ sub add_new_threads_to_list {
 
 # main program - read trap lines and addTrapLineToQueue($trapLine) {{{1
 
-&Systemd::Daemon::notify( READY => 1, STATUS => "Ready", unset => 1 );
+Systemd::Daemon::notify( READY => 1, STATUS => "Ready", unset => 1 );
 my $currentTrapLine = undef;
 my $completeTrapLine;
 my $inMultiLineTrap = 0;
@@ -2113,7 +2113,7 @@ sub add_to_switch_locker {
 END {
     if ( ( !$man ) && ( !$help ) ) {
         $logger->info("stopping pfsetvlan");
-        &Systemd::Daemon::notify( STOPPING => 1 );
+        Systemd::Daemon::notify( STOPPING => 1 );
         deletepid();
         foreach my $t (@completeThreadList) {
             $t->detach;

--- a/sbin/pfsetvlan
+++ b/sbin/pfsetvlan
@@ -45,7 +45,7 @@ use Getopt::Long;
 use Net::SMTP;
 use Pod::Usage;
 use POSIX;
-use Systemd::Daemon();
+use Systemd::Daemon qw{ -soft -notify };
 
 use constant {
     PFCMD_FILE => INSTALL_DIR . "/bin/pfcmd"

--- a/sbin/pfsetvlan
+++ b/sbin/pfsetvlan
@@ -2111,9 +2111,9 @@ sub add_to_switch_locker {
 }
 
 END {
-    &Systemd::Daemon::notify( STOPPING => 1 );
     if ( ( !$man ) && ( !$help ) ) {
         $logger->info("stopping pfsetvlan");
+        &Systemd::Daemon::notify( STOPPING => 1 );
         deletepid();
         foreach my $t (@completeThreadList) {
             $t->detach;

--- a/sbin/pfsetvlan
+++ b/sbin/pfsetvlan
@@ -45,7 +45,7 @@ use Getopt::Long;
 use Net::SMTP;
 use Pod::Usage;
 use POSIX;
-use Systemd::Daemon qw{ -soft -notify };
+use Systemd::Daemon qw{ -soft };
 
 use constant {
     PFCMD_FILE => INSTALL_DIR . "/bin/pfcmd"

--- a/sbin/winbindd-wrapper
+++ b/sbin/winbindd-wrapper
@@ -118,7 +118,7 @@ our $PARENT_PID = $$;
 
 sub start {
     run_all_winbindd();
-    &Systemd::Daemon::notify( READY => 1, STATUS => "Ready", unset => 1 );
+    Systemd::Daemon::notify( READY => 1, STATUS => "Ready", unset => 1 );
     while($running) {
         pause;
     }
@@ -131,7 +131,7 @@ cleanup();
 END {
     if ( !$args{h} && $HAS_LOCK ) {
         unless($IS_CHILD) {
-            &Systemd::Daemon::notify( STOPPING => 1 );
+            Systemd::Daemon::notify( STOPPING => 1 );
             deletepid();
             $logger->info("stopping winbindd-wrapper");
         }

--- a/sbin/winbindd-wrapper
+++ b/sbin/winbindd-wrapper
@@ -23,6 +23,7 @@ use File::Basename qw(basename);
 use POSIX qw(:signal_h pause :sys_wait_h SIG_BLOCK SIG_UNBLOCK);
 use Pod::Usage;
 use Fcntl qw(:flock);
+use Systemd::Daemon qw{ -soft -notify };
 
 #pf::log must always be initilized first
 BEGIN {
@@ -117,6 +118,7 @@ our $PARENT_PID = $$;
 
 sub start {
     run_all_winbindd();
+    &Systemd::Daemon::notify( READY => 1, STATUS => "Ready", unset => 1 );
     while($running) {
         pause;
     }
@@ -127,6 +129,7 @@ start();
 cleanup();
 
 END {
+    &Systemd::Daemon::notify( STOPPING => 1 );
     if ( !$args{h} && $HAS_LOCK ) {
         unless($IS_CHILD) {
             deletepid();

--- a/sbin/winbindd-wrapper
+++ b/sbin/winbindd-wrapper
@@ -129,9 +129,9 @@ start();
 cleanup();
 
 END {
-    &Systemd::Daemon::notify( STOPPING => 1 );
     if ( !$args{h} && $HAS_LOCK ) {
         unless($IS_CHILD) {
+            &Systemd::Daemon::notify( STOPPING => 1 );
             deletepid();
             $logger->info("stopping winbindd-wrapper");
         }

--- a/sbin/winbindd-wrapper
+++ b/sbin/winbindd-wrapper
@@ -23,7 +23,7 @@ use File::Basename qw(basename);
 use POSIX qw(:signal_h pause :sys_wait_h SIG_BLOCK SIG_UNBLOCK);
 use Pod::Usage;
 use Fcntl qw(:flock);
-use Systemd::Daemon qw{ -soft -notify };
+use Systemd::Daemon();
 
 #pf::log must always be initilized first
 BEGIN {

--- a/sbin/winbindd-wrapper
+++ b/sbin/winbindd-wrapper
@@ -23,7 +23,7 @@ use File::Basename qw(basename);
 use POSIX qw(:signal_h pause :sys_wait_h SIG_BLOCK SIG_UNBLOCK);
 use Pod::Usage;
 use Fcntl qw(:flock);
-use Systemd::Daemon qw{ -soft -notify };
+use Systemd::Daemon qw{ -soft };
 
 #pf::log must always be initilized first
 BEGIN {

--- a/sbin/winbindd-wrapper
+++ b/sbin/winbindd-wrapper
@@ -23,7 +23,7 @@ use File::Basename qw(basename);
 use POSIX qw(:signal_h pause :sys_wait_h SIG_BLOCK SIG_UNBLOCK);
 use Pod::Usage;
 use Fcntl qw(:flock);
-use Systemd::Daemon();
+use Systemd::Daemon qw{ -soft -notify };
 
 #pf::log must always be initilized first
 BEGIN {


### PR DESCRIPTION
# Description
Adds systemd sd_notify support to 

- sbin/pfbandwidthd
- sbin/pfconfig 
- sbin/pfdetect
- sbin/pfdhcplistener
- sbin/pffilter
- sbin/pfmon
- sbin/pfqueue
- sbin/pfsetvlan
- sbin/winbindd-wrapper

Also reconfigure Mariadb to use sd_notify.

# Impacts
All the above services should now require a "READY" notification before systemd considers them started.


# Delete branch after merge
YES 


## Enhancements
* PF sbin/ daemons now include support for systemd notify service type

