### PR TITLE
Added a check to ignore broadcasts in cluster when not holding the VIP.

### DIFF
--- a/sbin/pfdhcplistener
+++ b/sbin/pfdhcplistener
@@ -97,6 +97,8 @@ my $pcap;
 my $net_type;
 my $process;
 my $interface;
+my $is_clustered = $FALSE;
+my $holds_vip = $FALSE;
 
 my $rate_limit_hash = {};
 my $rate_limit_cache = CHI->new( driver => 'Memory', datastore => $rate_limit_hash );
@@ -107,6 +109,8 @@ sub reload_config {
     }
     elsif ( pf::cluster::is_vip_running($interface) ) { 
         $process = $TRUE;
+        $is_clustered = $TRUE;
+        $holds_vip = $TRUE;
     }
     elsif ( !$pf::cluster::cluster_enabled ) { 
         $process = $TRUE;
@@ -245,6 +249,11 @@ sub process_pkt {
             }
 
             my $l3 = $l2->{type} eq ETH_TYPE_IP ? NetPacket::IP->decode($l2->{'data'}) : NetPacket::IPv6->decode($l2->{'data'});
+
+            # ignore broadcasts unless this is the VIP in clustered mode
+            if ( $is_clustered && ! $holds_vip ) { 
+                return if $l3->{'dest_ip'} eq '255.255.255.255';
+            }
             my $l4 = NetPacket::UDP->decode($l3->{'data'});
             my %args = (
                 src_mac => clean_mac($l2->{'src_mac'}),
@@ -257,7 +266,7 @@ sub process_pkt {
                 interface_vlan => $interface_vlan,
                 net_type => $net_type,
                 inline_sub_connection_type => $inline_sub_connection_type,
-            );
+            );cket::IP
 
             my $statsd_interface = $interface;
             $statsd_interface =~ s/\./_/g;

--- a/sbin/pfdhcplistener
+++ b/sbin/pfdhcplistener
@@ -224,6 +224,10 @@ sub process_pkt {
         eval {
             my $l2 = NetPacket::Ethernet->decode($pkt);
 
+            # ignore broadcasts unless this is the VIP in clustered mode
+            if ( $is_clustered && ! $holds_vip ) { 
+                return if $l2->{'dest_mac'} eq 'ffffffffff';
+            }
             # Skip frames that has a VLAN tag to avoid processing frames more than
             # once when pfdhcplistener listens on both a vlan interface and its parent
             #
@@ -250,10 +254,6 @@ sub process_pkt {
 
             my $l3 = $l2->{type} eq ETH_TYPE_IP ? NetPacket::IP->decode($l2->{'data'}) : NetPacket::IPv6->decode($l2->{'data'});
 
-            # ignore broadcasts unless this is the VIP in clustered mode
-            if ( $is_clustered && ! $holds_vip ) { 
-                return if $l3->{'dest_ip'} eq '255.255.255.255';
-            }
             my $l4 = NetPacket::UDP->decode($l3->{'data'});
             my %args = (
                 src_mac => clean_mac($l2->{'src_mac'}),
@@ -266,7 +266,7 @@ sub process_pkt {
                 interface_vlan => $interface_vlan,
                 net_type => $net_type,
                 inline_sub_connection_type => $inline_sub_connection_type,
-            );cket::IP
+            );
 
             my $statsd_interface = $interface;
             $statsd_interface =~ s/\./_/g;

--- a/sbin/pfdhcplistener
+++ b/sbin/pfdhcplistener
@@ -224,7 +224,6 @@ sub process_pkt {
         eval {
             my $l2 = NetPacket::Ethernet->decode($pkt);
 
-            # ignore broadcasts unless this is the VIP in clustered mode
             if ( $is_clustered && ! $holds_vip ) { 
                 $logger->trace("Skipping broadcast request since we don't hold the cluster's VIP.");
                 return if $l2->{'dest_mac'} eq 'ffffffffff';

--- a/sbin/pfdhcplistener
+++ b/sbin/pfdhcplistener
@@ -226,6 +226,7 @@ sub process_pkt {
 
             # ignore broadcasts unless this is the VIP in clustered mode
             if ( $is_clustered && ! $holds_vip ) { 
+                $logger->trace("Skipping broadcast request since we don't hold the cluster's VIP.");
                 return if $l2->{'dest_mac'} eq 'ffffffffff';
             }
             # Skip frames that has a VLAN tag to avoid processing frames more than


### PR DESCRIPTION
# Description
Adds a check to pfdhcplistener to ignore broadcast dhcprequests in clustered mode if this server is hot currently holding the VIP.

# Impacts
DHCPv4 requests to the broadcast ip (255.255.255.255) should be ignored in a cluster when the node does not hold the VIP.

# Issue
fixes #2408 

# Delete branch after merge
YES 

# NEWS file entries

## Bug Fixes
If an issue exists on Github, please refer to it (name) along with it's number...
* Fixed issue where dhcp broadcast requests are handled multiple times in a cluster (#2408)
