### PR TITLE
feature/pfcmd_pfqueue_clear_expired_counters

### DIFF
--- a/lib/pf/cmd/pf/pfqueue.pm
+++ b/lib/pf/cmd/pf/pfqueue.pm
@@ -10,10 +10,11 @@ pf::cmd::pf::pfqueue
 
   Commands:
 
-   clear <queue>    | clear a queue
-   list             | list all queues
-   stats            | show stats of pfqueue
-   count <queue>    | show the queue count
+   clear <queue>          | clear a queue
+   clear_expired_counters | clear a queue
+   count <queue>          | show the queue count
+   list                   | list all queues
+   stats                  | show stats of pfqueue
 
 =head1 DESCRIPTION
 
@@ -25,7 +26,7 @@ use strict;
 use warnings;
 use pf::constants;
 use pf::constants::exit_code qw($EXIT_SUCCESS);
-use pf::constants::pfqueue qw($PFQUEUE_COUNTER);
+use pf::constants::pfqueue qw($PFQUEUE_COUNTER $PFQUEUE_EXPIRED_COUNTER);
 use pf::config::pfqueue;
 use pf::util::pfqueue qw(consumer_redis_client);
 use pf::pfqueue::stats;
@@ -111,6 +112,20 @@ sub action_count {
     my ($queue) = $self->action_args;
     print $self->stats->queue_count($queue),"\n";
     return $EXIT_SUCCESS;
+}
+
+=head2 action_clear_expired_counters
+
+clear expired counters
+
+=cut
+
+sub action_clear_expired_counters {
+    my ($self) = @_;
+    my $redis = consumer_redis_client();
+    $redis->del($PFQUEUE_EXPIRED_COUNTER);
+    return $EXIT_SUCCESS;
+    return ;
 }
 
 =head1 AUTHOR

--- a/lib/pf/cmd/pf/pfqueue.pm
+++ b/lib/pf/cmd/pf/pfqueue.pm
@@ -125,7 +125,6 @@ sub action_clear_expired_counters {
     my $redis = consumer_redis_client();
     $redis->del($PFQUEUE_EXPIRED_COUNTER);
     return $EXIT_SUCCESS;
-    return ;
 }
 
 =head1 AUTHOR

--- a/lib/pf/cmd/pf/pfqueue.pm
+++ b/lib/pf/cmd/pf/pfqueue.pm
@@ -11,7 +11,7 @@ pf::cmd::pf::pfqueue
   Commands:
 
    clear <queue>          | clear a queue
-   clear_expired_counters | clear a queue
+   clear_expired_counters | clear expired tasks counters
    count <queue>          | show the queue count
    list                   | list all queues
    stats                  | show stats of pfqueue


### PR DESCRIPTION
Description
===========
Allow the pfqueue counters to be cleared via the cli

Impacts
=======
pfcmd

Delete branch after merge
=========================
NO

NEWS file entries
=================

Enhancements
------------
* New pfcmd command pfcmd pfqueue clear_expired_counters to clear the expired task counters