### PR TITLE
Updated the inner tunnel to set EAP-Type when doing TTLS.

### DIFF
--- a/conf/radiusd/packetfence-tunnel.example
+++ b/conf/radiusd/packetfence-tunnel.example
@@ -20,6 +20,13 @@ server packetfence-tunnel {
 #  Make *sure* that 'preprocess' comes before any realm if you
 #  need to setup hints for the remote radius server
 authorize {
+    # TTLS does not send an EAP-Message to be parsed so the eap module
+    # cannot assign the EAP-Type
+    if ( outer.EAP-Type == TTLS) {
+        update request {
+            &EAP-Type := TTLS
+        }
+    }
 	#
 	#  Take a User-Name, and perform some checks on it, for spaces and other
 	#  invalid characters.  If the User-Name appears invalid, reject the


### PR DESCRIPTION
# Description
Fixes EAP-TTLS authentication by setting the EAP-Type inside the tunnel.

# Impacts
EAP-TTLS does not always send an EAP-Message inside the tunnel (depending on the sub-type).
This means that the EAP-Type is not set and thus the Connection-Type will be wrong in PacketFence. This PR fixes that by copying the EAP-Type from the outer request to the inner.

# Issue
fixes #2582

# Delete branch after merge
YES

# NEWS file entries

## Bug Fixes
* Fixes incorrect Connection-Type when using EAP-TTLS (#2582)
