### PR TITLE
Limit journal maximum size on disk.

### DIFF
--- a/addons/packages/packetfence.spec
+++ b/addons/packages/packetfence.spec
@@ -521,6 +521,7 @@ cp addons/*.pl $RPM_BUILD_ROOT/usr/local/pf/addons/
 cp addons/*.sh $RPM_BUILD_ROOT/usr/local/pf/addons/
 %{__install} -D packetfence.logrotate $RPM_BUILD_ROOT/etc/logrotate.d/packetfence
 %{__install} -D packetfence.rsyslog $RPM_BUILD_ROOT/etc/rsyslog.d/packetfence.conf
+%{__install} -D packetfence.journald $RPM_BUILD_ROOT/usr/lib/systemd/journald.conf.d/01-packetfence.conf
 cp -r sbin $RPM_BUILD_ROOT/usr/local/pf/
 cp -r conf $RPM_BUILD_ROOT/usr/local/pf/
 cp -r raddb $RPM_BUILD_ROOT/usr/local/pf/
@@ -640,11 +641,6 @@ fi
 %post -n %{real_name}
 
 /usr/bin/mkdir -p /var/log/journal/
-/usr/bin/mkdir -p /usr/lib/systemd/journald.conf.d
-echo "[Journal]" > /usr/lib/systemd/journald.conf.d/01-packetfence.conf
-echo "RateLimitInterval=0" >> /usr/lib/systemd/journald.conf.d/01-packetfence.conf
-echo "RateLimitBurst=0" >> /usr/lib/systemd/journald.conf.d/01-packetfence.conf
-echo "ForwardToWall=no" >> /usr/lib/systemd/journald.conf.d/01-packetfence.conf
 echo "Restarting journald to enable persistent logging"
 /bin/systemctl restart systemd-journald
 

--- a/debian/packetfence.preinst
+++ b/debian/packetfence.preinst
@@ -64,6 +64,8 @@ case "$1" in
         echo "RateLimitInterval=0" >> /etc/systemd/journald.conf
         echo "RateLimitBurst=0" >> /etc/systemd/journald.conf
         echo "ForwardToWall=no" >> /etc/systemd/journald.conf
+        echo "SystemMaxUse=1G" >> /etc/systemd/journald.conf
+        echo "SystemKeepFree=1G" >> /etc/systemd/journald.conf
         echo "Restarting journald to enable persistent logging"
         /bin/systemctl restart systemd-journald
 

--- a/packetfence.journald
+++ b/packetfence.journald
@@ -1,0 +1,10 @@
+# journald overrides
+# The values in this file override the system's defaults.
+# See journald.conf(5) for details.
+
+[Journal]
+SystemMaxUse=1G
+SystemKeepFree=1G
+RateLimitInterval=0
+RateLimitBurst=0
+ForwardToWall=no


### PR DESCRIPTION
# Description
Adds configuration to ensure journald never uses more than 1GB on disk, and always leaves a minimum of 1Gb free disk space.

# Impacts
/var/log/journald should not grow over 1Gb of usage.

# Issue
fixes #2380 

# Delete branch after merge
YES

# NEWS file entries

## Enhancements
* Journald total file size is now capped at 1Gb
