### PR TITLE
feature/normalize_radius_username

### DIFF
--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1127,7 +1127,7 @@ EOT
 type=toggle
 options=enabled|disabled
 description=<<EOT
-Use the radius username instead of the TLS certificate common name when doing machine auth.
+Use the RADIUS username instead of the TLS certificate common name when doing machine authentication.
 EOT
 
 [omapi.ip2mac_lookup]

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1123,6 +1123,13 @@ description=<<EOT
 Ability to manage all active devices from a same switch port
 EOT
 
+[advanced.normalize_radius_machine_auth_username]
+type=toggle
+options=enabled|disabled
+description=<<EOT
+Normalize the radius machine auth username
+EOT
+
 [omapi.ip2mac_lookup]
 type=toggle
 options=enabled|disabled

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1127,7 +1127,7 @@ EOT
 type=toggle
 options=enabled|disabled
 description=<<EOT
-Normalize the radius machine auth username
+Use the radius username instead of the TLS certificate common name when doing machine auth.
 EOT
 
 [omapi.ip2mac_lookup]

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -826,6 +826,11 @@ source_to_send_sms_when_creating_users=
 #
 # Ability to manage all active devices from a same switch port
 multihost=disabled
+#
+# advanced.normalize_radius_machine_auth_username
+#
+# Normalize the radius machine auth username
+normalize_radius_machine_auth_username=disabled
 
 [omapi]
 #

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -124,6 +124,8 @@ sub authorize {
 
     my ($nas_port_type, $eap_type, $mac, $port, $user_name, $nas_port_id, $session_id, $ifDesc) = $switch->parseRequest($radius_request);
 
+    $user_name = normalize_username($user_name, $radius_request);
+
     if (!$mac) {
         return [$RADIUS::RLM_MODULE_FAIL, ('Reply-Message' => "Mac is empty")];
     }
@@ -331,6 +333,24 @@ AUDIT:
     $args->{'time'} = time;
     push @$RAD_REPLY_REF, $self->_addRadiusAudit($args);
     return $RAD_REPLY_REF;
+}
+
+=item normalize_username
+
+normalize username
+
+=cut
+
+sub normalize_username {
+    my ($username, $radius_request) = @_;
+    my $tls_username = $radius_request->{'TLS-Client-Cert-Common-Name'} // '';
+    if ($username eq $tls_username ) {
+       my $radius_username = $radius_request->{'User-Name'};
+       if ( "host/$tls_username" =~ /\Q$radius_username\E/i ) {
+            $username = $radius_username;
+       }
+    }
+    return $username;
 }
 
 =item accounting

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -343,6 +343,9 @@ normalize username
 
 sub normalize_username {
     my ($username, $radius_request) = @_;
+    if (isdisabled($Config{advanced}{normalize_radius_machine_auth_username})) {
+        return $username;
+    }
     my $tls_username = $radius_request->{'TLS-Client-Cert-Common-Name'} // '';
     if ($username eq $tls_username ) {
        my $radius_username = $radius_request->{'User-Name'};


### PR DESCRIPTION
Description
===========
Normalize the radius username for machine auth when using TLS

Impacts
=======
RADIUS authorize workflow

Delete branch after merge
=========================
NO

NEWS file entries
=================

Enhancements
------------
* Have the ability to normalize the machine auth username when using TLS