### PR TITLE
Fix/pfconfig lock timeout

### DIFF
--- a/go/caddy/pfconfig/pool.go
+++ b/go/caddy/pfconfig/pool.go
@@ -2,12 +2,13 @@ package caddypfconfig
 
 import (
 	"context"
-	"github.com/inverse-inc/packetfence/go/caddy/caddy"
-	"github.com/inverse-inc/packetfence/go/caddy/caddy/caddyhttp/httpserver"
-	"github.com/inverse-inc/packetfence/go/pfconfigdriver"
 	"net/http"
 	"sync"
 	"time"
+
+	"github.com/inverse-inc/packetfence/go/caddy/caddy"
+	"github.com/inverse-inc/packetfence/go/caddy/caddy/caddyhttp/httpserver"
+	"github.com/inverse-inc/packetfence/go/pfconfigdriver"
 )
 
 func init() {
@@ -33,8 +34,8 @@ type PoolHandler struct {
 
 // Middleware that ensures there is a read-lock on the pool during every request and released when the request is done
 func (h PoolHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
-	pfconfigdriver.PfconfigPool.ReadLock(r.Context())
-	defer pfconfigdriver.PfconfigPool.ReadUnlock(r.Context())
+	id := pfconfigdriver.PfconfigPool.ReadLock(r.Context())
+	defer pfconfigdriver.PfconfigPool.ReadUnlock(r.Context(), id)
 
 	// We launch the refresh job once, the first time a request comes in
 	// This ensures that the pool will run with a context that represents a request (log level for instance)

--- a/go/timedlock/rw_lock.go
+++ b/go/timedlock/rw_lock.go
@@ -1,0 +1,208 @@
+package timedlock
+
+import (
+	"fmt"
+	"runtime"
+	"sync"
+	"time"
+)
+
+var timerPool = &sync.Pool{}
+var chanPool = &sync.Pool{
+	New: func() interface{} {
+		return make(chan int)
+	},
+}
+
+type RWLock struct {
+	rwMutex      *sync.RWMutex
+	doneChans    map[uint64]chan int
+	internalLock *sync.Mutex
+
+	// A counter to track the amount of allocated locks for providing the next ID
+	c uint64
+
+	// When defined, failures in the locks will be sent to that channel
+	// Defaults to being nil, so it needs to be initialized
+	LockFailures chan uint64
+
+	// The timeout for Lock operations
+	Timeout time.Duration
+
+	// The timeout for RLock operations
+	RTimeout time.Duration
+
+	// Whether or not this should panic on timeouts
+	// Otherwise, it will just release the lock
+	Panic bool
+
+	// Whether or not the errors should be printed
+	PrintErrors bool
+
+	// tracks whether or not this is RW locked
+	isLocked bool
+}
+
+func NewRWLock() *RWLock {
+	return &RWLock{
+		rwMutex:      &sync.RWMutex{},
+		Timeout:      10 * time.Second,
+		RTimeout:     10 * time.Second,
+		internalLock: &sync.Mutex{},
+		Panic:        true,
+		PrintErrors:  false,
+	}
+}
+
+func (l *RWLock) getDoneChan() (uint64, chan int) {
+	l.internalLock.Lock()
+	defer l.internalLock.Unlock()
+
+	l.c++
+	u := l.c
+	if l.doneChans == nil {
+		l.doneChans = make(map[uint64]chan int)
+	}
+
+	if _, ok := l.doneChans[u]; ok {
+		panic(fmt.Sprintf("Done channel already exists for identifier %d", u))
+	}
+
+	c := chanPool.Get().(chan int)
+
+	l.doneChans[u] = c
+
+	return u, l.doneChans[u]
+}
+
+func (l *RWLock) deleteChan(id uint64) {
+	l.internalLock.Lock()
+	defer l.internalLock.Unlock()
+	chanPool.Put(l.doneChans[id])
+	delete(l.doneChans, id)
+}
+
+func (l *RWLock) sendDoneSig(id uint64) {
+	l.internalLock.Lock()
+	defer l.internalLock.Unlock()
+	l.doneChans[id] <- 1
+}
+
+func (l *RWLock) getTimer(d time.Duration) *time.Timer {
+	o := timerPool.Get()
+	if o == nil {
+		return time.NewTimer(d)
+	} else {
+		t := o.(*time.Timer)
+		t.Reset(d)
+		return t
+	}
+}
+
+func (l *RWLock) releaseTimer(t *time.Timer) {
+	t.Stop()
+	timerPool.Put(t)
+}
+
+func (l *RWLock) Lock() uint64 {
+	id, doneChan := l.getDoneChan()
+
+	stack := make([]uintptr, 20)
+	runtime.Callers(0, stack)
+
+	go func() {
+		timeoutTimer := l.getTimer(l.Timeout)
+		defer l.releaseTimer(timeoutTimer)
+		select {
+		case <-timeoutTimer.C:
+			l.internalLock.Lock()
+			if l.isLocked {
+				l.rwMutex.Unlock()
+			}
+			l.internalLock.Unlock()
+
+			l.handleTimeout(id, "Timeout obtaining or releasing lock that came from: \n", stack)
+		case <-doneChan:
+			timeoutTimer.Stop()
+			l.deleteChan(id)
+		}
+	}()
+
+	l.rwMutex.Lock()
+
+	l.internalLock.Lock()
+	l.isLocked = true
+	l.internalLock.Unlock()
+	return id
+}
+
+func (l *RWLock) Unlock(id uint64) {
+	l.sendDoneSig(id)
+	l.internalLock.Lock()
+	if l.isLocked {
+		l.rwMutex.Unlock()
+	}
+	l.isLocked = false
+	l.internalLock.Unlock()
+}
+
+func (l *RWLock) handleTimeout(id uint64, msg string, stack []uintptr) {
+	stackStr := ""
+	frames := runtime.CallersFrames(stack)
+	for {
+		frame, more := frames.Next()
+		if frame.Function == "" {
+			break
+		}
+		stackStr += fmt.Sprintf("%s\n\t%s:%d\n", frame.Function, frame.File, frame.Line)
+		if !more {
+			break
+		}
+	}
+
+	l.deleteChan(id)
+	if l.LockFailures != nil {
+		l.LockFailures <- id
+	}
+	msg = msg + stackStr
+	if l.Panic {
+		panic(msg)
+	} else if l.PrintErrors {
+		fmt.Println(msg)
+	}
+}
+
+func (l *RWLock) RLock() uint64 {
+	id, doneChan := l.getDoneChan()
+
+	stack := make([]uintptr, 20)
+	runtime.Callers(0, stack)
+
+	go func() {
+		timeoutTimer := l.getTimer(l.RTimeout)
+		defer l.releaseTimer(timeoutTimer)
+		select {
+		case <-timeoutTimer.C:
+
+			l.internalLock.Lock()
+			if l.isLocked {
+				l.rwMutex.Unlock()
+			}
+			l.internalLock.Unlock()
+
+			l.rwMutex.RUnlock()
+			l.handleTimeout(id, "Timeout obtaining or releasing read lock that came from: \n", stack)
+		case <-doneChan:
+			timeoutTimer.Stop()
+			l.deleteChan(id)
+		}
+	}()
+
+	l.rwMutex.RLock()
+	return id
+}
+
+func (l *RWLock) RUnlock(id uint64) {
+	l.sendDoneSig(id)
+	l.rwMutex.RUnlock()
+}

--- a/go/timedlock/rw_lock_test.go
+++ b/go/timedlock/rw_lock_test.go
@@ -1,0 +1,225 @@
+package timedlock
+
+import (
+	"fmt"
+	"math"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestRWLockLock(t *testing.T) {
+	{
+		l := NewRWLock()
+		l.Timeout = 100 * time.Millisecond
+
+		id := l.Lock()
+
+		if l.doneChans[id] == nil {
+			t.Error("Locking didn't create a done channel")
+		}
+
+		l.Unlock(id)
+
+		// Sleep for twice the timeout to make sure this will not panic
+		time.Sleep(200 * time.Millisecond)
+
+		if l.doneChans[id] != nil {
+			t.Error("Channel is still there even after unlocking")
+		}
+	}
+
+	{
+		l := NewRWLock()
+		l.Timeout = 100 * time.Millisecond
+		l.Panic = false
+		l.LockFailures = make(chan uint64)
+
+		id := l.Lock()
+
+		if l.doneChans[id] == nil {
+			t.Error("Locking didn't create a done channel")
+		}
+
+		// Sleep for twice the timeout
+		time.Sleep(200 * time.Millisecond)
+
+		select {
+		case failId := <-l.LockFailures:
+			if id != failId {
+				t.Error("ID from the LockFailures channel doesn't match")
+			}
+		case <-time.After(1 * time.Second):
+			t.Error("Couldn't detect failure via the LockFailures chan")
+		}
+
+		if l.doneChans[id] != nil {
+			t.Error("Channel is still there even after unlocking via a timeout")
+		}
+
+		// Should now be able to lock again
+		id2 := l.Lock()
+		l.Unlock(id2)
+
+		select {
+		case <-l.LockFailures:
+			t.Error("There was a lock failure but there shouldn't have been one")
+		case <-time.After(1 * time.Second):
+			// All good
+		}
+	}
+
+}
+
+func TestRWLockRLock(t *testing.T) {
+	{
+		l := NewRWLock()
+		l.RTimeout = 100 * time.Millisecond
+
+		id := l.RLock()
+
+		if l.doneChans[id] == nil {
+			t.Error("Locking didn't create a done channel")
+		}
+
+		l.RUnlock(id)
+
+		// Sleep for twice the timeout
+		time.Sleep(200 * time.Millisecond)
+
+		if l.doneChans[id] != nil {
+			t.Error("Channel is still there even after unlocking")
+		}
+	}
+
+	{
+		l := NewRWLock()
+		l.RTimeout = 100 * time.Millisecond
+
+		id1 := l.RLock()
+		id2 := l.RLock()
+
+		if l.doneChans[id1] == nil {
+			t.Error("Locking didn't create a done channel")
+		}
+		if l.doneChans[id2] == nil {
+			t.Error("Locking didn't create a done channel")
+		}
+
+		l.RUnlock(id1)
+		l.RUnlock(id2)
+
+		// Sleep for twice the timeout
+		time.Sleep(200 * time.Millisecond)
+
+		if l.doneChans[id1] != nil {
+			t.Error("Channel is still there even after unlocking")
+		}
+
+		if l.doneChans[id2] != nil {
+			t.Error("Channel is still there even after unlocking")
+		}
+	}
+
+	{
+		l := NewRWLock()
+		l.RTimeout = 100 * time.Millisecond
+		l.Panic = false
+		l.LockFailures = make(chan uint64)
+
+		id1 := l.RLock()
+		id2 := l.RLock()
+		fmt.Println(id2)
+
+		if l.doneChans[id1] == nil {
+			t.Error("Locking didn't create a done channel")
+		}
+		if l.doneChans[id2] == nil {
+			t.Error("Locking didn't create a done channel")
+		}
+
+		l.RUnlock(id1)
+
+		// Sleep for twice the timeout
+		time.Sleep(200 * time.Millisecond)
+
+		if l.doneChans[id1] != nil {
+			t.Error("Channel is still there even after unlocking")
+		}
+
+		select {
+		case failId := <-l.LockFailures:
+			if id2 != failId {
+				t.Error("ID from the LockFailures channel doesn't match")
+			}
+		case <-time.After(1 * time.Second):
+			t.Error("Couldn't detect failure via the LockFailures chan")
+		}
+
+		if l.doneChans[id2] != nil {
+			t.Error("Channel is still there even after timeout unlocking")
+		}
+
+	}
+}
+
+func TestRWLockMaxRestart(t *testing.T) {
+	l := NewRWLock()
+
+	l.c = math.MaxUint64 - 1
+
+	id := l.Lock()
+	if id != math.MaxUint64 {
+		t.Error("Wrong ID came out of the lock")
+	}
+	l.Unlock(id)
+
+	id = l.Lock()
+	// Should now go back to the beginning
+	if id != 0 {
+		t.Error("Wrong ID came out of the lock")
+	}
+	l.Unlock(id)
+}
+
+func TestRWLockOverflow(t *testing.T) {
+	l := NewRWLock()
+
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("Didn't recover an error when a non deleted channel ID was reused")
+			}
+		}()
+
+		id := l.Lock()
+		l.c = id - 1
+		l.Lock()
+	}()
+}
+
+func BenchmarkSyncRWMutex(b *testing.B) {
+	m := sync.RWMutex{}
+	for i := 0; i < b.N; i++ {
+		m.Lock()
+		m.Unlock()
+	}
+
+	for i := 0; i < b.N; i++ {
+		m.RLock()
+		m.RUnlock()
+	}
+}
+
+func BenchmarkRWLock(b *testing.B) {
+	m := NewRWLock()
+	for i := 0; i < b.N; i++ {
+		id := m.Lock()
+		m.Unlock(id)
+	}
+
+	for i := 0; i < b.N; i++ {
+		id := m.RLock()
+		m.RUnlock(id)
+	}
+}


### PR DESCRIPTION
# Description
Reworks the pfconfigpool to use the timedlock library that was made for the FB collector
Should be more resilient to failures and introduces read timeouts as well

# Impacts
All of pfconfig pool usage in Golang

# Issue
fixes #3148 

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* Reworked the pfconfig Golang driver to be more resilient to lock failures (#3148)
