### PR TITLE
Fixes #3387

### DIFF
--- a/html/pfappserver/root/graph/dashboard.tt
+++ b/html/pfappserver/root/graph/dashboard.tt
@@ -674,6 +674,7 @@ END
         </div>
         <div class="tab-pane[% IF tab == "dhcp" %] active[% END %]" id="dhcp">
         [% FOREACH network IN networks.keys %]
+            [% IF networks.$network.dhcpd == "enabled" %]
             <div class="card">
                 <div class="card-title">
                     <h2>[% l('DHCP on') %] [% network %]</h2>
@@ -747,6 +748,7 @@ END
                     </div>
                 </div>
             </div>
+            [% END %]
         [% END %]
         </div>
         <div class="tab-pane[% IF tab == "endpoints" %] active[% END %]" id="endpoints">

--- a/html/pfappserver/root/graph/dashboard.tt
+++ b/html/pfappserver/root/graph/dashboard.tt
@@ -748,6 +748,12 @@ END
                     </div>
                 </div>
             </div>
+            [% ELSE %]
+            <div class="card">
+              <div class="card-title">
+                <h2>[% l('DHCP on') %] [% network %] [% l('disabled') %]</h2>
+              </div>
+            </div>
             [% END %]
         [% END %]
         </div>

--- a/lib/pfconfig/namespaces/config/Stats.pm
+++ b/lib/pfconfig/namespaces/config/Stats.pm
@@ -21,6 +21,7 @@ use warnings;
 use pfconfig::namespaces::config;
 use pf::log;
 use pf::file_paths qw($stats_config_file);
+use pf::util qw(isdisabled);
 
 use base 'pfconfig::namespaces::config';
 
@@ -41,6 +42,7 @@ sub build_child {
     foreach my $network (keys $self->{network_config}) {
         my $dev = $self->{network_config}{$network}{'interface'}{'int'};
         next if !defined $dev;
+        next if isdisabled($self->{network_config}{$network}{'dhcpd'});
         $tmp_cfg{"metric 'total dhcp leases remaining on $network' past day"} = {
             'type' => 'api',
             'statsd_type' => 'gauge',


### PR DESCRIPTION
# Description
pfstat: don't fetch the stats from pfdhcp if the dhcp is disabled.
Dashboard: removed dhcp graph where the dhcp is disabled

# Issue
fixes #3387 

# Delete branch after merge
YES

# NEWS file entries

## Bug Fixes
* Fixes pfstats collects information on DHCP scopes even if pfdhcp is disabled (#3387)

