### PR TITLE
Feature/detect transport change

### DIFF
--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -71,6 +71,14 @@ Will identify hostname changes and send an e-mail with these changes.
 This can help detect MAC spoofing.
 EOT
 
+[network.connection_type_change_detection]
+type=toggle
+options=enabled|disabled
+description=<<EOT
+Will identify if a device switches from wired to wireless (or the opposite) and send an e-mail with these changes.
+This can help detect MAC spoofing.
+EOT
+
 [network.dhcp_filter_by_message_types]
 type=hidden
 options=DHCPDISCOVER|DHCPOFFER|DHCPREQUEST|DHCPDECLINE|DHCPACK|DHCPNAK|DHCPRELEASE|DHCPINFORM

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -56,6 +56,12 @@ rogueinterval=10
 # This can help detect MAC spoofing.
 hostname_change_detection=disabled
 #
+# network.connection_type_change_detection
+#
+# Will identify if a device switches from wired to wireless (or the opposite) and send an e-mail with these changes.
+# This can help detect MAC spoofing.
+connection_type_change_detection=disabled
+#
 # network.dhcpoption82logger
 #
 # If enabled PacketFence will monitor DHCP option82 location-based information.

--- a/conf/violations.conf.defaults
+++ b/conf/violations.conf.defaults
@@ -142,6 +142,12 @@ trigger=internal::hostname_change
 actions=log
 enabled=Y
 
+[1100014]
+desc=Connection transport change
+trigger=internal::connection_type_change
+actions=log
+enabled=Y
+
 #
 #  1200000 - 120099 Reserved for required administration violations
 #

--- a/html/pfappserver/lib/pfappserver/I18N/en.po
+++ b/html/pfappserver/lib/pfappserver/I18N/en.po
@@ -11560,3 +11560,6 @@ msgstr "Actions"
 
 msgid "multi_source_ids"
 msgstr "Sources"
+
+msgid "network.connection_type_change_detection"
+msgstr "Detect changes in connection type"

--- a/lib/pf/constants/trigger.pm
+++ b/lib/pf/constants/trigger.pm
@@ -61,6 +61,7 @@ Readonly::Scalar our $TRIGGER_MAP => {
     "1100010" => "Rogue DHCP detection",
     "new_dhcp_info" => "DHCP packet received",
     "hostname_change" => "Hostname changed",
+    "connection_type_change" => "Connection transport changed",
     "parking_detected" => "Parking detected",
     "node_discovered" => "Node discovered",
   },

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -144,9 +144,7 @@ sub authorize {
         $logger->debug("SSID resolved to: $ssid") if (defined($ssid));
     }
 
-    if (isenabled($Config{network}{connection_type_change_detection})) {
-        $self->checkConnectionTypeChange($mac, $connection);
-    }
+    $self->handleConnectionTypeChange($mac, $connection);
 
     {
         my $timer = pf::StatsD::Timer->new({ 'stat' => called() . ".getIfIndex", level => 7});
@@ -909,24 +907,11 @@ Detect if a device has changed its transport type (wired vs wireless) since a MA
 
 =cut
 
-sub checkConnectionTypeChange {
+sub handleConnectionTypeChange {
     my ($self, $mac, $current_connection) = @_;
-    my $locationlog = locationlog_view_open_mac($mac);
-    if($locationlog) {
-        my $old_connection = pf::Connection->new;
-        $old_connection->backwardCompatibleToAttributes($locationlog->{connection_type});
-        my $old_transport = $old_connection->transport;
-        my $current_transport = $current_connection->transport;
-        if($old_transport ne $current_transport) {
-            get_logger->info("Device transport has changed from $old_transport to $current_transport.");
-            violation_trigger( { 'mac' => $mac, 'tid' => "connection_type_change", 'type' => "internal" } );
-        }
-        else {
-            get_logger->debug("Device transport hasn't changed ($old_transport)");
-        }
-    } 
-    else {
-        get_logger->debug("Not performing connection type change detection for this device since there is no previously opened locationlog entry");
+    if (isenabled($Config{network}{connection_type_change_detection})) {
+        my $client = pf::api::queue->new(queue => "general");
+        $client->notify("detect_connection_type_transport_change", $mac, $current_connection);
     }
 }
 


### PR DESCRIPTION
# Description
Allow to detect a change between wired and wireless connection for the same MAC

# Impacts
RADIUS

# Issue
fixes #2540 

# Delete branch after merge
YES

# NEWS file entries
## New Features
* Added ability to trigger a violation when detecting a change of network transport (wired vs wireless) for a single MAC address