### PR TITLE
Add network_detection_initial_delay and network_detection_retry_delay…

### DIFF
--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -966,6 +966,18 @@ to reach your PacketFence server and put your LAN's PacketFence IP. By default
 we will make this reach PacketFence's website as an easy solution.
 EOT
 
+[captive_portal.network_detection_initial_delay]
+type=time
+description=<<EOT
+The amount of time before network connectivity detection is started.
+EOT
+
+[captive_portal.network_detection_retry_delay]
+type=time
+description=<<EOT
+The amount of time between network connectivity detection checks.
+EOT
+
 [captive_portal.image_path]
 type=text
 description=<<EOT

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -478,14 +478,6 @@ Location of the ip binary. Only necessary to change if you are not
 running the RPMed version.
 EOT
 
-[fencing.redirtimer]
-type=time
-description=<<EOT
-How long to display the progress bar during trap release. Default value is 
-based on VLAN enforcement techniques. Inline enforcement only users could 
-lower the value.
-EOT
-
 [fencing.wait_for_redirect]
 type=numeric
 description=<<EOT
@@ -976,6 +968,14 @@ EOT
 type=time
 description=<<EOT
 The amount of time between network connectivity detection checks.
+EOT
+
+[captive_portal.network_redirect_delay]
+type=time
+description=<<EOT
+How long to display the progress bar during trap release. Default value is 
+based on VLAN enforcement techniques. Inline enforcement only users could 
+lower the value.
 EOT
 
 [captive_portal.image_path]

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -90,13 +90,6 @@ interfaceSNAT=
 tools/stinger.exe=http://download.nai.com/products/mcafee-avert/stng260.exe
 
 [fencing]
-#
-# fencing.redirtimer
-#
-# How long to display the progress bar during trap release. Default value is 
-# based on VLAN enforcement techniques. Inline enforcement only users could
-# lower the value.
-redirtimer=20s
 # 
 # fencing.wait_for_redirect
 #
@@ -711,6 +704,13 @@ network_detection_initial_delay = 5s
 #
 # This is the amount of time between network connectivity detection checks.
 network_detection_retry_delay = 2s
+#
+# captive_portal.network_redirect_delay
+#
+# How long to display the progress bar during trap release. Default value is 
+# based on VLAN enforcement techniques. Inline enforcement only users could
+# lower the value.
+network_redirect_delay = 20s
 #
 # captive_portal.image_path
 #

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -702,6 +702,16 @@ network_detection=enabled
 #
 network_detection_ip = 192.95.20.194
 #
+# captive_portal.network_detection_initial_delay
+#
+# This is the amount of time before network connectivity detection is started. 
+network_detection_initial_delay = 5s
+#
+# captive_portal.network_detection_retry_delay
+#
+# This is the amount of time between network connectivity detection checks.
+network_detection_retry_delay = 2s
+#
 # captive_portal.image_path
 #
 # This is the path where the gif is on the webserver to detect if the network access

--- a/go/pfconfigdriver/structs.go
+++ b/go/pfconfigdriver/structs.go
@@ -69,26 +69,28 @@ type PfConfFencing struct {
 	Whitelist             string   `json:"whitelist"`
 	ProxyPassthroughs     []string `json:"proxy_passthroughs"`
 	Passthroughs          []string `json:"passthroughs"`
-	Redirtimer            int      `json:"redirtimer"`
 	WaitForRedirect       string   `json:"wait_for_redirect"`
 	Passthrough           string   `json:"passthrough"`
 }
 
 type PfConfCaptivePortal struct {
 	StructConfig
-	PfconfigMethod          string   `val:"hash_element"`
-	PfconfigNS              string   `val:"config::Pf"`
-	PfconfigHashNS          string   `val:"captive_portal"`
-	DetectionMecanismBypass string   `json:"detection_mecanism_bypass"`
-	DetectionMecanismUrls   []string `json:"detection_mecanism_urls"`
-	NetworkDetection        string   `json:"network_detection"`
-	NetworkDetectionIP      string   `json:"network_detection_ip"`
-	ImagePath               string   `json:"image_path"`
-	LoadbalancersIP         string   `json:"loadbalancers_ip"`
-	RequestTimeout          string   `json:"request_timeout"`
-	SecureRedirect          string   `json:"secure_redirect"`
-	StatusOnlyOnProduction  string   `json:"status_only_on_production"`
-	WisprRedirection        string   `json:"wispr_redirection"`
+	PfconfigMethod               string   `val:"hash_element"`
+	PfconfigNS                   string   `val:"config::Pf"`
+	PfconfigHashNS               string   `val:"captive_portal"`
+	DetectionMecanismBypass      string   `json:"detection_mecanism_bypass"`
+	DetectionMecanismUrls        []string `json:"detection_mecanism_urls"`
+	NetworkDetection             string   `json:"network_detection"`
+	NetworkDetectionIP           string   `json:"network_detection_ip"`
+	NetworkDetectionInitialDelay string   `json:"network_detection_initial_delay"`
+	NetworkDetectionRetryDelay   string   `json:"network_detection_retry_delay"`
+	NetworkRedirectDelay         int      `json:"network_redirect_delay"`
+	ImagePath                    string   `json:"image_path"`
+	LoadbalancersIP              string   `json:"loadbalancers_ip"`
+	RequestTimeout               string   `json:"request_timeout"`
+	SecureRedirect               string   `json:"secure_redirect"`
+	StatusOnlyOnProduction       string   `json:"status_only_on_production"`
+	WisprRedirection             string   `json:"wispr_redirection"`
 }
 
 type ManagementNetwork struct {

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Remediation.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Remediation.pm
@@ -80,7 +80,7 @@ sub scan_status : Private {
     $c->stash(
         title => "scan: scan in progress",
         template    => 'scan-in-progress.html',
-        timer         => $Config{'fencing'}{'redirtimer'},
+        timer         => $Config{'captive_portal'}{'network_redirect_delay'},
         txt_message => [
             'scan in progress contact support if too long',
             $scan_start_time

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Violation.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Violation.pm
@@ -60,7 +60,7 @@ sub index : Path : Args(0) {
                     template => "scan.html",
                     txt_message => "system scan in progress",
                     title => "scan: scan in progress",
-                    timer => $Config{'fencing'}{'redirtimer'},
+                    timer => $Config{'captive_portal'}{'network_redirect_delay'},
                 );
                 $c->detach();
             }

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module.pm
@@ -213,8 +213,8 @@ sub _release_args {
     return {
         timer         => $Config{'fencing'}{'redirtimer'},
         destination_url  => $self->app->session->{destination_url},
-        initial_delay => $CAPTIVE_PORTAL{'NET_DETECT_INITIAL_DELAY'},
-        retry_delay   => $CAPTIVE_PORTAL{'NET_DETECT_RETRY_DELAY'},
+        initial_delay => $Config{'captive_portal'}{'network_detection_initial_delay'},
+        retry_delay   => $Config{'captive_portal'}{'network_detection_retry_delay'},
         external_ip => $Config{'captive_portal'}{'network_detection_ip'},
         auto_redirect => $Config{'captive_portal'}{'network_detection'},
         image_path => $Config{'captive_portal'}{'image_path'},

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module.pm
@@ -211,7 +211,7 @@ The arguments that are used when releasing a device on the network
 sub _release_args {
     my ($self) = @_;
     return {
-        timer         => $Config{'fencing'}{'redirtimer'},
+        timer => $Config{'captive_portal'}{'network_redirect_delay'},
         destination_url  => $self->app->session->{destination_url},
         initial_delay => $Config{'captive_portal'}{'network_detection_initial_delay'},
         retry_delay   => $Config{'captive_portal'}{'network_detection_retry_delay'},

--- a/html/pfappserver/lib/pfappserver/I18N/en.po
+++ b/html/pfappserver/lib/pfappserver/I18N/en.po
@@ -3283,7 +3283,7 @@ msgstr ""
 msgid "How long can an unregistered node be inactive on the network before being deleted.<br>This shouldn't be used if you are using port-security"
 msgstr ""
 
-# conf/documentation.conf (fencing.redirtimer)
+# conf/documentation.conf (captive_portal.network_redirect_delay)
 msgid "How long to display the progress bar during trap release. Default value is based on VLAN enforcement techniques. Inline enforcement only users could lower the value."
 msgstr ""
 
@@ -9509,6 +9509,10 @@ msgid "captive_portal.network_detection_retry_delay"
 msgstr "Retry delay"
 
 # conf/documentation.conf
+msgid "captive_portal.network_redirect_delay"
+msgstr "Redirection delay"
+
+# conf/documentation.conf
 msgid "captive_portal.rate_limiting"
 msgstr "Rate limiting"
 
@@ -10011,10 +10015,6 @@ msgstr "Proxy Passthroughs"
 # conf/documentation.conf
 msgid "fencing.range"
 msgstr "Addresses ranges"
-
-# conf/documentation.conf
-msgid "fencing.redirtimer"
-msgstr "Redirection delay"
 
 # conf/documentation.conf
 msgid "fencing.wait_for_redirect"

--- a/html/pfappserver/lib/pfappserver/I18N/en.po
+++ b/html/pfappserver/lib/pfappserver/I18N/en.po
@@ -9501,6 +9501,14 @@ msgid "captive_portal.network_detection_ip"
 msgstr "IP"
 
 # conf/documentation.conf
+msgid "captive_portal.network_detection_initial_delay"
+msgstr "Initial delay"
+
+# conf/documentation.conf
+msgid "captive_portal.network_detection_retry_delay"
+msgstr "Retry delay"
+
+# conf/documentation.conf
 msgid "captive_portal.rate_limiting"
 msgstr "Rate limiting"
 

--- a/html/pfappserver/lib/pfappserver/I18N/fr.po
+++ b/html/pfappserver/lib/pfappserver/I18N/fr.po
@@ -3525,7 +3525,7 @@ msgid ""
 "deleted.<br>This shouldn't be used if you are using port-security"
 msgstr "Combien de temps un périphérique enregistré peut être inactif sur le réseau avant d’être supprimé. <br/> Cette fonctionnalité ne devrait pas être utilisé avec du port-security"
 
-# conf/documentation.conf (fencing.redirtimer)
+# conf/documentation.conf (captive_portal.network_redirect_delay)
 msgid ""
 "How long to display the progress bar during trap release. Default value is "
 "based on VLAN enforcement techniques. Inline enforcement only users could "
@@ -10314,6 +10314,10 @@ msgid "captive_portal.network_detection_retry_delay"
 msgstr "Retry delay"
 
 # conf/documentation.conf
+msgid "captive_portal.network_redirect_delay"
+msgstr "Delais de redirection"
+
+# conf/documentation.conf
 msgid "captive_portal.rate_limiting"
 msgstr "Limite de débit"
 
@@ -10826,10 +10830,6 @@ msgstr "Proxy Passthroughs"
 # conf/documentation.conf
 msgid "fencing.range"
 msgstr "Plages d’adressage"
-
-# conf/documentation.conf
-msgid "fencing.redirtimer"
-msgstr "Delais de redirection"
 
 # conf/documentation.conf
 msgid "fencing.wait_for_redirect"

--- a/html/pfappserver/lib/pfappserver/I18N/fr.po
+++ b/html/pfappserver/lib/pfappserver/I18N/fr.po
@@ -8841,7 +8841,7 @@ msgstr "Ceci est le délais qui permets à un invité enregistré par email de s
 # conf/documentation.conf (captive_portal.image_path)
 msgid ""
 "This is the path where the gif is on the webserver to detect if the network "
-"accesshas been enabled."
+"access has been enabled."
 msgstr "Ceci est le chemin d’accès pour l’emplacement du gif sur le serveur. Cette option permet de détecter si l’accès réseau a été activé."
 
 # html/pfappserver/lib/pfappserver/Form/Config/Domain.pm
@@ -10304,6 +10304,14 @@ msgstr "Détection réseau"
 # conf/documentation.conf
 msgid "captive_portal.network_detection_ip"
 msgstr "IP"
+
+# conf/documentation.conf
+msgid "captive_portal.network_detection_initial_delay"
+msgstr "Délai initial"
+
+# conf/documentation.conf
+msgid "captive_portal.network_detection_retry_delay"
+msgstr "Retry delay"
 
 # conf/documentation.conf
 msgid "captive_portal.rate_limiting"

--- a/lib/pf/web.pm
+++ b/lib/pf/web.pm
@@ -186,8 +186,8 @@ sub generate_release_page {
     $portalSession->stash({
         timer => $Config{'fencing'}{'redirtimer'},
         destination_url => $portalSession->getDestinationUrl(),
-        initial_delay => $CAPTIVE_PORTAL{'NET_DETECT_INITIAL_DELAY'},
-        retry_delay => $CAPTIVE_PORTAL{'NET_DETECT_RETRY_DELAY'},
+        initial_delay => $Config{'captive_portal'}{'network_detection_initial_delay'},
+        retry_delay => $Config{'captive_portal'}{'network_detection_retry_delay'},
         external_ip => $Config{'captive_portal'}{'network_detection_ip'},
         auto_redirect => $Config{'captive_portal'}{'network_detection'},
     });

--- a/lib/pf/web.pm
+++ b/lib/pf/web.pm
@@ -184,7 +184,7 @@ sub generate_release_page {
     my ( $portalSession, $r ) = @_;
 
     $portalSession->stash({
-        timer => $Config{'fencing'}{'redirtimer'},
+        timer => $Config{'captive_portal'}{'network_redirect_delay'},
         destination_url => $portalSession->getDestinationUrl(),
         initial_delay => $Config{'captive_portal'}{'network_detection_initial_delay'},
         retry_delay => $Config{'captive_portal'}{'network_detection_retry_delay'},

--- a/lib/pfconfig/namespaces/resource/CaptivePortal.pm
+++ b/lib/pfconfig/namespaces/resource/CaptivePortal.pm
@@ -31,11 +31,7 @@ sub build {
     # CAPTIVE-PORTAL RELATED
     # Captive Portal constants
     my %CAPTIVE_PORTAL = (
-        "NET_DETECT_INITIAL_DELAY"         => floor( $Config{'fencing'}{'redirtimer'} / 4 ),
-        "NET_DETECT_RETRY_DELAY"           => 2,
-        "NET_DETECT_PENDING_INITIAL_DELAY" => 2 * 60,
-        "NET_DETECT_PENDING_RETRY_DELAY"   => 30,
-        "TEMPLATE_DIR"                     => "$install_dir/html/captive-portal/templates",
+        "TEMPLATE_DIR" => "$install_dir/html/captive-portal/templates",
     );
 
     # process pf.conf's parameter into an IP => 1 hash


### PR DESCRIPTION
# Description
Add network_detection_initial_delay and network_detection_retry_delay configuration vars for captive_portal

# Issue
Fixes #383 

# Delete branch after merge
YES

## Enhancements
* Adds `Initial Delay` configuration to Admin > Advanced Access Configuration > Captive Portal.
* Adds `Retry Delay` configuration to Admin > Advanced Access Configuration > Captive Portal.
* Spelling correction from "accesshas" to "access has" in `IMG Path`.
* Deprecate `$CAPTIVE_PORTAL` GLOBALS `NET_DETECT_INITIAL_DELAY`, `NET_DETECT_RETRY_DELAY`, `NET_DETECT_PENDING_INITIAL_DELAY`, `NET_DETECT_PENDING_RETRY_DELAY`.
