### PR TITLE
Rework pfdhcplistener to conditionally handle broadcasts

### DIFF
--- a/sbin/pfdhcplistener
+++ b/sbin/pfdhcplistener
@@ -96,27 +96,22 @@ my $interface_ip;
 my $interface_vlan;
 my $pcap;
 my $net_type;
-my $process;
 my $interface;
+my $process_broadcast = $TRUE;
 
 my $rate_limit_hash = {};
 my $rate_limit_cache = CHI->new( driver => 'Memory', datastore => $rate_limit_hash );
 
 sub reload_config {
-    if ( $net_type eq "internal" ) { 
-        $process = $TRUE;
-    }
-    elsif ( pf::cluster::is_vip_running($interface) ) { 
-        $process = $TRUE;
-    }
-    elsif ( !$pf::cluster::cluster_enabled ) { 
-        $process = $TRUE;
-    }
-    else { 
-        $process = $FALSE;
-    }
 
-    $logger->info("Reload configuration on $interface with status $process");
+    # reload the defaults every time
+    $process_broadcast = $TRUE;
+
+    # We do not process broadcast on the node which does not hold the VIP
+    if ( $pf::cluster::cluster_enabled && ! pf::cluster::is_vip_running($interface) ) { 
+        $process_broadcast = $FALSE;
+    }
+    $logger->info("Reload configuration on $interface");
 }
 
 my $pidfile = "${var_dir}/run/$PROGRAM_NAME.pid";
@@ -219,31 +214,86 @@ sub setup_pcap {
 
 sub process_pkt {
     my ( $user_data, $hdr, $pkt ) = @_;
-    if ($process){
-        eval {
-            my $l2 = NetPacket::Ethernet->decode($pkt);
+    eval {
+        my $l2 = NetPacket::Ethernet->decode($pkt);
 
-            # Skip frames that has a VLAN tag to avoid processing frames more than
-            # once when pfdhcplistener listens on both a vlan interface and its parent
-            #
-            # On post-2008 kernels, with network devices supporting VLAN acceleration
-            # (HW tagging/stripping), ethernet frames always appear untagged to libpcap.
-            # The library reconstructs the original frame by looking at the PACKET_AUXDATA
-            # (pcap-linux.c: pcap_read_packet) *after* the frame has passed the bpf filters.
-            # In other words, we cannot use bpf filters to ignore VLAN packets.
-            #
-            # Also, NetPacket::Ethernet::decode will skip the VLAN header from
-            # a tagged frame and return the 'inner' ether_type of the frame.
-            #
-            # For this reason we check to see if $l2->{tpid} is set
-            if ( defined $l2->{tpid} && $net_type ne "monitor" ) {
-                $logger->trace("Skipping VLAN packets since it is probably addressed to another interface (offload decapsulated tagged packet).");
+        if ( ! $process_broadcast ) { 
+            if ( $l2->{'dest_mac'} eq 'ffffffffff' ) { 
+                $logger->trace("Skipping broadcast request.");
+                return;
+            } 
+        }
+        # Skip frames that has a VLAN tag to avoid processing frames more than
+        # once when pfdhcplistener listens on both a vlan interface and its parent
+        #
+        # On post-2008 kernels, with network devices supporting VLAN acceleration
+        # (HW tagging/stripping), ethernet frames always appear untagged to libpcap.
+        # The library reconstructs the original frame by looking at the PACKET_AUXDATA
+        # (pcap-linux.c: pcap_read_packet) *after* the frame has passed the bpf filters.
+        # In other words, we cannot use bpf filters to ignore VLAN packets.
+        #
+        # Also, NetPacket::Ethernet::decode will skip the VLAN header from
+        # a tagged frame and return the 'inner' ether_type of the frame.
+        #
+        # For this reason we check to see if $l2->{tpid} is set
+        if ( defined $l2->{tpid} && $net_type ne "monitor" ) {
+            $logger->trace("Skipping VLAN packets since it is probably addressed to another interface (offload decapsulated tagged packet).");
+            return;
+        }
+
+        # Skip frames that aren't ETH_TYPE_IP/ETH_TYPE_IPv6
+        if ( ($l2->{type} ne ETH_TYPE_IP) && ($l2->{type} ne ETH_TYPE_IPv6) ) {
+            $logger->trace("Skipping non ETH_TYPE_IP (IPv4) / ETH_TYPE_IPv6 (IPv6) packet");
+            return;
+        }
+
+        my $l3 = $l2->{type} eq ETH_TYPE_IP ? NetPacket::IP->decode($l2->{'data'}) : NetPacket::IPv6->decode($l2->{'data'});
+
+        my $l4 = NetPacket::UDP->decode($l3->{'data'});
+        my %args = (
+            src_mac => clean_mac($l2->{'src_mac'}),
+            dest_mac => clean_mac($l2->{'dest_mac'}),
+            src_ip => $l3->{'src_ip'},
+            dest_ip => $l3->{'dest_ip'},
+            is_inline_vlan => $is_inline_vlan,
+            interface => $interface,
+            interface_ip => $interface_ip,
+            interface_vlan => $interface_vlan,
+            net_type => $net_type,
+            inline_sub_connection_type => $inline_sub_connection_type,
+        );
+
+        my $statsd_interface = $interface;
+        $statsd_interface =~ s/\./_/g;
+        $pf::StatsD::statsd->increment("pfdhcplistener_$statsd_interface\::process_pkt_total.count" );
+
+        # IPv4 processing
+        if ( $l2->{type} eq ETH_TYPE_IP ) {
+            $pf::StatsD::statsd->increment("pfdhcplistener_$statsd_interface\::process_pkt_ipv4.count" );
+            my ($dhcp);
+
+            # we need success flag here because we can't next inside try catch
+            my $success;
+            try {
+                $dhcp = decode_dhcp($l4->{'data'});
+                $success = 1;
+            } catch {
+                $logger->warn("Unable to parse DHCP packet: $_");
+            };
+            return if (!$success);
+            $args{dhcp} = $dhcp;
+            
+            my $dhcp_mac = clean_mac( substr( $dhcp->{'chaddr'}, 0, 12 ) );
+            if ( $dhcp_mac ne "00:00:00:00:00:00" && !valid_mac($dhcp_mac) ) {
+                $logger->debug( sub {
+                    "invalid CHADDR value ($dhcp_mac) in DHCP packet from $dhcp->{src_mac} ($dhcp->{src_ip})"
+                });
                 return;
             }
-
-            # Skip frames that aren't ETH_TYPE_IP/ETH_TYPE_IPv6
-            if ( ($l2->{type} ne ETH_TYPE_IP) && ($l2->{type} ne ETH_TYPE_IPv6) ) {
-                $logger->trace("Skipping non ETH_TYPE_IP (IPv4) / ETH_TYPE_IPv6 (IPv6) packet");
+            
+            # don't process a packet for which we don't have a MAC address
+            unless($dhcp_mac) {
+                $logger->debug("chaddr is undefined in DHCP packet");
                 return;
             }
 
@@ -266,105 +316,103 @@ sub process_pkt {
             $statsd_interface =~ s/\./_/g;
             $pf::StatsD::statsd->increment("pfdhcplistener_$statsd_interface\::process_pkt_total.count" );
 
-            # IPv4 processing
-            if ( $l2->{type} eq ETH_TYPE_IP ) {
-                $pf::StatsD::statsd->increment("pfdhcplistener_$statsd_interface\::process_pkt_ipv4.count" );
-                my ($dhcp);
+        # IPv4 processing
+        if ( $l2->{type} eq ETH_TYPE_IP ) {
+            $pf::StatsD::statsd->increment("pfdhcplistener_$statsd_interface\::process_pkt_ipv4.count" );
+            my ($dhcp);
 
-                # we need success flag here because we can't next inside try catch
-                my $success;
-                try {
-                    $dhcp = decode_dhcp($l4->{'data'});
-                    $success = 1;
-                } catch {
-                    $logger->warn("Unable to parse DHCP packet: $_");
-                };
-                return if (!$success);
-                $args{dhcp} = $dhcp;
-                
-                my $dhcp_mac = clean_mac( substr( $dhcp->{'chaddr'}, 0, 12 ) );
-                if ( $dhcp_mac ne "00:00:00:00:00:00" && !valid_mac($dhcp_mac) ) {
-                    $logger->debug( sub {
-                        "invalid CHADDR value ($dhcp_mac) in DHCP packet from $dhcp->{src_mac} ($dhcp->{src_ip})"
-                    });
-                    return;
-                }
-                
-                # don't process a packet for which we don't have a MAC address
-                unless($dhcp_mac) {
-                    $logger->debug("chaddr is undefined in DHCP packet");
-                    return;
-                }
+            # we need success flag here because we can't next inside try catch
+            my $success;
+            try {
+                $dhcp = decode_dhcp($l4->{'data'});
+                $success = 1;
+            } catch {
+                $logger->warn("Unable to parse DHCP packet: $_");
+            };
+            return if (!$success);
+            $args{dhcp} = $dhcp;
+            
+            my $dhcp_mac = clean_mac( substr( $dhcp->{'chaddr'}, 0, 12 ) );
+            if ( $dhcp_mac ne "00:00:00:00:00:00" && !valid_mac($dhcp_mac) ) {
+                $logger->debug( sub {
+                    "invalid CHADDR value ($dhcp_mac) in DHCP packet from $dhcp->{src_mac} ($dhcp->{src_ip})"
+                });
+                return;
+            }
+            
+            # don't process a packet for which we don't have a MAC address
+            unless($dhcp_mac) {
+                $logger->debug("chaddr is undefined in DHCP packet");
+                return;
+            }
+            
+            # adding to dhcp hashref some frame information we care about
+            $dhcp->{'src_mac'} = $args{'src_mac'};
+            $dhcp->{'dest_mac'} = $args{'dest_mac'};
+            $dhcp->{'src_ip'} = $args{'src_ip'};
+            $dhcp->{'dest_ip'} = $args{'dest_ip'};
+            $dhcp->{'chaddr'} = $dhcp_mac;
 
-
-                # adding to dhcp hashref some frame information we care about
-                $dhcp->{'src_mac'} = $args{'src_mac'};
-                $dhcp->{'dest_mac'} = $args{'dest_mac'};
-                $dhcp->{'src_ip'} = $args{'src_ip'};
-                $dhcp->{'dest_ip'} = $args{'dest_ip'};
-                $dhcp->{'chaddr'} = $dhcp_mac;
-
-                if (!valid_mac($dhcp->{'src_mac'})) {
-                    $logger->debug("Source MAC is invalid. skipping");
-                    return;
-                }
-
-
-                if ($is_inline_vlan) {
-                    my $ip = new NetAddr::IP::Lite clean_ip($l3->{'src_ip'});
-                    if ($net_addr->contains($ip)) {
-                        $args{inline_sub_connection_type} = $NET_TYPE_INLINE_L2;
-                    } else {
-                        $args{inline_sub_connection_type} = $NET_TYPE_INLINE_L3;
-                   }
-                }
-
-                # If its a DHCPREQUEST, we take the IP address from the option
-                my $dhcp_ip = ( $dhcp->{'op'} == 1 && $dhcp->{'options'}{'53'} == 3 ) ? $dhcp->{'options'}{'50'} : $dhcp->{yiaddr};
-                my $rate_limit_key;
-                if(defined($dhcp_ip)) {
-                    # Key is with BOOT type, DHCP type, IP and MAC
-                    $rate_limit_key = $dhcp->{'op'} . "-" . $dhcp->{'options'}{'53'} . "-$dhcp_ip-" . $dhcp_mac;
-                    $logger->trace("Rate limit key : $rate_limit_key");
-                }
-
-                my $rate_limiting = $Config{network}->{dhcp_rate_limiting};
-                # We send the packet to be processed if:
-                #  - there is no rate limit key (packet doesn't contain info to be rate-limited)
-                #  - there is no rate limiting configured
-                #  - there is no cache entry (packet wasn't seen in the last $rate_limiting seconds)
-                if(!defined($rate_limit_key) || $rate_limiting == 0 || !$rate_limit_cache->get($rate_limit_key)) {
-                    my $apiclient = pf::api::queue->new(queue => 'pfdhcplistener');
-                    $apiclient->notify('process_dhcpv4', %args);
-                    if(defined($rate_limit_key) && $rate_limiting != 0) {
-                        $rate_limit_cache->set($rate_limit_key, 1, $rate_limiting);
-                    }
-                }
-                else {
-                    $logger->debug("[$dhcp_mac] Ignoring packet due to rate-limiting ($rate_limit_key)");
-                }
+            if (!valid_mac($dhcp->{'src_mac'})) {
+                $logger->debug("Source MAC is invalid. skipping");
+                return;
             }
 
-            # IPv6 processing
-            elsif ( $l2->{type} eq ETH_TYPE_IPv6 ) {
-                $pf::StatsD::statsd->increment("pfdhcplistener_$statsd_interface\::process_pkt_ipv6.count" );
 
-                # TODO: Rate-limiting for IPv6 just as for IPv4
+            if ($is_inline_vlan) {
+                my $ip = new NetAddr::IP::Lite clean_ip($l3->{'src_ip'});
+                if ($net_addr->contains($ip)) {
+                    $args{inline_sub_connection_type} = $NET_TYPE_INLINE_L2;
+                } else {
+                    $args{inline_sub_connection_type} = $NET_TYPE_INLINE_L3;
+               }
+            }
 
+            # If its a DHCPREQUEST, we take the IP address from the option
+            my $dhcp_ip = ( $dhcp->{'op'} == 1 && $dhcp->{'options'}{'53'} == 3 ) ? $dhcp->{'options'}{'50'} : $dhcp->{yiaddr};
+            my $rate_limit_key;
+            if(defined($dhcp_ip)) {
+                # Key is with BOOT type, DHCP type, IP and MAC
+                $rate_limit_key = $dhcp->{'op'} . "-" . $dhcp->{'options'}{'53'} . "-$dhcp_ip-" . $dhcp_mac;
+                $logger->trace("Rate limit key : $rate_limit_key");
+            }
+
+            my $rate_limiting = $Config{network}->{dhcp_rate_limiting};
+            # We send the packet to be processed if:
+            #  - there is no rate limit key (packet doesn't contain info to be rate-limited)
+            #  - there is no rate limiting configured
+            #  - there is no cache entry (packet wasn't seen in the last $rate_limiting seconds)
+            if(!defined($rate_limit_key) || $rate_limiting == 0 || !$rate_limit_cache->get($rate_limit_key)) {
                 my $apiclient = pf::api::queue->new(queue => 'pfdhcplistener');
-                $apiclient->notify('process_dhcpv6', MIME::Base64::encode($l4->{data}));
+                $apiclient->notify('process_dhcpv4', %args);
+                if(defined($rate_limit_key) && $rate_limiting != 0) {
+                    $rate_limit_cache->set($rate_limit_key, 1, $rate_limiting);
+                }
             }
-
-            # Non IPv4 nor IPv6 packet
             else {
-                $logger->debug("Skipping non IPv4 nor IPv6 DHCP packet from MAC address '$args{'src_mac'}' (IP: '$args{'src_ip'}') for IP '$args{'dest_ip'}'");
-                return; 
+                $logger->debug("[$dhcp_mac] Ignoring packet due to rate-limiting ($rate_limit_key)");
             }
-        };
-
-        if($@) {
-            $logger->error("Error processing packet: $@");
         }
+
+        # IPv6 processing
+        elsif ( $l2->{type} eq ETH_TYPE_IPv6 ) {
+            $pf::StatsD::statsd->increment("pfdhcplistener_$statsd_interface\::process_pkt_ipv6.count" );
+
+            # TODO: Rate-limiting for IPv6 just as for IPv4
+
+            my $apiclient = pf::api::queue->new(queue => 'pfdhcplistener');
+            $apiclient->notify('process_dhcpv6', MIME::Base64::encode($l4->{data}));
+        }
+
+        # Non IPv4 nor IPv6 packet
+        else {
+            $logger->debug("Skipping non IPv4 nor IPv6 DHCP packet from MAC address '$args{'src_mac'}' (IP: '$args{'src_ip'}') for IP '$args{'dest_ip'}'");
+            return; 
+        }
+    };
+
+    if($@) {
+        $logger->error("Error processing packet: $@");
     }
     #reload all cached configs after each iteration
     pf::CHI::Request::clear_all();


### PR DESCRIPTION
NOT READY
# Description
Reworks the pfdhcplistener logic to handle broadcast requests only on the VIP node of a cluster.

# Impacts
Reworks the logic of dhcp request processing.
From now on, the only packets that are not processed are the DHCP broadcast sent to a cluster node that does not hold the VIP.

# Issue
fixes #2408 

# Delete branch after merge
YES 

# NEWS file entries
## Bug Fixes
If an issue exists on Github, please refer to it (name) along with it's number...
* Fixed an issue where DHCP broadcast were treated more than once in clustered mode

