### PR TITLE
JAMF provisionner

### DIFF
--- a/html/captive-portal/templates/provisioner/jamf.html
+++ b/html/captive-portal/templates/provisioner/jamf.html
@@ -1,0 +1,13 @@
+
+<div class="layout--center">
+  <h5 class="u-mb--">[% i18n("To complete your network activation you need to install the JAMF client.") %]</h5>
+  <p>[% i18n("Once the application is installed, click 'Continue' to activate your network connection") %]</p>
+
+  <a href="/captive-portal" class="btn btn--full btn--light u-mt">
+    <div class="flag">
+      <div class="flag__img">[% svgIcon(id='ic_forward_black_24px',size='small') %]</div>
+      <p class="flag__body">[% i18n("Continue") %]</p>
+    </div>
+  </a>
+</div>
+

--- a/html/pfappserver/lib/pfappserver/Form/Config/Provisioning/jamf.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Provisioning/jamf.pm
@@ -1,0 +1,99 @@
+package pfappserver::Form::Config::Provisioning::jamf;
+
+=head1 NAME
+
+pfappserver::Form::Config::Provisioning::jamf
+
+=head1 DESCRIPTION
+
+Web form for a JAMF provisioner
+
+=cut
+
+use HTML::FormHandler::Moose;
+extends 'pfappserver::Form::Config::Provisioning';
+with 'pfappserver::Base::Form::Role::Help';
+
+use pf::constants;
+
+has_field 'host' => (
+    type => 'Text',
+);
+
+has_field 'port' => (
+    type        => 'PosInteger',
+    required    => $TRUE,
+    default     => $HTTPS_PORT,
+);
+
+has_field 'protocol' => (
+    type    => 'Select',
+    options => [ { label => $HTTP, value => $HTTP }, { label => $HTTPS , value => $HTTPS } ],
+    default => $HTTPS,
+);
+
+has_field 'api_username' => (
+    type        => 'Text',
+    label       => 'API username',
+    required    => $TRUE,
+);
+
+has_field 'api_password' => (
+    type        => 'ObfuscatedText',
+    label       => 'API password',
+    required    => $TRUE,
+);
+
+has_field 'device_type_detection' => (
+    type            => 'Toggle',
+    label           => 'Automatic device detection',
+    checkbox_value  => 'enabled',
+    unchecked_value => 'disabled',
+    default         => 'disabled',
+);
+
+has_field 'query_computers' => (
+    type            => 'Toggle',
+    label           => 'Query JAMF computers inventory',
+    checkbox_value  => 'enabled',
+    unchecked_value => 'disabled',
+    default         => 'enabled',
+);
+
+has_field 'query_mobiledevices' => (
+    type            => 'Toggle',
+    label           => 'Query JAMF mobile devices inventory',
+    checkbox_value  => 'enabled',
+    unchecked_value => 'disabled',
+    default         => 'enabled',
+);
+
+has_block definition => (
+    render_list => [ qw(id type description category oses host port protocol api_username api_password device_type_detection query_computers query_mobiledevices) ],
+);
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2017 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+__PACKAGE__->meta->make_immutable unless $ENV{"PF_SKIP_MAKE_IMMUTABLE"};
+1;

--- a/html/pfappserver/lib/pfappserver/Form/Config/Provisioning/jamf.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Provisioning/jamf.pm
@@ -74,7 +74,7 @@ has_block definition => (
 
 =head1 COPYRIGHT
 
-Copyright (C) 2005-2017 Inverse inc.
+Copyright (C) 2005-2018 Inverse inc.
 
 =head1 LICENSE
 

--- a/html/pfappserver/root/config/provisioning/type/jamf.tt
+++ b/html/pfappserver/root/config/provisioning/type/jamf.tt
@@ -1,0 +1,1 @@
+[% form.block('definition').render | none %]

--- a/lib/pf/provisioner/jamf.pm
+++ b/lib/pf/provisioner/jamf.pm
@@ -237,7 +237,7 @@ sub parse_device_information {
 
     my $json = decode_json($device_information);
 
-    if ( $device_type eq $JAMF_COMPUTER_INVENTORY ) {
+    if ( $device_type eq $JAMF_COMPUTERS_INVENTORY ) {
         return $json->{'computer'}{'general'}{'remote_management'}{'managed'};
     }
     elsif ( $device_type eq $JAMF_MOBILEDEVICES_INVENTORY ) {

--- a/lib/pf/provisioner/jamf.pm
+++ b/lib/pf/provisioner/jamf.pm
@@ -1,0 +1,263 @@
+package pf::provisioner::jamf;
+
+=head1 NAME
+
+pf::provisioner::jamf
+
+=cut
+
+=head1 DESCRIPTION
+
+Allows to validate installation of management client using the JAMF API
+
+=cut
+
+use strict;
+use warnings;
+
+use Moo;
+extends 'pf::provisioner';
+
+use pf::error qw(is_error is_success);
+use pf::constants;
+use pf::log;
+
+use JSON::MaybeXS qw(decode_json);
+use LWP::UserAgent;
+use HTTP::Request::Common;
+
+
+=head1 Atrributes
+
+=head2 api_username
+
+Username to connect to the API
+
+=cut
+
+has api_username => ( is => 'rw', required => $TRUE );
+
+=head2 api_password
+
+Password to connect to the API
+
+=cut
+
+has api_password => ( is => 'rw', required => $TRUE );
+
+=head2 host
+
+Host of the JAMF web API
+
+=cut
+
+has host => ( is => 'rw', required => $TRUE );
+
+=head2 port
+
+Port to connect to the JAMF web API
+
+=cut
+
+has port => ( is => 'rw', default => sub { $HTTPS_PORT } );
+
+=head2 protocol
+
+Protocol to connect to the JAMF web API
+
+=cut
+
+has protocol => ( is => 'rw', default => sub { $HTTPS } );
+
+=head2 device_type_detection
+
+Option to automacally detects device type
+
+=cut
+
+has device_type_detection => ( is => 'rw', default => sub { $FALSE } );
+
+=head2 query_computers
+
+Option to query the "computers" inventory
+
+=cut
+
+has query_computers => ( is => 'rw', default => sub { $TRUE } );
+
+=head2 query_mobiledevices
+
+Option to query the "mobile devices" inventory
+
+=cut
+
+has query_mobiledevices => ( is => 'rw', default => sub { $TRUE } );
+
+
+=head1 Methods
+
+=head2 authorize
+
+Check whether the device exists or not in the JAMF API
+
+=cut
+
+sub authorize {
+    my ( $self, $mac ) = @_;
+    my $logger = get_logger;
+
+    my ( $status, $device_type, $device_information ) = $self->get_device_information($mac);
+
+    unless ( is_sucess($status) ) {
+        $logger->info("Unable to complete a JAMF query for MAC address '$mac'");
+        return $FALSE;
+    }
+
+    my $result = $self->parse_device_information($device_type, $device_information);
+}
+
+
+=head2 get_device_information
+
+=cut
+
+sub get_device_information {
+    my ( $self, $mac ) = @_;
+    my $logger = get_logger;
+
+    # JAMF API separates realms for "computers" and "mobiledevices" assets. Therefore, a different API call is required whether it is a computer or a mobile device.
+    # To ease the configuration and the flow, different implementation options are offered:
+    # - Automatically detect device type using Fingerbank
+    # - Query both JAMF realms subsequently (query "computers" and if there is no answer, query "mobiledevices")
+    # - Query only "computers" JAMF realm
+    # - Query only "mobiledevices" JAMF realm
+    my ( $status, $device_type, $device_information ) = 0;    # Initiating "status" to 0 not to trigger a success clause
+    if ( is_enabled($self->device_type_detection) ) {
+        $device_type = $self->detect_device_type($mac);
+        ( $status, $device_information ) = $self->execute_request($mac, $device_type) if defined $device_type;
+    }
+    unless ( is_success($status) ) {
+        if ( is_enabled($self->query_computers) ) {
+            $device_type = 'computers';
+            ( $status, $device_information ) = $self->execute_request($mac, $device_type);
+        }
+        if ( (is_enabled($self->query_mobiledevices)) && (!is_success($status)) ) {
+            $device_type = 'mobiledevices';
+            ( $status, $device_information ) = $self->execute_request($mac, $device_type);
+        }
+    }
+
+    return ($status, $device_type, $device_information);
+}
+
+
+=head2 detect_device_type
+
+Detects whether it is an Apple computer or an Apple Mobile device.
+
+NOT YET IMPLEMENTED
+
+=cut
+
+sub detect_device_type {
+    my ( $self, $mac ) = @_;
+    my $logger = get_logger;
+}
+
+
+=head2 execute_request
+
+Execute a request to the JAMF API
+
+=cut
+
+sub execute_request {
+    my ( $self, $mac, $realm ) = @_;
+    my $logger = get_logger;
+
+    my $ua = LWP::UserAgent->new();
+    my $request = $self->build_request($mac, $realm);
+    $request->authorization_basic($self->api_username, $self->api_password);
+    $request->header( 'content-type' => 'application/json' );
+    $request->header( 'Accept'       => 'application/json' );
+
+    my $response = $ua->request($request);
+
+    if ( $response->is_success ) {
+        $logger->info("Successfully queried JAMF API for '$realm' with MAC address '$mac'");
+    } else {
+        $logger->info("Failure while querying JAMF API for '$realm' with MAC address '$mac'. Return code: '$response->status_line'");
+    }
+
+    return ( $response->code, $response->decoded_content );
+}
+
+
+=head2 build_request
+
+Build the request to be executed base of the MAC address and the JAMF realm
+
+=cut
+
+sub build_request {
+    my ( $self, $mac, $realm ) = @_;
+    my $logger = get_logger;
+
+    my $method = 'GET';
+    my $escaped_mac_address = uri_escape($mac);
+    my $uri = $self->protocol . "://" . $self->host . "/JSSResource/" . $realm . "/macaddress/" . $escaped_mac_address;
+
+    my $request = "$method '$uri'";
+    $logger->debug("Request to query: '$request'");
+
+    return $request;
+}
+
+
+=head2 parse_device_information
+
+=cut
+
+sub parse_device_information {
+    my ( $self, $device_type, $device_information ) = @_;
+    my $logger = get_logger;
+
+    my $json = decode_json($device_information);
+
+    if ( $device_type eq 'computers' ) {
+        return $json->{'computer'}{'general'}{'remote_management'}{'managed'};
+    }
+    elsif ( $device_type eq 'mobiledevices' ) {
+        return $json->{'mobile_device'}{'general'}{'managed'};
+    }
+}
+
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2017 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;

--- a/lib/pf/provisioner/jamf.pm
+++ b/lib/pf/provisioner/jamf.pm
@@ -27,6 +27,7 @@ use URI::Escape::XS qw(uri_escape);
 use pf::constants;
 use pf::error qw(is_error is_success);
 use pf::log;
+use pf::node;
 use pf::util qw(isenabled);
 
 
@@ -170,13 +171,26 @@ sub get_device_information {
 
 Detects whether it is an Apple computer or an Apple Mobile device.
 
-NOT YET IMPLEMENTED
-
 =cut
 
 sub detect_device_type {
     my ( $self, $mac ) = @_;
     my $logger = get_logger;
+
+    my $fingerbank_info = pf::node::fingerbank_info($mac);
+    $fingerbank_info = $fingerbank_info->{'device_fq'};
+
+    my $device_type;
+    if ( $fingerbank_info =~ /iPod|iPhone|iPad/ ) {
+        $device_type = $JAMF_MOBILEDEVICES_INVENTORY;
+    }
+    elsif ( $fingerbank_info =~ /Macintosh/ ) {
+        $device_type = $JAMF_COMPUTERS_INVENTORY;
+    }
+
+    $logger->info("Detected a '$device_type' for MAC address '$mac' based of Fingerbank reply '$fingerbank_info'") if defined $device_type;
+
+    return $device_type;
 }
 
 

--- a/lib/pf/provisioner/jamf.pm
+++ b/lib/pf/provisioner/jamf.pm
@@ -18,13 +18,18 @@ use warnings;
 use Moo;
 extends 'pf::provisioner';
 
+use HTTP::Request::Common;
+use JSON::MaybeXS qw(decode_json);
+use LWP::UserAgent;
+use Readonly;
+
 use pf::error qw(is_error is_success);
 use pf::constants;
 use pf::log;
 
-use JSON::MaybeXS qw(decode_json);
-use LWP::UserAgent;
-use HTTP::Request::Common;
+
+Readonly our $JAMF_COMPUTERS_INVENTORY => 'computers';
+Readonly our $JAMF_MOBILEDEVICES_INVENTORY => 'mobiledevices';
 
 
 =head1 Atrributes
@@ -138,11 +143,11 @@ sub get_device_information {
     }
     unless ( is_success($status) ) {
         if ( is_enabled($self->query_computers) ) {
-            $device_type = 'computers';
+            $device_type = $JAMF_COMPUTERS_INVENTORY;
             ( $status, $device_information ) = $self->execute_request($mac, $device_type);
         }
         if ( (is_enabled($self->query_mobiledevices)) && (!is_success($status)) ) {
-            $device_type = 'mobiledevices';
+            $device_type = $JAMF_MOBILEDEVICES_INVENTORY;
             ( $status, $device_information ) = $self->execute_request($mac, $device_type);
         }
     }
@@ -224,10 +229,10 @@ sub parse_device_information {
 
     my $json = decode_json($device_information);
 
-    if ( $device_type eq 'computers' ) {
+    if ( $device_type eq $JAMF_COMPUTER_INVENTORY ) {
         return $json->{'computer'}{'general'}{'remote_management'}{'managed'};
     }
-    elsif ( $device_type eq 'mobiledevices' ) {
+    elsif ( $device_type eq $JAMF_MOBILEDEVICES_INVENTORY ) {
         return $json->{'mobile_device'}{'general'}{'managed'};
     }
 }

--- a/lib/pf/provisioner/jamf.pm
+++ b/lib/pf/provisioner/jamf.pm
@@ -119,6 +119,14 @@ sub authorize {
     }
 
     my $result = $self->parse_device_information($device_type, $device_information);
+
+    if ( $result eq $TRUE ) {
+        $logger->info("MAC address '$mac' seems to be managed by JAMF");
+        return $TRUE;
+    } else {
+        $logger->info("MAC address '$mac' does not seems to be managed by JAMF");
+        return $FALSE;
+    }
 }
 
 

--- a/lib/pf/provisioner/jamf.pm
+++ b/lib/pf/provisioner/jamf.pm
@@ -24,8 +24,8 @@ use LWP::UserAgent;
 use Readonly;
 use URI::Escape::XS qw(uri_escape);
 
-use pf::error qw(is_error is_success);
 use pf::constants;
+use pf::error qw(is_error is_success);
 use pf::log;
 use pf::util qw(isenabled);
 
@@ -201,7 +201,7 @@ sub execute_request {
     if ( $response->is_success ) {
         $logger->info("Successfully queried JAMF API for '$realm' with MAC address '$mac'");
     } else {
-        $logger->info("Failure while querying JAMF API for '$realm' with MAC address '$mac'. Return code: '$response->status_line'");
+        $logger->info("Failure while querying JAMF API for '$realm' with MAC address '$mac'. Return code: '" . $response->status_line . "'");
     }
 
     return ( $response->code, $response->decoded_content );

--- a/lib/pf/provisioner/jamf.pm
+++ b/lib/pf/provisioner/jamf.pm
@@ -266,7 +266,7 @@ Inverse inc. <info@inverse.ca>
 
 =head1 COPYRIGHT
 
-Copyright (C) 2005-2017 Inverse inc.
+Copyright (C) 2005-2018 Inverse inc.
 
 =head1 LICENSE
 


### PR DESCRIPTION
# Description
Add PacketFence integration with JAMF API for Apple computers and mobile devices management
Currently only supports the check whether or not the device exists in a JAMF inventory (computers, mobiledevices, both) and if that device is managed (client installed).

# Impacts
Provisioners flow

# Delete branch after merge
YES

# NEWS file entries
## New Features
* Add PacketFence integration with JAMF API for Apple computers and mobile devices management