### PR TITLE
Ruckus SmartZone: Disable SSL to contact the controller

### DIFF
--- a/docs/PacketFence_Network_Devices_Configuration_Guide.asciidoc
+++ b/docs/PacketFence_Network_Devices_Configuration_Guide.asciidoc
@@ -5804,6 +5804,11 @@ image::docs/images/ruckus-smartzone-webauth-ssid.png[scaledwidth="100%",alt="Ruc
 
 Now, you should configure the Northbound API of the SmartZone so PacketFence can communicate with it. In order to do so, go in 'Configuration->System->Northbound Portal Interface' and set the 'Password' and save it. Keep the password closeby as it will be required for the PacketFence configuration. In this example, it will be `passwordForNorthboundAPI`.
 
+In order to receive the information not encrypted in the URL, you will need to connect on the Ruckus SmartZone controller using SSH and do the following command:
+
+ no encrypt-mac-ip
+
+
 PacketFence configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/lib/pf/Switch/Ruckus/SmartZone.pm
+++ b/lib/pf/Switch/Ruckus/SmartZone.pm
@@ -120,13 +120,14 @@ sub deauthenticateMacWebservices {
     }
     my $ua = LWP::UserAgent->new;
     $ua->timeout(10);
+    $ua->ssl_opts(verify_hostname => 0);
     my $res = $ua->post("https://$controllerIp:9443/portalintf", Content => $payload, "Content-Type" => "application/json");
     if($res->is_success) {
         $logger->info("Contacted Ruckus to perform deauthentication");
         $logger->debug("Got the following response: ".$res->decoded_content);
     }
     else {
-        $logger->error("Failed to contact Ruckus for deauthentication");
+        $logger->error("Failed to contact Ruckus for deauthentication: ".$res->status_line);
     }
 }
 


### PR DESCRIPTION
# Description
Disable SSL to contact the controller

# Impacts
Ruckus SmartZone switch mopdule

# Issue
fixes #3005
fixes #3006

# Delete branch after merge
YES 

# NEWS file entries
Ruckus SmartZone Disable SSL to contact the controller