### PR TITLE
Enhancements to AD integration scripts

### DIFF
--- a/addons/AD/unreg_node_deleted_account.ps1
+++ b/addons/AD/unreg_node_deleted_account.ps1
@@ -1,6 +1,7 @@
-########################################################################################
-#Powershell script to unregister deleted Active Directory account based on the UserName.#
-########################################################################################
+##########################################################################################
+#Powershell script to unregister disabled Active Directory account based on the UserName.#
+##########################################################################################
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
 Get-EventLog -LogName Security -InstanceId 4726 |
    Select ReplacementStrings,"Account name"|
@@ -8,20 +9,31 @@ Get-EventLog -LogName Security -InstanceId 4726 |
     $url = "https://@IP_PACKETFENCE:9090/"
     $username = "admin" # Username for the webservice
     $password = "admin" # Password for the webservice
-    [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}
-    $command = '{"jsonrpc": "2.0", "method": "unreg_node_for_pid", "params": ["pid", "'+$_.ReplacementStrings[0]+'"]}'
 
-    $bytes = [System.Text.Encoding]::ASCII.GetBytes($command)
-    $web = [System.Net.WebRequest]::Create($url)
-    $web.Method = "POST"
-    $web.ContentLength = $bytes.Length
-    $web.ContentType = "application/json-rpc"
-    $web.Credentials = new-object System.Net.NetworkCredential($username, $password)
-    $stream = $web.GetRequestStream()
-    $stream.Write($bytes,0,$bytes.Length)
-    $stream.close()
-    
-    $reader = New-Object System.IO.Streamreader -ArgumentList $web.GetResponse().GetResponseStream()
-    $reader.ReadToEnd()
-    $reader.Close()
+    $netbiosdomain = $env:userdomain
+    $fqdndomain = $env:userdnsdomain.ToLower()
+    $nodomadusername = $_.ReplacementStrings[0]
+    $netbiosadusername = $netbiosdomain + "\\" + $nodomadusername
+    $upnadusername = $nodomadusername + "@" + $fqdndomain
+    $spnusername = "host/" + ($nodomadusername -replace "\$" , "") + "." + $fqdndomain
+    $adusernames = @($nodomadusername, $netbiosadusername, $upnadusername, $spnusername)
+
+    foreach ($adusername in $adusernames) {
+       [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}
+       $command = '{"jsonrpc": "2.0", "method": "unreg_node_for_pid", "params": ["pid", "'+$adusername+'"]}'
+
+       $bytes = [System.Text.Encoding]::ASCII.GetBytes($command)
+       $web = [System.Net.WebRequest]::Create($url)
+       $web.Method = "POST"
+       $web.ContentLength = $bytes.Length
+       $web.ContentType = "application/json-rpc"
+       $web.Credentials = new-object System.Net.NetworkCredential($username, $password)
+       $stream = $web.GetRequestStream()
+       $stream.Write($bytes,0,$bytes.Length)
+       $stream.close()
+
+       $reader = New-Object System.IO.Streamreader -ArgumentList $web.GetResponse().GetResponseStream()
+       $reader.ReadToEnd()
+       $reader.Close()
+    }
    }

--- a/addons/AD/unreg_node_disabled_account.ps1
+++ b/addons/AD/unreg_node_disabled_account.ps1
@@ -1,6 +1,7 @@
 ##########################################################################################
 #Powershell script to unregister disabled Active Directory account based on the UserName.#
 ##########################################################################################
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
 Get-EventLog -LogName Security -InstanceId 4725 |
    Select ReplacementStrings,"Account name"|
@@ -8,20 +9,31 @@ Get-EventLog -LogName Security -InstanceId 4725 |
     $url = "https://@IP_PACKETFENCE:9090/"
     $username = "admin" # Username for the webservice
     $password = "admin" # Password for the webservice
-    [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}
-    $command = '{"jsonrpc": "2.0", "method": "unreg_node_for_pid", "params": ["pid", "'+$_.ReplacementStrings[0]+'"]}'
 
-    $bytes = [System.Text.Encoding]::ASCII.GetBytes($command)
-    $web = [System.Net.WebRequest]::Create($url)
-    $web.Method = "POST"
-    $web.ContentLength = $bytes.Length
-    $web.ContentType = "application/json-rpc"
-    $web.Credentials = new-object System.Net.NetworkCredential($username, $password)
-    $stream = $web.GetRequestStream()
-    $stream.Write($bytes,0,$bytes.Length)
-    $stream.close()
-    
-    $reader = New-Object System.IO.Streamreader -ArgumentList $web.GetResponse().GetResponseStream()
-    $reader.ReadToEnd()
-    $reader.Close()
+    $netbiosdomain = $env:userdomain
+    $fqdndomain = $env:userdnsdomain.ToLower()
+    $nodomadusername = $_.ReplacementStrings[0]
+    $netbiosadusername = $netbiosdomain + "\\" + $nodomadusername
+    $upnadusername = $nodomadusername + "@" + $fqdndomain
+    $spnusername = "host/" + ($nodomadusername -replace "\$" , "") + "." + $fqdndomain
+    $adusernames = @($nodomadusername, $netbiosadusername, $upnadusername, $spnusername)
+
+    foreach ($adusername in $adusernames) {
+       [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}
+       $command = '{"jsonrpc": "2.0", "method": "unreg_node_for_pid", "params": ["pid", "'+$adusername+'"]}'
+
+       $bytes = [System.Text.Encoding]::ASCII.GetBytes($command)
+       $web = [System.Net.WebRequest]::Create($url)
+       $web.Method = "POST"
+       $web.ContentLength = $bytes.Length
+       $web.ContentType = "application/json-rpc"
+       $web.Credentials = new-object System.Net.NetworkCredential($username, $password)
+       $stream = $web.GetRequestStream()
+       $stream.Write($bytes,0,$bytes.Length)
+       $stream.close()
+
+       $reader = New-Object System.IO.Streamreader -ArgumentList $web.GetResponse().GetResponseStream()
+       $reader.ReadToEnd()
+       $reader.Close()
+    }
    }

--- a/addons/AD/unreg_node_locked_account.ps1
+++ b/addons/AD/unreg_node_locked_account.ps1
@@ -1,6 +1,7 @@
-#########################################################################################
-#Powershell script to unregister locked Active Directory account based on the UserName.#
-#########################################################################################
+##########################################################################################
+#Powershell script to unregister disabled Active Directory account based on the UserName.#
+##########################################################################################
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
 Get-EventLog -LogName Security -InstanceId 4740 |
    Select ReplacementStrings,"Account name"|
@@ -8,22 +9,31 @@ Get-EventLog -LogName Security -InstanceId 4740 |
     $url = "https://@IP_PACKETFENCE:9090/"
     $username = "admin" # Username for the webservice
     $password = "admin" # Password for the webservice
-    [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}
-    $command = '{"jsonrpc": "2.0", "method": "unreg_node_for_pid", "params": ["pid", "'+$_.ReplacementStrings[0]+'"]}'
 
-    $bytes = [System.Text.Encoding]::ASCII.GetBytes($command)
-    $web = [System.Net.WebRequest]::Create($url)
-    $web.Method = "POST"
-    $web.ContentLength = $bytes.Length
-    $web.ContentType = "application/json-rpc"
-    $web.Credentials = new-object System.Net.NetworkCredential($username, $password)
-    $stream = $web.GetRequestStream()
-    $stream.Write($bytes,0,$bytes.Length)
-    $stream.close()
+    $netbiosdomain = $env:userdomain
+    $fqdndomain = $env:userdnsdomain.ToLower()
+    $nodomadusername = $_.ReplacementStrings[0]
+    $netbiosadusername = $netbiosdomain + "\\" + $nodomadusername
+    $upnadusername = $nodomadusername + "@" + $fqdndomain
+    $spnusername = "host/" + ($nodomadusername -replace "\$" , "") + "." + $fqdndomain
+    $adusernames = @($nodomadusername, $netbiosadusername, $upnadusername, $spnusername)
 
-    $reader = New-Object System.IO.Streamreader -ArgumentList $web.GetResponse().GetResponseStream()
-    $reader.ReadToEnd()
-    $reader.Close()
+    foreach ($adusername in $adusernames) {
+       [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}
+       $command = '{"jsonrpc": "2.0", "method": "unreg_node_for_pid", "params": ["pid", "'+$adusername+'"]}'
 
+       $bytes = [System.Text.Encoding]::ASCII.GetBytes($command)
+       $web = [System.Net.WebRequest]::Create($url)
+       $web.Method = "POST"
+       $web.ContentLength = $bytes.Length
+       $web.ContentType = "application/json-rpc"
+       $web.Credentials = new-object System.Net.NetworkCredential($username, $password)
+       $stream = $web.GetRequestStream()
+       $stream.Write($bytes,0,$bytes.Length)
+       $stream.close()
+
+       $reader = New-Object System.IO.Streamreader -ArgumentList $web.GetResponse().GetResponseStream()
+       $reader.ReadToEnd()
+       $reader.Close()
+    }
    }
-


### PR DESCRIPTION
# Description
1) Enforce use of TLS in the powershell scripts which is required with the last versions of PF
2) Cycle through all the possible Active Directory usernames formats in PacketFence:
username
UPN (username@fqdndomain)
Netbios (DOMAIN\username)
SPN (host/computername)

# Impacts
AD integration scripts

# Delete branch after merge
YES 

## Enhancements
* Enforce use of TLS in the powershell scripts which is required with the last versions of PF
* Cycle through all the possible Active Directory usernames formats in PacketFence