### PR TITLE
feature/improve-clustering-guide

### DIFF
--- a/docs/PacketFence_Clustering_Guide.asciidoc
+++ b/docs/PacketFence_Clustering_Guide.asciidoc
@@ -96,10 +96,6 @@ On *all your servers*, add the following line in `/etc/sysctl.conf` and then rel
 
   net.ipv4.ip_nonlocal_bind = 1
 
-Then, disable the default MariaDB systemd service unit as PacketFence already provides one (`packetfence-mariadb`)
-
-  # systemctl disable mariadb
-
 Basic PacketFence configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Description
===========
Remove the instruction for disabling mariadb since packetfence masks the service at install time