### PR TITLE
Reworked dhcp statistics

### DIFF
--- a/conf/monitoring/statsd.d/packetfence.conf.example
+++ b/conf/monitoring/statsd.d/packetfence.conf.example
@@ -83,7 +83,7 @@
     type = stacked
     dimension = pattern 'source.packetfence.redis.queue_stats_outstanding.*' '' last 1 1
 
-[dhcp.dhcp_free_leases]
+[dhcp.free_leases]
     name = dhcp.free_leases
     title = Dhcp free leases
     family = packetfence
@@ -93,7 +93,7 @@
     type = line
     dimension = pattern 'source.packetfence.dhcp_leases.free.*' '' last 1 1
 
-[dhcp.dhcp_used_leases]
+[dhcp.used_leases]
     name = dhcp.used_leases
     title = Dhcp used leases
     family = packetfence
@@ -103,9 +103,9 @@
     type = line
     dimension = pattern 'source.packetfence.dhcp_leases.used.*' '' last 1 1
 
-[dhcp.dhcp_percent_free_leases]
+[dhcp.percent_free_leases]
     name = dhcp.percent_free_leases
-    title = Dhcp percent_free leases
+    title = Dhcp percent free leases
     family = packetfence
     context = chart.context
     units = Percent
@@ -113,7 +113,7 @@
     type = line
     dimension = pattern 'source.packetfence.dhcp_leases.percentfree.*' '' last 1 1
 
-[dhcp.dhcp_percent_used_leases]
+[dhcp.percent_used_leases]
     name = dhcp.percent_used_leases
     title = Dhcp percent used leases
     family = packetfence
@@ -122,4 +122,3 @@
     priority = 91000
     type = line
     dimension = pattern 'source.packetfence.dhcp_leases.percentused.*' '' last 1 1
-

--- a/conf/monitoring/statsd.d/packetfence.conf.example
+++ b/conf/monitoring/statsd.d/packetfence.conf.example
@@ -83,13 +83,43 @@
     type = stacked
     dimension = pattern 'source.packetfence.redis.queue_stats_outstanding.*' '' last 1 1
 
-[dhcp.dhcp_lease]
+[dhcp.dhcp_free_leases]
     name = dhcp.free_leases
-    title = DHCP free leases
+    title = Dhcp free leases
     family = packetfence
     context = chart.context
     units = Free
     priority = 91000
     type = line
-    dimension = pattern 'source.packetfence.dhcp_leases.*' '' last 1 1
+    dimension = pattern 'source.packetfence.dhcp_leases.free.*' '' last 1 1
+
+[dhcp.dhcp_used_leases]
+    name = dhcp.used_leases
+    title = Dhcp used leases
+    family = packetfence
+    context = chart.context
+    units = Used
+    priority = 91000
+    type = line
+    dimension = pattern 'source.packetfence.dhcp_leases.used.*' '' last 1 1
+
+[dhcp.dhcp_percent_free_leases]
+    name = dhcp.percent_free_leases
+    title = Dhcp percent_free leases
+    family = packetfence
+    context = chart.context
+    units = Percent
+    priority = 91000
+    type = line
+    dimension = pattern 'source.packetfence.dhcp_leases.percentfree.*' '' last 1 1
+
+[dhcp.dhcp_percent_used_leases]
+    name = dhcp.percent_used_leases
+    title = Dhcp percent used leases
+    family = packetfence
+    context = chart.context
+    units = Percent
+    priority = 91000
+    type = line
+    dimension = pattern 'source.packetfence.dhcp_leases.percentused.*' '' last 1 1
 

--- a/conf/monitoring/statsd.d/packetfence.conf.example
+++ b/conf/monitoring/statsd.d/packetfence.conf.example
@@ -82,3 +82,14 @@
     priority = 91000
     type = stacked
     dimension = pattern 'source.packetfence.redis.queue_stats_outstanding.*' '' last 1 1
+
+[dhcp.dhcp_lease]
+    name = dhcp.free_leases
+    title = DHCP free leases
+    family = packetfence
+    context = chart.context
+    units = Free
+    priority = 91000
+    type = line
+    dimension = pattern 'source.packetfence.dhcp_leases.*' '' last 1 1
+

--- a/conf/stats.conf.example
+++ b/conf/stats.conf.example
@@ -144,7 +144,7 @@ randomize=true
 [metric 'number of dhcp free ip addresses']
 type=api
 statsd_type=gauge
-statsd_ns=source.packetfence.dhcp_leases
+statsd_ns=source.packetfence.dhcp_leases.free
 api_method=GET
 api_path=/api/v1/dhcp/stats
 api_compile=$.items[*].network.free, $.items[*].free
@@ -154,7 +154,7 @@ randomize=true
 [metric 'number of dhcp used ip addresses']
 type=api
 statsd_type=gauge
-statsd_ns=source.packetfence.dhcp_leases
+statsd_ns=source.packetfence.dhcp_leases.used
 api_method=GET
 api_path=/api/v1/dhcp/stats
 api_compile=$.items[*].network.used, $.items[*].used
@@ -164,19 +164,19 @@ randomize=true
 [metric 'percent of dhcp free ip addresses']
 type=api
 statsd_type=gauge
-statsd_ns=source.packetfence.dhcp_leases
+statsd_ns=source.packetfence.dhcp_leases.percentfree
 api_method=GET
 api_path=/api/v1/dhcp/stats
-api_compile=$.items[*].network.percentfree, $.items[*].percentfree
+api_compile=$.items[*].network, $.items[*].percentfree
 interval=60s
 randomize=true
 
-[metric 'percent of dhcp free ip addresses']
+[metric 'percent of dhcp used ip addresses']
 type=api
 statsd_type=gauge
-statsd_ns=source.packetfence.dhcp_leases
+statsd_ns=source.packetfence.dhcp_leases.percentused
 api_method=GET
 api_path=/api/v1/dhcp/stats
-api_compile=$.items[*].network.percentused, $.items[*].percentused
+api_compile=$.items[*].network, $.items[*].percentused
 interval=60s
 randomize=true

--- a/conf/stats.conf.example
+++ b/conf/stats.conf.example
@@ -140,3 +140,13 @@ statsd_ns=source.packetfence.authentication.failed_last_day
 mysql_query=select count(1) from radius_audit_log where auth_status='Reject' and created_at >= NOW() - INTERVAL 1 DAY;
 interval=60s
 randomize=true
+
+[metric 'number of dhcp free ip addresses']
+type=api
+statsd_type=gauge
+statsd_ns=source.packetfence.dhcp_leases
+api_method=GET
+api_path=/api/v1/dhcp/stats
+api_compile=$.items[*].network, $.items[*].free
+interval=60s
+randomize=true

--- a/conf/stats.conf.example
+++ b/conf/stats.conf.example
@@ -147,6 +147,36 @@ statsd_type=gauge
 statsd_ns=source.packetfence.dhcp_leases
 api_method=GET
 api_path=/api/v1/dhcp/stats
-api_compile=$.items[*].network, $.items[*].free
+api_compile=$.items[*].network.free, $.items[*].free
+interval=60s
+randomize=true
+
+[metric 'number of dhcp used ip addresses']
+type=api
+statsd_type=gauge
+statsd_ns=source.packetfence.dhcp_leases
+api_method=GET
+api_path=/api/v1/dhcp/stats
+api_compile=$.items[*].network.used, $.items[*].used
+interval=60s
+randomize=true
+
+[metric 'percent of dhcp free ip addresses']
+type=api
+statsd_type=gauge
+statsd_ns=source.packetfence.dhcp_leases
+api_method=GET
+api_path=/api/v1/dhcp/stats
+api_compile=$.items[*].network.percentfree, $.items[*].percentfree
+interval=60s
+randomize=true
+
+[metric 'percent of dhcp free ip addresses']
+type=api
+statsd_type=gauge
+statsd_ns=source.packetfence.dhcp_leases
+api_method=GET
+api_path=/api/v1/dhcp/stats
+api_compile=$.items[*].network.percentused, $.items[*].percentused
 interval=60s
 randomize=true

--- a/go/dhcp/api.go
+++ b/go/dhcp/api.go
@@ -33,6 +33,9 @@ type Stats struct {
 	EthernetName string            `json:"interface"`
 	Net          string            `json:"network"`
 	Free         int               `json:"free"`
+	PercentFree  int               `json:"percentfree"`
+	Used         int               `json:"used"`
+	PercentUsed  int               `json:"percentused"`
 	Category     string            `json:"category"`
 	Options      map[string]string `json:"options"`
 	Members      []Node            `json:"members"`
@@ -360,13 +363,17 @@ func (h *Interface) handleApiReq(Request ApiReq) interface{} {
 			}
 
 			availableCount := (int(statistics.RunContainerValues) + int(statistics.ArrayContainerValues))
+			usedCount := (v.dhcpHandler.leaseRange - availableCount)
+			percentfree := ((availableCount / v.dhcpHandler.leaseRange) * 100)
+			percentused := ((usedCount / v.dhcpHandler.leaseRange) * 100)
+
 			if Count == (v.dhcpHandler.leaseRange - availableCount) {
 				Status = "Normal"
 			} else {
 				Status = "Calculated available IP " + strconv.Itoa(v.dhcpHandler.leaseRange-Count) + " is different than what we have available in the pool " + strconv.Itoa(availableCount)
 			}
 
-			stats = append(stats, Stats{EthernetName: Request.NetInterface, Net: v.network.String(), Free: int(statistics.RunContainerValues) + int(statistics.ArrayContainerValues), Category: v.dhcpHandler.role, Options: Options, Members: Members, Status: Status, Size: availableCount})
+			stats = append(stats, Stats{EthernetName: Request.NetInterface, Net: v.network.String(), Free: availableCount, Category: v.dhcpHandler.role, Options: Options, Members: Members, Status: Status, Size: v.dhcpHandler.leaseRange, Used: usedCount, PercentFree: percentfree, PercentUsed: percentused})
 		}
 		return stats
 	}

--- a/go/dhcp/api.go
+++ b/go/dhcp/api.go
@@ -364,8 +364,8 @@ func (h *Interface) handleApiReq(Request ApiReq) interface{} {
 
 			availableCount := (int(statistics.RunContainerValues) + int(statistics.ArrayContainerValues))
 			usedCount := (v.dhcpHandler.leaseRange - availableCount)
-			percentfree := ((availableCount / v.dhcpHandler.leaseRange) * 100)
-			percentused := ((usedCount / v.dhcpHandler.leaseRange) * 100)
+			percentfree := int((float64(availableCount) / float64(v.dhcpHandler.leaseRange)) * 100)
+			percentused := int((float64(usedCount) / float64(v.dhcpHandler.leaseRange)) * 100)
 
 			if Count == (v.dhcpHandler.leaseRange - availableCount) {
 				Status = "Normal"

--- a/go/stats/metrics.go
+++ b/go/stats/metrics.go
@@ -229,6 +229,37 @@ func ProcessMetricConfig(ctx context.Context, conf pfconfigdriver.PfStats) error
 					default:
 						log.LoggerWContext(ctx).Warn("Unhandled statsd_type " + conf.StatsdType + " for " + conf.Type)
 					}
+				case [][3]interface{}:
+					//triple column
+					var namespace string
+					for _, row := range res.([][3]interface{}) {
+						namespace = CleanNameSpace(conf.StatsdNS + "." + row[0].(string))
+						f64Result, _ := strconv.ParseFloat(row[1][0].(string), 64)
+						f64Result2, _ := strconv.ParseFloat(row[1][1].(string), 64)
+						switch conf.StatsdType {
+						case "count":
+							StatsdClient.Count(namespace, f64Result)
+							StatsdClient.Count(namespace, f64Result2)
+
+						case "gauge":
+							StatsdClient.Gauge(namespace, f64Result)
+							StatsdClient.Gauge(namespace, f64Result2)
+
+						case "histogram":
+							StatsdClient.Histogram(namespace, f64Result)
+							StatsdClient.Histogram(namespace, f64Result2)
+
+						case "increment":
+							StatsdClient.Increment(namespace)
+							StatsdClient.Increment(namespace)
+
+						case "unique":
+							StatsdClient.Unique(namespace, row[1][0].(string))
+							StatsdClient.Unique(namespace, row[1][1].(string))
+
+						default:
+							log.LoggerWContext(ctx).Warn("Unhandled statsd_type " + conf.StatsdType + " for " + conf.Type)
+						}
 
 				}
 
@@ -274,6 +305,30 @@ func ProcessMetricConfig(ctx context.Context, conf pfconfigdriver.PfStats) error
  */
 func CompileJson(json interface{}, compile string) (interface{}, error) {
 	c := strings.Split(compile, ",")
+	if len(c) == 2 {
+		// multiple XPath(s)
+		r1, err := CompileJson(json, c[0])
+		if err != nil {
+			return nil, err
+		}
+
+		r2, err := CompileJson(json, c[1])
+		if err != nil {
+			return nil, err
+		}
+
+		r3, err := CompileJson(json, c[2])
+		if err != nil {
+			return nil, err
+		}
+
+		zipped, err := Zip3(r1.([]interface{}), r2.([]interface{}), r3.([]interface{}))
+		if err != nil {
+			return nil, err
+		}
+
+		return zipped, nil
+	}
 	if len(c) > 1 {
 		// multiple XPath(s)
 		r1, err := CompileJson(json, c[0])
@@ -352,6 +407,23 @@ func Zip(a, b []interface{}) ([][2]interface{}, error) {
 	r := make([][2]interface{}, len(a), len(a))
 	for i, e := range a {
 		r[i] = [2]interface{}{e, b[i]}
+	}
+
+	return r, nil
+}
+
+/*
+ * Glues 2 []interface{} together into a single slice with 2 elements,
+ *     example: Zip([santa tooth], [clause, fairy]) = [[santa clause] [tooth fairy]]
+ * Used to match name(s) with value(s) from 2 separate JSON Xpaths
+ */
+func Zip3(a, b, c []interface{}) ([][3]interface{}, error) {
+	if len(a) != len(b) {
+		return nil, errors.New("Zip arguments must be of same length")
+	}
+	r := make([][3]interface{}, len(a), len(a))
+	for i, e := range a {
+		r[i] = [3]interface{}{e, b[i], c[i]}
 	}
 
 	return r, nil

--- a/html/pfappserver/root/graph/dashboard.tt
+++ b/html/pfappserver/root/graph/dashboard.tt
@@ -420,30 +420,18 @@ END;
         </div>
 
         <div class="tab-pane[% IF tab == "dhcp" %] active[% END %]" id="dhcp">
-          [% FOREACH network IN networks.keys %]
-            [% IF networks.$network.dhcpd == "enabled" %]
             <div class="card">
               <div class="card-title">
-                <h2>[% l('DHCP on') %] [% network %]</h2>
+                <h2>[% l('DHCP free leases') %]</h2>
               </div>
               <div class="card-block">
                 <div class="row-flex">
-                  [% FOREACH scope IN ["day", "week", "month", "year"] %]
-                    [% graph("statsd_gauge_source.packetfence.dhcp_leases_" _ network _ "_" _ scope, "DHCP leases free on " _ network _ " for the past " _ scope, {"width" => halfGridSize, "filter_graph" => "gauge"}) | none %]
-                  [% END %]
+                    [% graph("packetfence.dhcp.free_leases", {"width" => halfGridSize, "filter_graph" => "gauge"}) | none %]
                 </div>
               </div>
             </div>
-            [% ELSE %]
-            <div class="card">
-              <div class="card-title">
-                <h2>[% l('DHCP on') %] [% network %] [% l('disabled') %]</h2>
-              </div>
-            </div>
-            [% END %]
-          [% END %]
         </div>
-        
+ 
         <div class="tab-pane[% IF tab == "endpoints" %] active[% END %]" id="endpoints">
           <div class="card">
             <div class="card-title">

--- a/html/pfappserver/root/graph/dashboard.tt
+++ b/html/pfappserver/root/graph/dashboard.tt
@@ -422,16 +422,26 @@ END;
         <div class="tab-pane[% IF tab == "dhcp" %] active[% END %]" id="dhcp">
             <div class="card">
               <div class="card-title">
-                <h2>[% l('DHCP free leases') %]</h2>
+                <h2>[% l('DHCP used leases') %]</h2>
               </div>
               <div class="card-block">
                 <div class="row-flex">
-                    [% graph("packetfence.dhcp.free_leases", {"width" => halfGridSize, "filter_graph" => "gauge"}) | none %]
+                    [% graph("packetfence.dhcp.used_leases", "Numbers of ip addresses assigned", {"width" => halfGridSize, "filter_graph" => "gauge"}) | none %]
+                </div>
+              </div>
+            </div>
+            <div class="card">
+              <div class="card-title">
+                <h2>[% l('DHCP percent used leases') %]</h2>
+              </div>
+              <div class="card-block">
+                <div class="row-flex">
+                    [% graph("packetfence.dhcp.percent_used_leases", "Percent of ip addresses used", {"width" => halfGridSize, "filter_graph" => "gauge"}) | none %]
                 </div>
               </div>
             </div>
         </div>
- 
+
         <div class="tab-pane[% IF tab == "endpoints" %] active[% END %]" id="endpoints">
           <div class="card">
             <div class="card-title">

--- a/lib/pf/services/manager/netdata.pm
+++ b/lib/pf/services/manager/netdata.pm
@@ -142,13 +142,12 @@ families: *
       on: statsd_gauge.source.packetfence.dhcp_leases.percentused.$cidr
       os: linux
    hosts: *
-  lookup: DHCP Leases usage
    units: %
    every: 1m
-    warn: \$this > ((\$status >= \$WARNING)  ? (75) : (85))
-    crit: \$this > ((\$status == \$CRITICAL) ? (85) : (95))
-   delay: down 15m multiplier 1.5 max 1h
-    info: DHCP leases usage for the last 10 minutes
+    warn: \$gauge > 80
+    crit: \$gauge > 90
+   delay: down 5m multiplier 1.5 max 1h
+    info: DHCP leases usage $cidr
       to: sysadmin
 
 EOT

--- a/lib/pf/services/manager/netdata.pm
+++ b/lib/pf/services/manager/netdata.pm
@@ -92,7 +92,7 @@ sub generateConfig {
             $tags{'alerts'} .= <<"EOT";
 template: eduroam1__source_available
 families: *
-      on: source.$type.eduroam1
+      on: statsd_gauge.source.$type.Eduroam1
    every: 10s
     crit: \$gauge != 1
    units: ok/failed
@@ -102,7 +102,7 @@ families: *
 
 template: eduroam2_source_available
 families: *
-      on: source.$type.eduroam2
+      on: statsd_gauge.source.$type.Eduroam2
    every: 10s
     crit: \$gauge != 1
    units: ok/failed
@@ -136,11 +136,10 @@ EOT
         next if isdisabled($NetworkConfig{$network}{'dhcpd'});
         my $net_addr = NetAddr::IP->new($network,$NetworkConfig{$network}{'netmask'});
         my $cidr = $net_addr->cidr();
-        $cidr =~ s/\//_/g;
         $tags{'alerts'} .= <<"EOT";
 template: dhcp_missing_leases_$cidr
 families: *
-      on: statsd_gauge_source.packetfence.dhcp_leases.percentused.$cidr
+      on: statsd_gauge.source.packetfence.dhcp_leases.percentused.$cidr
       os: linux
    hosts: *
   lookup: DHCP Leases usage


### PR DESCRIPTION
# Description
Reduced the call to the api to have the dhcp statistics
Created 2 graphs with the usage on each networks and percent of usage
Created warning alarms that pop if the percent of used ip is greater than 80%, error if greater than 90%

# Impacts
pfstats and pfdhcp

# Issue
fixes #3634

# Delete branch after merge
YES

## Bug Fixes
* pfstats hammers pfdhcp and the API frontend with requests (#3634)
