### PR TITLE
feature/ldap-source-cache-by-rule

### DIFF
--- a/t/data/authentication.conf
+++ b/t/data/authentication.conf
@@ -118,6 +118,29 @@ class=administration
 match=all
 action0=mark_as_sponsor=1
 
+[LDAP0]
+description=pf-test
+password=
+scope=sub
+binddn=CN=test,DC=inverse,DC=ca
+basedn=DC=ldap,DC=inverse,DC=ca
+usernameattribute=user
+connection_timeout=5
+encryption=none
+port=33389
+type=AD
+host=127.0.0.1
+cache_match=1
+
+[LDAP0 rule Network_Team_Auth]
+description=Full Access
+class=authentication
+match=any
+condition0=memberOf,equals,CN=NOC Users,DC=ldap,DC=inverse,DC=ca
+action0=set_role=default
+action1=set_unreg_date=2022-02-02
+
+
 [LDAP]
 description=pf-test
 password=
@@ -129,7 +152,7 @@ connection_timeout=5
 encryption=none
 port=33389
 type=AD
-host=localhost
+host=127.0.0.1
 cache_match=1
 
 [LDAP rule Network_Team_Auth]

--- a/t/ldap-auth-cache.t
+++ b/t/ldap-auth-cache.t
@@ -133,7 +133,7 @@ unless ($pid) {
         }
     );
     close($reader);
-    $writer->write("\n");
+    $writer->write("done\n");
     close($writer);
     $listener->Bind;
     exit 0;
@@ -157,7 +157,9 @@ use Test::NoWarnings;
 use pf::authentication;
 use pf::Authentication::constants;
 
-my $source = getAuthenticationSource('LDAP');
+my $source = getAuthenticationSource('LDAP0');
+
+$source->cache->clear;
 
 #my $ldap = Net::LDAP->new( 'localhost', port => 33389 ) or die "$@";
 
@@ -168,6 +170,7 @@ my $params = { username => 'bob'};
 is(0,SHM::getCount(),"No search was done");
 
 my @action = pf::authentication::match([$source], $params, $Actions::SET_ROLE);
+
 is(SHM::getCount(),1,"The search was done the first time");
 
 @action = pf::authentication::match([$source], $params, $Actions::SET_ROLE);


### PR DESCRIPTION
Description
===========
Cache ldap matches by source id, rule id, and filter id

Impacts
=======
Ldap sources when mathing rules

Issue
=====
Fixes #2346

Delete branch after merge
=========================
NO

NEWS file entries
=================

Enhancements
------------
* Make LDAP Source cache more granular