### PR TITLE
Added Cisco WLC Wired authentication

### DIFF
--- a/lib/pf/Switch/Cisco/WLC.pm
+++ b/lib/pf/Switch/Cisco/WLC.pm
@@ -133,6 +133,8 @@ sub description { 'Cisco Wireless Controller (WLC)' }
 sub supportsWirelessDot1x { return $TRUE; }
 sub supportsWirelessMacAuth { return $TRUE; }
 sub supportsRoleBasedEnforcement { return $TRUE; }
+sub supportsWiredMacAuth { return $TRUE; }
+sub supportsWiredDot1x { return $TRUE; }
 
 # disabling special features supported by generic Cisco's but not on WLCs
 sub supportsSaveConfig { return $FALSE; }


### PR DESCRIPTION
# Description
New APs now have wired ports, thus added wired authentication capabilities to WLC.

# Impacts
Wired authentication on Cisco WLC

# Delete branch after merge
YES
