### PR TITLE
Fixed useless check for SNMP return on Extricom controllers.

### DIFF
--- a/lib/pf/Switch/Extricom.pm
+++ b/lib/pf/Switch/Extricom.pm
@@ -169,6 +169,7 @@ sub connectWrite {
                 ]
             );
        }
+       # We no longer check the $result here since it is always false even when the call succeeds.
     }
     return 1;
 }

--- a/lib/pf/Switch/Extricom.pm
+++ b/lib/pf/Switch/Extricom.pm
@@ -168,17 +168,6 @@ sub connectWrite {
                     $sysLocation
                 ]
             );
-            if ( !defined($result) ) {
-                $logger->error( "error creating SNMP v"
-                        . $self->{_SNMPVersion}
-                        . " write connection to "
-                        . $self->{_id} . ": "
-                        . $self->{_sessionWrite}->error()
-                        . " it looks like you specified a read-only community instead of a read-write one"
-                );
-                $self->{_sessionWrite} = undef;
-                return 0;
-            }
        }
     }
     return 1;


### PR DESCRIPTION
# Description
Extricom controllers never return the right value when connecting using SNMP.
This removes a check that will always fail.

# Impacts
Any SNMP calls to the controller should now work.


# Issue
fixes #2590

# Delete branch after merge
YES 

# NEWS file entries


## Bug Fixes
If an issue exists on Github, please refer to it (name) along with it's number...
* Fixed SNMP connection issues on Extricom controllers

