### PR TITLE
Max node per role under autoreg ,moved unreg on accounting stop on the connection profile and vlan filters enhancement

### DIFF
--- a/UPGRADE.asciidoc
+++ b/UPGRADE.asciidoc
@@ -1718,6 +1718,13 @@ Once completed, update the file /usr/local/pf/conf/currently-at to match the new
 Upgrading from a version prior to X.Y.Z
 ---------------------------------------
 
+Changes on unreg_on_accounting_stop parameter
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The global configuration parameter unreg_on_accounting_stop has been moved in the connection profile.
+So if you enabled it then make sure to enable it now in the connection profile.
+
+
 Database schema update (All linux distributions)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1144,13 +1144,6 @@ description=<<EOT
 Trigger Single-Sign-On (Firewall SSO) on dhcp
 EOT
 
-[advanced.unreg_on_accounting_stop]
-type=toggle
-options=enabled|disabled
-description=<<EOT
-Unregister the device on accounting stop
-EOT
-
 [advanced.record_accounting_in_sql]
 type=toggle
 options=enabled|disabled

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -825,11 +825,6 @@ sso_on_accounting=disabled
 # Trigger Single-Sign-On (Firewall SSO) on dhcp
 sso_on_dhcp=enabled
 #
-# advanced.unreg_on_accounting_stop
-#
-# Unregister the device on accounting stop
-unreg_on_accounting_stop=disabled
-#
 # advanced.record_accounting_in_sql
 #
 # Record the accounting data in the SQL tables.

--- a/conf/profiles.conf.defaults
+++ b/conf/profiles.conf.defaults
@@ -29,3 +29,4 @@ access_registration_when_registered=disabled
 device_registration=
 dpsk=disabled
 status=enabled
+unreg_on_acct_stop=disabled

--- a/html/pfappserver/lib/pfappserver/Form/Config/ProfileCommon.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/ProfileCommon.pm
@@ -40,7 +40,7 @@ The main definition block
 
 has_block 'definition' =>
   (
-    render_list => [qw(id description root_module status preregistration autoregister reuse_dot1x_credentials dot1x_recompute_role_from_portal dpsk default_psk_key)],
+    render_list => [qw(id description root_module status preregistration autoregister reuse_dot1x_credentials dot1x_recompute_role_from_portal dpsk default_psk_key unreg_on_acct_stop)],
   );
 
 =head2 captive_portal
@@ -228,6 +228,23 @@ has_field 'default_psk_key' =>
    label => 'Default PSK key',
    tags => { after_element => \&help,
              help => 'This is the default PSK key when you enable DPSK on this connection profile. The minimum length is eight characters.' },
+  );
+
+=head2 unreg_on_acct_stop
+
+Controls whether or not this connection profile will unregister a devices on accounting stop
+
+=cut
+
+has_field 'unreg_on_acct_stop' =>
+  (
+   type => 'Toggle',
+   label => 'Automatically deregister devices on accounting stop',
+   checkbox_value => 'enabled',
+   unchecked_value => 'disabled',
+   default => 'disabled',
+   tags => { after_element => \&help,
+             help => 'This activates automatic deregistation of devices for the profile if PacketFence receives a RADIUS accounting stop.' },
   );
 
 =head2 sources

--- a/lib/pf/Connection/Profile.pm
+++ b/lib/pf/Connection/Profile.pm
@@ -628,7 +628,7 @@ Deregister device on accounting stop
 
 sub unregOnAcctStop {
     my ($self) = @_;
-    return $self->{'_unreg_on_acct_stop'};
+    return isenabled($self->{'_unreg_on_acct_stop'});
 }
 
 =back

--- a/lib/pf/Connection/Profile.pm
+++ b/lib/pf/Connection/Profile.pm
@@ -618,6 +618,17 @@ Is DPSK is enable or not on this connection profile
 sub dpskEnabled {
     my ($self) = @_;
     return isenabled($self->{'_dpsk'});
+};
+
+=item unregOnAcctStop
+
+Deregister device on accounting stop
+
+=cut
+
+sub unregOnAcctStop {
+    my ($self) = @_;
+    return $self->{'_unreg_on_acct_stop'};
 }
 
 =back

--- a/lib/pf/api.pm
+++ b/lib/pf/api.pm
@@ -1387,7 +1387,7 @@ sub handle_accounting_metadata : Public {
         }
     }
     if ($RAD_REQUEST{'Acct-Status-Type'} == $ACCOUNTING::STOP){
-        if (pf::util::isenabled($pf::config::Config{advanced}{unreg_on_accounting_stop})) {
+        if (pf::Connection::ProfileFactory->instantiate($mac)->unregOnAcctStop()) {
             $client->notify("deregister_node", mac => $mac);
         }
     }

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -243,17 +243,17 @@ sub authorize {
     my $profile = pf::Connection::ProfileFactory->instantiate($args->{'mac'},$options);
     $args->{'profile'} = $profile; 
     
-    $args->{'autoreg'} = 0;
+    $args->{'autoreg'} = 'no';
     # should we auto-register? let's ask the VLAN object
     my ( $status, $status_msg );
     $do_auto_reg = $role_obj->shouldAutoRegister($args);
     if ($do_auto_reg) {
-        $args->{'autoreg'} = 1;
+        $args->{'autoreg'} = 'yes';
         %autoreg_node_defaults = $role_obj->getNodeInfoForAutoReg($args);
         $node_obj->merge(\%autoreg_node_defaults);
         $logger->debug("[$mac] auto-registering node");
         # automatic registration
-        $info{autoreg} = 1;
+        $info{autoreg} = 'yes';
         ($status, $status_msg) = pf::registration::setup_node_for_registration($node_obj, \%info);
         if (is_error($status)) {
             $logger->error("auto-registration of node failed $status_msg");

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -258,6 +258,7 @@ sub authorize {
         if (is_error($status)) {
             $logger->error("auto-registration of node failed $status_msg");
             $do_auto_reg = 0;
+	    $args->{'node_info'}->{'category'} = 'REJECT';
         }
     }
 

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -258,7 +258,8 @@ sub authorize {
         if (is_error($status)) {
             $logger->error("auto-registration of node failed $status_msg");
             $do_auto_reg = 0;
-	    $args->{'node_info'}->{'category'} = 'REJECT';
+            $RAD_REPLY_REF = [ $RADIUS::RLM_MODULE_USERLOCK, ('Reply-Message' => $status_msg) ];
+            goto CLEANUP;
         }
     }
 

--- a/lib/pf/registration.pm
+++ b/lib/pf/registration.pm
@@ -43,25 +43,14 @@ sub setup_node_for_registration {
     my ($node, $info) = @_;
     my $logger = get_logger();
     my $mac = $node->mac;
-    my $auto_registered = 0;
 
     my $status_msg = "";
     my $pid = $node->pid;
 
-    # if it's for auto-registration and mac is already registered, we are done
-    if ($info->{'autoreg'}) {
-        $node->autoreg('yes');
-        if ($node->status eq 'reg' ) {
-            return ($STATUS::OK, '');
-        }
-    }
-    else {
-    # do not check for max_node if it's for auto-register
-        if ( is_max_reg_nodes_reached($mac, $pid, $node->category, $node->category_id) ) {
-            $status_msg = "max nodes per pid met or exceeded";
-            $logger->error( "$status_msg - registration of $mac to $pid failed" );
-            return ($STATUS::PRECONDITION_FAILED, $status_msg);
-        }
+    if ( pf::node::is_max_reg_nodes_reached($mac, $pid, $node->category, $node->category_id) ) {
+        $status_msg = "max nodes per pid met or exceeded";
+        $logger->error( "$status_msg - registration of $mac to $pid failed" );
+        return ($STATUS::PRECONDITION_FAILED, $status_msg);
     }
     $node->status($STATUS_REGISTERED);
     $node->regdate(mysql_date());

--- a/lib/pf/role.pm
+++ b/lib/pf/role.pm
@@ -415,7 +415,7 @@ sub getRegisteredRole {
     # the role based on the rules defined in the different authentication sources.
     # FIRST HIT MATCH
     elsif ( defined $args->{'user_name'} && $args->{'connection_type'} && ($args->{'connection_type'} & $EAP) == $EAP ) {
-        if ( isdisabled($profile->dot1xRecomputeRoleFromPortal) ) {
+        if ( isdisabled($profile->dot1xRecomputeRoleFromPortal)  || $args->{'autoreg'} == 1) {
             $logger->info("Role has already been computed and we don't want to recompute it. Getting role from node_info" );
             $role = $args->{'node_info'}->{'category'};
         } else {

--- a/lib/pf/role.pm
+++ b/lib/pf/role.pm
@@ -415,7 +415,7 @@ sub getRegisteredRole {
     # the role based on the rules defined in the different authentication sources.
     # FIRST HIT MATCH
     elsif ( defined $args->{'user_name'} && $args->{'connection_type'} && ($args->{'connection_type'} & $EAP) == $EAP ) {
-        if ( isdisabled($profile->dot1xRecomputeRoleFromPortal)  || $args->{'autoreg'} == 1) {
+        if ( isdisabled($profile->dot1xRecomputeRoleFromPortal)  || $args->{'autoreg'} eq 'yes') {
             $logger->info("Role has already been computed and we don't want to recompute it. Getting role from node_info" );
             $role = $args->{'node_info'}->{'category'};
         } else {


### PR DESCRIPTION
# Description
Allow PacketFence to test MAx device allowed by role when autoregister
Moved unregister on accounting stop parameter on the connection profile
Allow a value return by the vlan filters to be dynamic.

# Impacts
Radius

# Delete branch after merge
YES

# NEWS file entries

## Enhancements
* Allow max node per role on autoregister
* Moved unregister on accounting stop parameter on the connection profile
* Vlan filters can be set to ${node_info.category} and it will return the current category of the device
