### PR TITLE
Fix/captiveportal sms telephone validation v2

### DIFF
--- a/conf/locale/en/LC_MESSAGES/packetfence.po
+++ b/conf/locale/en/LC_MESSAGES/packetfence.po
@@ -1050,3 +1050,22 @@ msgstr "Your system is being scanned"
 msgid "system scan in progress"
 msgstr "Your system is being scanned - this process will take approximately %s seconds."
 
+# html/captive-portal/lib/captiveportal/PacketFence/Authentication.pm
+msgid "After registering, you will be given temporary network access%s"
+msgstr ""
+
+# html/captive-portal/lib/captiveportal/PacketFence/Authentication.pm
+msgid "AUP is required and it's value is : %s"
+msgstr ""
+
+# html/captive-portal/lib/captiveportal/PacketFence/Authentication.pm
+msgid "You must accept the terms and conditions"
+msgstr ""
+
+# html/captive-portal/lib/captiveportal/PacketFence/Authentication.pm
+msgid "Enter a valid telephone number"
+msgstr ""
+
+# html/captive-portal/lib/captiveportal/PacketFence/Authentication.pm
+msgid "Telephone number %s is not valid"
+msgstr ""

--- a/conf/locale/en/LC_MESSAGES/packetfence.po
+++ b/conf/locale/en/LC_MESSAGES/packetfence.po
@@ -1051,11 +1051,11 @@ msgid "system scan in progress"
 msgstr "Your system is being scanned - this process will take approximately %s seconds."
 
 # html/captive-portal/lib/captiveportal/PacketFence/Authentication.pm
-msgid "After registering, you will be given temporary network access%s"
+msgid "After registering, you will be given temporary network access %s"
 msgstr ""
 
 # html/captive-portal/lib/captiveportal/PacketFence/Authentication.pm
-msgid "AUP is required and it's value is : %s"
+msgid "AUP is required and its value is : %s"
 msgstr ""
 
 # html/captive-portal/lib/captiveportal/PacketFence/Authentication.pm

--- a/html/captive-portal/lib/captiveportal/PacketFence/Form/Authentication.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Form/Authentication.pm
@@ -22,6 +22,7 @@ has '+widget_name_space' => ( default => 'captiveportal::Form::Widget' );
 use pf::log;
 use pf::sms_carrier;
 use pf::util;
+use pf::web::util;
 
 has 'source' => (is => 'rw');
 
@@ -118,7 +119,7 @@ Check telephone form
 sub check_telephone_form {
     my ($self, $field) = @_;
     if($self->app->request->method eq "POST"){
-        if ( $field->value !~ /^(\+?[0-9]+[0-9-\.\*\(\)\ ]+[0-9]+)$/ ) {
+        if (pf::web::util::validate_phone_number($field->value)) {
             $field->add_error($self->app->i18n("Enter a valid telephone number"));
             $self->app->flash->{error} = $self->app->i18n("Telephone number is not valid");
         }
@@ -178,7 +179,7 @@ Inverse inc. <info@inverse.ca>
 
 =head1 COPYRIGHT
 
-Copyright (C) 2005-2018 Inverse inc.
+Copyright (C) 2005-2017 Inverse inc.
 
 =head1 LICENSE
 

--- a/html/captive-portal/lib/captiveportal/PacketFence/Form/Authentication.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Form/Authentication.pm
@@ -118,7 +118,7 @@ Check telephone form
 sub check_telephone_form {
     my ($self, $field) = @_;
     if($self->app->request->method eq "POST"){
-        if ( $field->value !~ /^(\+?[0-9]+[0-9-\.\(\)\ ]+[0-9]+)$/ ) {
+        if ( $field->value !~ /^(\+?[0-9]+[0-9-\.\*\(\)\ ]+[0-9]+)$/ ) {
             $field->add_error($self->app->i18n("Enter a valid telephone number"));
             $self->app->flash->{error} = $self->app->i18n("Telephone number is not valid");
         }else{

--- a/html/captive-portal/lib/captiveportal/PacketFence/Form/Authentication.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Form/Authentication.pm
@@ -45,7 +45,7 @@ has_field 'fields[password]' => (type => 'Password', label => 'Password');
 
 has_field 'fields[email]' => (type => "Email", label => "Email");
 
-has_field 'fields[telephone]' => (type => "Text", label => "Telephone", html5_type_attr => "tel");
+has_field 'fields[telephone]' => (type => "Text", label => "Telephone", html5_type_attr => "tel", validate_method => \&check_telephone);
 
 has_field 'fields[sponsor]' => (type => "Email", label => "Sponsor Email");
 
@@ -109,6 +109,35 @@ sub check_aup {
     $self->form->check_aup_form($self);
     return ;
 }
+
+=head2 check_telephone_form
+
+Check telephone form
+
+=cut
+
+sub check_telephone_form {
+    my ($self, $field) = @_;
+    if($self->app->request->method eq "POST"){
+        if ( $field->value !~ /^([0-9]+[0-9-\.]+[0-9]+)$/ ) {
+            $field->add_error("Enter a valid telephone <em>number</em>");
+            $self->app->flash->{error} = "Telephone number is not valid";
+        }
+    }
+}
+
+=head2 check_telephone
+
+Check that the telephone is valid
+
+=cut
+
+sub check_telephone {
+    my ($self) = @_;
+    $self->form->check_telephone_form($self);
+    return ;
+}
+
 
 =head2 get_field
 

--- a/html/captive-portal/lib/captiveportal/PacketFence/Form/Authentication.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Form/Authentication.pm
@@ -74,8 +74,7 @@ sub render_email_instructions {
     }
     my $email_timeout = normalize_time($source->email_activation_timeout);
     $email_timeout = int($email_timeout / 60);
-    return 
-        "<div class='text-center email-instructions'>" .
+    return "<div class='text-center email-instructions'>" .
         $self->app->i18n_format("After registering, you will be given temporary network access for %s minutes. In order to complete your registration, you will need to click on the link emailed to you.", $email_timeout) .
         "</div>" .
         "<input name='fields[email_instructions]' type='hidden' value='1'>";
@@ -90,10 +89,10 @@ Check AUP form
 sub check_aup_form {
     my ($self, $field) = @_;
     if($self->module->with_aup && $self->app->request->method eq "POST"){
-        get_logger->debug("AUP is required and it's value is : ". $field->value);
+        get_logger->debug($self->app->i18n_format("AUP is required and it's value is : %s", $field->value));
         unless($field->value){
-            $field->add_error("You must accept the terms and conditions");
-            $self->app->flash->{error} = "You must accept the terms and conditions";
+            $field->add_error($self->app->i18n("You must accept the terms and conditions"));
+            $self->app->flash->{error} = $self->app->i18n("You must accept the terms and conditions");
         }
     }
 }
@@ -120,8 +119,8 @@ sub check_telephone_form {
     my ($self, $field) = @_;
     if($self->app->request->method eq "POST"){
         if ( $field->value !~ /^([0-9]+[0-9-\.]+[0-9]+)$/ ) {
-            $field->add_error("Enter a valid telephone <em>number</em>");
-            $self->app->flash->{error} = "Telephone number is not valid";
+            $field->add_error($self->app->i18n("Enter a valid telephone number"));
+            $self->app->flash->{error} = $self->app->i18n("Telephone number is not valid");
         }
     }
 }

--- a/html/captive-portal/lib/captiveportal/PacketFence/Form/Authentication.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Form/Authentication.pm
@@ -118,9 +118,12 @@ Check telephone form
 sub check_telephone_form {
     my ($self, $field) = @_;
     if($self->app->request->method eq "POST"){
-        if ( $field->value !~ /^([0-9]+[0-9-\.]+[0-9]+)$/ ) {
+        if ( $field->value !~ /^(\+?[0-9]+[0-9-\.\(\)\ ]+[0-9]+)$/ ) {
             $field->add_error($self->app->i18n("Enter a valid telephone number"));
             $self->app->flash->{error} = $self->app->i18n("Telephone number is not valid");
+        }else{
+            $field->add_error($self->app->i18n_format("Good: %s", $field->value));
+            $self->app->flash->{error} = $self->app->i18n_format("Good: %s", $field->value);            
         }
     }
 }

--- a/html/captive-portal/lib/captiveportal/PacketFence/Form/Authentication.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Form/Authentication.pm
@@ -121,9 +121,6 @@ sub check_telephone_form {
         if ( $field->value !~ /^(\+?[0-9]+[0-9-\.\*\(\)\ ]+[0-9]+)$/ ) {
             $field->add_error($self->app->i18n("Enter a valid telephone number"));
             $self->app->flash->{error} = $self->app->i18n("Telephone number is not valid");
-        }else{
-            $field->add_error($self->app->i18n_format("Good: %s", $field->value));
-            $self->app->flash->{error} = $self->app->i18n_format("Good: %s", $field->value);            
         }
     }
 }


### PR DESCRIPTION
# Description
Add basic PCRE with error control on Captiveportal SMS Auth for telephone number

# Impacts
Simple PCRE. Doesn't enforce mandatory country-code or a specific format. More robust expression(s) may be needed per-"Mobile Provider".

# Issue
* Fixes "Guest Portal validate_phone_number check not work" #2783

# Delete branch after merge
YES