### PR TITLE
require SSID field for Provisioner

### DIFF
--- a/html/pfappserver/lib/pfappserver/Form/Config/Provisioning/mobileconfig.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Provisioning/mobileconfig.pm
@@ -22,6 +22,7 @@ has_field 'ssid' =>
   (
    type => 'Text',
    label => 'SSID',
+   required => 1,
   );
 
 has_field 'broadcast' =>


### PR DESCRIPTION
# Description
SSID field is now required when creating a new Provisioner.

# Issue
fixes #3605 

# Delete branch after merge
YES