### PR TITLE
Fix/pfsso logging

### DIFF
--- a/conf/systemd/packetfence-httpd.dispatcher.service
+++ b/conf/systemd/packetfence-httpd.dispatcher.service
@@ -7,7 +7,7 @@ Before=packetfence-httpd.portal.service
 [Service]
 Type=notify
 LimitNOFILE=8192
-ExecStart=/usr/local/pf/bin/pfhttpd -conf /usr/local/pf/conf/caddy-services/httpdispatcher.conf
+ExecStart=/usr/local/pf/bin/pfhttpd -conf /usr/local/pf/conf/caddy-services/httpdispatcher.conf -log-name httpd.dispatcher
 Restart=on-failure
 Slice=packetfence.slice
 

--- a/conf/systemd/packetfence-pfsso.service
+++ b/conf/systemd/packetfence-pfsso.service
@@ -7,7 +7,7 @@ Before=packetfence-httpd.portal.service
 [Service]
 Type=notify
 LimitNOFILE=8192
-ExecStart=/usr/local/pf/bin/pfhttpd -conf /usr/local/pf/conf/caddy-services/pfsso.conf
+ExecStart=/usr/local/pf/bin/pfhttpd -conf /usr/local/pf/conf/caddy-services/pfsso.conf -log-name pfsso
 Restart=on-failure
 Slice=packetfence.slice
 

--- a/go/caddy/caddy/caddy/caddymain/run.go
+++ b/go/caddy/caddy/caddy/caddymain/run.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/xenolf/lego/acme"
 
+	"github.com/erikdubbelboer/gspt"
 	"github.com/inverse-inc/packetfence/go/caddy/caddy"
 	// plug in the HTTP server type
 	_ "github.com/inverse-inc/packetfence/go/caddy/caddy/caddyhttp"
@@ -27,6 +28,7 @@ import (
 	_ "github.com/inverse-inc/packetfence/go/caddy/pfsso"
 	_ "github.com/inverse-inc/packetfence/go/caddy/requestlimit"
 	_ "github.com/inverse-inc/packetfence/go/caddy/statsd"
+	pflog "github.com/inverse-inc/packetfence/go/log"
 )
 
 func init() {
@@ -47,6 +49,7 @@ func init() {
 	flag.StringVar(&serverType, "type", "http", "Type of server to run")
 	flag.BoolVar(&version, "version", false, "Show version")
 	flag.BoolVar(&validate, "validate", false, "Parse the Caddyfile but do not start the server")
+	flag.StringVar(&psName, "process-name", "pfhttpd", "Name of the process as shown by ps")
 
 	caddy.RegisterCaddyfileLoader("flag", caddy.LoaderFunc(confLoader))
 	caddy.SetDefaultCaddyfileLoader("default", caddy.LoaderFunc(defaultLoader))
@@ -55,6 +58,8 @@ func init() {
 // Run is Caddy's main() function.
 func Run() {
 	flag.Parse()
+	gspt.SetProcTitle(psName)
+	pflog.ProcessName = psName
 
 	caddy.AppName = appName
 	caddy.AppVersion = appVersion
@@ -248,6 +253,7 @@ var (
 	cpu        string
 	logfile    string
 	revoke     string
+	psName     string
 	version    bool
 	plugins    bool
 	validate   bool

--- a/go/caddy/caddy/caddy/caddymain/run.go
+++ b/go/caddy/caddy/caddy/caddymain/run.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/xenolf/lego/acme"
 
-	"github.com/erikdubbelboer/gspt"
 	"github.com/inverse-inc/packetfence/go/caddy/caddy"
 	// plug in the HTTP server type
 	_ "github.com/inverse-inc/packetfence/go/caddy/caddy/caddyhttp"
@@ -49,7 +48,7 @@ func init() {
 	flag.StringVar(&serverType, "type", "http", "Type of server to run")
 	flag.BoolVar(&version, "version", false, "Show version")
 	flag.BoolVar(&validate, "validate", false, "Parse the Caddyfile but do not start the server")
-	flag.StringVar(&psName, "process-name", "pfhttpd", "Name of the process as shown by ps")
+	flag.StringVar(&psName, "log-name", "pfhttpd", "Name of the process as sent to syslog")
 
 	caddy.RegisterCaddyfileLoader("flag", caddy.LoaderFunc(confLoader))
 	caddy.SetDefaultCaddyfileLoader("default", caddy.LoaderFunc(defaultLoader))
@@ -58,7 +57,6 @@ func init() {
 // Run is Caddy's main() function.
 func Run() {
 	flag.Parse()
-	gspt.SetProcTitle(psName)
 	pflog.ProcessName = psName
 
 	caddy.AppName = appName

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -57,6 +57,12 @@
 			"revisionTime": "2017-01-10T07:11:07Z"
 		},
 		{
+			"checksumSHA1": "A3dgvLcUyiMw566IDcxEg8YzDlo=",
+			"path": "github.com/erikdubbelboer/gspt",
+			"revision": "1413420207d2f210b0a7839ba51178e0781d437f",
+			"revisionTime": "2016-11-24T03:32:27Z"
+		},
+		{
 			"checksumSHA1": "VdXZPcDRHK1T7XjBu2KW8Mb8S6w=",
 			"path": "github.com/flynn/go-shlex",
 			"revision": "3f9db97f856818214da2e1057f8ad84803971cff",

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -57,12 +57,6 @@
 			"revisionTime": "2017-01-10T07:11:07Z"
 		},
 		{
-			"checksumSHA1": "A3dgvLcUyiMw566IDcxEg8YzDlo=",
-			"path": "github.com/erikdubbelboer/gspt",
-			"revision": "1413420207d2f210b0a7839ba51178e0781d437f",
-			"revisionTime": "2016-11-24T03:32:27Z"
-		},
-		{
 			"checksumSHA1": "VdXZPcDRHK1T7XjBu2KW8Mb8S6w=",
 			"path": "github.com/flynn/go-shlex",
 			"revision": "3f9db97f856818214da2e1057f8ad84803971cff",

--- a/packetfence.rsyslog
+++ b/packetfence.rsyslog
@@ -136,3 +136,7 @@ if $programname == "pfdetect" then -/usr/local/pf/logs/pfdetect.log
 if $programname == "pfbandwidthd" then -/usr/local/pf/logs/pfbandwidthd.log
 & stop
 
+# PFSSO
+if $programname == "pfsso" then -/usr/local/pf/logs/pfsso.log
+& stop
+

--- a/packetfence.rsyslog
+++ b/packetfence.rsyslog
@@ -137,6 +137,11 @@ if $programname == "pfbandwidthd" then -/usr/local/pf/logs/pfbandwidthd.log
 & stop
 
 # PFSSO
-if $programname == "pfsso" then -/usr/local/pf/logs/pfsso.log
+if $programname == "pfsso" then -/usr/local/pf/logs/packetfence.log
 & stop
 
+if $programname == "httpd.dispatcher" then -/usr/local/pf/logs/httpd.dispatcher.log
+& stop
+
+if $programname == "pfhttpd" then -/usr/local/pf/logs/packetfence.log
+& stop


### PR DESCRIPTION
# Description
Allows pfsso to log to a separate file.
Adds a command line option to pfhttpd to set the process name sent to syslog (does not actually set the process name as seen from ps).

# Impacts
Adds a pfsso.log destination to rsyslog.
Changes the pfsso unitfile to add the -log-name option to the command.

# Issue
fixes #2553 

# Delete branch after merge
YES 

# NEWS file entries

## Bug Fixes

* pfsso now logs to logs/pfsso.log (#2553)
