### PR TITLE
Use several email addresses in alerting.emailaddr

### DIFF
--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -632,8 +632,8 @@ EOT
 [alerting.emailaddr]
 type=text
 description=<<EOT
-Email address to which notifications of rogue DHCP servers, violations 
-with an action of "email", or any other PacketFence-related message 
+Comma-delimited list of email addresses to which notifications of rogue DHCP servers, violations 
+with an action of "email", or any other PacketFence-related message.
 goes to.
 EOT
 

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -633,8 +633,7 @@ EOT
 type=text
 description=<<EOT
 Comma-delimited list of email addresses to which notifications of rogue DHCP servers, violations 
-with an action of "email", or any other PacketFence-related message.
-goes to.
+with an action of "email", or any other PacketFence-related message goes to.
 EOT
 
 [alerting.smtpserver]

--- a/conf/keepalived.conf.example
+++ b/conf/keepalived.conf.example
@@ -1,6 +1,6 @@
 global_defs {
    notification_email {
-     %%emailaddr%%
+    %%emailaddr%%
    }
    notification_email_from %%fromaddr%%
    smtp_server %%smtpserver%%

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -175,7 +175,7 @@ default_access_duration=12h
 #
 # alerting.emailaddr
 #
-# Email address to which notifications of rogue DHCP servers, violations with an action of "email", or any other 
+# Comma-delimited list of email addresses to which notifications of rogue DHCP servers, violations with an action of "email", or any other
 # PacketFence-related message goes to.
 emailaddr=pf@localhost
 #

--- a/lib/pf/config/util.pm
+++ b/lib/pf/config/util.pm
@@ -144,12 +144,12 @@ sub ip2device {
 
 sub pfmailer {
     my (%data) = @_;
-    my @to = split( /\s*,\s*/, $Config{'alerting'}{'emailaddr'} );
+    my $to = $Config{'alerting'}{'emailaddr'};
     my $host_prefix = $cluster_enabled ? " ($host_id)" : '';
     my $date = POSIX::strftime( "%m/%d/%y %H:%M:%S", localtime );
     my $subject = $Config{'alerting'}{'subjectprefix'} . $host_prefix . " " . $data{'subject'} . " ($date)";
     my $msg = MIME::Lite->new(
-        To      => \@to,
+        To      => $to,
         Subject => $subject,
         Data    => $data{message} . "\n",
     );

--- a/lib/pf/constants.pm
+++ b/lib/pf/constants.pm
@@ -17,7 +17,7 @@ use Readonly;
 use base qw(Exporter);
 our @EXPORT = qw(
     $FALSE $TRUE $YES $NO $default_pid $admin_pid $BLUE_COLOR $YELLOW_COLOR $RED_COLOR $GREEN_COLOR
-    $HTTP $HTTPS $HTTP_PORT $HTTPS_PORT $ZERO_DATE $DEFAULT_TENANT_ID
+    $HTTP $HTTPS $HTTP_PORT $HTTPS_PORT $ZERO_DATE $SPACE $SPACE_NUMBERS $DEFAULT_TENANT_ID
 );
 
 # some global constants
@@ -32,6 +32,8 @@ Readonly::Scalar our $RED_COLOR => 'red';
 Readonly::Scalar our $GREEN_COLOR => 'green';
 Readonly::Scalar our $BLUE_COLOR => 'blue';
 Readonly::Scalar our $ZERO_DATE => '0000-00-00 00:00:00';
+Readonly::Scalar our $SPACE => q{ };
+Readonly::Scalar our $SPACE_NUMBERS => 4;
 
 Readonly::Hash our %BUILTIN_USERS => (
     $default_pid => 1, 

--- a/lib/pf/services/manager/keepalived.pm
+++ b/lib/pf/services/manager/keepalived.pm
@@ -58,7 +58,8 @@ sub generateConfig {
 
     my %tags;
     $tags{'template'} = "$conf_dir/keepalived.conf";
-    $tags{'emailaddr'} = $Config{'alerting'}{'emailaddr'};
+    # split email addresses then rejoin them with line feed
+    $tags{'emailaddr'} = join("\n", split( /\s*,\s*/, $Config{'alerting'}{'emailaddr'}));
     $tags{'fromaddr'} = $Config{'alerting'}{'fromaddr'} || "keepalived\@$host_id";
     $tags{'smtpserver'} = $Config{'alerting'}{'smtpserver'};
     $tags{'router_id'} = "PacketFence-$host_id";

--- a/lib/pf/services/manager/keepalived.pm
+++ b/lib/pf/services/manager/keepalived.pm
@@ -32,6 +32,7 @@ use pf::file_paths qw(
 );
 use pf::log;
 use pf::util;
+use pf::constants qw($SPACE $SPACE_NUMBERS);
 use pf::cluster;
 
 extends 'pf::services::manager';
@@ -58,8 +59,10 @@ sub generateConfig {
 
     my %tags;
     $tags{'template'} = "$conf_dir/keepalived.conf";
-    # split email addresses then rejoin them with line feed
-    $tags{'emailaddr'} = join("\n", split( /\s*,\s*/, $Config{'alerting'}{'emailaddr'}));
+    
+    # split email addresses then rejoin them with line feed and indent
+    $tags{'emailaddr'} = join("\n" . ($SPACE x $SPACE_NUMBERS), split( /\s*,\s*/, $Config{'alerting'}{'emailaddr'}));
+    
     $tags{'fromaddr'} = $Config{'alerting'}{'fromaddr'} || "keepalived\@$host_id";
     $tags{'smtpserver'} = $Config{'alerting'}{'smtpserver'};
     $tags{'router_id'} = "PacketFence-$host_id";

--- a/lib/pf/util.pm
+++ b/lib/pf/util.pm
@@ -527,8 +527,6 @@ sub parse_template {
     while (<$template_fh>) {
         study $_;
         foreach my $tag ( keys %{$tags} ) {
-#            use Data::Dumper;
-#            print Dumper($tag, $tags->{$tag});
             $_ =~ s/%%$tag%%/$tags->{$tag}/ig;
         }
         push @parsed, $_;


### PR DESCRIPTION
# Description
Permit to use several email addresses in `alerting.emailaddr` (variable in `pf.conf`).
This variable is also used to generate `keepalived` configuration.

# Impacts
- `keepalived` config
- documentation
- `pfmailer()` function

# Issue
fixes #3578 

# Delete branch after merge
YES

# TODO

- [x] Correctly indent email addresses in `keepalived` generated config.