### PR TITLE
Add haproxy-db frontend on management IP (cluster VIP)

### DIFF
--- a/conf/haproxy-db.conf.example
+++ b/conf/haproxy-db.conf.example
@@ -30,6 +30,12 @@ defaults
         timeout server 50000
         errorfile 403 %%captiveportal_templates_path%%/rate-limiting.http
 
+frontend  management_ip
+    bind %%active_active_ip%%:3306
+    mode tcp
+    option tcplog
+    default_backend             mysql
+
 frontend  main
     bind 127.0.0.1:3306
     mode tcp


### PR DESCRIPTION
# Description
Adds a new bind for the DB on the cluster virtual IP for direct remote access to the DB

# Impacts
haproxy-db

# Delete branch after merge
YES

# NEWS file entries
## Enhancements
* The database load-balancer now listens on the cluster management IP address