### PR TITLE
Use pfdhcp API to perform mac2ip + ip2mac

### DIFF
--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1499,3 +1499,30 @@ type=text
 description=<<EOT
 EAP-FAST authority ID
 EOT
+
+[pfdhcp.ip2mac_lookup]
+type=toggle
+options=enabled|disabled
+description=<<EOT
+Use the Unified API to query pfdhcp for the MAC address of a given IP address
+EOT
+
+[pfdhcp.mac2ip_lookup]
+type=toggle
+options=enabled|disabled
+description=<<EOT
+Use the Unified API to query pfdhcp for the IP address of a given MAC address
+EOT
+
+[pfdhcp.connect_timeout_ms]
+type=numeric
+description=<<EOT
+Timeout (in milliseconds) to connect to the Unified API when performing queries
+EOT
+
+[pfdhcp.timeout_ms]
+type=numeric
+description=<<EOT
+Timeout (in milliseconds) when performing queries to the Unified API
+EOT
+

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -1120,3 +1120,26 @@ eap_fast_opaque_key=0123456789abcdef0123456789ABCDEF
 #
 # EAP-FAST authority ID (Considered only if EAP-FAST is enabled)
 eap_fast_authority_identity=1234
+
+[pfdhcp]
+#
+# pfdhcp.ip2mac_lookup
+#
+# Use the Unified API to query pfdhcp for the MAC address of a given IP address
+ip2mac_lookup=enabled
+#
+# pfdhcp.mac2ip_lookup
+#
+# Use the Unified API to query pfdhcp for the IP address of a given MAC address
+mac2ip_lookup=enabled
+#
+# pfdhcp.connect_timeout_ms
+#
+# Timeout (in milliseconds) to connect to the Unified API when performing queries
+connect_timeout_ms=200
+#
+# pfdhcp.timeout_ms
+#
+# Timeout (in milliseconds) when performing queries to the Unified API
+timeout_ms=200
+

--- a/docs/api/spec/components/responses/dhcp.yaml
+++ b/docs/api/spec/components/responses/dhcp.yaml
@@ -3,7 +3,7 @@ DhcpMacIp:
   content:
     application/json:
       schema:
-        $ref: "#/components/schemas/DhcpMapIp"
+        $ref: "#/components/schemas/DhcpMacIp"
 
 DhcpInterfaceStats:
   description: A response that contains interface statistics

--- a/docs/api/spec/components/schemas/dhcp.yaml
+++ b/docs/api/spec/components/schemas/dhcp.yaml
@@ -2,16 +2,13 @@ DhcpMacIp:
     type: object
     description: The schema used when returning a DHCP MAC address and IPv4 address pair
     properties:
-        result:
-            type: object
-            description: A MAC address and IPv4 address pair
-            properties:
-                mac:
-                    type: string
-                    description: The MAC address
-                ip:
-                    type: string
-                    description: The IPv4 address
+      description: A MAC address and IPv4 address pair
+      mac:
+          type: string
+          description: The MAC address
+      ip:
+          type: string
+          description: The IPv4 address
 
 DhcpInterfaceStats:
     type: array
@@ -73,16 +70,13 @@ DhcpMacResponse:
     type: object
     description: The schema used when options are added or deleted from a MAC address
     properties:
-        result:
-            type: object
-            properties:
-                mac:
-                    type: string
-                    description: The MAC address
-                status:
-                    type: string
-                    description: Whether the request succeeded "ACK", or failed "NAK"
-                    enum: [ACK, NAK]
+      mac:
+          type: string
+          description: The MAC address
+      status:
+          type: string
+          description: Whether the request succeeded "ACK", or failed "NAK"
+          enum: [ACK, NAK]
 
 DhcpNetworkResponse:
     type: object

--- a/docs/api/spec/components/schemas/dhcp.yaml
+++ b/docs/api/spec/components/schemas/dhcp.yaml
@@ -82,13 +82,10 @@ DhcpNetworkResponse:
     type: object
     description: The schema used when options are added or deleted from a Network
     properties:
-        result:
-            type: object
-            properties:
-                network:
-                    type: string
-                    description: The networks IPv4 address
-                status:
-                    type: string
-                    description: Whether the request succeeded "ACK", or failed "NAK"
-                    enum: [ACK, NAK]
+        network:
+            type: string
+            description: The networks IPv4 address
+        status:
+            type: string
+            description: Whether the request succeeded "ACK", or failed "NAK"
+            enum: [ACK, NAK]

--- a/go/dhcp/api.go
+++ b/go/dhcp/api.go
@@ -196,13 +196,9 @@ func handleReleaseIP(res http.ResponseWriter, req *http.Request) {
 	vars := mux.Vars(req)
 	_ = InterfaceScopeFromMac(vars["mac"])
 
-	var result = map[string][]*Info{
-		"result": {
-			&Info{Mac: vars["mac"], Status: "ACK"},
-		},
-	}
+	var result = &Info{Mac: vars["mac"], Status: "ACK"},
 
-	res.Header().Set("Content-Type", "application/json; charset=UTF-8")
+		res.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	res.WriteHeader(http.StatusOK)
 	if err := json.NewEncoder(res).Encode(result); err != nil {
 		panic(err)
@@ -224,13 +220,9 @@ func handleOverrideOptions(res http.ResponseWriter, req *http.Request) {
 	// Insert information in etcd
 	_ = etcdInsert(vars["mac"], sharedutils.ConvertToString(body))
 
-	var result = map[string][]*Info{
-		"result": {
-			&Info{Mac: vars["mac"], Status: "ACK"},
-		},
-	}
+	var result = &Info{Mac: vars["mac"], Status: "ACK"},
 
-	res.Header().Set("Content-Type", "application/json; charset=UTF-8")
+		res.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	res.WriteHeader(http.StatusOK)
 	if err := json.NewEncoder(res).Encode(result); err != nil {
 		panic(err)
@@ -252,13 +244,9 @@ func handleOverrideNetworkOptions(res http.ResponseWriter, req *http.Request) {
 	// Insert information in etcd
 	_ = etcdInsert(vars["network"], sharedutils.ConvertToString(body))
 
-	var result = map[string][]*Info{
-		"result": {
-			&Info{Network: vars["network"], Status: "ACK"},
-		},
-	}
+	var result = &Info{Network: vars["network"], Status: "ACK"},
 
-	res.Header().Set("Content-Type", "application/json; charset=UTF-8")
+		res.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	res.WriteHeader(http.StatusOK)
 	if err := json.NewEncoder(res).Encode(result); err != nil {
 		panic(err)
@@ -269,19 +257,11 @@ func handleRemoveOptions(res http.ResponseWriter, req *http.Request) {
 
 	vars := mux.Vars(req)
 
-	var result = map[string][]*Info{
-		"result": {
-			&Info{Mac: vars["mac"], Status: "ACK"},
-		},
-	}
+	var result = &Info{Mac: vars["mac"], Status: "ACK"}
 
 	err := etcdDel(vars["mac"])
 	if !err {
-		result = map[string][]*Info{
-			"result": {
-				&Info{Mac: vars["mac"], Status: "NAK"},
-			},
-		}
+		result = &Info{Mac: vars["mac"], Status: "NAK"}
 	}
 	res.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	res.WriteHeader(http.StatusOK)
@@ -294,19 +274,11 @@ func handleRemoveNetworkOptions(res http.ResponseWriter, req *http.Request) {
 
 	vars := mux.Vars(req)
 
-	var result = map[string][]*Info{
-		"result": {
-			&Info{Network: vars["network"], Status: "ACK"},
-		},
-	}
+	var result = &Info{Network: vars["network"], Status: "ACK"}
 
 	err := etcdDel(vars["network"])
 	if !err {
-		result = map[string][]*Info{
-			"result": {
-				&Info{Network: vars["network"], Status: "NAK"},
-			},
-		}
+		result = &Info{Network: vars["network"], Status: "NAK"}
 	}
 	res.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	res.WriteHeader(http.StatusOK)

--- a/go/dhcp/api.go
+++ b/go/dhcp/api.go
@@ -196,9 +196,9 @@ func handleReleaseIP(res http.ResponseWriter, req *http.Request) {
 	vars := mux.Vars(req)
 	_ = InterfaceScopeFromMac(vars["mac"])
 
-	var result = &Info{Mac: vars["mac"], Status: "ACK"},
+	var result = &Info{Mac: vars["mac"], Status: "ACK"}
 
-		res.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	res.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	res.WriteHeader(http.StatusOK)
 	if err := json.NewEncoder(res).Encode(result); err != nil {
 		panic(err)
@@ -220,9 +220,9 @@ func handleOverrideOptions(res http.ResponseWriter, req *http.Request) {
 	// Insert information in etcd
 	_ = etcdInsert(vars["mac"], sharedutils.ConvertToString(body))
 
-	var result = &Info{Mac: vars["mac"], Status: "ACK"},
+	var result = &Info{Mac: vars["mac"], Status: "ACK"}
 
-		res.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	res.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	res.WriteHeader(http.StatusOK)
 	if err := json.NewEncoder(res).Encode(result); err != nil {
 		panic(err)
@@ -244,9 +244,9 @@ func handleOverrideNetworkOptions(res http.ResponseWriter, req *http.Request) {
 	// Insert information in etcd
 	_ = etcdInsert(vars["network"], sharedutils.ConvertToString(body))
 
-	var result = &Info{Network: vars["network"], Status: "ACK"},
+	var result = &Info{Network: vars["network"], Status: "ACK"}
 
-		res.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	res.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	res.WriteHeader(http.StatusOK)
 	if err := json.NewEncoder(res).Encode(result); err != nil {
 		panic(err)

--- a/go/dhcp/api.go
+++ b/go/dhcp/api.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/gorilla/mux"
 	"github.com/inverse-inc/packetfence/go/api-frontend/unifiedapierrors"
 	"github.com/inverse-inc/packetfence/go/pfconfigdriver"
@@ -79,7 +78,6 @@ func handleMac2Ip(res http.ResponseWriter, req *http.Request) {
 	vars := mux.Vars(req)
 
 	if index, expiresAt, found := GlobalMacCache.GetWithExpiration(vars["mac"]); found {
-		spew.Dump(expiresAt)
 		var node = &Node{Mac: vars["mac"], IP: index.(string), EndsAt: expiresAt}
 
 		outgoingJSON, err := json.Marshal(node)

--- a/lib/pf/CHI.pm
+++ b/lib/pf/CHI.pm
@@ -74,7 +74,7 @@ Hash::Merge::specify_behavior(
     'PF_CHI_MERGE'
 );
 
-our @CACHE_NAMESPACES = qw(configfilesdata configfiles httpd.admin httpd.portal pfdns switch.overlay ldap_auth fingerbank firewall_sso switch metadefender accounting clustering person_lookup route_int provisioning switch_distributed);
+our @CACHE_NAMESPACES = qw(configfilesdata configfiles httpd.admin httpd.portal pfdns switch.overlay ldap_auth fingerbank firewall_sso switch metadefender accounting clustering person_lookup route_int provisioning switch_distributed pfdhcp_api);
 
 our $chi_default_config = pf::IniFiles->new( -file => $chi_defaults_config_file) or die "Cannot open $chi_defaults_config_file";
 

--- a/lib/pf/constants/dhcp.pm
+++ b/lib/pf/constants/dhcp.pm
@@ -21,6 +21,10 @@ our @EXPORT_OK = qw($DEFAULT_LEASE_LENGTH);
 
 Readonly our $DEFAULT_LEASE_LENGTH => 86400;
 
+# The default timeouts for calling the DHCP API
+Readonly our $DHCP_API_DEFAULT_TIMEOUT => 500;
+Readonly our $DHCP_API_DEFAULT_CONNECT_TIMEOUT => 500;
+
 =head1 AUTHOR
 
 Inverse inc. <info@inverse.ca>

--- a/lib/pf/dhcp/api.pm
+++ b/lib/pf/dhcp/api.pm
@@ -27,6 +27,7 @@ use pf::log;
 use pf::cluster;
 use POSIX::AtFork;
 use pf::api::unifiedapiclient;
+use pf::config qw(%Config);
 
 our $VERSION = '0.01';
 my $default_client;
@@ -67,6 +68,8 @@ Perform a IP to MAC translation using the DHCP API
 =cut
 
 sub ip2mac {
+    my $timer = pf::StatsD::Timer->new();
+
     my ($self, $ip) = @_;
     my $logger = get_logger;
 
@@ -88,6 +91,8 @@ Perform a MAC to IP translation using the DHCP API
 =cut
 
 sub mac2ip {
+    my $timer = pf::StatsD::Timer->new();
+
     my ($self, $mac) = @_;
     my $logger = get_logger;
 
@@ -119,8 +124,8 @@ sub CLONE {
     $default_client->host($api_host);
 
     # Setting agressive timeouts
-    $default_client->unified_api_client->timeout_ms(500);
-    $default_client->unified_api_client->connect_timeout_ms(500);
+    $default_client->unified_api_client->timeout_ms($Config{pfdhcp}{timeout_ms});
+    $default_client->unified_api_client->connect_timeout_ms($Config{pfdhcp}{connect_timeout_ms});
 }
 POSIX::AtFork->add_to_child(\&CLONE);
 CLONE();

--- a/lib/pf/dhcp/api.pm
+++ b/lib/pf/dhcp/api.pm
@@ -104,7 +104,6 @@ sub CLONE {
     $default_client->unified_api_client(pf::api::unifiedapiclient->new);
     $default_client->host($api_host);
 
-    # Setting agressive timeouts
     $default_client->unified_api_client->timeout_ms($Config{pfdhcp}{timeout_ms});
     $default_client->unified_api_client->connect_timeout_ms($Config{pfdhcp}{connect_timeout_ms});
 }

--- a/lib/pf/dhcp/api.pm
+++ b/lib/pf/dhcp/api.pm
@@ -1,4 +1,5 @@
 package pf::dhcp::api;
+
 =head1 NAME
 
 pf::dhcp::api
@@ -15,7 +16,7 @@ Allows to access the pfdhcp API through the Unified API
 
     my $dhcp_api = pf::dhcp::api->new(host => 'localhost');
 
-    my $data = $dhcp_api->lookup({'ip-address' => "10.229.25.247" });
+    my $data = $dhcp_api->get_lease("ip", "10.229.25.247");
 
 =cut
 

--- a/lib/pf/dhcp/api.pm
+++ b/lib/pf/dhcp/api.pm
@@ -76,7 +76,7 @@ sub ip2mac {
         $mac = $res->{result}->{mac};
     };
     if($@) {
-        $logger->warn("Cannot get IP address for $mac through the pfdhcp API: $@");
+        $logger->warn("Cannot get IP address for $ip through the pfdhcp API: $@");
     }
     return $mac;
 }
@@ -117,6 +117,10 @@ sub CLONE {
     $default_client = pf::dhcp::api->new;
     $default_client->unified_api_client(pf::api::unifiedapiclient->new);
     $default_client->host($api_host);
+
+    # Setting agressive timeouts
+    $default_client->unified_api_client->timeout_ms(500);
+    $default_client->unified_api_client->connect_timeout_ms(500);
 }
 POSIX::AtFork->add_to_child(\&CLONE);
 CLONE();

--- a/lib/pf/dhcp/api.pm
+++ b/lib/pf/dhcp/api.pm
@@ -28,6 +28,7 @@ use pf::cluster;
 use POSIX::AtFork;
 use pf::api::unifiedapiclient;
 use pf::config qw(%Config);
+use pf::StatsD::Timer;
 
 our $VERSION = '0.01';
 my $default_client;
@@ -76,7 +77,7 @@ sub ip2mac {
     my $mac;
     eval {
         my $res = $self->unified_api_client->call("GET", "/api/v1/dhcp/ip/$ip");
-        $mac = $res->{result}->{mac};
+        $mac = $res->{mac};
     };
     if($@) {
         $logger->warn("Cannot get IP address for $ip through the pfdhcp API: $@");
@@ -99,7 +100,7 @@ sub mac2ip {
     my $ip;
     eval {
         my $res = $self->unified_api_client->call("GET", "/api/v1/dhcp/mac/$mac");
-        $ip = $res->{result}->{ip};
+        $ip = $res->{ip};
     };
     if($@) {
         $logger->warn("Cannot get IP address for $mac through the pfdhcp API: $@");

--- a/lib/pf/dhcp/api.pm
+++ b/lib/pf/dhcp/api.pm
@@ -1,0 +1,135 @@
+package pf::dhcp::api;
+=head1 NAME
+
+pf::dhcp::api
+
+=cut
+
+=head1 DESCRIPTION
+
+Allows to access the pfdhcp API through the Unified API
+
+=head1 SYNOPSIS
+
+    use pf::dhcp::api;
+
+    my $dhcp_api = pf::dhcp::api->new(host => 'localhost');
+
+    my $data = $dhcp_api->lookup({'ip-address' => "10.229.25.247" });
+
+=cut
+
+use strict;
+use warnings;
+use Moo;
+use MIME::Base64;
+use pf::log;
+use pf::cluster;
+use pf::api::unifiedapiclient;
+
+our $VERSION = '0.01';
+
+
+=head1 ATTRIBUTES
+
+=head2 host
+
+host of dhcp server
+
+=cut
+
+has host => (is => 'rw', default => sub  { 'localhost' });
+
+
+=head2 unified_api_client
+
+The Unified API client
+
+=cut
+
+has unified_api_client => (is => 'rw');
+
+=head2 ip2mac
+
+Perform a IP to MAC translation using the DHCP API
+
+=cut
+
+sub ip2mac {
+    my ($self, $ip) = @_;
+    my $logger = get_logger;
+
+    my $mac;
+    eval {
+        my $res = pf::api::unifiedapiclient->default_client->call("GET", "/api/v1/dhcp/ip/$ip");
+        $mac = $res->{result}->{mac};
+    };
+    if($@) {
+        $logger->warn("Cannot get IP address for $mac through the pfdhcp API: $@");
+    }
+    return $mac;
+}
+
+=head2 mac2ip
+
+Perform a MAC to IP translation using the DHCP API
+
+=cut
+
+sub mac2ip {
+    my ($self, $mac) = @_;
+    my $logger = get_logger;
+
+    my $ip;
+    eval {
+        my $res = pf::api::unifiedapiclient->default_client->call("GET", "/api/v1/dhcp/mac/$mac");
+        $ip = $res->{result}->{ip};
+    };
+    if($@) {
+        $logger->warn("Cannot get IP address for $mac through the pfdhcp API: $@");
+    }
+    return $ip;
+}
+
+=head2 get_client
+
+Get the default DHCP API client based on the configuration
+
+=cut
+
+sub get_client {
+    my ($class) = @_;
+    my $api_host = $cluster_enabled ? pf::cluster::management_cluster_ip : '127.0.0.1'; 
+    my $self = $class->new(host => $api_host);
+    $self->unified_api_client(pf::api::unifiedapiclient->default_client);
+    return $self;
+}
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2018 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and::or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;

--- a/lib/pf/ip4log.pm
+++ b/lib/pf/ip4log.pm
@@ -121,13 +121,12 @@ sub mac2ip {
 
     my $ip;
 
-    # TODO: replace by pfdhcp api call
-    # We first query OMAPI since it is the fastest way and more reliable source of info in most cases
-    #if ( isenabled($Config{omapi}{mac2ip_lookup}) ) {
-    #    $logger->debug("Trying to match IP address to MAC '$mac' using OMAPI");
-    #    $ip = _mac2ip_omapi($mac);
-    #    $logger->debug("Matched MAC '$mac' to IP address '$ip' using OMAPI") if $ip;
-    #}
+    # We first query the pfdhcp API since it is the fastest way and more reliable source of info in most cases
+    if ( isenabled($Config{pfdhcp}{mac2ip_lookup}) ) {
+        $logger->debug("Trying to match IP address to MAC '$mac' using the pfdhcp API");
+        $ip = _mac2ip_pfdhcp_api($mac);
+        $logger->debug("Matched MAC '$mac' to IP address '$ip' using the pfdhcp API") if $ip;
+    }
 
     # If we don't have a result from OMAPI, we use the SQL 'ip4log' table
     unless ($ip) {

--- a/lib/pf/ip4log.pm
+++ b/lib/pf/ip4log.pm
@@ -33,6 +33,7 @@ use pf::error qw(is_error is_success);
 use pf::log;
 use pf::node qw(node_add_simple node_exist);
 use pf::util;
+use pf::dhcp::api;
 
 use constant IP4LOG                         => 'ip4log';
 use constant IP4LOG_CACHE_EXPIRE            => 60;
@@ -65,13 +66,15 @@ sub ip2mac {
         return ( pf::util::clean_mac("00:11:22:33:44:55") );
     }
 
-    # TODO: replace by pfdhcp api call
-    # We first query OMAPI since it is the fastest way and more reliable source of info in most cases
-    #if ( isenabled($Config{omapi}{ip2mac_lookup}) ) {
-    #    $logger->debug("Trying to match MAC address to IP '$ip' using OMAPI");
-    #    $mac = _ip2mac_omapi($ip);
-    #    $logger->debug("Matched IP '$ip' to MAC address '$mac' using OMAPI") if $mac;
-    #}
+    # We first query the pfdhcp API since it is the fastest way and more reliable source of info in most cases
+    if ( isenabled($Config{pfdhcp}{ip2mac_lookup}) ) {
+        $logger->debug("Trying to match MAC address to IP '$ip' using the pfdhcp API");
+        my $res = _lookup_cached_pfdhcp_api("ip", $ip);
+        if(defined($res)) {
+            $mac = $res->{mac};
+            $logger->debug("Matched IP '$ip' to MAC address '$mac' using the pfdhcp API");
+        }
+    }
 
     # If we don't have a result from OMAPI, we use the SQL 'ip4log' table
     unless ($mac) {
@@ -124,8 +127,11 @@ sub mac2ip {
     # We first query the pfdhcp API since it is the fastest way and more reliable source of info in most cases
     if ( isenabled($Config{pfdhcp}{mac2ip_lookup}) ) {
         $logger->debug("Trying to match IP address to MAC '$mac' using the pfdhcp API");
-        $ip = _mac2ip_pfdhcp_api($mac);
-        $logger->debug("Matched MAC '$mac' to IP address '$ip' using the pfdhcp API") if $ip;
+        my $res = _lookup_cached_pfdhcp_api("mac", $mac);
+        if(defined($res)) {
+            $ip = $res->{ip};
+            $logger->debug("Matched MAC '$mac' to IP address '$ip' using the pfdhcp API");
+        }
     }
 
     # If we don't have a result from OMAPI, we use the SQL 'ip4log' table
@@ -634,6 +640,66 @@ sub _cleanup {
         $time_limit
     );
     return ($rows);
+}
+
+sub pfdhcp_cache {
+    return pf::CHI->new(namespace => "pfdhcp_api");
+}
+
+=head2 _lookup_cached_pfdhcp_api
+
+Will retrieve the lease from the cache or from the DHCP server using the pfdhcp API
+
+=cut
+
+sub _lookup_cached_pfdhcp_api {
+    my ($type, $id) = @_;
+    my $cache = pfdhcp_cache();
+    return $cache->compute(
+        "$type:$id",
+        {expire_if => \&_expire_lease, expires_in => IP4LOG_CACHE_EXPIRE},
+        sub {
+            get_logger->debug("Getting lease from the pfdhcp API");
+            my $data = _get_lease_from_pfdhcp_api($type, $id);
+            return unless $data;
+            #Do not return if the lease is expired
+            return if $data->{ends_at} < time;
+            return $data;
+        }
+    );
+}
+
+=head2 _get_lease_from_omapi
+
+Get the lease information using the pfdhcp API
+
+=cut
+
+sub _get_lease_from_pfdhcp_api {
+    my ($type,$id) = @_;
+    my $client = pf::dhcp::api->default_client();
+    return unless $client;
+    my $data;
+    eval {
+        $data = $client->get_lease($type, $id);
+    };
+    if($@) {
+        get_logger->error("$@");
+    }
+    return $data;
+}
+
+=head2 _expire_lease
+
+Check if the lease has expired
+
+=cut
+
+sub _expire_lease {
+    my ($cache_object) = @_;
+    my $lease = $cache_object->value;
+    return 1 unless defined $lease && defined $lease->{ends_at};
+    return $lease->{ends_at} < time;
 }
 
 =head1 AUTHOR


### PR DESCRIPTION
# Description
Allows to use the pfdhcp API for ip/mac lookups similarly to what we were doing with the OMAPI

# Impacts
IP/MAC lookups

# Issue
fixes #3133 

# Delete branch after merge
YES