### PR TITLE
support passthroughs for domains with dns load balance

### DIFF
--- a/go/coredns/plugin/pfdns/pfdns.go
+++ b/go/coredns/plugin/pfdns/pfdns.go
@@ -174,7 +174,7 @@ func (pf *pfdns) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 			answer, err := pf.LocalResolver(state)
 			if err != nil {
 				fmt.Println("Local resolver error for fqdn" + state.QName() + " with the following error" + err.Error())
-				} else {
+			} else {
 				for _, ans := range append(answer.Answer, answer.Extra...) {
 					switch ansb := ans.(type) {
 					case *dns.A:

--- a/go/coredns/plugin/pfdns/pfdns.go
+++ b/go/coredns/plugin/pfdns/pfdns.go
@@ -122,21 +122,22 @@ func (pf *pfdns) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 		if k.MatchString(state.QName()) {
 			answer, err := pf.LocalResolver(state)
 			if err != nil {
-				fmt.Println("Local resolver error with the following error" + err.Error())
+				fmt.Println("Local resolver error for fqdn" + state.QName() + " with the following error" + err.Error())
 			} else {
 				for _, ans := range append(answer.Answer, answer.Extra...) {
 					switch ansb := ans.(type) {
 					case *dns.A:
 						for _, valeur := range v {
 							if err := pf.SetPassthrough(ctx, "passthrough", ansb.A.String(), valeur, true); err != nil {
-								fmt.Println("Not able to contact localhost", err)
+								fmt.Println("Not able to contact localhost for setPassthrough", err)
 							}
 						}
 					}
 				}
+				fmt.Println(srcIP + " : " + mac + " Domain bypass for fqdn " + state.QName())
+				w.WriteMsg(answer)
 			}
-			fmt.Println(srcIP + ":" + mac + " Domain bypass for fqdn " + state.QName())
-			return pf.Next.ServeDNS(ctx, w, r)
+			return 0, nil
 		}
 	}
 
@@ -147,7 +148,7 @@ func (pf *pfdns) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 			if k.MatchString(state.QName()) {
 				answer, err := pf.LocalResolver(state)
 				if err != nil {
-					fmt.Println("Local resolver error with the following error" + err.Error())
+					fmt.Println("Local resolver error for fqdn" + state.QName() + " with the following error" + err.Error())
 				} else {
 					for _, ans := range append(answer.Answer, answer.Extra...) {
 						switch ansb := ans.(type) {
@@ -159,9 +160,10 @@ func (pf *pfdns) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 							}
 						}
 					}
+					fmt.Println(srcIP + " : " + mac + " isolation passthrough  for fqdn " + state.QName())
+					w.WriteMsg(answer)
 				}
-				fmt.Println(srcIP + " : " + mac + " isolation passthrough  for fqdn " + state.QName())
-				return pf.Next.ServeDNS(ctx, w, r)
+				return 0, nil
 			}
 		}
 	}
@@ -171,8 +173,8 @@ func (pf *pfdns) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 		if k.MatchString(state.QName()) {
 			answer, err := pf.LocalResolver(state)
 			if err != nil {
-				fmt.Println("Local resolver error with the following error" + err.Error())
-			} else {
+				fmt.Println("Local resolver error for fqdn" + state.QName() + " with the following error" + err.Error())
+				} else {
 				for _, ans := range append(answer.Answer, answer.Extra...) {
 					switch ansb := ans.(type) {
 					case *dns.A:
@@ -182,10 +184,12 @@ func (pf *pfdns) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 							}
 						}
 					}
+					
 				}
+				w.WriteMsg(answer)
+				fmt.Println(srcIP + " : " + mac + " passthrough for fqdn " + state.QName())
 			}
-			fmt.Println(srcIP + " : " + mac + " passthrough for fqdn " + state.QName())
-			return pf.Next.ServeDNS(ctx, w, r)
+			return 0, nil
 		}
 	}
 


### PR DESCRIPTION
# Description
Improved the handling of domains where DNS is performing load-balance so that the response back to the client and the whitelist added to pfilter matches. If the local resolver returns a valid response, this response is used to populate pffilter and also shortcuts pfdns proxy plugins sending the response directly back to the customer. In case of DNS errors, it also propagates the error back to the client (not returning the portal but rather an error)

# Impacts
PFDNS 

# Issue
fixes #3417 

# Delete branch after merge
YES 

# NEWS file entries
## Bug Fixes
* Wrong IPSET entries are being created for a DNS query for some bypassed domains (#3417)