### PR TITLE
Ignore DHCP broadcasts on the node that does not hold the VIP

### DIFF
--- a/sbin/pfdhcplistener
+++ b/sbin/pfdhcplistener
@@ -217,7 +217,7 @@ sub process_pkt {
             my $l2 = NetPacket::Ethernet->decode($pkt);
 
             if ( ! $process_broadcast ) { 
-                if ( $l2->{'dest_mac'} eq 'ffffffffff' ) { 
+                if ( $l2->{'dest_mac'} eq 'ffffffffffff' ) { 
                     $logger->trace("Skipping broadcast request.");
                     return;
                 } 

--- a/sbin/pfdhcplistener
+++ b/sbin/pfdhcplistener
@@ -96,27 +96,21 @@ my $interface_ip;
 my $interface_vlan;
 my $pcap;
 my $net_type;
-my $process;
+my $process_broadcast;
 my $interface;
 
 my $rate_limit_hash = {};
 my $rate_limit_cache = CHI->new( driver => 'Memory', datastore => $rate_limit_hash );
 
 sub reload_config {
-    if ( $net_type eq "internal" ) { 
-        $process = $TRUE;
-    }
-    elsif ( pf::cluster::is_vip_running($interface) ) { 
-        $process = $TRUE;
-    }
-    elsif ( !$pf::cluster::cluster_enabled ) { 
-        $process = $TRUE;
-    }
-    else { 
-        $process = $FALSE;
-    }
+    # reload the defaults every time
+    $process_broadcast = $TRUE;
 
-    $logger->info("Reload configuration on $interface with status $process");
+    # We do not process broadcast on the node which does not hold the VIP
+    if ( $pf::cluster::cluster_enabled && ! pf::cluster::is_vip_running($interface) ) { 
+        $process_broadcast = $FALSE;
+    }
+    $logger->info("Reload configuration on $interface");
 }
 
 my $pidfile = "${var_dir}/run/$PROGRAM_NAME.pid";
@@ -219,10 +213,15 @@ sub setup_pcap {
 
 sub process_pkt {
     my ( $user_data, $hdr, $pkt ) = @_;
-    if ($process){
         eval {
             my $l2 = NetPacket::Ethernet->decode($pkt);
 
+            if ( ! $process_broadcast ) { 
+                if ( $l2->{'dest_mac'} eq 'ffffffffff' ) { 
+                    $logger->trace("Skipping broadcast request.");
+                    return;
+                } 
+            }       
             # Skip frames that has a VLAN tag to avoid processing frames more than
             # once when pfdhcplistener listens on both a vlan interface and its parent
             #
@@ -365,7 +364,7 @@ sub process_pkt {
         if($@) {
             $logger->error("Error processing packet: $@");
         }
-    }
+    
     #reload all cached configs after each iteration
     pf::CHI::Request::clear_all();
     #Only perform stats when in debug mode


### PR DESCRIPTION
# Description
Reworks the pfdhcplistener logic to handle broadcast requests only on the VIP node of a cluster.

# Impacts
Reworks the logic of dhcp request processing.
From now on, the only packets that are not processed are the DHCP broadcast sent to a cluster node that does not hold the VIP.

# Issue
fixes #2408 

# Delete branch after merge
YES 

# NEWS file entries
## Bug Fixes
If an issue exists on Github, please refer to it (name) along with it's number...
* Fixed an issue where DHCP broadcast were treated more than once in clustered mode

