### PR TITLE
Use $db var for expansion on the db_fingerbank configuration name

### DIFF
--- a/html/pfappserver/lib/pfappserver/PacketFence/Controller/DB.pm
+++ b/html/pfappserver/lib/pfappserver/PacketFence/Controller/DB.pm
@@ -72,7 +72,7 @@ sub assign :Path('assign') :Args(1) {
             $db_model->commit();
             my $pfconfig = $c->model('Config::Pfconfig');
             $pfconfig->update_mysql_credentials($pf_user, $pf_password);
-            fingerbank::Config::write_config({ mysql => { 'username' => $pf_user, 'password' => $pf_password, 'database' => 'pf_fingerbank' } });
+            fingerbank::Config::write_config({ mysql => { 'username' => $pf_user, 'password' => $pf_password, 'database' => $db . '_fingerbank' } });
             pf::db::db_disconnect();
         }
     }


### PR DESCRIPTION
# Description
Removes static fingerbank database name, adds dynamic $db var expansion

# Impacts
n/a

# Issue
Fixes #2665

# Delete branch after merge
YES

## Bug Fixes
* Configurator: when using a different DB name, the fingerbank.conf mysql section isn't updated (#2665)