### PR TITLE
Livraison module Rapid7 Nexpose

### DIFF
--- a/conf/nexpose-responses.txt
+++ b/conf/nexpose-responses.txt
@@ -1,4 +1,3 @@
-
 2007 Microsoft
 2007 Office
 3Com 8760
@@ -2101,7 +2100,6 @@ NAT-PMP Malicious
 Navigational Target
 NetBIOS NBSTAT
 NetBus backdoor
-.netrc files
 Netscape/Sun iPlanet
 Netscreen device
 Net-SNMP Trap
@@ -2502,7 +2500,6 @@ Remotely Exploitable
 Reverse Clickjacking
 Reverse Proxy
 'rexec' Remote
-.rhosts files
 RHSA
 'rlogin' Remote
 robots.txt Files
@@ -4415,7 +4412,7 @@ USN-1892-1 ubuntu-release-upgrader
 USN-1893-1 Subversion
 USN-1894-1 curl
 USN-1895-1 libvirt
-USN-1896-1 Module:Signature
+USN-1896-1 ModuleSignature
 USN-1897-1 PyMongo
 USN-1898-1 OpenSSL
 USN-1899-1 Linux
@@ -4809,7 +4806,7 @@ USN-2288-1 Linux
 USN-2289-1 Linux
 USN-2290-1 Linux
 USN-2291-1 MySQL
-USN-2292-1 LWP:Protocol:https
+USN-2292-1 LWPProtocolhttps
 USN-2293-1 CUPS
 USN-2294-1 Libtasn1
 USN-2295-1 Firefox
@@ -5119,7 +5116,7 @@ USN-2588-1 Linux
 USN-2589-1 Linux
 USN-2590-1 Linux
 USN-2591-1 curl
-USN-2592-1 XML:LibXML
+USN-2592-1 XMLLibXML
 USN-2593-1 Dnsmasq
 USN-2594-1 ClamAV
 USN-2595-1 ppp
@@ -5136,7 +5133,7 @@ USN-2602-1 Firefox
 USN-2603-1 Thunderbird
 USN-2604-1 Libtasn1
 USN-2605-1 ICU
-USN-2607-1 Module:Signature
+USN-2607-1 ModuleSignature
 USN-2608-1 QEMU
 USN-2609-1 Apport
 USN-2610-1 Oxide

--- a/docs/PacketFence_Rapid7NexposeInsightVM_Quick_Install_Guide-docinfo.xml
+++ b/docs/PacketFence_Rapid7NexposeInsightVM_Quick_Install_Guide-docinfo.xml
@@ -1,0 +1,24 @@
+<copyright>
+  <year>2014</year>
+  <holder>Inverse inc.</holder>
+</copyright>
+
+<revhistory>
+  <revision>
+    <revnumber>1.0</revnumber>
+    <date>2014-10-20</date>
+    <revremark>First revision</revremark>
+  </revision>
+</revhistory>
+
+<authorgroup>
+  <author>
+    <firstname>Inverse</firstname>
+    <surname>Inc.</surname>
+    <affiliation>
+      <address>
+        <email>info@inverse.ca</email>
+      </address>
+    </affiliation>
+  </author>
+</authorgroup>

--- a/docs/PacketFence_Rapid7NexposeInsightVM_Quick_Install_Guide-docinfo.xml
+++ b/docs/PacketFence_Rapid7NexposeInsightVM_Quick_Install_Guide-docinfo.xml
@@ -1,12 +1,12 @@
 <copyright>
-  <year>2014</year>
+  <year>2017</year>
   <holder>Inverse inc.</holder>
 </copyright>
 
 <revhistory>
   <revision>
     <revnumber>1.0</revnumber>
-    <date>2014-10-20</date>
+    <date>2017-11-24</date>
     <revremark>First revision</revremark>
   </revision>
 </revhistory>

--- a/docs/PacketFence_Rapid7NexposeInsightVM_Quick_Install_Guide.asciidoc
+++ b/docs/PacketFence_Rapid7NexposeInsightVM_Quick_Install_Guide.asciidoc
@@ -114,16 +114,17 @@ WARNING: If you are using a PacketFence cluster, you will need to do these steps
 
 * Restart the 'rsyslog' service
 ** Run this command:
-----
-service rsyslog restart
-----
+  
+  service rsyslog restart
 
 At this point Packetfence must be able to get the Nexpose audits results.
 
 TIP: You can see if the Nexpose server is sending to the right server by minitoring both sides traffic, with a 'tcpdump -i any dst host YOUR_PACKETFENCE_SERVERI' on your Rapid7 Nexpose server and 'tcpdump -i any port 514' on the PacketFence server.
 
-Get PacketFence to be able to configure what acvtion need to be taken
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Get PacketFence to be able to configure what action need to be taken
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Let's give PacketFence the Nexpose parser it needs to detect Nexpose events ::
 * Logon to PacketFence Server with a browser on the PacketFenceGUI 
 ** _https://YOUR_PACKETFENCE_SERVER_IP:1443_
 
@@ -131,18 +132,54 @@ Get PacketFence to be able to configure what acvtion need to be taken
 * On the drop list 'ADD SYSLOG PARSER', take 'Nexpose'
 * As Detector, put the name of your choice for this parser.
 * In Alert pipe, put the 'absolute' path to our nexpose pipe
-----
-/usr/local/pf/var/run/nexpose_pipe
-----
+
+  /usr/local/pf/var/run/nexpose_pipe
+
 * Click on 'SAVE'.
 
-Once done, we need to restart the good services
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Once done, we need to restart the good services ::
 * Restart the 'pfdetect' and the 'pfqueue' service.
 ----
 /usr/local/pf/pfcmd service pfdetect restart
 /usr/local/pf/pfcmd service pfqueue restart
 ----
+
+Now that PacketFence got the datas to process, lets tell it what to do with it ::
+* In the PacketFence GUI, go to *Configuration -> Compliance -> Violations*
+* Go down on the page to the end of the section and note the last violation ID XXXXXXX
+* Click on *ADD VIOLATION*
+
+|===
+|*Definition*
+|*Enable*: Set it to *ON* 
+
+*Identifier*: Use the previously noted violation ID and add 1 to it. (But you can use what ever you want.)
+
+*Action*: This is where you put what you want PacketFence to do, in this case.
+|===
+
+
+|===
+|*Triggers*
+|Click on the plus *(+)*, on the right side of the page.
+
+On the seconde line, choose the appropriate trigger between "*nexpose_event_contains*" or "*nexpose_event_start_with*"
+
+Choose "nexpose_event_contains" if you know, for exemple, the "*Common Vulnerabilities and Exposures*" you want to take action on.
+
+| For "*nexpose_event_contains*": You can put there the CVE or the vlnerability name you are looking for.
+
+For "*nexpose_event_start_with*": Put there the full vulnerability name you can find in the Nexpose report, on the Nexpose GUI
+
+| Click on *ADD*, then *SAVE*
+
+INFO: You can only have one trigger, for one violation.
+
+|===
+
+
+For more info on violation actions, go to the _PacketFence Administration Guide_, in _Blocking malicious activities with violations_ 
+
 
 
 

--- a/docs/PacketFence_Rapid7NexposeInsightVM_Quick_Install_Guide.asciidoc
+++ b/docs/PacketFence_Rapid7NexposeInsightVM_Quick_Install_Guide.asciidoc
@@ -17,14 +17,15 @@ include::includes/global-attributes.asciidoc[]
 About this Guide
 ----------------
 
-This guide has been created in order to help the configuration of Rapid7 InsighVM Nexpose and PacketFence, to provide informations and actions about devices compliances before and during network access.
+This guide has been created in order to help you with the configuration of Rapid7 InsighVM Nexpose and PacketFence, to provide information and actions about devices compliance before and during network access.
+
 
 Assumptions
 -----------
 * You have a configured PacketFence server environment with working test equipment.
-* You have a Centos7 server, ready and updated, we will use it as the 'Rapid7 InsightVM' server.
+* You have a Centos 7 server, ready and updated, we will use it as the 'Rapid7 InsightVM' server.
 * You have created an account at https://www.rapid7.com/[Rapid7] and downloaded the https://www.rapid7.com/products/insightvm/[InsightVM] binaries.
-* You have, at least, a trial available licence.
+* You have, at least, a trial licence.
 
 Installation
 ------------
@@ -34,7 +35,7 @@ Step 1: Rapid7 Insight Configuration
 
 How to configure Rapid7 InsightVM Nexpose Server to send data to the PacketFence server in a way it can understand and process it.
 
-WARNING: Disable the firewalld service, the iptables services, the SELinux services, and ... others IDS services.
+WARNING: Disable the firewalld service, the iptables services, SELinux, and ... others filtering services.
 
 Application Installation
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -61,8 +62,8 @@ What you will write:What Nexpose will understand
 * In the upper *Menu*, select *Templates* and define the scope of the audit you want.
 * In the *Menu*, select *Engines* and define the engine, depending on the licence and scope you have.
 
-How to sent Syslogs to PacketFence
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Sending syslog information to PacketFenc
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 * On the left, create a new alert.
 * In the *Menu*, select now *Alerts*
 
@@ -85,18 +86,18 @@ How to sent Syslogs to PacketFence
 In the *Menu*, select now *Schedule*, and define the schedules of your audits.
 
 
-Step 2: PacketFence configuration
+Step 2: PacketFence Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-"What need to be done on the PacketFence Server to understand and take action about endpoints containing threats"
+"What needs to be done on the PacketFence Server to understand and take action about endpoints containing threats"
 
-Get PacketFence ready to welcome Nexpose Syslogs
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+PacketFence changes to handle Nexpose syslog information
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-WARNING: If you are using a PacketFence cluster, you will need to do these steps in all your PacketFence servers.
+WARNING: If you are using a PacketFence cluster, you will need to do these steps on all your PacketFence servers.
 
 * Logon to PacketFence Server with a _ssh_ terminal.
-* Create the fifo pipe file that PacketFence will use to get datas from Nexpose
+* Create the fifo pipe file that PacketFence will use to get data from Nexpose
  
  mkfifo /usr/local/pf/var/run/nexpose_pipe
 
@@ -106,7 +107,7 @@ WARNING: If you are using a PacketFence cluster, you will need to do these steps
  if $programname == 'Nexpose' then /usr/local/pf/var/run/nexpose_pipe
  & ~
 
-* Modify /etc/rsyslog.conf to accept syslogs on 'udp 514'
+* Modify /etc/rsyslog.conf to accept syslogs data on 'udp 514'
 ** Uncomment the two lines:
 
  $ModLoad imudp
@@ -117,15 +118,15 @@ WARNING: If you are using a PacketFence cluster, you will need to do these steps
   
   service rsyslog restart
 
-At this point Packetfence must be able to get the Nexpose audits results.
+At this point PacketFence must be able to get the Nexpose audit results.
 
-TIP: You can see if the Nexpose server is sending to the right server by minitoring both sides traffic, with a 'tcpdump -i any dst host YOUR_PACKETFENCE_SERVERI' on your Rapid7 Nexpose server and 'tcpdump -i any port 514' on the PacketFence server.
+TIP: You can see if the Nexpose server is sending to the right server by monitoring both sides traffic, with a 'tcpdump -i any dst host YOUR_PACKETFENCE_SERVERI' on your Rapid7 Nexpose server and 'tcpdump -i any port 514' on the PacketFence server.
 
-Get PacketFence to be able to configure what action need to be taken
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Integrating with PacketFence violation system
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Let's give PacketFence the Nexpose parser it needs to detect Nexpose events ::
-* Logon to PacketFence Server with a browser on the PacketFenceGUI 
+* Logon to PacketFence server with a browser on the PacketFence admin interface. 
 ** _https://YOUR_PACKETFENCE_SERVER_IP:1443_
 
 * Go to *Configuration -> Integration -> Syslog parsers*
@@ -144,7 +145,7 @@ Once done, we need to restart the good services ::
 /usr/local/pf/pfcmd service pfqueue restart
 ----
 
-Now that PacketFence got the datas to process, lets tell it what to do with it ::
+Now that PacketFence is properly configured to receive information from Nexpose, lets configure it to perform some actionsi ::
 * In the PacketFence GUI, go to *Configuration -> Compliance -> Violations*
 * Go down on the page to the end of the section and note the last violation ID XXXXXXX
 * Click on *ADD VIOLATION*
@@ -153,7 +154,7 @@ Now that PacketFence got the datas to process, lets tell it what to do with it :
 |*Definition*
 |*Enable*: Set it to *ON* 
 
-*Identifier*: Use the previously noted violation ID and add 1 to it. (But you can use what ever you want.)
+*Identifier*: Use the previously noted violation ID and add 1 to it. (But you can use whatever you want.)
 
 *Action*: This is where you put what you want PacketFence to do, in this case.
 |===
@@ -163,9 +164,9 @@ Now that PacketFence got the datas to process, lets tell it what to do with it :
 |*Triggers*
 |Click on the plus *(+)*, on the right side of the page.
 
-On the seconde line, choose the appropriate trigger between "*nexpose_event_contains*" or "*nexpose_event_start_with*"
+On the second line, choose the appropriate trigger between "*nexpose_event_contains*" or "*nexpose_event_start_with*"
 
-Choose "nexpose_event_contains" if you know, for exemple, the "*Common Vulnerabilities and Exposures*" you want to take action on.
+Choose "nexpose_event_contains" if you know, for example, the "*Common Vulnerabilities and Exposures*" you want to take action on.
 
 | For "*nexpose_event_contains*": You can put there the CVE or the vlnerability name you are looking for.
 

--- a/docs/PacketFence_Rapid7NexposeInsightVM_Quick_Install_Guide.asciidoc
+++ b/docs/PacketFence_Rapid7NexposeInsightVM_Quick_Install_Guide.asciidoc
@@ -1,0 +1,139 @@
+Rapid7 InsightVM Nexpose:Quick Integration Guide
+------------------------------------------------
+:doctype: book
+:toc: left
+
+include::includes/global-attributes.asciidoc[]
+
+About this Guide
+----------------
+
+This guide has been created in order to demonstrate the PacketFence capabilities on-site with an existing or potential customer. 
+It can also provide guidelines to setup a proof of concept for a potential PacketFence deployment using Rapid7 InsightVM Nexpose to provide informations about devices compliances before and during network access.
+
+Assumptions
+-----------
+* You have a configured PacketFence server environment with working test equipment.
+* You have a Centos7 server ready and updated, We will use it at the R7 InsightVM server.
+* You have created an account at https://www.rapid7.com/ and downloaded the InsightVM binaries.
+* You have, at least, a trial available licence.
+
+installation
+------------
+
+Step 1: Rapid7 Insight configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+How to configure R7 InsightVM Nexpose Server to send data to the PacketFence server in a way it can understatnd and process it.
+
+WARNING: Disable the firewalld service, the iptables services, the SELinux services, and ... others IDS services.
+
+Application installation
+^^^^^^^^^^^^^^^^^^^^^^^^
+* Install the InsighVM application 
+** https://insightvm.help.rapid7.com/docs/installing-in-linux-environments#section-installing-in-red-hat
+
+* Run the application 
+** https://insightvm.help.rapid7.com/docs/running-the-application#section-managing-the-application-in-linux
+
+* Logon to the server 
+** 'https://'YourRapid7ServerIP:3780'
+
+First Scan creation
+^^^^^^^^^^^^^^^^^^^
+* Create a new site by clicking the "Create" -> "Site" 
+* After naming the new site, create the New Assets: "Site configuration" -> "Assets"
+* In Include, create the list of assets you want to audit:
+
+*INFO* 
+:===
+What you will write:What 10.0.0.0/24:10.0.0.1-10.0.0.254
+10.0.0.1-10.0.0.254:10.0.0.1-10.0.0.254
+:===
+
+* In Exclude, put all the asset you want to exclude fromthe previous ranges.
+* In the upper Menu, select Templates and define the scope of the audit you want.
+* In the Menu, select Engines and define the Engine, depending on the licence and scope you have.
+
+How to sent Syslogs to PacketFence
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+* On the left, create a new alert.
+* In the Menu, select now Alerts,
+:===
+"Enable": Must be checked. 
+"Alert Name": Rsyslog to PacketFence or else.
+"Maximum Alerts to send": blank (none)
+"Scan events": Check all.
+"Vulnerability Events": 'Any severity' ; Check as well "Confirmed", "Unconfirmed", "Potential"
+"Notification Method": Select 'Syslog message'
+"Syslog Server": "PacketFence cluster VIP or server IP for a standalone"  
+:===
+* In the Menu, select now Schedule, and define the schedules of your audits.
+
+IMPORTANT: *Go on the upper right and click on #"SAVE"# to avoid any losts configuration.* 
+
+
+Step 2: PacketFence configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+"What need to be done on the PacketFence Server to understand and take action about terminals containing threadts"
+
+Get PacketFence ready to welcome Nexpose Syslogs
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+WARNING: If you are using a PacketFence cluster, you will need to do thoses steps in all your PacketFence servers.
+
+* Logon to PacketFence Server with a _ssh_ terminal.
+* Create the fifo pipe file that PacketFence will use to get datas from Nexpose
+----
+mkfifo /usr/local/pf/var/run/nexpose_pipe
+----
+
+* Create a new file named /etc/rsyslog.d/nexpose-log.conf.
+----
+# rsyslog conf for Rapid7 Nexpose server logs reception
+if $programname == 'Nexpose' then /usr/local/pf/var/run/nexpose_pipe
+& ~
+----
+
+* Modifie /etc/rsyslog.conf to accept syslogs on 'udp 514'
+** Uncomment the two lines:
+----
+$ModLoad imudp
+$UDPServerRun 514
+----
+
+* Restart the 'rsyslog' service
+** Run this command:
+----
+service rsyslog restart
+----
+
+At this point Packetfence must be able to get the Nexpose audits results.
+
+TIP: You can see if the Nexpose server is sending to the right server by minitoring both sides traffic, with a 'tcpdump -i any dst host YOUR_PACKETFENCE_SERVERI' on your Rapid7 Nexpose server and 'tcpdump -i any port 514' on the PacketFence server.
+
+Get PacketFence to be able to configure what acvtion need to be taken
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+* Logon to PacketFence Server with a browser on the PacketFenceGUI 
+** 'https://YOUR_PACKETFENCE_SERVER_IP:1443'
+
+* Go to *Configuration -> Integration -> Syslog parsers*
+* On the drop list 'ADD SYSLOG PARSER', take 'Nexpose'
+* As Detector, put the name of your choice for this parser.
+* In Alert pipe, put the 'absolute' path to our nexpose pipe
+----
+/usr/local/pf/var/run/nexpose_pipe
+----
+* Click on 'SAVE'.
+
+Once done, we need to restart the good services
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+* Restart the 'pfdetect' and the 'pfqueue' service.
+----
+/usr/local/pf/pfcmd service pfdetect restart
+/usr/local/pf/pfcmd service pfqueue restart
+----
+
+
+

--- a/docs/PacketFence_Rapid7NexposeInsightVM_Quick_Install_Guide.asciidoc
+++ b/docs/PacketFence_Rapid7NexposeInsightVM_Quick_Install_Guide.asciidoc
@@ -1,34 +1,42 @@
-Rapid7 InsightVM Nexpose:Quick Integration Guide
-------------------------------------------------
+Rapid7 InsightVM Nexpose: Quick Integration Guide
+-------------------------------------------------
 :doctype: book
 :toc: left
 
 include::includes/global-attributes.asciidoc[]
 
+////
+
+    This file is part of the PacketFence project.
+
+    See PacketFence_Administration_Guide-docinfo.xml for authors, copyright 
+    and license information.
+
+////
+
 About this Guide
 ----------------
 
-This guide has been created in order to demonstrate the PacketFence capabilities on-site with an existing or potential customer. 
-It can also provide guidelines to setup a proof of concept for a potential PacketFence deployment using Rapid7 InsightVM Nexpose to provide informations about devices compliances before and during network access.
+This guide has been created in order to help the configuration of Rapid7 InsighVM Nexpose and PacketFence, to provide informations and actions about devices compliances before and during network access.
 
 Assumptions
 -----------
 * You have a configured PacketFence server environment with working test equipment.
-* You have a Centos7 server ready and updated, We will use it at the R7 InsightVM server.
-* You have created an account at https://www.rapid7.com/ and downloaded the InsightVM binaries.
+* You have a Centos7 server, ready and updated, we will use it as the 'Rapid7 InsightVM' server.
+* You have created an account at https://www.rapid7.com/[Rapid7] and downloaded the https://www.rapid7.com/products/insightvm/[InsightVM] binaries.
 * You have, at least, a trial available licence.
 
-installation
+Installation
 ------------
 
-Step 1: Rapid7 Insight configuration
+Step 1: Rapid7 Insight Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-How to configure R7 InsightVM Nexpose Server to send data to the PacketFence server in a way it can understatnd and process it.
+How to configure Rapid7 InsightVM Nexpose Server to send data to the PacketFence server in a way it can understand and process it.
 
 WARNING: Disable the firewalld service, the iptables services, the SELinux services, and ... others IDS services.
 
-Application installation
+Application Installation
 ^^^^^^^^^^^^^^^^^^^^^^^^
 * Install the InsighVM application 
 ** https://insightvm.help.rapid7.com/docs/installing-in-linux-environments#section-installing-in-red-hat
@@ -36,72 +44,73 @@ Application installation
 * Run the application 
 ** https://insightvm.help.rapid7.com/docs/running-the-application#section-managing-the-application-in-linux
 
-* Logon to the server 
-** 'https://'YourRapid7ServerIP:3780'
+* Logon to the server: _https://'YourRapid7ServerIP:3780_
 
-First Scan creation
+First Scan Creation
 ^^^^^^^^^^^^^^^^^^^
-* Create a new site by clicking the "Create" -> "Site" 
-* After naming the new site, create the New Assets: "Site configuration" -> "Assets"
+* Create a new site by clicking the *Create -> Site* 
+* After naming the new site, create the new assets: *Site configuration -> Assets*
 * In Include, create the list of assets you want to audit:
-
-*INFO* 
 :===
-What you will write:What 10.0.0.0/24:10.0.0.1-10.0.0.254
+What you will write:What Nexpose will understand
+10.0.0.0/24:10.0.0.1-10.0.0.254
 10.0.0.1-10.0.0.254:10.0.0.1-10.0.0.254
 :===
 
-* In Exclude, put all the asset you want to exclude fromthe previous ranges.
-* In the upper Menu, select Templates and define the scope of the audit you want.
-* In the Menu, select Engines and define the Engine, depending on the licence and scope you have.
+* In *Exclude*, put all the assets you want to exclude from the previous ranges.
+* In the upper *Menu*, select *Templates* and define the scope of the audit you want.
+* In the *Menu*, select *Engines* and define the engine, depending on the licence and scope you have.
 
 How to sent Syslogs to PacketFence
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 * On the left, create a new alert.
-* In the Menu, select now Alerts,
-:===
-"Enable": Must be checked. 
-"Alert Name": Rsyslog to PacketFence or else.
-"Maximum Alerts to send": blank (none)
-"Scan events": Check all.
-"Vulnerability Events": 'Any severity' ; Check as well "Confirmed", "Unconfirmed", "Potential"
-"Notification Method": Select 'Syslog message'
-"Syslog Server": "PacketFence cluster VIP or server IP for a standalone"  
-:===
-* In the Menu, select now Schedule, and define the schedules of your audits.
+* In the *Menu*, select now *Alerts*
 
-IMPORTANT: *Go on the upper right and click on #"SAVE"# to avoid any losts configuration.* 
+|===
+|*Enable*: Must be checked. 
+
+*Alert Name*: Rsyslog to PacketFence or else.
+
+*Maximum Alerts to send*: blank (none)
+
+*Scan events*: Check all.
+
+*Vulnerability Events*: _Any severity_ ; Check as well _Confirmed_, _Unconfirmed_, _Potential_
+
+*Notification Method*: Select _Syslog message_
+
+*Syslog Server*: "PacketFence cluster VIP or server IP for a standalone"  
+|===
+
+In the *Menu*, select now *Schedule*, and define the schedules of your audits.
 
 
 Step 2: PacketFence configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-"What need to be done on the PacketFence Server to understand and take action about terminals containing threadts"
+"What need to be done on the PacketFence Server to understand and take action about endpoints containing threats"
 
 Get PacketFence ready to welcome Nexpose Syslogs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-WARNING: If you are using a PacketFence cluster, you will need to do thoses steps in all your PacketFence servers.
+WARNING: If you are using a PacketFence cluster, you will need to do these steps in all your PacketFence servers.
 
 * Logon to PacketFence Server with a _ssh_ terminal.
 * Create the fifo pipe file that PacketFence will use to get datas from Nexpose
-----
-mkfifo /usr/local/pf/var/run/nexpose_pipe
-----
+ 
+ mkfifo /usr/local/pf/var/run/nexpose_pipe
 
 * Create a new file named /etc/rsyslog.d/nexpose-log.conf.
-----
-# rsyslog conf for Rapid7 Nexpose server logs reception
-if $programname == 'Nexpose' then /usr/local/pf/var/run/nexpose_pipe
-& ~
-----
 
-* Modifie /etc/rsyslog.conf to accept syslogs on 'udp 514'
+ # rsyslog conf for Rapid7 Nexpose server logs reception
+ if $programname == 'Nexpose' then /usr/local/pf/var/run/nexpose_pipe
+ & ~
+
+* Modify /etc/rsyslog.conf to accept syslogs on 'udp 514'
 ** Uncomment the two lines:
-----
-$ModLoad imudp
-$UDPServerRun 514
-----
+
+ $ModLoad imudp
+ $UDPServerRun 514
 
 * Restart the 'rsyslog' service
 ** Run this command:
@@ -116,7 +125,7 @@ TIP: You can see if the Nexpose server is sending to the right server by minitor
 Get PacketFence to be able to configure what acvtion need to be taken
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 * Logon to PacketFence Server with a browser on the PacketFenceGUI 
-** 'https://YOUR_PACKETFENCE_SERVER_IP:1443'
+** _https://YOUR_PACKETFENCE_SERVER_IP:1443_
 
 * Go to *Configuration -> Integration -> Syslog parsers*
 * On the drop list 'ADD SYSLOG PARSER', take 'Nexpose'

--- a/html/pfappserver/lib/pfappserver/Form/Config/Pfdetect/nexpose.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Pfdetect/nexpose.pm
@@ -1,0 +1,44 @@
+package pfappserver::Form::Config::Pfdetect::nexpose;
+
+=head1 NAME
+
+pfappserver::Form::Config::Pfdetect::nexpose - Web form for a pfdetect detector
+
+=head1 DESCRIPTION
+
+Form definition to create or update a pfdetect detector.
+
+=cut
+
+use HTML::FormHandler::Moose;
+extends 'pfappserver::Form::Config::Pfdetect';
+
+=over
+
+=back
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2017 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+__PACKAGE__->meta->make_immutable unless $ENV{"PF_SKIP_MAKE_IMMUTABLE"};
+1;

--- a/html/pfappserver/lib/pfappserver/I18N/en.po
+++ b/html/pfappserver/lib/pfappserver/I18N/en.po
@@ -10679,6 +10679,10 @@ msgid "pf_domain"
 msgstr "Domain"
 
 # pf::factory::detect::parser (Detect Parsers)
+msgid "pfdetect_type_nexpose"
+msgstr "Nexpose"
+
+# pf::factory::detect::parser (Detect Parsers)
 msgid "pfdetect_type_dhcp"
 msgstr "DHCP"
 

--- a/html/pfappserver/root/config/pfdetect/type/nexpose.tt
+++ b/html/pfappserver/root/config/pfdetect/type/nexpose.tt
@@ -1,0 +1,1 @@
+[% form.block('definition').render | none %]

--- a/lib/pf/condition/matches.pm
+++ b/lib/pf/condition/matches.pm
@@ -40,7 +40,7 @@ sub match {
     my ($self,$arg) = @_;
     my $match = $self->value;
     return 0 if(!defined($arg));
-    return $arg =~ /\Q$match\E/;
+    return $arg =~ /\Q$match\E/i;
 }
 
 =head1 AUTHOR

--- a/lib/pf/condition/not_matches.pm
+++ b/lib/pf/condition/not_matches.pm
@@ -39,7 +39,7 @@ sub match {
     my ($self,$arg) = @_;
     my $match = $self->value;
     return $FALSE if(!defined($arg));
-    return $arg !~ /\Q$match\E/;
+    return $arg !~ /\Q$match\E/i;
 }
 
 =head1 AUTHOR

--- a/lib/pf/constants/trigger.pm
+++ b/lib/pf/constants/trigger.pm
@@ -16,7 +16,10 @@ use warnings;
 use base qw(Exporter);
 use Readonly;
 use pf::metadefender();
-use pf::file_paths qw($suricata_categories_file);
+use pf::file_paths qw(
+    $suricata_categories_file
+    $nexpose_categories_file
+);
 use File::Slurp;
 use pf::SwitchFactory;
 use pf::config qw(
@@ -40,6 +43,7 @@ Readonly::Scalar our $TRIGGER_TYPE_OPENVAS => 'openvas';
 Readonly::Scalar our $TRIGGER_TYPE_METADEFENDER => 'metadefender';
 Readonly::Scalar our $TRIGGER_TYPE_OS => 'os';
 Readonly::Scalar our $TRIGGER_TYPE_SURICATA_EVENT => 'suricata_event';
+Readonly::Scalar our $TRIGGER_TYPE_NEXPOSE_EVENT => 'nexpose_event';
 Readonly::Scalar our $TRIGGER_TYPE_USERAGENT => 'useragent';
 Readonly::Scalar our $TRIGGER_TYPE_VENDORMAC => 'vendormac';
 Readonly::Scalar our $TRIGGER_TYPE_PROVISIONER => 'provisioner';
@@ -50,6 +54,15 @@ Readonly::Scalar our $TRIGGER_TYPE_SWITCH_GROUP => 'switch_group';
 Readonly::Scalar our $SURICATA_CATEGORIES => sub {
     my %map;
     my @categories = split("\n", read_file($suricata_categories_file));
+    foreach my $category (@categories){
+        $map{$category} = $category;
+    }
+    return \%map;
+}->();
+
+Readonly::Scalar our $NEXPOSE_CATEGORIES => sub {
+    my %map;
+    my @categories = split("\n", read_file($nexpose_categories_file));
     foreach my $category (@categories){
         $map{$category} = $category;
     }
@@ -68,6 +81,7 @@ Readonly::Scalar our $TRIGGER_MAP => {
     $TRIGGER_ID_PROVISIONER => "Check status",
   },
   $TRIGGER_TYPE_SURICATA_EVENT => $SURICATA_CATEGORIES,
+  $TRIGGER_TYPE_NEXPOSE_EVENT => $NEXPOSE_CATEGORIES,
   $TRIGGER_TYPE_METADEFENDER => $pf::metadefender::METADEFENDER_RESULT_IDS,
   $TRIGGER_TYPE_SWITCH => \%ConfigSwitchesList,
   $TRIGGER_TYPE_SWITCH_GROUP => \%ConfigSwitchesGroup,

--- a/lib/pf/constants/trigger.pm
+++ b/lib/pf/constants/trigger.pm
@@ -43,7 +43,7 @@ Readonly::Scalar our $TRIGGER_TYPE_OPENVAS => 'openvas';
 Readonly::Scalar our $TRIGGER_TYPE_METADEFENDER => 'metadefender';
 Readonly::Scalar our $TRIGGER_TYPE_OS => 'os';
 Readonly::Scalar our $TRIGGER_TYPE_SURICATA_EVENT => 'suricata_event';
-Readonly::Scalar our $TRIGGER_TYPE_NEXPOSE_EVENT => 'nexpose_event';
+Readonly::Scalar our $TRIGGER_TYPE_NEXPOSE_EVENT_STARTS_WITH => 'nexpose_event_starts_with';
 Readonly::Scalar our $TRIGGER_TYPE_USERAGENT => 'useragent';
 Readonly::Scalar our $TRIGGER_TYPE_VENDORMAC => 'vendormac';
 Readonly::Scalar our $TRIGGER_TYPE_PROVISIONER => 'provisioner';
@@ -81,7 +81,7 @@ Readonly::Scalar our $TRIGGER_MAP => {
     $TRIGGER_ID_PROVISIONER => "Check status",
   },
   $TRIGGER_TYPE_SURICATA_EVENT => $SURICATA_CATEGORIES,
-  $TRIGGER_TYPE_NEXPOSE_EVENT => $NEXPOSE_CATEGORIES,
+  $TRIGGER_TYPE_NEXPOSE_EVENT_STARTS_WITH => $NEXPOSE_CATEGORIES,
   $TRIGGER_TYPE_METADEFENDER => $pf::metadefender::METADEFENDER_RESULT_IDS,
   $TRIGGER_TYPE_SWITCH => \%ConfigSwitchesList,
   $TRIGGER_TYPE_SWITCH_GROUP => \%ConfigSwitchesGroup,

--- a/lib/pf/detect/parser/nexpose.pm
+++ b/lib/pf/detect/parser/nexpose.pm
@@ -35,6 +35,7 @@ sub parse {
         };
         return { date => $data->{date}, srcip => $data->{serverip}, dstip => $data->{deviceip}, events => { nexpose_event => $data->{descr} } } if $data->{alerttype} eq 'VULNERABILITY' ;
     }
+    return undef;
 }
 
 =head1 AUTHOR

--- a/lib/pf/detect/parser/nexpose.pm
+++ b/lib/pf/detect/parser/nexpose.pm
@@ -1,0 +1,67 @@
+package pf::detect::parser::nexpose;
+
+=head1 NAME
+
+pf::detect::parser::nexpose
+
+=cut
+
+=head1 DESCRIPTION
+
+pf::detect::parser::nexpose
+
+Class to parse syslog from a Insight Nexpose appliance
+
+=cut
+
+use strict;
+use warnings;
+use Moo;
+extends qw(pf::detect::parser);
+
+sub parse {
+    my ($self,$line) = @_;
+
+    # Alert line example
+    # Nov 13 11:38:09 172.20.120.70 Nexpose: 10.0.0.20 VULNERABILITY: OpenSSL SSL/TLS MITM vulnerability (CVE-2014-0224) (http-openssl-cve-2014-0224)
+    if ($line =~ /^(\w+ \d+ \d+:\d+:\d+) ([0-9.]+) \w+: ([0-9.]+) (\w+): (.*)/) {
+
+        my $data = {
+            date        => $1,
+            serverip    => $2,
+            deviceip    => $3,
+            alerttype   => $4,
+            descr       => $5,
+        };
+        return { date => $data->{date}, srcip => $data->{serverip}, dstip => $data->{deviceip}, events => { nexpos_event => $data->{descr} } };
+    }
+}
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2017 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;

--- a/lib/pf/detect/parser/nexpose.pm
+++ b/lib/pf/detect/parser/nexpose.pm
@@ -24,7 +24,7 @@ sub parse {
 
     # Alert line example
     # Nov 13 11:38:09 172.20.120.70 Nexpose: 10.0.0.20 VULNERABILITY: OpenSSL SSL/TLS MITM vulnerability (CVE-2014-0224) (http-openssl-cve-2014-0224)
-    if ($line =~ /^(\w+ \d+ \d+:\d+:\d+) ([0-9.]+) \w+: ([0-9.]+) (\w+): (.*)/) {
+    if ($line =~ /^(\w+\s*\d+ \d+:\d+:\d+) ([0-9.]+) \w+: ([0-9.]+) (\w+): (.*)/) {
 
         my $data = {
             date        => $1,

--- a/lib/pf/detect/parser/nexpose.pm
+++ b/lib/pf/detect/parser/nexpose.pm
@@ -33,7 +33,7 @@ sub parse {
             alerttype   => $4,
             descr       => $5,
         };
-        return { date => $data->{date}, srcip => $data->{serverip}, dstip => $data->{deviceip}, events => { nexpos_event => $data->{descr} } };
+        return { date => $data->{date}, srcip => $data->{serverip}, dstip => $data->{deviceip}, events => { nexpose_event => $data->{descr} } };
     }
 }
 

--- a/lib/pf/detect/parser/nexpose.pm
+++ b/lib/pf/detect/parser/nexpose.pm
@@ -33,7 +33,7 @@ sub parse {
             alerttype   => $4,
             descr       => $5,
         };
-        return { date => $data->{date}, srcip => $data->{serverip}, dstip => $data->{deviceip}, events => { nexpose_event => $data->{descr} } };
+        return { date => $data->{date}, srcip => $data->{serverip}, dstip => $data->{deviceip}, events => { nexpose_event => $data->{descr} } } if $data->{alerttype} eq 'VULNERABILITY' ;
     }
 }
 

--- a/lib/pf/detect/parser/nexpose.pm
+++ b/lib/pf/detect/parser/nexpose.pm
@@ -33,7 +33,7 @@ sub parse {
             alerttype   => $4,
             descr       => $5,
         };
-        return { date => $data->{date}, srcip => $data->{serverip}, dstip => $data->{deviceip}, events => { nexpose_event => $data->{descr} } } if $data->{alerttype} eq 'VULNERABILITY' ;
+        return { date => $data->{date}, srcip => $data->{deviceip}, dstip => undef, events => { nexpose_event => $data->{descr} } } if $data->{alerttype} eq 'VULNERABILITY' ;
     }
     return undef;
 }

--- a/lib/pf/factory/condition/violation.pm
+++ b/lib/pf/factory/condition/violation.pm
@@ -45,6 +45,7 @@ our %TRIGGER_TYPE_TO_CONDITION_TYPE = (
     'openvas'           => {type => 'equals',        key  => 'last_openvas_id',         event => $TRUE},
     'metadefender'      => {type => 'equals',        key  => 'last_metadefender_id',    event => $TRUE},
     'provisioner'       => {type => 'equals',        key  => 'last_provisioner_id',     event => $TRUE},
+    'nexpose_event'     => {type => 'starts_with',   key  => 'last_nexpose_event',      event => $TRUE},
     'suricata_event'    => {type => 'starts_with',   key  => 'last_suricata_event',     event => $TRUE},
     'suricata_md5'      => {type => 'equals',        key  => 'last_suricata_md5',       event => $TRUE},
     'useragent'         => {type => 'equals',        key  => 'user_agent_id'},

--- a/lib/pf/factory/condition/violation.pm
+++ b/lib/pf/factory/condition/violation.pm
@@ -45,12 +45,13 @@ our %TRIGGER_TYPE_TO_CONDITION_TYPE = (
     'openvas'           => {type => 'equals',        key  => 'last_openvas_id',         event => $TRUE},
     'metadefender'      => {type => 'equals',        key  => 'last_metadefender_id',    event => $TRUE},
     'provisioner'       => {type => 'equals',        key  => 'last_provisioner_id',     event => $TRUE},
-    'nexpose_event'     => {type => 'starts_with',   key  => 'last_nexpose_event',      event => $TRUE},
     'suricata_event'    => {type => 'starts_with',   key  => 'last_suricata_event',     event => $TRUE},
     'suricata_md5'      => {type => 'equals',        key  => 'last_suricata_md5',       event => $TRUE},
     'useragent'         => {type => 'equals',        key  => 'user_agent_id'},
     'switch'            => {type => 'equals',        key  => 'last_switch'},
     'switch_group'      => {type => 'switch_group',  key  => 'last_switch'},
+    'nexpose_event_contains'     => {type => 'matches',       key  => 'last_nexpose_event',      event => $TRUE},
+    'nexpose_event_starts_with'  => {type => 'starts_with',   key  => 'last_nexpose_event',      event => $TRUE},
 );
 
 sub modules {

--- a/lib/pf/file_paths.pm
+++ b/lib/pf/file_paths.pm
@@ -80,6 +80,7 @@ our (
     $wmi_config_file,
     $pki_provider_config_file,
     $suricata_categories_file,
+    $nexpose_categories_file,
     $radius_filters_config_file,
     $billing_tiers_config_file,
     $dhcp_filters_config_file,
@@ -152,6 +153,7 @@ BEGIN {
         $wmi_config_file
         $pki_provider_config_file
         $suricata_categories_file
+        $nexpose_categories_file
         $radius_filters_config_file
         $billing_tiers_config_file
         $dhcp_filters_config_file
@@ -197,6 +199,7 @@ $pfcmd_binary = catfile( $bin_dir, "pfcmd" );
 
 $oui_file           = catfile($conf_dir, "oui.txt");
 $suricata_categories_file = catfile($conf_dir, "suricata_categories.txt");
+$nexpose_categories_file = catfile($conf_dir, "nexpose-responses.txt");
 $pf_omapi_key_file  = catfile($conf_dir, "pf_omapi_key");
 $local_secret_file  = catfile($conf_dir, "local_secret");
 $pf_doc_file        = catfile($conf_dir, "documentation.conf");

--- a/t/data/pfdetect.conf
+++ b/t/data/pfdetect.conf
@@ -13,6 +13,11 @@ type=snort
 status=enabled
 path=/dev/null
 
+[nexpose]
+type=nexpose
+status=enabled
+path=/dev/null
+
 [suricata_md5]
 type=suricata_md5
 status=enabled

--- a/t/unittest/detect/parser/nexpose.t
+++ b/t/unittest/detect/parser/nexpose.t
@@ -1,0 +1,74 @@
+=head1 NAME
+
+example pf test
+
+=cut
+
+=head1 DESCRIPTION
+
+example pf test script
+
+=cut
+
+use strict;
+use warnings;
+#
+use lib '/usr/local/pf/lib';
+
+use Test::More tests => 5;
+
+BEGIN {
+    #include test libs
+    use lib qw(/usr/local/pf/t);
+    #Module for overriding configuration paths
+    use setup_test_config;
+}
+
+use_ok('pf::factory::detect::parser');
+
+my $alert = 'Nov 13 11:38:09 172.20.120.70 Nexpose: 10.0.0.20 VULNERABILITY: OpenSSL SSL/TLS MITM vulnerability (CVE-2014-0224) (http-openssl-cve-2014-0224)';
+ 
+my $parser = pf::factory::detect::parser->new('nexpose');
+my $result = $parser->parse($alert);
+
+is($result->{dstip}, "10.0.0.20");
+is($result->{srcip}, "172.20.120.70");
+is($result->{events}->{nexpose_event}, "OpenSSL SSL/TLS MITM vulnerability (CVE-2014-0224) (http-openssl-cve-2014-0224)");
+
+# non-matching alert coming from nexpose
+$alert = "Dec 4 11:34:27 172.20.120.70 Nexpose: SCAN STARTED: Zammit-Site";
+$result = $parser->parse($alert);
+
+is($result, undef);
+
+#This test will running last
+use Test::NoWarnings;
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2017 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;


### PR DESCRIPTION
# Description
   Rapid7 Nexpose modules allows PF to get informations from nexpose audits.

# Impacts
   Modules not finished, need the Lord Semaan Mojo touch.

# Issue
   Modules not finished, need the Lord Semaan Mojo touch.

# Delete branch after merge
   YES

# NEWS file entries
    conf/nexpose-responces.txt
    html/pfappserver/lib/pfappserver/Form/Config/Pfdetect/nexpose.pm 
    html/pfappserver/root/config/pfdetect/type/nexpose.tt
    lib/pf/detect/parser/nexpose.pm

## New Features
    Rapid7 Nexpose results interpretations
    Module configuration in the PF GUI

# Upgrade notes

## Changes to filtering engines

The "matches" operator of the filtering engines (VLAN filters, RADIUS filters, etc) is now matching in a case insensitive way. If you need to perform case sensitive matches, switch to using regular expressions using the regex operator.