### PR TITLE
Remove binary log from mysql config.

### DIFF
--- a/conf/mariadb/mariadb.conf.tt.example
+++ b/conf/mariadb/mariadb.conf.tt.example
@@ -46,7 +46,7 @@ thread_concurrency = [% thread_concurrency %]
 [% IF cluster_enabled %]
 # Replication Master Server (default)
 # binary logging is required for replication
-log-bin=mysql-bin
+#log-bin=mysql-bin
 binlog-format=row
 expire_logs_days=2
 max_binlog_size=13107200

--- a/conf/mariadb/mariadb.conf.tt.example
+++ b/conf/mariadb/mariadb.conf.tt.example
@@ -45,7 +45,6 @@ thread_concurrency = [% thread_concurrency %]
 
 [% IF cluster_enabled %]
 # Replication Master Server (default)
-# binary logging is required for replication
 #log-bin=mysql-bin
 binlog-format=row
 expire_logs_days=2


### PR DESCRIPTION
# Description
mysql binary log fill the disk and it's useless.

# Impacts
Mysql

# Delete branch after merge
YES

# NEWS file entries

## Enhancements
* Removed binary log from mysql configuration


