### PR TITLE
Replace MySQL user_name and computer_name column '=5C' with '\'

### DIFF
--- a/UPGRADE.asciidoc
+++ b/UPGRADE.asciidoc
@@ -19,7 +19,7 @@ Database backup
 Before making any changes to your database, ensure that you have a backup.
 A complete database backup can be taken using this command:
 
-  mysqldump --opt -u root -p pf | gzip > /root/packetfence_db.sql.gz
+  mysqldump --opt --routines -u root -p pf | gzip > /root/packetfence_db.sql.gz
 
 If your database is more than a few hundred megabytes, you may also want to consider using a tool such as Percona XtraBackup which makes for much faster restores than mysqldump.
 
@@ -427,7 +427,7 @@ Database schema update
 Before making any changes to your database, ensure that you have a backup.
 A complete database backup can be taken using this command:
 
-  mysqldump --opt -u root -p pf | gzip > /root/packetfence_db.sql.gz
+  mysqldump --opt --routines -u root -p pf | gzip > /root/packetfence_db.sql.gz
 
 If your database is more than a few hundred megabytes, you may also want to consider using a tool such as Percona XtraBackup which makes for much faster restores than mysqldump.
 

--- a/addons/database-backup-and-maintenance.sh
+++ b/addons/database-backup-and-maintenance.sh
@@ -133,7 +133,7 @@ if [ $SHOULD_BACKUP -eq 1 ] && { [ -f /var/run/mysqld/mysqld.pid ] || [ -f /var/
         else
             find $BACKUP_DIRECTORY -name "$BACKUP_DB_FILENAME-*.sql.gz" -mtime +$NB_DAYS_TO_KEEP_DB -delete
             current_filename=$BACKUP_DIRECTORY/$BACKUP_DB_FILENAME-`date +%F_%Hh%M`.sql.gz
-            mysqldump --opt -h $DB_HOST -u $DB_USER -p$DB_PWD $DB_NAME --ignore-table=$DB_NAME.locationlog_archive --ignore-table=$DB_NAME.iplog_archive | gzip > ${current_filename}
+            mysqldump --opt --routines -h $DB_HOST -u $DB_USER -p$DB_PWD $DB_NAME --ignore-table=$DB_NAME.locationlog_archive --ignore-table=$DB_NAME.iplog_archive | gzip > ${current_filename}
             BACKUPRC=$?
             if (( $BACKUPRC > 0 )); then 
                 echo "mysqldump returned  error code: $?" >&2

--- a/db/pf-schema-X.Y.Z.sql
+++ b/db/pf-schema-X.Y.Z.sql
@@ -1266,6 +1266,28 @@ CREATE TABLE `api_user` (
 ) ENGINE=InnoDB;
 
 --
+-- Dumping routines for database 'pf'
+--
+DROP FUNCTION IF EXISTS `FREERADIUS_DECODE`;
+DELIMITER ;;
+CREATE DEFINER=`root`@`localhost` FUNCTION `FREERADIUS_DECODE`(str text) RETURNS text CHARSET latin1
+    DETERMINISTIC
+BEGIN 
+    DECLARE result text;
+    DECLARE ind INT DEFAULT 0;
+
+    SET result = str;
+    WHILE ind <= 255 DO
+       SET result = REPLACE(result, CONCAT('=', LPAD(LOWER(HEX(ind)), 2, 0)), CHAR(ind));
+       SET result = REPLACE(result, CONCAT('=', LPAD(HEX(ind), 2, 0)), CHAR(ind));
+       SET ind = ind + 1;
+    END WHILE;
+
+    RETURN result;
+END ;;
+DELIMITER ;
+
+--
 -- Updating to current version
 --
 

--- a/db/upgrade-X.X.X-X.Y.Z.sql
+++ b/db/upgrade-X.X.X-X.Y.Z.sql
@@ -63,4 +63,27 @@ INSERT INTO sms_carrier VALUES(100125, 'Freedom', 'txt.freedommobile.ca', now(),
 INSERT INTO sms_carrier VALUES(100126, 'PC Mobile', '%s@msg.telus.com', now(), now());
 INSERT INTO sms_carrier VALUES(100127, 'TBayTel', '%s@pcs.rogers.com', now(), now());
 
+--
+-- Add Freeradius decode procedure
+-- 
+DELIMITER $$
+DROP FUNCTION IF EXISTS FREERADIUS_DECODE $$
+CREATE FUNCTION FREERADIUS_DECODE (str text) 
+RETURNS text
+DETERMINISTIC
+BEGIN 
+    DECLARE result text;
+    DECLARE ind INT DEFAULT 0;
+
+    SET result = str;
+    WHILE ind <= 255 DO
+       SET result = REPLACE(result, CONCAT('=', LPAD(LOWER(HEX(ind)), 2, 0)), CHAR(ind));
+       SET result = REPLACE(result, CONCAT('=', LPAD(HEX(ind), 2, 0)), CHAR(ind));
+       SET ind = ind + 1;
+    END WHILE;
+
+    RETURN result;
+END$$
+DELIMITER ;
+
 INSERT INTO pf_version (id, version) VALUES (@VERSION_INT, CONCAT_WS('.', @MAJOR_VERSION, @MINOR_VERSION, @SUBMINOR_VERSION)); 

--- a/docs/PacketFence_Clustering_Guide.asciidoc
+++ b/docs/PacketFence_Clustering_Guide.asciidoc
@@ -833,7 +833,7 @@ Backups
 
 First, ensure you have taken backups of your data. We highly encourage you to perform snapshots of all the virtual machines prior to the upgrade. You should also take a backup of the database and the `/usr/local/pf` directory using:
 
-  # mysqldump --opt -u root -p pf | gzip > /root/packetfence_db.sql.gz
+  # mysqldump --opt --routines -u root -p pf | gzip > /root/packetfence_db.sql.gz
   # tar -C /usr/local -czf /root/packetfence.tar.gz pf --exclude='pf/logs' --exclude='pf/var'
 
 Disabling the auto-correction of configuration

--- a/lib/pf/pfcmd/report.pm
+++ b/lib/pf/pfcmd/report.pm
@@ -412,7 +412,7 @@ sub report_db_prepare {
 
     $report_statements->{'report_topauthenticationfailures_by_username_sql'} = get_db_handle()->prepare(qq[
         SELECT
-            `user_name`, 
+            REPLACE(`user_name`, '=5C', '\') AS `user_name`,
             COUNT(1) AS `count`, 
             SUM(100) / `total` AS `percent`
         FROM `radius_audit_log`
@@ -475,7 +475,7 @@ sub report_db_prepare {
 
     $report_statements->{'report_topauthenticationsuccesses_by_username_sql'} = get_db_handle()->prepare(qq[
         SELECT
-            `user_name`, 
+            REPLACE(`user_name`, '=5C', '\') AS `user_name`,
             COUNT(1) AS `count`, 
             SUM(100) / `total` AS `percent`
         FROM `radius_audit_log`
@@ -496,7 +496,7 @@ sub report_db_prepare {
 
     $report_statements->{'report_topauthenticationsuccesses_by_computername_sql'} = get_db_handle()->prepare(qq[
         SELECT
-            `computer_name`, 
+            REPLACE(`computer_name`, '=5C', '\') AS `computer_name`,
             COUNT(1) AS `count`, 
             SUM(100) / `total` AS `percent`
         FROM `radius_audit_log`

--- a/lib/pf/pfcmd/report.pm
+++ b/lib/pf/pfcmd/report.pm
@@ -412,7 +412,7 @@ sub report_db_prepare {
 
     $report_statements->{'report_topauthenticationfailures_by_username_sql'} = get_db_handle()->prepare(qq[
         SELECT
-            REPLACE(`user_name`, '=5C', '\') AS `user_name`,
+            FREERADIUS_DECODE(`user_name`) AS `user_name`,
             COUNT(1) AS `count`, 
             SUM(100) / `total` AS `percent`
         FROM `radius_audit_log`
@@ -475,7 +475,7 @@ sub report_db_prepare {
 
     $report_statements->{'report_topauthenticationsuccesses_by_username_sql'} = get_db_handle()->prepare(qq[
         SELECT
-            REPLACE(`user_name`, '=5C', '\') AS `user_name`,
+            FREERADIUS_DECODE(`user_name`) AS `user_name`,
             COUNT(1) AS `count`, 
             SUM(100) / `total` AS `percent`
         FROM `radius_audit_log`
@@ -496,7 +496,7 @@ sub report_db_prepare {
 
     $report_statements->{'report_topauthenticationsuccesses_by_computername_sql'} = get_db_handle()->prepare(qq[
         SELECT
-            REPLACE(`computer_name`, '=5C', '\') AS `computer_name`,
+            FREERADIUS_DECODE(`computer_name`) AS `computer_name`,
             COUNT(1) AS `count`, 
             SUM(100) / `total` AS `percent`
         FROM `radius_audit_log`

--- a/t/test_apply_schema.sh
+++ b/t/test_apply_schema.sh
@@ -10,7 +10,7 @@ PRISTINE_DB="${DB_PREFIX}_pristine_$$"
 
 MYSQL="mysql -upf_smoke_tester -ppacket"
 
-MYSQLDUMP="mysqldump -upf_smoke_tester --no-data -a --skip-comments -ppacket"
+MYSQLDUMP="mysqldump -upf_smoke_tester --no-data -a --skip-comments --routines -ppacket"
 
 for db in $UPGRADED_DB $PRISTINE_DB;do
     echo "Created test db $db"


### PR DESCRIPTION
# Description
Replaces '=5C'  with '\' in reports for top authentication successes and failures user_name and computer_name.

# Impacts
none

# Issue
fixes #3508 

# Delete branch after merge
YES

## Bug Fixes
* Backslash in usernames in Reports section is shown as "=5C" (#3508)