### PR TITLE
Add statsd metrics to dashboard

### DIFF
--- a/conf/monitoring/netdata.conf.example
+++ b/conf/monitoring/netdata.conf.example
@@ -13,3 +13,18 @@
         # Netdata is not designed to be exposed to potentially hostile networks
         # See https://github.com/firehol/netdata/issues/164
 	bind to = %%management_ip%%,127.0.0.1
+
+[statsd_gauge_source.packetfence.devices.registered_last_hour]
+	history=3600
+
+[statsd_gauge_source.packetfence.devices.registered_last_day]
+	history=86400
+
+[statsd_gauge_source.packetfence.devices.registered_last_week]
+	history=604800
+
+[statsd_gauge_source.packetfence.devices.registered_last_month]
+	history=2592000
+
+[statsd_gauge_source.packetfence.devices.registered_last_year]
+	history=31536000

--- a/conf/monitoring/netdata.conf.example
+++ b/conf/monitoring/netdata.conf.example
@@ -28,3 +28,9 @@
 
 [statsd_gauge_source.packetfence.devices.registered_last_year]
 	history=31536000
+
+[statsd_gauge_source.packetfence.devices.online_last_month]
+	history=2592000
+
+[statsd_gauge_source.packetfence.devices.offline_last_month]
+	history=2592000

--- a/conf/monitoring/netdata.conf.example
+++ b/conf/monitoring/netdata.conf.example
@@ -13,24 +13,3 @@
         # Netdata is not designed to be exposed to potentially hostile networks
         # See https://github.com/firehol/netdata/issues/164
 	bind to = %%management_ip%%,127.0.0.1
-
-[statsd_gauge_source.packetfence.devices.registered_last_hour]
-	history=3600
-
-[statsd_gauge_source.packetfence.devices.registered_last_day]
-	history=86400
-
-[statsd_gauge_source.packetfence.devices.registered_last_week]
-	history=604800
-
-[statsd_gauge_source.packetfence.devices.registered_last_month]
-	history=2592000
-
-[statsd_gauge_source.packetfence.devices.registered_last_year]
-	history=31536000
-
-[statsd_gauge_source.packetfence.devices.online_last_month]
-	history=2592000
-
-[statsd_gauge_source.packetfence.devices.offline_last_month]
-	history=2592000

--- a/conf/stats.conf.example
+++ b/conf/stats.conf.example
@@ -14,21 +14,19 @@ mysql_query=select count(distinct mac) from node where status='unreg'
 interval=60s
 randomize=true
 
-[metric 'total online devices']
+[metric 'total online devices for the past month']
 type=mysql_query
 statsd_type=gauge
-statsd_ns=source.packetfence.devices.online
+statsd_ns=source.packetfence.devices.online_last_month
 mysql_query=select count(distinct callingstationid) from radacct where acctstoptime is null
-interval=60s
-randomize=true
+interval=720s
 
-[metric 'total offline devices']
+[metric 'total offline devices for the past month']
 type=mysql_query
 statsd_type=gauge
-statsd_ns=source.packetfence.devices.offline
+statsd_ns=source.packetfence.devices.offline_last_month
 mysql_query=select count(distinct callingstationid) from radacct where acctstoptime <= NOW()
-interval=60s
-randomize=true
+interval=720s
 
 [metric 'number of new registered devices during the past hour']
 type=mysql_query

--- a/conf/stats.conf.example
+++ b/conf/stats.conf.example
@@ -2,7 +2,7 @@
 type=mysql_query
 statsd_type=gauge
 statsd_ns=source.packetfence.devices.registered_per_role
-mysql_query=select name, count(distinct node.mac) from node_category right join node on node.category_id=node_category.category_id where node.status='reg' group by node_category.category_id;
+mysql_query=select name, count(distinct node.mac) from node_category left join node on node.category_id=node_category.category_id and node.status='reg' group by node_category.category_id
 interval=60s
 
 [metric 'total number of unregistered devices']

--- a/conf/stats.conf.example
+++ b/conf/stats.conf.example
@@ -4,6 +4,7 @@ statsd_type=gauge
 statsd_ns=source.packetfence.devices.registered_per_role
 mysql_query=select name, count(distinct node.mac) from node_category left join node on node.category_id=node_category.category_id and node.status='reg' group by node_category.category_id
 interval=60s
+randomize=true
 
 [metric 'total number of unregistered devices']
 type=mysql_query
@@ -11,6 +12,7 @@ statsd_type=gauge
 statsd_ns=source.packetfence.devices.unregistered
 mysql_query=select count(distinct mac) from node where status='unreg'
 interval=60s
+randomize=true
 
 [metric 'total online devices']
 type=mysql_query
@@ -18,6 +20,7 @@ statsd_type=gauge
 statsd_ns=source.packetfence.devices.online
 mysql_query=select count(distinct callingstationid) from radacct where acctstoptime is null
 interval=60s
+randomize=true
 
 [metric 'total offline devices']
 type=mysql_query
@@ -25,41 +28,42 @@ statsd_type=gauge
 statsd_ns=source.packetfence.devices.offline
 mysql_query=select count(distinct callingstationid) from radacct where acctstoptime <= NOW()
 interval=60s
+randomize=true
 
 [metric 'number of new registered devices during the past hour']
 type=mysql_query
 statsd_type=gauge
 statsd_ns=source.packetfence.devices.registered_last_hour
 mysql_query=select count(distinct mac) from node where status='reg' and regdate >= NOW() - INTERVAL 1 HOUR
-interval=60s
+interval=1s
 
 [metric 'number of new registered devices during the past day']
 type=mysql_query
 statsd_type=gauge
 statsd_ns=source.packetfence.devices.registered_last_day
 mysql_query=select count(distinct mac) from node where status='reg' and regdate >= NOW() - INTERVAL 1 DAY
-interval=60s
+interval=24s
 
 [metric 'number of new registered devices during the past week']
 type=mysql_query
 statsd_type=gauge
 statsd_ns=source.packetfence.devices.registered_last_week
 mysql_query=select count(distinct mac) from node where status='reg' and regdate >= NOW() - INTERVAL 1 WEEK
-interval=60s
+interval=168s
 
 [metric 'number of new registered devices during the past month']
 type=mysql_query
 statsd_type=gauge
 statsd_ns=source.packetfence.devices.registered_last_month
 mysql_query=select count(distinct mac) from node where status='reg' and regdate >= NOW() - INTERVAL 1 MONTH
-interval=60s
+interval=720s
 
 [metric 'number of new registered devices during the past year']
 type=mysql_query
 statsd_type=gauge
 statsd_ns=source.packetfence.devices.registered_last_year
 mysql_query=select count(distinct mac) from node where status='reg' and regdate >= NOW() - INTERVAL 1 YEAR
-interval=60s
+interval=8760s
 
 [metric 'number of devices currently online and in the registration network']
 type=mysql_query
@@ -67,6 +71,7 @@ statsd_type=gauge
 statsd_ns=source.packetfence.devices.online_registered
 mysql_query=select count(distinct n.mac) from node n join radacct r on r.callingstationid=n.mac where n.status='reg' and (n.unregdate >= NOW() or n.unregdate = '0000-00-00 00:00:00') and r.acctstoptime is null
 interval=60s
+randomize=true
 
 [metric 'number of devices currently registered']
 type=mysql_query
@@ -74,6 +79,7 @@ statsd_type=gauge
 statsd_ns=source.packetfence.devices.registered
 mysql_query=select count(distinct mac) from node where status='reg' and (unregdate >= NOW() or unregdate = '0000-00-00 00:00:00')
 interval=60s
+randomize=true
 
 [metric 'number of currently open violations']
 type=mysql_query
@@ -81,6 +87,7 @@ statsd_type=gauge
 statsd_ns=source.packetfence.violations
 mysql_query=select count(distinct mac) from violation where status='open'
 interval=60s
+randomize=true
 
 [metric 'number of successful radius authentications in the last day']
 type=mysql_query
@@ -88,6 +95,7 @@ statsd_type=gauge
 statsd_ns=source.packetfence.authentication.success_last_day
 mysql_query=select count(1) from radius_audit_log where auth_status='Accept' and created_at >= NOW() - INTERVAL 1 DAY;
 interval=60s
+randomize=true
 
 [metric 'number of failed radius authentications in the last day']
 type=mysql_query
@@ -95,3 +103,4 @@ statsd_type=gauge
 statsd_ns=source.packetfence.authentication.failed_last_day
 mysql_query=select count(1) from radius_audit_log where auth_status='Reject' and created_at >= NOW() - INTERVAL 1 DAY;
 interval=60s
+randomize=true

--- a/go/dhcp/main.go
+++ b/go/dhcp/main.go
@@ -151,6 +151,7 @@ func main() {
 	router.HandleFunc("/api/v1/dhcp/mac/{mac:(?:[0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}}", handleMac2Ip).Methods("GET")
 	router.HandleFunc("/api/v1/dhcp/mac/{mac:(?:[0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}}", handleReleaseIP).Methods("DELETE")
 	router.HandleFunc("/api/v1/dhcp/ip/{ip:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}", handleIP2Mac).Methods("GET")
+	router.HandleFunc("/api/v1/dhcp/stats", handleAllStats).Methods("GET")
 	router.HandleFunc("/api/v1/dhcp/stats/{int:.*}", handleStats).Methods("GET")
 	router.HandleFunc("/api/v1/dhcp/debug/{int:.*}/{role:(?:[^/]*)}", handleDebug).Methods("GET")
 	router.HandleFunc("/api/v1/dhcp/initialease/{int:.*}", handleInitiaLease).Methods("GET")

--- a/go/pfconfigdriver/structs.go
+++ b/go/pfconfigdriver/structs.go
@@ -383,6 +383,7 @@ type PfStats struct {
 	StatsdNS       string `json:"statsd_ns"`
 	MySQLQuery     string `json:"mysql_query"`
 	Interval       string `json:"interval"`
+	Randomize      string `json:"randomize"`
 	Host           string `json:"host"`
 	ApiMethod      string `json:"api_method"`
 	ApiPayload     string `json:"api_payload"`

--- a/go/stats/metrics.go
+++ b/go/stats/metrics.go
@@ -162,14 +162,14 @@ func ProcessMetricConfig(ctx context.Context, conf pfconfigdriver.PfStats) error
 			case "GET":
 				err := apiclient.Call(ctx, "GET", conf.ApiPath, &raw)
 				if err != nil {
-					log.LoggerWContext(ctx).Error("API error", err.Error())
+					log.LoggerWContext(ctx).Error("API error: " + err.Error())
 					return
 				}
 				break
 			case "DELETE", "PATCH", "POST", "PUT":
 				err := apiclient.CallWithStringBody(ctx, conf.ApiMethod, conf.ApiPath, conf.ApiPayload, &raw)
 				if err != nil {
-					log.LoggerWContext(ctx).Error("API error", err.Error())
+					log.LoggerWContext(ctx).Error("API error: " + err.Error())
 					return
 				}
 				break
@@ -186,12 +186,12 @@ func ProcessMetricConfig(ctx context.Context, conf pfconfigdriver.PfStats) error
 			json.Unmarshal([]byte(raw), &json_data)
 			prs, err := jsonpath.Parse(conf.ApiCompile)
 			if err != nil {
-				log.LoggerWContext(ctx).Warn("api_compile '"+conf.ApiCompile+"' parse error from "+conf.ApiMethod+" "+conf.ApiPath, err.Error())
+				log.LoggerWContext(ctx).Warn("api_compile '" + conf.ApiCompile + "' parse error from " + conf.ApiMethod + " " + conf.ApiPath + ": " + err.Error())
 				return
 			}
 			res, err := prs.Apply(json_data)
 			if err != nil {
-				log.LoggerWContext(ctx).Warn("api_compile '"+conf.ApiCompile+"' apply error from "+conf.ApiMethod+" "+conf.ApiPath, err.Error())
+				log.LoggerWContext(ctx).Warn("api_compile '" + conf.ApiCompile + "' apply error from " + conf.ApiMethod + " " + conf.ApiPath + ": " + err.Error())
 				return
 			}
 			if res == nil {

--- a/go/stats/metrics.go
+++ b/go/stats/metrics.go
@@ -53,7 +53,6 @@ func ProcessMetricConfig(ctx context.Context, conf pfconfigdriver.PfStats) error
 						log.LoggerWContext(ctx).Error(err.Error())
 						return
 					}
-					break
 
 				case 2:
 					err := rows.Scan(&field, &result)
@@ -64,12 +63,10 @@ func ProcessMetricConfig(ctx context.Context, conf pfconfigdriver.PfStats) error
 					switch field.String {
 					case "":
 						namespace = conf.StatsdNS + ";NULL"
-						break
 
 					default:
 						namespace = conf.StatsdNS + ";" + field.String
 					}
-					break
 
 				default:
 					return
@@ -78,25 +75,20 @@ func ProcessMetricConfig(ctx context.Context, conf pfconfigdriver.PfStats) error
 				case "count":
 					f64Result, _ := strconv.ParseFloat(result, 64)
 					StatsdClient.Count(namespace, f64Result)
-					break
 
 				case "gauge":
 					f64Result, _ := strconv.ParseFloat(result, 64)
 					StatsdClient.Gauge(namespace, f64Result)
-					break
 
 				case "histogram":
 					f64Result, _ := strconv.ParseFloat(result, 64)
 					StatsdClient.Histogram(namespace, f64Result)
-					break
 
 				case "increment":
 					StatsdClient.Increment(namespace)
-					break
 
 				case "unique":
 					StatsdClient.Unique(namespace, result)
-					break
 
 				default:
 					log.LoggerWContext(ctx).Warn("Unhandled statsd_type " + conf.StatsdType + " for " + conf.Type)
@@ -104,7 +96,6 @@ func ProcessMetricConfig(ctx context.Context, conf pfconfigdriver.PfStats) error
 			}
 			return
 		}
-		break
 
 	case "icmp_ipv4":
 		job = func() {
@@ -130,21 +121,17 @@ func ProcessMetricConfig(ctx context.Context, conf pfconfigdriver.PfStats) error
 					case "count":
 						f64Duration := float64(duration / time.Millisecond)
 						StatsdClient.Count(conf.StatsdNS, f64Duration)
-						break
 
 					case "gauge":
 						f64Duration := float64(duration / time.Millisecond)
 						StatsdClient.Gauge(conf.StatsdNS, f64Duration)
-						break
 
 					case "histogram":
 						f64Duration := float64(duration / time.Millisecond)
 						StatsdClient.Histogram(conf.StatsdNS, f64Duration)
-						break
 
 					case "timing":
 						c.Send(conf.StatsdNS)
-						break
 
 					default:
 						log.LoggerWContext(ctx).Warn("Unhandled statsd_type " + conf.StatsdType + " for " + conf.Type)
@@ -152,7 +139,6 @@ func ProcessMetricConfig(ctx context.Context, conf pfconfigdriver.PfStats) error
 				}
 			}
 		}
-		break
 
 	case "api":
 		job = func() {
@@ -165,14 +151,14 @@ func ProcessMetricConfig(ctx context.Context, conf pfconfigdriver.PfStats) error
 					log.LoggerWContext(ctx).Error("API error: " + err.Error())
 					return
 				}
-				break
+
 			case "DELETE", "PATCH", "POST", "PUT":
 				err := apiclient.CallWithStringBody(ctx, conf.ApiMethod, conf.ApiPath, conf.ApiPayload, &raw)
 				if err != nil {
 					log.LoggerWContext(ctx).Error("API error: " + err.Error())
 					return
 				}
-				break
+
 			default:
 				log.LoggerWContext(ctx).Warn("Unhandled api_method " + conf.ApiMethod)
 				return
@@ -201,23 +187,18 @@ func ProcessMetricConfig(ctx context.Context, conf pfconfigdriver.PfStats) error
 			switch conf.StatsdType {
 			case "count":
 				StatsdClient.Count(conf.StatsdNS, res.(float64))
-				break
 
 			case "gauge":
 				StatsdClient.Gauge(conf.StatsdNS, res.(float64))
-				break
 
 			case "histogram":
 				StatsdClient.Histogram(conf.StatsdNS, res.(float64))
-				break
 
 			case "increment":
 				StatsdClient.Increment(conf.StatsdNS)
-				break
 
 			case "unique":
 				StatsdClient.Unique(conf.StatsdNS, res.(string))
-				break
 
 			default:
 				log.LoggerWContext(ctx).Warn("Unhandled statsd_type " + conf.StatsdType + " for " + conf.Type)
@@ -229,11 +210,7 @@ func ProcessMetricConfig(ctx context.Context, conf pfconfigdriver.PfStats) error
 	}
 
 	switch strings.ToLower(conf.Randomize) {
-	case "1":
-	case "t":
-	case "true":
-	case "y":
-	case "yes":
+	case "1", "t", "true", "y", "yes":
 		_, err := interval.Every(conf.Interval).Randomize().Run(job)
 		if err != nil {
 			return err

--- a/go/stats/metrics.go
+++ b/go/stats/metrics.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"net"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gdey/jsonpath"
@@ -227,9 +228,22 @@ func ProcessMetricConfig(ctx context.Context, conf pfconfigdriver.PfStats) error
 		log.LoggerWContext(ctx).Warn("Unhandled type: " + conf.Type)
 	}
 
-	_, err := interval.Every(conf.Interval).Randomize().Run(job)
-	if err != nil {
-		return err
+	switch strings.ToLower(conf.Randomize) {
+	case "1":
+	case "t":
+	case "true":
+	case "y":
+	case "yes":
+		_, err := interval.Every(conf.Interval).Randomize().Run(job)
+		if err != nil {
+			return err
+		}
+
+	default:
+		_, err := interval.Every(conf.Interval).Run(job)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/html/pfappserver/lib/pfappserver/PacketFence/Controller/Graph.pm
+++ b/html/pfappserver/lib/pfappserver/PacketFence/Controller/Graph.pm
@@ -27,6 +27,7 @@ use pf::config qw(
 );
 use pfconfig::cached_array;
 use pf::cluster;
+use pf::nodecategory;
 use Sys::Hostname;
 DateTime::Locale->add_aliases({
     'i_default' => 'en',
@@ -482,11 +483,13 @@ sub dashboard :Local :AdminRole('REPORTS') {
     }
 
     $c->stash(
-        graphs       => \@graphs,
-        cluster      => pf::cluster::members_ips(),
-        sources      => \@authentication_sources_monitored,
-        current_view => 'HTML',
-        tab          => $tab,
+        graphs         => \@graphs,
+        cluster        => pf::cluster::members_ips(),
+        sources        => \@authentication_sources_monitored,
+        nodecategories => [pf::nodecategory::nodecategory_view_all()],
+        current_view   => 'HTML',
+        tab            => $tab,
+        listen_ints => [@listen_ints],
     );
 }
 

--- a/html/pfappserver/lib/pfappserver/PacketFence/Controller/Graph.pm
+++ b/html/pfappserver/lib/pfappserver/PacketFence/Controller/Graph.pm
@@ -486,7 +486,7 @@ sub dashboard :Local :AdminRole('REPORTS') {
         graphs         => \@graphs,
         cluster        => pf::cluster::members_ips(),
         sources        => \@authentication_sources_monitored,
-        nodecategories => [pf::nodecategory::nodecategory_view_all()],
+        roles          => \[pf::nodecategory::nodecategory_view_all()],
         current_view   => 'HTML',
         tab            => $tab,
         listen_ints => [@listen_ints],

--- a/html/pfappserver/lib/pfappserver/PacketFence/Controller/Graph.pm
+++ b/html/pfappserver/lib/pfappserver/PacketFence/Controller/Graph.pm
@@ -24,6 +24,7 @@ use pf::config qw(
     $management_network
     %Config
     %ConfigReport
+    @listen_ints
 );
 use pfconfig::cached_array;
 use pf::cluster;
@@ -486,10 +487,10 @@ sub dashboard :Local :AdminRole('REPORTS') {
         graphs         => \@graphs,
         cluster        => pf::cluster::members_ips(),
         sources        => \@authentication_sources_monitored,
-        roles          => \[pf::nodecategory::nodecategory_view_all()],
+        roles          => pf::nodecategory::nodecategory_view_all(),
         current_view   => 'HTML',
         tab            => $tab,
-        listen_ints => [@listen_ints],
+        listen_ints    => \@listen_ints,
     );
 }
 

--- a/html/pfappserver/root/graph/dashboard.tt
+++ b/html/pfappserver/root/graph/dashboard.tt
@@ -129,10 +129,12 @@ END
         <!-- alarms -->
     </div>
     <div class="text-center">
+<<<<<<< 2c31faca5062cde815be0ba331c41fe713be4a5e
         <ul class="nav nav-pills" id="status-tabs">
             <li [% IF tab == "system" %]class="active"[% END %]><a data-toggle="pill" href="#system">System</a></li>
             <li [% IF tab == "radius" %]class="active"[% END %]><a data-toggle="pill" href="#radius">RADIUS</a></li>
             <li [% IF tab == "authentication" %]class="active"[% END %]><a data-toggle="pill" href="#authentication">Authentication</a></li>
+            <li>[% IF tab == "dhcp" %]class="active"[% END %]<a data-toggle="pill" href="#dhcp">DHCP</a></li>
             <li [% IF tab == "endpoints" %]class="active"[% END %]><a data-toggle="pill" href="#endpoints">Endpoints</a></li>
         </ul>
     </div>
@@ -351,7 +353,7 @@ END
                             data-chart-library="dygraph"
                             data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
                             data-height="200px"
-                            data-after="-3600"
+                            data-after="-86400"
                             data-decimal-digits="0"></div>
                         </div>
                         <div class="span[% spanSize %]">
@@ -363,12 +365,75 @@ END
                             data-chart-library="dygraph"
                             data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
                             data-height="200px"
-                            data-after="-3600"
+                            data-after="-86400"
                             data-decimal-digits="0"></div>
                         </div>
                     </div>
                 </div>
             </div>
+        </div>
+        <div class="tab-pane[% IF tab == "dhcp" %] active[% END %]" id="dhcp">
+        [% FOREACH interface IN listen_ints %]
+            <div class="card">
+                <div class="card-title">
+                    <h2>DHCP on [% interface %]</h2>
+                </div>
+                <div class="card-block">
+                    <div class="row-fluid">
+                        <div class="span[% spanSize %]">
+                            <div data-netdata="statsd_gauge_source.packetfence.dhcp_leases_[% interface %]_day"
+                            data-host="/netdata/127.0.0.1"
+                            data-common-max="day"
+                            data-common-min="day"
+                            data-title="number of dhcp leases free on [% interface %] for the past day"
+                            data-chart-library="dygraph"
+                            data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
+                            data-height="200px"
+                            data-after="-86400"
+                            data-decimal-digits="0"></div>
+                        </div>
+                        <div class="span[% spanSize %]">
+                            <div data-netdata="statsd_gauge_source.packetfence.dhcp_leases_[% interface %]_week"
+                            data-host="/netdata/127.0.0.1"
+                            data-common-max="week"
+                            data-common-min="week"
+                            data-title="number of dhcp leases free on [% interface %] for the past week"
+                            data-chart-library="dygraph"
+                            data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
+                            data-height="200px"
+                            data-after="-604800"
+                            data-decimal-digits="0"></div>
+                        </div>
+                    </div>
+                    <div class="row-fluid">
+                        <div class="span[% spanSize %]">
+                            <div data-netdata="statsd_gauge_source.packetfence.dhcp_leases_[% interface %]_month"
+                            data-host="/netdata/127.0.0.1"
+                            data-common-max="traffic"
+                            data-common-min="traffic"
+                            data-title="number of dhcp leases free on [% interface %] for the past month"
+                            data-chart-library="dygraph"
+                            data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
+                            data-height="200px"
+                            data-after="-2592000"
+                            data-decimal-digits="0"></div>
+                        </div>
+                        <div class="span[% spanSize %]">
+                            <div data-netdata="statsd_gauge_source.packetfence.dhcp_leases_[% interface %]_year"
+                            data-host="/netdata/127.0.0.1"
+                            data-common-max="year"
+                            data-common-min="year"
+                            data-title="number of dhcp leases free on [% interface %] for the past year"
+                            data-chart-library="dygraph"
+                            data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
+                            data-height="200px"
+                            data-after="-31536000"
+                            data-decimal-digits="0"></div>                        
+                        </div>
+                    </div>
+                </div>
+            </div>
+        [% END %]
         </div>
         <div class="tab-pane[% IF tab == "endpoints" %] active[% END %]" id="endpoints">
             <div class="card">

--- a/html/pfappserver/root/graph/dashboard.tt
+++ b/html/pfappserver/root/graph/dashboard.tt
@@ -350,7 +350,7 @@ END
                             data-common-min="traffic"
                             data-title="number of successful radius authentications in the last day"
                             data-chart-library="dygraph"
-                            data-colors="[% palette(loop.index) %]"
+                            data-colors="[% palette(0) %]"
                             data-height="200px"
                             data-after="-86400"
                             data-decimal-digits="0"></div>
@@ -362,7 +362,7 @@ END
                             data-common-min="traffic"
                             data-title="number of failed radius authentications in the last day"
                             data-chart-library="dygraph"
-                            data-colors="[% palette(loop.index) %]"
+                            data-colors="[% palette(0) %]"
                             data-height="200px"
                             data-after="-86400"
                             data-decimal-digits="0"></div>
@@ -379,7 +379,7 @@ END
                 </div>
                 <div class="card-block">
                     <div class="row-fluid">
-                        <div class="span[% spanSize %]">
+                        <div class="span9">
                             <div data-netdata="statsd_gauge_source.packetfence.dhcp_leases_[% interface %]_day"
                             data-host="/netdata/127.0.0.1"
                             data-common-max="day"
@@ -391,7 +391,7 @@ END
                             data-after="-86400"
                             data-decimal-digits="0"></div>
                         </div>
-                        <div class="span[% spanSize %]">
+                        <div class="span9">
                             <div data-netdata="statsd_gauge_source.packetfence.dhcp_leases_[% interface %]_week"
                             data-host="/netdata/127.0.0.1"
                             data-common-max="week"
@@ -405,7 +405,7 @@ END
                         </div>
                     </div>
                     <div class="row-fluid">
-                        <div class="span[% spanSize %]">
+                        <div class="span9">
                             <div data-netdata="statsd_gauge_source.packetfence.dhcp_leases_[% interface %]_month"
                             data-host="/netdata/127.0.0.1"
                             data-common-max="traffic"
@@ -417,7 +417,7 @@ END
                             data-after="-2592000"
                             data-decimal-digits="0"></div>
                         </div>
-                        <div class="span[% spanSize %]">
+                        <div class="span9">
                             <div data-netdata="statsd_gauge_source.packetfence.dhcp_leases_[% interface %]_year"
                             data-host="/netdata/127.0.0.1"
                             data-common-max="year"
@@ -441,26 +441,26 @@ END
                 </div>
                 <div class="card-block">
                     <div class="row-fluid">
-                        <div class="span[% spanSize %]">
+                        <div class="span9">
                             <div data-netdata="statsd_gauge_source.packetfence.devices.online_last_month"
                             data-host="/netdata/127.0.0.1"
                             data-common-max="traffic"
                             data-common-min="traffic"
                             data-title="total online devices for the past month"
                             data-chart-library="dygraph"
-                            data-colors="[% palette(loop.index) %]"
+                            data-colors="[% palette(0) %]"
                             data-height="200px"
                             data-after="-2592000"
                             data-decimal-digits="0"></div>
                         </div>
-                        <div class="span[% spanSize %]">
+                        <div class="span9">
                             <div data-netdata="statsd_gauge_source.packetfence.devices.offline_last_month"
                             data-host="/netdata/127.0.0.1"
                             data-common-max="traffic"
                             data-common-min="traffic"
                             data-title="total offline devices for the past month"
                             data-chart-library="dygraph"
-                            data-colors="[% palette(loop.index) %]"
+                            data-colors="[% palette(0) %]"
                             data-height="200px"
                             data-after="-2592000"
                             data-decimal-digits="0"></div>
@@ -474,40 +474,40 @@ END
                 </div>
                 <div class="card-block">
                     <div class="row-fluid">
-                        <div class="span[% spanSize %]">
+                        <div class="span9">
                             <div data-netdata="statsd_gauge_source.packetfence.devices.registered"
                             data-host="/netdata/127.0.0.1"
                             data-common-max="traffic"
                             data-common-min="traffic"
                             data-title="total number of devices currently registered"
                             data-chart-library="dygraph"
-                            data-colors="[% palette(loop.index) %]"
+                            data-colors="[% palette(0) %]"
                             data-height="200px"
                             data-after="-3600"
                             data-decimal-digits="0"></div>
                         </div>
-                        <div class="span[% spanSize %]">
+                        <div class="span9">
                             <div data-netdata="statsd_gauge_source.packetfence.devices.unregistered"
                             data-host="/netdata/127.0.0.1"
                             data-common-max="traffic"
                             data-common-min="traffic"
                             data-title="total number of unregistered devices"
                             data-chart-library="dygraph"
-                            data-colors="[% palette(loop.index) %]"
+                            data-colors="[% palette(0) %]"
                             data-height="200px"
                             data-after="-3600"
                             data-decimal-digits="0"></div>
                         </div>
                     </div>
                     <div class="row-fluid">
-                        <div class="span[% spanSize %]">
+                        <div class="span9">
                             <div data-netdata="statsd_gauge_source.packetfence.devices.online_registered"
                             data-host="/netdata/127.0.0.1"
                             data-common-max="traffic"
                             data-common-min="traffic"
                             data-title="number of devices currently online and in the registration network"
                             data-chart-library="dygraph"
-                            data-colors="[% palette(loop.index) %]"
+                            data-colors="[% palette(0) %]"
                             data-height="200px"
                             data-after="-3600"
                             data-decimal-digits="0"></div>
@@ -522,14 +522,14 @@ END
                 <div class="card-block">
                     <div class="row-fluid">
                     [% FOREACH role IN roles %]
-                        <div class="span[% spanSize %]">
+                        <div class="span9">
                             <div data-netdata="statsd_gauge_source.packetfence.devices.registered_per_role_[% role.name FILTER lower %]"
                             data-host="/netdata/127.0.0.1"
                             data-common-max="traffic"
                             data-common-min="traffic"
                             data-title="total number of registered devices in role: [% role.name %]"
                             data-chart-library="dygraph"
-                            data-colors="[% palette(loop.index) %]"
+                            data-colors="[% palette(0) %]"
                             data-height="200px"
                             data-after="-3600"
                             data-decimal-digits="0"></div>
@@ -548,66 +548,66 @@ END
                 </div>
                 <div class="card-block">
                     <div class="row-fluid">
-                        <div class="span[% spanSize %]">
+                        <div class="span9">
                             <div data-netdata="statsd_gauge_source.packetfence.devices.registered_last_hour"
                             data-host="/netdata/127.0.0.1"
                             data-common-max="hour"
                             data-common-min="hour"
                             data-title="number of new registered devices during the past hour"
                             data-chart-library="dygraph"
-                            data-colors="[% palette(loop.index) %]"
+                            data-colors="[% palette(0) %]"
                             data-height="200px"
                             data-after="-3600"
                             data-decimal-digits="0"></div>
                         </div>
-                        <div class="span[% spanSize %]">
+                        <div class="span9">
                             <div data-netdata="statsd_gauge_source.packetfence.devices.registered_last_day"
                             data-host="/netdata/127.0.0.1"
                             data-common-max="day"
                             data-common-min="day"
                             data-title="number of new registered devices during the past day"
                             data-chart-library="dygraph"
-                            data-colors="[% palette(loop.index) %]"
+                            data-colors="[% palette(0) %]"
                             data-height="200px"
                             data-after="-86400"
                             data-decimal-digits="0"></div>
                         </div>
                     </div>
                     <div class="row-fluid">
-                        <div class="span[% spanSize %]">
+                        <div class="span9">
                             <div data-netdata="statsd_gauge_source.packetfence.devices.registered_last_week"
                             data-host="/netdata/127.0.0.1"
                             data-common-max="week"
                             data-common-min="week"
                             data-title="number of new registered devices during the past week"
                             data-chart-library="dygraph"
-                            data-colors="[% palette(loop.index) %]"
+                            data-colors="[% palette(0) %]"
                             data-height="200px"
                             data-after="-604800"
                             data-decimal-digits="0"></div>
                         </div>
-                        <div class="span[% spanSize %]">
+                        <div class="span9">
                             <div data-netdata="statsd_gauge_source.packetfence.devices.registered_last_month"
                             data-host="/netdata/127.0.0.1"
                             data-common-max="month"
                             data-common-min="month"
                             data-title="number of new registered devices during the past month"
                             data-chart-library="dygraph"
-                            data-colors="[% palette(loop.index) %]"
+                            data-colors="[% palette(0) %]"
                             data-height="200px"
                             data-after="-2592000"
                             data-decimal-digits="0"></div>
                         </div>
                     </div>
                     <div class="row-fluid">
-                        <div class="span[% spanSize %]">
+                        <div class="span9">
                             <div data-netdata="statsd_gauge_source.packetfence.devices.registered_last_year"
                             data-host="/netdata/127.0.0.1"
                             data-common-max="year"
                             data-common-min="year"
                             data-title="number of new registered devices during the past year"
                             data-chart-library="dygraph"
-                            data-colors="[% palette(loop.index) %]"
+                            data-colors="[% palette(0) %]"
                             data-height="200px"
                             data-after="-31536000"
                             data-decimal-digits="0"></div>
@@ -621,14 +621,14 @@ END
                 </div>
                 <div class="card-block">
                     <div class="row-fluid">
-                        <div class="span[% spanSize %]">
+                        <div class="span9">
                             <div data-netdata="statsd_gauge_source.packetfence.violations"
                             data-host="/netdata/127.0.0.1"
                             data-common-max="traffic"
                             data-common-min="traffic"
                             data-title="number of currently open violations"
                             data-chart-library="dygraph"
-                            data-colors="[% palette(loop.index) %]"
+                            data-colors="[% palette(0) %]"
                             data-height="200px"
                             data-after="-3600"
                             data-decimal-digits="0"></div>

--- a/html/pfappserver/root/graph/dashboard.tt
+++ b/html/pfappserver/root/graph/dashboard.tt
@@ -129,7 +129,6 @@ END
         <!-- alarms -->
     </div>
     <div class="text-center">
-<<<<<<< 2c31faca5062cde815be0ba331c41fe713be4a5e
         <ul class="nav nav-pills" id="status-tabs">
             <li [% IF tab == "system" %]class="active"[% END %]><a data-toggle="pill" href="#system">System</a></li>
             <li [% IF tab == "radius" %]class="active"[% END %]><a data-toggle="pill" href="#radius">RADIUS</a></li>
@@ -344,7 +343,7 @@ END
                 </div>
                 <div class="card-block">
                     <div class="row-fluid">
-                        <div class="span[% spanSize %]">
+                        <div class="span9">
                             <div data-netdata="statsd_gauge_source.packetfence.authentication.success_last_day"
                             data-host="/netdata/127.0.0.1"
                             data-common-max="traffic"
@@ -356,7 +355,7 @@ END
                             data-after="-86400"
                             data-decimal-digits="0"></div>
                         </div>
-                        <div class="span[% spanSize %]">
+                        <div class="span9">
                             <div data-netdata="statsd_gauge_source.packetfence.authentication.failed_last_day"
                             data-host="/netdata/127.0.0.1"
                             data-common-max="traffic"

--- a/html/pfappserver/root/graph/dashboard.tt
+++ b/html/pfappserver/root/graph/dashboard.tt
@@ -336,9 +336,228 @@ END
                     </div>
                 </div>
             </div>
+            <div class="card">
+                <div class="card-title">
+                    <h2>Successful &amp; Unsuccessful RADIUS Authentications</h2>
+                </div>
+                <div class="card-block">
+                    <div class="row-fluid">
+                        <div class="span[% spanSize %]">
+                            <div data-netdata="statsd_gauge_source.packetfence.authentication.success_last_day"
+                            data-host="/netdata/127.0.0.1"
+                            data-common-max="traffic"
+                            data-common-min="traffic"
+                            data-title="number of successful radius authentications in the last day"
+                            data-chart-library="dygraph"
+                            data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
+                            data-height="200px"
+                            data-after="-300"></div>
+                        </div>
+                        <div class="span[% spanSize %]">
+                            <div data-netdata="statsd_gauge_source.packetfence.authentication.failed_last_day"
+                            data-host="/netdata/127.0.0.1"
+                            data-common-max="traffic"
+                            data-common-min="traffic"
+                            data-title="number of failed radius authentications in the last day"
+                            data-chart-library="dygraph"
+                            data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
+                            data-height="200px"
+                            data-after="-300"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
         <div class="tab-pane[% IF tab == "endpoints" %] active[% END %]" id="endpoints">
-            Endpoints
+            <div class="card">
+                <div class="card-title">
+                    <h2>Online &amp; Offline Devices</h2>
+                </div>
+                <div class="card-block">
+                    <div class="row-fluid">
+                        <div class="span[% spanSize %]">
+                            <div data-netdata="statsd_gauge_source.packetfence.devices.online"
+                            data-host="/netdata/127.0.0.1"
+                            data-common-max="traffic"
+                            data-common-min="traffic"
+                            data-title="total online devices"
+                            data-chart-library="dygraph"
+                            data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
+                            data-height="200px"
+                            data-after="-300"></div>
+                        </div>
+                        <div class="span[% spanSize %]">
+                            <div data-netdata="statsd_gauge_source.packetfence.devices.offline"
+                            data-host="/netdata/127.0.0.1"
+                            data-common-max="traffic"
+                            data-common-min="traffic"
+                            data-title="total offline devices"
+                            data-chart-library="dygraph"
+                            data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
+                            data-height="200px"
+                            data-after="-300"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="card">
+                <div class="card-title">
+                    <h2>Registered &amp; Unregistered Devices</h2>
+                </div>
+                <div class="card-block">
+                    <div class="row-fluid">
+                        <div class="span[% spanSize %]">
+                            <div data-netdata="statsd_gauge_source.packetfence.devices.registered"
+                            data-host="/netdata/127.0.0.1"
+                            data-common-max="traffic"
+                            data-common-min="traffic"
+                            data-title="total number of devices currently registered"
+                            data-chart-library="dygraph"
+                            data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
+                            data-height="200px"
+                            data-after="-300"></div>
+                        </div>
+                        <div class="span[% spanSize %]">
+                            <div data-netdata="statsd_gauge_source.packetfence.devices.unregistered"
+                            data-host="/netdata/127.0.0.1"
+                            data-common-max="traffic"
+                            data-common-min="traffic"
+                            data-title="total number of unregistered devices"
+                            data-chart-library="dygraph"
+                            data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
+                            data-height="200px"
+                            data-after="-300"></div>
+                        </div>
+                    </div>
+                    <div class="row-fluid">
+                        <div class="span[% spanSize %]">
+                            <div data-netdata="statsd_gauge_source.packetfence.devices.online_registered"
+                            data-host="/netdata/127.0.0.1"
+                            data-common-max="traffic"
+                            data-common-min="traffic"
+                            data-title="number of devices currently online and in the registration network"
+                            data-chart-library="dygraph"
+                            data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
+                            data-height="200px"
+                            data-after="-300"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="card">
+                <div class="card-title">
+                    <h2>Registered Devices Per Role</h2>
+                </div>
+                <div class="card-block">
+                    <div class="row-fluid">
+                    [% FOREACH nodecategory IN nodecategories %]
+                        <div class="span[% spanSize %]">
+                            <div data-netdata="statsd_gauge_source.packetfence.devices.registered_per_role_[% nodecategory.name FILTER lower %]"
+                            data-host="/netdata/127.0.0.1"
+                            data-common-max="traffic"
+                            data-common-min="traffic"
+                            data-title="total number of registered devices in role: [% nodecategory.name %]"
+                            data-chart-library="dygraph"
+                            data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
+                            data-height="200px"
+                            data-after="-300"></div>
+                        </div>
+                    [% IF loop.parity == "even" %]
+                    </div>
+                    <div class="row-fluid">
+                    [% END %]
+                    [% END %]
+                    </div>
+                </div>
+            </div>
+             <div class="card">
+                <div class="card-title">
+                    <h2>Registered Devices Per Timeframe</h2>
+                </div>
+                <div class="card-block">
+                    <div class="row-fluid">
+                        <div class="span[% spanSize %]">
+                            <div data-netdata="statsd_gauge_source.packetfence.devices.registered_last_hour"
+                            data-host="/netdata/127.0.0.1"
+                            data-common-max="traffic"
+                            data-common-min="traffic"
+                            data-title="number of new registered devices during the past hour"
+                            data-chart-library="dygraph"
+                            data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
+                            data-height="200px"
+                            data-after="-300"></div>
+                        </div>
+                        <div class="span[% spanSize %]">
+                            <div data-netdata="statsd_gauge_source.packetfence.devices.registered_last_day"
+                            data-host="/netdata/127.0.0.1"
+                            data-common-max="traffic"
+                            data-common-min="traffic"
+                            data-title="number of new registered devices during the past day"
+                            data-chart-library="dygraph"
+                            data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
+                            data-height="200px"
+                            data-after="-300"></div>
+                        </div>
+                    </div>
+                    <div class="row-fluid">
+                        <div class="span[% spanSize %]">
+                            <div data-netdata="statsd_gauge_source.packetfence.devices.registered_last_week"
+                            data-host="/netdata/127.0.0.1"
+                            data-common-max="traffic"
+                            data-common-min="traffic"
+                            data-title="number of new registered devices during the past week"
+                            data-chart-library="dygraph"
+                            data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
+                            data-height="200px"
+                            data-after="-300"></div>
+                        </div>
+                        <div class="span[% spanSize %]">
+                            <div data-netdata="statsd_gauge_source.packetfence.devices.registered_last_month"
+                            data-host="/netdata/127.0.0.1"
+                            data-common-max="traffic"
+                            data-common-min="traffic"
+                            data-title="number of new registered devices during the past month"
+                            data-chart-library="dygraph"
+                            data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
+                            data-height="200px"
+                            data-after="-300"></div>
+                        </div>
+                    </div>
+                    <div class="row-fluid">
+                        <div class="span[% spanSize %]">
+                            <div data-netdata="statsd_gauge_source.packetfence.devices.registered_last_year"
+                            data-host="/netdata/127.0.0.1"
+                            data-common-max="traffic"
+                            data-common-min="traffic"
+                            data-title="number of new registered devices during the past year"
+                            data-chart-library="dygraph"
+                            data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
+                            data-height="200px"
+                            data-after="-300"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="card">
+                <div class="card-title">
+                    <h2>Device Violations</h2>
+                </div>
+                <div class="card-block">
+                    <div class="row-fluid">
+                        <div class="span[% spanSize %]">
+                            <div data-netdata="statsd_gauge_source.packetfence.violations"
+                            data-host="/netdata/127.0.0.1"
+                            data-common-max="traffic"
+                            data-common-min="traffic"
+                            data-title="number of currently open violations"
+                            data-chart-library="dygraph"
+                            data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
+                            data-height="200px"
+                            data-after="-300"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 </div>

--- a/html/pfappserver/root/graph/dashboard.tt
+++ b/html/pfappserver/root/graph/dashboard.tt
@@ -378,27 +378,27 @@ END
                 <div class="card-block">
                     <div class="row-fluid">
                         <div class="span[% spanSize %]">
-                            <div data-netdata="statsd_gauge_source.packetfence.devices.online"
+                            <div data-netdata="statsd_gauge_source.packetfence.devices.online_last_month"
                             data-host="/netdata/127.0.0.1"
                             data-common-max="traffic"
                             data-common-min="traffic"
-                            data-title="total online devices"
+                            data-title="total online devices for the past month"
                             data-chart-library="dygraph"
                             data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
                             data-height="200px"
-                            data-after="-3600"
+                            data-after="-2592000"
                             data-decimal-digits="0"></div>
                         </div>
                         <div class="span[% spanSize %]">
-                            <div data-netdata="statsd_gauge_source.packetfence.devices.offline"
+                            <div data-netdata="statsd_gauge_source.packetfence.devices.offline_last_month"
                             data-host="/netdata/127.0.0.1"
                             data-common-max="traffic"
                             data-common-min="traffic"
-                            data-title="total offline devices"
+                            data-title="total offline devices for the past month"
                             data-chart-library="dygraph"
                             data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
                             data-height="200px"
-                            data-after="-3600"
+                            data-after="-2592000"
                             data-decimal-digits="0"></div>
                         </div>
                     </div>

--- a/html/pfappserver/root/graph/dashboard.tt
+++ b/html/pfappserver/root/graph/dashboard.tt
@@ -457,13 +457,13 @@ END
                 </div>
                 <div class="card-block">
                     <div class="row-fluid">
-                    [% FOREACH nodecategory IN nodecategories %]
+                    [% FOREACH role IN roles %]
                         <div class="span[% spanSize %]">
-                            <div data-netdata="statsd_gauge_source.packetfence.devices.registered_per_role_[% nodecategory.name FILTER lower %]"
+                            <div data-netdata="statsd_gauge_source.packetfence.devices.registered_per_role_[% role.name FILTER lower %]"
                             data-host="/netdata/127.0.0.1"
                             data-common-max="traffic"
                             data-common-min="traffic"
-                            data-title="total number of registered devices in role: [% nodecategory.name %]"
+                            data-title="total number of registered devices in role: [% role.name %]"
                             data-chart-library="dygraph"
                             data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
                             data-height="200px"

--- a/html/pfappserver/root/graph/dashboard.tt
+++ b/html/pfappserver/root/graph/dashboard.tt
@@ -351,7 +351,8 @@ END
                             data-chart-library="dygraph"
                             data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
                             data-height="200px"
-                            data-after="-300"></div>
+                            data-after="-3600"
+                            data-decimal-digits="0"></div>
                         </div>
                         <div class="span[% spanSize %]">
                             <div data-netdata="statsd_gauge_source.packetfence.authentication.failed_last_day"
@@ -362,7 +363,8 @@ END
                             data-chart-library="dygraph"
                             data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
                             data-height="200px"
-                            data-after="-300"></div>
+                            data-after="-3600"
+                            data-decimal-digits="0"></div>
                         </div>
                     </div>
                 </div>
@@ -384,7 +386,8 @@ END
                             data-chart-library="dygraph"
                             data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
                             data-height="200px"
-                            data-after="-300"></div>
+                            data-after="-3600"
+                            data-decimal-digits="0"></div>
                         </div>
                         <div class="span[% spanSize %]">
                             <div data-netdata="statsd_gauge_source.packetfence.devices.offline"
@@ -395,7 +398,8 @@ END
                             data-chart-library="dygraph"
                             data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
                             data-height="200px"
-                            data-after="-300"></div>
+                            data-after="-3600"
+                            data-decimal-digits="0"></div>
                         </div>
                     </div>
                 </div>
@@ -415,7 +419,8 @@ END
                             data-chart-library="dygraph"
                             data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
                             data-height="200px"
-                            data-after="-300"></div>
+                            data-after="-3600"
+                            data-decimal-digits="0"></div>
                         </div>
                         <div class="span[% spanSize %]">
                             <div data-netdata="statsd_gauge_source.packetfence.devices.unregistered"
@@ -426,7 +431,8 @@ END
                             data-chart-library="dygraph"
                             data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
                             data-height="200px"
-                            data-after="-300"></div>
+                            data-after="-3600"
+                            data-decimal-digits="0"></div>
                         </div>
                     </div>
                     <div class="row-fluid">
@@ -439,7 +445,8 @@ END
                             data-chart-library="dygraph"
                             data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
                             data-height="200px"
-                            data-after="-300"></div>
+                            data-after="-3600"
+                            data-decimal-digits="0"></div>
                         </div>
                     </div>
                 </div>
@@ -460,7 +467,8 @@ END
                             data-chart-library="dygraph"
                             data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
                             data-height="200px"
-                            data-after="-300"></div>
+                            data-after="-3600"
+                            data-decimal-digits="0"></div>
                         </div>
                     [% IF loop.parity == "even" %]
                     </div>
@@ -479,61 +487,66 @@ END
                         <div class="span[% spanSize %]">
                             <div data-netdata="statsd_gauge_source.packetfence.devices.registered_last_hour"
                             data-host="/netdata/127.0.0.1"
-                            data-common-max="traffic"
-                            data-common-min="traffic"
+                            data-common-max="hour"
+                            data-common-min="hour"
                             data-title="number of new registered devices during the past hour"
                             data-chart-library="dygraph"
                             data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
                             data-height="200px"
-                            data-after="-300"></div>
+                            data-after="-3600"
+                            data-decimal-digits="0"></div>
                         </div>
                         <div class="span[% spanSize %]">
                             <div data-netdata="statsd_gauge_source.packetfence.devices.registered_last_day"
                             data-host="/netdata/127.0.0.1"
-                            data-common-max="traffic"
-                            data-common-min="traffic"
+                            data-common-max="day"
+                            data-common-min="day"
                             data-title="number of new registered devices during the past day"
                             data-chart-library="dygraph"
                             data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
                             data-height="200px"
-                            data-after="-300"></div>
+                            data-after="-86400"
+                            data-decimal-digits="0"></div>
                         </div>
                     </div>
                     <div class="row-fluid">
                         <div class="span[% spanSize %]">
                             <div data-netdata="statsd_gauge_source.packetfence.devices.registered_last_week"
                             data-host="/netdata/127.0.0.1"
-                            data-common-max="traffic"
-                            data-common-min="traffic"
+                            data-common-max="week"
+                            data-common-min="week"
                             data-title="number of new registered devices during the past week"
                             data-chart-library="dygraph"
                             data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
                             data-height="200px"
-                            data-after="-300"></div>
+                            data-after="-604800"
+                            data-decimal-digits="0"></div>
                         </div>
                         <div class="span[% spanSize %]">
                             <div data-netdata="statsd_gauge_source.packetfence.devices.registered_last_month"
                             data-host="/netdata/127.0.0.1"
-                            data-common-max="traffic"
-                            data-common-min="traffic"
+                            data-common-max="month"
+                            data-common-min="month"
                             data-title="number of new registered devices during the past month"
                             data-chart-library="dygraph"
                             data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
                             data-height="200px"
-                            data-after="-300"></div>
+                            data-after="-2592000"
+                            data-decimal-digits="0"></div>
                         </div>
                     </div>
                     <div class="row-fluid">
                         <div class="span[% spanSize %]">
                             <div data-netdata="statsd_gauge_source.packetfence.devices.registered_last_year"
                             data-host="/netdata/127.0.0.1"
-                            data-common-max="traffic"
-                            data-common-min="traffic"
+                            data-common-max="year"
+                            data-common-min="year"
                             data-title="number of new registered devices during the past year"
                             data-chart-library="dygraph"
                             data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
                             data-height="200px"
-                            data-after="-300"></div>
+                            data-after="-31536000"
+                            data-decimal-digits="0"></div>
                         </div>
                     </div>
                 </div>
@@ -553,7 +566,8 @@ END
                             data-chart-library="dygraph"
                             data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
                             data-height="200px"
-                            data-after="-300"></div>
+                            data-after="-3600"
+                            data-decimal-digits="0"></div>
                         </div>
                     </div>
                 </div>

--- a/html/pfappserver/root/graph/dashboard.tt
+++ b/html/pfappserver/root/graph/dashboard.tt
@@ -521,8 +521,18 @@ END
                 </div>
                 <div class="card-block">
                     <div class="row-fluid">
+                    [%
+                        SET sourcesSize = roles.size;
+                        IF sourcesSize == 1;
+                            SET spanSize = gridSize;
+                        ELSIF sourcesSize MOD 3 == 0;
+                            SET spanSize = gridSize / 3;
+                        ELSE;
+                            SET spanSize = gridSize / 2;
+                        END
+                    %]                    
                     [% FOREACH role IN roles %]
-                        <div class="span9">
+                        <div class="span[% spanSize %] text-center">
                             <div data-netdata="statsd_gauge_source.packetfence.devices.registered_per_role_[% role.name FILTER lower %]"
                             data-host="/netdata/127.0.0.1"
                             data-common-max="traffic"

--- a/html/pfappserver/root/graph/dashboard.tt
+++ b/html/pfappserver/root/graph/dashboard.tt
@@ -350,7 +350,7 @@ END
                             data-common-min="traffic"
                             data-title="number of successful radius authentications in the last day"
                             data-chart-library="dygraph"
-                            data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
+                            data-colors="[% palette(loop.index) %]"
                             data-height="200px"
                             data-after="-86400"
                             data-decimal-digits="0"></div>
@@ -362,7 +362,7 @@ END
                             data-common-min="traffic"
                             data-title="number of failed radius authentications in the last day"
                             data-chart-library="dygraph"
-                            data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
+                            data-colors="[% palette(loop.index) %]"
                             data-height="200px"
                             data-after="-86400"
                             data-decimal-digits="0"></div>
@@ -386,7 +386,7 @@ END
                             data-common-min="day"
                             data-title="number of dhcp leases free on [% interface %] for the past day"
                             data-chart-library="dygraph"
-                            data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
+                            data-colors="[% palette(loop.index) %]"
                             data-height="200px"
                             data-after="-86400"
                             data-decimal-digits="0"></div>
@@ -398,7 +398,7 @@ END
                             data-common-min="week"
                             data-title="number of dhcp leases free on [% interface %] for the past week"
                             data-chart-library="dygraph"
-                            data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
+                            data-colors="[% palette(loop.index) %]"
                             data-height="200px"
                             data-after="-604800"
                             data-decimal-digits="0"></div>
@@ -412,7 +412,7 @@ END
                             data-common-min="traffic"
                             data-title="number of dhcp leases free on [% interface %] for the past month"
                             data-chart-library="dygraph"
-                            data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
+                            data-colors="[% palette(loop.index) %]"
                             data-height="200px"
                             data-after="-2592000"
                             data-decimal-digits="0"></div>
@@ -424,7 +424,7 @@ END
                             data-common-min="year"
                             data-title="number of dhcp leases free on [% interface %] for the past year"
                             data-chart-library="dygraph"
-                            data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
+                            data-colors="[% palette(loop.index) %]"
                             data-height="200px"
                             data-after="-31536000"
                             data-decimal-digits="0"></div>                        
@@ -448,7 +448,7 @@ END
                             data-common-min="traffic"
                             data-title="total online devices for the past month"
                             data-chart-library="dygraph"
-                            data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
+                            data-colors="[% palette(loop.index) %]"
                             data-height="200px"
                             data-after="-2592000"
                             data-decimal-digits="0"></div>
@@ -460,7 +460,7 @@ END
                             data-common-min="traffic"
                             data-title="total offline devices for the past month"
                             data-chart-library="dygraph"
-                            data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
+                            data-colors="[% palette(loop.index) %]"
                             data-height="200px"
                             data-after="-2592000"
                             data-decimal-digits="0"></div>
@@ -481,7 +481,7 @@ END
                             data-common-min="traffic"
                             data-title="total number of devices currently registered"
                             data-chart-library="dygraph"
-                            data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
+                            data-colors="[% palette(loop.index) %]"
                             data-height="200px"
                             data-after="-3600"
                             data-decimal-digits="0"></div>
@@ -493,7 +493,7 @@ END
                             data-common-min="traffic"
                             data-title="total number of unregistered devices"
                             data-chart-library="dygraph"
-                            data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
+                            data-colors="[% palette(loop.index) %]"
                             data-height="200px"
                             data-after="-3600"
                             data-decimal-digits="0"></div>
@@ -507,7 +507,7 @@ END
                             data-common-min="traffic"
                             data-title="number of devices currently online and in the registration network"
                             data-chart-library="dygraph"
-                            data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
+                            data-colors="[% palette(loop.index) %]"
                             data-height="200px"
                             data-after="-3600"
                             data-decimal-digits="0"></div>
@@ -529,7 +529,7 @@ END
                             data-common-min="traffic"
                             data-title="total number of registered devices in role: [% role.name %]"
                             data-chart-library="dygraph"
-                            data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
+                            data-colors="[% palette(loop.index) %]"
                             data-height="200px"
                             data-after="-3600"
                             data-decimal-digits="0"></div>
@@ -555,7 +555,7 @@ END
                             data-common-min="hour"
                             data-title="number of new registered devices during the past hour"
                             data-chart-library="dygraph"
-                            data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
+                            data-colors="[% palette(loop.index) %]"
                             data-height="200px"
                             data-after="-3600"
                             data-decimal-digits="0"></div>
@@ -567,7 +567,7 @@ END
                             data-common-min="day"
                             data-title="number of new registered devices during the past day"
                             data-chart-library="dygraph"
-                            data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
+                            data-colors="[% palette(loop.index) %]"
                             data-height="200px"
                             data-after="-86400"
                             data-decimal-digits="0"></div>
@@ -581,7 +581,7 @@ END
                             data-common-min="week"
                             data-title="number of new registered devices during the past week"
                             data-chart-library="dygraph"
-                            data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
+                            data-colors="[% palette(loop.index) %]"
                             data-height="200px"
                             data-after="-604800"
                             data-decimal-digits="0"></div>
@@ -593,7 +593,7 @@ END
                             data-common-min="month"
                             data-title="number of new registered devices during the past month"
                             data-chart-library="dygraph"
-                            data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
+                            data-colors="[% palette(loop.index) %]"
                             data-height="200px"
                             data-after="-2592000"
                             data-decimal-digits="0"></div>
@@ -607,7 +607,7 @@ END
                             data-common-min="year"
                             data-title="number of new registered devices during the past year"
                             data-chart-library="dygraph"
-                            data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
+                            data-colors="[% palette(loop.index) %]"
                             data-height="200px"
                             data-after="-31536000"
                             data-decimal-digits="0"></div>
@@ -628,7 +628,7 @@ END
                             data-common-min="traffic"
                             data-title="number of currently open violations"
                             data-chart-library="dygraph"
-                            data-colors="#5D737E #6399B5 #BFE8FC #D8F2FF #FCFEFF"
+                            data-colors="[% palette(loop.index) %]"
                             data-height="200px"
                             data-after="-3600"
                             data-decimal-digits="0"></div>

--- a/lib/pfconfig/namespaces/config/Stats.pm
+++ b/lib/pfconfig/namespaces/config/Stats.pm
@@ -41,14 +41,41 @@ sub build_child {
     }
 
     foreach my $int (@{$self->{listen_ints}}) {
-        $tmp_cfg{"metric 'total dhcp leases remaining on $int'"} = {
+        $tmp_cfg{"metric 'total dhcp leases remaining on $int' past day"} = {
             'type' => 'api',
             'statsd_type' => 'gauge',
-            'statsd_ns' => 'source.packetfence.dhcp_leases_'.$int,
+            'statsd_ns' => 'source.packetfence.dhcp_leases_'.$int.'_day',
             'api_method' => 'GET',
             'api_path' => "/api/v1/dhcp/stats/$int",
             'api_compile' => '$[0].free',
-            'interval' => '60s',
+            'interval' => '24s',
+        };
+        $tmp_cfg{"metric 'total dhcp leases remaining on $int' past week"} = {
+            'type' => 'api',
+            'statsd_type' => 'gauge',
+            'statsd_ns' => 'source.packetfence.dhcp_leases_'.$int.'_week',
+            'api_method' => 'GET',
+            'api_path' => "/api/v1/dhcp/stats/$int",
+            'api_compile' => '$[0].free',
+            'interval' => '168s',
+        };
+        $tmp_cfg{"metric 'total dhcp leases remaining on $int' past month"} = {
+            'type' => 'api',
+            'statsd_type' => 'gauge',
+            'statsd_ns' => 'source.packetfence.dhcp_leases_'.$int.'_month',
+            'api_method' => 'GET',
+            'api_path' => "/api/v1/dhcp/stats/$int",
+            'api_compile' => '$[0].free',
+            'interval' => '720s',
+        };
+        $tmp_cfg{"metric 'total dhcp leases remaining on $int' past year"} = {
+            'type' => 'api',
+            'statsd_type' => 'gauge',
+            'statsd_ns' => 'source.packetfence.dhcp_leases_'.$int.'_year',
+            'api_method' => 'GET',
+            'api_path' => "/api/v1/dhcp/stats/$int",
+            'api_compile' => '$[0].free',
+            'interval' => '8760s',
         };
     }
 


### PR DESCRIPTION
# Description
Adds the statsd metrics to the admin dashboard
  - Endpoints
    - Online & Offline Devices
      - Total online devices for the past month
      - Total offline devices for the past month
    - Registered & Unregistered Devices
      - Total number of devices currently registered
      - Total number of unregistered devices
      - Number of devices currently online and in the registration network
    - Registered Devices Per Role (_[foreach node_category]_)
      - Total number of registered devices in role: _[foreach node_category]_
    - Registered Devices Per Timeframe
      - Number of new registered devices in the past hour
      - Number of new registered devices in the past day
      - Number of new registered devices in the past week
      - Number of new registered devices in the past month
      - Number of new registered devices in the past year
    - Device Violations
      - Number of currently open device violations
  - Authentication
    - Successful & Unsuccessful RADIUS Authentications
      - Number of successful RADIUS authentications in the last day
      - Number of unsuccessful RADIUS authentications in the last day
  - DHCP
    - DHCP on (_[foreach listen_ints]_)
      - Number of DHCP leases on _[foreach listen_ints]_ for the past day
      - Number of DHCP leases on _[foreach listen_ints]_ for the past week
      - Number of DHCP leases on _[foreach listen_ints]_ for the past month
      - Number of DHCP leases on _[foreach listen_ints]_ for the past year

# Issue
 * fixes #1981 
 * fixes #2924
 * fixes #3119 

# Delete branch after merge
YES

## Enhancements
* tweak SQL query for metric: _total number of registered devices per role_ in order to provide zero/empty metrics for unused roles.

## Bug Fixes
 * fixes #1981 
 * fixes #2924
 * fixes #3119 
