### PR TITLE
Fix LLDP detection for Snom phones (regexp not matching mac address)

### DIFF
--- a/lib/pf/Switch/Brocade.pm
+++ b/lib/pf/Switch/Brocade.pm
@@ -288,7 +288,7 @@ sub getPhonesLLDPAtIfIndex {
                 );
                 next if (!defined($portIdResult));
                 if ($portIdResult->{"$oid_lldpRemPortId.$CISCO::DEFAULT_LLDP_REMTIMEMARK.$lldpPort.$lldpRemIndex"}
-                        =~ /^0x([0-9A-Z]{2})([0-9A-Z]{2})([0-9A-Z]{2})([0-9A-Z]{2})([0-9A-Z]{2})([0-9A-Z]{2})$/i) {
+                        =~ /^(?:0x)?([0-9A-Z]{2})([0-9A-Z]{2})([0-9A-Z]{2})([0-9A-Z]{2})([0-9A-Z]{2})([0-9A-Z]{2})(?::..)?$/i) {
                     push @phones, lc("$1:$2:$3:$4:$5:$6");
                 }
             }

--- a/lib/pf/Switch/Cisco/Catalyst_2950.pm
+++ b/lib/pf/Switch/Cisco/Catalyst_2950.pm
@@ -1125,7 +1125,7 @@ sub getPhonesLLDPAtIfIndex {
                 );
                 next if (!defined($portIdResult));
                 if ($portIdResult->{"$oid_lldpRemPortId.$CISCO::DEFAULT_LLDP_REMTIMEMARK.$lldpPort.$lldpRemIndex"}
-                        =~ /^0x([0-9A-Z]{2})([0-9A-Z]{2})([0-9A-Z]{2})([0-9A-Z]{2})([0-9A-Z]{2})([0-9A-Z]{2})$/i) {
+                        =~ /^(?:0x)?([0-9A-Z]{2})([0-9A-Z]{2})([0-9A-Z]{2})([0-9A-Z]{2})([0-9A-Z]{2})([0-9A-Z]{2})(?::..)?$/i) {
                     push @phones, lc("$1:$2:$3:$4:$5:$6");
                 }
             }

--- a/lib/pf/Switch/HP/Procurve_2920.pm
+++ b/lib/pf/Switch/HP/Procurve_2920.pm
@@ -103,7 +103,7 @@ sub getPhonesLLDPAtIfIndex {
                     );
                     if ($MACresult
                         && ($MACresult->{"$oid_lldpRemPortId.$cache_lldpRemTimeMark.$cache_lldpRemLocalPortNum.$cache_lldpRemIndex"}
-                            =~ /^0x([0-9A-Z]{2})([0-9A-Z]{2})([0-9A-Z]{2})([0-9A-Z]{2})([0-9A-Z]{2})([0-9A-Z]{2})$/i
+                            =~ /^(?:0x)?([0-9A-Z]{2})([0-9A-Z]{2})([0-9A-Z]{2})([0-9A-Z]{2})([0-9A-Z]{2})([0-9A-Z]{2})(?::..)?$/i
                         )
                         )
                     {

--- a/lib/pf/Switch/Nortel.pm
+++ b/lib/pf/Switch/Nortel.pm
@@ -775,7 +775,7 @@ sub getPhonesLLDPAtIfIndex {
                         && ($MACresult->{
                                 "$oid_lldpRemPortId.$cache_lldpRemTimeMark.$cache_lldpRemLocalPortNum.$cache_lldpRemIndex"
                             }
-                            =~ /^0x([0-9A-Z]{2})([0-9A-Z]{2})([0-9A-Z]{2})([0-9A-Z]{2})([0-9A-Z]{2})([0-9A-Z]{2})$/i
+                            =~ /^(?:0x)?([0-9A-Z]{2})([0-9A-Z]{2})([0-9A-Z]{2})([0-9A-Z]{2})([0-9A-Z]{2})([0-9A-Z]{2})(?::..)?$/i
                         )
                         )
                     {


### PR DESCRIPTION
# Description
Snom voip phones announce themeselves with the followinf string
`iso.0.8802.1.1.2.1.4.1.1.7.0.1.22 = STRING: "00041324FA59:P1"
`
in LLDP-MIB::lldpRemPortId.0

Packetfence matches this string to the following regexp to verify the mac address:
/^0x([0-9A-Z]{2})([0-9A-Z]{2})([0-9A-Z]{2})([0-9A-Z]{2})([0-9A-Z]{2})([0-9A-Z]{2})$/i

So we have to take into account the missing 0x at the start and the phone port at the end

# Impacts
LLDP detection of voip devices in Switch modules

# Issue
fixes #2524 

# Delete branch after merge
YES

## Bug Fixes
* LLDP detection for Snom phones, regexp not matching mac address (#2524)
