### PR TITLE
fix/dhcp-computername-encoding

### DIFF
--- a/lib/pf/condition/fingerbank/device_is_a.pm
+++ b/lib/pf/condition/fingerbank/device_is_a.pm
@@ -47,6 +47,10 @@ match the last ip to see if it is in defined network
 
 sub match {
     my ($self, $device) = @_;
+    if (!defined $device) {
+        return $FALSE;
+    }
+
     $logger->debug("Checking if device $device is a ".$self->value);
     return fingerbank::Model::Device->is_a($device, $self->value);
 }

--- a/t/data/violations.conf
+++ b/t/data/violations.conf
@@ -47,3 +47,7 @@ trigger=DEVICE::13
 actions=log
 enabled=Y
 
+[1100014]
+desc=test hostname violation
+trigger=internal::hostname_change
+actions=log,reevaluate_access

--- a/t/unittest/dhcp/processor_v4.t
+++ b/t/unittest/dhcp/processor_v4.t
@@ -1,0 +1,84 @@
+#!/usr/bin/perl
+
+=head1 NAME
+
+processor_v4
+
+=head1 DESCRIPTION
+
+unit test for processor_v4
+
+=cut
+
+use strict;
+use warnings;
+#
+use lib '/usr/local/pf/lib';
+
+BEGIN {
+    #include test libs
+    use lib qw(/usr/local/pf/t);
+    #Module for overriding configuration paths
+    use setup_test_config;
+}
+
+use Test::More tests => 3;
+use pf::dhcp::processor_v4;
+use pf::node;
+use pf::util;
+use pf::api;
+use pf::api::local;
+
+#This test will running last
+use Test::NoWarnings;
+
+my $mac = random_mac();
+
+while (node_exist($mac)) {
+    my $mac = random_mac();
+}
+
+my $computername = "bob";
+my $new_computername = "bobette";
+my $apiClient = pf::api::local->new();
+
+ok(!pf::dhcp::processor_v4::do_hostname_change_detection($mac, $computername, $apiClient), "node does not exists");
+node_modify($mac, computername => $computername);
+ok(!pf::dhcp::processor_v4::do_hostname_change_detection($mac, $computername, $apiClient), "computername did not change");
+ok(pf::dhcp::processor_v4::do_hostname_change_detection($mac, $new_computername, $apiClient), "computername did change");
+my @violations = pf::violation::violation_view_open($mac);
+ok (scalar @violations, "A violation was added");
+
+sub random_mac {
+    clean_mac( unpack("H*",pack("S", int(rand(65536)))) . unpack("H*",pack("L",$$)));
+}
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2018 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;
+


### PR DESCRIPTION
NOT READY
=========

Description
===========
If the hostname contains non UTF-8 characters in the DHCP packet.
Then packetfence incorrectly detects that the hostname has changed. 

Impacts
=======
DHCP processing

Issue
=====
Fixes #3622

Delete branch after merge
=========================
NO

NEWS file entries
=================

Bug Fixes
------------

* False positives for change violation trigger (#3622)