### PR TITLE
Deregister a device on accounting stop

### DIFF
--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1142,6 +1142,12 @@ type=toggle
 options=enabled|disabled
 description=<<EOT
 Trigger Single-Sign-On (Firewall SSO) on dhcp
+
+[advanced.unreg_on_accounting_stop]
+type=toggle
+options=enabled|disabled
+description=<<EOT
+Unregister the device on accounting stop
 EOT
 
 [advanced.record_accounting_in_sql]

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -824,6 +824,10 @@ sso_on_accounting=disabled
 # Trigger Single-Sign-On (Firewall SSO) on dhcp
 sso_on_dhcp=enabled
 #
+# advanced.unreg_on_accounting_stop
+#
+# Unregister the device on accounting stop
+unreg_on_accounting_stop=disabled
 #
 # advanced.record_accounting_in_sql
 #

--- a/lib/pf/api.pm
+++ b/lib/pf/api.pm
@@ -1351,9 +1351,6 @@ sub handle_accounting_metadata : Public {
         if (pf::util::isenabled($pf::config::Config{advanced}{unreg_on_accounting_stop})) {
            $client->notify("deregister_node", mac => $mac);
         }
-    }
-
-        }
         else {
             pf::log::get_logger->debug("Not handling iplog update because we're not configured to do so on accounting packets.");
         }

--- a/lib/pf/api.pm
+++ b/lib/pf/api.pm
@@ -1348,6 +1348,12 @@ sub handle_accounting_metadata : Public {
             $logger->info("Updating iplog from accounting request");
             $client->notify("update_ip4log", mac => $mac, ip => $RAD_REQUEST{'Framed-IP-Address'}) if ($RAD_REQUEST{'Framed-IP-Address'} );
         }
+        if (pf::util::isenabled($pf::config::Config{advanced}{unreg_on_accounting_stop})) {
+           $client->notify("deregister_node", mac => $mac);
+        }
+    }
+
+        }
         else {
             pf::log::get_logger->debug("Not handling iplog update because we're not configured to do so on accounting packets.");
         }


### PR DESCRIPTION
# Description
If PacketFence receive an accounting stop then we unregister the device in the database.

# Impacts
Radius Accounting flow


# Delete branch after merge
YES

# NEWS file entries
## New Features
* Added a configuration parameter to allow to unregister a device on an accounting stop

