### PR TITLE
rework maintenance script to be able to patch golang binaries

### DIFF
--- a/addons/pf-maint.pl
+++ b/addons/pf-maint.pl
@@ -268,6 +268,7 @@ sub download_and_install_binaries {
 
         rename($binary_path, "$binary_path-pre-maintenance") or die "Cannot backup binary: $!\n";
         rename("$binary_path-maintenance-decrypted", $binary_path) or die "Cannot install binary: $!\n";
+        unlink("$binary_path-maintenance-encrypted") or warn "Couldn't delete temporary download file, everything will keep working but the stale file will still be there ($!)\n";
         chmod 0755, "$binary_path";
     }
 

--- a/addons/pf-maint.pl
+++ b/addons/pf-maint.pl
@@ -71,6 +71,7 @@ our @patchable_binaries = (
     "pfhttpd",
     "pfdns",
     "pfdhcp",
+    "pfstats",
 );
 
 GetOptions(

--- a/addons/pf-maint.pl
+++ b/addons/pf-maint.pl
@@ -260,7 +260,7 @@ sub accept_binary_patching {
 }
 
 sub install_binary_sign_key_if_needed {
-    my $rc = system("gpg --list-keys | grep $BINARIES_SIGN_KEY_ID");
+    my $rc = system("gpg --list-keys $BINARIES_SIGN_KEY_ID");
     if($rc != 0) {
         $rc = system("gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys $BINARIES_SIGN_KEY_ID");
         die "Cannot install signing key\n" if $rc != 0;

--- a/addons/pf-maint.pl
+++ b/addons/pf-maint.pl
@@ -270,6 +270,9 @@ sub download_and_install_binaries {
         rename("$binary_path-maintenance-decrypted", $binary_path) or die "Cannot install binary: $!\n";
         unlink("$binary_path-maintenance-encrypted") or warn "Couldn't delete temporary download file, everything will keep working but the stale file will still be there ($!)\n";
         chmod 0755, "$binary_path";
+        my ($login,$pass,$uid,$gid) = getpwnam('pf')
+            or die "pf not in passwd file";
+        chown $uid, $gid, $binary_path;
     }
 
     print "=" x 110 . "\n";

--- a/addons/pf-maint.pl
+++ b/addons/pf-maint.pl
@@ -109,7 +109,7 @@ our $BASE_GITHUB_URL =
 
 our $BASE_BINARIES_URL;
 if(-f "/etc/debian_version") {
-    print "WARNING: Patching of the Golang binaries is currently not supported on Debian\nYou can still apply the Perl patches\n";
+    $BASE_BINARIES_URL = "https://inverse.ca/downloads/PacketFence/debian";
 }
 else {
     $BASE_BINARIES_URL = "https://inverse.ca/downloads/PacketFence/CentOS7/binaries";

--- a/addons/pf-maint.pl
+++ b/addons/pf-maint.pl
@@ -117,6 +117,8 @@ else {
 
 our $BINARIES_DIRECTORY = "/usr/local/pf/bin";
 
+our $BINARIES_SIGN_KEY_ID = "A0030E2C";
+
 my $base = $BASE_COMMIT || get_base();
 
 die "Cannot base commit\n" unless $base;
@@ -142,6 +144,7 @@ apply_patch( $patch_data, $base, $head );
 
 if($BASE_BINARIES_URL) {
     accept_binary_patching() unless $NO_ASK;
+    install_binary_sign_key_if_needed();
     print "Downloading and replacing the binaries........\n";
     download_and_install_binaries();
 }
@@ -253,6 +256,14 @@ sub accept_binary_patching {
     chomp(my $yes_no = <STDIN>);
     if ($yes_no =~ /n/) {
         exit;
+    }
+}
+
+sub install_binary_sign_key_if_needed {
+    my $rc = system("gpg --list-keys | grep $BINARIES_SIGN_KEY_ID");
+    if($rc != 0) {
+        $rc = system("gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys $BINARIES_SIGN_KEY_ID");
+        die "Cannot install signing key\n" if $rc != 0;
     }
 }
 

--- a/addons/pf-maint.pl
+++ b/addons/pf-maint.pl
@@ -109,7 +109,7 @@ our $BASE_GITHUB_URL =
 
 our $BASE_BINARIES_URL;
 if(-f "/etc/debian_version") {
-    $BASE_BINARIES_URL = "https://somewhere-on-the-internet.com";
+    print "WARNING: Patching of the Golang binaries is currently not supported on Debian\nYou can still apply the Perl patches\n";
 }
 else {
     $BASE_BINARIES_URL = "https://inverse.ca/downloads/PacketFence/CentOS7/binaries";
@@ -140,9 +140,11 @@ save_patch( $patch_data, $base, $head );
 print "Applying the patch........\n";
 apply_patch( $patch_data, $base, $head );
 
-accept_binary_patching() unless $NO_ASK;
-print "Downloading and replacing the binaries........\n";
-download_and_install_binaries();
+if($BASE_BINARIES_URL) {
+    accept_binary_patching() unless $NO_ASK;
+    print "Downloading and replacing the binaries........\n";
+    download_and_install_binaries();
+}
 
 sub get_release_full {
     chomp( my $release = read_file( catfile( $PF_DIR, 'conf/pf-release' ) ) );


### PR DESCRIPTION
# Description
Allow to patch Golang binaries through the maintenance branch

# Impacts
Maintenance script

# Delete branch after merge
YES

# NEWS file entries
## Enhancements
* Can now patch the Golang binaries through the maintenance script (addons/pf-maint.pl)
