### PR TITLE
run the configreload as the pf user

### DIFF
--- a/lib/pf/cmd/pf/configreload.pm
+++ b/lib/pf/cmd/pf/configreload.pm
@@ -23,6 +23,7 @@ pf::cmd::pf::configreload
 use strict;
 use warnings;
 use pf::constants::exit_code qw($EXIT_SUCCESS);
+use pf::util;
 
 use base qw(pf::base::cmd::action_cmd);
 
@@ -41,6 +42,7 @@ sub action_hard {
 
 sub configreload {
     my ($self,$force)  = @_;
+    run_as_pf();
     require pf::config;
     pf::config::configreload($force);
     return $EXIT_SUCCESS;


### PR DESCRIPTION
# Description
Runs the configreload as the pf user

# Impacts
Command line config reload
It shouldn't cause any issue to do it as pf as the admin already runs as pf and reloads the config but unexpected stuff may occur so we will want to test this thoroughly.

# Code / PR Dependencies
#2509 because run_as_pf is defined in that PR

# Issue
Part of the fix for #2378

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* Run the configreload as the pf user when done through pfcmd
