### PR TITLE
pfdns intercept all trafic of L2 for registration / isolation

### DIFF
--- a/lib/pf/iptables.pm
+++ b/lib/pf/iptables.pm
@@ -683,23 +683,27 @@ sub generate_interception_rules {
         if ($enforcement_type eq $IF_ENFORCEMENT_VLAN) {
             # send everything from vlan interfaces to the vlan chain
             $$nat_if_src_to_chain .= "-A PREROUTING --in-interface $dev --jump $FW_PREROUTING_INT_VLAN\n";
-            if (defined($Config{'fencing'}{'interception_proxy_port'}) && isenabled($Config{'fencing'}{'interception_proxy'})) {
-                foreach my $network ( keys %ConfigNetworks ) {
-                    next if (pf::config::is_network_type_inline($network));
-                    my %net = %{$ConfigNetworks{$network}};
-                    my $ip;
-                    if (defined($net{'next_hop'})) {
-                        $ip = new NetAddr::IP::Lite clean_ip($net{'next_hop'});
-                    } else {
-                        $ip = new NetAddr::IP::Lite clean_ip($net{'gateway'});
-                    }
-                    if ($net_addr->contains($ip)) {
+            foreach my $network ( keys %ConfigNetworks ) {
+                next if (pf::config::is_network_type_inline($network));
+                my %net = %{$ConfigNetworks{$network}};
+                my $ip;
+                if (defined($net{'next_hop'})) {
+                    $ip = new NetAddr::IP::Lite clean_ip($net{'next_hop'});
+                } else {
+                    $ip = new NetAddr::IP::Lite clean_ip($net{'gateway'});
+                }
+                if ($net_addr->contains($ip)) {
+                    my $destination = $Config{"interface $dev"}{'vip'} || $Config{"interface $dev"}{'ip'};
+                    if (defined($Config{'fencing'}{'interception_proxy_port'}) && isenabled($Config{'fencing'}{'interception_proxy'})) {
                         foreach my $intercept_port ( split( ',', $Config{'fencing'}{'interception_proxy_port'} ) ) {
-                            my $destination = $Config{"interface $dev"}{'vip'} || $Config{"interface $dev"}{'ip'};
                             my $rule = "--protocol tcp --destination-port $intercept_port -s $network/$ConfigNetworks{$network}{'netmask'}";
                             $$nat_prerouting_vlan .= "-A $FW_PREROUTING_INT_VLAN $rule --jump DNAT --to $destination\n";
                         }
                     }
+                    my $rule = "--protocol udp --destination-port 53 -s $network/$ConfigNetworks{$network}{'netmask'}";
+                    $$nat_prerouting_vlan .= "-A $FW_PREROUTING_INT_VLAN $rule --jump DNAT --to $destination\n";
+                    $rule = "--protocol tcp --destination-port 53 -s $network/$ConfigNetworks{$network}{'netmask'}";
+                    $$nat_prerouting_vlan .= "-A $FW_PREROUTING_INT_VLAN $rule --jump DNAT --to $destination\n";
                 }
             }
         }


### PR DESCRIPTION
# Description
All dns requests in the registration network should be forwarded to PFDNS.
This feature will fix the devices that have static dns entries.

# Impacts
- Inline
- Registration network
- Isolation network
- iptables

# Issue
fixes #2381

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* pfdns: catch all the dns traffic in the registration network (#2381)