### PR TITLE
Add support for filtering google oauth login for specific google-apps domainms

### DIFF
--- a/db/pf-schema-7.4.0.sql
+++ b/db/pf-schema-7.4.0.sql
@@ -3,8 +3,8 @@
 --
 
 SET @MAJOR_VERSION = 7;
-SET @MINOR_VERSION = 3;
-SET @SUBMINOR_VERSION = 9;
+SET @MINOR_VERSION = 4;
+SET @SUBMINOR_VERSION = 0;
 
 --
 -- The VERSION_INT to ensure proper ordering of the version in queries

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/OAuth/Google.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/OAuth/Google.pm
@@ -18,56 +18,27 @@ use pf::auth_log;
 
 has '+source' => (isa => 'pf::Authentication::Source::GoogleSource');
 
-=head2 handle_callback
+=head2 filter_response
 
-Google override to handle the callback from the OAuth2 provider and fetch the protected resource
+Google  override of filter_response to validate hosted domain
 
 =cut
 
-sub handle_callback {
-    my ($self) = @_;
-
-    my $token = $self->get_token();
-    return unless($token);
-
-    # request a JSON response
-    my $h = HTTP::Headers->new( 'x-li-format' => 'json' );
-    my $response = $token->get($self->source->{'protected_resource_url'}, $h ); 
-
-    if ($response->is_success) {
-        my $info = $self->_decode_response($response); 
-        my $pid = $self->_extract_username_from_response($info);
-        my $hd = $info->{hd};
-        my $hosted_domain = $self->source->hosted_domain;
-        # get_logger->info(sub { use Data::Dumper; "OAuth2  response : ".Dumper($info) });   
-        if ( defined $hosted_domain && $hosted_domain ne "" && (!defined $hd || $hosted_domain ne $hd)){
-            get_logger->info("OAuth2: google domain for user: ".$pid." did not match the allowed domain: ".$hosted_domain);
-            get_logger->debug(sub { use Data::Dumper; "OAuth2 failed response : ".Dumper($response) });
-            pf::auth_log::change_record_status($self->source->id, $self->current_mac, $pf::auth_log::FAILED);
-            $self->app->flash->{error} = "OAuth2: google domain did not match the allowed domain: ".$hosted_domain ;
-            $self->landing();
-            return;    
-        }
-        
-        $self->username($pid);
-
-        get_logger->info("OAuth2 successfull for username ".$self->username);
-        $self->source->lookup_from_provider_info($self->username, $info);
-        
-        pf::auth_log::record_completed_oauth($self->source->id, $self->current_mac, $pid, $pf::auth_log::COMPLETED);
-
-        $self->done();
+sub filter_response {
+    my ($self, $info) = @_;
+    # Return accept/reject response and status message to display to the user in case of failure
+    
+    my $hd = $info->{hd};
+    my $hosted_domain = $self->source->hosted_domain;
+    my $status = "";
+    my $retval = 1;
+    if ( defined $hosted_domain && $hosted_domain ne "" && (!defined $hd || $hosted_domain ne $hd)){
+        $retval = 0;
+        get_logger->debug(sub { use Data::Dumper; "OAuth2 rejected by google OAuth filter_respponse: ".Dumper($info) });
+        $status = "Google domain(".$hd.") did not match the allowed domain: ".$hosted_domain ;
     }
-    else {
-        get_logger->info("OAuth2: failed to validate the token, redireting to login page.");
-        get_logger->debug(sub { use Data::Dumper; "OAuth2 failed response : ".Dumper($response) });
-        pf::auth_log::change_record_status($self->source->id, $self->current_mac, $pf::auth_log::FAILED);
-        $self->app->flash->{error} = "OAuth2 Error: Failed to validate the token, please retry";
-        $self->landing();
-        return;
-    }
+    return ($retval,$status);
 }
-
 
 =head1 AUTHOR
 

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source/Google.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source/Google.pm
@@ -104,6 +104,15 @@ has_field 'domains' =>
    tags => { after_element => \&help,
              help => 'Comma separated list of domains that will be resolve with the correct IP addresses.' },
   );
+has_field 'hosted_domain' =>
+  (
+   type => 'Text',
+   label => 'Google domain',
+   required => 1,
+   element_class => ['input-xlarge'],
+   tags => { after_element => \&help,
+             help => 'Google hosted domain to restrict the login info to. Will only present accounts from this domain on Google\'s login screen' },
+  );
 
 =head1 COPYRIGHT
 

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source/Google.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source/Google.pm
@@ -108,7 +108,8 @@ has_field 'hosted_domain' =>
   (
    type => 'Text',
    label => 'Google domain',
-   required => 1,
+   default => '',
+   # Default value needed for creating dummy source
    element_class => ['input-xlarge'],
    tags => { after_element => \&help,
              help => 'Google hosted domain to restrict the login info to. Will only present accounts from this domain on Google\'s login screen' },

--- a/lib/pf/Authentication/Source/GoogleSource.pm
+++ b/lib/pf/Authentication/Source/GoogleSource.pm
@@ -25,6 +25,7 @@ has 'scope' => (isa => 'Str', is => 'rw', default => 'https://www.googleapis.com
 has 'protected_resource_url' => (isa => 'Str', is => 'rw', default => 'https://www.googleapis.com/oauth2/v2/userinfo');
 has 'redirect_url' => (isa => 'Str', is => 'rw', required => 1, default => 'https://<hostname>/oauth2/callback');
 has 'domains' => (isa => 'Str', is => 'rw', required => 1, default => '*.google.com,*.gstatic.com,googleapis.com,accounts.youtube.com,*.googleusercontent.com');
+has 'hosted_domain' => (isa => 'Str', is => 'rw');
 
 =head2 dynamic_routing_module
 
@@ -43,6 +44,21 @@ Lookup the person information from the authentication hash received during the O
 sub lookup_from_provider_info {
     my ( $self, $pid, $info ) = @_;
     person_modify( $pid, firstname => $info->{given_name}, lastname => $info->{family_name}, email => $info->{email}, gender => $info->{gender} );
+}
+
+
+=head2 additional_client_attributes
+
+Supply a google-apps domain filter (hd parameter). See below
+https://developers.google.com/identity/protocols/OpenIDConnect#hd-param
+
+=cut
+
+sub additional_client_attributes {
+    my ($self) = @_;
+    if ($self->hosted_domain ne ""){
+        return (hd => $self->hosted_domain);
+    }
 }
 
 =head1 AUTHOR


### PR DESCRIPTION
# Description
Adds a "hosted domain" field to the Google OAuth authentication so that the user is presented with a login field with the domain of the organization and the returend token is verified to match the specific domain as well (via the HD attribute). More details here: [(https://developers.google.com/identity/protocols/OpenIDConnect#hd-param)]

This is very useful for enterprise or education uses where only employees / students should be able to login and not just anyone with a google account

# Impacts
Oauth workflow - callback is altered to verify the returned hosted domain attribute. Additionally, the google oauth class is extended to support the additional_client_attributes method so that the "hd" field is added on the outgoing oauth request (this allows google to present a login screen with only the accepted domain's accounts) 

# Code / PR Dependencies
The second part (of google presenting the login prompt with only the hosted domain) requires a minimal patch on the Net::OAuth2 library. This patch has not yet been pushed to the library but is available here:
[https://github.com/garci66/NetOauth2/commit/c4c97237e3870f3b606efa2c17407638f17d4532]
This patch is not mandatory. IF not applied, the login screen will be the typical google login screen and could contain multiple google accounts (@gmail, your own google apps account, etc). The returned oauth ticket will still be verified by packetfence to belong to the correct domain, but the user experience will be less than ideal as he could try - and fail- to login with his gmail account instead of his school  / work / whatever.
The proposed patch to Net::OAuth2 has been tested in production during the last few weeks without issues.

It was implemented identically to the "state" parameter used for linked-in OAuth logins. 

# NEW Package(s) required
Updated Net::OAuth2 library. (change has not yet been pushed upstream). Changes have been proposed to Mark Overmeer (maintainer of Oauth2) but I still need to hear from hi,

# Delete branch after merge
YES 

# NEWS file entries
## Enhancements
* Google OAuth now supports filtering for specific google apps domains

# UPGRADE file entries
Potentially upgrade Net::OAuth2 or require a newer version (0.64 proposed but not yet accepted)

# NOTE:
Not sure why the commits by @julsemaan got added and not 100% sure how to remove them. Sorry for the additional noise in the PR.

