### PR TITLE
Add type="api" to statsd configuration

### DIFF
--- a/conf/stats.conf.example
+++ b/conf/stats.conf.example
@@ -1,97 +1,97 @@
 [metric 'total number of registered devices per role']
 type=mysql_query
-statsd_type=histogram
+statsd_type=gauge
 statsd_ns=source.packetfence.devices.registered_per_role
 mysql_query=select name, count(distinct node.mac) from node_category right join node on node.category_id=node_category.category_id where node.status='reg' group by node_category.category_id;
 interval=60s
 
 [metric 'total number of unregistered devices']
 type=mysql_query
-statsd_type=histogram
+statsd_type=gauge
 statsd_ns=source.packetfence.devices.unregistered
 mysql_query=select count(distinct mac) from node where status='unreg'
 interval=60s
 
 [metric 'total online devices']
 type=mysql_query
-statsd_type=histogram
+statsd_type=gauge
 statsd_ns=source.packetfence.devices.online
 mysql_query=select count(distinct callingstationid) from radacct where acctstoptime is null
 interval=60s
 
 [metric 'total offline devices']
 type=mysql_query
-statsd_type=histogram
+statsd_type=gauge
 statsd_ns=source.packetfence.devices.offline
 mysql_query=select count(distinct callingstationid) from radacct where acctstoptime <= NOW()
 interval=60s
 
 [metric 'number of new registered devices during the past hour']
 type=mysql_query
-statsd_type=histogram
+statsd_type=gauge
 statsd_ns=source.packetfence.devices.registered_last_hour
 mysql_query=select count(distinct mac) from node where status='reg' and regdate >= NOW() - INTERVAL 1 HOUR
 interval=60s
 
 [metric 'number of new registered devices during the past day']
 type=mysql_query
-statsd_type=histogram
+statsd_type=gauge
 statsd_ns=source.packetfence.devices.registered_last_day
 mysql_query=select count(distinct mac) from node where status='reg' and regdate >= NOW() - INTERVAL 1 DAY
 interval=60s
 
 [metric 'number of new registered devices during the past week']
 type=mysql_query
-statsd_type=histogram
+statsd_type=gauge
 statsd_ns=source.packetfence.devices.registered_last_week
 mysql_query=select count(distinct mac) from node where status='reg' and regdate >= NOW() - INTERVAL 1 WEEK
 interval=60s
 
 [metric 'number of new registered devices during the past month']
 type=mysql_query
-statsd_type=histogram
+statsd_type=gauge
 statsd_ns=source.packetfence.devices.registered_last_month
 mysql_query=select count(distinct mac) from node where status='reg' and regdate >= NOW() - INTERVAL 1 MONTH
 interval=60s
 
 [metric 'number of new registered devices during the past year']
 type=mysql_query
-statsd_type=histogram
+statsd_type=gauge
 statsd_ns=source.packetfence.devices.registered_last_year
 mysql_query=select count(distinct mac) from node where status='reg' and regdate >= NOW() - INTERVAL 1 YEAR
 interval=60s
 
 [metric 'number of devices currently online and in the registration network']
 type=mysql_query
-statsd_type=histogram
+statsd_type=gauge
 statsd_ns=source.packetfence.devices.online_registered
 mysql_query=select count(distinct n.mac) from node n join radacct r on r.callingstationid=n.mac where n.status='reg' and (n.unregdate >= NOW() or n.unregdate = '0000-00-00 00:00:00') and r.acctstoptime is null
 interval=60s
 
 [metric 'number of devices currently registered']
 type=mysql_query
-statsd_type=histogram
+statsd_type=gauge
 statsd_ns=source.packetfence.devices.registered
 mysql_query=select count(distinct mac) from node where status='reg' and (unregdate >= NOW() or unregdate = '0000-00-00 00:00:00')
 interval=60s
 
 [metric 'number of currently open violations']
 type=mysql_query
-statsd_type=histogram
+statsd_type=gauge
 statsd_ns=source.packetfence.violations
 mysql_query=select count(distinct mac) from violation where status='open'
 interval=60s
 
 [metric 'number of successful radius authentications in the last day']
 type=mysql_query
-statsd_type=histogram
+statsd_type=gauge
 statsd_ns=source.packetfence.authentication.success_last_day
 mysql_query=select count(1) from radius_audit_log where auth_status='Accept' and created_at >= NOW() - INTERVAL 1 DAY;
 interval=60s
 
 [metric 'number of failed radius authentications in the last day']
 type=mysql_query
-statsd_type=histogram
+statsd_type=gauge
 statsd_ns=source.packetfence.authentication.failed_last_day
 mysql_query=select count(1) from radius_audit_log where auth_status='Reject' and created_at >= NOW() - INTERVAL 1 DAY;
 interval=60s

--- a/conf/stats.conf.example
+++ b/conf/stats.conf.example
@@ -4,7 +4,7 @@ statsd_type=histogram
 statsd_ns=source.packetfence.dhcp_leases_enp0s8
 api_method=GET
 api_path=/api/v1/dhcp/stats/enp0s8
-api_compile=$.items[0].free
+api_compile=$[0].free
 interval=5s
 
 [metric 'test ICMP IPv4']

--- a/conf/stats.conf.example
+++ b/conf/stats.conf.example
@@ -4,8 +4,21 @@ statsd_type=histogram
 statsd_ns=source.packetfence.dhcp_leases_enp0s8
 api_method=GET
 api_path=/api/v1/dhcp/stats/enp0s8
+# api_compile options see: http://goessner.net/articles/JsonPath/
 api_compile=$[0].free
 interval=5s
+
+[metric 'dummy POST example']
+type=api
+statsd_type=histogram
+statsd_ns=source.packetfence.test_api_post
+api_method=POST
+api_path=/api/v1/ipset/unmark_ip
+api_payload={"ip": "1.2.3.4"}
+# api_compile options see: http://goessner.net/articles/JsonPath/
+api_compile=$.some_random_value
+interval=5s
+
 
 [metric 'test ICMP IPv4']
 type=icmp_ipv4

--- a/conf/stats.conf.example
+++ b/conf/stats.conf.example
@@ -1,3 +1,10 @@
+[metric 'total number of registered devices per role']
+type=mysql_query
+statsd_type=histogram
+statsd_ns=source.packetfence.devices.registered_per_role
+mysql_query=select name, count(distinct node.mac) from node_category right join node on node.category_id=node_category.category_id where node.status='reg' group by node_category.category_id;
+interval=60s
+
 [metric 'total number of unregistered devices']
 type=mysql_query
 statsd_type=histogram

--- a/conf/stats.conf.example
+++ b/conf/stats.conf.example
@@ -1,37 +1,7 @@
-[metric 'total dhcp leases remaining on enp0s8']
-type=api
-statsd_type=histogram
-statsd_ns=source.packetfence.dhcp_leases_enp0s8
-api_method=GET
-api_path=/api/v1/dhcp/stats/enp0s8
-# api_compile options see: http://goessner.net/articles/JsonPath/
-api_compile=$[0].free
-interval=5s
-
-[metric 'dummy POST example']
-type=api
-statsd_type=histogram
-statsd_ns=source.packetfence.test_api_post
-api_method=POST
-api_path=/api/v1/ipset/unmark_ip
-api_payload={"ip": "1.2.3.4"}
-# api_compile options see: http://goessner.net/articles/JsonPath/
-api_compile=$.some_random_value
-interval=5s
-
-
-[metric 'test ICMP IPv4']
-type=icmp_ipv4
-statsd_type=timing
-statsd_ns=source.packetfence.ping_google
-host=google.ca
-interval=5s
-
 [metric 'total number of unregistered devices']
 type=mysql_query
 statsd_type=histogram
 statsd_ns=source.packetfence.devices.unregistered
-# mysql_query must return a single column with a single row
 mysql_query=select count(distinct mac) from node where status='unreg'
 interval=60s
 
@@ -39,7 +9,6 @@ interval=60s
 type=mysql_query
 statsd_type=histogram
 statsd_ns=source.packetfence.devices.online
-# mysql_query must return a single column with a single row
 mysql_query=select count(distinct callingstationid) from radacct where acctstoptime is null
 interval=60s
 
@@ -47,7 +16,6 @@ interval=60s
 type=mysql_query
 statsd_type=histogram
 statsd_ns=source.packetfence.devices.offline
-# mysql_query must return a single column with a single row
 mysql_query=select count(distinct callingstationid) from radacct where acctstoptime <= NOW()
 interval=60s
 
@@ -55,7 +23,6 @@ interval=60s
 type=mysql_query
 statsd_type=histogram
 statsd_ns=source.packetfence.devices.registered_last_hour
-# mysql_query must return a single column with a single row
 mysql_query=select count(distinct mac) from node where status='reg' and regdate >= NOW() - INTERVAL 1 HOUR
 interval=60s
 
@@ -63,7 +30,6 @@ interval=60s
 type=mysql_query
 statsd_type=histogram
 statsd_ns=source.packetfence.devices.registered_last_day
-# mysql_query must return a single column with a single row
 mysql_query=select count(distinct mac) from node where status='reg' and regdate >= NOW() - INTERVAL 1 DAY
 interval=60s
 
@@ -71,7 +37,6 @@ interval=60s
 type=mysql_query
 statsd_type=histogram
 statsd_ns=source.packetfence.devices.registered_last_week
-# mysql_query must return a single column with a single row
 mysql_query=select count(distinct mac) from node where status='reg' and regdate >= NOW() - INTERVAL 1 WEEK
 interval=60s
 
@@ -79,7 +44,6 @@ interval=60s
 type=mysql_query
 statsd_type=histogram
 statsd_ns=source.packetfence.devices.registered_last_month
-# mysql_query must return a single column with a single row
 mysql_query=select count(distinct mac) from node where status='reg' and regdate >= NOW() - INTERVAL 1 MONTH
 interval=60s
 
@@ -87,7 +51,6 @@ interval=60s
 type=mysql_query
 statsd_type=histogram
 statsd_ns=source.packetfence.devices.registered_last_year
-# mysql_query must return a single column with a single row
 mysql_query=select count(distinct mac) from node where status='reg' and regdate >= NOW() - INTERVAL 1 YEAR
 interval=60s
 
@@ -95,7 +58,6 @@ interval=60s
 type=mysql_query
 statsd_type=histogram
 statsd_ns=source.packetfence.devices.online_registered
-# mysql_query must return a single column with a single row
 mysql_query=select count(distinct n.mac) from node n join radacct r on r.callingstationid=n.mac where n.status='reg' and (n.unregdate >= NOW() or n.unregdate = '0000-00-00 00:00:00') and r.acctstoptime is null
 interval=60s
 
@@ -103,7 +65,6 @@ interval=60s
 type=mysql_query
 statsd_type=histogram
 statsd_ns=source.packetfence.devices.registered
-# mysql_query must return a single column with a single row
 mysql_query=select count(distinct mac) from node where status='reg' and (unregdate >= NOW() or unregdate = '0000-00-00 00:00:00')
 interval=60s
 
@@ -111,7 +72,6 @@ interval=60s
 type=mysql_query
 statsd_type=histogram
 statsd_ns=source.packetfence.violations
-# mysql_query must return a single column with a single row
 mysql_query=select count(distinct mac) from violation where status='open'
 interval=60s
 
@@ -119,7 +79,6 @@ interval=60s
 type=mysql_query
 statsd_type=histogram
 statsd_ns=source.packetfence.authentication.success_last_day
-# mysql_query must return a single column with a single row
 mysql_query=select count(1) from radius_audit_log where auth_status='Accept' and created_at >= NOW() - INTERVAL 1 DAY;
 interval=60s
 
@@ -127,6 +86,5 @@ interval=60s
 type=mysql_query
 statsd_type=histogram
 statsd_ns=source.packetfence.authentication.failed_last_day
-# mysql_query must return a single column with a single row
 mysql_query=select count(1) from radius_audit_log where auth_status='Reject' and created_at >= NOW() - INTERVAL 1 DAY;
 interval=60s

--- a/conf/stats.conf.example
+++ b/conf/stats.conf.example
@@ -1,7 +1,7 @@
 [metric 'total dhcp leases remaining on enp0s8']
 type=api
 statsd_type=histogram
-statsd_ns=source.packetfence.test_api
+statsd_ns=source.packetfence.dhcp_leases_enp0s8
 api_method=GET
 api_path=/api/v1/dhcp/stats/enp0s8
 api_compile=$.items[0].free

--- a/conf/stats.conf.example
+++ b/conf/stats.conf.example
@@ -1,3 +1,12 @@
+[metric 'total dhcp leases remaining on enp0s8']
+type=api
+statsd_type=histogram
+statsd_ns=source.packetfence.test_api
+api_method=GET
+api_path=/api/v1/dhcp/stats/enp0s8
+api_compile=$.items[0].free
+interval=5s
+
 [metric 'test ICMP IPv4']
 type=icmp_ipv4
 statsd_type=timing

--- a/conf/stats.conf.example
+++ b/conf/stats.conf.example
@@ -27,6 +27,14 @@ statsd_ns=source.packetfence.ping_google
 host=google.ca
 interval=5s
 
+[metric 'total number of unregistered devices']
+type=mysql_query
+statsd_type=histogram
+statsd_ns=source.packetfence.devices.unregistered
+# mysql_query must return a single column with a single row
+mysql_query=select count(distinct mac) from node where status='unreg'
+interval=60s
+
 [metric 'total online devices']
 type=mysql_query
 statsd_type=histogram

--- a/go/pfconfigdriver/structs.go
+++ b/go/pfconfigdriver/structs.go
@@ -361,4 +361,8 @@ type PfStats struct {
 	MySQLQuery     string `json:"mysql_query"`
 	Interval       string `json:"interval"`
 	Host           string `json:"host"`
+	ApiMethod      string `json:"api_method"`
+	ApiPayload     string `json:"api_payload"`
+	ApiPath        string `json:"api_path"`
+	ApiCompile     string `json:"api_compile"`
 }

--- a/go/stats/metrics.go
+++ b/go/stats/metrics.go
@@ -137,8 +137,7 @@ func ProcessMetricConfig(ctx context.Context, conf pfconfigdriver.PfStats) error
 				}
 				break
 			case "DELETE", "PATCH", "POST", "PUT":
-				//err := apiclient.CallWithStringBody(ctx, conf.ApiMethod, conf.ApiPath, conf.ApiPayload, &raw)
-				err := apiclient.CallWithBody(ctx, conf.ApiMethod, conf.ApiPath, conf.ApiPayload, &raw)
+				err := apiclient.CallWithStringBody(ctx, conf.ApiMethod, conf.ApiPath, conf.ApiPayload, &raw)
 				if err != nil {
 					log.LoggerWContext(ctx).Error("API error", err.Error())
 					return

--- a/lib/pfconfig/namespaces/config/Stats.pm
+++ b/lib/pfconfig/namespaces/config/Stats.pm
@@ -27,6 +27,9 @@ use base 'pfconfig::namespaces::config';
 sub init {
     my ($self) = @_;
     $self->{file} = $stats_config_file;
+    
+    $self->{listen_ints} = $self->{cache}->get_cache('interfaces::listen_ints');
+    $self->{roles} = $self->{cache}->get_cache('config::Roles');
 }
 
 sub build_child {
@@ -36,6 +39,19 @@ sub build_child {
 
     foreach my $key ( keys %tmp_cfg){
         $self->cleanup_whitespaces( \%tmp_cfg );
+    }
+
+    foreach my $int (@{$self->{listen_ints}}) {
+        $tmp_cfg{"metric 'doing something on $int'"} = {
+            'api_compile' => '$.some_random_value',
+            'statsd_type' => 'histogram',
+            'interval' => '5s',
+            'statsd_ns' => 'source.packetfence.test_api_post',
+            'api_path' => "/whatever/$int",
+            'api_payload' => '{"ip": "1.2.3.4"}',
+            'api_method' => 'POST',
+            'type' => 'api',
+        };
     }
 
     return \%tmp_cfg;

--- a/lib/pfconfig/namespaces/config/Stats.pm
+++ b/lib/pfconfig/namespaces/config/Stats.pm
@@ -29,7 +29,6 @@ sub init {
     $self->{file} = $stats_config_file;
     
     $self->{listen_ints} = $self->{cache}->get_cache('interfaces::listen_ints');
-    $self->{roles} = $self->{cache}->get_cache('config::Roles');
 }
 
 sub build_child {

--- a/lib/pfconfig/namespaces/config/Stats.pm
+++ b/lib/pfconfig/namespaces/config/Stats.pm
@@ -42,15 +42,14 @@ sub build_child {
     }
 
     foreach my $int (@{$self->{listen_ints}}) {
-        $tmp_cfg{"metric 'doing something on $int'"} = {
-            'api_compile' => '$.some_random_value',
-            'statsd_type' => 'histogram',
-            'interval' => '5s',
-            'statsd_ns' => 'source.packetfence.test_api_post',
-            'api_path' => "/whatever/$int",
-            'api_payload' => '{"ip": "1.2.3.4"}',
-            'api_method' => 'POST',
+        $tmp_cfg{"metric 'total dhcp leases remaining on $int'"} = {
             'type' => 'api',
+            'statsd_type' => 'histogram',
+            'statsd_ns' => 'source.packetfence.dhcp_leases_'.$int,
+            'api_method' => 'GET',
+            'api_path' => "/api/v1/dhcp/stats/$int",
+            'api_compile' => '$[0].free',
+            'interval' => '60s',
         };
     }
 

--- a/lib/pfconfig/namespaces/config/Stats.pm
+++ b/lib/pfconfig/namespaces/config/Stats.pm
@@ -44,7 +44,7 @@ sub build_child {
     foreach my $int (@{$self->{listen_ints}}) {
         $tmp_cfg{"metric 'total dhcp leases remaining on $int'"} = {
             'type' => 'api',
-            'statsd_type' => 'histogram',
+            'statsd_type' => 'gauge',
             'statsd_ns' => 'source.packetfence.dhcp_leases_'.$int,
             'api_method' => 'GET',
             'api_path' => "/api/v1/dhcp/stats/$int",

--- a/lib/pfconfig/namespaces/interfaces/listen_ints.pm
+++ b/lib/pfconfig/namespaces/interfaces/listen_ints.pm
@@ -19,6 +19,8 @@ use base 'pfconfig::namespaces::interfaces';
 
 sub init {
     my ($self, $host_id) = @_;
+    $self->{child_resources} = [ 'config::Stats' ];
+
     $self->{_interfaces} = defined($host_id) ? $self->{cache}->get_cache("interfaces($host_id)") : $self->{cache}->get_cache("interfaces");
 }
 


### PR DESCRIPTION
# Description
Allows API requests to feed statsd metrics

**GET example** in `conf/stats.conf`:
```
[metric 'total dhcp leases remaining on enp0s8']
type=api
statsd_type=histogram
statsd_ns=source.packetfence.dhcp_leases_enp0s8
api_method=GET
api_path=/api/v1/dhcp/stats/enp0s8
api_compile=$.items[0].free
interval=5s
```

**POST example** in `conf/stats.conf`:
```
[metric 'dummy POST example']
type=api
statsd_type=histogram
statsd_ns=source.packetfence.test_api_post
api_method=POST
api_path=/api/v1/ipset/unmark_ip
api_payload={"ip": "1.2.3.4"}
api_compile=$.some_random_value
interval=5s
```
Note: currently only supports API endpoints on localhost. Remote requests are not supported.

# Code / PR Dependencies
Uses https://github.com/oliveagle/jsonpath for `api_compile`, see the examples at the bottom of this projects page for compile options.

# Delete branch after merge
YES 

# NEWS file entries
## New Features
* Add API requests to `pfstatsd` configuration.