### PR TITLE
authorize.net using accept.js

### DIFF
--- a/html/captive-portal/content/billing/authorizenet.js
+++ b/html/captive-portal/content/billing/authorizenet.js
@@ -2,8 +2,6 @@
 
   var varsEl = $('#variables');
   var vars = JSON.parse(varsEl.html());
-console.log(vars);
-
 
   function sendPaymentDataToAnet() {
       var secureData = {}; authData = {}; cardData = {};
@@ -23,8 +21,6 @@ console.log(vars);
       authData.apiLoginID = vars.api_login_id;
       secureData.authData = authData;
 
-console.log(secureData);
-
       // Pass the card number and expiration date to Accept.js for submission to Authorize.Net.
       Accept.dispatchData(secureData, responseHandler);
 
@@ -35,10 +31,10 @@ console.log(secureData);
               for (var i = 0; i < response.messages.message.length; i++) {
                   console.log(response.messages.message[i].code + ": " + response.messages.message[i].text);
               }
-              alert("acceptJS library error!")
+              var $form = $('#payment-form');
+              $form.find('.payment-errors p').text('Unable to proceed with payment please contact your service provider');
+              $form.find('.payment-errors').removeClass('hide');
           } else {
-              console.log(response.opaqueData.dataDescriptor);
-              console.log(response.opaqueData.dataValue);
               processTransaction(response.opaqueData);
           }
       }

--- a/html/captive-portal/content/billing/authorizenet.js
+++ b/html/captive-portal/content/billing/authorizenet.js
@@ -13,6 +13,7 @@ console.log(vars);
       cardData.month = document.getElementById("monthID").value;
       cardData.year = document.getElementById("yearID").value;
       cardData.cardCode = document.getElementById("cardCodeID").value;
+      cardData.fullName = document.getElementById("name").value;
       secureData.cardData = cardData;
 
       // The Authorize.Net Client Key is used in place of the traditional Transaction Key. The Transaction Key

--- a/html/captive-portal/content/billing/authorizenet.js
+++ b/html/captive-portal/content/billing/authorizenet.js
@@ -1,0 +1,70 @@
+/* -*- Mode: javascript; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+
+  var varsEl = $('#variables');
+  var vars = JSON.parse(varsEl.html());
+console.log(vars);
+
+
+  function sendPaymentDataToAnet() {
+      var secureData = {}; authData = {}; cardData = {};
+
+      // Extract the card number, expiration date, and card code.
+      cardData.cardNumber = document.getElementById("cardNumberID").value;
+      cardData.month = document.getElementById("monthID").value;
+      cardData.year = document.getElementById("yearID").value;
+      cardData.cardCode = document.getElementById("cardCodeID").value;
+      secureData.cardData = cardData;
+
+      // The Authorize.Net Client Key is used in place of the traditional Transaction Key. The Transaction Key
+      // is a shared secret and must never be exposed. The Client Key is a public key suitable for use where
+      // someone outside the merchant might see it.
+      authData.clientKey = vars.public_client_key;
+      authData.apiLoginID = vars.api_login_id;
+      secureData.authData = authData;
+
+console.log(secureData);
+
+      // Pass the card number and expiration date to Accept.js for submission to Authorize.Net.
+      Accept.dispatchData(secureData, responseHandler);
+
+      // Process the response from Authorize.Net to retrieve the two elements of the payment nonce.
+      // If the data looks correct, record the OpaqueData to the console and call the transaction processing function.
+      function responseHandler(response) {
+          if (response.messages.resultCode === "Error") {
+              for (var i = 0; i < response.messages.message.length; i++) {
+                  console.log(response.messages.message[i].code + ": " + response.messages.message[i].text);
+              }
+              alert("acceptJS library error!")
+          } else {
+              console.log(response.opaqueData.dataDescriptor);
+              console.log(response.opaqueData.dataValue);
+              processTransaction(response.opaqueData);
+          }
+      }
+  }
+
+
+  function processTransaction(responseData) {
+      //create the form and attach to the document
+      var transactionForm = document.createElement("form");
+      transactionForm.setAttribute("method", "post");
+      transactionForm.setAttribute("action", "/billing/" + vars.id + "/verify");
+      document.body.appendChild(transactionForm);
+
+      //create form "input" elements corresponding to each parameter
+      dataDesc = document.createElement("input")
+      dataDesc.hidden = true;
+      dataDesc.value = responseData.dataDescriptor;
+      dataDesc.name = "dataDesc";
+      transactionForm.appendChild(dataDesc);
+
+      dataValue = document.createElement("input")
+      dataValue.hidden = true;
+      dataValue.value = responseData.dataValue;
+      dataValue.name = "dataValue";
+      transactionForm.appendChild(dataValue);
+
+      //submit the new form
+      transactionForm.submit();
+  }
+

--- a/html/captive-portal/lib/captiveportal.pm
+++ b/html/captive-portal/lib/captiveportal.pm
@@ -137,9 +137,9 @@ Return CSP (Content-Security-Policy) headers
 
 sub csp_server_headers {
     my ($c) = @_;
-    
+
     my $captive_portal_network_detection_ip = $Config{'captive_portal'}{'network_detection_ip'};
-    $c->response->header('Content-Security-Policy' => "default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self' http://$captive_portal_network_detection_ip/; style-src 'self'; font-src 'self';");
+    $c->response->header('Content-Security-Policy' => "default-src 'none'; script-src 'self' https://js.stripe.com https://jstest.authorize.net https://js.authorize.net; connect-src 'self'; img-src 'self' http://$captive_portal_network_detection_ip/; style-src 'self'; font-src 'self';");
 }
 
 =head2 user_cache

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/Billing.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/Billing.pm
@@ -343,6 +343,7 @@ sub confirm {
         billing => $billing,
         tier => $self->session->{tier},
         title => "Tier confirmation",
+        request_fields => $self->session->{request_fields},
     });
 }
 

--- a/html/captive-portal/templates/billing/confirm_AuthorizeNet.html
+++ b/html/captive-portal/templates/billing/confirm_AuthorizeNet.html
@@ -1,6 +1,6 @@
 [% INCLUDE 'billing/tier.html' %]
 
-<form>
+<form id="payment-form">
   <div class="payment-errors o-media o-media--error u-padding u-margin hide">
     <div class="o-media__img">[% flashIcon(level='error') %]</div>
     <p class="o-media__body"></p>

--- a/html/captive-portal/templates/billing/confirm_AuthorizeNet.html
+++ b/html/captive-portal/templates/billing/confirm_AuthorizeNet.html
@@ -20,7 +20,7 @@
 
       <div class="input-container">
         <label for="cardNumberID">[% i18n("Card Number") %]</label>
-        <input type="tel" id="cardNumberID" placeholder="5424000000000015" />
+        <input type="tel" id="cardNumberID" />
       </div>
 
       <div class="input-container">

--- a/html/captive-portal/templates/billing/confirm_AuthorizeNet.html
+++ b/html/captive-portal/templates/billing/confirm_AuthorizeNet.html
@@ -1,25 +1,60 @@
-[% INCLUDE billing/tier.html %]
+[% INCLUDE 'billing/tier.html' %]
 
-<form method="POST" action="https://test.authorize.net/gateway/transact.dll">
-  <input type="hidden" name="x_fp_hash" value="[% fp_hash %]">
-  <input type="hidden" name="x_fp_sequence" value="[% fp_sequence %]">
-  <input type="hidden" name="x_fp_timestamp" value="[% fp_timestamp %]">
-  <input type="hidden" name="x_version" value="3.1">
-  <input type="hidden" name="x_login" value="[% billing.api_login_id %]">
-  <input type="hidden" name="x_show_form" value="PAYMENT_FORM">
-  <input type="hidden" name="x_method" value="CC">
-  <input type="hidden" name="x_amount" value="[% tier.price %]">
-  <input type="hidden" name="x_test_request" value="Y" >
-  <input type="hidden" name="x_receipt_link_method" value="POST" >
-  <input type="hidden" name="x_receipt_link_text" value="Click here to get access" >
-  <input type="hidden" name="x_receipt_link_url" value="[% billing.verify_url %]" >
-  <!-- Display the payment button. -->
-  <div class="o-layout o-layout--center u-padding-bottom">
-    <div class="o-layout__item u-1/1 u-2/3@tablet u-3/5@desktop">
-      <button type="submit" name="submit" class="c-btn c-btn--primary u-1/1">
-        Checkout on Authorize.net
-      </button>
+<form>
+  <div class="payment-errors media media--error u-p u-m" style="display: none">
+    <div class="media__img">[% flashIcon(level='error') %]</div>
+    <p class="media__body"></p>
+  </div>
+
+  <div class="layout layout--center u-mt">
+    <div class="layout__item u-2/3 u-1/1-palm">
+
+      <div class="input-container">
+        <label for="name">Name on Card</label>
+        [% IF request_fields.defined(firstname) && request_fields.defined(lastname) %]
+        <input id="name" type="text" size="20" />
+        [% ELSE %]
+        <input id="name" type="text" size="20" value="[% request_fields.firstname %] [% request_fields.lastname %]"/>
+        [% END %]
+      </div>
+
+      <div class="input-container">
+        <label for="cardNumberID">Card Number</label>
+        <input type="tel" id="cardNumberID" placeholder="5424000000000015" />
+      </div>
+
+      <div class="input-container">
+        <label>Expiration (MM/YYYY)</label>
+        <input class="u-1/4" type="number" min="1" max="12" placeholder="MM" id="monthID" />
+        /
+        <input class="u-1/2" type="number" placeholder="YYYY" id="yearID" />
+      </div>
+
+      <div class="input-container">
+        <label for="cardCodeID">CVC</label>
+        <input type="text" size="4" placeholder="123" id="cardCodeID" />
+      </div>
+
+      <div class="u-mt">
+        <button type="button" id="submitButton" onclick="sendPaymentDataToAnet()" name="submit-btn" class="btn btn--full">
+          <div class="flag">
+            <div class="flag__img">[% svgIcon(id='ic_credit_card_black_24px',size='small') %]</div>
+            <p class="flag__body">[% i18n("Pay with Authorize.Net") %]</p>
+          </div>
+        </button>
+      </div>
     </div>
   </div>
+
 </form>
 
+<script type="text/javascript" src="[% billing.acceptjs_uri %]" charset="utf-8"></script>
+
+<script id="variables" type="text/json">
+{
+  "public_client_key": "[% billing.public_client_key %]",
+  "api_login_id": "[% billing.api_login_id %]",
+  "id": "[% billing.id %]"
+}
+</script>
+<script type="text/javascript" src="/content/billing/authorizenet.js"></script>

--- a/html/captive-portal/templates/billing/confirm_AuthorizeNet.html
+++ b/html/captive-portal/templates/billing/confirm_AuthorizeNet.html
@@ -1,16 +1,16 @@
 [% INCLUDE 'billing/tier.html' %]
 
 <form>
-  <div class="payment-errors media media--error u-p u-m" style="display: none">
-    <div class="media__img">[% flashIcon(level='error') %]</div>
-    <p class="media__body"></p>
+  <div class="payment-errors o-media o-media--error u-padding u-margin hide">
+    <div class="o-media__img">[% flashIcon(level='error') %]</div>
+    <p class="o-media__body"></p>
   </div>
 
-  <div class="layout layout--center u-mt">
-    <div class="layout__item u-2/3 u-1/1-palm">
+  <div class="o-layout o-layout--center u-margin-top">
+    <div class="o-layout__item u-1/1 u-2/3@tablet u-3/5@desktop">
 
       <div class="input-container">
-        <label for="name">Name on Card</label>
+        <label for="name">[% i18n("Name on Card") %]</label>
         [% IF request_fields.defined(firstname) && request_fields.defined(lastname) %]
         <input id="name" type="text" size="20" />
         [% ELSE %]
@@ -19,23 +19,23 @@
       </div>
 
       <div class="input-container">
-        <label for="cardNumberID">Card Number</label>
+        <label for="cardNumberID">[% i18n("Card Number") %]</label>
         <input type="tel" id="cardNumberID" placeholder="5424000000000015" />
       </div>
 
       <div class="input-container">
-        <label>Expiration (MM/YYYY)</label>
+        <label>[% i18n("Expiration (MM/YYYY)") %]</label>
         <input class="u-1/4" type="number" min="1" max="12" placeholder="MM" id="monthID" />
         /
         <input class="u-1/2" type="number" placeholder="YYYY" id="yearID" />
       </div>
 
       <div class="input-container">
-        <label for="cardCodeID">CVC</label>
+        <label for="cardCodeID">[% i18n("CVC") %]</label>
         <input type="text" size="4" placeholder="123" id="cardCodeID" />
       </div>
 
-      <div class="u-mt">
+      <div class="u-padding-vertical">
         <button type="button" id="submitButton" onclick="sendPaymentDataToAnet()" name="submit-btn" class="btn btn--full">
           <div class="flag">
             <div class="flag__img">[% svgIcon(id='ic_credit_card_black_24px',size='small') %]</div>

--- a/html/captive-portal/templates/billing/confirm_AuthorizeNet.html
+++ b/html/captive-portal/templates/billing/confirm_AuthorizeNet.html
@@ -12,9 +12,9 @@
       <div class="input-container">
         <label for="name">[% i18n("Name on Card") %]</label>
         [% IF request_fields.defined(firstname) && request_fields.defined(lastname) %]
-        <input id="name" type="text" size="20" />
-        [% ELSE %]
         <input id="name" type="text" size="20" value="[% request_fields.firstname %] [% request_fields.lastname %]"/>
+        [% ELSE %]
+        <input id="name" type="text" size="20" />
         [% END %]
       </div>
 

--- a/html/captive-portal/templates/billing/confirm_AuthorizeNet.html
+++ b/html/captive-portal/templates/billing/confirm_AuthorizeNet.html
@@ -37,10 +37,7 @@
 
       <div class="u-padding-vertical">
         <button type="button" id="submitButton" onclick="sendPaymentDataToAnet()" name="submit-btn" class="c-btn c-btn--primary u-1/1">
-          <div class="flag">
-            <div class="flag__img">[% svgIcon(id='ic_credit_card_black_24px',size='small') %]</div>
             [% i18n("Pay with Authorize.Net") %]
-          </div>
         </button>
       </div>
     </div>

--- a/html/captive-portal/templates/billing/confirm_AuthorizeNet.html
+++ b/html/captive-portal/templates/billing/confirm_AuthorizeNet.html
@@ -12,9 +12,9 @@
       <div class="input-container">
         <label for="name">[% i18n("Name on Card") %]</label>
         [% IF request_fields.defined(firstname) && request_fields.defined(lastname) %]
-        <input id="name" type="text" size="20" value="[% request_fields.firstname %] [% request_fields.lastname %]"/>
+        <input id="name" type="text" value="[% request_fields.firstname %] [% request_fields.lastname %]"/>
         [% ELSE %]
-        <input id="name" type="text" size="20" />
+        <input id="name" type="text"/>
         [% END %]
       </div>
 
@@ -32,14 +32,14 @@
 
       <div class="input-container">
         <label for="cardCodeID">[% i18n("CVC") %]</label>
-        <input type="text" size="4" placeholder="123" id="cardCodeID" />
+        <input type="text" size="4" placeholder="---" id="cardCodeID" />
       </div>
 
       <div class="u-padding-vertical">
-        <button type="button" id="submitButton" onclick="sendPaymentDataToAnet()" name="submit-btn" class="btn btn--full">
+        <button type="button" id="submitButton" onclick="sendPaymentDataToAnet()" name="submit-btn" class="c-btn c-btn--primary u-1/1">
           <div class="flag">
             <div class="flag__img">[% svgIcon(id='ic_credit_card_black_24px',size='small') %]</div>
-            <p class="flag__body">[% i18n("Pay with Authorize.Net") %]</p>
+            [% i18n("Pay with Authorize.Net") %]
           </div>
         </button>
       </div>

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source/AuthorizeNet.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source/AuthorizeNet.pm
@@ -20,24 +20,21 @@ extends 'pfappserver::Form::Config::Source::Billing';
 with 'pfappserver::Base::Form::Role::Help';
 
 has_field api_login_id => (
+    label => "API login ID",
     type => 'Text',
     required => 1,
-    # Default value needed for creating dummy source
-    default => '',
 );
 
 has_field transaction_key => (
+    label => "Transaction key",
     type => 'Text',
     required => 1,
-    # Default value needed for creating dummy source
 );
 
-has_field md5_hash => (
-    label => 'MD5 hash',
+has_field public_client_key => (
+    label => 'Public Client Key',
     type => 'Text',
     required => 1,
-    # Default value needed for creating dummy source
-    default => '',
 );
 
 has_field 'domains' =>
@@ -51,6 +48,11 @@ has_field 'domains' =>
    tags => { after_element => \&help,
              help => 'Comma separated list of domains that will be resolve with the correct IP addresses.' },
   );
+
+has_block definition => (
+    render_list => [qw(api_login_id transaction_key public_client_key domains currency test_mode send_email_confirmation)]
+);
+
 
 =head1 AUTHOR
 

--- a/lib/pf/Authentication/Source/AuthorizeNetSource.pm
+++ b/lib/pf/Authentication/Source/AuthorizeNetSource.pm
@@ -8,45 +8,55 @@ pf::Authentication::Source::AuthorizeNetSource
 
 =head1 DESCRIPTION
 
-pf::Authentication::Source::AuthorizeNetSource
+Object oriented class to interact with Authorize.Net payment gateway using Accept.js
 
 =cut
 
 use strict;
 use warnings;
 use Moose;
+
+use pf::Authentication::constants;
 use pf::config qw($default_pid $fqdn);
 use pf::constants qw($FALSE $TRUE);
-use pf::Authentication::constants;
-use pf::util;
 use pf::log;
-use WWW::Curl::Easy;
-use JSON::MaybeXS;
-use List::Util qw(first);
-use Digest::HMAC_MD5 qw(hmac_md5_hex);
-use Digest::MD5 qw(md5_hex);
-use Time::Local;
+use pf::util;
+
+use LWP::UserAgent;
+use XML::Simple;
 
 extends 'pf::Authentication::Source::BillingSource';
 with 'pf::Authentication::CreateLocalAccountRole';
 
-=head2 Attributes
 
-=head2 class
+=head2 Attributes
 
 =cut
 
-has '+class' => (default => 'billing');
+has '+class'            => (default => 'billing');
 
-has '+type' => (default => 'AuthorizeNet');
+has '+type'             => (default => 'AuthorizeNet');
 
-has 'api_login_id' => (is => 'rw', required => 1);
+has 'acceptjs_uri'      => (is => 'rw');
 
-has 'transaction_key' => (is => 'rw', required => 1);
+has 'acceptjs_prod_uri' => (is => 'rw', default => 'https://js.authorize.net/v1/Accept.js');
 
-has 'md5_hash' => (is => 'rw', required => 1);
+has 'acceptjs_test_uri' => (is => 'rw', default => 'https://jstest.authorize.net/v1/Accept.js');
 
-has 'domains' => (is => 'rw', required => 1, default => '*.authorize.net');
+has 'api_uri'           => (is => 'rw');
+
+has 'api_prod_uri'      => (is => 'rw', default => 'https://api.authorize.net/xml/v1/request.api');
+
+has 'api_test_uri'      => (is => 'rw', default => 'https://apitest.authorize.net/xml/v1/request.api');
+
+has 'api_login_id'      => (is => 'rw', required => 1);
+
+has 'transaction_key'   => (is => 'rw', required => 1);
+
+has 'public_client_key' => (is => 'rw', required => 1);
+
+has 'domains'           => (is => 'rw', required => 1, default => '*.authorize.net');
+
 
 =head2 prepare_payment
 
@@ -56,28 +66,12 @@ Prepare the payment from authorize.net
 
 sub prepare_payment {
     my ($self, $session, $tier, $params, $uri) = @_;
-    my $hash = {};
-    $self->_calculate_fingerpint_hash($hash,$tier);
-    return $hash;
+
+    $self->_set_uris();
+
+    return {};
 }
 
-=head2 _calculate_fingerpint_hash
-
-Calculate the fingerprint hash
-
-=cut
-
-sub _calculate_fingerpint_hash {
-    my ($self, $hash, $tier) = @_;
-    my $amount    = $tier->{price};
-    my $sequence  = time() + int(rand(10000));
-#    my $timestamp = timegm(localtime());
-    my $timestamp = time();
-    my $fingerprint = hmac_md5_hex($self->api_login_id . "^" . $sequence . "^" . $timestamp . "^" . $amount . "^", $self->transaction_key);
-    $hash->{fp_hash}      = $fingerprint;
-    $hash->{fp_sequence}  = $sequence;
-    $hash->{fp_timestamp} = $timestamp;
-}
 
 =head2 verify
 
@@ -88,15 +82,30 @@ Verify the payment from authorize.net
 sub verify {
     my ($self, $session, $parameters, $uri) = @_;
     my $logger = pf::log::get_logger;
-    my $md5_validation = md5_hex($self->md5_hash.$self->api_login_id.$parameters->{x_trans_id}.$parameters->{x_amount});
-    if(uc($md5_validation) eq $parameters->{x_MD5_Hash}){
-        $logger->info("Payment validation succeeded.");
+
+    use Data::Dumper; $logger->debug(Dumper($parameters));
+    my $error_message;
+
+    unless ( defined $parameters->{'dataValue'} ) {
+        $error_message = "No Payment Nonce found";
+        $logger->error($error_message);
+        die $error_message;
     }
-    else {
-        die "Payment validation failed.";
+
+    $self->_set_uris();
+
+    my $response = $self->process_transaction($parameters, $session->{'tier'});
+    $logger->debug("Authorize.Net response: ".Dumper($response));
+
+    unless ( $response->{'transactionResponse'}->{'responseCode'} == 1 ) {
+        my $msg = "Unable to process payment: ".$response->{transactionResponse}->{errors}->{error}->{errorTest};
+        $logger->error($msg);
+        die $msg ;
     }
+
     return {};
 }
+
 
 =head2 cancel
 
@@ -108,6 +117,71 @@ sub cancel {
     my ($self, $session, $parameters, $uri) = @_;
     return {};
 }
+
+
+=head2 _set_uris
+
+=cut
+
+sub _set_uris {
+    my ( $self ) = @_;
+    my $logger = pf::log::get_logger;
+
+    if ( $self->test_mode ) {
+        $logger->debug("Running in test mode");
+        $self->acceptjs_uri($self->acceptjs_test_uri);
+        $self->api_uri($self->api_test_uri);
+    }
+    else {
+        $logger->debug("Running in production mode");
+        $self->acceptjs_uri($self->acceptjs_prod_uri);
+        $self->api_uri($self->api_prod_uri);
+    }
+}
+
+=head2 process_transaction
+
+Process the transaction with Authorize.net using the amount and the payment nonce
+
+=cut
+
+sub process_transaction {
+    my ( $self, $params, $tier ) = @_;
+    my $logger = pf::log::get_logger;
+
+    my $api_login_id = $self->api_login_id;
+    my $transaction_key = $self->transaction_key;
+    my $currency = $self->currency;
+
+    my $transaction_xml = <<XMLREQUEST
+<?xml version="1.0" encoding="UTF-8"?>
+<createTransactionRequest xmlns="AnetApi/xml/v1/schema/AnetApiSchema.xsd">
+    <merchantAuthentication>
+        <name>$api_login_id</name>
+        <transactionKey>$transaction_key</transactionKey>
+    </merchantAuthentication>
+    <transactionRequest>
+        <transactionType>authCaptureTransaction</transactionType>
+        <amount>$tier->{'price'}</amount>
+        <currencyCode>$currency</currencyCode>
+        <payment>
+            <opaqueData>
+                <dataDescriptor>$params->{'dataDesc'}</dataDescriptor>
+                <dataValue>$params->{'dataValue'}</dataValue>
+            </opaqueData>
+        </payment>
+    </transactionRequest>
+</createTransactionRequest>
+XMLREQUEST
+;
+
+    my $ua = LWP::UserAgent->new;
+    my $response = $ua->post($self->api_uri, Content => $transaction_xml);
+
+    my $xml = new XML::Simple;
+    return $xml->XMLin($response->decoded_content(), NoAttr => 1);
+}
+
 
 =head1 AUTHOR
 
@@ -123,7 +197,7 @@ This program is free software; you can redistribute it and::or
 modify it under the terms of the GNU General Public License
 as published by the Free Software Foundation; either version 2
 of the License, or (at your option) any later version.
-
+    
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/lib/pf/Authentication/Source/AuthorizeNetSource.pm
+++ b/lib/pf/Authentication/Source/AuthorizeNetSource.pm
@@ -83,12 +83,11 @@ sub verify {
     my ($self, $session, $parameters, $uri) = @_;
     my $logger = pf::log::get_logger;
 
-    use Data::Dumper; $logger->debug(Dumper($parameters));
     my $error_message;
 
     unless ( defined $parameters->{'dataValue'} ) {
         $error_message = "No Payment Nonce found";
-        $logger->error($error_message);
+        $logger->warn($error_message);
         die $error_message;
     }
 
@@ -197,7 +196,7 @@ This program is free software; you can redistribute it and::or
 modify it under the terms of the GNU General Public License
 as published by the Free Software Foundation; either version 2
 of the License, or (at your option) any later version.
-    
+
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the

--- a/lib/pf/Authentication/Source/AuthorizeNetSource.pm
+++ b/lib/pf/Authentication/Source/AuthorizeNetSource.pm
@@ -98,7 +98,7 @@ sub verify {
     $logger->debug("Authorize.Net response: ".Dumper($response));
 
     unless ( $response->{'transactionResponse'}->{'responseCode'} == 1 ) {
-        my $msg = "Unable to process payment: ".$response->{transactionResponse}->{errors}->{error}->{errorTest};
+        my $msg = "Unable to process payment: ".$response->{transactionResponse}->{errors}->{error}->{errorText};
         $logger->error($msg);
         die $msg ;
     }


### PR DESCRIPTION
# Description
Switch Authorize.Net to the Accept.js method which has the whole flow done in the portal

# Impacts
Authorize.Net

# Delete branch after merge
YES

# NEWS file entries
## Enhancements
* Reworked the Authorize.Net integration to use the Accept.js method

# UPGRADE file entries

The payment flow of Authorize.Net has been changed so if you are using Authorize.Net, you will need to create a public key in Authorize.Net and configure it in all your Authorize.Net sources in order for payments to still work correctly.