### PR TITLE
Fix portal default PID overwriting a valid previous PID

### DIFF
--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Root.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Root.pm
@@ -239,6 +239,8 @@ sub apply_new_node_info {
     my ($self) = @_;
     get_logger->debug(sub { use Data::Dumper; "Applying new node_info to user ".Dumper($self->new_node_info)});
 
+    my $node_view = node_view($self->current_mac);
+
     # When device is pending, we take the role+unregdate from the computed node info. 
     # This way, if the role wasn't set during the portal process (like in provisioning agent re-install), then it will pick the role it had before
     if($self->node_info->{status} eq $pf::node::STATUS_PENDING) {
@@ -256,6 +258,12 @@ sub apply_new_node_info {
     # We take the role+unregdate from the computed node info. This way, if the role wasn't set during the portal process (like in provisioning agent re-install), then it will pick the role it had before
     $self->new_node_info->{category} = $self->node_info->{category};
     $self->new_node_info->{unregdate} = $self->node_info->{unregdate};
+
+    # We check if the username is the default PID. If it is and there is a non-default PID already on the node, we take it instead of the default PID
+    if($self->username eq $default_pid) {
+        get_logger->debug("Username is set to the default PID and there is already a PID set on the node (".$node_view->{pid}."). Keeping it instead of the default PID.");
+        $self->username($node_view->{pid});
+    }
 
     my ( $status, $status_msg );
     ( $status, $status_msg ) = pf::node::node_register($self->current_mac, $self->username, %{$self->new_node_info()});


### PR DESCRIPTION
# Description
Fix portal default PID overwriting a valid previous PID

# Impacts
Portal node assignments (particularly the PID)

# Issue
fixes #2825 

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* Prevent a valid PID from being overwritten at the end of the portal registration if the new PID is default (#2825)

