### PR TITLE
redirect to plain HTTP for access detection in portal

### DIFF
--- a/conf/httpd.conf.d/httpd.portal.tt.example
+++ b/conf/httpd.conf.d/httpd.portal.tt.example
@@ -247,6 +247,7 @@ NameVirtualHost [% vhost %]:443
      PerlTransHandler pf::web::dispatcher::custom
      [% IF captive_portal.secure_redirect %]
      RewriteEngine On
+     RewriteCond %{REQUEST_URI} !^/access.* [NC]
      RewriteCond %{HTTP:X-Forwarded-Proto} !=https
      RewriteCond %{HTTP:X-Forwarded-For-PacketFence} =""
      RewriteCond %{HTTPS} !=on

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Root.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Root.pm
@@ -86,7 +86,7 @@ sub release {
     # One last check for the violations
     return unless($self->handle_violations());
 
-    return $self->app->redirect("/access") unless($self->app->request->path eq "access");
+    return $self->app->redirect("http://" . $self->app->request->header("host") . "/access") unless($self->app->request->path eq "access");
 
     get_logger->info("Releasing device");
 


### PR DESCRIPTION
# Description
Redirect to plain HTTP for network access detection to prevent mixed content warnings

# Impacts
The **whole** network detection flow, so we need to test this against as many devices we can

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* Use plain HTTP for network access detection page
