### PR TITLE
Removed duplicate field 'device_type' from nodes. Moved 'device_class…

### DIFF
--- a/html/pfappserver/root/admin/nodes.tt
+++ b/html/pfappserver/root/admin/nodes.tt
@@ -6,13 +6,12 @@
     <option value="bypass_vlan">[% l('Bypass VLAN') %]</option>
     <option value="computername">[% l('Computer Name') %]</option>
     <option value="connection_type">[% l('Connection Type') %]</option>
+    <option value="device_class">[% l('Device Class') %]</option>
     <option value="device_type">[% l('Device Type') %]</option>
     <option value="last_ip">[% l('Node IP') %]</option>
     <option value="category">[% l('Node Role') %]</option>
     <option value="notes">[% l('Notes') %]</option>
     <option value="online">[% l('Online Status') %]</option>
-    <option value="device_class">[% l('Device class') %]</option>
-    <option value="device_type">[% l('Device type') %]</option>
     <option value="person_name">[% l('Person Name') %]</option>
     <option value="status">[% l('Status') %]</option>
     <option value="switch_id">[% l('Source Switch Identifier') %]</option>


### PR DESCRIPTION
# Description
Removed duplicate field 'device_type' from nodes. 
Moved 'device_class' beside sibling.

# Impacts
Ensure device_type is singleton choice in node types.

# Delete branch after merge
YES

## Bug Fixes
* Fixes "Admin: Multiple 'Device Type' options in Nodes tab" #2789
