### PR TITLE
Systemd will no longer kill only master httpd process.

### DIFF
--- a/conf/systemd/packetfence-httpd.aaa.service
+++ b/conf/systemd/packetfence-httpd.aaa.service
@@ -14,13 +14,6 @@ PIDFile=/usr/local/pf/var/run/httpd.aaa.pid
 ExecStartPre=/usr/local/pf/bin/pfcmd service httpd.aaa generateconfig
 ExecStart=/usr/sbin/httpd -f /usr/local/pf/var/conf/httpd.conf.d/httpd.aaa -DFOREGROUND  -Drhel
 ExecReload=/bin/kill -USR1 ${MAINPID}
-ExecStop=/bin/kill -WINCH ${MAINPID}
-# We want systemd to give httpd some time to finish gracefully, but still want
-# it to kill httpd after TimeoutStopSec if something went wrong during the
-# graceful stop. Normally, Systemd sends SIGTERM signal right after the
-# ExecStop, which would kill httpd. We are sending useless SIGCONT here to give
-# httpd time to finish.
-KillSignal=SIGCONT
 PrivateTmp=true
 Restart=on-failure
 Slice=packetfence.slice

--- a/conf/systemd/packetfence-httpd.admin.service
+++ b/conf/systemd/packetfence-httpd.admin.service
@@ -20,7 +20,8 @@ ExecStop=/bin/kill -WINCH ${MAINPID}
 # graceful stop. Normally, Systemd sends SIGTERM signal right after the
 # ExecStop, which would kill httpd. We are sending useless SIGCONT here to give
 # httpd time to finish.
-KillMode=process
+TimeoutStopSec=60
+KillMode=mixed
 KillSignal=SIGCONT
 PrivateTmp=true
 Restart=on-failure

--- a/conf/systemd/packetfence-httpd.collector.service
+++ b/conf/systemd/packetfence-httpd.collector.service
@@ -19,6 +19,8 @@ ExecStop=/bin/kill -WINCH ${MAINPID}
 # graceful stop. Normally, Systemd sends SIGTERM signal right after the
 # ExecStop, which would kill httpd. We are sending useless SIGCONT here to give
 # httpd time to finish.
+TimeoutStopSec=60
+KillMode=mixed
 KillSignal=SIGCONT
 PrivateTmp=true
 Restart=on-failure

--- a/conf/systemd/packetfence-httpd.graphite.service
+++ b/conf/systemd/packetfence-httpd.graphite.service
@@ -19,6 +19,8 @@ ExecStop=/bin/kill -WINCH ${MAINPID}
 # graceful stop. Normally, Systemd sends SIGTERM signal right after the
 # ExecStop, which would kill httpd. We are sending useless SIGCONT here to give
 # httpd time to finish.
+TimeoutStopSec=60
+KillMode=mixed
 KillSignal=SIGCONT
 PrivateTmp=true
 Restart=on-failure

--- a/conf/systemd/packetfence-httpd.parking.service
+++ b/conf/systemd/packetfence-httpd.parking.service
@@ -18,6 +18,8 @@ ExecStop=/bin/kill -WINCH ${MAINPID}
 # graceful stop. Normally, Systemd sends SIGTERM signal right after the
 # ExecStop, which would kill httpd. We are sending useless SIGCONT here to give
 # httpd time to finish.
+TimeoutStopSec=60
+KillMode=mixed
 KillSignal=SIGCONT
 PrivateTmp=true
 Restart=on-failure

--- a/conf/systemd/packetfence-httpd.portal.service
+++ b/conf/systemd/packetfence-httpd.portal.service
@@ -19,6 +19,8 @@ ExecStop=/bin/kill -WINCH ${MAINPID}
 # graceful stop. Normally, Systemd sends SIGTERM signal right after the
 # ExecStop, which would kill httpd. We are sending useless SIGCONT here to give
 # httpd time to finish.
+TimeoutStopSec=60
+KillMode=mixed
 KillSignal=SIGCONT
 PrivateTmp=true
 Restart=on-failure

--- a/conf/systemd/packetfence-httpd.proxy.service
+++ b/conf/systemd/packetfence-httpd.proxy.service
@@ -13,13 +13,6 @@ PIDFile=/usr/local/pf/var/run/httpd.proxy.pid
 ExecStartPre=/usr/local/pf/bin/pfcmd service httpd.proxy generateconfig
 ExecStart=/usr/sbin/httpd -f /usr/local/pf/var/conf/httpd.conf.d/httpd.proxy -DFOREGROUND  -Drhel
 ExecReload=/bin/kill -USR1 ${MAINPID}
-ExecStop=/bin/kill -WINCH ${MAINPID}
-# We want systemd to give httpd some time to finish gracefully, but still want
-# it to kill httpd after TimeoutStopSec if something went wrong during the
-# graceful stop. Normally, Systemd sends SIGTERM signal right after the
-# ExecStop, which would kill httpd. We are sending useless SIGCONT here to give
-# httpd time to finish.
-KillSignal=SIGCONT
 PrivateTmp=true
 Restart=on-failure
 Slice=packetfence.slice

--- a/conf/systemd/packetfence-httpd.webservices.service
+++ b/conf/systemd/packetfence-httpd.webservices.service
@@ -19,6 +19,8 @@ ExecStop=/bin/kill -WINCH ${MAINPID}
 # graceful stop. Normally, Systemd sends SIGTERM signal right after the
 # ExecStop, which would kill httpd. We are sending useless SIGCONT here to give
 # httpd time to finish.
+TimeoutStopSec=60
+KillMode=mixed
 KillSignal=SIGCONT
 PrivateTmp=true
 Restart=on-failure


### PR DESCRIPTION
# Description
This changes the way systemd kills httpd processes.
It will no longer only kill the parent process.
I will now kill all processes left after a maximum of TimeoutStopSec.

# Impacts
When restarting httpd processes through systemd there should be no left over child processes.

# Issue
fixes #2439 

# Delete branch after merge
YES 

# NEWS file entries


## Bug Fixes
* Fixes leftover httpd processes when restarting (#2439)
