### PR TITLE
Feature/pfconfigpool locking timeout

### DIFF
--- a/go/caddy/pfconfig/pool.go
+++ b/go/caddy/pfconfig/pool.go
@@ -34,8 +34,8 @@ type PoolHandler struct {
 
 // Middleware that ensures there is a read-lock on the pool during every request and released when the request is done
 func (h PoolHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
-	id, success := pfconfigdriver.PfconfigPool.ReadLock(r.Context())
-	if success {
+	id, err := pfconfigdriver.PfconfigPool.ReadLock(r.Context())
+	if err == nil {
 		defer pfconfigdriver.PfconfigPool.ReadUnlock(r.Context(), id)
 
 		// We launch the refresh job once, the first time a request comes in

--- a/go/caddy/pfconfig/pool.go
+++ b/go/caddy/pfconfig/pool.go
@@ -2,12 +2,13 @@ package caddypfconfig
 
 import (
 	"context"
-	"github.com/inverse-inc/packetfence/go/caddy/caddy"
-	"github.com/inverse-inc/packetfence/go/caddy/caddy/caddyhttp/httpserver"
-	"github.com/inverse-inc/packetfence/go/pfconfigdriver"
 	"net/http"
 	"sync"
 	"time"
+
+	"github.com/inverse-inc/packetfence/go/caddy/caddy"
+	"github.com/inverse-inc/packetfence/go/caddy/caddy/caddyhttp/httpserver"
+	"github.com/inverse-inc/packetfence/go/pfconfigdriver"
 )
 
 func init() {
@@ -33,20 +34,24 @@ type PoolHandler struct {
 
 // Middleware that ensures there is a read-lock on the pool during every request and released when the request is done
 func (h PoolHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
-	pfconfigdriver.PfconfigPool.ReadLock(r.Context())
-	defer pfconfigdriver.PfconfigPool.ReadUnlock(r.Context())
+	id, success := pfconfigdriver.PfconfigPool.ReadLock(r.Context())
+	if success {
+		defer pfconfigdriver.PfconfigPool.ReadUnlock(r.Context(), id)
 
-	// We launch the refresh job once, the first time a request comes in
-	// This ensures that the pool will run with a context that represents a request (log level for instance)
-	h.refreshLauncher.Do(func() {
-		ctx := r.Context()
-		go func(ctx context.Context) {
-			for {
-				pfconfigdriver.PfconfigPool.Refresh(ctx)
-				time.Sleep(1 * time.Second)
-			}
-		}(ctx)
-	})
+		// We launch the refresh job once, the first time a request comes in
+		// This ensures that the pool will run with a context that represents a request (log level for instance)
+		h.refreshLauncher.Do(func() {
+			ctx := r.Context()
+			go func(ctx context.Context) {
+				for {
+					pfconfigdriver.PfconfigPool.Refresh(ctx)
+					time.Sleep(1 * time.Second)
+				}
+			}(ctx)
+		})
 
-	return h.Next.ServeHTTP(w, r)
+		return h.Next.ServeHTTP(w, r)
+	} else {
+		panic("Unable to obtain pfconfigpool lock in caddy middleware")
+	}
 }

--- a/go/pfconfigdriver/pool.go
+++ b/go/pfconfigdriver/pool.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"sync"
 	"time"
 
 	"github.com/inverse-inc/packetfence/go/log"
+	"github.com/inverse-inc/packetfence/go/timedlock"
 )
 
 var PfconfigPool Pool
@@ -19,10 +19,7 @@ var PfconfigPool Pool
 type Pool struct {
 	refreshables []Refreshable
 	structs      map[string]interface{}
-	lock         *sync.RWMutex
-	// The time to wait for the lock for the refresh in ms
-	// Defaults to 1 seconds
-	RefreshLockTimeout time.Duration
+	lock         *timedlock.RWLock
 }
 
 // Init the default global pool when importing this package
@@ -38,8 +35,11 @@ type Refreshable interface {
 // Create a new Pool with a 1 second refresh timeout and initialize the lock
 func NewPool() Pool {
 	p := Pool{}
-	p.lock = &sync.RWMutex{}
-	p.RefreshLockTimeout = time.Duration(100 * time.Millisecond)
+	p.lock = timedlock.NewRWLock()
+	p.lock.Timeout = 1 * time.Second
+	p.lock.RTimeout = 1 * time.Second
+	p.lock.PrintErrors = true
+	p.lock.Panic = false
 	p.structs = make(map[string]interface{})
 	return p
 }
@@ -48,36 +48,39 @@ func NewPool() Pool {
 // All the goroutines that use resources from the pool should call this and release it when they are done
 // Long running processes should aim to retain this lock for the smallest time possible since Refresh will need a RW lock to refresh the resources
 // This lock can be acquired multiple times given its a read lock
-func (p *Pool) ReadLock(ctx context.Context) {
-	p.lock.RLock()
+func (p *Pool) ReadLock(ctx context.Context) (uint64, bool) {
+	return p.lock.RLock()
 }
 
 // Unlock the read lock
-func (p *Pool) ReadUnlock(ctx context.Context) {
-	p.lock.RUnlock()
+func (p *Pool) ReadUnlock(ctx context.Context, id uint64) {
+	p.lock.RUnlock(id)
 }
 
 // Add a refreshable resource to the pool
 // Requires the RW lock and will not timeout like Refresh does
 func (p *Pool) AddRefreshable(ctx context.Context, r Refreshable) {
-	p.lock.Lock()
-	defer p.lock.Unlock()
-
-	p.refreshables = append(p.refreshables, r)
-	r.Refresh(ctx)
+	id, success := p.lock.Lock()
+	if success {
+		defer p.lock.Unlock(id)
+		p.refreshables = append(p.refreshables, r)
+		r.Refresh(ctx)
+	}
 }
 
 // Add a struct to the pool
 // Requires the RW lock and will not timeout like Refresh does
 func (p *Pool) AddStruct(ctx context.Context, s interface{}) {
-	p.lock.Lock()
-	defer p.lock.Unlock()
+	id, success := p.lock.Lock()
+	if success {
+		defer p.lock.Unlock(id)
 
-	addr := fmt.Sprintf("%p", s)
-	log.LoggerWContext(ctx).Debug("Adding struct with address " + addr + " to the pool")
+		addr := fmt.Sprintf("%p", s)
+		log.LoggerWContext(ctx).Debug("Adding struct with address " + addr + " to the pool")
 
-	p.structs[addr] = s
-	p.refreshStruct(ctx, s)
+		p.structs[addr] = s
+		p.refreshStruct(ctx, s)
+	}
 }
 
 // Refresh all the refreshables of the pool
@@ -122,30 +125,20 @@ func (p *Pool) refreshStructs(ctx context.Context) {
 // Even if the timeout gets reached, the lock will still be acquired when available but it will be immediately released
 // This is done by sending a message twice in the timeoutChan, one will be caught by the main waiting goroutine, the other one by the lock-waiting goroutine
 // When the lock-waiting goroutine is able to get something out of the timeoutChan channel, it knows it must release the lock immediately
-func (p *Pool) acquireWriteLock(ctx context.Context) bool {
-	// timeoutChan has a capacity of 2 because it signals the timeout to the locking goroutine and the lock-waiting goroutine
-	timeoutChan := make(chan int, 2)
-	go func() {
-		time.Sleep(p.RefreshLockTimeout)
-		timeoutChan <- 1
+func (p *Pool) acquireWriteLock(ctx context.Context) (bool, uint64) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.LoggerWContext(ctx).Error("Couldn't acquire lock for pfconfig pool")
+		}
 	}()
 
-	lockChan := make(chan int, 1)
-	go func() {
-		p.lock.Lock()
-		lockChan <- 1
-	}()
-
-	select {
-	case <-lockChan:
-		log.LoggerWContext(ctx).Debug("Acquired lock for pfconfig pool")
-		return true
-	case <-timeoutChan:
-		log.LoggerWContext(ctx).Error("Couldn't acquire lock for pfconfig pool")
-		p.lock.Unlock()
-		return false
+	id, success := p.lock.Lock()
+	if !success {
+		panic("Couldn't acquire lock for pfconfig pool")
 	}
 
+	log.LoggerWContext(ctx).Debug("Acquired lock for pfconfig pool")
+	return success, id
 }
 
 // Refresh all the structs and resources of the pool using the RW lock
@@ -153,10 +146,16 @@ func (p *Pool) acquireWriteLock(ctx context.Context) bool {
 func (p *Pool) Refresh(ctx context.Context) bool {
 	log.LoggerWContext(ctx).Debug("Refreshing pfconfig pool")
 
-	if !p.acquireWriteLock(ctx) {
+	var locked bool
+	var id uint64
+	if locked, id = p.acquireWriteLock(ctx); !locked {
 		return false
 	}
-	defer p.lock.Unlock()
+	log.LoggerWContext(ctx).Debug("Refresh got lock ID", id)
+	defer func(ctx context.Context) {
+		log.LoggerWContext(ctx).Debug("Refresh is releasing lock ID", id)
+		p.lock.Unlock(id)
+	}(ctx)
 
 	p.refreshStructs(ctx)
 	p.refreshRefreshables(ctx)

--- a/go/pfconfigdriver/pool.go
+++ b/go/pfconfigdriver/pool.go
@@ -36,8 +36,8 @@ type Refreshable interface {
 func NewPool() Pool {
 	p := Pool{}
 	p.lock = timedlock.NewRWLock()
-	p.lock.Timeout = 1 * time.Second
-	p.lock.RTimeout = 1 * time.Second
+	p.lock.Timeout = 100 * time.Millisecond
+	p.lock.RTimeout = 100 * time.Millisecond
 	p.lock.PrintErrors = true
 	p.lock.Panic = false
 	p.structs = make(map[string]interface{})

--- a/go/timedlock/rw_lock.go
+++ b/go/timedlock/rw_lock.go
@@ -101,6 +101,7 @@ func (l *RWLock) Lock() (uint64, error) {
 				return id, nil
 			} else {
 				l.internalLock.Unlock()
+				time.Sleep(1 * time.Millisecond)
 			}
 		}
 

--- a/go/timedlock/rw_lock.go
+++ b/go/timedlock/rw_lock.go
@@ -8,19 +8,21 @@ import (
 )
 
 var timerPool = &sync.Pool{}
+var chanPool = &sync.Pool{
+	New: func() interface{} {
+		return make(chan int)
+	},
+}
 
 type RWLock struct {
-	rwlockChan chan uint64
-	rlockChan  chan uint64
-
+	doneChans    map[uint64]chan int
 	internalLock *sync.Mutex
+
+	lockChan  chan int
+	rlockChan chan int
 
 	// A counter to track the amount of allocated locks for providing the next ID
 	c uint64
-
-	// When defined, failures in the locks will be sent to that channel
-	// Defaults to being nil, so it needs to be initialized
-	LockFailures chan uint64
 
 	// The timeout for Lock operations
 	Timeout time.Duration
@@ -34,21 +36,25 @@ type RWLock struct {
 
 	// Whether or not the errors should be printed
 	PrintErrors bool
-
-	// Whether or not to enable output for debugging
-	Debug bool
 }
 
 func NewRWLock() *RWLock {
-	return &RWLock{
-		rwlockChan:   make(chan uint64, 1),
-		rlockChan:    make(chan uint64, 1024),
+	l := &RWLock{
+		lockChan: make(chan int, 1),
+		// TODO: change this magic number
+		rlockChan:    make(chan int, 1000),
 		Timeout:      10 * time.Second,
 		RTimeout:     10 * time.Second,
 		internalLock: &sync.Mutex{},
 		Panic:        true,
 		PrintErrors:  false,
+		c:            1,
 	}
+	l.lockChan <- 1
+	for i := 0; i < 1000; i++ {
+		l.rlockChan <- 1
+	}
+	return l
 }
 
 func (l *RWLock) getTimer(d time.Duration) *time.Timer {
@@ -67,123 +73,62 @@ func (l *RWLock) releaseTimer(t *time.Timer) {
 	timerPool.Put(t)
 }
 
-func (l *RWLock) getNextLockId() uint64 {
+func (l *RWLock) getNextId() uint64 {
 	l.internalLock.Lock()
 	defer l.internalLock.Unlock()
 	l.c++
+	// 0 isn't an acceptable ID
+	if l.c == 0 {
+		l.c++
+	}
 	return l.c
 }
 
-func (l *RWLock) isLocked() bool {
-	l.internalLock.Lock()
-	defer l.internalLock.Unlock()
-	return l.isLockedUnsafe()
-}
+func (l *RWLock) Lock() uint64 {
+	id := l.getNextId()
+	stopAt := time.Now().Add(l.Timeout)
+	timeoutTimer := l.getTimer(l.Timeout)
+	defer l.releaseTimer(timeoutTimer)
 
-func (l *RWLock) isLockedUnsafe() bool {
-	return len(l.rwlockChan) > 0
-}
-
-func (l *RWLock) isRLocked() bool {
-	l.internalLock.Lock()
-	defer l.internalLock.Unlock()
-	return l.isRLockedUnsafe()
-}
-
-func (l *RWLock) isRLockedUnsafe() bool {
-	return len(l.rlockChan) > 0
-}
-
-func (l *RWLock) obtainExclusiveRLock(id uint64) bool {
-	exChan := make(chan uint64, 1)
-	go func() {
-		start := time.Now()
-		for {
-			if !time.Now().Before(start.Add(l.Timeout)) {
-				return
-			}
-
-			if !l.isRLockedUnsafe() {
-				// We don't give a lot of time for this to happen
-				// If the exChan isn't ready to receive, that means the timeout has hit
-				timeoutTimer := l.getTimer(1 * time.Millisecond)
-				defer l.releaseTimer(timeoutTimer)
-
-				select {
-				case exChan <- 1:
-				case <-timeoutTimer.C:
-				}
-				return
+	select {
+	case <-timeoutTimer.C:
+		l.handleTimeout(id, "Timeout obtaining or releasing lock that came from: \n")
+		return 0
+	case <-l.lockChan:
+		timeoutTimer.Stop()
+		for time.Now().Before(stopAt) {
+			l.internalLock.Lock()
+			// TODO: magic number
+			if len(l.rlockChan) == 1000 {
+				l.internalLock.Unlock()
+				return id
 			} else {
+				l.internalLock.Unlock()
 			}
 		}
-	}()
 
-	timeoutTimer := l.getTimer(l.Timeout)
-	defer l.releaseTimer(timeoutTimer)
-	select {
-	case <-timeoutTimer.C:
-		if l.Debug {
-			fmt.Println("Failed to obtain the exclusive RLock", id)
-		}
-		return false
-	case <-exChan:
-		timeoutTimer.Stop()
-		return true
+		l.lockChan <- 1
+		l.handleTimeout(id, "Timeout obtaining or releasing lock that came from: \n")
 	}
-}
-
-func (l *RWLock) Lock() (uint64, bool) {
-	id := l.getNextLockId()
-
-	timeoutTimer := l.getTimer(l.Timeout)
-	defer l.releaseTimer(timeoutTimer)
-
-	l.internalLock.Lock()
-	defer l.internalLock.Unlock()
-
-	select {
-	case <-timeoutTimer.C:
-		l.handleTimeout(id, "Timeout obtaining or releasing lock that came from, failed while waiting to obtain the RW lock: \n")
-		return id, false
-	case l.rwlockChan <- id:
-		timeoutTimer.Stop()
-		if l.obtainExclusiveRLock(id) {
-			if l.Debug {
-				fmt.Println("Locked", id)
-			}
-			return id, true
-		} else {
-			defer func() {
-				if l.Debug {
-					fmt.Println("Released failed lock", id)
-				}
-				<-l.rwlockChan
-			}()
-			l.handleTimeout(id, "Timeout obtaining or releasing lock that came from, failed while waiting for the RLocks to clear: \n")
-			return id, false
-		}
-	}
+	return 0
 }
 
 func (l *RWLock) Unlock(id uint64) {
 	l.internalLock.Lock()
 	defer l.internalLock.Unlock()
-	if len(l.rwlockChan) != 1 {
-		panic(fmt.Sprintf("Unlocking non-locked lock with ID %d", id))
-	}
-	chanId := <-l.rwlockChan
-	if id != chanId {
-		panic(fmt.Sprintf("Unmatched ID while unlocking. Expected %d and got %d", id, chanId))
-	}
-	if l.Debug {
-		fmt.Println("Unlocked", id)
+	if len(l.lockChan) != 0 {
+		panic("Unlock of unlocked mutex")
+	} else if id == 0 {
+		panic("Unlocking mutex with ID 0")
+	} else {
+		l.lockChan <- 1
 	}
 }
 
-func (l *RWLock) handleTimeout(id uint64, msg string) {
+func (l *RWLock) getStack() string {
 	stack := make([]uintptr, 20)
-	runtime.Callers(0, stack)
+	runtime.Callers(2, stack)
+
 	stackStr := ""
 	frames := runtime.CallersFrames(stack)
 	for {
@@ -191,16 +136,19 @@ func (l *RWLock) handleTimeout(id uint64, msg string) {
 		if frame.Function == "" {
 			break
 		}
-		stackStr += fmt.Sprintf("%d - %s\n\t%s:%d\n", id, frame.Function, frame.File, frame.Line)
+		stackStr += fmt.Sprintf("%s\n\t%s:%d\n", frame.Function, frame.File, frame.Line)
 		if !more {
 			break
 		}
 	}
 
-	if l.LockFailures != nil {
-		l.LockFailures <- id
-	}
-	msg = msg + stackStr
+	return stackStr
+}
+
+func (l *RWLock) handleTimeout(id uint64, msg string) {
+	stackStr := l.getStack()
+
+	msg = fmt.Sprintf("%d %s %s", id, msg, stackStr)
 	if l.Panic {
 		panic(msg)
 	} else if l.PrintErrors {
@@ -208,48 +156,41 @@ func (l *RWLock) handleTimeout(id uint64, msg string) {
 	}
 }
 
-func (l *RWLock) RLock() (uint64, bool) {
-	id := l.getNextLockId()
-
-	l.internalLock.Lock()
-	defer l.internalLock.Unlock()
-
-	exChan := make(chan uint64, 1)
-	go func() {
-		start := time.Now()
-		for {
-			if !time.Now().Before(start.Add(l.RTimeout)) {
-				return
-			}
-			if !l.isLockedUnsafe() {
-				// We don't give a lot of time for this to happen
-				// If the exChan isn't ready to receive, that means the timeout has hit
-				timeoutTimer := l.getTimer(1 * time.Millisecond)
-				defer l.releaseTimer(timeoutTimer)
-
-				select {
-				case exChan <- 1:
-				case <-timeoutTimer.C:
-				}
-				return
-			}
-		}
-	}()
-
+func (l *RWLock) RLock() uint64 {
+	id := l.getNextId()
 	timeoutTimer := l.getTimer(l.RTimeout)
 	defer l.releaseTimer(timeoutTimer)
+
 	select {
 	case <-timeoutTimer.C:
-		l.handleTimeout(id, "Timeout obtaining or releasing lock that came from: \n")
-		return id, false
-	case <-exChan:
-		timeoutTimer.Stop()
-		l.rlockChan <- id
-		return id, true
+		l.handleTimeout(id, "Timeout obtaining or releasing read lock that came from: \n")
+		return 0
+	case <-l.lockChan:
+		l.internalLock.Lock()
+		select {
+		case <-timeoutTimer.C:
+			l.lockChan <- 1
+			l.internalLock.Unlock()
+			l.handleTimeout(id, "Timeout obtaining or releasing read lock that came from: \n")
+			return 0
+		case <-l.rlockChan:
+			l.lockChan <- 1
+			timeoutTimer.Stop()
+			l.internalLock.Unlock()
+			return id
+		}
 	}
-
 }
 
 func (l *RWLock) RUnlock(id uint64) {
-	<-l.rlockChan
+	l.internalLock.Lock()
+	defer l.internalLock.Unlock()
+	// TODO: magic number
+	if len(l.rlockChan) >= 1000 {
+		panic("RUnlock of unlocked mutex")
+	} else if id == 0 {
+		panic("Unlocking mutex with ID 0")
+	} else {
+		l.rlockChan <- 1
+	}
 }

--- a/go/timedlock/rw_lock.go
+++ b/go/timedlock/rw_lock.go
@@ -8,14 +8,8 @@ import (
 )
 
 var timerPool = &sync.Pool{}
-var chanPool = &sync.Pool{
-	New: func() interface{} {
-		return make(chan int)
-	},
-}
 
 type RWLock struct {
-	doneChans    map[uint64]chan int
 	internalLock *sync.Mutex
 
 	lockChan  chan int
@@ -175,7 +169,6 @@ func (l *RWLock) RLock() uint64 {
 			return 0
 		case <-l.rlockChan:
 			l.lockChan <- 1
-			timeoutTimer.Stop()
 			l.internalLock.Unlock()
 			return id
 		}

--- a/go/timedlock/rw_lock.go
+++ b/go/timedlock/rw_lock.go
@@ -1,0 +1,255 @@
+package timedlock
+
+import (
+	"fmt"
+	"runtime"
+	"sync"
+	"time"
+)
+
+var timerPool = &sync.Pool{}
+
+type RWLock struct {
+	rwlockChan chan uint64
+	rlockChan  chan uint64
+
+	internalLock *sync.Mutex
+
+	// A counter to track the amount of allocated locks for providing the next ID
+	c uint64
+
+	// When defined, failures in the locks will be sent to that channel
+	// Defaults to being nil, so it needs to be initialized
+	LockFailures chan uint64
+
+	// The timeout for Lock operations
+	Timeout time.Duration
+
+	// The timeout for RLock operations
+	RTimeout time.Duration
+
+	// Whether or not this should panic on timeouts
+	// Otherwise, it will just release the lock
+	Panic bool
+
+	// Whether or not the errors should be printed
+	PrintErrors bool
+
+	// Whether or not to enable output for debugging
+	Debug bool
+}
+
+func NewRWLock() *RWLock {
+	return &RWLock{
+		rwlockChan:   make(chan uint64, 1),
+		rlockChan:    make(chan uint64, 1024),
+		Timeout:      10 * time.Second,
+		RTimeout:     10 * time.Second,
+		internalLock: &sync.Mutex{},
+		Panic:        true,
+		PrintErrors:  false,
+	}
+}
+
+func (l *RWLock) getTimer(d time.Duration) *time.Timer {
+	o := timerPool.Get()
+	if o == nil {
+		return time.NewTimer(d)
+	} else {
+		t := o.(*time.Timer)
+		t.Reset(d)
+		return t
+	}
+}
+
+func (l *RWLock) releaseTimer(t *time.Timer) {
+	t.Stop()
+	timerPool.Put(t)
+}
+
+func (l *RWLock) getNextLockId() uint64 {
+	l.internalLock.Lock()
+	defer l.internalLock.Unlock()
+	l.c++
+	return l.c
+}
+
+func (l *RWLock) isLocked() bool {
+	l.internalLock.Lock()
+	defer l.internalLock.Unlock()
+	return l.isLockedUnsafe()
+}
+
+func (l *RWLock) isLockedUnsafe() bool {
+	return len(l.rwlockChan) > 0
+}
+
+func (l *RWLock) isRLocked() bool {
+	l.internalLock.Lock()
+	defer l.internalLock.Unlock()
+	return l.isRLockedUnsafe()
+}
+
+func (l *RWLock) isRLockedUnsafe() bool {
+	return len(l.rlockChan) > 0
+}
+
+func (l *RWLock) obtainExclusiveRLock(id uint64) bool {
+	exChan := make(chan uint64, 1)
+	go func() {
+		start := time.Now()
+		for {
+			if !time.Now().Before(start.Add(l.Timeout)) {
+				return
+			}
+
+			if !l.isRLockedUnsafe() {
+				// We don't give a lot of time for this to happen
+				// If the exChan isn't ready to receive, that means the timeout has hit
+				timeoutTimer := l.getTimer(1 * time.Millisecond)
+				defer l.releaseTimer(timeoutTimer)
+
+				select {
+				case exChan <- 1:
+				case <-timeoutTimer.C:
+				}
+				return
+			} else {
+			}
+		}
+	}()
+
+	timeoutTimer := l.getTimer(l.Timeout)
+	defer l.releaseTimer(timeoutTimer)
+	select {
+	case <-timeoutTimer.C:
+		if l.Debug {
+			fmt.Println("Failed to obtain the exclusive RLock", id)
+		}
+		return false
+	case <-exChan:
+		timeoutTimer.Stop()
+		return true
+	}
+}
+
+func (l *RWLock) Lock() (uint64, bool) {
+	id := l.getNextLockId()
+
+	timeoutTimer := l.getTimer(l.Timeout)
+	defer l.releaseTimer(timeoutTimer)
+
+	l.internalLock.Lock()
+	defer l.internalLock.Unlock()
+
+	select {
+	case <-timeoutTimer.C:
+		l.handleTimeout(id, "Timeout obtaining or releasing lock that came from, failed while waiting to obtain the RW lock: \n")
+		return id, false
+	case l.rwlockChan <- id:
+		timeoutTimer.Stop()
+		if l.obtainExclusiveRLock(id) {
+			if l.Debug {
+				fmt.Println("Locked", id)
+			}
+			return id, true
+		} else {
+			defer func() {
+				if l.Debug {
+					fmt.Println("Released failed lock", id)
+				}
+				<-l.rwlockChan
+			}()
+			l.handleTimeout(id, "Timeout obtaining or releasing lock that came from, failed while waiting for the RLocks to clear: \n")
+			return id, false
+		}
+	}
+}
+
+func (l *RWLock) Unlock(id uint64) {
+	l.internalLock.Lock()
+	defer l.internalLock.Unlock()
+	if len(l.rwlockChan) != 1 {
+		panic(fmt.Sprintf("Unlocking non-locked lock with ID %d", id))
+	}
+	chanId := <-l.rwlockChan
+	if id != chanId {
+		panic(fmt.Sprintf("Unmatched ID while unlocking. Expected %d and got %d", id, chanId))
+	}
+	if l.Debug {
+		fmt.Println("Unlocked", id)
+	}
+}
+
+func (l *RWLock) handleTimeout(id uint64, msg string) {
+	stack := make([]uintptr, 20)
+	runtime.Callers(0, stack)
+	stackStr := ""
+	frames := runtime.CallersFrames(stack)
+	for {
+		frame, more := frames.Next()
+		if frame.Function == "" {
+			break
+		}
+		stackStr += fmt.Sprintf("%d - %s\n\t%s:%d\n", id, frame.Function, frame.File, frame.Line)
+		if !more {
+			break
+		}
+	}
+
+	if l.LockFailures != nil {
+		l.LockFailures <- id
+	}
+	msg = msg + stackStr
+	if l.Panic {
+		panic(msg)
+	} else if l.PrintErrors {
+		fmt.Println(msg)
+	}
+}
+
+func (l *RWLock) RLock() (uint64, bool) {
+	id := l.getNextLockId()
+
+	l.internalLock.Lock()
+	defer l.internalLock.Unlock()
+
+	exChan := make(chan uint64, 1)
+	go func() {
+		start := time.Now()
+		for {
+			if !time.Now().Before(start.Add(l.RTimeout)) {
+				return
+			}
+			if !l.isLockedUnsafe() {
+				// We don't give a lot of time for this to happen
+				// If the exChan isn't ready to receive, that means the timeout has hit
+				timeoutTimer := l.getTimer(1 * time.Millisecond)
+				defer l.releaseTimer(timeoutTimer)
+
+				select {
+				case exChan <- 1:
+				case <-timeoutTimer.C:
+				}
+				return
+			}
+		}
+	}()
+
+	timeoutTimer := l.getTimer(l.RTimeout)
+	defer l.releaseTimer(timeoutTimer)
+	select {
+	case <-timeoutTimer.C:
+		l.handleTimeout(id, "Timeout obtaining or releasing lock that came from: \n")
+		return id, false
+	case <-exChan:
+		timeoutTimer.Stop()
+		l.rlockChan <- id
+		return id, true
+	}
+
+}
+
+func (l *RWLock) RUnlock(id uint64) {
+	<-l.rlockChan
+}

--- a/go/timedlock/rw_lock_test.go
+++ b/go/timedlock/rw_lock_test.go
@@ -12,7 +12,7 @@ func TestRWLockLock(t *testing.T) {
 		l := NewRWLock()
 		l.Timeout = 100 * time.Millisecond
 
-		id := l.Lock()
+		id, _ := l.Lock()
 
 		if id == 0 {
 			t.Error("Error while locking, got zero ID")
@@ -30,7 +30,7 @@ func TestRWLockLock(t *testing.T) {
 		l.Timeout = 100 * time.Millisecond
 		l.Panic = false
 
-		id1 := l.Lock()
+		id1, _ := l.Lock()
 
 		if id1 == 0 {
 			t.Error("Error while locking, got zero ID")
@@ -41,7 +41,7 @@ func TestRWLockLock(t *testing.T) {
 		}
 
 		// Can't lock twice
-		id2 := l.Lock()
+		id2, _ := l.Lock()
 
 		if id2 != 0 {
 			t.Error("Got non-zero ID when attempting to lock locked mutex for longer than the timeout")
@@ -59,7 +59,7 @@ func TestRWLockLock(t *testing.T) {
 
 		// Should now be able to lock again
 
-		id3 := l.Lock()
+		id3, _ := l.Lock()
 
 		if id3 == 0 {
 			t.Error("Error while locking, got zero ID")
@@ -76,8 +76,8 @@ func TestRWLockLock(t *testing.T) {
 		l.RTimeout = 100 * time.Millisecond
 		l.Panic = false
 
-		id1 := l.RLock()
-		id2 := l.Lock()
+		id1, _ := l.RLock()
+		id2, _ := l.Lock()
 
 		if id1 == 0 || id2 != 0 {
 			t.Error("Wrong ID came out of the lock")
@@ -95,7 +95,7 @@ func TestRWLockLock(t *testing.T) {
 		// Will be able to lock when its unlocked
 		l.RUnlock(id1)
 
-		id3 := l.Lock()
+		id3, _ := l.Lock()
 
 		if id3 == 0 {
 			t.Error("Wrong ID came out of the lock")
@@ -108,7 +108,7 @@ func TestRWLockRLock(t *testing.T) {
 		l := NewRWLock()
 		l.RTimeout = 100 * time.Millisecond
 
-		id := l.RLock()
+		id, _ := l.RLock()
 
 		if id == 0 {
 			t.Error("Wrong ID came out of the lock")
@@ -133,8 +133,8 @@ func TestRWLockRLock(t *testing.T) {
 		l.RTimeout = 100 * time.Millisecond
 		l.Panic = false
 
-		id1 := l.RLock()
-		id2 := l.RLock()
+		id1, _ := l.RLock()
+		id2, _ := l.RLock()
 
 		if id1 == 0 || id2 == 0 {
 			t.Error("Wrong ID came out of the lock")
@@ -152,8 +152,8 @@ func TestRWLockRLock(t *testing.T) {
 		l.RTimeout = 100 * time.Millisecond
 		l.Panic = false
 
-		id1 := l.Lock()
-		id2 := l.RLock()
+		id1, _ := l.Lock()
+		id2, _ := l.RLock()
 
 		if id1 == 0 || id2 != 0 {
 			t.Error("Wrong ID came out of the lock")
@@ -171,7 +171,7 @@ func TestRWLockRLock(t *testing.T) {
 		// Will be able to lock when its unlocked
 		l.Unlock(id1)
 
-		id3 := l.RLock()
+		id3, _ := l.RLock()
 
 		if id3 == 0 {
 			t.Error("Wrong ID came out of the lock")
@@ -184,13 +184,13 @@ func TestRWLockMaxRestart(t *testing.T) {
 
 	l.c = math.MaxUint64 - 1
 
-	id := l.Lock()
+	id, _ := l.Lock()
 	if id != math.MaxUint64 {
 		t.Error("Wrong ID came out of the lock")
 	}
 	l.Unlock(id)
 
-	id = l.Lock()
+	id, _ = l.Lock()
 	// Should now go back to the beginning but not at zero
 	if id != 1 {
 		t.Error("Wrong ID came out of the lock")
@@ -208,7 +208,7 @@ func TestRWLockOverflow(t *testing.T) {
 			}
 		}()
 
-		id := l.Lock()
+		id, _ := l.Lock()
 		l.c = id - 1
 		l.Lock()
 	}()
@@ -230,12 +230,12 @@ func BenchmarkSyncRWMutex(b *testing.B) {
 func BenchmarkRWLock(b *testing.B) {
 	m := NewRWLock()
 	for i := 0; i < b.N; i++ {
-		id := m.Lock()
+		id, _ := m.Lock()
 		m.Unlock(id)
 	}
 
 	for i := 0; i < b.N; i++ {
-		id := m.RLock()
+		id, _ := m.RLock()
 		m.RUnlock(id)
 	}
 }

--- a/go/timedlock/rw_lock_test.go
+++ b/go/timedlock/rw_lock_test.go
@@ -1,0 +1,191 @@
+package timedlock
+
+import (
+	"fmt"
+	"math"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestRWLockLock(t *testing.T) {
+	{
+		l := NewRWLock()
+		l.Timeout = 100 * time.Millisecond
+
+		id, success := l.Lock()
+
+		if !success {
+			t.Error("Failed to lock")
+		}
+
+		l.Unlock(id)
+
+		// Sleep for twice the timeout to make sure this will not panic
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	{
+		l := NewRWLock()
+		l.Timeout = 100 * time.Millisecond
+		l.Panic = false
+		l.LockFailures = make(chan uint64, 10)
+
+		id0, _ := l.Lock()
+		id1, _ := l.Lock()
+
+		// Sleep for twice the timeout
+		time.Sleep(200 * time.Millisecond)
+
+		select {
+		case failId := <-l.LockFailures:
+			if id1 != failId {
+				t.Error("ID from the LockFailures channel doesn't match")
+			}
+		case <-time.After(1 * time.Second):
+			t.Error("Couldn't detect failure via the LockFailures chan")
+		}
+
+		l.Unlock(id0)
+
+		// Should now be able to lock again
+		id2, success := l.Lock()
+
+		if !success {
+			t.Error("Failed to lock")
+		}
+
+		l.Unlock(id2)
+
+		select {
+		case <-l.LockFailures:
+			t.Error("There was a lock failure but there shouldn't have been one")
+		case <-time.After(1 * time.Second):
+			// All good
+		}
+	}
+
+}
+
+func TestRWLockRLock(t *testing.T) {
+	{
+		l := NewRWLock()
+		l.RTimeout = 100 * time.Millisecond
+
+		id, success := l.RLock()
+
+		if !success {
+			t.Error("Failed to RLock")
+		}
+
+		l.RUnlock(id)
+
+		// Sleep for twice the timeout
+		time.Sleep(200 * time.Millisecond)
+
+	}
+
+	{
+		l := NewRWLock()
+		l.RTimeout = 100 * time.Millisecond
+
+		id1, success := l.RLock()
+		if !success {
+			t.Error("Failed to RLock")
+		}
+
+		id2, success := l.RLock()
+		if !success {
+			t.Error("Failed to RLock")
+		}
+
+		l.RUnlock(id1)
+		l.RUnlock(id2)
+
+		// Sleep for twice the timeout
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	{
+		l := NewRWLock()
+		l.RTimeout = 100 * time.Millisecond
+		l.Panic = false
+		l.LockFailures = make(chan uint64, 1)
+
+		id1, success := l.RLock()
+		if !success {
+			t.Error("Failed to obtain RLock")
+		}
+		id2, success := l.RLock()
+		if !success {
+			t.Error("Failed to obtain RLock")
+		}
+		fmt.Println(id2)
+
+		l.RUnlock(id1)
+
+		// Sleep for twice the timeout
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+func TestRWLockMaxRestart(t *testing.T) {
+	l := NewRWLock()
+
+	l.c = math.MaxUint64 - 1
+
+	id, _ := l.Lock()
+	if id != math.MaxUint64 {
+		t.Error("Wrong ID came out of the lock")
+	}
+	l.Unlock(id)
+
+	id, _ = l.Lock()
+	// Should now go back to the beginning
+	if id != 0 {
+		t.Error("Wrong ID came out of the lock")
+	}
+	l.Unlock(id)
+}
+
+func TestRWLockOverflow(t *testing.T) {
+	l := NewRWLock()
+
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("Didn't recover an error when a non deleted channel ID was reused")
+			}
+		}()
+
+		id, _ := l.Lock()
+		l.c = id - 1
+		l.Lock()
+	}()
+}
+
+func BenchmarkSyncRWMutex(b *testing.B) {
+	m := sync.RWMutex{}
+	for i := 0; i < b.N; i++ {
+		m.Lock()
+		m.Unlock()
+	}
+
+	for i := 0; i < b.N; i++ {
+		m.RLock()
+		m.RUnlock()
+	}
+}
+
+func BenchmarkRWLock(b *testing.B) {
+	m := NewRWLock()
+	for i := 0; i < b.N; i++ {
+		id, _ := m.Lock()
+		m.Unlock(id)
+	}
+
+	for i := 0; i < b.N; i++ {
+		id, _ := m.RLock()
+		m.RUnlock(id)
+	}
+}


### PR DESCRIPTION
# Description
Reworks the pfconfig pool locking strategy to use channels instead of sync.Mutex

# Impacts
pfconfig in golang

# Issue
fixes #3360 

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* Reworked the Golang pfconfig locking to prevent deadlocks while refreshing the configuration
