### PR TITLE
Feature/dashboard redis queue

### DIFF
--- a/conf/monitoring/statsd.d/packetfence.conf.example
+++ b/conf/monitoring/statsd.d/packetfence.conf.example
@@ -52,3 +52,35 @@
     priority = 91000
     type = line
     dimension = pattern 'source.packetfence.devices.connected_per_ssid;*' '' last 1 1
+    type = stacked
+    dimension = pattern 'source.packetfence.devices.registered_per_role;*' '' last 1 1
+
+[redis.queue_stats_count]
+    name = redis.queue_stats_count
+    title = redis queue stats counters
+    family = packetfence
+    context = chart.context
+    units = count
+    priority = 91000
+    type = stacked
+    dimension = pattern 'source.packetfence.redis.queue_stats_count;*' '' last 1 1
+
+[redis.queue_stats_expired]
+    name = redis.queue_stats_expired
+    title = redis queue stats expired counters
+    family = packetfence
+    context = chart.context
+    units = expired
+    priority = 91000
+    type = stacked
+    dimension = pattern 'source.packetfence.redis.queue_stats_expired;*' '' last 1 1
+
+[redis.queue_stats_outstanding]
+    name = redis.queue_stats_outstanding
+    title = redis queue stats outstanding counters
+    family = packetfence
+    context = chart.context
+    units = outstanding
+    priority = 91000
+    type = stacked
+    dimension = pattern 'source.packetfence.redis.queue_stats_outstanding;*' '' last 1 1

--- a/conf/stats.conf.example
+++ b/conf/stats.conf.example
@@ -1,3 +1,33 @@
+[metric 'redis queue stats count']
+type=api
+statsd_type=gauge
+statsd_ns=source.packetfence.redis.queue_stats_count
+api_method=GET
+api_path=/api/v1/redis/queue/stats
+api_compile=$.items[*].queue, $.items[*].stats.count
+interval=60s
+randomize=true
+
+[metric 'redis queue stats expired']
+type=api
+statsd_type=gauge
+statsd_ns=source.packetfence.redis.queue_stats_expired
+api_method=GET
+api_path=/api/v1/redis/queue/stats
+api_compile=$.items[*].stats.expired[*].name, $.items[*].stats.expired[*].count
+interval=60s
+randomize=true
+
+[metric 'redis queue stats outstanding']
+type=api
+statsd_type=gauge
+statsd_ns=source.packetfence.redis.queue_stats_outstanding
+api_method=GET
+api_path=/api/v1/redis/queue/stats
+api_compile=$.items[*].stats.outstanding[*].name, $.items[*].stats.outstanding[*].count
+interval=60s
+randomize=true
+
 [metric 'total number of registered devices per role']
 type=mysql_query
 statsd_type=gauge

--- a/docs/api/spec/components/responses/redis.yaml
+++ b/docs/api/spec/components/responses/redis.yaml
@@ -1,0 +1,6 @@
+RedisQueueStats:
+  description: A response that contains the pfqueue stats
+  content:
+    application/json:
+      schema:
+        $ref: "#/components/schemas/RedisQueueStats"

--- a/docs/api/spec/components/schemas/redis.yaml
+++ b/docs/api/spec/components/schemas/redis.yaml
@@ -1,0 +1,43 @@
+RedisQueueStats:
+    type: array
+    description: The schema used for a collection of Redis queue stats
+    items:
+        type: object
+        description: Statistics of the Redis queue
+        properties:
+            queue:
+                type: string
+                description: The name of the queue
+            stats:
+                type: object
+                description: The statistics for the queue
+                properties:
+                    count:
+                        type: integer
+                        description: The queue count
+                    expired:
+                        type: array
+                        description: The collection of expired task counters
+                        items:
+                            type: object
+                            description: An expired task
+                            properties:
+                                count: 
+                                    type: integer
+                                    description: The expired task counter
+                                name: 
+                                    type: string
+                                    description: The name of the expired task
+                    outstanding:
+                        type: array
+                        description: The collection of outstanding task counters
+                        items:
+                            type: object
+                            description: An outstanding task
+                            properties:
+                                count: 
+                                    type: integer
+                                    description: The outstanding task counter
+                                name: 
+                                    type: string
+                                    description: The name of the outstanding task

--- a/docs/api/spec/paths/redis.yaml
+++ b/docs/api/spec/paths/redis.yaml
@@ -1,0 +1,6 @@
+/redis/queue/stats:
+    get:
+        description: Show stats of pfqueue
+        responses:
+            '200':
+                $ref: "#/components/responses/RedisQueueStats"

--- a/go/stats/metrics.go
+++ b/go/stats/metrics.go
@@ -273,7 +273,7 @@ func ProcessMetricConfig(ctx context.Context, conf pfconfigdriver.PfStats) error
  *         or 2x Xpaths separated with a comma (eg: $.items[0].somekey, $.item[0].somevalue)
  */
 func CompileJson(json interface{}, compile string) (interface{}, error) {
-	c := strings.Split(strings.Trim(compile, " "), ",")
+	c := strings.Split(compile, ",")
 	if len(c) > 1 {
 		// multiple XPath(s)
 		r1, err := CompileJson(json, c[0])
@@ -294,6 +294,7 @@ func CompileJson(json interface{}, compile string) (interface{}, error) {
 		return zipped, nil
 	}
 	//single Xpath
+	compile = strings.Trim(compile, " ")
 	p, err := jsonpath.Parse(compile)
 	if err != nil {
 		return nil, err

--- a/go/stats/metrics.go
+++ b/go/stats/metrics.go
@@ -206,6 +206,7 @@ func ProcessMetricConfig(ctx context.Context, conf pfconfigdriver.PfStats) error
 
 			case [][2]interface{}:
 				//double column
+                var namespace string
 				for _, row := range res.([][2]interface{}) {
 					namespace = CleanNameSpace(conf.StatsdNS + ";" + row[0].(string))
 					f64Result, _ := strconv.ParseFloat(row[1].(string), 64)
@@ -272,7 +273,7 @@ func ProcessMetricConfig(ctx context.Context, conf pfconfigdriver.PfStats) error
  *         or 2x Xpaths separated with a comma (eg: $.items[0].somekey, $.item[0].somevalue)
  */
 func CompileJson(json interface{}, compile string) (interface{}, error) {
-	c := strings.Split(strings.Trim(compile), ",")
+	c := strings.Split(strings.Trim(compile, " "), ",")
 	if len(c) > 1 {
 		// multiple XPath(s)
 		r1, err := CompileJson(json, c[0])

--- a/go/stats/metrics.go
+++ b/go/stats/metrics.go
@@ -270,7 +270,7 @@ func ProcessMetricConfig(ctx context.Context, conf pfconfigdriver.PfStats) error
  *
  *     Can be either:
  *         a single Xpath (eg: $.items[0].somevalue)
- *         or 2x Xpaths separated with a comma (eg: $.items[0].somekey, $.item[0].somevalue
+ *         or 2x Xpaths separated with a comma (eg: $.items[0].somekey, $.item[0].somevalue)
  */
 func CompileJson(json interface{}, compile string) (interface{}, error) {
 	c := strings.Split(compile, ",")

--- a/go/stats/metrics.go
+++ b/go/stats/metrics.go
@@ -206,7 +206,7 @@ func ProcessMetricConfig(ctx context.Context, conf pfconfigdriver.PfStats) error
 
 			case [][2]interface{}:
 				//double column
-                var namespace string
+				var namespace string
 				for _, row := range res.([][2]interface{}) {
 					namespace = CleanNameSpace(conf.StatsdNS + ";" + row[0].(string))
 					f64Result, _ := strconv.ParseFloat(row[1].(string), 64)

--- a/go/stats/metrics.go
+++ b/go/stats/metrics.go
@@ -69,7 +69,7 @@ func ProcessMetricConfig(ctx context.Context, conf pfconfigdriver.PfStats) error
 						namespace = conf.StatsdNS + ";NULL"
 
 					default:
-						namespace = conf.StatsdNS + ";" + strings.Replace(field.String, ":", ".", -1)
+						namespace = conf.StatsdNS + ";" + strings.Replace(field.String, ":", "_", -1)
 					}
 
 				default:
@@ -208,7 +208,7 @@ func ProcessMetricConfig(ctx context.Context, conf pfconfigdriver.PfStats) error
 				//double column
 				namespace := conf.StatsdNS
 				for _, row := range res.([][2]interface{}) {
-					namespace = conf.StatsdNS + ";" + strings.Replace(row[0].(string), ":", ".", -1)
+					namespace = conf.StatsdNS + ";" + strings.Replace(row[0].(string), ":", "_", -1)
 					f64Result, _ := strconv.ParseFloat(row[1].(string), 64)
 					switch conf.StatsdType {
 					case "count":

--- a/html/pfappserver/root/graph/dashboard.tt
+++ b/html/pfappserver/root/graph/dashboard.tt
@@ -126,6 +126,7 @@ END
                 [% IF listen_ints.size > 0 %]<li [% IF tab == "dhcp" %]class="active"[% END %]><a data-toggle="pill" href="#dhcp">DHCP</a></li>[% END %]
                 <li [% IF tab == "endpoints" %]class="active"[% END %]><a data-toggle="pill" href="#endpoints">[% l('Endpoints') %]</a></li>
                 <li [% IF tab == "portal" %]class="active"[% END %]><a data-toggle="pill" href="#portal">[% l('Portal') %]</a></li>
+                <li [% IF tab == "queue" %]class="active"[% END %]><a data-toggle="pill" href="#queue">[% l('Queue') %]</a></li>
             </ul>
         </div>
     </div>
@@ -975,5 +976,53 @@ END
                 </div>
             </div>
          </div>
+        <div class="tab-pane[% IF tab == "queue" %] active[% END %]" id="queue">
+            <div class="card">
+                <div class="card-title">
+                    <h2>[% l('Queue Counters') %]</h2>
+                </div>
+                <div class="card-block">
+                    <div class="row-fluid">
+                        <div class="span18 card">
+                            <div data-netdata="packetfence.redis.queue_stats_count"
+                            data-host="/netdata/127.0.0.1"
+                            data-title="PFQueue Stats Counters"
+                            data-hide-missing="true"
+                            data-chart-library="dygraph"
+                            data-colors="[% palette(0) %]"
+                            data-height="200px"
+                            data-after="-3600"
+                            data-decimal-digits="0"></div>
+                        </div>
+                    </div>
+                    <div class="row-fluid">
+                        <div class="span18 card">
+                            <div data-netdata="packetfence.redis.queue_stats_expired"
+                            data-host="/netdata/127.0.0.1"
+                            data-title="PFQueue Stats Expired"
+                            data-hide-missing="true"
+                            data-chart-library="dygraph"
+                            data-colors="[% palette(0) %]"
+                            data-height="200px"
+                            data-after="-3600"
+                            data-decimal-digits="0"></div>
+                        </div>
+                    </div>
+                    <div class="row-fluid">
+                        <div class="span18 card">
+                            <div data-netdata="packetfence.redis.queue_stats_outstanding"
+                            data-host="/netdata/127.0.0.1"
+                            data-title="PFQueue Stats Outstanding"
+                            data-hide-missing="true"
+                            data-chart-library="dygraph"
+                            data-colors="[% palette(0) %]"
+                            data-height="200px"
+                            data-after="-3600"
+                            data-decimal-digits="0"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
 </div>

--- a/lib/pf/UnifiedApi.pm
+++ b/lib/pf/UnifiedApi.pm
@@ -242,6 +242,16 @@ our @API_V1_ROUTES = (
             subroutes => undef,
         },
     },
+    {
+        controller => 'Redis',
+        collection => {
+            subroutes    => {
+                'queue' => {
+                    get => 'queue'
+                },
+            },
+        },
+    }
 );
 
 sub startup {

--- a/lib/pf/UnifiedApi.pm
+++ b/lib/pf/UnifiedApi.pm
@@ -246,11 +246,12 @@ our @API_V1_ROUTES = (
         controller => 'Redis',
         collection => {
             subroutes    => {
-                'queue/stats' => {
+                'queue' => {
                     get => 'queue'
                 },
             },
         },
+        resource => undef,
     }
 );
 

--- a/lib/pf/UnifiedApi.pm
+++ b/lib/pf/UnifiedApi.pm
@@ -246,7 +246,7 @@ our @API_V1_ROUTES = (
         controller => 'Redis',
         collection => {
             subroutes    => {
-                'queue' => {
+                'queue/stats' => {
                     get => 'queue'
                 },
             },

--- a/lib/pf/UnifiedApi/Controller/Redis.pm
+++ b/lib/pf/UnifiedApi/Controller/Redis.pm
@@ -1,0 +1,76 @@
+package pf::UnifiedApi::Controller::Redis;
+
+=head1 NAME
+
+pf::UnifiedApi::Controller::Redis -
+
+=cut
+
+=head1 DESCRIPTION
+
+pf::UnifiedApi::Controller::Redis
+
+=cut
+
+use strict;
+use warnings;
+use Mojo::Base 'pf::UnifiedApi::Controller::RestRoute';
+use pf::pfqueue::stats;
+
+
+sub queue {
+    my ($self) = @_;
+    my $stats = pf::pfqueue::stats->new;
+    # build hashref
+    my %queue = ();
+    foreach my $item (@{ $stats->queue_counts }) {
+        $queue{$item->{name}} = { count => $item->{count}, outstanding => [], expired => [] };
+    }
+    foreach my $item (@{ $stats->counters }) {
+        push $queue{$item->{queue}}{outstanding}, { name => $item->{name}, count => $item->{count} };
+    }
+    foreach my $item (@{ $stats->miss_counters }) {
+        push $queue{$item->{queue}}{expired}, { name => $item->{name}, count => $item->{count} };
+    }
+    #build json
+    my $json = [];
+    while( my( $key, $value ) = each %queue ){
+        push $json, { queue => $key, stats => {
+            count => $value->{count},
+            expired => ( $value->{expired}->[0] ? $value->{expired} : undef ),
+            outstanding => ( $value->{outstanding}->[0] ? $value->{outstanding} : undef )
+        } };
+    }
+    
+    return $self->render(status => 200, json => $json);
+}
+
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2018 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;

--- a/lib/pf/UnifiedApi/Controller/Redis.pm
+++ b/lib/pf/UnifiedApi/Controller/Redis.pm
@@ -35,6 +35,8 @@ sub queue {
     #build json
     my $json = [];
     while( my( $key, $value ) = each %queue ){
+        # rebuild hash,
+        #   replace empty []'s w/ undef
         push $json, { queue => $key, stats => {
             count => $value->{count},
             expired => ( $value->{expired}->[0] ? $value->{expired} : undef ),
@@ -42,7 +44,7 @@ sub queue {
         } };
     }
     
-    return $self->render(status => 200, json => $json);
+    return $self->render(status => 200, json => { items => $json });
 }
 
 

--- a/lib/pf/UnifiedApi/Controller/Redis.pm
+++ b/lib/pf/UnifiedApi/Controller/Redis.pm
@@ -37,11 +37,7 @@ sub queue {
     while( my( $key, $value ) = each %queue ){
         # rebuild hash,
         #   replace empty []'s w/ undef
-        push $json, { queue => $key, stats => {
-            count => $value->{count},
-            expired => ( $value->{expired}->[0] ? $value->{expired} : undef ),
-            outstanding => ( $value->{outstanding}->[0] ? $value->{outstanding} : undef )
-        } };
+        push $json, { queue => $key, stats => $value };
     }
     
     return $self->render(status => 200, json => { items => $json });


### PR DESCRIPTION
# Description
 * Advance the capability of `pfstats`.
   * Add plural (1x or 2x only) JSON Xpaths for appending metric namespace based on results (mirror `type=mysql_query` capability)
   * Add support for multiple JSON Xpath results/rows (mirror `type=mysql_query` capability)
   * Minor `pfstats` bugfixes

# Issue
* Fixes #2981

# Delete branch after merge
YES

# NEWS file entries
* Add API endpoint `/redis/queue/stats`

## Bug Fixes
* Issue with Monitoring of the redis queues via monit (#2981) 