### PR TITLE
adjustments to pfdhcp for multi-zone cluster

### DIFF
--- a/go/dhcp/main.go
+++ b/go/dhcp/main.go
@@ -292,7 +292,7 @@ func (h *Interface) ServeDHCP(ctx context.Context, p dhcp.Packet, msgType dhcp.M
 			GlobalTransactionLock.Unlock()
 			return answer
 		} else {
-			GlobalTransactionCache.Set(cacheKey, 1, time.Duration(5)*time.Second)
+			GlobalTransactionCache.Set(cacheKey, 1, time.Duration(1)*time.Second)
 			GlobalTransactionLock.Unlock()
 		}
 

--- a/go/dhcp/main.go
+++ b/go/dhcp/main.go
@@ -458,7 +458,7 @@ func (h *Interface) ServeDHCP(ctx context.Context, p dhcp.Packet, msgType dhcp.M
 			if len(serverIdBytes) == 4 {
 				serverId := net.IPv4(serverIdBytes[0], serverIdBytes[1], serverIdBytes[2], serverIdBytes[3])
 				if !serverId.Equal(handler.ip.To4()) {
-					log.LoggerWContext(ctx).Info(fmt.Sprintf("Not replying to %s because this server didn't perform the offer (offered by %s, we are %s)", prettyType, serverId, handler.ip.To4()))
+					log.LoggerWContext(ctx).Debug(fmt.Sprintf("Not replying to %s because this server didn't perform the offer (offered by %s, we are %s)", prettyType, serverId, handler.ip.To4()))
 					return Answer{}
 				}
 			}
@@ -501,7 +501,7 @@ func (h *Interface) ServeDHCP(ctx context.Context, p dhcp.Packet, msgType dhcp.M
 						}
 					} else {
 						// Not in the cache so we don't reply
-						log.LoggerWContext(ctx).Info(fmt.Sprintf("Not replying to %s because this server didn't perform the offer", prettyType))
+						log.LoggerWContext(ctx).Debug(fmt.Sprintf("Not replying to %s because this server didn't perform the offer", prettyType))
 						return Answer{}
 					}
 				}

--- a/go/dhcp/main.go
+++ b/go/dhcp/main.go
@@ -435,6 +435,7 @@ func (h *Interface) ServeDHCP(ctx context.Context, p dhcp.Packet, msgType dhcp.M
 					GlobalOptions[key] = value
 				}
 			}
+
 			log.LoggerWContext(ctx).Info("DHCPOFFER on " + answer.IP.String() + " to " + clientMac + " (" + clientHostname + ")")
 
 			answer.D = dhcp.ReplyPacket(p, dhcp.Offer, handler.ip.To4(), answer.IP, leaseDuration,
@@ -443,13 +444,24 @@ func (h *Interface) ServeDHCP(ctx context.Context, p dhcp.Packet, msgType dhcp.M
 			return answer
 
 		case dhcp.Request, dhcp.Inform:
-
 			reqIP := net.IP(options[dhcp.OptionRequestedIPAddress])
 			if reqIP == nil {
 				reqIP = net.IP(p.CIAddr())
 			}
 
 			log.LoggerWContext(ctx).Info(prettyType + " for " + reqIP.String() + " from " + clientMac + " (" + clientHostname + ")")
+
+			cacheKey := p.CHAddr().String() + " " + msgType.String() + " xID " + sharedutils.ByteToString(p.XId())
+
+			// In the event of a DHCPREQUEST, we do not reply if we're not the server ID in the request
+			serverIdBytes := options[dhcp.OptionServerIdentifier]
+			if len(serverIdBytes) == 4 {
+				serverId := net.IPv4(serverIdBytes[0], serverIdBytes[1], serverIdBytes[2], serverIdBytes[3])
+				if !serverId.Equal(handler.ip.To4()) {
+					log.LoggerWContext(ctx).Info(fmt.Sprintf("Not replying to %s because this server didn't perform the offer (offered by %s, we are %s)", prettyType, serverId, handler.ip.To4()))
+					return Answer{}
+				}
+			}
 
 			answer.IP = reqIP
 			answer.Iface = h.intNet
@@ -466,7 +478,6 @@ func (h *Interface) ServeDHCP(ctx context.Context, p dhcp.Packet, msgType dhcp.M
 
 						if dhcp.IPAdd(handler.start, index.(int)).Equal(reqIP) {
 							GlobalTransactionLock.Lock()
-							cacheKey := p.CHAddr().String() + " " + msgType.String() + " xID " + sharedutils.ByteToString(p.XId())
 							if _, found = RequestGlobalTransactionCache.Get(cacheKey); found {
 								log.LoggerWContext(ctx).Debug("Not answering to REQUEST. Already processed")
 								Reply = false
@@ -489,8 +500,9 @@ func (h *Interface) ServeDHCP(ctx context.Context, p dhcp.Packet, msgType dhcp.M
 							}
 						}
 					} else {
-						// Not in the cache so refuse
-						Reply = false
+						// Not in the cache so we don't reply
+						log.LoggerWContext(ctx).Info(fmt.Sprintf("Not replying to %s because this server didn't perform the offer", prettyType))
+						return Answer{}
 					}
 				}
 				if Reply {

--- a/go/dhcp/pool.go
+++ b/go/dhcp/pool.go
@@ -22,7 +22,7 @@ func doWork(id int, jobe job) {
 	if ans = jobe.handler.ServeDHCP(jobe.localCtx, jobe.p, jobe.msgType); ans.D != nil {
 		ipStr, _, _ := net.SplitHostPort(jobe.addr.String())
 		if !(jobe.p.GIAddr().Equal(net.IPv4zero) && net.ParseIP(ipStr).Equal(net.IPv4zero)) {
-			sendUnicastDHCP(ans.D, jobe.addr, jobe.dst, jobe.p.GIAddr(), ans.Local)
+			sendUnicastDHCP(ans.D, jobe.addr, jobe.dst, jobe.p.GIAddr(), true)
 		} else {
 			client, _ := NewRawClient(ans.Iface)
 			client.sendDHCP(ans.MAC, ans.D, ans.IP, ans.SrcIP)


### PR DESCRIPTION
# Description
Adjust pfdhcp so that it supports working with a peer in multi-zone cluster

# Impacts
pfdhcp, specifically the fact we won't be sending a NAK to a request for which we don't have a lease. Instead no reply at all will be made. In the case of a device attempting to do a request for a lease from another network, the lack of reply should start a discovery process

# Issue
fixes #3726 

# Delete branch after merge
YES

