### PR TITLE
feature/pfdhcplistener-no-ipv6

### DIFF
--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -87,6 +87,13 @@ Which dhcp message types are being listened by the pfdhcplistener.
 Do not change unless you know what you are doing
 EOT
 
+[network.dhcp_process_ipv6]
+type=toggle
+options=enabled|disabled
+description<<EOT
+Enable/disable ipv6 dhcp packets processing by pfdhcplistener.
+EOT
+
 [network.force_listener_update_on_ack]
 type=toggle
 options=enabled|disabled

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -75,6 +75,11 @@ dhcpoption82logger=disabled
 #Possibilities are: DHCPOFFER,DHCPREQUEST,DHCPDECLINE,DHCPACK,DHCPRELEASE
 dhcp_filter_by_message_types=DHCPREQUEST,DHCPACK
 #
+# network.dhcp_process_ipv6
+#
+# Enable/disable ipv6 dhcp packets processing by pfdhcplistener.
+dhcp_process_ipv6=enabled
+#
 # network.force_listener_update_on_ack
 #
 # This will only do the iplog update and other DHCP related task on a DHCPACK.

--- a/sbin/pfdhcplistener
+++ b/sbin/pfdhcplistener
@@ -362,7 +362,7 @@ sub process_pkt {
             }
 
             # IPv6 processing
-            elsif ( $l2->{type} eq ETH_TYPE_IPv6 ) {
+            elsif ( $l2->{type} eq ETH_TYPE_IPv6 && isenabled($Config{network}{dhcp_process_ipv6})) {
                 $pf::StatsD::statsd->increment("pfdhcplistener_$statsd_interface\::process_pkt_ipv6.count" );
 
                 # TODO: Rate-limiting for IPv6 just as for IPv4


### PR DESCRIPTION
Description
===========
Allow disabling processing of ipv6 packets in the pfdhcplistener

Impacts
=======
pfdhcplistener

Issue
=====
Fixes #2855

Delete branch after merge
=========================
NO

NEWS file entries
=================

Enhancements
------------
* Allow disabling processing of ipv6 packets in the pfdhcplistener