### PR TITLE
Increase the column size for node bandwidth_balance

### DIFF
--- a/db/pf-schema-X.Y.Z.sql
+++ b/db/pf-schema-X.Y.Z.sql
@@ -154,7 +154,7 @@ CREATE TABLE node (
   unregdate datetime NOT NULL default "0000-00-00 00:00:00",
   lastskip datetime NOT NULL default "0000-00-00 00:00:00",
   time_balance int(10) unsigned DEFAULT NULL,
-  bandwidth_balance int(10) unsigned DEFAULT NULL,
+  bandwidth_balance bigint(20) unsigned DEFAULT NULL,
   status varchar(15) NOT NULL default "unreg",
   user_agent varchar(255) default NULL,
   computername varchar(255) default NULL,

--- a/db/upgrade-X.X.X-X.Y.Z.sql
+++ b/db/upgrade-X.X.X-X.Y.Z.sql
@@ -50,6 +50,11 @@ call ValidateVersion;
 --
 -- Adjust the pf_version engine so its synchronized in a cluster
 --
+ALTER TABLE `node` MODIFY `bandwidth_balance` bigint(20) unsigned DEFAULT NULL;
+
+--
+-- Adjust the pf_version engine so its synchronized in a cluster
+--
 ALTER TABLE pf_version engine = InnoDB;
 
 INSERT INTO pf_version (id, version) VALUES (@VERSION_INT, CONCAT_WS('.', @MAJOR_VERSION, @MINOR_VERSION, @SUBMINOR_VERSION)); 

--- a/db/upgrade-X.X.X-X.Y.Z.sql
+++ b/db/upgrade-X.X.X-X.Y.Z.sql
@@ -48,7 +48,7 @@ DELIMITER ;
 call ValidateVersion;                                                                                                  
 
 --
--- Adjust the pf_version engine so its synchronized in a cluster
+-- Increase node bandwidth_balance
 --
 ALTER TABLE `node` MODIFY `bandwidth_balance` bigint(20) unsigned DEFAULT NULL;
 


### PR DESCRIPTION
# Description
Increase the column size for node bandwidth_balance.

# Impacts
Maximum node bandwidth

# Issue
fixes #3477 

# Delete branch after merge
YES 

# NEWS file entries

## Enhancements
* Increased maximum node bandwidth balance from `4 GB` to `18.4467441 XB` (exabytes)

## Bug Fixes
* Issue with Max Bandwidth Balance (#3477)