### PR TITLE
Update haproxy version to 1.8

### DIFF
--- a/addons/packages/packetfence.spec
+++ b/addons/packages/packetfence.spec
@@ -326,7 +326,7 @@ Requires: %{real_name}-pfcmd-suid = %{version}
 Requires: %{real_name}-config = %{version}-%{rev}%{?dist}
 Requires: %{real_name}-pfcmd-suid = %{version}-%{rev}%{?dist}
 %endif
-Requires: haproxy >= 1.6, keepalived >= 1.3.6
+Requires: haproxy >= 1.8, keepalived >= 1.3.6
 # CAUTION: we need to require the version we want for Fingerbank and ensure we don't want anything equal or above the next major release as it can add breaking changes
 Requires: fingerbank >= 4.0.0, fingerbank < 5.0.0
 Requires: perl(File::Tempdir)

--- a/conf/haproxy-db.conf.example
+++ b/conf/haproxy-db.conf.example
@@ -28,13 +28,7 @@ defaults
         timeout connect 5000
         timeout client 50000
         timeout server 50000
-        errorfile 400 %%os_path%%400.http
         errorfile 403 %%captiveportal_templates_path%%/rate-limiting.http
-        errorfile 408 %%os_path%%408.http
-        errorfile 500 %%os_path%%500.http
-        errorfile 502 %%os_path%%502.http
-        errorfile 503 %%os_path%%503.http
-        errorfile 504 %%os_path%%504.http
 
 frontend  main
     bind 127.0.0.1:3306

--- a/conf/haproxy-portal.conf.example
+++ b/conf/haproxy-portal.conf.example
@@ -39,13 +39,7 @@ defaults
         timeout connect 5000
         timeout client 50000
         timeout server 50000
-        errorfile 400 %%os_path%%400.http
         errorfile 403 %%captiveportal_templates_path%%/rate-limiting.http
-        errorfile 408 %%os_path%%408.http
-        errorfile 500 %%os_path%%500.http
-        errorfile 502 %%os_path%%502.http
-        errorfile 503 %%os_path%%503.http
-        errorfile 504 %%os_path%%504.http
 
 backend proxy
     option httpclose

--- a/conf/systemd/packetfence-haproxy-db.service
+++ b/conf/systemd/packetfence-haproxy-db.service
@@ -8,7 +8,7 @@ StartLimitBurst=3
 StartLimitInterval=10
 PIDFile=/usr/local/pf/var/run/haproxy-db.pid
 ExecStartPre=/usr/local/pf/bin/pfcmd service haproxy-db generateconfig
-ExecStart=/usr/sbin/haproxy-systemd-wrapper -f /usr/local/pf/var/conf/haproxy-db.conf -p /usr/local/pf/var/run/haproxy-db.pid
+ExecStart=/usr/sbin/haproxy -Ws -f /usr/local/pf/var/conf/haproxy-db.conf -p /usr/local/pf/var/run/haproxy-db.pid
 ExecReload=/bin/kill -USR2 $MAINPID
 Restart=on-failure
 

--- a/conf/systemd/packetfence-haproxy-db.service
+++ b/conf/systemd/packetfence-haproxy-db.service
@@ -4,6 +4,7 @@ Before=packetfence-httpd.portal.service packetfence-httpd.admin.service
 Wants=packetfence-config.service 
 
 [Service]
+Type=notify
 StartLimitBurst=3
 StartLimitInterval=10
 PIDFile=/usr/local/pf/var/run/haproxy-db.pid

--- a/conf/systemd/packetfence-haproxy-portal.service
+++ b/conf/systemd/packetfence-haproxy-portal.service
@@ -8,7 +8,7 @@ StartLimitBurst=3
 StartLimitInterval=10
 PIDFile=/usr/local/pf/var/run/haproxy-portal.pid
 ExecStartPre=/usr/local/pf/bin/pfcmd service haproxy-portal generateconfig
-ExecStart=/usr/sbin/haproxy-systemd-wrapper -f /usr/local/pf/var/conf/haproxy-portal.conf -p /usr/local/pf/var/run/haproxy-portal.pid
+ExecStart=/usr/sbin/haproxy -Ws -f /usr/local/pf/var/conf/haproxy-portal.conf -p /usr/local/pf/var/run/haproxy-portal.pid
 ExecReload=/bin/kill -USR2 $MAINPID
 Restart=on-failure
 

--- a/conf/systemd/packetfence-haproxy-portal.service
+++ b/conf/systemd/packetfence-haproxy-portal.service
@@ -4,6 +4,7 @@ Before=packetfence-httpd.portal.service packetfence-httpd.admin.service
 Wants=packetfence-config.service 
 
 [Service]
+Type=notify
 StartLimitBurst=3
 StartLimitInterval=10
 PIDFile=/usr/local/pf/var/run/haproxy-portal.pid

--- a/debian/control
+++ b/debian/control
@@ -123,7 +123,7 @@ Depends: ${misc:Depends}, vlan,
 # used by bin/pftest
  libio-interactive-perl,
 # cluster
- haproxy (>= 1.6), keepalived (>= 1.3.6), arping,
+ haproxy (>= 1.8), keepalived (>= 1.3.6), arping,
 # monitoring
  fping, python-mysqldb,
 # EAP TLS


### PR DESCRIPTION
# Description
Updated haproxy version up to 1.8
Better systemd support

# Impacts
Portal and db

# NEW Package(s) required
haproxy >= 1.8

# Delete branch after merge
YES

# NEWS file entries

## Enhancements
* Support for haproxy 1.8

