### PR TITLE
sponsor: CC address should be BCC

### DIFF
--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Activate/Email.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Activate/Email.pm
@@ -203,7 +203,7 @@ sub doSponsorRegistration : Private {
 
             # username
             $info{'pid'} = $pid;
-            $info{'cc'} = $source->{sponsorship_cc};
+            $info{'bcc'} = $source->{sponsorship_bcc};
 
             # we create a password using the actions from the sponsor authentication source;
             # NOTE: When sponsoring a network access, the new user will be created (in the password table) using

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/Sponsor.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/Sponsor.pm
@@ -169,7 +169,7 @@ sub do_sponsor_registration {
 
     get_logger->info( "Adding guest person " . $pid );
 
-    $info{'cc'} = $source->{sponsorship_cc};
+    $info{'bcc'} = $source->{sponsorship_bcc};
     $info{'activation_domain'} = $source->{activation_domain} if (defined($source->{activation_domain}));
     $info{'activation_timeout'} = normalize_time($source->{email_activation_timeout});
     # fetch more info for the activation email

--- a/html/pfappserver/lib/pfappserver/Form/Config/Authentication/Source/SponsorEmail.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Authentication/Source/SponsorEmail.pm
@@ -72,13 +72,13 @@ has_field 'activation_domain' =>
     },
   );
 
-has_field 'sponsorship_cc' => (
+has_field 'sponsorship_bcc' => (
     type        => 'Text',
-    label       => 'Sponsorship CC',
+    label       => 'Sponsorship BCC',
     required    => 0,
     tags        => {
         after_element   => \&help,
-        help            => "Sponsors requesting access and access confirmation emails are CC'ed to this address. Multiple destinations can be comma separated.",
+        help            => "Sponsors requesting access and access confirmation emails are BCC'ed to this address. Multiple destinations can be comma separated.",
     },
 );
 

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source/SponsorEmail.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source/SponsorEmail.pm
@@ -50,13 +50,13 @@ has_field 'activation_domain' =>
     },
   );
 
-has_field 'sponsorship_cc' => (
+has_field 'sponsorship_bcc' => (
     type        => 'Text',
-    label       => 'Sponsorship CC',
+    label       => 'Sponsorship BCC',
     required    => 0,
     tags        => {
         after_element   => \&help,
-        help            => "Sponsors requesting access and access confirmation emails are CC'ed to this address. Multiple destinations can be comma separated.",
+        help            => "Sponsors requesting access and access confirmation emails are BCC'ed to this address. Multiple destinations can be comma separated.",
     },
 );
 

--- a/html/pfappserver/lib/pfappserver/PacketFence/Controller/Config/Profile.pm
+++ b/html/pfappserver/lib/pfappserver/PacketFence/Controller/Config/Profile.pm
@@ -397,7 +397,7 @@ sub preview_emails :Chained('object') :PathPart('preview/emails') :Args() :Admin
     my $msg = MIME::Lite::TT->new(
         From        =>  $info{'from'},
         To          =>  $info{'contact_info'},
-        Cc          =>  $info{'cc'},
+        Bcc         =>  $info{'bcc'},
         Subject     =>  encode("MIME-Header", $info{'subject'}),
         Template    =>  $template,
         TmplOptions =>  \%TmplOptions,

--- a/html/pfappserver/root/authentication/source/type/SponsorEmail.tt
+++ b/html/pfappserver/root/authentication/source/type/SponsorEmail.tt
@@ -1,6 +1,6 @@
 [% form.field('activation_domain').render | none %]
 [% form.field('email_activation_timeout').render | none %]
 [% form.field('allow_localdomain').render | none %]
-[% form.field('sponsorship_cc').render | none %]
+[% form.field('sponsorship_bcc').render | none %]
 [% form.field('create_local_account').render | none %]
 [% form.field('local_account_logins').render | none %]

--- a/lib/pf/Authentication/Source/SponsorEmailSource.pm
+++ b/lib/pf/Authentication/Source/SponsorEmailSource.pm
@@ -24,7 +24,7 @@ has '+class' => (default => 'external');
 has '+type' => (default => 'SponsorEmail');
 has 'allow_localdomain' => (isa => 'Str', is => 'rw', default => 'yes');
 has 'activation_domain' => (isa => 'Maybe[Str]', is => 'rw');
-has 'sponsorship_cc' => (isa => 'Maybe[Str]', is => 'rw');
+has 'sponsorship_bcc' => (isa => 'Maybe[Str]', is => 'rw');
 has 'email_activation_timeout' => (isa => 'Str', is => 'rw', default => '30m');
 
 =head2 dynamic_routing_module

--- a/lib/pf/activation.pm
+++ b/lib/pf/activation.pm
@@ -486,7 +486,7 @@ sub send_email {
     my $msg = MIME::Lite::TT->new(
         From        =>  $info{'from'},
         To          =>  $info{'contact_info'},
-        Cc          =>  $info{'cc'},
+        Bcc         =>  $info{'bcc'},
         Subject     =>  encode("MIME-Header", $info{'subject'}),
         Template    =>  "emails-$template.html",
         TmplOptions =>  \%TmplOptions,

--- a/lib/pf/config/util.pm
+++ b/lib/pf/config/util.pm
@@ -195,7 +195,7 @@ sub send_email {
     my $msg = MIME::Lite::TT->new(
         From        =>  $data->{'from'},
         To          =>  $email,
-        Cc          =>  $data->{'cc'} || '',
+        Bcc         =>  $data->{'bcc'} || '',
         Subject     =>  $subject,
         Template    =>  "emails-$template.html",
         TmplOptions =>  \%TmplOptions,

--- a/lib/pf/util.pm
+++ b/lib/pf/util.pm
@@ -1166,7 +1166,7 @@ sub send_email {
     my $msg = MIME::Lite::TT->new(
         From        =>  $from,
         To          =>  $to,
-        Cc          =>  $info{'cc'},
+        Bcc         =>  $info{'bcc'},
         Subject     =>  encode("MIME-Header", $subject),
         'Content-Type' => 'text/html; charset="UTF-8"',
         Template    =>  "emails-$template.html",

--- a/lib/pf/web/guest.pm
+++ b/lib/pf/web/guest.pm
@@ -136,7 +136,7 @@ sub send_template_email {
     my $msg = MIME::Lite::TT->new(
         From        =>  $from,
         To          =>  $info->{'email'},
-        Cc          =>  $info->{'cc'},
+        Bcc         =>  $info->{'bcc'},
         Subject     =>  encode("MIME-Header", $subject),
         Template    =>  "emails-$template.html",
         TmplOptions =>  \%TmplOptions,


### PR DESCRIPTION
# Description
Changed the Cc option to be Bcc

# Impacts
- Sending emails
- Sponsor flow

# Issue
fixes #2267 

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* sponsor: CC address should be BCC (#2267)

# UPGRADE file entries
- authentication.conf: Change `sponsorship_cc` to `sponsorship_bcc`
