### PR TITLE
Sync step names with tab names

### DIFF
--- a/docs/PacketFence_Installation_Guide.asciidoc
+++ b/docs/PacketFence_Installation_Guide.asciidoc
@@ -230,8 +230,8 @@ First open PacketFence's configurator - you can access it from https://@ip_of_pa
 
  * Step 1 - Enforcement, choose 'RADIUS enforcement' - this will make PacketFence act as simple RADIUS server
  * Step 2 - Networks, make sure you define only one interface with the Management type. That network interface will be the one for which the Cisco 2960 access switch will talk to. The management interface of PacketFence and the Cisco 2960 should normally be in the same network. To set the interface to the Management type, click on the logical name to edit it
- * Step 3 - Database Configuration - provide the required information to properly create the PacketFence database
- * Step 4 - PacketFence Configuration - provide your domain name, DHCP servers list and other required information
+ * Step 3 - Database - provide the required information to properly create the PacketFence database
+ * Step 4 - PacketFence - provide your domain name, DHCP servers list and other required information
  * Step 5 - Administration - provide the PacketFence's admin username and password to be used
  * Step 6 - Fingerbank - provide your Fingerbank API key. Fingerbank is used to accurately identify Internet of Things (IoT) devices, medical devices, industrial and robotics equipment and more on your network. It is recommended to have a key for your PacketFence deployment. Without a Fingerbank API key, device profiling will not be available in PacketFence
  * Step 7 - Configuration - start all services.

--- a/html/pfappserver/lib/pfappserver/I18N/en.po
+++ b/html/pfappserver/lib/pfappserver/I18N/en.po
@@ -1990,11 +1990,8 @@ msgid "Dashboard"
 msgstr ""
 
 # html/pfappserver/root/graph/dashboard.tt
-msgid "Database"
-msgstr ""
-
 # html/pfappserver/root/configurator/database.tt
-msgid "Database Configuration"
+msgid "Database"
 msgstr ""
 
 # html/pfappserver/root/configuration/system_config.tt
@@ -4849,10 +4846,6 @@ msgstr "Provisioning - Read"
 # pf::admin_roles (Actions)
 msgid "PROVISIONING_UPDATE"
 msgstr "Provisioning - Update"
-
-# html/pfappserver/root/configurator/configuration.tt
-msgid "PacketFence Configuration"
-msgstr ""
 
 # html/pfappserver/lib/pfappserver/Form/Config/Source/Eduroam.pm
 msgid "PacketFence Eduroam RADIUS virtual server authentication listening port"

--- a/html/pfappserver/root/configurator/configuration.tt
+++ b/html/pfappserver/root/configurator/configuration.tt
@@ -9,7 +9,7 @@
         </div>
         <div class="span14">
           <div class="page-header">
-            <h1>[% l('PacketFence Configuration') %]
+            <h1>[% l('PacketFence') %]
             <small>[% l('Setup your NAC') %]</small></h1>
           </div>
         </div>

--- a/html/pfappserver/root/configurator/database.tt
+++ b/html/pfappserver/root/configurator/database.tt
@@ -40,7 +40,7 @@
         </div>
         <div class="span14">
           <div class="page-header">
-            <h1>[% l('Database Configuration') %]
+            <h1>[% l('Database') %]
             <small>[% l('Create a user in your MySQL server') %]</small></h1>
           </div>
         </div>


### PR DESCRIPTION
# Description
Having "Database" and "PacketFence" step names in place of "Database configuration" and "PacketFence configuration" in configurator.

# Impacts
- I18N
- Configurator

# Issue
fixes #3305

# Delete branch after merge
YES

## Bug Fixes
#3305
