### PR TITLE
Don't allow the portal FQDN as a passthrough

### DIFF
--- a/html/pfappserver/lib/pfappserver/Form/Config/Pf.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Pf.pm
@@ -250,8 +250,10 @@ sub field_list {
 }
 
 our %FIELD_VALIDATORS = (
-    "fencing.passthroughs" => sub { validate_fqdn_not_in_passthroughs(@_, "passthroughs") },
-    "fencing.isolation_passthroughs" => sub { validate_fqdn_not_in_passthroughs(@_, "isolation_passthroughs") },
+    "general.hostname" => sub { validate_fqdn_not_in_passthroughs(@_, [ "passthroughs", "isolation_passthroughs" ]) },
+    "general.domain" => sub { validate_fqdn_not_in_passthroughs(@_, [ "passthroughs", "isolation_passthroughs" ]) },
+    "fencing.passthroughs" => sub { validate_fqdn_not_in_passthroughs(@_, ["passthroughs"]) },
+    "fencing.isolation_passthroughs" => sub { validate_fqdn_not_in_passthroughs(@_, ["isolation_passthroughs"]) },
 );
 
 =head2 validator_for_field
@@ -266,25 +268,48 @@ sub validator_for_field {
     return $FIELD_VALIDATORS{$field};
 }
 
+=head2 validate_fqdn_field
 
-=head2 validate_fqdn_not_in_passthroughs
+For an FQDN, this validates that its not part of the passthroughs
+
+=cut
+
+=head2 validate_passthroughs_field
 
 For a passthrough form field, this validates that the passthroughs it contains won't match the portal FQDN
 
 =cut
 
 sub validate_fqdn_not_in_passthroughs {
-    my (undef, $field, $module) = @_; 
+    my (undef, $field, $modules) = @_; 
+
+    get_logger->debug("Validating field ".$field->name);
 
     my $cs = pf::ConfigStore::Pf->new;
     my $general = $cs->read("general");
-    my $fqdn = $general->{hostname}.".".$general->{domain};
+    my $fencing = $cs->read("fencing");
 
-    my $passthroughs = "pfconfig::namespaces::resource::$module"->_build([ split(/\r?\n/, $field->value) ]);
-    my ($res, undef) = pf::util::dns::_matches_passthrough($passthroughs, $fqdn);
+    use Data::Dumper ; get_logger->info(Dumper($field->form->params->{"hostname"}));
 
-    if($res) {
-        $field->add_error("Passthroughs cannot contain the portal FQDN ($fqdn) or any wildcard for this domain");
+    my $params = $field->form->params;
+    # Use the hostname + domain from the form if its there, otherwise, restore it from the ConfigStore
+    my $hostname = $params->{hostname} // $general->{hostname};
+    my $domain = $params->{domain} // $general->{domain};
+    my $fqdn = "$hostname.$domain";
+
+    get_logger->debug("Validating passthroughs using FQDN $fqdn");
+
+    for my $module (@$modules) {
+        my $passthroughs_txt = [ split(/\r?\n/, (defined($params->{$module}) ? $params->{$module} : $fencing->{$module})) ];
+
+        get_logger->debug("Validating FQDN against passthroughs: " . join(",", @$passthroughs_txt));
+
+        my $passthroughs = "pfconfig::namespaces::resource::$module"->_build($passthroughs_txt);
+        my ($res, undef) = pf::util::dns::_matches_passthrough($passthroughs, $fqdn);
+
+        if($res) {
+            $field->add_error("Passthroughs cannot contain the portal FQDN ($fqdn) or any wildcard for this domain");
+        }
     }
 }
 

--- a/html/pfappserver/lib/pfappserver/Form/Config/Pf.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Pf.pm
@@ -249,6 +249,11 @@ sub field_list {
     return $list;
 }
 
+our %FIELD_VALIDATORS = (
+    "fencing.passthroughs" => sub { validate_fqdn_not_in_passthroughs(@_, "passthroughs") },
+    "fencing.isolation_passthroughs" => sub { validate_fqdn_not_in_passthroughs(@_, "isolation_passthroughs") },
+);
+
 =head2 validator_for_field
 
 Get the validator for a field
@@ -258,10 +263,7 @@ Get the validator for a field
 sub validator_for_field {
     my ($self, $field) = @_;
 
-    return {
-        "fencing.passthroughs" => sub { validate_fqdn_not_in_passthroughs(@_, "passthroughs") },
-        "fencing.isolation_passthroughs" => sub { validate_fqdn_not_in_passthroughs(@_, "isolation_passthroughs") },
-    }->{$field};
+    return $FIELD_VALIDATORS{$field};
 }
 
 

--- a/html/pfappserver/lib/pfappserver/Form/Config/Pf.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Pf.pm
@@ -289,8 +289,6 @@ sub validate_fqdn_not_in_passthroughs {
     my $general = $cs->read("general");
     my $fencing = $cs->read("fencing");
 
-    use Data::Dumper ; get_logger->info(Dumper($field->form->params->{"hostname"}));
-
     my $params = $field->form->params;
     # Use the hostname + domain from the form if its there, otherwise, restore it from the ConfigStore
     my $hostname = $params->{hostname} // $general->{hostname};

--- a/lib/pf/util/dns.pm
+++ b/lib/pf/util/dns.pm
@@ -38,6 +38,14 @@ Returns 2 values
 
 sub matches_passthrough {
     my ($domain, $zone) = @_;
+    
+    unless(defined($zone)) {
+        die "Undefined passthrough zone provided\n";
+    }
+
+    unless(exists $ZONE_LOOKUP{$zone}) {
+        die "Invalid passthrough zone $zone\n";
+    }
 
     return _matches_passthrough($ZONE_LOOKUP{$zone}, $domain);
 }

--- a/lib/pf/util/dns.pm
+++ b/lib/pf/util/dns.pm
@@ -33,16 +33,42 @@ Returns 2 values
 
 sub matches_passthrough {
     my ($domain, $zone) = @_;
+
+    return _matches_passthrough(eval("\\%$zone"), $domain);
+}
+
+sub _matches_passthrough {
+    my ($passthroughs, $domain) = @_;
+
     # undef domains are not passthroughs
     return ($FALSE, []) unless(defined($domain));
     $domain = lc($domain);
 
+    my ($res, $passthrough) = _matches_normal_passthrough($passthroughs, $domain);
+    return ($res, $passthrough) if($res);
+
+    ($res, $passthrough) = _matches_wildcard_passthrough($passthroughs, $domain);
+    return ($res, $passthrough) if($res);
+
+    # Fallback to not a passthrough
+    return ($FALSE, []);
+}
+
+sub _matches_normal_passthrough {
+    my ($passthroughs, $domain) = @_;
+
     # Check for non-wildcard passthroughs
-    my $normal = '$'.$zone.'{normal}{$domain}';
-    $normal = eval($normal);
+    my $normal = $passthroughs->{normal}->{$domain};
     if(defined($normal)) {
         return ($TRUE, $normal);
     }
+    else {
+        return ($FALSE, []);
+    }
+}
+
+sub _matches_wildcard_passthrough {
+    my ($passthroughs, $domain) = @_;
 
     # check if its a sub-domain of a wildcard domain
     my @parts = split(/\./, $domain);
@@ -50,14 +76,12 @@ sub matches_passthrough {
     for (my $i=$last_element; $i>0; $i--) {
         my @sub_parts = @parts[$i..$last_element];
         my $domain = join('.', @sub_parts);
-        my $wildcard = '$'.$zone.'{wildcard}{$domain}';
-        $wildcard = eval($wildcard);
+        my $wildcard = $passthroughs->{wildcard}->{$domain};
         if(defined($wildcard)) {
             return ($TRUE, $wildcard);
         }
     }
 
-    # Fallback to not a passthrough
     return ($FALSE, []);
 }
 

--- a/lib/pf/util/dns.pm
+++ b/lib/pf/util/dns.pm
@@ -21,6 +21,11 @@ use pfconfig::cached_hash;
 tie our %passthroughs, 'pfconfig::cached_hash', 'resource::passthroughs';
 tie our %isolation_passthroughs, 'pfconfig::cached_hash', 'resource::isolation_passthroughs';
 
+our %ZONE_LOOKUP = (
+    passthroughs => \%passthroughs,
+    isolation_passthroughs => \%isolation_passthroughs,
+);
+
 =head2 matches_passthrough
 
 Whether or not a domain matches a configured DNS passthrough
@@ -34,7 +39,7 @@ Returns 2 values
 sub matches_passthrough {
     my ($domain, $zone) = @_;
 
-    return _matches_passthrough(eval("\\%$zone"), $domain);
+    return _matches_passthrough($ZONE_LOOKUP{$zone}, $domain);
 }
 
 sub _matches_passthrough {

--- a/lib/pfconfig/namespaces/resource/isolation_passthroughs.pm
+++ b/lib/pfconfig/namespaces/resource/isolation_passthroughs.pm
@@ -43,26 +43,7 @@ sub build {
         @{$self->{config}->{fencing}->{isolation_passthroughs} // []},
     );
 
-    my %passthroughs = (
-        normal => {}, 
-        wildcard => {},  
-    );
-    foreach my $passthrough (@all_passthroughs) {
-        my ($domain, $ports) = $self->_new_passthrough($passthrough);
-        my $ns = "normal";
-        if($domain =~ /\*\.(.*)/) {
-            $ns = "wildcard";
-            $domain = $1;
-        }
-        if(defined($passthroughs{$ns}{$domain})) {
-            push @{$passthroughs{$ns}{$domain}}, @$ports;
-        }
-        else {
-            $passthroughs{$ns}{$domain} = $ports;
-        }
-    }
-
-    return \%passthroughs;
+    return $self->_build(\@all_passthroughs);
 }
 
 =head1 AUTHOR

--- a/lib/pfconfig/namespaces/resource/passthroughs.pm
+++ b/lib/pfconfig/namespaces/resource/passthroughs.pm
@@ -60,11 +60,17 @@ sub build {
         } @{$self->{authentication_sources} // []},
     );
 
+    return $self->_build(\@all_passthroughs);
+}
+
+sub _build {
+    my ($self, $all_passthroughs) = @_;
+    
     my %passthroughs = (
         normal => {}, 
         wildcard => {},  
     );
-    foreach my $passthrough (@all_passthroughs) {
+    foreach my $passthrough (@$all_passthroughs) {
         my ($domain, $ports) = $self->_new_passthrough($passthrough);
         my $ns = "normal";
         if($domain =~ /\*\.(.*)/) {

--- a/t/data/pf.conf
+++ b/t/data/pf.conf
@@ -4,6 +4,7 @@ hostname=pf
 
 [fencing]
 passthroughs=zammitcorp.com,*.zamm.it,dinde.ca:tcp:2828,*.yes.hello:1234,*.tld,zammitcorp.com:tcp:22,*.github.com:tcp:1234,*.github.com
+isolation_passthroughs=isolation.zammitcorp.com,*.wild-isolation.zammitcorp.com
 
 [database]
 pass=packet

--- a/t/unittest/util/dns.t
+++ b/t/unittest/util/dns.t
@@ -22,7 +22,7 @@ BEGIN {
 }
 
 use Test::Deep;
-use Test::More tests => 33;
+use Test::More tests => 35;
 #This test will running last
 use Test::NoWarnings;
 use Socket;
@@ -34,6 +34,16 @@ my ($match, $ports);
 
 ($match, $ports) = pf::util::dns::matches_passthrough(undef, 'passthroughs');
 is($match, $FALSE, "undef domain will not match passthroughs");
+
+eval {
+    ($match, $ports) = pf::util::dns::matches_passthrough("zammitcorp.com", undef);
+};
+is($@, "Undefined passthrough zone provided\n", "undef zone will die with an error");
+
+eval {
+    ($match, $ports) = pf::util::dns::matches_passthrough("zammitcorp.com", "vidange");
+};
+is($@, "Invalid passthrough zone vidange\n", "undef zone will die with an error");
 
 ($match, $ports) = pf::util::dns::matches_passthrough("zammitcorp.com", 'passthroughs');
 is($match, $TRUE, "valid passthrough domain will match passthroughs");

--- a/t/unittest/util/dns.t
+++ b/t/unittest/util/dns.t
@@ -22,7 +22,7 @@ BEGIN {
 }
 
 use Test::Deep;
-use Test::More tests => 35;
+use Test::More tests => 37;
 #This test will running last
 use Test::NoWarnings;
 use Socket;
@@ -105,6 +105,10 @@ cmp_deeply([], $ports, "ports for previous test are OK");
 
 ($match, $ports) = pf::util::dns::matches_passthrough("isolation.zammitcorp.com", 'isolation_passthroughs');
 is($match, $TRUE, "normal isolation passthrough should match");
+cmp_deeply(['tcp:80', 'tcp:443'], $ports, "ports for previous test are OK");
+
+($match, $ports) = pf::util::dns::matches_passthrough("something.wild-isolation.zammitcorp.com", 'isolation_passthroughs');
+is($match, $TRUE, "wildcard isolation passthrough should match");
 cmp_deeply(['tcp:80', 'tcp:443'], $ports, "ports for previous test are OK");
 
 =head1 AUTHOR

--- a/t/unittest/util/dns.t
+++ b/t/unittest/util/dns.t
@@ -32,7 +32,7 @@ use_ok("pf::util::dns");
 
 my ($match, $ports);
 
-($match, $ports) = pf::util::dns::matches_passthrough();
+($match, $ports) = pf::util::dns::matches_passthrough(undef, 'passthroughs');
 is($match, $FALSE, "undef domain will not match passthroughs");
 
 ($match, $ports) = pf::util::dns::matches_passthrough("zammitcorp.com", 'passthroughs');

--- a/t/unittest/util/dns.t
+++ b/t/unittest/util/dns.t
@@ -22,7 +22,7 @@ BEGIN {
 }
 
 use Test::Deep;
-use Test::More tests => 29;
+use Test::More tests => 33;
 #This test will running last
 use Test::NoWarnings;
 use Socket;
@@ -86,6 +86,16 @@ cmp_deeply([], $ports, "ports for previous test are OK");
 ($match, $ports) = pf::util::dns::matches_passthrough("www.github.com", 'passthroughs');
 is($match, $TRUE, "valid wildcard passthrough domain that multiple ports will match wildcard passthroughs");
 cmp_deeply(['tcp:1234', 'tcp:80', 'tcp:443'], $ports, "ports for previous test are OK");
+
+# test isolation passthroughs
+
+($match, $ports) = pf::util::dns::matches_passthrough("www.github.com", 'isolation_passthroughs');
+is($match, $FALSE, "invalid passthrough shouldn't match");
+cmp_deeply([], $ports, "ports for previous test are OK");
+
+($match, $ports) = pf::util::dns::matches_passthrough("isolation.zammitcorp.com", 'isolation_passthroughs');
+is($match, $TRUE, "normal isolation passthrough should match");
+cmp_deeply(['tcp:80', 'tcp:443'], $ports, "ports for previous test are OK");
 
 =head1 AUTHOR
 


### PR DESCRIPTION
# Description
Don't allow the portal FQDN as a passthrough

# Impacts
Passthroughs + the admin interface

# Issue
fixes #2815 

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* Don't allow the portal domain name as a passthrough (#2815)
