### PR TITLE
Refactor realms

### DIFF
--- a/addons/upgrade/to-7.3-authentication-conf.pl
+++ b/addons/upgrade/to-7.3-authentication-conf.pl
@@ -37,12 +37,13 @@ for my $section ( $inirealm->Sections() ) {
             if (my $previous = $iniauth->val($authsection, 'realm')) {
                 $iniauth->setval($authsection, 'realm', lc($section).",$previous");
             } else {
-                $iniauth->setval($authsection, 'realm', lc($section));
+                $iniauth->newval($authsection, 'realm', lc($section));
             }
         }
     }
     $inirealm->delval($section, 'source');
 }
+$iniauth->newval('local', 'realm', 'null');
 $inirealm->RewriteConfig();
 $iniauth->RewriteConfig();
 

--- a/addons/upgrade/to-7.3-authentication-conf.pl
+++ b/addons/upgrade/to-7.3-authentication-conf.pl
@@ -1,0 +1,74 @@
+#!/usr/bin/perl
+
+=head1 NAME
+
+Move source associated to a realm to realms associated to a source 
+
+=cut
+
+=head1 DESCRIPTION
+
+Moved realms to authentication.conf that was defined in realm.conf
+
+=cut
+
+use strict;
+use warnings;
+use lib qw(/usr/local/pf/lib);
+use pf::IniFiles;
+use pf::file_paths qw($authentication_config_file $realm_config_file);
+
+exit 0 unless -e $realm_config_file;
+exit 0 unless -e $authentication_config_file;
+
+my $inirealm =
+  pf::IniFiles->new( -file => $realm_config_file, -allowempty => 1 );
+
+my $iniauth =
+  pf::IniFiles->new( -file => $authentication_config_file, -allowempty => 1 );
+
+for my $section ( $inirealm->Sections() ) {
+    next if $section =~ / /;
+    next unless $inirealm->exists( $section, 'source' );
+    my $source = $inirealm->val( $section, 'source' );
+    
+    for my $authsection ( $iniauth->Sections() ) {
+        if ($authsection eq $source) {
+            if (my $previous = $iniauth->val($authsection, 'realm')) {
+                $iniauth->setval($authsection, 'realm', lc($section).",$previous");
+            } else {
+                $iniauth->setval($authsection, 'realm', lc($section));
+            }
+        }
+    }
+    $inirealm->delval($section, 'source');
+}
+$inirealm->RewriteConfig();
+$iniauth->RewriteConfig();
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2017 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut

--- a/addons/upgrade/to-7.3-authentication-conf.pl
+++ b/addons/upgrade/to-7.3-authentication-conf.pl
@@ -32,7 +32,7 @@ for my $section ( $inirealm->Sections() ) {
     next if $section =~ / /;
     next unless $inirealm->exists( $section, 'source' );
     my $source = $inirealm->val( $section, 'source' );
-    
+
     for my $authsection ( $iniauth->Sections() ) {
         if ($authsection eq $source) {
             if (my $previous = $iniauth->val($authsection, 'realm')) {
@@ -48,6 +48,12 @@ for my $section ( $inirealm->Sections() ) {
 for my $authsection ( $iniauth->Sections() ) {
     next if $authsection =~ / /;
     my $source_def = pf::authentication::getAuthenticationSource($authsection);
+    if ( defined($iniauth->val($authsection, 'type')) && $iniauth->val($authsection, 'type') eq 'Kerberos') {
+        if (defined($iniauth->val( $authsection, 'realm'))) {
+            $iniauth->newval($authsection, 'authenticate_realm', $iniauth->val( $authsection, 'realm'));
+            $iniauth->setval($authsection, 'realm', 'null');
+        }
+    }
     if ($source_def->class eq 'internal') {
          if (!defined($iniauth->val( $authsection, 'realm')) || $iniauth->val( $authsection, 'realm') eq '') {
              $iniauth->setval( $authsection, 'realm', 'null');

--- a/addons/upgrade/to-7.3-authentication-conf.pl
+++ b/addons/upgrade/to-7.3-authentication-conf.pl
@@ -35,10 +35,10 @@ for my $section ( $inirealm->Sections() ) {
 
     for my $authsection ( $iniauth->Sections() ) {
         if ($authsection eq $source) {
-            if (my $previous = $iniauth->val($authsection, 'realm')) {
-                $iniauth->setval($authsection, 'realm', lc($section).",$previous");
+            if (my $previous = $iniauth->val($authsection, 'realms')) {
+                $iniauth->setval($authsection, 'realms', lc($section).",$previous");
             } else {
-                $iniauth->newval($authsection, 'realm', lc($section));
+                $iniauth->newval($authsection, 'realms', lc($section));
             }
         }
     }
@@ -49,14 +49,14 @@ for my $authsection ( $iniauth->Sections() ) {
     next if $authsection =~ / /;
     my $source_def = pf::authentication::getAuthenticationSource($authsection);
     if ( defined($iniauth->val($authsection, 'type')) && $iniauth->val($authsection, 'type') eq 'Kerberos') {
-        if (defined($iniauth->val( $authsection, 'realm'))) {
+        if (defined($iniauth->val( $authsection, 'realms'))) {
             $iniauth->newval($authsection, 'authenticate_realm', $iniauth->val( $authsection, 'realm'));
-            $iniauth->setval($authsection, 'realm', 'null');
+            $iniauth->setval($authsection, 'realms', 'null');
         }
     }
     if ($source_def->class eq 'internal') {
-         if (!defined($iniauth->val( $authsection, 'realm')) || $iniauth->val( $authsection, 'realm') eq '') {
-             $iniauth->setval( $authsection, 'realm', 'null');
+         if (!defined($iniauth->val( $authsection, 'realms')) || $iniauth->val( $authsection, 'realms') eq '') {
+             $iniauth->setval( $authsection, 'realms', 'null');
          }
     }
 }

--- a/conf/authentication.conf.example
+++ b/conf/authentication.conf.example
@@ -1,6 +1,7 @@
 [local]
 description=Local Users
 type=SQL
+realm=null
 
 [file1]
 description=Legacy Source

--- a/conf/authentication.conf.example
+++ b/conf/authentication.conf.example
@@ -7,6 +7,7 @@ realm=null
 description=Legacy Source
 path=/usr/local/pf/conf/admin.conf
 type=Htpasswd
+realm=null
 
 [file1 rule admins]
 description=All admins

--- a/conf/authentication.conf.example
+++ b/conf/authentication.conf.example
@@ -1,13 +1,13 @@
 [local]
 description=Local Users
 type=SQL
-realm=null
+realms=null
 
 [file1]
 description=Legacy Source
 path=/usr/local/pf/conf/admin.conf
 type=Htpasswd
-realm=null
+realms=null
 
 [file1 rule admins]
 description=All admins

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Authenticate.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Authenticate.pm
@@ -157,13 +157,10 @@ sub getSources : Private {
         }
     }
 
-    my $realm_source = get_realm_authentication_source($stripped_username, $realm);
-    if( $realm_source && any { $_ eq $realm_source} @sources ){
+    my $realm_source = get_realm_authentication_source($stripped_username, $realm, @sources);
+    if (ref($realm_source) eq 'ARRAY') {
         $c->log->info("Realm source is part of the connection profile sources. Using it as the only auth source.");
         return ($realm_source);
-    }
-    elsif ( $realm_source ) {
-        $c->log->info("Realm source ".$realm_source->id." is configured in the realm $realm but is not in the connection profile. Ignoring it and using the connection profile sources.");
     }
     return @sources;
 }

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Authenticate.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Authenticate.pm
@@ -115,7 +115,7 @@ sub authenticationLogin : Private {
 
     # validate login and password
     ( $return, $message, $source_id, $extra ) =
-      pf::authentication::authenticate( { 'username' => $username, 'password' => $password, 'rule_class' => $Rules::AUTH }, @sources );
+      pf::authentication::authenticate( { 'username' => $username, 'password' => $password, 'rule_class' => $Rules::AUTH }, @{$sources} );
     if ( defined($return) && $return == 1 ) {
         pf::auth_log::record_auth($source_id, $portalSession->clientMac, $username, $pf::auth_log::COMPLETED);
         # save login into session
@@ -128,7 +128,7 @@ sub authenticationLogin : Private {
         # Logging USER/IP/MAC of the just-authenticated user
         $logger->info("Successfully authenticated ".$username."/".$portalSession->clientIP->normalizedIP."/".$portalSession->clientMac);
     } else {
-        pf::auth_log::record_auth(join(',',map { $_->id } @sources), $portalSession->clientMac, $username, $pf::auth_log::FAILED);
+        pf::auth_log::record_auth(join(',',map { $_->id } @{$sources}), $portalSession->clientMac, $username, $pf::auth_log::FAILED);
         $c->error($message);
     }
 }

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Authenticate.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Authenticate.pm
@@ -104,11 +104,11 @@ sub authenticationLogin : Private {
     my ($stripped_username, $realm) = strip_username($username);
     my $password = $request->param("password");
 
-    my @sources = $self->getSources($c, $username, $realm);
+    my $sources = $self->getSources($c, $username, $realm);
 
     # If all sources use the stripped username, we strip it
     # Otherwise, we leave it as is
-    my $use_stripped = all { isenabled($_->{stripped_user_name}) } @sources;
+    my $use_stripped = all { isenabled($_->{stripped_user_name}) } @{$sources};
     if($use_stripped){
         $username = $stripped_username;
     }
@@ -157,12 +157,12 @@ sub getSources : Private {
         }
     }
 
-    my $realm_source = get_realm_authentication_source($stripped_username, $realm, @sources);
+    my $realm_source = get_realm_authentication_source($stripped_username, $realm, \@sources);
     if (ref($realm_source) eq 'ARRAY') {
         $c->log->info("Realm source is part of the connection profile sources. Using it as the only auth source.");
         return ($realm_source);
     }
-    return @sources;
+    return \@sources;
 }
 
 sub _clean_username {

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/Login.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/Login.pm
@@ -124,10 +124,10 @@ sub authenticate {
 
     my ($stripped_username, $realm) = strip_username($username);
 
-    my @sources = filter_authentication_sources($self->sources, $stripped_username, $realm);
-    get_logger->info("Authenticating user using sources : ", join(',', (map {$_->id} @sources)));
+    my $sources = filter_authentication_sources($self->sources, $stripped_username, $realm);
+    get_logger->info("Authenticating user using sources : ", join(',', (map {$_->id} @{$sources})));
 
-    unless(@sources){
+    unless(@{$sources}){
         get_logger->info("No sources found for $username");
         $self->app->flash->{error} = "No authentication source found for this username";
         $self->prompt_fields();
@@ -136,7 +136,7 @@ sub authenticate {
 
     # If all sources use the stripped username, we strip it
     # Otherwise, we leave it as is
-    my $use_stripped = all { isenabled($_->{stripped_user_name}) } @sources;
+    my $use_stripped = all { isenabled($_->{stripped_user_name}) } @{$sources};
     if($use_stripped){
         $username = $stripped_username;
     }
@@ -155,7 +155,7 @@ sub authenticate {
         get_logger->info("Reusing 802.1x credentials with username '$username' and realm '$realm'");
 
         # Fetch appropriate source to use with 'reuseDot1xCredentials' feature
-        my $source = pf::config::util::get_realm_authentication_source($username, $realm, @sources);
+        my $source = pf::config::util::get_realm_authentication_source($username, $realm, \@{$sources});
         
         # No source found for specified realm
         unless ( ref($source) eq 'ARRAY' ) {

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/Login.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/Login.pm
@@ -176,8 +176,7 @@ sub authenticate {
             realm => $node_info->{'realm'},
         };
         my $source_id;
-        my $role;
-        $role = pf::authentication::match([@{$source}], $params, $Actions::SET_ROLE, \$source_id);
+        my $role = pf::authentication::match([@{$source}], $params, $Actions::SET_ROLE, \$source_id);
 
         if ( defined($role) ) {
             $self->source(pf::authentication::getAuthenticationSource($source_id));

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/Login.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/Login.pm
@@ -155,10 +155,10 @@ sub authenticate {
         get_logger->info("Reusing 802.1x credentials with username '$username' and realm '$realm'");
 
         # Fetch appropriate source to use with 'reuseDot1xCredentials' feature
-        my $source = pf::config::util::get_realm_authentication_source($username, $realm);
+        my $source = pf::config::util::get_realm_authentication_source($username, $realm, @sources);
         
         # No source found for specified realm
-        unless ( defined($source) ) {
+        unless ( ref($source) eq 'ARRAY' ) {
             get_logger->error("Unable to find an authentication source for the specified realm '$realm' while using reuseDot1xCredentials");
             $self->app->flash->{error} = "Cannot find a valid authentication source for '" . $node_info->{'last_dot1x_username'} . "'";
 
@@ -176,7 +176,8 @@ sub authenticate {
             realm => $node_info->{'realm'},
         };
         my $source_id;
-        my $role = pf::authentication::match($source->id, $params, $Actions::SET_ROLE, \$source_id);
+        my $role;
+        $role = pf::authentication::match([@{$source}], $params, $Actions::SET_ROLE, \$source_id);
 
         if ( defined($role) ) {
             $self->source(pf::authentication::getAuthenticationSource($source_id));

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/Login.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/Login.pm
@@ -198,9 +198,9 @@ sub authenticate {
 
         # validate login and password
         my ( $return, $message, $source_id, $extra ) =
-          pf::authentication::authenticate( { 'username' => $username, 'password' => $password, 'rule_class' => $Rules::AUTH }, @sources );
+          pf::authentication::authenticate( { 'username' => $username, 'password' => $password, 'rule_class' => $Rules::AUTH }, @{$sources} );
         if (!defined $return || $return == $LOGIN_FAILURE) {
-            pf::auth_log::record_auth(join(',',map { $_->id } @sources), $self->current_mac, $username, $pf::auth_log::FAILED);
+            pf::auth_log::record_auth(join(',',map { $_->id } @{$sources}), $self->current_mac, $username, $pf::auth_log::FAILED);
             $self->app->flash->{error} = $message;
             $self->prompt_fields();
             return;

--- a/html/pfappserver/lib/pfappserver/Authentication/Store/PacketFence/User.pm
+++ b/html/pfappserver/lib/pfappserver/Authentication/Store/PacketFence/User.pm
@@ -51,7 +51,7 @@ sub check_password {
   my $user = $self->{_user};
   if (ref($realm_source) eq 'ARRAY') {
     foreach my $source (@{$realm_source}) {
-      get_logger->info("Found realm source ".$source->id." for user $stripped_username in realm $realm. Using it as the only source.");
+      get_logger->info("Found a realm source ".$source->id." for user $stripped_username in realm $realm.");
       $user = isenabled($source->{'stripped_user_name'}) ? $stripped_username : $self->{_user};
       my ($result, $message, $source_id, $extra) = pf::authentication::authenticate( { 'username' => $user, 'password' => $password, 'rule_class' => $Rules::ADMIN }, $source);
       if ($result) {

--- a/html/pfappserver/lib/pfappserver/Base/Form/Role/InternalSource.pm
+++ b/html/pfappserver/lib/pfappserver/Base/Form/Role/InternalSource.pm
@@ -31,7 +31,7 @@ has_field 'stripped_user_name' => (
         help          => 'Use stripped username to test the  rules.'
     },
 );
-has_field 'realm' => (
+has_field 'realms' => (
     type           => 'Select',
     multiple       => 1,
     label          => 'Associated Realms',
@@ -46,7 +46,7 @@ has_field 'realm' => (
 );
 
 has_block internal_sources => (
-    render_list => [qw(stripped_user_name realm)],
+    render_list => [qw(stripped_user_name realms)],
 );
 
 =head2 options_realm

--- a/html/pfappserver/lib/pfappserver/Base/Form/Role/InternalSource.pm
+++ b/html/pfappserver/lib/pfappserver/Base/Form/Role/InternalSource.pm
@@ -1,0 +1,92 @@
+package pfappserver::Base::Form::Role::InternalSource;
+
+=head1 NAME
+
+pfappserver::Base::Form::Role::InternalSource - Role for Local Accounts
+
+=cut
+
+=head1 DESCRIPTION
+
+pfappserver::Base::Form::Role::InternalSource
+
+=cut
+
+use strict;
+use warnings;
+use namespace::autoclean;
+use HTML::FormHandler::Moose::Role;
+use pf::config qw(%ConfigRealm);
+with 'pfappserver::Base::Form::Role::Help';
+
+has_field 'stripped_user_name' => (
+    type            => 'Toggle',
+    checkbox_value  => 'yes',
+    unchecked_value => 'no',
+    default         => 'yes',
+    order_index     => 0,
+    label           => 'Use stripped username ',
+    tags            => {
+        after_element => \&help,
+        help          => 'Use stripped username to test the  rules.'
+    },
+);
+has_field 'realm' => (
+    type           => 'Select',
+    multiple       => 1,
+    label          => 'Associated Realms',
+    options_method => \&options_realm,
+    element_class  => ['chzn-deselect'],
+    element_attr   => { 'data-placeholder' => 'Click to add a realm' },
+    tags           => {
+        after_element => \&help,
+        help          => 'Realms that will be associated with this source'
+    },
+    default => '',
+);
+
+has_block internal_sources => (
+    render_list => [qw(stripped_user_name realm)],
+);
+
+=head2 options_realm
+
+retrive the realms
+
+=cut
+
+sub options_realm {
+    my ($self) = @_;
+    my @roles = map { $_ => $_ } sort keys %ConfigRealm;
+    return @roles;
+}
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2017 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;
+

--- a/html/pfappserver/lib/pfappserver/Form/Config/Authentication/Source/LDAP.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Authentication/Source/LDAP.pm
@@ -92,16 +92,6 @@ has_field 'password' =>
    label => 'Password',
    trim => undef,
   );
-has_field 'stripped_user_name' =>
-  (
-   type            => 'Toggle',
-   checkbox_value  => 'yes',
-   unchecked_value => 'no',
-   default         => 'yes',
-   label           => 'Use stripped username ',
-   tags => { after_element => \&help,
-             help => 'Use stripped username returned by RADIUS to test the following rules.' },
-  );
 
 has_field 'cache_match',
   (

--- a/html/pfappserver/lib/pfappserver/Form/Config/Authentication/Source/RADIUS.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Authentication/Source/RADIUS.pm
@@ -42,16 +42,6 @@ has_field 'timeout' =>
    element_class => ['input-mini'],
    element_attr => {'placeholder' => '1'},
   );
-has_field 'stripped_user_name' =>
-  (
-   type            => 'Toggle',
-   checkbox_value  => 'yes',
-   unchecked_value => 'no',
-   default         => 'yes',
-   label           => 'Use stripped username ',
-   tags => { after_element => \&help,
-             help => 'Use stripped username returned by RADIUS to test the following rules.' },
-  );
 
 =head1 COPYRIGHT
 

--- a/html/pfappserver/lib/pfappserver/Form/Config/Realm.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Realm.pm
@@ -19,7 +19,6 @@ use pf::authentication;
 use pf::util;
 
 has domains => ( is => 'rw');
-has sources => ( is => 'rw');
 
 ## Definition
 has_field 'id' =>
@@ -52,20 +51,6 @@ has_field 'domain' =>
              help => 'The domain to use for the authentication in that realm' },
   );
 
-has_field 'source' =>
-  (
-   type => 'Select',
-   multiple => 0,
-   label => 'Source',
-   options_method => \&options_sources,
-   element_class => ['chzn-deselect'],
-   element_attr => {'data-placeholder' => 'Click to select a source'},
-   tags => { after_element => \&help,
-             help => 'The authentication source to use in that realm.<br/>(Must also be defined in the connection profile)' },
-  );
-
-
-
 =head2 options_roles
 
 =cut
@@ -77,17 +62,6 @@ sub options_domains {
     return @domains;
 }
 
-=head2 options_sources
-
-=cut
-
-sub options_sources {
-    my $self = shift;
-    my @sources = map { $_->id => $_->id } @{$self->form->sources} if ($self->form->sources);
-    unshift @sources, ("" => "");
-    return @sources;
-}
-
 =head2 ACCEPT_CONTEXT
 
 To automatically add the context to the Form
@@ -97,7 +71,7 @@ To automatically add the context to the Form
 sub ACCEPT_CONTEXT {
     my ($self, $c, @args) = @_;
     my (undef, $domains) = $c->model('Config::Domain')->readAll();
-    return $self->SUPER::ACCEPT_CONTEXT($c, domains => $domains, sources => pf::authentication::getInternalAuthenticationSources(), @args);
+    return $self->SUPER::ACCEPT_CONTEXT($c, domains => $domains, @args);
 }
 
 

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source.pm
@@ -374,8 +374,11 @@ sub getSourceArgs {
             }
         }
     }
-    if (ref($args->{'realm'}) ne "ARRAY") {
-        $args->{'realm'} = [$args->{'realm'}];
+    for my $r (qw(realm)) {
+        $args->{$r} //= [];
+        if (ref($args->{$r}) ne "ARRAY" ) {
+            $args->{$r} = [$args->{$r}];
+        }
     }
     return $args;
 }

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source.pm
@@ -374,6 +374,9 @@ sub getSourceArgs {
             }
         }
     }
+    if (ref($args->{'realm'}) ne "ARRAY") {
+        $args->{'realm'} = [$args->{'realm'}];
+    }
     return $args;
 }
 

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source.pm
@@ -131,6 +131,11 @@ has_block local_account =>
     render_list => [],
   );
 
+has_block internal_sources =>
+  (
+    render_list => [],
+  );
+
 
 has_block action_templates => (
     attr => {
@@ -163,6 +168,8 @@ our %EXCLUDE = (
     local_account => 1,
     create_local_account => 1,
     local_account_logins => 1,
+    stripped_user_name => 1,
+    realm => 1,
     (map { ("${_}_rules"  => 1) } @Rules::CLASSES),
     (map { ("${_}_action" => 1) } keys %ACTION_FIELD_OPTIONS),
     (map { ("${_}_operator" => 1, "${_}_value" => 1) } @Conditions::TYPES),

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source.pm
@@ -52,19 +52,6 @@ has_field 'description' =>
    default => '',
   );
 
-has_field 'realm' =>
-  (
-   type => 'Select',
-   multiple => 1,
-   label => 'Associated Realms',
-   options_method => \&options_realm,
-   element_class => ['chzn-deselect'],
-   element_attr => {'data-placeholder' => 'Click to add a realm'},
-   tags => { after_element => \&help,
-             help => 'Realms that will be associated with this source' },
-   default => '',
-  );
-
 has_field "${Rules::AUTH}_rules" =>
   (
    type => 'DynamicList',
@@ -394,7 +381,7 @@ sub getSourceArgs {
             }
         }
     }
-    for my $r (qw(realm)) {
+    for my $r (qw(realms)) {
         $args->{$r} //= [];
         if (ref($args->{$r}) ne "ARRAY" ) {
             $args->{$r} = [$args->{$r}];
@@ -441,18 +428,6 @@ sub validate {
         }
     }
     return ;
-}
-
-=head2 options_realm
-
-retrive the realms
-
-=cut
-
-sub options_realm {
-    my ($self) = @_;
-    my @roles = map { $_ => $_ } sort keys %pf::config::ConfigRealm;
-    return @roles;
 }
 
 =head1 COPYRIGHT

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source.pm
@@ -156,7 +156,7 @@ our %EXCLUDE = (
     create_local_account => 1,
     local_account_logins => 1,
     stripped_user_name => 1,
-    realm => 1,
+    realms => 1,
     (map { ("${_}_rules"  => 1) } @Rules::CLASSES),
     (map { ("${_}_action" => 1) } keys %ACTION_FIELD_OPTIONS),
     (map { ("${_}_operator" => 1, "${_}_value" => 1) } @Conditions::TYPES),

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source.pm
@@ -52,6 +52,19 @@ has_field 'description' =>
    default => '',
   );
 
+has_field 'realm' =>
+  (
+   type => 'Select',
+   multiple => 1,
+   label => 'Associated Realms',
+   options_method => \&options_realm,
+   element_class => ['chzn-deselect'],
+   element_attr => {'data-placeholder' => 'Click to add a realm'},
+   tags => { after_element => \&help,
+             help => 'Realms that will be associated with this source' },
+   default => '',
+  );
+
 has_field "${Rules::AUTH}_rules" =>
   (
    type => 'DynamicList',
@@ -421,6 +434,18 @@ sub validate {
         }
     }
     return ;
+}
+
+=head2 options_realm
+
+retrive the realms
+
+=cut
+
+sub options_realm {
+    my ($self) = @_;
+    my @roles = map { $_ => $_ } sort keys %pf::config::ConfigRealm;
+    return @roles;
 }
 
 =head1 COPYRIGHT

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source/HTTP.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source/HTTP.pm
@@ -73,6 +73,43 @@ has_field 'authorization_url' =>
    tags => { after_element => \&help,
              help => 'Note : The URL is always prefixed by a slash (/)' },
   );
+has_field 'stripped_user_name' =>
+  (
+   type            => 'Toggle',
+   checkbox_value  => 'yes',
+   unchecked_value => 'no',
+   default         => 'yes',
+   label           => 'Use stripped username ',
+   tags => { after_element => \&help,
+             help => 'Use stripped username returned by RADIUS to test the following rules.' },
+  );
+
+has_field 'realm' =>
+  (
+   type => 'Select',
+   multiple => 1,
+   label => 'Associated Realms',
+   options_method => \&options_realm,
+   element_class => ['chzn-deselect'],
+   element_attr => {'data-placeholder' => 'Click to add a realm'},
+   tags => { after_element => \&help,
+             help => 'Realms that will be associated with this source' },
+   default => '',
+  );
+
+=head2 options_realm
+
+retrive the realms
+
+=cut
+
+sub options_realm {
+    my ($self) = @_;
+    my @roles = map { $_ => $_ } sort keys %pf::config::ConfigRealm;
+    return @roles;
+}
+
+
 =head1 COPYRIGHT
 
 Copyright (C) 2005-2017 Inverse inc.

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source/HTTP.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source/HTTP.pm
@@ -81,34 +81,8 @@ has_field 'stripped_user_name' =>
    default         => 'yes',
    label           => 'Use stripped username ',
    tags => { after_element => \&help,
-             help => 'Use stripped username returned by RADIUS to test the following rules.' },
+             help => 'Use stripped username to test the following rules.' },
   );
-
-has_field 'realm' =>
-  (
-   type => 'Select',
-   multiple => 1,
-   label => 'Associated Realms',
-   options_method => \&options_realm,
-   element_class => ['chzn-deselect'],
-   element_attr => {'data-placeholder' => 'Click to add a realm'},
-   tags => { after_element => \&help,
-             help => 'Realms that will be associated with this source' },
-   default => '',
-  );
-
-=head2 options_realm
-
-retrive the realms
-
-=cut
-
-sub options_realm {
-    my ($self) = @_;
-    my @roles = map { $_ => $_ } sort keys %pf::config::ConfigRealm;
-    return @roles;
-}
-
 
 =head1 COPYRIGHT
 

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source/HTTP.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source/HTTP.pm
@@ -13,7 +13,7 @@ Form definition to create or update a HTTP user source.
 use HTML::FormHandler::Moose;
 use pf::Authentication::Source::HTTPSource;
 extends 'pfappserver::Form::Config::Source';
-with 'pfappserver::Base::Form::Role::Help';
+with 'pfappserver::Base::Form::Role::Help', 'pfappserver::Base::Form::Role::InternalSource';
 
 # Form fields
 has_field 'host' =>
@@ -72,16 +72,6 @@ has_field 'authorization_url' =>
    required => 1,
    tags => { after_element => \&help,
              help => 'Note : The URL is always prefixed by a slash (/)' },
-  );
-has_field 'stripped_user_name' =>
-  (
-   type            => 'Toggle',
-   checkbox_value  => 'yes',
-   unchecked_value => 'no',
-   default         => 'yes',
-   label           => 'Use stripped username ',
-   tags => { after_element => \&help,
-             help => 'Use stripped username to test the following rules.' },
   );
 
 =head1 COPYRIGHT

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source/Htpasswd.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source/Htpasswd.pm
@@ -36,6 +36,32 @@ has_field 'stripped_user_name' =>
              help => 'Use stripped username returned by RADIUS to test the following rules.' },
   );
 
+has_field 'realm' =>
+  (
+   type => 'Select',
+   multiple => 1,
+   label => 'Associated Realms',
+   options_method => \&options_realm,
+   element_class => ['chzn-deselect'],
+   element_attr => {'data-placeholder' => 'Click to add a realm'},
+   tags => { after_element => \&help,
+             help => 'Realms that will be associated with this source' },
+   default => '',
+  );
+
+=head2 options_realm
+
+retrive the realms
+
+=cut
+
+sub options_realm {
+    my ($self) = @_;
+    my @roles = map { $_ => $_ } sort keys %pf::config::ConfigRealm;
+    return @roles;
+}
+
+
 =head2 validate
 
 Make sure the htpasswd file is readable.

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source/Htpasswd.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source/Htpasswd.pm
@@ -13,7 +13,7 @@ Form definition to create or update a htpasswd user source.
 use HTML::FormHandler::Moose;
 use pf::Authentication::Source::HtpasswdSource;
 extends 'pfappserver::Form::Config::Source';
-with 'pfappserver::Base::Form::Role::Help';
+with 'pfappserver::Base::Form::Role::Help', 'pfappserver::Base::Form::Role::InternalSource';
 
 # Form fields
 has_field 'path' =>
@@ -24,16 +24,6 @@ has_field 'path' =>
    element_class => ['input-xxlarge'],
    # Default value needed for creating dummy source
    default => '',
-  );
-has_field 'stripped_user_name' =>
-  (
-   type            => 'Toggle',
-   checkbox_value  => 'yes',
-   unchecked_value => 'no',
-   default         => 'yes',
-   label           => 'Use stripped username ',
-   tags => { after_element => \&help,
-             help => 'Use stripped username returned by RADIUS to test the following rules.' },
   );
 
 =head2 validate

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source/Htpasswd.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source/Htpasswd.pm
@@ -36,32 +36,6 @@ has_field 'stripped_user_name' =>
              help => 'Use stripped username returned by RADIUS to test the following rules.' },
   );
 
-has_field 'realm' =>
-  (
-   type => 'Select',
-   multiple => 1,
-   label => 'Associated Realms',
-   options_method => \&options_realm,
-   element_class => ['chzn-deselect'],
-   element_attr => {'data-placeholder' => 'Click to add a realm'},
-   tags => { after_element => \&help,
-             help => 'Realms that will be associated with this source' },
-   default => '',
-  );
-
-=head2 options_realm
-
-retrive the realms
-
-=cut
-
-sub options_realm {
-    my ($self) = @_;
-    my @roles = map { $_ => $_ } sort keys %pf::config::ConfigRealm;
-    return @roles;
-}
-
-
 =head2 validate
 
 Make sure the htpasswd file is readable.

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source/Kerberos.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source/Kerberos.pm
@@ -25,14 +25,15 @@ has_field 'host' =>
    element_class => ['input-small'],
    element_attr => {'placeholder' => '127.0.0.1'},
   );
-has_field 'realm' =>
+has_field 'authenticate_realm' =>
   (
    type => 'Text',
-   label => 'Realm',
+   label => 'Realm to use to authenticate',
    required => 1,
    # Default value needed for creating dummy source
    default => "",
   );
+
 has_field 'stripped_user_name' =>
   (
    type            => 'Toggle',
@@ -43,6 +44,31 @@ has_field 'stripped_user_name' =>
    tags => { after_element => \&help,
              help => 'Use stripped username returned by RADIUS to test the following rules.' },
   );
+
+has_field 'realm' =>
+  (
+   type => 'Select',
+   multiple => 1,
+   label => 'Associated Realms',
+   options_method => \&options_realm,
+   element_class => ['chzn-deselect'],
+   element_attr => {'data-placeholder' => 'Click to add a realm'},
+   tags => { after_element => \&help,
+             help => 'Realms that will be associated with this source' },
+   default => '',
+  );
+
+=head2 options_realm
+
+retrive the realms
+
+=cut
+
+sub options_realm {
+    my ($self) = @_;
+    my @roles = map { $_ => $_ } sort keys %pf::config::ConfigRealm;
+    return @roles;
+}
 
 =head1 COPYRIGHT
 

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source/Kerberos.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source/Kerberos.pm
@@ -45,31 +45,6 @@ has_field 'stripped_user_name' =>
              help => 'Use stripped username returned by RADIUS to test the following rules.' },
   );
 
-has_field 'realm' =>
-  (
-   type => 'Select',
-   multiple => 1,
-   label => 'Associated Realms',
-   options_method => \&options_realm,
-   element_class => ['chzn-deselect'],
-   element_attr => {'data-placeholder' => 'Click to add a realm'},
-   tags => { after_element => \&help,
-             help => 'Realms that will be associated with this source' },
-   default => '',
-  );
-
-=head2 options_realm
-
-retrive the realms
-
-=cut
-
-sub options_realm {
-    my ($self) = @_;
-    my @roles = map { $_ => $_ } sort keys %pf::config::ConfigRealm;
-    return @roles;
-}
-
 =head1 COPYRIGHT
 
 Copyright (C) 2005-2017 Inverse inc.

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source/Kerberos.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source/Kerberos.pm
@@ -12,7 +12,7 @@ Form definition to create or update a Kerberos user source.
 
 use HTML::FormHandler::Moose;
 extends 'pfappserver::Form::Config::Source';
-with 'pfappserver::Base::Form::Role::Help';
+with 'pfappserver::Base::Form::Role::Help', 'pfappserver::Base::Form::Role::InternalSource';
 
 # Form fields
 has_field 'host' =>
@@ -32,17 +32,6 @@ has_field 'authenticate_realm' =>
    required => 1,
    # Default value needed for creating dummy source
    default => "",
-  );
-
-has_field 'stripped_user_name' =>
-  (
-   type            => 'Toggle',
-   checkbox_value  => 'yes',
-   unchecked_value => 'no',
-   default         => 'yes',
-   label           => 'Use stripped username ',
-   tags => { after_element => \&help,
-             help => 'Use stripped username returned by RADIUS to test the following rules.' },
   );
 
 =head1 COPYRIGHT

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source/LDAP.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source/LDAP.pm
@@ -141,6 +141,19 @@ has_field 'email_attribute' => (
     },
 );
 
+has_field 'realm' =>
+  (
+   type => 'Select',
+   multiple => 1,
+   label => 'Associated Realms',
+   options_method => \&options_realm,
+   element_class => ['chzn-deselect'],
+   element_attr => {'data-placeholder' => 'Click to add a realm'},
+   tags => { after_element => \&help,
+             help => 'Realms that will be associated with this source' },
+   default => '',
+  );
+
 =head2 validate
 
 Make sure a password is specified when a bind DN is specified.
@@ -157,6 +170,18 @@ sub validate {
             $self->field('password')->add_error('Please specify a password.');
         }
     }
+}
+
+=head2 options_realm
+
+retrive the realms
+
+=cut
+
+sub options_realm {
+    my ($self) = @_;
+    my @roles = map { $_ => $_ } sort keys %pf::config::ConfigRealm;
+    return @roles;
 }
 
 =head1 COPYRIGHT

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source/LDAP.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source/LDAP.pm
@@ -141,19 +141,6 @@ has_field 'email_attribute' => (
     },
 );
 
-has_field 'realm' =>
-  (
-   type => 'Select',
-   multiple => 1,
-   label => 'Associated Realms',
-   options_method => \&options_realm,
-   element_class => ['chzn-deselect'],
-   element_attr => {'data-placeholder' => 'Click to add a realm'},
-   tags => { after_element => \&help,
-             help => 'Realms that will be associated with this source' },
-   default => '',
-  );
-
 =head2 validate
 
 Make sure a password is specified when a bind DN is specified.
@@ -170,18 +157,6 @@ sub validate {
             $self->field('password')->add_error('Please specify a password.');
         }
     }
-}
-
-=head2 options_realm
-
-retrive the realms
-
-=cut
-
-sub options_realm {
-    my ($self) = @_;
-    my @roles = map { $_ => $_ } sort keys %pf::config::ConfigRealm;
-    return @roles;
 }
 
 =head1 COPYRIGHT

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source/LDAP.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source/LDAP.pm
@@ -13,7 +13,7 @@ Form definition to create or update a LDAP user source.
 use pf::Authentication::Source::LDAPSource;
 use HTML::FormHandler::Moose;
 extends 'pfappserver::Form::Config::Source';
-with 'pfappserver::Base::Form::Role::Help';
+with 'pfappserver::Base::Form::Role::Help', 'pfappserver::Base::Form::Role::InternalSource';
 
 our $META = pf::Authentication::Source::LDAPSource->meta;
 
@@ -107,18 +107,6 @@ has_field 'password' =>
    # Default value needed for creating dummy source
    default => '',
   );
-has_field 'stripped_user_name' =>
-  (
-   type            => 'Toggle',
-   checkbox_value  => 'yes',
-   unchecked_value => 'no',
-   default         => 'yes',
-   label           => 'Use stripped username ',
-   tags => { after_element => \&help,
-             help => 'Use stripped username returned by RADIUS to test the following rules.' },
-   default => $META->get_attribute('stripped_user_name')->default,
-  );
-
 has_field 'cache_match',
   (
    type => 'Toggle',

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source/RADIUS.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source/RADIUS.pm
@@ -12,7 +12,7 @@ Form definition to create or update a RADIUS user source.
 
 use HTML::FormHandler::Moose;
 extends 'pfappserver::Form::Config::Source';
-with 'pfappserver::Base::Form::Role::Help';
+with 'pfappserver::Base::Form::Role::Help', 'pfappserver::Base::Form::Role::InternalSource';
 
 # Form fields
 has_field 'host' =>
@@ -49,16 +49,6 @@ has_field 'timeout' =>
    element_class => ['input-mini'],
    element_attr => {'placeholder' => '1'},
    default => 1,
-  );
-has_field 'stripped_user_name' =>
-  (
-   type            => 'Toggle',
-   checkbox_value  => 'yes',
-   unchecked_value => 'no',
-   default         => 'yes',
-   label           => 'Use stripped username ',
-   tags => { after_element => \&help,
-             help => 'Use stripped username returned by RADIUS to test the following rules.' },
   );
 
 =head1 COPYRIGHT

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source/RADIUS.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source/RADIUS.pm
@@ -61,6 +61,31 @@ has_field 'stripped_user_name' =>
              help => 'Use stripped username returned by RADIUS to test the following rules.' },
   );
 
+has_field 'realm' =>
+  (
+   type => 'Select',
+   multiple => 1,
+   label => 'Associated Realms',
+   options_method => \&options_realm,
+   element_class => ['chzn-deselect'],
+   element_attr => {'data-placeholder' => 'Click to add a realm'},
+   tags => { after_element => \&help,
+             help => 'Realms that will be associated with this source' },
+   default => '',
+  );
+
+=head2 options_realm
+
+retrive the realms
+
+=cut
+
+sub options_realm {
+    my ($self) = @_;
+    my @roles = map { $_ => $_ } sort keys %pf::config::ConfigRealm;
+    return @roles;
+}
+
 =head1 COPYRIGHT
 
 Copyright (C) 2005-2017 Inverse inc.

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source/RADIUS.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source/RADIUS.pm
@@ -61,31 +61,6 @@ has_field 'stripped_user_name' =>
              help => 'Use stripped username returned by RADIUS to test the following rules.' },
   );
 
-has_field 'realm' =>
-  (
-   type => 'Select',
-   multiple => 1,
-   label => 'Associated Realms',
-   options_method => \&options_realm,
-   element_class => ['chzn-deselect'],
-   element_attr => {'data-placeholder' => 'Click to add a realm'},
-   tags => { after_element => \&help,
-             help => 'Realms that will be associated with this source' },
-   default => '',
-  );
-
-=head2 options_realm
-
-retrive the realms
-
-=cut
-
-sub options_realm {
-    my ($self) = @_;
-    my @roles = map { $_ => $_ } sort keys %pf::config::ConfigRealm;
-    return @roles;
-}
-
 =head1 COPYRIGHT
 
 Copyright (C) 2005-2017 Inverse inc.

--- a/html/pfappserver/root/config/source/type/HTTP.tt
+++ b/html/pfappserver/root/config/source/type/HTTP.tt
@@ -8,3 +8,4 @@
 [% form.field('password').render | none %]
 [% form.field('authentication_url').render | none %]
 [% form.field('authorization_url').render | none %]
+[% form.field('realm').render | none %]

--- a/html/pfappserver/root/config/source/type/HTTP.tt
+++ b/html/pfappserver/root/config/source/type/HTTP.tt
@@ -8,4 +8,3 @@
 [% form.field('password').render | none %]
 [% form.field('authentication_url').render | none %]
 [% form.field('authorization_url').render | none %]
-[% form.field('realm').render | none %]

--- a/html/pfappserver/root/config/source/type/LDAP.tt
+++ b/html/pfappserver/root/config/source/type/LDAP.tt
@@ -11,6 +11,7 @@
 [% form.field('email_attribute').render | none %]
 [% form.field('binddn').render | none %]
 [% form.field('cache_match').render | none %]
+[% form.field('realm').render | none %]
 <div class="control-group">
   <label class="control-label">[% l('Password') %] <i class="icon-required"></i></label>
   <div class="controls">

--- a/html/pfappserver/root/config/source/type/LDAP.tt
+++ b/html/pfappserver/root/config/source/type/LDAP.tt
@@ -11,7 +11,6 @@
 [% form.field('email_attribute').render | none %]
 [% form.field('binddn').render | none %]
 [% form.field('cache_match').render | none %]
-[% form.field('realm').render | none %]
 <div class="control-group">
   <label class="control-label">[% l('Password') %] <i class="icon-required"></i></label>
   <div class="controls">
@@ -22,4 +21,3 @@
     </div>
   </div>
 </div>
-[% form.field('stripped_user_name').render | none %]

--- a/html/pfappserver/root/config/source/view.tt
+++ b/html/pfappserver/root/config/source/view.tt
@@ -35,6 +35,7 @@
         [% form.block('standard').render | none %]
         [% INCLUDE "config/source/type/${item.type}.tt" %]
         [% form.block('local_account').render | none %]
+        [% form.block('internal_sources').render | none %]
         [% form.block('rules').render | none %]
 
     <div class="form-actions">

--- a/lib/pf/Authentication/InternalRole.pm
+++ b/lib/pf/Authentication/InternalRole.pm
@@ -1,0 +1,62 @@
+package pf::Authentication::InternalRole;
+
+=head1 NAME
+
+pf::Authentication::InternalRole -
+
+=cut
+
+=head1 DESCRIPTION
+
+pf::Authentication::InternalRole
+
+=cut
+
+use strict;
+use warnings;
+
+use Moose::Role;
+
+has 'stripped_user_name' => (isa => 'Str', is => 'rw', default => 'yes');
+has 'realms' => (isa => 'ArrayRef[Str]', is => 'rw');
+
+=head2 search_attributes
+
+=cut
+
+sub search_attributes {
+    my ($self,$username) = @_;
+    my $realm;
+    ($username,$realm) = strip_username($username) if isenabled($self->{'stripped_user_name'});
+    return $self->search_attributes_in_subclass($username);
+}
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2017 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;
+

--- a/lib/pf/Authentication/Source.pm
+++ b/lib/pf/Authentication/Source.pm
@@ -263,8 +263,6 @@ sub match_condition {
 
 sub search_attributes {
     my ($self,$username) = @_;
-    my $realm;
-    ($username,$realm) = strip_username($username) if isenabled($self->{'stripped_user_name'});
     return $self->search_attributes_in_subclass($username);
 }
 

--- a/lib/pf/Authentication/Source/HTTPSource.pm
+++ b/lib/pf/Authentication/Source/HTTPSource.pm
@@ -30,6 +30,7 @@ has 'username' => ( isa => 'Maybe[Str]', is => 'rw', default => undef );
 has 'password' => ( isa => 'Maybe[Str]', is => 'rw', default => undef );
 has 'authentication_url' => ( isa => 'Str', is => 'rw', default => '' );
 has 'authorization_url' => ( isa => 'Str', is => 'rw', default => '' );
+has 'realm' => (isa => 'ArrayRef[Str]', is => 'rw');
 
 =head1 METHODS
 

--- a/lib/pf/Authentication/Source/HTTPSource.pm
+++ b/lib/pf/Authentication/Source/HTTPSource.pm
@@ -21,6 +21,7 @@ use pf::util;
 
 use Moose;
 extends 'pf::Authentication::Source';
+with qw(pf::Authentication::InternalRole);
 
 has '+type' => ( default => 'HTTP' );
 has 'protocol' => ( isa => 'Str', is => 'rw', default => 'http' );
@@ -30,7 +31,6 @@ has 'username' => ( isa => 'Maybe[Str]', is => 'rw', default => undef );
 has 'password' => ( isa => 'Maybe[Str]', is => 'rw', default => undef );
 has 'authentication_url' => ( isa => 'Str', is => 'rw', default => '' );
 has 'authorization_url' => ( isa => 'Str', is => 'rw', default => '' );
-has 'realms' => (isa => 'ArrayRef[Str]', is => 'rw');
 
 =head1 METHODS
 

--- a/lib/pf/Authentication/Source/HTTPSource.pm
+++ b/lib/pf/Authentication/Source/HTTPSource.pm
@@ -30,7 +30,7 @@ has 'username' => ( isa => 'Maybe[Str]', is => 'rw', default => undef );
 has 'password' => ( isa => 'Maybe[Str]', is => 'rw', default => undef );
 has 'authentication_url' => ( isa => 'Str', is => 'rw', default => '' );
 has 'authorization_url' => ( isa => 'Str', is => 'rw', default => '' );
-has 'realm' => (isa => 'ArrayRef[Str]', is => 'rw');
+has 'realms' => (isa => 'ArrayRef[Str]', is => 'rw');
 
 =head1 METHODS
 

--- a/lib/pf/Authentication/Source/HtpasswdSource.pm
+++ b/lib/pf/Authentication/Source/HtpasswdSource.pm
@@ -23,6 +23,7 @@ extends 'pf::Authentication::Source';
 has '+type' => (default => 'Htpasswd');
 has 'path' => (isa => 'Str', is => 'rw', required => 1);
 has 'stripped_user_name' => (isa => 'Str', is => 'rw', default => 'yes');
+has 'realm' => (isa => 'ArrayRef[Str]', is => 'rw');
 
 =head1 METHODS
 

--- a/lib/pf/Authentication/Source/HtpasswdSource.pm
+++ b/lib/pf/Authentication/Source/HtpasswdSource.pm
@@ -23,7 +23,7 @@ extends 'pf::Authentication::Source';
 has '+type' => (default => 'Htpasswd');
 has 'path' => (isa => 'Str', is => 'rw', required => 1);
 has 'stripped_user_name' => (isa => 'Str', is => 'rw', default => 'yes');
-has 'realm' => (isa => 'ArrayRef[Str]', is => 'rw');
+has 'realms' => (isa => 'ArrayRef[Str]', is => 'rw');
 
 =head1 METHODS
 

--- a/lib/pf/Authentication/Source/HtpasswdSource.pm
+++ b/lib/pf/Authentication/Source/HtpasswdSource.pm
@@ -19,11 +19,10 @@ use Apache::Htpasswd;
 
 use Moose;
 extends 'pf::Authentication::Source';
+with qw(pf::Authentication::InternalRole);
 
 has '+type' => (default => 'Htpasswd');
 has 'path' => (isa => 'Str', is => 'rw', required => 1);
-has 'stripped_user_name' => (isa => 'Str', is => 'rw', default => 'yes');
-has 'realms' => (isa => 'ArrayRef[Str]', is => 'rw');
 
 =head1 METHODS
 

--- a/lib/pf/Authentication/Source/KerberosSource.pm
+++ b/lib/pf/Authentication/Source/KerberosSource.pm
@@ -20,8 +20,9 @@ extends 'pf::Authentication::Source';
 
 has '+type' => ( default => 'Kerberos' );
 has 'host' => (isa => 'Str', is => 'rw', required => 1);
-has 'realm' => (isa => 'Str', is => 'rw', required => 1);
+has 'authenticate_realm' => (isa => 'Str', is => 'rw', required => 1);
 has 'stripped_user_name' => (isa => 'Str', is => 'rw', default => 'yes');
+has 'realm' => (isa => 'ArrayRef[Str]', is => 'rw');
 
 =head2 dynamic_routing_module
 
@@ -48,7 +49,7 @@ sub authenticate {
 
   my ( $self, $username, $password ) = @_;
 
-  my $kerberos = Authen::Krb5::Simple->new( realm => $self->{'realm'} );
+  my $kerberos = Authen::Krb5::Simple->new( realm => $self->{'authenticate_realm'} );
 
   if ($kerberos->authenticate($username, $password)) {
     return ($TRUE, $AUTH_SUCCESS_MSG);

--- a/lib/pf/Authentication/Source/KerberosSource.pm
+++ b/lib/pf/Authentication/Source/KerberosSource.pm
@@ -22,7 +22,7 @@ has '+type' => ( default => 'Kerberos' );
 has 'host' => (isa => 'Str', is => 'rw', required => 1);
 has 'authenticate_realm' => (isa => 'Str', is => 'rw', required => 1);
 has 'stripped_user_name' => (isa => 'Str', is => 'rw', default => 'yes');
-has 'realm' => (isa => 'ArrayRef[Str]', is => 'rw');
+has 'realms' => (isa => 'ArrayRef[Str]', is => 'rw');
 
 =head2 dynamic_routing_module
 

--- a/lib/pf/Authentication/Source/KerberosSource.pm
+++ b/lib/pf/Authentication/Source/KerberosSource.pm
@@ -17,12 +17,11 @@ use Authen::Krb5::Simple;
 
 use Moose;
 extends 'pf::Authentication::Source';
+with qw(pf::Authentication::InternalRole);
 
 has '+type' => ( default => 'Kerberos' );
 has 'host' => (isa => 'Str', is => 'rw', required => 1);
 has 'authenticate_realm' => (isa => 'Str', is => 'rw', required => 1);
-has 'stripped_user_name' => (isa => 'Str', is => 'rw', default => 'yes');
-has 'realms' => (isa => 'ArrayRef[Str]', is => 'rw');
 
 =head2 dynamic_routing_module
 

--- a/lib/pf/Authentication/Source/LDAPSource.pm
+++ b/lib/pf/Authentication/Source/LDAPSource.pm
@@ -61,6 +61,7 @@ has 'stripped_user_name' => (isa => 'Str', is => 'rw', default => 'yes');
 has '_cached_connection' => (is => 'rw');
 has 'cache_match' => ( isa => 'Bool', is => 'rw', default => 0 );
 has 'email_attribute' => (isa => 'Maybe[Str]', is => 'rw', default => 'mail');
+has 'realm' => (isa => 'ArrayRef[Str]', is => 'rw');
 
 our $logger = get_logger();
 

--- a/lib/pf/Authentication/Source/LDAPSource.pm
+++ b/lib/pf/Authentication/Source/LDAPSource.pm
@@ -61,7 +61,7 @@ has 'stripped_user_name' => (isa => 'Str', is => 'rw', default => 'yes');
 has '_cached_connection' => (is => 'rw');
 has 'cache_match' => ( isa => 'Bool', is => 'rw', default => 0 );
 has 'email_attribute' => (isa => 'Maybe[Str]', is => 'rw', default => 'mail');
-has 'realm' => (isa => 'ArrayRef[Str]', is => 'rw');
+has 'realms' => (isa => 'ArrayRef[Str]', is => 'rw');
 
 our $logger = get_logger();
 

--- a/lib/pf/Authentication/Source/LDAPSource.pm
+++ b/lib/pf/Authentication/Source/LDAPSource.pm
@@ -27,6 +27,7 @@ use pf::util::statsd qw(called);
 
 use Moose;
 extends 'pf::Authentication::Source';
+with qw(pf::Authentication::InternalRole);
 
 # available encryption
 use constant {
@@ -57,11 +58,9 @@ has 'password' => (isa => 'Maybe[Str]', is => 'rw');
 has 'encryption' => (isa => 'Str', is => 'rw', required => 1);
 has 'scope' => (isa => 'Str', is => 'rw', required => 1);
 has 'usernameattribute' => (isa => 'Str', is => 'rw', required => 1);
-has 'stripped_user_name' => (isa => 'Str', is => 'rw', default => 'yes');
 has '_cached_connection' => (is => 'rw');
 has 'cache_match' => ( isa => 'Bool', is => 'rw', default => 0 );
 has 'email_attribute' => (isa => 'Maybe[Str]', is => 'rw', default => 'mail');
-has 'realms' => (isa => 'ArrayRef[Str]', is => 'rw');
 
 our $logger = get_logger();
 

--- a/lib/pf/Authentication/Source/RADIUSSource.pm
+++ b/lib/pf/Authentication/Source/RADIUSSource.pm
@@ -30,6 +30,7 @@ has 'port' => (isa => 'Maybe[Int]', is => 'rw', default => 1812);
 has 'timeout' => (isa => 'Maybe[Int]', is => 'rw', default => 1);
 has 'secret' => (isa => 'Str', is => 'rw', required => 1);
 has 'stripped_user_name' => (isa => 'Str', is => 'rw', default => 'yes');
+has 'realm' => (isa => 'ArrayRef[Str]', is => 'rw');
 
 =head2 dynamic_routing_module
 

--- a/lib/pf/Authentication/Source/RADIUSSource.pm
+++ b/lib/pf/Authentication/Source/RADIUSSource.pm
@@ -30,7 +30,7 @@ has 'port' => (isa => 'Maybe[Int]', is => 'rw', default => 1812);
 has 'timeout' => (isa => 'Maybe[Int]', is => 'rw', default => 1);
 has 'secret' => (isa => 'Str', is => 'rw', required => 1);
 has 'stripped_user_name' => (isa => 'Str', is => 'rw', default => 'yes');
-has 'realm' => (isa => 'ArrayRef[Str]', is => 'rw');
+has 'realms' => (isa => 'ArrayRef[Str]', is => 'rw');
 
 =head2 dynamic_routing_module
 

--- a/lib/pf/Authentication/Source/RADIUSSource.pm
+++ b/lib/pf/Authentication/Source/RADIUSSource.pm
@@ -23,14 +23,13 @@ Authen::Radius->load_dictionary("/usr/share/freeradius/dictionary");
 
 use Moose;
 extends 'pf::Authentication::Source';
+with qw(pf::Authentication::InternalRole);
 
 has '+type' => ( default => 'RADIUS' );
 has 'host' => (isa => 'Maybe[Str]', is => 'rw', default => '127.0.0.1');
 has 'port' => (isa => 'Maybe[Int]', is => 'rw', default => 1812);
 has 'timeout' => (isa => 'Maybe[Int]', is => 'rw', default => 1);
 has 'secret' => (isa => 'Str', is => 'rw', required => 1);
-has 'stripped_user_name' => (isa => 'Str', is => 'rw', default => 'yes');
-has 'realms' => (isa => 'ArrayRef[Str]', is => 'rw');
 
 =head2 dynamic_routing_module
 

--- a/lib/pf/Authentication/Source/SQLSource.pm
+++ b/lib/pf/Authentication/Source/SQLSource.pm
@@ -20,6 +20,7 @@ extends 'pf::Authentication::Source';
 
 has '+type' => ( default => 'SQL' );
 has 'stripped_user_name' => (isa => 'Str', is => 'rw', default => 'yes');
+has 'realm' => (isa => 'ArrayRef[Str]', is => 'rw');
 
 =head1 METHODS
 

--- a/lib/pf/Authentication/Source/SQLSource.pm
+++ b/lib/pf/Authentication/Source/SQLSource.pm
@@ -17,10 +17,9 @@ use pf::Authentication::Source;
 
 use Moose;
 extends 'pf::Authentication::Source';
+with qw(pf::Authentication::InternalRole);
 
 has '+type' => ( default => 'SQL' );
-has 'stripped_user_name' => (isa => 'Str', is => 'rw', default => 'yes');
-has 'realms' => (isa => 'ArrayRef[Str]', is => 'rw');
 
 =head1 METHODS
 

--- a/lib/pf/Authentication/Source/SQLSource.pm
+++ b/lib/pf/Authentication/Source/SQLSource.pm
@@ -20,7 +20,7 @@ extends 'pf::Authentication::Source';
 
 has '+type' => ( default => 'SQL' );
 has 'stripped_user_name' => (isa => 'Str', is => 'rw', default => 'yes');
-has 'realm' => (isa => 'ArrayRef[Str]', is => 'rw');
+has 'realms' => (isa => 'ArrayRef[Str]', is => 'rw');
 
 =head1 METHODS
 

--- a/lib/pf/ConfigStore/Source.pm
+++ b/lib/pf/ConfigStore/Source.pm
@@ -95,7 +95,7 @@ sub cleanupAfterRead {
     if ($item->{type} eq 'SMS') {
         $self->expand_list($item, 'sms_carriers');
     }
-    $self->expand_list($item, qw(realm));
+    $self->expand_list($item, qw(realms));
 }
 
 sub cleanupBeforeCommit {
@@ -106,7 +106,7 @@ sub cleanupBeforeCommit {
     if ($item->{type} eq 'Eduroam') {
         $self->flatten_list($item, qw(local_realm reject_realm));
     }
-    $self->flatten_list($item, qw(realm));
+    $self->flatten_list($item, qw(realms));
 }
 
 before rewriteConfig => sub {

--- a/lib/pf/ConfigStore/Source.pm
+++ b/lib/pf/ConfigStore/Source.pm
@@ -95,6 +95,7 @@ sub cleanupAfterRead {
     if ($item->{type} eq 'SMS') {
         $self->expand_list($item, 'sms_carriers');
     }
+    $self->expand_list($item, qw(realm));
 }
 
 sub cleanupBeforeCommit {
@@ -105,6 +106,7 @@ sub cleanupBeforeCommit {
     if ($item->{type} eq 'Eduroam') {
         $self->flatten_list($item, qw(local_realm reject_realm));
     }
+    $self->flatten_list($item, qw(realm));
 }
 
 before rewriteConfig => sub {

--- a/lib/pf/Connection/Profile.pm
+++ b/lib/pf/Connection/Profile.pm
@@ -555,7 +555,7 @@ Return a list of authentication sources for the given connection profile filtere
 
 sub getFilteredAuthenticationSources {
     my ($self, $username, $realm) = @_;
-    return filter_authentication_sources([ $self->getInternalSources, $self->getExclusiveSources ], $username, $realm);
+    return @{filter_authentication_sources([ $self->getInternalSources, $self->getExclusiveSources ], $username, $realm) // []};
 }
 
 =item getRootModuleId

--- a/lib/pf/config/util.pm
+++ b/lib/pf/config/util.pm
@@ -410,11 +410,11 @@ Filter a given list of authentication sources based on a username / realm
 sub filter_authentication_sources {
     my ( $sources, $username, $realm ) = @_;
 
-    return @$sources unless ( defined($username) || defined($realm) );
+    return $sources unless ( defined($username) || defined($realm) );
 
-    my $realm_authentication_source = get_realm_authentication_source($username, $realm, \@$sources);
+    my $realm_authentication_source = get_realm_authentication_source($username, $realm, $sources);
 
-    return @$sources unless ( ref($realm_authentication_source) eq 'ARRAY');
+    return $sources unless ( ref($realm_authentication_source) eq 'ARRAY');
 
     $realm = "null" unless ( defined($realm) );
 

--- a/lib/pf/config/util.pm
+++ b/lib/pf/config/util.pm
@@ -391,7 +391,7 @@ sub get_realm_authentication_source {
     $realm = lc $realm;
 
     my @sources = grep { defined $_->realm && grep( /^$realm$/, @{$_->realm} ) } @{$sources};
-
+    @sources = (@sources, grep { defined $_->realm && !grep( defined($_), @{$_->realm} ) } @{$sources} ) if ($realm ne "null");
     return \@sources;
 
 }
@@ -410,6 +410,8 @@ sub filter_authentication_sources {
     my $realm_authentication_source = get_realm_authentication_source($username, $realm, \@$sources);
 
     return @$sources unless ( ref($realm_authentication_source) eq 'ARRAY');
+
+    $realm = "null" unless ( defined($realm) );
 
     get_logger->info("Found authentication source(s) : '", join(',', (map {$_->id} @{$realm_authentication_source})) . "' for realm '$realm'");
 

--- a/lib/pf/config/util.pm
+++ b/lib/pf/config/util.pm
@@ -395,8 +395,8 @@ sub get_realm_authentication_source {
     $realm = 'null' unless ( defined($realm) );
     $realm = lc $realm;
 
-    my @sources = grep { defined $_->realm && grep( /^$realm$/, @{$_->realm} ) } @{$sources};
-    @sources = (@sources, grep { defined $_->realm && ($_->realm eq '') && !grep( defined($_), @{$_->realm} ) } @{$sources} );
+    my @sources = grep { defined $_->realms && grep( /^$realm$/, @{$_->realms} ) } @{$sources};
+    @sources = (@sources, grep { defined $_->realms && ($_->realms eq '') && !grep( defined($_), @{$_->realms} ) } @{$sources} );
     return \@sources;
 
 }

--- a/lib/pf/config/util.pm
+++ b/lib/pf/config/util.pm
@@ -407,21 +407,13 @@ sub filter_authentication_sources {
 
     return @$sources unless ( defined($username) || defined($realm) );
 
-    my $realm_authentication_source = get_realm_authentication_source($username, $realm, $sources);
+    my $realm_authentication_source = get_realm_authentication_source($username, $realm, \@$sources);
 
-    return @$sources unless ( defined($realm_authentication_source) && defined($realm_authentication_source->{id}) && $realm_authentication_source->{id} ne "" );
+    return @$sources unless ( ref($realm_authentication_source) eq 'ARRAY');
 
-    get_logger->info("Found authentication source '" . $realm_authentication_source->{id} . "' for realm '$realm'");
-    
-    if ( any { $_ eq $realm_authentication_source} @$sources ) {
-        get_logger->info("Realm '$realm' authentication source '" . $realm_authentication_source->{id} . "' is part of the available connection profile authentication sources. Using it as the only authentication source.");
-        return ($realm_authentication_source);
-    }
-    else {
-        get_logger->info("Realm '$realm' authentication source '" . $realm_authentication_source->{id} . "' is not configured in the connection profile. Ignoring it and using the connection profile authentication sources");
-    }
+    get_logger->info("Found authentication source(s) : '", join(',', (map {$_->id} @{$realm_authentication_source})) . "' for realm '$realm'");
 
-    return @$sources;
+    return $realm_authentication_source;
 }
 
 =head2 get_captive_portal_uri

--- a/lib/pf/config/util.pm
+++ b/lib/pf/config/util.pm
@@ -392,11 +392,11 @@ Get a source for a specific realm
 sub get_realm_authentication_source {
     my ( $username, $realm, $sources ) = @_;
 
-    $realm = "null" unless ( defined($realm) );
+    $realm = 'null' unless ( defined($realm) );
     $realm = lc $realm;
 
     my @sources = grep { defined $_->realm && grep( /^$realm$/, @{$_->realm} ) } @{$sources};
-    @sources = (@sources, grep { defined $_->realm && !grep( defined($_), @{$_->realm} ) } @{$sources} ) if ($realm ne "null");
+    @sources = (@sources, grep { defined $_->realm && ($_->realm eq '') && !grep( defined($_), @{$_->realm} ) } @{$sources} );
     return \@sources;
 
 }

--- a/lib/pf/config/util.pm
+++ b/lib/pf/config/util.pm
@@ -383,35 +383,16 @@ sub portal_hosts {
     return @hosts;
 }
 
-=head2 get_realm_authentication_source
-
-Get a source for a specific username and realm
-Will look it up in the realm configuration
-
-=cut
 
 sub get_realm_authentication_source {
-    my ( $username, $realm ) = @_;
+    my ( $username, $realm, $sources ) = @_;
 
     $realm = "null" unless ( defined($realm) );
     $realm = lc $realm;
 
-    my $realm_authentication_source;
+    my @sources = grep { defined $_->realm && grep( /^$realm$/, @{$_->realm} ) } @{$sources};
 
-    if ( exists $ConfigRealm{$realm} ) {
-        if ( my $source = $ConfigRealm{$realm}{source} ) {
-            get_logger->info("Found authentication source '$source' for realm '$realm'");
-            $realm_authentication_source = pf::authentication::getAuthenticationSource($source);
-        }
-    }
-    elsif ( exists $ConfigRealm{default} && $realm ne "null" ) {
-        if ( my $source = $ConfigRealm{default}{source} ) {
-            get_logger->info("Found authentication source '$source' for realm '$realm' through the default realm");
-            $realm_authentication_source = pf::authentication::getAuthenticationSource($source);
-        }
-    }
-
-    return $realm_authentication_source;
+    return \@sources;
 
 }
 
@@ -426,7 +407,7 @@ sub filter_authentication_sources {
 
     return @$sources unless ( defined($username) || defined($realm) );
 
-    my $realm_authentication_source = get_realm_authentication_source($username, $realm);
+    my $realm_authentication_source = get_realm_authentication_source($username, $realm, $sources);
 
     return @$sources unless ( defined($realm_authentication_source) && defined($realm_authentication_source->{id}) && $realm_authentication_source->{id} ne "" );
 

--- a/lib/pf/config/util.pm
+++ b/lib/pf/config/util.pm
@@ -383,6 +383,11 @@ sub portal_hosts {
     return @hosts;
 }
 
+=head2 get_realm_authentication_source
+
+Get a source for a specific realm
+
+=cut
 
 sub get_realm_authentication_source {
     my ( $username, $realm, $sources ) = @_;

--- a/lib/pfconfig/namespaces/config/Authentication.pm
+++ b/lib/pfconfig/namespaces/config/Authentication.pm
@@ -173,6 +173,11 @@ sub cleanup_after_read {
     $self->expand_list( $data, qw(local_realm reject_realm) );
 }
 
+sub cleanup_after_read {
+    my ( $self, $id, $data ) = @_;
+    $self->expand_list( $data, qw(realm) );
+}
+
 =head1 AUTHOR
 
 Inverse inc. <info@inverse.ca>

--- a/lib/pfconfig/namespaces/config/Authentication.pm
+++ b/lib/pfconfig/namespaces/config/Authentication.pm
@@ -170,7 +170,7 @@ sub newAuthenticationSource {
 
 sub cleanup_after_read {
     my ( $self, $id, $data ) = @_;
-    $self->expand_list( $data, qw(realm local_realm reject_realm) );
+    $self->expand_list( $data, qw(realms local_realm reject_realm) );
 }
 
 =head1 AUTHOR

--- a/lib/pfconfig/namespaces/config/Authentication.pm
+++ b/lib/pfconfig/namespaces/config/Authentication.pm
@@ -170,12 +170,7 @@ sub newAuthenticationSource {
 
 sub cleanup_after_read {
     my ( $self, $id, $data ) = @_;
-    $self->expand_list( $data, qw(local_realm reject_realm) );
-}
-
-sub cleanup_after_read {
-    my ( $self, $id, $data ) = @_;
-    $self->expand_list( $data, qw(realm) );
+    $self->expand_list( $data, qw(realm local_realm reject_realm) );
 }
 
 =head1 AUTHOR


### PR DESCRIPTION
# Description
Associate realm(s) in authentication sources instead of associating a source to a realm.

# Impacts
Username without a realm must match a source with null realm (by default local).
Username with a realm will try to match first sources associated with the realm and try source without a realm associated.

# Issue
fixes #2536
fixes #2529
fixes #2538

# Delete branch after merge
YES

# NEWS file entries

## Bug Fixes
reuseDot1x: Security concern #2536 
We need a realm admin_local by default #2529

# UPGRADE file entries
You have to run the following script to change the configuration:
addons/upgrade/to-7.3-authentication-conf.pl