### PR TITLE
Server certs and keys are now never overwritten if they exist.

### DIFF
--- a/addons/packages/packetfence.spec
+++ b/addons/packages/packetfence.spec
@@ -667,13 +667,8 @@ echo "Restarting rsyslogd"
 /bin/systemctl restart rsyslog
 
 #Make ssl certificate
-if [ ! -f /usr/local/pf/conf/ssl/server.crt ]; then
-    openssl req -x509 -new -nodes -days 365 -batch\
-    	-out /usr/local/pf/conf/ssl/server.crt\
-    	-keyout /usr/local/pf/conf/ssl/server.key\
-    	-nodes -config /usr/local/pf/conf/openssl.cnf
-    cat /usr/local/pf/conf/ssl/server.crt /usr/local/pf/conf/ssl/server.key > /usr/local/pf/conf/ssl/server.pem
-fi
+cd /usr/local/pf
+make conf/ssl/server.pem
 
 # Create OMAPI key
 if [ ! -f /usr/local/pf/conf/pf_omapi_key ]; then

--- a/debian/packetfence.postinst
+++ b/debian/packetfence.postinst
@@ -80,13 +80,9 @@ case "$1" in
         done
 
         #Make ssl certificate
-        if [ ! -f /usr/local/pf/conf/ssl/server.crt ]; then
-            openssl req -x509 -new -nodes -days 3650 -batch\
-            -out /usr/local/pf/conf/ssl/server.crt\
-            -keyout /usr/local/pf/conf/ssl/server.key\
-            -nodes -config /usr/local/pf/conf/openssl.cnf
-            cat /usr/local/pf/conf/ssl/server.crt /usr/local/pf/conf/ssl/server.key > /usr/local/pf/conf/ssl/server.pem
-        fi
+        cd /usr/local/pf
+        make conf/ssl/server.pem
+
 
         # Create OMAPI key
         if [ ! -f /usr/local/pf/conf/pf_omapi_key ]; then


### PR DESCRIPTION
# Description
Adds targets to the Makefile to create the TLS certs and key if and only if the files do not already exist.

# Impacts
server.key, server.crt, and server.pem will only get created if they don't exist already.
Otherwise they will remain untouched.

# Issue
fixes #2366 

# Delete branch after merge
YES 

# NEWS file entries

## Bug Fixes
If an issue exists on Github, please refer to it (name) along with it's number...
* TLS certificates and keys will no longer be overwritten (#2366)
