### PR TITLE
Feature/switch filter instantiate

### DIFF
--- a/conf/switch_filters.conf.example
+++ b/conf/switch_filters.conf.example
@@ -21,7 +21,8 @@
 # operator = OPERATOR
 # value = VALUE
 #
-# Filter can be:
+###############################
+# For the radius_authorize scope, the filter can be:
 #     node_info.autoreg
 #     node_info.status
 #     node_info.bypass_vlan
@@ -135,6 +136,36 @@
 # - for the params
 #     It correspond of the attributes in the uri when the device hit the portal
 #
+###############################
+# For the instantiate_module scope, the filter can be:
+#     radius_request (when used in the context of a RADIUS request)
+#     locationlog (when used outside of the context of a RADIUS request)
+#
+# Attribute can be:
+# - for the radius_request
+#     All the attributes you can have in the RADIUS request (run FreeRADIUS in debug mode to see these attributes)
+# - for the locationlog
+#     id
+#     tenant_id
+#     mac
+#     switch
+#     port
+#     vlan
+#     role
+#     connection_type
+#     connection_sub_type
+#     dot1x_username
+#     ssid
+#     start_time
+#     end_time
+#     switch_ip
+#     switch_mac
+#     stripped_user_name
+#     realm
+#     session_id
+#     ifDesc
+#
+###############################
 # Actions
 # -------
 # Structure example of an action
@@ -214,3 +245,19 @@
 #[1:login&post&magic&usermac&apmac&apip&userip]
 #scope = external_portal
 #switch = Fortinet::FortiGate
+#
+# - If the device is authenticating on a wireless connection, then use the Cisco::WLC_5500 module
+#
+#[wireless_radius]
+#filter = radius_request.NAS-Port-Type
+#operator = is
+#value = 19
+#
+#[wireless_locationlog]
+#filter = locationlog.connection_type
+#operator = regex
+#value = ^Wireless
+#
+#[msmodule4wired:wireless_locationlog|wireless_radius]
+#scope=instantiate_module
+#switch = Cisco::WLC_5500

--- a/lib/pf/SwitchFactory.pm
+++ b/lib/pf/SwitchFactory.pm
@@ -75,7 +75,7 @@ sub hasId { exists $SwitchConfig{$_[0]} }
 
 sub instantiate {
     my $timer = pf::StatsD::Timer->new({level => 7});
-    my ( $class, $switchRequest ) = @_;
+    my ( $class, $switchRequest, $args ) = @_;
     my $logger = get_logger();
     my @requestedSwitches;
     my $requestedSwitch;
@@ -149,6 +149,11 @@ sub instantiate {
     my $switchOverlay = $switch_overlay_cache->get($requestedSwitch) || {};
     my ($module, $type);
     $type = untaint_chain( $switch_data->{'type'} );
+    
+    my $filter = pf::access_filter::switch->new;
+    my $type_switch = $filter->filter('instantiate_module', $args);
+    $type = $type_switch if($type_switch);
+
     if ($requestedSwitch ne 'default') {
         $module = getModule($type);
     } else {

--- a/lib/pf/SwitchFactory.pm
+++ b/lib/pf/SwitchFactory.pm
@@ -76,6 +76,10 @@ sub hasId { exists $SwitchConfig{$_[0]} }
 sub instantiate {
     my $timer = pf::StatsD::Timer->new({level => 7});
     my ( $class, $switchRequest, $args ) = @_;
+
+    # Defaults to an empty hash to be backward compatible
+    $args //= {};
+
     my $logger = get_logger();
     my @requestedSwitches;
     my $requestedSwitch;

--- a/lib/pf/api.pm
+++ b/lib/pf/api.pm
@@ -330,7 +330,7 @@ sub ReAssignVlan : Public : Fork {
         return;
     }
 
-    my $switch = pf::SwitchFactory->instantiate( $postdata{'switch'} );
+    my $switch = pf::SwitchFactory->instantiate( $postdata{'switch'}, {locationlog => pf::locationlog::locationlog_view_open_mac($postdata{'mac'})} );
     unless ($switch) {
         $logger->error("switch $postdata{'switch'} not found for ReAssignVlan");
         return;
@@ -372,7 +372,7 @@ sub desAssociate : Public : Fork {
 
     my $logger = pf::log::get_logger();
 
-    my $switch = pf::SwitchFactory->instantiate($postdata{'switch'});
+    my $switch = pf::SwitchFactory->instantiate($postdata{'switch'}, {locationlog => pf::locationlog::locationlog_view_open_mac($postdata{'mac'})});
     unless ($switch) {
         $logger->error("switch $postdata{'switch'} not found for desAssociate");
         return;

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -380,7 +380,7 @@ sub accounting {
     my ( $switch_mac, $switch_ip, $source_ip, $stripped_user_name, $realm ) = $self->_parseRequest($radius_request);
 
     $logger->debug("instantiating switch");
-    my $switch = pf::SwitchFactory->instantiate( { switch_mac => $switch_mac, switch_ip => $switch_ip, controllerIp => $switch_ip } );
+    my $switch = pf::SwitchFactory->instantiate( { switch_mac => $switch_mac, switch_ip => $switch_ip, controllerIp => $switch_ip }, {radius_request => $radius_request} );
 
     # is switch object correct?
     if ( !$switch ) {
@@ -486,7 +486,7 @@ sub update_locationlog_accounting {
     my ( $switch_mac, $switch_ip, $source_ip, $stripped_user_name, $realm ) = $self->_parseRequest($radius_request);
 
     $logger->debug("instantiating switch");
-    my $switch = pf::SwitchFactory->instantiate( { switch_mac => $switch_mac, switch_ip => $switch_ip, controllerIp => $switch_ip } );
+    my $switch = pf::SwitchFactory->instantiate( { switch_mac => $switch_mac, switch_ip => $switch_ip, controllerIp => $switch_ip }, {radius_request => $radius_request} );
 
     # is switch object correct?
     if ( !$switch ) {
@@ -680,7 +680,7 @@ sub _handleStaticPortSecurityMovement {
         return undef;
     }
 
-    my $oldSwitch = pf::SwitchFactory->instantiate($old_switch_id);
+    my $oldSwitch = pf::SwitchFactory->instantiate($old_switch_id, {radius_request => $args->{radius_request}});
     if (!$oldSwitch) {
         $logger->error("Can not instantiate switch $old_switch_id !");
         return;
@@ -780,7 +780,7 @@ sub switch_access {
     my($switch_mac, $switch_ip,$source_ip,$stripped_user_name,$realm) = $self->_parseRequest($radius_request);
 
     $logger->debug("instantiating switch");
-    my $switch = pf::SwitchFactory->instantiate({ switch_mac => $switch_mac, switch_ip => $switch_ip, controllerIp => $switch_ip});
+    my $switch = pf::SwitchFactory->instantiate({ switch_mac => $switch_mac, switch_ip => $switch_ip, controllerIp => $switch_ip}, {radius_request => $radius_request});
 
     # is switch object correct?
     if (!$switch) {

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -111,7 +111,7 @@ sub authorize {
     $self->handleNtlmCaching($radius_request);
 
     $logger->debug("instantiating switch");
-    my $switch = pf::SwitchFactory->instantiate({ switch_mac => $switch_mac, switch_ip => $switch_ip, controllerIp => $switch_ip});
+    my $switch = pf::SwitchFactory->instantiate({ switch_mac => $switch_mac, switch_ip => $switch_ip, controllerIp => $switch_ip}, {radius_request => $radius_request});
 
     # is switch object correct?
     if (!$switch) {


### PR DESCRIPTION
# NOT READY

# Description
Allow to instantiate a different switch module based on the connection information of a device

# Impacts
Switch instantiation

# Delete branch after merge
YES

# NEWS file entries
## Enhancements
* Switch filters can now be used to override the switch module that is instantiated during a RADIUS connection