### PR TITLE
Fix/normalize time type output

### DIFF
--- a/go/pfconfigdriver/structs.go
+++ b/go/pfconfigdriver/structs.go
@@ -69,7 +69,7 @@ type PfConfFencing struct {
 	Whitelist             string   `json:"whitelist"`
 	ProxyPassthroughs     []string `json:"proxy_passthroughs"`
 	Passthroughs          []string `json:"passthroughs"`
-	Redirtimer            string   `json:"redirtimer"`
+	Redirtimer            int      `json:"redirtimer"`
 	WaitForRedirect       string   `json:"wait_for_redirect"`
 	Passthrough           string   `json:"passthrough"`
 }

--- a/lib/pf/util.pm
+++ b/lib/pf/util.pm
@@ -1046,7 +1046,7 @@ sub normalize_time {
     } else {
         my ( $num, $modifier ) = $date =~ /^(\d+)($pf::constants::config::TIME_MODIFIER_RE)/ or return (0);
 
-        if ( $modifier eq "s" ) { return ($num);
+        if ( $modifier eq "s" ) { return ($num * 1);
         } elsif ( $modifier eq "m" ) { return ( $num * 60 );
         } elsif ( $modifier eq "h" ) { return ( $num * 60 * 60 );
         } elsif ( $modifier eq "D" ) { return ( $num * 24 * 60 * 60 );


### PR DESCRIPTION
# Description
Normalize the output time of pf::util::normalize_time so that its always an int instead of a string or an int

# Impacts
Everything that uses normalize_time which is a lot

# Issue
fixes #2489 

# Delete branch after merge
YES
