### PR TITLE
make haproxy rate limiting configurable

### DIFF
--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1011,6 +1011,21 @@ description=<<EOT
 Enable or disable WISPr redirection capabilities on the captive-portal
 EOT
 
+[captive_portal.rate_limiting]
+type=toggle
+options=enabled|disabled
+description=<<EOT
+Temporarily deny access to a user that performs too many requests on the captive portal on invalid URLs
+Requires to restart haproxy in order to apply the change.
+EOT
+
+[captive_portal.rate_limiting_threshold]
+type=numeric
+description=<<EOT
+Amount of requests on invalid URLs after which the rate limiting will kick in for this device.
+Requires to restart haproxy in order to apply the change.
+EOT
+
 [advanced.language]
 type=toggle
 options=none|de_DE|en_US|es_ES|fr_FR|he_IL|it_IT|nl_NL|pl_PL|pt_BR

--- a/conf/haproxy.conf.example
+++ b/conf/haproxy.conf.example
@@ -42,7 +42,7 @@ defaults
         timeout client 50000
         timeout server 50000
         errorfile 400 %%os_path%%400.http
-        errorfile 403 %%os_path%%403.http
+        errorfile 403 %%captiveportal_templates_path%%/rate-limiting.http
         errorfile 408 %%os_path%%408.http
         errorfile 500 %%os_path%%500.http
         errorfile 502 %%os_path%%502.http

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -738,6 +738,17 @@ detection_mecanism_urls = http://www.gstatic.com/generate_204,http://clients3.go
 #
 # Enable or disable WISPr redirection capabilities on the captive-portal
 wispr_redirection = enabled
+#
+# captive_portal.rate_limiting
+#
+# Temporarily deny access to a user that performs too many requests on the captive portal on invalid URLs
+rate_limiting = enabled
+#
+# captive_portal.rate_limiting_threshold
+#
+# Amount of requests on invalid URLs after which the rate limiting will kick in for this device
+rate_limiting_threshold = 24
+
 
 [advanced]
 #

--- a/html/captive-portal/templates/rate-limiting.http
+++ b/html/captive-portal/templates/rate-limiting.http
@@ -1,0 +1,10 @@
+HTTP/1.0 429 Too Many Requests
+Cache-Control: no-cache
+Connection: close
+Content-Type: text/html
+
+<html><body><h1>Too Many Requests</h1>
+You have sent too many requests to this server. Try closing any web intensive background application and try again.
+</body></html>
+
+

--- a/html/pfappserver/lib/pfappserver/I18N/en.po
+++ b/html/pfappserver/lib/pfappserver/I18N/en.po
@@ -8916,6 +8916,14 @@ msgstr "Status URI only on production network"
 msgid "captive_portal.wispr_redirection"
 msgstr "WISPr redirection capabilities"
 
+# conf/documentation.conf
+msgid "captive_portal.rate_limiting"
+msgstr "Rate limiting"
+
+# conf/documentation.conf
+msgid "captive_portal.rate_limiting_threshold"
+msgstr "Rate limiting threshold"
+
 # html/pfappserver/lib/pfappserver/Form/User.pm
 # html/pfappserver/root/admin/users.tt
 msgid "cell_phone"

--- a/lib/pf/services/manager/haproxy.pm
+++ b/lib/pf/services/manager/haproxy.pm
@@ -158,9 +158,15 @@ frontend portal-http-$cluster_ip
         http-request set-header Host %[var(req.host)] if host_exist
         http-request lua.select
         acl action var(req.action) -m found
+EOT
+            if($rate_limiting) {
+            $tags{'http'} .= <<"EOT";
         acl unflag_abuser src_clr_gpc0 --
         http-request allow if action unflag_abuser
         http-request deny if { src_get_gpc0 gt 0 }
+EOT
+            }
+            $tags{'http'} .= <<"EOT";
         reqadd X-Forwarded-Proto:\\ http
         use_backend %[var(req.action)]
         default_backend $cluster_ip-backend
@@ -175,9 +181,15 @@ frontend portal-https-$cluster_ip
         http-request set-header Host %[var(req.host)] if host_exist
         http-request lua.select
         acl action var(req.action) -m found
+EOT
+            if($rate_limiting) {
+            $tags{'http'} .= <<"EOT";
         acl unflag_abuser src_clr_gpc0 --
         http-request allow if action unflag_abuser
         http-request deny if { src_get_gpc0 gt 0 }
+EOT
+            }
+            $tags{'http'} .= <<"EOT";
         reqadd X-Forwarded-Proto:\\ https
         use_backend %[var(req.action)]
         default_backend $cluster_ip-backend

--- a/lib/pf/services/manager/haproxy.pm
+++ b/lib/pf/services/manager/haproxy.pm
@@ -30,6 +30,7 @@ use pf::file_paths qw(
     $install_dir
     $conf_dir
     $var_dir
+    $captiveportal_templates_path
 );
 use pf::log;
 use pf::util;
@@ -144,6 +145,9 @@ EOT
 EOT
             }
 
+            my $rate_limiting = isenabled($Config{captive_portal}{rate_limiting});
+            my $rate_limiting_threshold = $Config{captive_portal}{rate_limiting_threshold};
+
             $tags{'http'} .= <<"EOT";
 frontend portal-http-$cluster_ip
         bind $cluster_ip:80
@@ -183,12 +187,18 @@ backend $cluster_ip-backend
         balance source
         option httpclose
         option forwardfor
+EOT
+            if($rate_limiting) {
+            $tags{'http'} .= <<"EOT";
         acl status_501 status 501
-        acl abuse  src_http_req_rate(portal-http-$cluster_ip) ge 20
+        acl abuse  src_http_req_rate(portal-http-$cluster_ip) ge $rate_limiting_threshold
         acl flag_abuser src_inc_gpc0(portal-http-$cluster_ip) --
-        acl abuse  src_http_req_rate(portal-https-$cluster_ip) ge 20
+        acl abuse  src_http_req_rate(portal-https-$cluster_ip) ge $rate_limiting_threshold
         acl flag_abuser src_inc_gpc0(portal-https-$cluster_ip) --
         http-response deny if abuse status_501 flag_abuser
+EOT
+            }
+            $tags{'http'} .= <<"EOT";
 $backend_ip_config
 EOT
 
@@ -236,6 +246,7 @@ EOT
         }
     }
 
+    $tags{captiveportal_templates_path} = $captiveportal_templates_path;
     parse_template( \%tags, "$conf_dir/haproxy.conf", "$generated_conf_dir/haproxy.conf" );
 
     my $fqdn = $Config{'general'}{'hostname'}.".".$Config{'general'}{'domain'};


### PR DESCRIPTION
# Description
make haproxy rate limiting configurable and add a more meaningful message when a user is rate-limited

# Impacts
haproxy rate limiting

# Issue
fixes #2418 

# Delete branch after merge
YES

# NEWS file entries
## Enhancements
* Allowed haproxy captive portal rate-limiting to be configurable

