### PR TITLE
feature/jsonrpc-tenant-id

### DIFF
--- a/lib/pf/WebAPI/JSONRPC.pm
+++ b/lib/pf/WebAPI/JSONRPC.pm
@@ -17,6 +17,7 @@ use warnings;
 use JSON::MaybeXS;
 use pf::log;
 use pf::util::webapi;
+use pf::dal;
 use Apache2::RequestIO;
 use Apache2::RequestRec;
 use Apache2::Response;
@@ -58,6 +59,7 @@ sub handler {
             $content_type,
         );
     }
+    pf::dal->reset_tenant();
     my $ref_type = ref $data;
     unless ($ref_type && $ref_type eq 'HASH') {
         get_logger->error("Invalid request");
@@ -69,7 +71,7 @@ sub handler {
         );
     }
 
-    my ($method, $id, $jsonrpc) = @{$data}{qw(method id jsonrpc)};
+    my ($method, $id, $jsonrpc, $tenant_id) = @{$data}{qw(method id jsonrpc tenant_id)};
     unless (defined $method) {
         get_logger->error("Invalid request, no method defined");
         return $self->send_response(
@@ -79,6 +81,10 @@ sub handler {
             $content_type,
         );
     }
+    if (defined $tenant_id) {
+        pf::dal->set_tenant($tenant_id);
+    }
+
     my $dispatch_to = $self->dispatch_to;
     my $response_content = '';
     my $method_sub;

--- a/t/unittest/api/jsonrpcclient.t
+++ b/t/unittest/api/jsonrpcclient.t
@@ -1,0 +1,78 @@
+#!/usr/bin/perl
+
+=head1 NAME
+
+jsonrpcclient
+
+=cut
+
+=head1 DESCRIPTION
+
+unit test for jsonrpcclient
+
+=cut
+
+use strict;
+use warnings;
+#
+use lib '/usr/local/pf/lib';
+
+BEGIN {
+    #include test libs
+    use lib qw(/usr/local/pf/t);
+    #Module for overriding configuration paths
+    use setup_test_config;
+}
+
+use Test::More tests => 6;
+
+#This test will running last
+use Test::NoWarnings;
+use pf::api::jsonrpcclient;
+use JSON::MaybeXS;
+
+my $client = pf::api::jsonrpcclient->new;
+
+is($client->next_id, 0);
+is($client->next_id, 1);
+is($client->next_id, 2);
+
+is_deeply(
+    decode_json($client->build_jsonrpc_request("method", 1)),
+    {method => "method", jsonrpc=>"2.0", params=>1, id => 3, tenant_id => 1}
+);
+
+is_deeply(
+    decode_json($client->build_jsonrpc_notification("method", 1)),
+    {method => "method", jsonrpc=>"2.0", params=>1, tenant_id => 1}
+);
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2018 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;
+


### PR DESCRIPTION
Description
===========
pf::api::jsonrpc requests need to take the current tenant into consideration

Impacts
=======
httpd.webservices

Issue
=====
Fixes #3271

Delete branch after merge
=========================
NO

NEWS file entries
=================

Bug Fixes
------------
* jsonrpc requests send the current tenant_id (#3271)