### PR TITLE
put HAProxy stats files in var/run/ and rename them

### DIFF
--- a/conf/haproxy-db.conf.example
+++ b/conf/haproxy-db.conf.example
@@ -5,7 +5,7 @@ global
 	daemon
 	pidfile %%var_dir%%/run/haproxy-db.pid
 	log /dev/log local0 notice
-        stats socket %%var_dir%%/run/haproxy-db.stats level admin process 1
+	stats socket %%var_dir%%/run/haproxy-db.stats level admin process 1
 	maxconn 4000
 
 listen stats

--- a/conf/haproxy-db.conf.example
+++ b/conf/haproxy-db.conf.example
@@ -5,7 +5,7 @@ global
 	daemon
 	pidfile %%var_dir%%/run/haproxy-db.pid
 	log /dev/log local0 notice
-	stats socket /tmp/proxydbstats level admin process 1
+        stats socket %%var_dir%%/run/haproxy-db.stats level admin process 1
 	maxconn 4000
 
 listen stats

--- a/conf/haproxy-portal.conf.example
+++ b/conf/haproxy-portal.conf.example
@@ -5,7 +5,7 @@ global
 	daemon
 	pidfile %%var_dir%%/run/haproxy-portal.pid
 	log /dev/log local0
-	stats socket /tmp/proxystats level admin process 1
+	stats socket %%var_dir%%/run/haproxy-portal.stats level admin process 1
 	maxconn 4000
 	#Followup of https://github.com/inverse-inc/packetfence/pull/893
 	#haproxy 1.6.11 | intermediate profile | OpenSSL 1.0.1e | SRC: https://mozilla.github.io/server-side-tls/ssl-config-generator/?server=haproxy-1.6.11&openssl=1.0.1e&hsts=yes&profile=intermediate


### PR DESCRIPTION
# Description
- Change paths of HAProxy stats files (portal and db) to be consistent with PF folder layout.
- Rename stats files

- [x] cherry-pick in maintenance

# Impacts
- `haproxy-portal` daemon
- `haproxy-db` daemon

# Issue
fixes #3640 

# Delete branch after merge
YES

# NEWS file entries
## Enhancements
* HAProxy stats files are now located in var/run/ with explicit filenames

# UPGRADE file entries
HAProxy stats files are now located in `var/run/` directory with explicit filenames. To apply that new configuration, you should merge changes from `conf/haproxy-portal.conf.example` and `conf/haproxy-db.conf.example` into `conf/haproxy-portal.conf` and `conf/haproxy-db.conf`, respectively.