### PR TITLE
Fix/galera readonly strategy

### DIFF
--- a/conf/mariadb/mariadb.conf.tt.example
+++ b/conf/mariadb/mariadb.conf.tt.example
@@ -143,7 +143,7 @@ max_connections=[% max_connections %]
 [galera]
 # Mandatory settings
 wsrep_on=ON
-wsrep_provider=[% libgalera %]
+wsrep_provider=/usr/lib64/galera/libgalera_smm.so
 default_storage_engine=InnoDB
 innodb_autoinc_lock_mode=2
 wsrep_cluster_name=pfcluster
@@ -153,8 +153,11 @@ wsrep_node_address="[% server_ip %]"
 wsrep_on=ON 
 wsrep_sst_method = xtrabackup
 wsrep_sst_auth = "[% replication_user %]:[% replication_password %]"
-wsrep_notify_cmd=/usr/local/pf/var/run/db-update
+# Uncomment the line below so that the database goes into read_only mode when its not a primary view or there is only 1 member left in your cluster
+# This was known to cause issues with rapid cluster state changes, see #2593 for details
+#wsrep_notify_cmd=/usr/local/pf/var/run/db-update
 wsrep_provider_options=''
+wsrep_dirty_reads=ON
 #
 # Optional setting
 wsrep_slave_threads=1

--- a/conf/mariadb/mariadb.conf.tt.example
+++ b/conf/mariadb/mariadb.conf.tt.example
@@ -143,7 +143,7 @@ max_connections=[% max_connections %]
 [galera]
 # Mandatory settings
 wsrep_on=ON
-wsrep_provider=/usr/lib64/galera/libgalera_smm.so
+wsrep_provider=[% libgalera %]
 default_storage_engine=InnoDB
 innodb_autoinc_lock_mode=2
 wsrep_cluster_name=pfcluster

--- a/lib/pf/db.pm
+++ b/lib/pf/db.pm
@@ -463,11 +463,10 @@ sub db_readonly_mode {
     my $row = $sth->fetch;
     $sth->finish;
     my $readonly = $row->[0];
-
-    my $wsrep_healthy = db_wsrep_healthy();
-
-    # If the read_only flag is set or wsrep isn't ready, we are in read only
-    return $readonly || !$wsrep_healthy;
+    # If readonly no need to check wsrep health
+    return 1 if $readonly;
+    # If wsrep is not healthly then it is in readonly mode
+    return !db_wsrep_healthy();
 }
 
 =head2 db_wsrep_healthy

--- a/lib/pf/db.pm
+++ b/lib/pf/db.pm
@@ -497,7 +497,7 @@ sub db_wsrep_healthy {
         $sth->finish;
         # If there is no wsrep_ready row, then we're not in read only because we don't use wsrep
         # If its there and not set to ON, then we're in read only
-        my $wsrep_ready = (defined($row) && $row->[1] eq "ON");
+        return (defined($row) && $row->[1] eq "ON");
     }
     # wsrep isn't enabled
     else {

--- a/sbin/pf-mariadb
+++ b/sbin/pf-mariadb
@@ -175,22 +175,15 @@ Test the connection to the database for a specific host using the replication cr
 
 sub test_db {
     my ($host) = @_;
-    eval {
-        local $SIG{ALRM} = sub {die "Timeout connecting to MySQL for host $host\n";};
-        alarm($MYSQL_CONNECT_TIMEOUT);
-        my $mydbh = DBI->connect( "dbi:mysql:dbname=mysql;host=$host;port=3306",
-            $Config{active_active}{galera_replication_username}, $Config{active_active}{galera_replication_password}, { RaiseError => 0, PrintError => 0, mysql_auto_reconnect => 1 } );
-        alarm(0);
-        # make sure we have a database handle
-        if ($mydbh) {
-            return 1;
-        }
-        else {
-            return 0;
-        }
-    };
-    # we left the eval so that means we died
-    return 0;
+    my $mydbh = DBI->connect( "dbi:mysql:dbname=mysql;host=$host;port=3306;mysql_connect_timeout=$MYSQL_CONNECT_TIMEOUT",
+        $Config{active_active}{galera_replication_username}, $Config{active_active}{galera_replication_password}, { RaiseError => 0, PrintError => 0, mysql_auto_reconnect => 1 } );
+    # make sure we have a database handle
+    if ($mydbh) {
+        return 1;
+    }
+    else {
+        return 0;
+    }
 }
 
 =head2 db_available

--- a/sbin/pf-mariadb
+++ b/sbin/pf-mariadb
@@ -47,6 +47,8 @@ our $WAIT_TIME_ALIVE = 10;
 our $failed = $TRUE;
 our $failed_counts = {};
 
+our $MYSQL_CONNECT_TIMEOUT = 5;
+
 # init signal handlers
 my $old_child_sigaction = POSIX::SigAction->new;
 POSIX::sigaction(
@@ -173,16 +175,22 @@ Test the connection to the database for a specific host using the replication cr
 
 sub test_db {
     my ($host) = @_;
-    my $mydbh = DBI->connect( "dbi:mysql:dbname=mysql;host=$host;port=3306",
-        $Config{active_active}{galera_replication_username}, $Config{active_active}{galera_replication_password}, { RaiseError => 0, PrintError => 0, mysql_auto_reconnect => 1 } );
-
-    # make sure we have a database handle
-    if ($mydbh) {
-        return 1;
-    }
-    else {
-        return 0;
-    }
+    eval {
+        local $SIG{ALRM} = sub {die "Timeout connecting to MySQL for host $host\n";};
+        alarm($MYSQL_CONNECT_TIMEOUT);
+        my $mydbh = DBI->connect( "dbi:mysql:dbname=mysql;host=$host;port=3306",
+            $Config{active_active}{galera_replication_username}, $Config{active_active}{galera_replication_password}, { RaiseError => 0, PrintError => 0, mysql_auto_reconnect => 1 } );
+        alarm(0);
+        # make sure we have a database handle
+        if ($mydbh) {
+            return 1;
+        }
+        else {
+            return 0;
+        }
+    };
+    # we left the eval so that means we died
+    return 0;
 }
 
 =head2 db_available


### PR DESCRIPTION
# Description
Use the wsrep_ready state of the DB as a read only indicator
Stop putting the DB in read only on quorum + primary loss of MariaDB and trust wsrep_ready instead

# Impacts
The galera cluster stack
## This will require a lot of testing before its put in official production, there shouldn't be anything that goes wrong but we should test it thoroughly and BETA try it in a couple of production environments before merging it

# Issue
fixes #2593 

# Delete branch after merge
NO

# NEWS file entries
## Bug Fixes
* Trust the wsrep_ready flag of MariaDB Galera cluster for read only detection as putting the DB in read-only can result in occasional de-synchronization between members.

# UPGRADE file entries

Ensure you merge changes in the galera section of conf/mariadb/mariadb.conf.tt.rpmnew into conf/mariadb/mariadb.conf.tt
