### PR TITLE
Ipset service in GO

### DIFF
--- a/addons/packages/build-go.sh
+++ b/addons/packages/build-go.sh
@@ -85,6 +85,8 @@ if build_mode; then
   # Create any binaries here and make sure to move them to the BINDST specified
   make pfhttpd
   mv pfhttpd $BINDST/
+  make go_ipset
+  mv go_ipset $BINDST/
 elif test_mode; then
   PFCONFIG_TESTING=y $GOPATH/bin/govendor test ./...  
 fi

--- a/addons/packages/packetfence.spec
+++ b/addons/packages/packetfence.spec
@@ -56,7 +56,7 @@ Source: http://www.packetfence.org/downloads/PacketFence/src/%{real_name}-%{vers
 %global logfiles packetfence.log snmptrapd.log pfdetect pfmon
 %global logdir /usr/local/pf/logs
 
-BuildRequires: gettext, httpd
+BuildRequires: gettext, httpd, ipset-devel, pkgconfig
 BuildRequires: perl(Parse::RecDescent)
 # Required to build documentation
 # See docs/docbook/README.asciidoc for more info about installing requirements.
@@ -135,7 +135,7 @@ requires: perl(Const::Fast)
 # Perl core modules but still explicitly defined just in case distro's core perl get stripped
 Requires: perl(Time::HiRes)
 # Required for inline mode.
-Requires: ipset, sudo, ipset-devel
+Requires: ipset, sudo
 Requires: perl(File::Which), perl(NetAddr::IP)
 Requires: perl(Net::LDAP)
 Requires: perl(Net::IP)

--- a/addons/packages/packetfence.spec
+++ b/addons/packages/packetfence.spec
@@ -135,7 +135,7 @@ requires: perl(Const::Fast)
 # Perl core modules but still explicitly defined just in case distro's core perl get stripped
 Requires: perl(Time::HiRes)
 # Required for inline mode.
-Requires: ipset, sudo
+Requires: ipset, sudo, ipset-devel
 Requires: perl(File::Which), perl(NetAddr::IP)
 Requires: perl(Net::LDAP)
 Requires: perl(Net::IP)

--- a/addons/packages/packetfence.spec
+++ b/addons/packages/packetfence.spec
@@ -488,6 +488,7 @@ done
 %{__install} -D -m0644 conf/systemd/packetfence-snmptrapd.service $RPM_BUILD_ROOT/usr/lib/systemd/system/packetfence-snmptrapd.service
 %{__install} -D -m0644 conf/systemd/packetfence-statsd.service $RPM_BUILD_ROOT/usr/lib/systemd/system/packetfence-statsd.service
 %{__install} -D -m0644 conf/systemd/packetfence-winbindd.service $RPM_BUILD_ROOT/usr/lib/systemd/system/packetfence-winbindd.service
+%{__install} -D -m0644 conf/systemd/packetfence-go_ipset.service $RPM_BUILD_ROOT/usr/lib/systemd/system/packetfence-go_ipset.service
 
 %{__install} -d $RPM_BUILD_ROOT/usr/local/pf/addons
 %{__install} -d $RPM_BUILD_ROOT/usr/local/pf/addons/AD
@@ -867,6 +868,7 @@ fi
 %attr(0755, pf, pf)     /usr/local/pf/bin/cluster/pfupdate
 %attr(0755, pf, pf)     /usr/local/pf/bin/cluster/maintenance
 %attr(0755, pf, pf)     /usr/local/pf/bin/cluster/node
+%attr(0755, pf, pf)     /usr/local/pf/bin/go_ipset
 %attr(0755, pf, pf)     /usr/local/pf/bin/mysql_fingerbank_import.sh
 %doc                    /usr/local/pf/ChangeLog
                         /usr/local/pf/conf/*.example

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -119,6 +119,13 @@ description=<<EOT
 Should DHCPd be managed by PacketFence?
 EOT
 
+[services.go_ipset]
+type=toggle
+options=enabled|disabled
+description=<<EOT
+Should go_ipset be managed by PacketFence?
+EOT
+
 [services.haproxy]
 type=toggle
 options=enabled|disabled
@@ -314,6 +321,12 @@ type=hidden
 description=<<EOT
 Location of the haproxy binary. Only necessary to change if you are
 not running the RPMed version.
+EOT
+
+[services.go_ipset_binary]
+type=hidden
+description=<<EOT
+Location of the go_ipset binary.
 EOT
 
 [services.winbindd]

--- a/conf/iptables.conf.example
+++ b/conf/iptables.conf.example
@@ -60,6 +60,9 @@
 # -A input-management-if --protocol tcp --match tcp --dport 9393 --jump ACCEPT
 # -A input-management-if --protocol tcp --match tcp --dport 9292 --jump ACCEPT
 
+# GO IPSET API
+-A input-management-if --protocol tcp --match tcp --dport 22223 --jump ACCEPT
+
 # VRRP
 -A input-management-if -d 224.0.0.0/8 -j ACCEPT
 -A input-management-if -p vrrp -j ACCEPT

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -341,7 +341,7 @@ dhcpd_binary=/usr/sbin/dhcpd
 # services.go_ipset
 #
 # Should go_ipset be managed by PacketFence?
-go_ipset=disabled
+go_ipset=enabled
 #
 # services.go_ipset_binary
 #

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -338,6 +338,15 @@ dhcpd=enabled
 #
 # Location of the dhcpd binary. Only necessary to change if you are not running the RPMed version.
 dhcpd_binary=/usr/sbin/dhcpd
+# services.go_ipset
+#
+# Should go_ipset be managed by PacketFence?
+go_ipset=disabled
+#
+# services.go_ipset_binary
+#
+# Location of the go_ipset binary.
+go_ipset_binary=/usr/local/pf/bin/go_ipset
 #
 # services.haproxy
 #

--- a/conf/systemd/packetfence-go_ipset.service
+++ b/conf/systemd/packetfence-go_ipset.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=PacketFence Ipset Daemon
+Wants=packetfence-base.target packetfence-config.service packetfence-iptables.service
+After=packetfence-base.target packetfence-config.service packetfence-iptables.service
+Before=packetfence-httpd.portal.service
+
+[Service]
+StartLimitBurst=3
+StartLimitInterval=60
+Type=notify
+WatchdogSec=30s
+ExecStart=/usr/local/pf/bin/go_ipset
+Restart=on-failure
+Slice=packetfence.slice
+
+[Install]
+WantedBy=packetfence.target

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: packetfence
 Section: net
 Priority: optional
 Maintainer: Durand fabrice <fdurand@inverse.ca>
-Build-Depends: debhelper (>= 7.0.50~), gettext, libparse-recdescent-perl, gcc, dpkg-distribution, dh-systemd, libfile-fcntllock-perl, asciidoctor, golang-1.7-go, git
+Build-Depends: debhelper (>= 7.0.50~), gettext, libparse-recdescent-perl, gcc, dpkg-distribution, dh-systemd, libfile-fcntllock-perl, asciidoctor, golang-1.7-go, git, libipset-dev, pkg-config
 Standards-Version: 3.8.4
 Vcs-Git: git://github.com/inverse-inc/packetfence.git
 Vcs-browser: https://github.com/inverse-inc/packetfence/
@@ -138,7 +138,7 @@ Depends: ${misc:Depends}, vlan,
 # for packaging
  dpkg-distribution,
 # golang build
- golang-1.7-go, libipset-dev,
+ golang-1.7-go,
 # Distribution specific
  ${packetfence:dist}
 Description: PacketFence network registration / worm mitigation system

--- a/debian/control
+++ b/debian/control
@@ -138,7 +138,7 @@ Depends: ${misc:Depends}, vlan,
 # for packaging
  dpkg-distribution,
 # golang build
- golang-1.7-go,
+ golang-1.7-go, libipset-dev,
 # Distribution specific
  ${packetfence:dist}
 Description: PacketFence network registration / worm mitigation system

--- a/debian/packetfence-go_ipset.service
+++ b/debian/packetfence-go_ipset.service
@@ -1,0 +1,1 @@
+../conf/systemd/packetfence-go_ipset.service

--- a/debian/packetfence.conffiles
+++ b/debian/packetfence.conffiles
@@ -130,7 +130,6 @@
 /usr/local/pf/html/captive-portal/content/shared_mdm_profile.mobileconfig
 /usr/local/pf/html/captive-portal/content/timerbar.js
 /usr/local/pf/html/captive-portal/lib/captiveportal/Controller/Activate/Email.pm
-/usr/local/pf/html/captive-portal/lib/captiveportal/Controller/Authenticate.pm
 /usr/local/pf/html/captive-portal/lib/captiveportal/Controller/DeviceRegistration.pm
 /usr/local/pf/html/captive-portal/lib/captiveportal/Controller/Enabler.pm
 /usr/local/pf/html/captive-portal/lib/captiveportal/Controller/Node/Manager.pm

--- a/debian/packetfence.conffiles
+++ b/debian/packetfence.conffiles
@@ -130,6 +130,7 @@
 /usr/local/pf/html/captive-portal/content/shared_mdm_profile.mobileconfig
 /usr/local/pf/html/captive-portal/content/timerbar.js
 /usr/local/pf/html/captive-portal/lib/captiveportal/Controller/Activate/Email.pm
+/usr/local/pf/html/captive-portal/lib/captiveportal/Controller/Authenticate.pm
 /usr/local/pf/html/captive-portal/lib/captiveportal/Controller/DeviceRegistration.pm
 /usr/local/pf/html/captive-portal/lib/captiveportal/Controller/Enabler.pm
 /usr/local/pf/html/captive-portal/lib/captiveportal/Controller/Node/Manager.pm

--- a/debian/rules
+++ b/debian/rules
@@ -233,6 +233,7 @@ endif
 	dh_installinit --name=packetfence-snmptrapd
 	dh_installinit --name=packetfence-statsd
 	dh_installinit --name=packetfence-winbindd
+	dh_installinit --name=packetfence-go_ipset
 
 	dh_installcron
 #	dh_installinfo

--- a/go/Makefile
+++ b/go/Makefile
@@ -18,7 +18,7 @@ pfhttpd-race:
 	cd - && \
 	mv caddy/caddy/caddy/caddy pfhttpd-race
 
-go_dhcpd:
+go_ipset:
 	cd ipset && \
 	go build && \
 	cd - && \

--- a/go/Makefile
+++ b/go/Makefile
@@ -18,6 +18,13 @@ pfhttpd-race:
 	cd - && \
 	mv caddy/caddy/caddy/caddy pfhttpd-race
 
+go_dhcpd:
+	cd ipset && \
+	go build && \
+	cd - && \
+	mv ipset/ipset go_ipset
+
+
 .PHONY: clean-caddy-src
 
 clean-caddy-src:

--- a/go/ipset/api.go
+++ b/go/ipset/api.go
@@ -103,7 +103,7 @@ func (IPSET *pfIPSET) IPSEThandleLayer2(IP string, Mac string, Network string, T
 			fmt.Println("Removed " + IP + " from " + v.Name)
 		}
 		// // Delete all entries with old ip addresses
-		Ips := IPSET.mac2ip(Mac, v.Name)
+		Ips := IPSET.mac2ip(Mac, v)
 		for _, i := range Ips {
 			// r = ipset.Test(v.Name, i)
 			// if r == nil {
@@ -230,7 +230,7 @@ func (IPSET *pfIPSET) handleUnmarkMac(res http.ResponseWriter, req *http.Request
 	Local := vars["local"]
 
 	for _, v := range IPSET.ListALL {
-		Ips := IPSET.mac2ip(Mac, v.Name)
+		Ips := IPSET.mac2ip(Mac, v)
 		for _, i := range Ips {
 			// r := ipset.Test(v.Name, i)
 			// if r == nil {

--- a/go/ipset/api.go
+++ b/go/ipset/api.go
@@ -1,12 +1,20 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 
+	"github.com/diegoguarnieri/go-conntrack/conntrack"
 	"github.com/digineo/go-ipset"
 	"github.com/gorilla/mux"
 )
+
+type Info struct {
+	Status string `json:"status"`
+	Mac    string `json:"MAC"`
+	Ip     string `json:"IP"`
+}
 
 func handleLayer2(res http.ResponseWriter, req *http.Request) {
 	vars := mux.Vars(req)
@@ -21,23 +29,85 @@ func handleLayer2(res http.ResponseWriter, req *http.Request) {
 	all, _ = ipset.ListAll()
 
 	for _, v := range all {
+		// Delete all entries with the new ip address
 		r := ipset.Test(v.Name, Ip)
 		if r == nil {
 			ipset.Del(v.Name, Ip)
 			fmt.Println("Removed " + Ip + " from " + v.Name)
 		}
+		// Delete all entries with old ip addresses
+		Ips := mac2ip(Mac)
+		for _, i := range Ips {
+			r = ipset.Test(v.Name, i)
+			if r == nil {
+				ipset.Del(v.Name, i)
+				fmt.Println("Removed " + i + " from " + v.Name)
+			}
+		}
 	}
+	// Add to the new ipset session
 	ipset.Add("pfsession_"+Type+"_"+Network, Ip+","+Mac)
 	fmt.Println("Added " + Ip + " " + Mac + " to pfsession_" + Type + "_" + Network)
 	if Type == "Reg" {
+		// Add to the ip ipset session
 		ipset.Add("PF-iL2_ID"+Catid+"_"+Network, Ip)
 		fmt.Println("Added " + Ip + " to PF-iL2_ID" + Catid + "_" + Network)
 	}
-
+	// Do we have to update the other members of the cluster
 	if Local == "0" {
 		updateClusterL2(Ip, Mac, Network, Type, Catid)
 	}
-	res.Write([]byte("Updated!\n"))
+	var result = map[string][]*Info{
+		"result": {
+			&Info{Mac: Mac, Status: "ACK"},
+		},
+	}
+
+	res.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	res.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(res).Encode(result); err != nil {
+		panic(err)
+	}
+}
+
+func handleMarkIpL2(res http.ResponseWriter, req *http.Request) {
+	vars := mux.Vars(req)
+	Ip := vars["ip"]
+	Network := vars["network"]
+	Catid := vars["catid"]
+	Local := vars["local"]
+	ipset.Add("PF-iL2_ID"+Catid+"_"+Network, Ip)
+	// Do we have to update the other members of the cluster
+	if Local == "0" {
+		updateClusterMarkIpL3(Ip, Network, Catid)
+	}
+	res.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	res.WriteHeader(http.StatusOK)
+}
+
+func handleMarkIpL3(res http.ResponseWriter, req *http.Request) {
+	vars := mux.Vars(req)
+	Ip := vars["ip"]
+	Network := vars["network"]
+	Catid := vars["catid"]
+	Local := vars["local"]
+
+	ipset.Add("PF-iL3_ID"+Catid+"_"+Network, Ip)
+	// Do we have to update the other members of the cluster
+	if Local == "0" {
+		updateClusterMarkIpL3(Ip, Network, Catid)
+	}
+	var result = map[string][]*Info{
+		"result": {
+			&Info{Ip: Ip, Status: "ACK"},
+		},
+	}
+
+	res.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	res.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(res).Encode(result); err != nil {
+		panic(err)
+	}
 }
 
 func handleLayer3(res http.ResponseWriter, req *http.Request) {
@@ -50,7 +120,7 @@ func handleLayer3(res http.ResponseWriter, req *http.Request) {
 
 	var all []ipset.IPSet
 	all, _ = ipset.ListAll()
-
+	// Delete all entries with the new ip address
 	for _, v := range all {
 		r := ipset.Test(v.Name, Ip)
 		if r == nil {
@@ -58,15 +128,99 @@ func handleLayer3(res http.ResponseWriter, req *http.Request) {
 			fmt.Println("Removed " + Ip + " from " + v.Name)
 		}
 	}
+	// Add to the new ipset session
 	ipset.Add("pfsession_"+Type+"_"+Network, Ip)
 	fmt.Println("Added " + Ip + " to pfsession_" + Type + "_" + Network)
 	if Type == "Reg" {
+		// Add to the ip ipset session
 		ipset.Add("PF-iL3_ID"+Catid+"_"+Network, Ip)
 		fmt.Println("Added " + Ip + " to PF-iL3_ID" + Catid + "_" + Network)
 	}
+	// Do we have to update the other members of the cluster
 	if Local == "0" {
 		updateClusterL3(Ip, Network, Type, Catid)
 	}
 
-	res.Write([]byte("Updated!\n"))
+	var result = map[string][]*Info{
+		"result": {
+			&Info{Ip: Ip, Status: "ACK"},
+		},
+	}
+
+	res.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	res.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(res).Encode(result); err != nil {
+		panic(err)
+	}
+}
+
+func handleUnmarkMac(res http.ResponseWriter, req *http.Request) {
+	vars := mux.Vars(req)
+	Mac := vars["mac"]
+	Local := vars["local"]
+
+	Ips := mac2ip(Mac)
+	for _, i := range Ips {
+		var all []ipset.IPSet
+		all, _ = ipset.ListAll()
+
+		for _, v := range all {
+			r := ipset.Test(v.Name, i)
+			if r == nil {
+				ipset.Del(v.Name, i)
+				conn, _ := conntrack.New()
+				conn.DeleteConnectionBySrcIp(i)
+				fmt.Println("Removed " + i + " from " + v.Name)
+			}
+		}
+	}
+	// Do we have to update the other members of the cluster
+	if Local == "0" {
+		updateClusterUnmarkMac(Mac)
+	}
+	var result = map[string][]*Info{
+		"result": {
+			&Info{Mac: Mac, Status: "ACK"},
+		},
+	}
+
+	res.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	res.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(res).Encode(result); err != nil {
+		panic(err)
+	}
+}
+
+func handleUnmarkIp(res http.ResponseWriter, req *http.Request) {
+	vars := mux.Vars(req)
+	Ip := vars["ip"]
+	Local := vars["local"]
+
+	var all []ipset.IPSet
+	all, _ = ipset.ListAll()
+
+	for _, v := range all {
+		r := ipset.Test(v.Name, Ip)
+		if r == nil {
+			ipset.Del(v.Name, Ip)
+			conn, _ := conntrack.New()
+			conn.DeleteConnectionBySrcIp(Ip)
+			fmt.Println("Removed " + Ip + " from " + v.Name)
+		}
+	}
+	// Do we have to update the other members of the cluster
+	if Local == "0" {
+		updateClusterUnmarkIp(Ip)
+	}
+	var result = map[string][]*Info{
+		"result": {
+			&Info{Ip: Ip, Status: "ACK"},
+		},
+	}
+
+	res.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	res.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(res).Encode(result); err != nil {
+		panic(err)
+	}
 }

--- a/go/ipset/api.go
+++ b/go/ipset/api.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/digineo/go-ipset"
@@ -23,12 +24,16 @@ func handleLayer2(res http.ResponseWriter, req *http.Request) {
 		r := ipset.Test(v.Name, Ip)
 		if r == nil {
 			ipset.Del(v.Name, Ip)
-		}
-		ipset.Add("pfsession_"+Type+"_"+Network, Ip+","+Mac)
-		if Type == "Reg" {
-			ipset.Add("PF-iL2_ID"+Catid+"_"+Network, Ip)
+			fmt.Println("Removed " + Ip + " from " + v.Name)
 		}
 	}
+	ipset.Add("pfsession_"+Type+"_"+Network, Ip+","+Mac)
+	fmt.Println("Added " + Ip + " " + Mac + " to pfsession_" + Type + "_" + Network)
+	if Type == "Reg" {
+		ipset.Add("PF-iL2_ID"+Catid+"_"+Network, Ip)
+		fmt.Println("Added " + Ip + " to PF-iL2_ID" + Catid + "_" + Network)
+	}
+
 	if Local == "0" {
 		updateClusterL2(Ip, Mac, Network, Type, Catid)
 	}
@@ -50,14 +55,18 @@ func handleLayer3(res http.ResponseWriter, req *http.Request) {
 		r := ipset.Test(v.Name, Ip)
 		if r == nil {
 			ipset.Del(v.Name, Ip)
-		}
-		ipset.Add("pfsession_"+Type+"_"+Network, Ip)
-		if Type == "Reg" {
-			ipset.Add("PF-iL3_ID"+Catid+"_"+Network, Ip)
-		}
-		if Local == "0" {
-			updateClusterL3(Ip, Network, Type, Catid)
+			fmt.Println("Removed " + Ip + " from " + v.Name)
 		}
 	}
+	ipset.Add("pfsession_"+Type+"_"+Network, Ip)
+	fmt.Println("Added " + Ip + " to pfsession_" + Type + "_" + Network)
+	if Type == "Reg" {
+		ipset.Add("PF-iL3_ID"+Catid+"_"+Network, Ip)
+		fmt.Println("Added " + Ip + " to PF-iL3_ID" + Catid + "_" + Network)
+	}
+	if Local == "0" {
+		updateClusterL3(Ip, Network, Type, Catid)
+	}
+
 	res.Write([]byte("Updated!\n"))
 }

--- a/go/ipset/api.go
+++ b/go/ipset/api.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/digineo/go-ipset"
+	"github.com/gorilla/mux"
+)
+
+func handleLayer2(res http.ResponseWriter, req *http.Request) {
+	vars := mux.Vars(req)
+	Ip := vars["ip"]
+	Mac := vars["mac"]
+	Network := vars["network"]
+	Type := vars["type"]
+	Catid := vars["catid"]
+	Local := vars["local"]
+
+	var all []ipset.IPSet
+	all, _ = ipset.ListAll()
+
+	for _, v := range all {
+		r := ipset.Test(v.Name, Ip)
+		if r == nil {
+			ipset.Del(v.Name, Ip)
+		}
+		ipset.Add("pfsession_"+Type+"_"+Network, Ip+","+Mac)
+		if Type == "Reg" {
+			ipset.Add("PF-iL2_ID"+Catid+"_"+Network, Ip)
+		}
+	}
+	if Local == "0" {
+		updateClusterL2(Ip, Mac, Network, Type, Catid)
+	}
+	res.Write([]byte("Updated!\n"))
+}
+
+func handleLayer3(res http.ResponseWriter, req *http.Request) {
+	vars := mux.Vars(req)
+	Ip := vars["ip"]
+	Network := vars["network"]
+	Type := vars["type"]
+	Catid := vars["catid"]
+	Local := vars["local"]
+
+	var all []ipset.IPSet
+	all, _ = ipset.ListAll()
+
+	for _, v := range all {
+		r := ipset.Test(v.Name, Ip)
+		if r == nil {
+			ipset.Del(v.Name, Ip)
+		}
+		ipset.Add("pfsession_"+Type+"_"+Network, Ip)
+		if Type == "Reg" {
+			ipset.Add("PF-iL3_ID"+Catid+"_"+Network, Ip)
+		}
+		if Local == "0" {
+			updateClusterL3(Ip, Network, Type, Catid)
+		}
+	}
+	res.Write([]byte("Updated!\n"))
+}

--- a/go/ipset/api.go
+++ b/go/ipset/api.go
@@ -17,13 +17,12 @@ type Info struct {
 }
 
 func handlePassthrough(res http.ResponseWriter, req *http.Request) {
-
 	vars := mux.Vars(req)
 	Ip := vars["ip"]
-	Port := vars["mac"]
+	Port := vars["port"]
 	Local := vars["local"]
 
-	ipset.Add("pfsession_passthrough", Ip, Port)
+	ipset.Add("pfsession_passthrough", Ip+","+Port)
 	if Local == "0" {
 		updateClusterPassthrough(Ip, Port)
 	}

--- a/go/ipset/api.go
+++ b/go/ipset/api.go
@@ -16,6 +16,31 @@ type Info struct {
 	Ip     string `json:"IP"`
 }
 
+func handlePassthrough(res http.ResponseWriter, req *http.Request) {
+
+	vars := mux.Vars(req)
+	Ip := vars["ip"]
+	Port := vars["mac"]
+	Local := vars["local"]
+
+	ipset.Add("pfsession_passthrough", Ip, Port)
+	if Local == "0" {
+		updateClusterPassthrough(Ip, Port)
+	}
+	var result = map[string][]*Info{
+		"result": {
+			&Info{Ip: Ip, Status: "ACK"},
+		},
+	}
+
+	res.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	res.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(res).Encode(result); err != nil {
+		panic(err)
+	}
+
+}
+
 func handleLayer2(res http.ResponseWriter, req *http.Request) {
 	vars := mux.Vars(req)
 	Ip := vars["ip"]

--- a/go/ipset/api.go
+++ b/go/ipset/api.go
@@ -40,6 +40,30 @@ func handlePassthrough(res http.ResponseWriter, req *http.Request) {
 
 }
 
+func handleIsolationPassthrough(res http.ResponseWriter, req *http.Request) {
+	vars := mux.Vars(req)
+	Ip := vars["ip"]
+	Port := vars["port"]
+	Local := vars["local"]
+
+	ipset.Add("pfsession_isol_passthrough", Ip+","+Port)
+	if Local == "0" {
+		updateClusterPassthroughIsol(Ip, Port)
+	}
+	var result = map[string][]*Info{
+		"result": {
+			&Info{Ip: Ip, Status: "ACK"},
+		},
+	}
+
+	res.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	res.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(res).Encode(result); err != nil {
+		panic(err)
+	}
+
+}
+
 func handleLayer2(res http.ResponseWriter, req *http.Request) {
 	vars := mux.Vars(req)
 	Ip := vars["ip"]

--- a/go/ipset/api.go
+++ b/go/ipset/api.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 
 	"github.com/diegoguarnieri/go-conntrack/conntrack"
-	"github.com/digineo/go-ipset"
+	"github.com/fdurand/go-ipset"
 	"github.com/gorilla/mux"
 )
 

--- a/go/ipset/main.go
+++ b/go/ipset/main.go
@@ -69,6 +69,7 @@ func main() {
 	}
 	srv := &http.Server{
 		Addr:         ":22223",
+		IdleTimeout:  5 * time.Second,
 		Handler:      router,
 		TLSConfig:    cfg,
 		TLSNextProto: make(map[string]func(*http.Server, *tls.Conn, http.Handler), 0),

--- a/go/ipset/main.go
+++ b/go/ipset/main.go
@@ -22,12 +22,8 @@ var IPSET = &pfIPSET{}
 var database *sql.DB
 
 func main() {
-	webservices = readWebservicesConfig()
 
-	// // Read DB config
-	// configDatabase := readDBConfig()
-	// spew.Dump(configDatabase)
-	// connectDB(configDatabase, database)
+	webservices = readWebservicesConfig()
 
 	// Default http timeout
 	http.DefaultClient.Timeout = 10 * time.Second
@@ -43,17 +39,17 @@ func main() {
 	go func() {
 		// Read DB config
 		for {
-			initIPSet()
+			IPSET.initIPSet()
 			fmt.Println("Reload")
-			time.Sleep(60 * time.Second)
+			time.Sleep(300 * time.Second)
 		}
 	}()
 
 	router := mux.NewRouter()
 	router.HandleFunc("/ipsetmarklayer3/{network:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{type:[a-zA-Z]+}/{catid:[0-9]+}/{ip:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{local:[0-1]}", handleLayer3).Methods("POST")
 	router.HandleFunc("/ipsetmarklayer2/{network:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{type:[a-zA-Z]+}/{catid:[0-9]+}/{ip:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{mac:(?:[0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}}/{local:[0-1]}", handleLayer2).Methods("POST")
-	router.HandleFunc("/ipsetunmarkmac/{mac:(?:[0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}}/{local:[0-1]}", handleUnmarkMac).Methods("POST")
-	router.HandleFunc("/ipsetunmarkip/{ip:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{local:[0-1]}", handleUnmarkIp).Methods("POST")
+	router.HandleFunc("/ipsetunmarkmac/{mac:(?:[0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}}/{local:[0-1]}", IPSET.handleUnmarkMac).Methods("POST")
+	router.HandleFunc("/ipsetunmarkip/{ip:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{local:[0-1]}", IPSET.handleUnmarkIp).Methods("POST")
 	router.HandleFunc("/ipsetmarkiplayer2/{network:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{catid:[0-9]+}/{ip:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{local:[0-1]}", handleMarkIpL2).Methods("POST")
 	router.HandleFunc("/ipsetmarkiplayer3/{network:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{catid:[0-9]+}/{ip:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{local:[0-1]}", handleMarkIpL3).Methods("POST")
 	router.HandleFunc("/ipsetpassthrough/{ip:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{port:(?:udp|tcp):[0-9]+}/{local:[0-1]}", handlePassthrough).Methods("POST")

--- a/go/ipset/main.go
+++ b/go/ipset/main.go
@@ -2,8 +2,7 @@ package main
 
 import (
 	"context"
-	"log"
-	"net"
+	"crypto/tls"
 	"net/http"
 	"time"
 
@@ -26,9 +25,22 @@ func main() {
 	router.HandleFunc("/ipsetmarkiplayer3/{network:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{catid:[0-9]+}/{ip:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{local:[0-1]}", handleMarkIpL3).Methods("POST")
 
 	// Api
-	l, err := net.Listen("tcp", ":22223")
-	if err != nil {
-		log.Panicf("cannot listen: %s", err)
+	cfg := &tls.Config{
+		MinVersion:               tls.VersionTLS12,
+		CurvePreferences:         []tls.CurveID{tls.CurveP521, tls.CurveP384, tls.CurveP256},
+		PreferServerCipherSuites: true,
+		CipherSuites: []uint16{
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+			tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+		},
+	}
+	srv := &http.Server{
+		Addr:         ":22223",
+		Handler:      router,
+		TLSConfig:    cfg,
+		TLSNextProto: make(map[string]func(*http.Server, *tls.Conn, http.Handler), 0),
 	}
 
 	// detectMembers()
@@ -40,13 +52,13 @@ func main() {
 			return
 		}
 		for {
-			_, err := http.Get("http://127.0.0.1:22223")
+			_, err := http.Get("https://127.0.0.1:22223")
 			if err == nil {
 				daemon.SdNotify(false, "WATCHDOG=1")
 			}
 			time.Sleep(interval / 3)
 		}
 	}()
-	http.Serve(l, router)
+	srv.ListenAndServeTLS("tls.crt", "tls.key")
 
 }

--- a/go/ipset/main.go
+++ b/go/ipset/main.go
@@ -19,7 +19,7 @@ func main() {
 
 	router := mux.NewRouter()
 	router.HandleFunc("/ipsetlayer3/{network:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{type:[a-zA-Z]+}/{catid:[0-9]+}/{ip:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{local:[0-1]}", handleLayer3).Methods("GET")
-	router.HandleFunc("/ipsetlayer2/{network:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{type:[a-zA-Z]+}/{catid:[0-9]+}/{ip:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{mac:(?:[0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}}/local:[0-1]", handleLayer2).Methods("GET")
+	router.HandleFunc("/ipsetlayer2/{network:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{type:[a-zA-Z]+}/{catid:[0-9]+}/{ip:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{mac:(?:[0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}}/{local:[0-1]}", handleLayer2).Methods("GET")
 
 	// Api
 	l, err := net.Listen("tcp", ":22223")

--- a/go/ipset/main.go
+++ b/go/ipset/main.go
@@ -36,6 +36,8 @@ func main() {
 
 	configDatabase := readDBConfig()
 	connectDB(configDatabase, database)
+	database.SetMaxIdleConns(0)
+	database.SetMaxOpenConns(500)
 
 	// Reload the set from the database each minutes
 	go func() {

--- a/go/ipset/main.go
+++ b/go/ipset/main.go
@@ -28,6 +28,7 @@ func main() {
 	router.HandleFunc("/ipsetunmarkip/{ip:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{local:[0-1]}", handleUnmarkIp).Methods("POST")
 	router.HandleFunc("/ipsetmarkiplayer2/{network:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{catid:[0-9]+}/{ip:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{local:[0-1]}", handleMarkIpL2).Methods("POST")
 	router.HandleFunc("/ipsetmarkiplayer3/{network:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{catid:[0-9]+}/{ip:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{local:[0-1]}", handleMarkIpL3).Methods("POST")
+	router.HandleFunc("/ipsetpassthrough/{ip:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{port:(?:udp:tcp):[0-9]+}/{local:[0-1]}", handlePassthrough).Methods("POST")
 	http.Handle("/", httpauth.SimpleBasicAuth(webservices.User, webservices.Pass)(router))
 	// Api
 	cfg := &tls.Config{

--- a/go/ipset/main.go
+++ b/go/ipset/main.go
@@ -40,9 +40,11 @@ func main() {
 	// Reload the set from the database each minutes
 	go func() {
 		// Read DB config
-		initIPSet()
-		fmt.Println("Reload")
-		time.Sleep(60 * time.Second)
+		for {
+			initIPSet()
+			fmt.Println("Reload")
+			time.Sleep(60 * time.Second)
+		}
 	}()
 
 	router := mux.NewRouter()

--- a/go/ipset/main.go
+++ b/go/ipset/main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"log"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/coreos/go-systemd/daemon"
+	"github.com/gorilla/mux"
+)
+
+var ctx = context.Background()
+
+func main() {
+	// Default http timeout
+	http.DefaultClient.Timeout = 10 * time.Second
+
+	router := mux.NewRouter()
+	router.HandleFunc("/ipsetlayer3/{network:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{type:[a-zA-Z]+}/{catid:[0-9]+}/{ip:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{local:[0-1]}", handleLayer3).Methods("GET")
+	router.HandleFunc("/ipsetlayer2/{network:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{type:[a-zA-Z]+}/{catid:[0-9]+}/{ip:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{mac:(?:[0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}}/local:[0-1]", handleLayer2).Methods("GET")
+
+	// Api
+	l, err := net.Listen("tcp", ":22223")
+	if err != nil {
+		log.Panicf("cannot listen: %s", err)
+	}
+
+	// detectMembers()
+	daemon.SdNotify(false, "READY=1")
+
+	go func() {
+		interval, err := daemon.SdWatchdogEnabled(false)
+		if err != nil || interval == 0 {
+			return
+		}
+		for {
+			_, err := http.Get("http://127.0.0.1:22223")
+			if err == nil {
+				daemon.SdNotify(false, "WATCHDOG=1")
+			}
+			time.Sleep(interval / 3)
+		}
+	}()
+	http.Serve(l, router)
+
+}

--- a/go/ipset/main.go
+++ b/go/ipset/main.go
@@ -17,6 +17,7 @@ import (
 
 var ctx = context.Background()
 var webservices pfconfigdriver.PfConfWebservices
+
 var IPSET = &pfIPSET{}
 var database *sql.DB
 
@@ -41,7 +42,7 @@ func main() {
 		// Read DB config
 		initIPSet()
 		fmt.Println("Reload")
-		time.Sleep(time.Duration(60) * time.Second)
+		time.Sleep(60 * time.Second)
 	}()
 
 	router := mux.NewRouter()

--- a/go/ipset/main.go
+++ b/go/ipset/main.go
@@ -28,7 +28,7 @@ func main() {
 	router.HandleFunc("/ipsetunmarkip/{ip:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{local:[0-1]}", handleUnmarkIp).Methods("POST")
 	router.HandleFunc("/ipsetmarkiplayer2/{network:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{catid:[0-9]+}/{ip:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{local:[0-1]}", handleMarkIpL2).Methods("POST")
 	router.HandleFunc("/ipsetmarkiplayer3/{network:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{catid:[0-9]+}/{ip:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{local:[0-1]}", handleMarkIpL3).Methods("POST")
-	router.HandleFunc("/ipsetpassthrough/{ip:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{port:(?:udp:tcp):[0-9]+}/{local:[0-1]}", handlePassthrough).Methods("POST")
+	router.HandleFunc("/ipsetpassthrough/{ip:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{port:(?:udp|tcp):[0-9]+}/{local:[0-1]}", handlePassthrough).Methods("POST")
 	http.Handle("/", httpauth.SimpleBasicAuth(webservices.User, webservices.Pass)(router))
 	// Api
 	cfg := &tls.Config{

--- a/go/ipset/main.go
+++ b/go/ipset/main.go
@@ -18,8 +18,12 @@ func main() {
 	http.DefaultClient.Timeout = 10 * time.Second
 
 	router := mux.NewRouter()
-	router.HandleFunc("/ipsetlayer3/{network:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{type:[a-zA-Z]+}/{catid:[0-9]+}/{ip:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{local:[0-1]}", handleLayer3).Methods("GET")
-	router.HandleFunc("/ipsetlayer2/{network:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{type:[a-zA-Z]+}/{catid:[0-9]+}/{ip:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{mac:(?:[0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}}/{local:[0-1]}", handleLayer2).Methods("GET")
+	router.HandleFunc("/ipsetmarklayer3/{network:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{type:[a-zA-Z]+}/{catid:[0-9]+}/{ip:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{local:[0-1]}", handleLayer3).Methods("POST")
+	router.HandleFunc("/ipsetmarklayer2/{network:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{type:[a-zA-Z]+}/{catid:[0-9]+}/{ip:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{mac:(?:[0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}}/{local:[0-1]}", handleLayer2).Methods("POST")
+	router.HandleFunc("/ipsetunmarkmac/{mac:(?:[0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}}/{local:[0-1]}", handleUnmarkMac).Methods("POST")
+	router.HandleFunc("/ipsetunmarkip/{ip:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{local:[0-1]}", handleUnmarkIp).Methods("POST")
+	router.HandleFunc("/ipsetmarkiplayer2/{network:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{catid:[0-9]+}/{ip:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{local:[0-1]}", handleMarkIpL2).Methods("POST")
+	router.HandleFunc("/ipsetmarkiplayer3/{network:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{catid:[0-9]+}/{ip:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{local:[0-1]}", handleMarkIpL3).Methods("POST")
 
 	// Api
 	l, err := net.Listen("tcp", ":22223")

--- a/go/ipset/main.go
+++ b/go/ipset/main.go
@@ -59,7 +59,10 @@ func main() {
 		for {
 			req, err := http.NewRequest("GET", "https://127.0.0.1:22223", nil)
 			req.SetBasicAuth(webservices.User, webservices.Pass)
-			cli := &http.Client{}
+			tr := &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			}
+			cli := &http.Client{Transport: tr}
 			_, err = cli.Do(req)
 			if err == nil {
 				daemon.SdNotify(false, "WATCHDOG=1")

--- a/go/ipset/main.go
+++ b/go/ipset/main.go
@@ -29,6 +29,7 @@ func main() {
 	router.HandleFunc("/ipsetmarkiplayer2/{network:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{catid:[0-9]+}/{ip:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{local:[0-1]}", handleMarkIpL2).Methods("POST")
 	router.HandleFunc("/ipsetmarkiplayer3/{network:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{catid:[0-9]+}/{ip:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{local:[0-1]}", handleMarkIpL3).Methods("POST")
 	router.HandleFunc("/ipsetpassthrough/{ip:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{port:(?:udp|tcp):[0-9]+}/{local:[0-1]}", handlePassthrough).Methods("POST")
+	router.HandleFunc("/ipsetpassthroughisolation/{ip:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}/{port:(?:udp|tcp):[0-9]+}/{local:[0-1]}", handleIsolationPassthrough).Methods("POST")
 	http.Handle("/", httpauth.SimpleBasicAuth(webservices.User, webservices.Pass)(router))
 	// Api
 	cfg := &tls.Config{

--- a/go/ipset/utils.go
+++ b/go/ipset/utils.go
@@ -190,7 +190,7 @@ func readDBConfig() pfconfigdriver.PfconfigDatabase {
 
 // initIPSet fetch the database to remove already assigned ip addresses
 func initIPSet() {
-	rows, err := database.Query("select n.mac, i.ip, n.category_id from node as n left join locationlog as l on n.mac=l.mac left join ip4log as i on n.mac=i.mac where l.connection_type = \"inline\" and n.status=\"reg\" and n.mac=i.mac and i.end_time > NOW()")
+	rows, err := database.Query("select distinct n.mac, i.ip, n.category_id from node as n left join locationlog as l on n.mac=l.mac left join ip4log as i on n.mac=i.mac where l.connection_type = \"inline\" and n.status=\"reg\" and n.mac=i.mac and i.end_time > NOW()")
 	if err != nil {
 		// Log here
 		fmt.Println(err)

--- a/go/ipset/utils.go
+++ b/go/ipset/utils.go
@@ -131,21 +131,17 @@ func updateClusterPassthroughIsol(Ip string, Port string) {
 	}
 }
 
-func (IPSET *pfIPSET) mac2ip(Mac string, Set string) []string {
+func (IPSET *pfIPSET) mac2ip(Mac string, Set ipset.IPSet) []string {
 	r := "((?:[0-9]{1,3}.){3}(?:[0-9]{1,3}))," + Mac
 	rgx := regexp.MustCompile(r)
 
 	var Ips []string
-	for _, v := range IPSET.ListALL {
-		if v.Name == Set {
-			for _, u := range v.Members {
+	for _, u := range Set.Members {
 
-				if rgx.Match([]byte(u.Elem)) {
-					result := rgx.FindStringSubmatch(u.Elem)
+		if rgx.Match([]byte(u.Elem)) {
+			result := rgx.FindStringSubmatch(u.Elem)
 
-					Ips = append(Ips, result[1])
-				}
-			}
+			Ips = append(Ips, result[1])
 		}
 	}
 	return Ips

--- a/go/ipset/utils.go
+++ b/go/ipset/utils.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"net"
 	"net/http"
 
@@ -47,9 +48,10 @@ func detectMembers() []net.IP {
 
 func updateClusterL2(Ip string, Mac string, Network string, Type string, Catid string) {
 	for _, member := range detectMembers() {
-		_, err := http.Get("http://" + member.String() + ":22223/ipsetlayer2/" + Type + "/" + Catid + "/" + Ip + "/" + Mac + "/1")
-		if err == nil {
-
+		_, err := http.Get("http://" + member.String() + ":22223/ipsetlayer2/" + Network + "/" + Type + "/" + Catid + "/" + Ip + "/" + Mac + "/1")
+		fmt.Println(member.String())
+		if err != nil {
+			fmt.Println("Not able to contact " + member.String())
 		}
 		spew.Dump(member)
 	}
@@ -57,9 +59,9 @@ func updateClusterL2(Ip string, Mac string, Network string, Type string, Catid s
 
 func updateClusterL3(Ip string, Network string, Type string, Catid string) {
 	for _, member := range detectMembers() {
-		_, err := http.Get("http://" + member.String() + ":22223/ipsetlayer3/" + Type + "/" + Catid + "/" + Ip + "/1")
-		if err == nil {
-
+		_, err := http.Get("http://" + member.String() + ":22223/ipsetlayer3/" + Network + "/" + Type + "/" + Catid + "/" + Ip + "/1")
+		if err != nil {
+			fmt.Println("Not able to contact " + member.String())
 		}
 		spew.Dump(member)
 	}

--- a/go/ipset/utils.go
+++ b/go/ipset/utils.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"regexp"
 
-	ipset "github.com/digineo/go-ipset"
+	ipset "github.com/fdurand/go-ipset"
 	"github.com/inverse-inc/packetfence/go/pfconfigdriver"
 )
 

--- a/go/ipset/utils.go
+++ b/go/ipset/utils.go
@@ -5,7 +5,6 @@ import (
 	"net"
 	"net/http"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/inverse-inc/packetfence/go/pfconfigdriver"
 )
 
@@ -32,8 +31,6 @@ func detectMembers() []net.IP {
 			addrs, _ := netInterface.Addrs()
 			for _, UnicastAddr := range addrs {
 				IPE, _, _ := net.ParseCIDR(UnicastAddr.String())
-				// spew.Dump(net.ParseCIDR(UnicastAddr.String()))
-				// spew.Dump(IP)
 				if IP.Equal(IPE) {
 					present = true
 				}
@@ -49,11 +46,10 @@ func detectMembers() []net.IP {
 func updateClusterL2(Ip string, Mac string, Network string, Type string, Catid string) {
 	for _, member := range detectMembers() {
 		_, err := http.Get("http://" + member.String() + ":22223/ipsetlayer2/" + Network + "/" + Type + "/" + Catid + "/" + Ip + "/" + Mac + "/1")
-		fmt.Println(member.String())
+		fmt.Println("Updated " + member.String())
 		if err != nil {
 			fmt.Println("Not able to contact " + member.String())
 		}
-		spew.Dump(member)
 	}
 }
 
@@ -63,6 +59,5 @@ func updateClusterL3(Ip string, Network string, Type string, Catid string) {
 		if err != nil {
 			fmt.Println("Not able to contact " + member.String())
 		}
-		spew.Dump(member)
 	}
 }

--- a/go/ipset/utils.go
+++ b/go/ipset/utils.go
@@ -50,7 +50,7 @@ func detectMembers() []net.IP {
 
 func updateClusterL2(Ip string, Mac string, Network string, Type string, Catid string) {
 	for _, member := range detectMembers() {
-		err := post("http://"+member.String()+":22223/ipsetmarklayer2/"+Network+"/"+Type+"/"+Catid+"/"+Ip+"/"+Mac+"/1", body)
+		err := post("https://"+member.String()+":22223/ipsetmarklayer2/"+Network+"/"+Type+"/"+Catid+"/"+Ip+"/"+Mac+"/1", body)
 		fmt.Println("Updated " + member.String())
 		if err != nil {
 			fmt.Println("Not able to contact " + member.String())
@@ -60,7 +60,7 @@ func updateClusterL2(Ip string, Mac string, Network string, Type string, Catid s
 
 func updateClusterL3(Ip string, Network string, Type string, Catid string) {
 	for _, member := range detectMembers() {
-		err := post("http://"+member.String()+":22223/ipsetmarklayer3/"+Network+"/"+Type+"/"+Catid+"/"+Ip+"/1", body)
+		err := post("https://"+member.String()+":22223/ipsetmarklayer3/"+Network+"/"+Type+"/"+Catid+"/"+Ip+"/1", body)
 		if err != nil {
 			fmt.Println("Not able to contact " + member.String())
 		}
@@ -69,7 +69,7 @@ func updateClusterL3(Ip string, Network string, Type string, Catid string) {
 
 func updateClusterUnmarkMac(Mac string) {
 	for _, member := range detectMembers() {
-		err := post("http://"+member.String()+":22223/ipsetunmarkmac/"+Mac+"/1", body)
+		err := post("https://"+member.String()+":22223/ipsetunmarkmac/"+Mac+"/1", body)
 		if err != nil {
 			fmt.Println("Not able to contact " + member.String())
 		}
@@ -79,7 +79,7 @@ func updateClusterUnmarkMac(Mac string) {
 func updateClusterUnmarkIp(Ip string) {
 	for _, member := range detectMembers() {
 
-		err := post("http://"+member.String()+":22223/ipsetunmarkip/"+Ip+"/1", body)
+		err := post("https://"+member.String()+":22223/ipsetunmarkip/"+Ip+"/1", body)
 		if err != nil {
 			fmt.Println("Not able to contact " + member.String())
 		}

--- a/go/ipset/utils.go
+++ b/go/ipset/utils.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/tls"
 	"fmt"
 	"io"
 	"net"
@@ -133,10 +134,13 @@ func readWebservicesConfig() pfconfigdriver.PfConfWebservices {
 }
 
 func post(url string, body io.Reader) error {
-	req, err := http.NewRequest("Post", url, body)
+	req, err := http.NewRequest("POST", url, body)
 	req.SetBasicAuth(webservices.User, webservices.Pass)
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
 	req.Header.Set("Content-Type", "application/json")
-	cli := &http.Client{}
+	cli := &http.Client{Transport: tr}
 	_, err = cli.Do(req)
 	return err
 }

--- a/go/ipset/utils.go
+++ b/go/ipset/utils.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"net"
+	"net/http"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/inverse-inc/packetfence/go/pfconfigdriver"
+)
+
+// Detect the vip on each interfaces
+func detectMembers() []net.IP {
+
+	var keyConfCluster pfconfigdriver.PfconfigKeys
+	keyConfCluster.PfconfigNS = "resource::cluster_hosts_ip"
+
+	// keyConfCluster.PfconfigHashNS = "interface " + v
+	pfconfigdriver.FetchDecodeSocket(ctx, &keyConfCluster)
+	var members []net.IP
+	for _, key := range keyConfCluster.Keys {
+		var ConfNet pfconfigdriver.PfClusterIp
+		ConfNet.PfconfigHashNS = key
+
+		pfconfigdriver.FetchDecodeSocket(ctx, &ConfNet)
+
+		IP := net.ParseIP(ConfNet.Ip)
+		var present bool
+
+		ifaces, _ := net.Interfaces()
+		for _, netInterface := range ifaces {
+			addrs, _ := netInterface.Addrs()
+			for _, UnicastAddr := range addrs {
+				IPE, _, _ := net.ParseCIDR(UnicastAddr.String())
+				// spew.Dump(net.ParseCIDR(UnicastAddr.String()))
+				// spew.Dump(IP)
+				if IP.Equal(IPE) {
+					present = true
+				}
+			}
+		}
+		if present == false {
+			members = append(members, IP)
+		}
+	}
+	return members
+}
+
+func updateClusterL2(Ip string, Mac string, Network string, Type string, Catid string) {
+	for _, member := range detectMembers() {
+		_, err := http.Get("http://" + member.String() + ":22223/ipsetlayer2/" + Type + "/" + Catid + "/" + Ip + "/" + Mac + "/1")
+		if err == nil {
+
+		}
+		spew.Dump(member)
+	}
+}
+
+func updateClusterL3(Ip string, Network string, Type string, Catid string) {
+	for _, member := range detectMembers() {
+		_, err := http.Get("http://" + member.String() + ":22223/ipsetlayer3/" + Type + "/" + Catid + "/" + Ip + "/1")
+		if err == nil {
+
+		}
+		spew.Dump(member)
+	}
+}

--- a/go/ipset/utils.go
+++ b/go/ipset/utils.go
@@ -50,7 +50,7 @@ func detectMembers() []net.IP {
 
 func updateClusterL2(Ip string, Mac string, Network string, Type string, Catid string) {
 	for _, member := range detectMembers() {
-		_, err := http.Post("http://"+member.String()+":22223/ipsetmarklayer2/"+Network+"/"+Type+"/"+Catid+"/"+Ip+"/"+Mac+"/1", "application/json", body)
+		_, err := http.Post("https://"+member.String()+":22223/ipsetmarklayer2/"+Network+"/"+Type+"/"+Catid+"/"+Ip+"/"+Mac+"/1", "application/json", body)
 		fmt.Println("Updated " + member.String())
 		if err != nil {
 			fmt.Println("Not able to contact " + member.String())
@@ -60,7 +60,7 @@ func updateClusterL2(Ip string, Mac string, Network string, Type string, Catid s
 
 func updateClusterL3(Ip string, Network string, Type string, Catid string) {
 	for _, member := range detectMembers() {
-		_, err := http.Post("http://"+member.String()+":22223/ipsetmarklayer3/"+Network+"/"+Type+"/"+Catid+"/"+Ip+"/1", "application/json", body)
+		_, err := http.Post("https://"+member.String()+":22223/ipsetmarklayer3/"+Network+"/"+Type+"/"+Catid+"/"+Ip+"/1", "application/json", body)
 		if err != nil {
 			fmt.Println("Not able to contact " + member.String())
 		}
@@ -69,7 +69,7 @@ func updateClusterL3(Ip string, Network string, Type string, Catid string) {
 
 func updateClusterUnmarkMac(Mac string) {
 	for _, member := range detectMembers() {
-		_, err := http.Post("http://"+member.String()+":22223/ipsetunmarkmac/"+Mac+"/1", "application/json", body)
+		_, err := http.Post("https://"+member.String()+":22223/ipsetunmarkmac/"+Mac+"/1", "application/json", body)
 		if err != nil {
 			fmt.Println("Not able to contact " + member.String())
 		}
@@ -79,7 +79,7 @@ func updateClusterUnmarkMac(Mac string) {
 func updateClusterUnmarkIp(Ip string) {
 	for _, member := range detectMembers() {
 
-		_, err := http.Post("http://"+member.String()+":22223/ipsetunmarkip/"+Ip+"/1", "application/json", body)
+		_, err := http.Post("https://"+member.String()+":22223/ipsetunmarkip/"+Ip+"/1", "application/json", body)
 		if err != nil {
 			fmt.Println("Not able to contact " + member.String())
 		}
@@ -88,7 +88,7 @@ func updateClusterUnmarkIp(Ip string) {
 
 func updateClusterMarkIpL3(Ip string, Network string, Catid string) {
 	for _, member := range detectMembers() {
-		_, err := http.Post("http://"+member.String()+":22223/ipsetmarkiplayer3/"+Network+"/"+Catid+"/"+Ip+"/1", "application/json", body)
+		_, err := http.Post("https://"+member.String()+":22223/ipsetmarkiplayer3/"+Network+"/"+Catid+"/"+Ip+"/1", "application/json", body)
 		if err != nil {
 			fmt.Println("Not able to contact " + member.String())
 		}
@@ -96,7 +96,7 @@ func updateClusterMarkIpL3(Ip string, Network string, Catid string) {
 }
 func updateClusterMarkIpL2(Ip string, Network string, Catid string) {
 	for _, member := range detectMembers() {
-		_, err := http.Post("http://"+member.String()+":22223/ipsetmarkiplayer2/"+Network+"/"+Catid+"/"+Ip+"/1", "application/json", body)
+		_, err := http.Post("https://"+member.String()+":22223/ipsetmarkiplayer2/"+Network+"/"+Catid+"/"+Ip+"/1", "application/json", body)
 		if err != nil {
 			fmt.Println("Not able to contact " + member.String())
 		}

--- a/go/ipset/utils.go
+++ b/go/ipset/utils.go
@@ -114,6 +114,16 @@ func updateClusterPassthrough(Ip string, Port string) {
 	}
 }
 
+func updateClusterPassthroughIsol(Ip string, Port string) {
+	for _, member := range detectMembers() {
+		err := post("https://"+member.String()+":22223/ipsetpassthroughisolation/"+Ip+"/"+Port+"/1", body)
+		fmt.Println("Updated " + member.String())
+		if err != nil {
+			fmt.Println("Not able to contact " + member.String())
+		}
+	}
+}
+
 func mac2ip(Mac string) []string {
 	var all []ipset.IPSet
 	all, _ = ipset.ListAll()

--- a/go/ipset/utils.go
+++ b/go/ipset/utils.go
@@ -103,6 +103,17 @@ func updateClusterMarkIpL2(Ip string, Network string, Catid string) {
 		}
 	}
 }
+
+func updateClusterPassthrough(Ip string, Port string) {
+	for _, member := range detectMembers() {
+		err := post("https://"+member.String()+":22223/ipsetpassthrough/"+Ip+"/"+Port+"/1", body)
+		fmt.Println("Updated " + member.String())
+		if err != nil {
+			fmt.Println("Not able to contact " + member.String())
+		}
+	}
+}
+
 func mac2ip(Mac string) []string {
 	var all []ipset.IPSet
 	all, _ = ipset.ListAll()

--- a/go/pfconfigdriver/structs.go
+++ b/go/pfconfigdriver/structs.go
@@ -126,6 +126,14 @@ type ListenInts struct {
 	Element        []string
 }
 
+type PfClusterIp struct {
+	StructConfig
+	PfconfigMethod string `val:"hash_element"`
+	PfconfigNS     string `val:"resource::cluster_hosts_ip"`
+	PfconfigHashNS string `val:"-"`
+	Ip             string `json:"ip"`
+}
+
 type configStruct struct {
 	Interfaces struct {
 		ListenInts        ListenInts

--- a/go/pfconfigdriver/structs.go
+++ b/go/pfconfigdriver/structs.go
@@ -93,6 +93,19 @@ type PfConfCaptivePortal struct {
 	WisprRedirection             string   `json:"wispr_redirection"`
 }
 
+type PfConfWebservices struct {
+	StructConfig
+	PfconfigMethod string `val:"hash_element"`
+	PfconfigNS     string `val:"config::Pf"`
+	PfconfigHashNS string `val:"webservices"`
+	Pass           string `json:"pass"`
+	Proto          string `json:"proto"`
+	User           string `json:"user"`
+	Port           string `json:"port"`
+	AAAPort        string `json:"aaa_port"`
+	Host           string `json:"host"`
+}
+
 type ManagementNetwork struct {
 	StructConfig
 	PfconfigMethod string `val:"element"`
@@ -143,6 +156,7 @@ type configStruct struct {
 		General       PfConfGeneral
 		Fencing       PfConfFencing
 		CaptivePortal PfConfCaptivePortal
+		Webservices   PfConfWebservices
 	}
 }
 

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -57,6 +57,12 @@
 			"revisionTime": "2017-01-10T07:11:07Z"
 		},
 		{
+			"checksumSHA1": "71AC/NWQAF6kQ6pKPwg4CqKnr4c=",
+			"path": "github.com/fdurand/go-ipset",
+			"revision": "1ca9a3170b97027181908a20927a2f4a0e7020c1",
+			"revisionTime": "2017-11-27T18:22:32Z"
+		},
+		{
 			"checksumSHA1": "VdXZPcDRHK1T7XjBu2KW8Mb8S6w=",
 			"path": "github.com/flynn/go-shlex",
 			"revision": "3f9db97f856818214da2e1057f8ad84803971cff",
@@ -189,7 +195,7 @@
 			"revisionTime": "2017-02-10T11:35:44Z"
 		},
 		{
-			"checksumSHA1": "XUdlanAUfQt+UjszRgtMeziyiG8=",
+			"checksumSHA1": "6FEaIYf3puE0Y5cwOKyWWJD/WUk=",
 			"path": "github.com/lucas-clemente/quic-go/crypto",
 			"revision": "08191fc5d9a6eeedc1eede6601427b12b35c057b",
 			"revisionTime": "2017-02-10T11:35:44Z"
@@ -309,7 +315,7 @@
 			"revisionTime": "2016-09-18T04:11:01Z"
 		},
 		{
-			"checksumSHA1": "A7svgQnqqqSmzjTrZxNGhmdu0es=",
+			"checksumSHA1": "bd03a9yO9N5nVkVLD9m1vsWOXwA=",
 			"path": "github.com/ulikunitz/xz",
 			"revision": "76f94b7c69c6f84be96bcfc2443042b198689565",
 			"revisionTime": "2016-12-02T21:56:20Z"
@@ -399,7 +405,7 @@
 			"revisionTime": "2017-01-26T11:54:58Z"
 		},
 		{
-			"checksumSHA1": "kEO69MIsqWDxBOIs3ez1faofNSg=",
+			"checksumSHA1": "O6yCEoGr0NU7ZM60PmyzBG+OC9s=",
 			"path": "golang.org/x/net/publicsuffix",
 			"revision": "61557ac0112b576429a0df080e1c2cef5dfbb642",
 			"revisionTime": "2017-01-26T11:54:58Z"
@@ -417,13 +423,13 @@
 			"revisionTime": "2016-10-16T16:34:30Z"
 		},
 		{
-			"checksumSHA1": "VoN1N+QSzZGXJuTX2mVH7fAUXNM=",
+			"checksumSHA1": "REJSgeNasH6Uehc27Wmqo1F7P1M=",
 			"path": "golang.org/x/text/unicode/bidi",
 			"revision": "5a42fa2464759cbb7ee0af9de00b54d69f09a29c",
 			"revisionTime": "2016-10-16T16:34:30Z"
 		},
 		{
-			"checksumSHA1": "Aj3JSVO324FCjEAGm4ZwmC79bbo=",
+			"checksumSHA1": "aihk1EHGiDFDRDZuRf5CWqWpcYs=",
 			"path": "golang.org/x/text/unicode/norm",
 			"revision": "5a42fa2464759cbb7ee0af9de00b54d69f09a29c",
 			"revisionTime": "2016-10-16T16:34:30Z"

--- a/go/vendor/vendor.json
+++ b/go/vendor/vendor.json
@@ -21,6 +21,12 @@
 			"revisionTime": "2016-10-29T20:57:26Z"
 		},
 		{
+			"checksumSHA1": "e+GyxNE5hA8Q6usX+penCPjeeJo=",
+			"path": "github.com/diegoguarnieri/go-conntrack/conntrack",
+			"revision": "9abb0707ff3199f9ab5a44b5a5ea588c41979476",
+			"revisionTime": "2016-12-08T18:04:11Z"
+		},
+		{
 			"checksumSHA1": "Mrmbqq23BIzwocC3m1wk479o35s=",
 			"path": "github.com/dsnet/compress",
 			"revision": "b9aab3c6a04eef14c56384b4ad065e7b73438862",
@@ -75,10 +81,22 @@
 			"revisionTime": "2016-05-14T03:44:11Z"
 		},
 		{
+			"checksumSHA1": "gC4yFu+0Iqb71rzQZVbGSKqsK6U=",
+			"path": "github.com/goji/httpauth",
+			"revision": "2da839ab0f4df05a6db5eb277995589dadbd4fb9",
+			"revisionTime": "2016-06-01T13:53:02Z"
+		},
+		{
 			"checksumSHA1": "UP2wONSE346WHWwT20G1Xedd6ZI=",
 			"path": "github.com/google/uuid",
 			"revision": "064e2069ce9c359c118179501254f67d7d37ba24",
 			"revisionTime": "2016-11-28T19:12:14Z"
+		},
+		{
+			"checksumSHA1": "F5dR3/i70EhSIMZfeIV+H8/PtvM=",
+			"path": "github.com/gorilla/mux",
+			"revision": "392c28fe23e1c45ddba891b0320b3b5df220beea",
+			"revisionTime": "2017-01-18T13:43:44Z"
 		},
 		{
 			"checksumSHA1": "ZVzABul4nD/fzyYnbe+5bsJ4nBg=",

--- a/lib/pf/constants/api.pm
+++ b/lib/pf/constants/api.pm
@@ -20,6 +20,7 @@ use Readonly;
 Readonly our $DEFAULT_CLIENT => "pf::api::jsonrpcclient";
 
 our $PFSSO_PORT = 8777;
+our $GO_IPSET_PORT = 22223;
 
 =head1 AUTHOR
 

--- a/lib/pf/ipset.pm
+++ b/lib/pf/ipset.pm
@@ -55,6 +55,12 @@ Readonly my $FW_FILTER_FORWARD_INT_INLINE => 'forward-internal-inline-if';
 Readonly my $FW_PREROUTING_INT_INLINE => 'prerouting-int-inline-if';
 Readonly my $FW_POSTROUTING_INT_INLINE => 'postrouting-int-inline-if';
 
+my $ipset_client = pf::api::jsonrestclient->new(
+                proto   => "http",
+                host    => "localhost",
+                port    => $pf::constants::api::GO_IPSET_PORT,
+            );
+
 =head1 SUBROUTINES
 
 TODO: This list is incomplete
@@ -264,31 +270,16 @@ sub iptables_mark_node {
         my $iplog = $newip || pf::ip4log::mac2ip($mac);
 
         if (defined $iplog) {
+            my $node_info = pf::node::node_view($mac);
+            my $role_id = $node_info->{'category_id'};
             my $ip = new NetAddr::IP::Lite clean_ip($iplog);
             if ($net_addr->contains($ip)) {
-                #Prevent double entries in ipset
-                $self->ipset_remove_ip($iplog, $mark, $network);
-                my $cmd;
 
                 if ($ConfigNetworks{$network}{'type'} =~ /^$NET_TYPE_INLINE_L3$/i) {
-                    $cmd = "sudo ipset --add pfsession_$mark_type_to_str{$mark}\_$network $iplog -exist 2>&1";
+                    $ipset_client->call("/ipsetmarklayer3/".$network."/".$mark_type_to_str{$mark}."/".$role_id."/".$iplog."/0",{});
                 } else {
-                    $cmd = "sudo ipset --add pfsession_$mark_type_to_str{$mark}\_$network $iplog,$mac -exist 2>&1";
+                    $ipset_client->call("/ipsetmarklayer2/".$network."/".$mark_type_to_str{$mark}."/".$role_id."/".$iplog."/".$mac."/0",{});
                 }
-
-                my @lines  = pf_run($cmd);
-
-                if ( $mark_type_to_str{$mark} eq "Reg" ) {
-                    my $node_info = pf::node::node_view($mac);
-                    my $role_id = $node_info->{'category_id'};
-                    if ($ConfigNetworks{$network}{'type'} =~ /^$NET_TYPE_INLINE_L3$/i) {
-                        $cmd = "sudo ipset --add PF-iL3_ID$role_id\_$network $iplog -exist 2>&1";
-                    } else {
-                        $cmd = "sudo ipset --add PF-iL2_ID$role_id\_$network $iplog -exist 2>&1";
-                    }
-                }
-
-                pf_run($cmd);
             }
         } else {
             $logger->error("Unable to mark mac $mac");
@@ -302,177 +293,22 @@ sub iptables_unmark_node {
     my ( $self, $mac, $mark ) = @_;
     my $logger = get_logger();
 
-    my $ipset = $self->get_ip_from_ipset_by_mac($mac, $mark);
+    $ipset_client->call("/ipsetunmarkmac/".$mac."/0",{});
 
-    my $node_info = pf::node::node_view($mac);
-    my $role_id = $node_info->{'category_id'};
-
-    while ( my ($network, $iplist) = each(%$ipset) ) {
-        if (defined($iplist)) {
-            foreach my $IP ( split( ',', $iplist ) ) {
-                my $cmd = "sudo ipset --del pfsession_$mark_type_to_str{$mark}\_$network $IP -exist 2>&1";
-                my @lines  = pf_run($cmd);
-
-                if ($ConfigNetworks{$network}{'type'} =~ /^$NET_TYPE_INLINE_L3$/i) {
-                    $cmd = "sudo ipset del PF-iL3_ID$role_id\_$network $IP -exist 2>&1";
-                } else {
-                    $cmd = "sudo ipset del PF-iL2_ID$role_id\_$network $IP -exist 2>&1";
-                }
-                pf_run($cmd);
-
-                $cmd = "sudo /usr/sbin/conntrack -D -s $IP 2>&1";
-                pf_run($cmd);
-                $logger->info("Flushed connections for $IP.");
-
-            }
-        }
-    }
     return (1);
 }
 
+
 =item get_mangle_mark_for_mac
 
-Fetches the current mangle mark for a given mark.
-Useful to re-evaluate what to do with a given node who's state changed.
-
-Returns IPTABLES MARK constant ($IPTABLES_MARK_...) or undef on failure.
+Return 4
 
 =cut
 
-# TODO migrate to IPTables::Interface (to get rid of IPTables::ChainMgr) once it supports fetching iptables info
 sub get_mangle_mark_for_mac {
     my ( $self, $mac ) = @_;
-
-    my $logger = get_logger();
-    my $_EXIT_CODE_EXISTS = 1;
-
-    my $iplog = pf::ip4log::mac2ip($mac);
-
-    foreach my $network ( keys %ConfigNetworks ) {
-        next if ( !pf::config::is_network_type_inline($network) );
-
-        my $net_addr = NetAddr::IP->new($network,$ConfigNetworks{$network}{'netmask'});
-
-        if (defined $iplog) {
-            my $ip = new NetAddr::IP::Lite clean_ip($iplog);
-
-            if ($net_addr->contains($ip)) {
-                foreach my $IPTABLES_MARK ($IPTABLES_MARK_UNREG, $IPTABLES_MARK_REG, $IPTABLES_MARK_ISOLATION) {
-                    my $cmd;
-                    if ($ConfigNetworks{$network}{'type'} =~ /^$NET_TYPE_INLINE_L3$/i) {
-                        $cmd = "sudo ipset --test pfsession_$mark_type_to_str{$IPTABLES_MARK}\_$network $iplog 2>&1";
-                    } else {
-                        $cmd = "sudo ipset --test pfsession_$mark_type_to_str{$IPTABLES_MARK}\_$network $iplog,$mac 2>&1";
-                    }
-                    my @out = pf_run($cmd, , accepted_exit_status => [ $_EXIT_CODE_EXISTS ]);
-
-                    if (defined($out[0]) && !($out[0] =~ m/NOT/i)) {
-                        return $IPTABLES_MARK;
-                    }
-                }
-            }
-        } else {
-            $logger->error("Unable to list iptables mangle table: $!");
-            return $IPTABLES_MARK_UNREG;
-        }
-    }
-    return $IPTABLES_MARK_UNREG;
+    return 4;
 }
-
-=item ipset_remove_ip
-
-Remove ip from ipset session
-
-=cut
-
-sub ipset_remove_ip {
-    my ( $self, $ip, $mark, $network) = @_;
-    my $logger = get_logger();
-    my ($cmd, $out);
-    $cmd = "sudo ipset --list pfsession_$mark_type_to_str{$mark}\_$network 2>&1";
-    $out  = pf_run($cmd);
-    my @lines = split "\n+", $out;
-
-    my $mac = pf::ip4log::ip2mac($ip);
-    my $node_info = pf::node::node_view($mac);
-    my $role_id = $node_info->{'category_id'};
-
-    foreach my $line (@lines) {
-
-        # skip emtpy lines from ipset list
-        next if $line =~ m/^\s*$/;
-
-        # skip comment lines from ipset list
-        next if $line =~ m/:\s|:\Z/;
-        if ($line =~ m/^\s* $ip , .* \s* $/ix) {
-            $cmd = "sudo ipset --del pfsession_$mark_type_to_str{$mark}\_$network $ip -exist 2>&1";
-            $out = pf_run($cmd);
-
-            if ($ConfigNetworks{$network}{'type'} =~ /^$NET_TYPE_INLINE_L3$/i) {
-                $cmd = "sudo ipset --del PF-iL3_ID$role_id\_$network $ip -exist 2>&1";
-            } else {
-                $cmd = "sudo ipset --del PF-iL2_ID$role_id\_$network $ip -exist 2>&1";
-            }
-            pf_run($cmd);
-
-            $cmd = "sudo /usr/sbin/conntrack -D -s $ip 2>&1";
-            pf_run($cmd);
-            $logger->info("Flushed connections for $ip.");
-        }
-    }
-}
-
-=item get_ip_from_ipset_by_mac
-
-Fetches all the ip address from ipset by mac address
-
-=cut
-
-sub get_ip_from_ipset_by_mac {
-    my ( $self, $mac, $mark) = @_;
-    my $logger = get_logger();
-    my $session = {};
-    my ($cmd, $out);
-    foreach my $network ( keys %ConfigNetworks ) {
-        next if ( !pf::config::is_network_type_inline($network) );
-        my $ip;
-        my $net_addr = NetAddr::IP->new($network,$ConfigNetworks{$network}{'netmask'});
-        if ($ConfigNetworks{$network}{'type'} =~ /^$NET_TYPE_INLINE_L3$/i) {
-            my $net_addr = NetAddr::IP->new($network,$ConfigNetworks{$network}{'netmask'});
-            my $tmp_ip = new NetAddr::IP::Lite clean_ip(pf::ip4log::mac2ip($mac));
-            if ($net_addr->contains($tmp_ip)) {
-                $ip = $tmp_ip->addr;
-            }
-        } else {
-            $cmd = "sudo ipset --list pfsession_$mark_type_to_str{$mark}\_$network 2>&1";
-            $out = pf_run($cmd);
-            my @lines = split "\n+", $out;
-
-            # ipv4 address in quad decimal
-            my $ip_quad_dec_rx = qr(\d{1,3} \. \d{1,3} \. \d{1,3} \. \d{1,3})x;
-
-            foreach my $line (@lines) {
-
-                # skip emtpy lines from ipset list
-                next if $line =~ m/^\s*$/;
-
-                # skip comment lines from ipset list
-                next if $line =~ m/:\s|:\Z/;
-
-                if ($line =~ m/^\s* ($ip_quad_dec_rx) , $mac \s* $/ix) {
-                    $ip  .= $1.",";
-                    unless ( $ip && $mac ) {
-                        $logger->warn("Couldn't parse line: $line");
-                        next;
-                    }
-                }
-            }
-        }
-        $session->{$network} = $ip;
-    }
-    return $session;
-}
-
 =item update_ipset
 
 Update session when the ip address change
@@ -486,8 +322,12 @@ sub update_node {
     my $src_ip = new NetAddr::IP::Lite clean_ip($srcip);
     my $old_ip = new NetAddr::IP::Lite clean_ip($oldip);
     my $id = $view_mac->{'category_id'};
+    my $open_violation_count = pf::violation::violation_count_reevaluate_access($srcmac);
+    my $mark = $IPTABLES_MARK_UNREG if ($view_mac->{'status'} eq 'unreg') // $IPTABLES_MARK_REG;
+    if ($open_violation_count != 0) {
+        $mark = $IPTABLES_MARK_ISOLATION;
+    }
     if ($view_mac->{'last_connection_type'} eq $connection_type_to_str{$INLINE}) {
-        my $mark = $self->get_mangle_mark_for_mac($srcmac);
         foreach my $network ( keys %ConfigNetworks ) {
             next if ( !pf::config::is_network_type_inline($network) );
 
@@ -495,18 +335,14 @@ sub update_node {
 
             #Delete from ipset session if the ip change
             if ($net_addr->contains($old_ip)) {
-                if ($ConfigNetworks{$network}{'type'} =~ /^$NET_TYPE_INLINE_L3$/i) {
-                    pf_run("sudo ipset del PF-iL3_ID$id\_$network $old_ip -exist 2>&1");
-                } else {
-                    pf_run("sudo ipset del PF-iL2_ID$id\_$network $old_ip -exist 2>&1");
-                }
+                 $ipset_client->call("/ipsetunmarkip/".$oldip."/0",{});
             }
             #Add in ipset session if the ip change
             if ($net_addr->contains($src_ip)) {
                  if ($ConfigNetworks{$network}{'type'} =~ /^$NET_TYPE_INLINE_L3$/i) {
-                    pf_run("sudo ipset add PF-iL3_ID$id\_$network $src_ip -exist 2>&1");
+                    $ipset_client->call("/ipsetmarkiplayer3/".$network."/".$id."/".$src_ip."/0",{});
                 } else {
-                    pf_run("sudo ipset add PF-iL2_ID$id\_$network $src_ip -exist 2>&1");
+                    $ipset_client->call("/ipsetmarkiplayer2/".$network."/".$id."/".$src_ip."/0",{});
                 }
             }
 

--- a/lib/pf/ipset.pm
+++ b/lib/pf/ipset.pm
@@ -56,7 +56,7 @@ Readonly my $FW_PREROUTING_INT_INLINE => 'prerouting-int-inline-if';
 Readonly my $FW_POSTROUTING_INT_INLINE => 'postrouting-int-inline-if';
 
 my $ipset_client = pf::api::jsonrestclient->new(
-                proto   => "http",
+                proto   => "https",
                 host    => "localhost",
                 port    => $pf::constants::api::GO_IPSET_PORT,
             );

--- a/lib/pf/services/manager/dhcpd.pm
+++ b/lib/pf/services/manager/dhcpd.pm
@@ -130,7 +130,7 @@ EOT
                     }
                     if ($members) {
                         if ($current_network->contains($ip)) {
-                            $dns = $members;
+                            $dns = $members if ( !pf::config::is_network_type_inline($network) );
                         $active = defined($net{next_hop}) ?
                                  NetAddr::IP::Lite->new($net{'next_hop'}, $cfg->{'mask'}) :
                                  NetAddr::IP::Lite->new($cfg->{'ip'}, $cfg->{'mask'});

--- a/lib/pf/services/manager/go_ipset.pm
+++ b/lib/pf/services/manager/go_ipset.pm
@@ -1,0 +1,60 @@
+package pf::services::manager::go_ipset;
+=head1 NAME
+
+pf::services::manager::go_ipset
+
+=cut
+
+=head1 DESCRIPTION
+
+pf::services::manager::go_ipset
+
+=cut
+
+use strict;
+use warnings;
+use Moo;
+use pf::cluster;
+use pf::config qw(
+    %Config
+);
+use pf::util;
+
+extends 'pf::services::manager';
+
+has '+name' => ( default => sub { 'go_ipset' } );
+
+sub isManaged {
+    my ($self) = @_;
+    return  $self->SUPER::isManaged();
+}
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2017 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;

--- a/lib/pfconfig/namespaces/resource/cluster_hosts_ip.pm
+++ b/lib/pfconfig/namespaces/resource/cluster_hosts_ip.pm
@@ -1,0 +1,68 @@
+package pfconfig::namespaces::resource::cluster_hosts_ip;
+
+=head1 NAME
+
+pfconfig::namespaces::resource::cluster_hosts_ip
+
+=cut
+
+=head1 DESCRIPTION
+
+pfconfig::namespaces::resource::cluster_host_ip
+
+=cut
+
+use strict;
+use warnings;
+
+use base 'pfconfig::namespaces::resource';
+use pfconfig::namespaces::config::Cluster;
+
+sub init {
+    my ($self) = @_;
+
+    $self->{cluster_resource} = pfconfig::namespaces::config::Cluster->new($self->{cache});
+}
+
+sub build {
+    my ($self) = @_;
+    $self->{cluster_resource}->build();
+
+    my %cluster_hosts = map { $_->{host} => { "ip" => $_->{management_ip} } } @{$self->{cluster_resource}->{_servers}};
+
+    return \%cluster_hosts;
+}
+
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2017 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;
+
+# vim: set shiftwidth=4:
+# vim: set expandtab:
+# vim: set backspace=indent,eol,start:

--- a/t/TestUtils.pm
+++ b/t/TestUtils.pm
@@ -102,6 +102,7 @@ and return all the normal files under
 =cut
 
 my @excluded_binaries = qw(
+   /usr/local/pf/bin/go_ipset
    /usr/local/pf/bin/pfcmd
    /usr/local/pf/bin/pfhttpd
    /usr/local/pf/sbin/pfdns


### PR DESCRIPTION
# Description
New go service that deal with ipset session directly with the libipset library.
Removed all ipset call in the perl code (except ipset --create)
Support for clustering
Added support for cluster inline

# Impacts
Inline/Passthrough

# Delete branch after merge
YES

# NEWS file entries
## New Features
* New golang ipset service
* Cluster support
* Inline Cluster support

## Bug Fixes
* Fixes passthrough and inline support in active/active cluster mode
