### PR TITLE
Use long key ids instead of (unsecure) short ids

### DIFF
--- a/docs/PacketFence_Administration_Guide.asciidoc
+++ b/docs/PacketFence_Administration_Guide.asciidoc
@@ -291,7 +291,7 @@ Once the repository is defined, you can install PacketFence with all its
 dependencies, and the required external services (Database
 server, DHCP server, RADIUS server) using:
 
-  sudo apt-key adv --keyserver keys.gnupg.net --recv-key 0x810273C4
+  sudo apt-key adv --keyserver keys.gnupg.net --recv-key 0xFE9E84327B18FF82B0378B6719CDA6A9810273C4
   sudo apt-get update
   sudo apt-get install packetfence
 

--- a/docs/PacketFence_PKI_Quick_Install_Guide.asciidoc
+++ b/docs/PacketFence_PKI_Quick_Install_Guide.asciidoc
@@ -82,7 +82,7 @@ In order to use the repository, create a file named `/etc/apt/sources.list.d/pac
 
 Once the repository is defined, you can install packetfence-pki using:
 
- # sudo apt-key adv --keyserver keys.gnupg.net --recv-key 0x810273C4
+ # sudo apt-key adv --keyserver keys.gnupg.net --recv-key 0xFE9E84327B18FF82B0378B6719CDA6A9810273C4
  # sudo apt-get update
  # sudo apt-get install packetfence-pki
 
@@ -95,7 +95,7 @@ In order to use the repository, create a file named `/etc/apt/sources.list.d/pac
 
 Once the repository is defined, you can install packetfence-pki using:
 
- # sudo apt-key adv --keyserver keys.gnupg.net --recv-key 0x810273C4
+ # sudo apt-key adv --keyserver keys.gnupg.net --recv-key 0xFE9E84327B18FF82B0378B6719CDA6A9810273C4
  # sudo apt-get update
  # sudo apt-get install packetfence-pki
 


### PR DESCRIPTION
# Description
Using 32bit key ids for GPG (the short ones) isn't recommended. It's trivial to generate keys with the same id in a few seconds (ref: https://evil32.com). The integrity checks with short ids wouldn't add a real security benefit.
Though it's easy to fix, just use 64bit key ids (the long ones). They currently are secure (for the technical situation of the next few years).

# Impacts
This PR changes the key ids mentioned in the documentation. **Please check carefully** whether they match your actual signing key (as I have the long key id from the keyservers).

# Delete branch after merge
yes

# Enhancements
* Introduces GPG's long key ids