### PR TITLE
Brocade SNMP deauth by default on switches

### DIFF
--- a/docs/PacketFence_Network_Devices_Configuration_Guide.asciidoc
+++ b/docs/PacketFence_Network_Devices_Configuration_Guide.asciidoc
@@ -828,6 +828,8 @@ Port 1 configuration:
 Brocade
 ~~~~~~~
 
+NOTE: By default, all deconnections will be done using SNMP.
+
 ICX 6400 Series
 ^^^^^^^^^^^^^^^
 

--- a/lib/pf/Switch/Brocade.pm
+++ b/lib/pf/Switch/Brocade.pm
@@ -199,7 +199,7 @@ sub wiredeauthTechniques {
     my ($self, $method, $connection_type) = @_;
     my $logger = $self->logger;
     if ($connection_type == $WIRED_802_1X) {
-        my $default = $SNMP::RADIUS;
+        my $default = $SNMP::SNMP;
         my %tech = (
             $SNMP::SNMP => 'dot1xPortReauthenticate',
             $SNMP::RADIUS => 'deauthenticateMacRadius',


### PR DESCRIPTION
# Description
Use the SNMP deauthentication by default on all Brocade switches.

# Impacts
Brocade Switch workflow