### PR TITLE
fix/sms-pincode-reuse

### DIFF
--- a/lib/pf/activation.pm
+++ b/lib/pf/activation.pm
@@ -202,6 +202,31 @@ sub view_by_code {
     return ($item->to_hash);
 }
 
+=head2 is_code_in_use
+
+is_code_in_use
+
+=cut
+
+sub is_code_in_use {
+    my ($type, $code) = @_;
+    my ($status, $iter) = pf::dal::activation->search(
+        -columns => [ \"1" ],
+        -where   => {
+            type            => $type,
+            activation_code => $code,
+            status          => $UNVERIFIED,
+            expiration => { ">=" => \['NOW()']},
+        },
+    );
+
+    if (is_error($status)) {
+        return undef;
+    }
+
+    return $iter->rows;
+}
+
 =head2 view_by_code_mac
 
 view_by_code_mac
@@ -417,7 +442,7 @@ sub _generate_activation_code {
             $code = substr($code, 0, $code_length);
         }
         # make sure the generated code is unique
-        $code = undef if (!$no_unique && view_by_code($type, $code));
+        $code = undef if (!$no_unique && is_code_in_use($type, $code));
     } while (!defined($code));
 
     return $code;

--- a/lib/pf/dal.pm
+++ b/lib/pf/dal.pm
@@ -332,14 +332,15 @@ sub update_items {
         @args,
     );
     return $status, undef if is_error($status);
-
+    my $rows = $sth->rows;
+    $sth->finish;
     my $info = $sth->{Database}{mysql_info};
-    if ($info =~ /^.*: (\d+).*: (\d+).*: (\d+)/) {
+    if ($info && $info =~ /^.*: (\d+).*: (\d+).*: (\d+)/) {
         my ($matched, $row, $warning) = ($1, $2, $3);
         return $STATUS::OK, $matched;
     }
 
-    return $STATUS::OK, $sth->rows;
+    return $STATUS::OK, $rows;
 }
 
 =head2 insert

--- a/t/unittest/activation.t
+++ b/t/unittest/activation.t
@@ -1,0 +1,88 @@
+#!/usr/bin/perl
+
+=head1 NAME
+
+activation
+
+=head1 DESCRIPTION
+
+unit test for activation
+
+=cut
+
+use strict;
+use warnings;
+#
+use lib '/usr/local/pf/lib';
+
+BEGIN {
+    #include test libs
+    use lib qw(/usr/local/pf/t);
+    #Module for overriding configuration paths
+    use setup_test_config;
+}
+
+use Test::More tests => 6;
+use Utils;
+
+#This test will running last
+use Test::NoWarnings;
+use pf::activation qw($UNVERIFIED $SMS_ACTIVATION);
+my $mac =  Utils::test_mac();
+my $mac2 = Utils::test_mac();
+my $pid = "default";
+
+my %data = (
+    'pid' => $pid,
+    'mac' => $mac,
+    'contact_info' => 'test@inverse.ca',
+    'status' => $UNVERIFIED,
+    'type' => 'sms',
+    'portal' => 'portal',
+    'carrier_id' => 100056,
+    'code_length' => 8,
+    'style'    => 'md5',
+    timeout    => 2,
+    'source_id' => 'local',
+);
+
+my $code = pf::activation::create(\%data);
+
+ok (defined $code ,"Code generated for $mac for $pid");
+
+ok (pf::activation::is_code_in_use('sms', $code, $mac), "code in use");
+ok (!pf::activation::is_code_in_use('sms', $code, $mac2), "code not in use for mac2");
+ok (!pf::activation::is_code_in_use('sms', "${code}_$$", $mac), "Is not code in use");
+
+sleep(3);
+
+ok (!pf::activation::is_code_in_use('sms', $code, $mac), "Is not in use");
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2018 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;


### PR DESCRIPTION
Description
===========
Allow activation pin codes to be reused

Impacts
=======
SMS/Email activations.

Issue
=====
Fixes #3436

Delete branch after merge
=========================
NO

NEWS file entries
=================

Bug Fixes
------------

* Allow activation pin codes to be reused (#3436)