### PR TITLE
Handle pure-text DHCP Option 82 suboptions Circuit-ID and Remote ID

### DIFF
--- a/lib/pf/ConfigStore/Switch.pm
+++ b/lib/pf/ConfigStore/Switch.pm
@@ -117,8 +117,8 @@ _normalizeUplink
 sub _normalizeUplink {
     my ($self, $switch) = @_;
     if ( $switch->{uplink_dynamic} ) {
-        $switch->{uplink}         = 'dynamic';
-        $switch->{uplink_dynamic} = undef;
+        $switch->{uplink_dynamic} = 'dynamic';
+        $switch->{uplink} = undef;
     }
 }
 

--- a/lib/pf/ConfigStore/Switch.pm
+++ b/lib/pf/ConfigStore/Switch.pm
@@ -65,7 +65,11 @@ sub cleanupAfterRead {
     # if the uplink attribute is set to dynamic or not set and the group we inherit from is dynamic
     if ( ($switch->{uplink} && $switch->{uplink} eq 'dynamic') ) {
         $switch->{uplink_dynamic} = 'dynamic';
+<<<<<<< HEAD
         $switch->{uplink} = undef;
+=======
+        $switch->{uplink}         = undef;
+>>>>>>> parent of b14e8dd... Undo.
     }
     $self->expand_list( $switch, 'inlineTrigger' );
     if ( exists $switch->{inlineTrigger} ) {

--- a/lib/pf/ConfigStore/Switch.pm
+++ b/lib/pf/ConfigStore/Switch.pm
@@ -64,8 +64,8 @@ sub cleanupAfterRead {
     my $config = $self->cachedConfig;
     # if the uplink attribute is set to dynamic or not set and the group we inherit from is dynamic
     if ( ($switch->{uplink} && $switch->{uplink} eq 'dynamic') ) {
-        $switch->{uplink}         = 'dynamic';
-        $switch->{uplink_dynamic} = undef;
+        $switch->{uplink_dynamic} = 'dynamic';
+        $switch->{uplink} = undef;
     }
     $self->expand_list( $switch, 'inlineTrigger' );
     if ( exists $switch->{inlineTrigger} ) {
@@ -118,7 +118,7 @@ sub _normalizeUplink {
     my ($self, $switch) = @_;
     if ( $switch->{uplink_dynamic} ) {
         $switch->{uplink_dynamic} = 'dynamic';
-        $switch->{uplink} = undef;
+        $switch->{uplink}         = undef;
     }
 }
 

--- a/lib/pf/ConfigStore/Switch.pm
+++ b/lib/pf/ConfigStore/Switch.pm
@@ -64,8 +64,8 @@ sub cleanupAfterRead {
     my $config = $self->cachedConfig;
     # if the uplink attribute is set to dynamic or not set and the group we inherit from is dynamic
     if ( ($switch->{uplink} && $switch->{uplink} eq 'dynamic') ) {
-        $switch->{uplink_dynamic} = 'dynamic';
-        $switch->{uplink}         = undef;
+        $switch->{uplink}         = 'dynamic';
+        $switch->{uplink_dynamic} = undef;
     }
     $self->expand_list( $switch, 'inlineTrigger' );
     if ( exists $switch->{inlineTrigger} ) {

--- a/lib/pf/util/dhcp.pm
+++ b/lib/pf/util/dhcp.pm
@@ -305,6 +305,13 @@ sub _decode_dhcp_option82_suboption1 {
     elsif ($type == 1) {
         $option->{circuit_id_string} = $data;
     }
+    else {
+	# Last resort fallback - use the whole option (if it only contains printable characters) as circuit id string
+	my $s = pack("C*", @$sub_option);
+	if ($s =~ /\p{XPosixPrint}/) {
+	    $option->{circuit_id_string} = $s;
+	}
+    }
 }
 
 =item _decode_dhcp_option82_suboption2
@@ -328,6 +335,13 @@ sub _decode_dhcp_option82_suboption2 {
     }
     elsif ($type == 1) {
         $option->{host} = $data;
+    }
+    else {
+	# Last resort fallback - use the whole option (if it only contains printable characters) as host
+	my $s = pack("C*", @$sub_option);
+	if ($s =~ /\p{XPosixPrint}/) {
+	    $option->{host} = $s;
+	}
     }
 }
 


### PR DESCRIPTION
# Description
Adds a few simple lines of code for handling pure-text suboptions for Circuit-ID and Remote ID for the DHCP Option-82 code. The current code is Cisco-specific and assumes that the first byte for ascii options is 0x01 which isn't the case for Alcatel switches (and possibly others). 

The Alcatel switch configuration we're using looks like this:
ip helper dhcp-snooping option-82 format ascii circuit-id interface vlan delimiter " "
ip helper dhcp-snooping option-82 format ascii remote-id system-name base-mac delimiter " "

# Impacts
pfdhcplistener, if Option-82 support is enabled, and you have non-cisco switches configured for ASCII option-82 sub options.

# Delete branch after merge
YES

# NEWS file entries
## New Features
* Adds support for pure ASCII Circuit-ID and Remote ID for the DHCP Option-82 support 

## Enhancements
