### PR TITLE
fix rsyslog/logrotate not catching certain logs

### DIFF
--- a/lib/pf/constants/syslog.pm
+++ b/lib/pf/constants/syslog.pm
@@ -93,6 +93,10 @@ our @SyslogInfo = (
         'conditions' => [ '$msg contains "api-frontend-access"' ],
     },
     {
+        'name'      => 'api-frontend.log',
+        'conditions' => [ '$programname == "api-frontend"' ],
+    },
+    {
         'name'       => 'pfstats.log',
         'conditions' => [ '$programname == "pfstats"' ]
     },
@@ -124,7 +128,7 @@ our @SyslogInfo = (
     },
     {
         'name'       => 'pfdns.log',
-        'conditions' => [ '$programname == "pfdns"' ]
+        'conditions' => [ '$programname contains "pfdns"' ]sys
     },
     {
         'name'       => 'pffilter.log',
@@ -176,8 +180,16 @@ our @SyslogInfo = (
         'conditions' => [ '$syslogtag contains "redis-queue"' ]
     },
     {
+        'name'       => 'redis_server.log',
+        'conditions' => [ '$programname == "redis-server"' ]
+    },
+    {
         'name'      => 'mariadb_error.log',
         'conditions' => [ '$syslogtag contains "mysqld"' ],
+    },
+    {
+        'name'      => 'haproxy_portal.log',
+        'conditions' => [ '$programname == "haproxy" and $msg contains "portal-http"' ],
     },
 );
 

--- a/lib/pf/constants/syslog.pm
+++ b/lib/pf/constants/syslog.pm
@@ -128,7 +128,7 @@ our @SyslogInfo = (
     },
     {
         'name'       => 'pfdns.log',
-        'conditions' => [ '$programname contains "pfdns"' ]sys
+        'conditions' => [ '$programname contains "pfdns"' ]
     },
     {
         'name'       => 'pffilter.log',

--- a/lib/pf/constants/syslog.pm
+++ b/lib/pf/constants/syslog.pm
@@ -89,7 +89,7 @@ our @SyslogInfo = (
         'conditions' => [ '$programname contains "httpd_webservices"' ]
     },
     {
-        'name'      => 'api-frontend.access',
+        'name'      => 'httpd.api-frontend.access',
         'conditions' => [ '$msg contains "api-frontend-access"' ],
     },
     {


### PR DESCRIPTION
# Description
Adds some missing filters to rsyslog.d config file that were causing messages to go to the system's syslog file (/var/log/messages) instead of the proper /user/local/pf/log/* files.

# Impacts
Logs for the following processes are now properly redirected
* api-frontend
* redis_server
* pfdns (some messages were going to /var/log/messages)
* haproxy_portal
Also api-frontend httpd log has been renamed to httpd.api-frontend.access to be caught by logrotate.

# Issue
fixes #3423 

# Delete branch after merge
YES

# NEWS file entries

## Bug Fixes
* issues with process logging to /var/log instead of local folder #3423 
* renames api-frontend.access log to be handled by logrotate
