### PR TITLE
Updated acct_stop procedure to avoid acct_stop packet if it's duplicate

### DIFF
--- a/db/upgrade-X.X.X-X.Y.Z.sql
+++ b/db/upgrade-X.X.X-X.Y.Z.sql
@@ -68,48 +68,48 @@ INSERT INTO sms_carrier VALUES(100128, 'Google Project Fi', '%s@msg.fi.google.co
 DROP PROCEDURE IF EXISTS acct_stop;
 DELIMITER /
 CREATE PROCEDURE acct_stop (
-  IN `p_timestamp` datetime,
-  IN `p_framedipaddress` varchar(15),
-  IN `p_acctsessiontime` int(12),
-  IN `p_acctinputoctets` bigint(20) unsigned,
-  IN `p_acctoutputoctets` bigint(20) unsigned,
-  IN `p_acctuniqueid` varchar(32),
-  IN `p_acctsessionid` varchar(64),
-  IN `p_username` varchar(64),
-  IN `p_realm` varchar(64),
-  IN `p_nasipaddress` varchar(15),
-  IN `p_nasportid` varchar(32),
-  IN `p_nasporttype` varchar(32),
-  IN `p_acctauthentic` varchar(32),
-  IN `p_connectinfo_stop` varchar(50),
-  IN `p_calledstationid` varchar(50),
-  IN `p_callingstationid` varchar(50),
-  IN `p_servicetype` varchar(32),
-  IN `p_framedprotocol` varchar(32),
-  IN `p_acctterminatecause` varchar(12),
-  IN `p_acctstatustype` varchar(25),
-  IN `p_tenant_id` int(11) unsigned
+  IN p_timestamp datetime,
+  IN p_framedipaddress varchar(15),
+  IN p_acctsessiontime int(12),
+  IN p_acctinputoctets bigint(20),
+  IN p_acctoutputoctets bigint(20),
+  IN p_acctuniqueid varchar(32),
+  IN p_acctsessionid varchar(64),
+  IN p_username varchar(64),
+  IN p_realm varchar(64),
+  IN p_nasipaddress varchar(15),
+  IN p_nasportid varchar(32),
+  IN p_nasporttype varchar(32),
+  IN p_acctauthentic varchar(32),
+  IN p_connectinfo_stop varchar(50),
+  IN p_calledstationid varchar(50),
+  IN p_callingstationid varchar(50),
+  IN p_servicetype varchar(32),
+  IN p_framedprotocol varchar(32),
+  IN p_acctterminatecause varchar(12),
+  IN p_acctstatustype varchar(25),
+  IN p_tenant_id int
 )
 BEGIN
-  DECLARE `Previous_Input_Octets` bigint(20) unsigned;
-  DECLARE `Previous_Output_Octets` bigint(20) unsigned;
-  DECLARE `Previous_Session_Time` int(12) unsigned;
+  DECLARE Previous_Input_Octets bigint(20);
+  DECLARE Previous_Output_Octets bigint(20);
+  DECLARE Previous_Session_Time int(12);
 
   # Collect traffic previous values in the radacct table
-  SELECT `acctinputoctets`, `acctoutputoctets`, `acctsessiontime`
-    INTO `Previous_Input_Octets`, `Previous_Output_Octets`, `Previous_Session_Time`
-    FROM `radacct`
-    WHERE `acctuniqueid` = `p_acctuniqueid`
-    AND (`acctstoptime` IS NULL OR `acctstoptime` = 0) LIMIT 1;
+  SELECT acctinputoctets, acctoutputoctets, acctsessiontime
+    INTO Previous_Input_Octets, Previous_Output_Octets, Previous_Session_Time
+    FROM radacct
+    WHERE acctuniqueid = p_acctuniqueid
+    AND (acctstoptime IS NULL OR acctstoptime = 0) LIMIT 1;
 
   # Set values to 0 when no previous records
-  IF (`Previous_Session_Time` IS NOT NULL) THEN
+  IF (Previous_Session_Time IS NOT NULL) THEN
     # Update record with new traffic
     UPDATE radacct SET
-      `acctstoptime` = `p_timestamp`,
-      `acctsessiontime` = `p_acctsessiontime`,
-      `acctinputoctets` = `p_acctinputoctets`,
-      `acctoutputoctets` = `p_acctoutputoctets`,
+      acctstoptime = p_timestamp,
+      acctsessiontime = p_acctsessiontime,
+      acctinputoctets = p_acctinputoctets,
+      acctoutputoctets = p_acctoutputoctets,
       acctterminatecause = p_acctterminatecause,
       connectinfo_stop = p_connectinfo_stop
       WHERE acctuniqueid = p_acctuniqueid

--- a/db/upgrade-X.X.X-X.Y.Z.sql
+++ b/db/upgrade-X.X.X-X.Y.Z.sql
@@ -53,7 +53,7 @@ DROP PROCEDURE IF EXISTS ValidateVersion;
 --
 DELETE FROM sms_carrier where id=100122 and name="Google Project Fi";
 --
--- Delete Google Project Fi from SMS carriers that may have been added during 8.1 to 8.2 upgrade if patched script was used 
+-- Delete Google Project Fi from SMS carriers that may have been added during 8.1 to 8.2 upgrade if patched script was used
 --
 DELETE FROM sms_carrier where id=100128;
 
@@ -96,33 +96,33 @@ BEGIN
   DECLARE `Previous_Session_Time` int(12) unsigned;
 
   # Collect traffic previous values in the radacct table
-  SELECT acctinputoctets, acctoutputoctets, acctsessiontime
-    INTO Previous_Input_Octets, Previous_Output_Octets, Previous_Session_Time
-    FROM radacct
-    WHERE acctuniqueid = p_acctuniqueid
-    AND (acctstoptime IS NULL OR acctstoptime = 0) LIMIT 1;
+  SELECT `acctinputoctets`, `acctoutputoctets`, `acctsessiontime`
+    INTO `Previous_Input_Octets`, `Previous_Output_Octets`, `Previous_Session_Time`
+    FROM `radacct`
+    WHERE `acctuniqueid` = `p_acctuniqueid`
+    AND (`acctstoptime` IS NULL OR `acctstoptime` = 0) LIMIT 1;
 
   # Set values to 0 when no previous records
-  IF (Previous_Session_Time IS NOT NULL) THEN
+  IF (`Previous_Session_Time` IS NOT NULL) THEN
     # Update record with new traffic
-    UPDATE radacct SET
-      acctstoptime = p_timestamp,
-      acctsessiontime = p_acctsessiontime,
-      acctinputoctets = p_acctinputoctets,
-      acctoutputoctets = p_acctoutputoctets,
-      acctterminatecause = p_acctterminatecause,
-      connectinfo_stop = p_connectinfo_stop
-      WHERE acctuniqueid = p_acctuniqueid
-      AND (acctstoptime IS NULL OR acctstoptime = 0);
+    UPDATE `radacct` SET
+      `acctstoptime` = `p_timestamp`,
+      `acctsessiontime` = `p_acctsessiontime`,
+      `acctinputoctets` = `p_acctinputoctets`,
+      `acctoutputoctets` = `p_acctoutputoctets`,
+      `acctterminatecause` = `p_acctterminatecause`,
+      `connectinfo_stop` = `p_connectinfo_stop`
+      WHERE `acctuniqueid` = `p_acctuniqueid`
+      AND (`acctstoptime` IS NULL OR `acctstoptime` = 0);
 
     # Create new record in the log table
-    INSERT INTO radacct_log
-     (acctsessionid, username, nasipaddress,
-      timestamp, acctstatustype, acctinputoctets, acctoutputoctets, acctsessiontime, acctuniqueid, tenant_id)
+    INSERT INTO `radacct_log`
+     (`acctsessionid`, `username`, `nasipaddress`,
+      `timestamp`, `acctstatustype`, `acctinputoctets`, `acctoutputoctets`, `acctsessiontime`, `acctuniqueid`, `tenant_id`)
     VALUES
-     (p_acctsessionid, p_username, p_nasipaddress,
-     p_timestamp, p_acctstatustype, (p_acctinputoctets - Previous_Input_Octets), (p_acctoutputoctets - Previous_Output_Octets),
-     (p_acctsessiontime - Previous_Session_Time), p_acctuniqueid, p_tenant_id);
+     (`p_acctsessionid`, `p_username`, `p_nasipaddress`,
+     `p_timestamp`, `p_acctstatustype`, (`p_acctinputoctets` - `Previous_Input_Octets`), (`p_acctoutputoctets` - `Previous_Output_Octets`),
+     (`p_acctsessiontime` - `Previous_Session_Time`), `p_acctuniqueid`, `p_tenant_id`);
   END IF;
 END /
 DELIMITER ;

--- a/db/upgrade-X.X.X-X.Y.Z.sql
+++ b/db/upgrade-X.X.X-X.Y.Z.sql
@@ -1,51 +1,51 @@
---                                                                                                                     
+--
 -- PacketFence SQL schema upgrade from X.X.X to X.Y.Z
---                                                                                                                     
-                                                                                                                       
+--
+
 
 --
--- Setting the major/minor/sub-minor version of the DB                                                                 
---                                                                                                                     
+-- Setting the major/minor/sub-minor version of the DB
+--
 
-SET @MAJOR_VERSION = 8; 
+SET @MAJOR_VERSION = 8;
 SET @MINOR_VERSION = 2;
-SET @SUBMINOR_VERSION = 9;                                                                                             
-                                                                                                                       
-SET @PREV_MAJOR_VERSION = 8;                                                                                           
+SET @SUBMINOR_VERSION = 9;
+
+SET @PREV_MAJOR_VERSION = 8;
 SET @PREV_MINOR_VERSION = 2;
-SET @PREV_SUBMINOR_VERSION = 0;                                                                                        
-                                                                                                                       
+SET @PREV_SUBMINOR_VERSION = 0;
 
---                                                                                                                     
+
+--
 -- The VERSION_INT to ensure proper ordering of the version in queries
---                                                                                                                     
+--
 
-SET @VERSION_INT = @MAJOR_VERSION << 16 | @MINOR_VERSION << 8 | @SUBMINOR_VERSION;                                     
+SET @VERSION_INT = @MAJOR_VERSION << 16 | @MINOR_VERSION << 8 | @SUBMINOR_VERSION;
 
-SET @PREV_VERSION_INT = @PREV_MAJOR_VERSION << 16 | @PREV_MINOR_VERSION << 8 | @PREV_SUBMINOR_VERSION;                 
+SET @PREV_VERSION_INT = @PREV_MAJOR_VERSION << 16 | @PREV_MINOR_VERSION << 8 | @PREV_SUBMINOR_VERSION;
 
-DROP PROCEDURE IF EXISTS ValidateVersion;                                                                              
+DROP PROCEDURE IF EXISTS ValidateVersion;
 --
 -- Updating to current version
---  
+--
 DELIMITER //
 CREATE PROCEDURE ValidateVersion()
-BEGIN                                                                                                                  
+BEGIN
     DECLARE PREVIOUS_VERSION int(11);
     DECLARE PREVIOUS_VERSION_STRING varchar(11);
     DECLARE _message varchar(255);
-    SELECT id, version INTO PREVIOUS_VERSION, PREVIOUS_VERSION_STRING FROM pf_version ORDER BY id DESC LIMIT 1;        
-              
-      IF PREVIOUS_VERSION != @PREV_VERSION_INT THEN                                                                    
-        SELECT CONCAT('PREVIOUS VERSION ', PREVIOUS_VERSION_STRING, ' DOES NOT MATCH ', CONCAT_WS('.', @PREV_MAJOR_VERSION, @PREV_MINOR_VERSION, @PREV_SUBMINOR_VERSION)) INTO _message;
-        SIGNAL SQLSTATE VALUE '99999'                                                                                  
-              SET MESSAGE_TEXT = _message;                                                                             
-      END IF;                                                                                                          
-END
-//                                                                                                                     
+    SELECT id, version INTO PREVIOUS_VERSION, PREVIOUS_VERSION_STRING FROM pf_version ORDER BY id DESC LIMIT 1;
 
-DELIMITER ;                                                                                                            
-call ValidateVersion;                                                                                                  
+      IF PREVIOUS_VERSION != @PREV_VERSION_INT THEN
+        SELECT CONCAT('PREVIOUS VERSION ', PREVIOUS_VERSION_STRING, ' DOES NOT MATCH ', CONCAT_WS('.', @PREV_MAJOR_VERSION, @PREV_MINOR_VERSION, @PREV_SUBMINOR_VERSION)) INTO _message;
+        SIGNAL SQLSTATE VALUE '99999'
+              SET MESSAGE_TEXT = _message;
+      END IF;
+END
+//
+
+DELIMITER ;
+call ValidateVersion;
 DROP PROCEDURE IF EXISTS ValidateVersion;
 
 --
@@ -56,7 +56,7 @@ DELETE FROM sms_carrier where id=100122 and name="Google Project Fi";
 -- Delete Google Project Fi from SMS carriers that may have been added during 8.1 to 8.2 upgrade if patched script was used 
 --
 DELETE FROM sms_carrier where id=100128;
---
+
 -- Add Project Fi SMS carrier now that its been fully removed above
 --
 INSERT INTO sms_carrier VALUES(100128, 'Google Project Fi', '%s@msg.fi.google.com', now(), now());
@@ -68,48 +68,48 @@ INSERT INTO sms_carrier VALUES(100128, 'Google Project Fi', '%s@msg.fi.google.co
 DROP PROCEDURE IF EXISTS acct_stop;
 DELIMITER /
 CREATE PROCEDURE acct_stop (
-  IN p_timestamp datetime,
-  IN p_framedipaddress varchar(15),
-  IN p_acctsessiontime int(12),
-  IN p_acctinputoctets bigint(20),
-  IN p_acctoutputoctets bigint(20),
-  IN p_acctuniqueid varchar(32),
-  IN p_acctsessionid varchar(64),
-  IN p_username varchar(64),
-  IN p_realm varchar(64),
-  IN p_nasipaddress varchar(15),
-  IN p_nasportid varchar(32),
-  IN p_nasporttype varchar(32),
-  IN p_acctauthentic varchar(32),
-  IN p_connectinfo_stop varchar(50),
-  IN p_calledstationid varchar(50),
-  IN p_callingstationid varchar(50),
-  IN p_servicetype varchar(32),
-  IN p_framedprotocol varchar(32),
-  IN p_acctterminatecause varchar(12),
-  IN p_acctstatustype varchar(25),
-  IN p_tenant_id int
+  IN `p_timestamp` datetime,
+  IN `p_framedipaddress` varchar(15),
+  IN `p_acctsessiontime` int(12),
+  IN `p_acctinputoctets` bigint(20) unsigned,
+  IN `p_acctoutputoctets` bigint(20) unsigned,
+  IN `p_acctuniqueid` varchar(32),
+  IN `p_acctsessionid` varchar(64),
+  IN `p_username` varchar(64),
+  IN `p_realm` varchar(64),
+  IN `p_nasipaddress` varchar(15),
+  IN `p_nasportid` varchar(32),
+  IN `p_nasporttype` varchar(32),
+  IN `p_acctauthentic` varchar(32),
+  IN `p_connectinfo_stop` varchar(50),
+  IN `p_calledstationid` varchar(50),
+  IN `p_callingstationid` varchar(50),
+  IN `p_servicetype` varchar(32),
+  IN `p_framedprotocol` varchar(32),
+  IN `p_acctterminatecause` varchar(12),
+  IN `p_acctstatustype` varchar(25),
+  IN `p_tenant_id` int(11) unsigned
 )
 BEGIN
-  DECLARE Previous_Input_Octets bigint(20);
-  DECLARE Previous_Output_Octets bigint(20);
-  DECLARE Previous_Session_Time int(12);
+  DECLARE `Previous_Input_Octets` bigint(20) unsigned;
+  DECLARE `Previous_Output_Octets` bigint(20) unsigned;
+  DECLARE `Previous_Session_Time` int(12) unsigned;
 
   # Collect traffic previous values in the radacct table
-  SELECT acctinputoctets, acctoutputoctets, acctsessiontime
-    INTO Previous_Input_Octets, Previous_Output_Octets, Previous_Session_Time
-    FROM radacct
-    WHERE acctuniqueid = p_acctuniqueid
-    AND (acctstoptime IS NULL OR acctstoptime = 0) LIMIT 1;
+  SELECT `acctinputoctets`, `acctoutputoctets`, `acctsessiontime`
+    INTO `Previous_Input_Octets`, `Previous_Output_Octets`, `Previous_Session_Time`
+    FROM `radacct`
+    WHERE `acctuniqueid` = `p_acctuniqueid`
+    AND (`acctstoptime` IS NULL OR `acctstoptime` = 0) LIMIT 1;
 
   # Set values to 0 when no previous records
-  IF (Previous_Session_Time IS NOT NULL) THEN
+  IF (`Previous_Session_Time` IS NOT NULL) THEN
     # Update record with new traffic
     UPDATE radacct SET
-      acctstoptime = p_timestamp,
-      acctsessiontime = p_acctsessiontime,
-      acctinputoctets = p_acctinputoctets,
-      acctoutputoctets = p_acctoutputoctets,
+      `acctstoptime` = `p_timestamp`,
+      `acctsessiontime` = `p_acctsessiontime`,
+      `acctinputoctets` = `p_acctinputoctets`,
+      `acctoutputoctets` = `p_acctoutputoctets`,
       acctterminatecause = p_acctterminatecause,
       connectinfo_stop = p_connectinfo_stop
       WHERE acctuniqueid = p_acctuniqueid
@@ -128,4 +128,4 @@ END /
 DELIMITER ;
 
 
-INSERT INTO pf_version (id, version) VALUES (@VERSION_INT, CONCAT_WS('.', @MAJOR_VERSION, @MINOR_VERSION, @SUBMINOR_VERSION)); 
+INSERT INTO pf_version (id, version) VALUES (@VERSION_INT, CONCAT_WS('.', @MAJOR_VERSION, @MINOR_VERSION, @SUBMINOR_VERSION));

--- a/db/upgrade-X.X.X-X.Y.Z.sql
+++ b/db/upgrade-X.X.X-X.Y.Z.sql
@@ -65,35 +65,35 @@ INSERT INTO sms_carrier VALUES(100128, 'Google Project Fi', '%s@msg.fi.google.co
 -- Updated freeradius acct_stop procedure
 --
 
-DROP PROCEDURE IF EXISTS acct_stop;
+DROP PROCEDURE IF EXISTS `acct_stop`;
 DELIMITER /
-CREATE PROCEDURE acct_stop (
-  IN p_timestamp datetime,
-  IN p_framedipaddress varchar(15),
-  IN p_acctsessiontime int(12),
-  IN p_acctinputoctets bigint(20),
-  IN p_acctoutputoctets bigint(20),
-  IN p_acctuniqueid varchar(32),
-  IN p_acctsessionid varchar(64),
-  IN p_username varchar(64),
-  IN p_realm varchar(64),
-  IN p_nasipaddress varchar(15),
-  IN p_nasportid varchar(32),
-  IN p_nasporttype varchar(32),
-  IN p_acctauthentic varchar(32),
-  IN p_connectinfo_stop varchar(50),
-  IN p_calledstationid varchar(50),
-  IN p_callingstationid varchar(50),
-  IN p_servicetype varchar(32),
-  IN p_framedprotocol varchar(32),
-  IN p_acctterminatecause varchar(12),
-  IN p_acctstatustype varchar(25),
-  IN p_tenant_id int
+CREATE PROCEDURE `acct_stop` (
+  IN `p_timestamp` datetime,
+  IN `p_framedipaddress` varchar(15),
+  IN `p_acctsessiontime` int(12),
+  IN `p_acctinputoctets` bigint(20) unsigned,
+  IN `p_acctoutputoctets` bigint(20) unsigned,
+  IN `p_acctuniqueid` varchar(32),
+  IN `p_acctsessionid` varchar(64),
+  IN `p_username` varchar(64),
+  IN `p_realm` varchar(64),
+  IN `p_nasipaddress` varchar(15),
+  IN `p_nasportid` varchar(32),
+  IN `p_nasporttype` varchar(32),
+  IN `p_acctauthentic` varchar(32),
+  IN `p_connectinfo_stop` varchar(50),
+  IN `p_calledstationid` varchar(50),
+  IN `p_callingstationid` varchar(50),
+  IN `p_servicetype` varchar(32),
+  IN `p_framedprotocol` varchar(32),
+  IN `p_acctterminatecause` varchar(12),
+  IN `p_acctstatustype` varchar(25),
+  IN `p_tenant_id` int(11) unsigned
 )
 BEGIN
-  DECLARE Previous_Input_Octets bigint(20);
-  DECLARE Previous_Output_Octets bigint(20);
-  DECLARE Previous_Session_Time int(12);
+  DECLARE `Previous_Input_Octets` bigint(20) unsigned;
+  DECLARE `Previous_Output_Octets` bigint(20) unsigned;
+  DECLARE `Previous_Session_Time` int(12) unsigned;
 
   # Collect traffic previous values in the radacct table
   SELECT acctinputoctets, acctoutputoctets, acctsessiontime

--- a/db/upgrade-X.X.X-X.Y.Z.sql
+++ b/db/upgrade-X.X.X-X.Y.Z.sql
@@ -61,4 +61,71 @@ DELETE FROM sms_carrier where id=100128;
 --
 INSERT INTO sms_carrier VALUES(100128, 'Google Project Fi', '%s@msg.fi.google.com', now(), now());
 
+--
+-- Updated freeradius acct_stop procedure
+--
+
+DROP PROCEDURE IF EXISTS acct_stop;
+DELIMITER /
+CREATE PROCEDURE acct_stop (
+  IN p_timestamp datetime,
+  IN p_framedipaddress varchar(15),
+  IN p_acctsessiontime int(12),
+  IN p_acctinputoctets bigint(20),
+  IN p_acctoutputoctets bigint(20),
+  IN p_acctuniqueid varchar(32),
+  IN p_acctsessionid varchar(64),
+  IN p_username varchar(64),
+  IN p_realm varchar(64),
+  IN p_nasipaddress varchar(15),
+  IN p_nasportid varchar(32),
+  IN p_nasporttype varchar(32),
+  IN p_acctauthentic varchar(32),
+  IN p_connectinfo_stop varchar(50),
+  IN p_calledstationid varchar(50),
+  IN p_callingstationid varchar(50),
+  IN p_servicetype varchar(32),
+  IN p_framedprotocol varchar(32),
+  IN p_acctterminatecause varchar(12),
+  IN p_acctstatustype varchar(25),
+  IN p_tenant_id int
+)
+BEGIN
+  DECLARE Previous_Input_Octets bigint(20);
+  DECLARE Previous_Output_Octets bigint(20);
+  DECLARE Previous_Session_Time int(12);
+
+  # Collect traffic previous values in the radacct table
+  SELECT acctinputoctets, acctoutputoctets, acctsessiontime
+    INTO Previous_Input_Octets, Previous_Output_Octets, Previous_Session_Time
+    FROM radacct
+    WHERE acctuniqueid = p_acctuniqueid
+    AND (acctstoptime IS NULL OR acctstoptime = 0) LIMIT 1;
+
+  # Set values to 0 when no previous records
+  IF (Previous_Session_Time IS NOT NULL) THEN
+    # Update record with new traffic
+    UPDATE radacct SET
+      acctstoptime = p_timestamp,
+      acctsessiontime = p_acctsessiontime,
+      acctinputoctets = p_acctinputoctets,
+      acctoutputoctets = p_acctoutputoctets,
+      acctterminatecause = p_acctterminatecause,
+      connectinfo_stop = p_connectinfo_stop
+      WHERE acctuniqueid = p_acctuniqueid
+      AND (acctstoptime IS NULL OR acctstoptime = 0);
+
+    # Create new record in the log table
+    INSERT INTO radacct_log
+     (acctsessionid, username, nasipaddress,
+      timestamp, acctstatustype, acctinputoctets, acctoutputoctets, acctsessiontime, acctuniqueid, tenant_id)
+    VALUES
+     (p_acctsessionid, p_username, p_nasipaddress,
+     p_timestamp, p_acctstatustype, (p_acctinputoctets - Previous_Input_Octets), (p_acctoutputoctets - Previous_Output_Octets),
+     (p_acctsessiontime - Previous_Session_Time), p_acctuniqueid, p_tenant_id);
+  END IF;
+END /
+DELIMITER ;
+
+
 INSERT INTO pf_version (id, version) VALUES (@VERSION_INT, CONCAT_WS('.', @MAJOR_VERSION, @MINOR_VERSION, @SUBMINOR_VERSION)); 

--- a/raddb/mods-config/sql/main/mysql/queries.conf
+++ b/raddb/mods-config/sql/main/mysql/queries.conf
@@ -367,40 +367,10 @@ accounting {
 					'%{Calling-Station-Id}', \
 					'%{Service-Type}', \
 					'%{Framed-Protocol}', \
-					 '%{Acct-Terminate-Cause}', \
-           '%{Acct-Status-Type}', \
-           '%{control:PacketFence-Tenant-Id}')"
-
-			#
-			#  The update condition matched no existing sessions. Use
-			#  the values provided in the update to create a new session.
-			#
-			query = "\
-				INSERT INTO ${....acct_table2} \
-					(${...column_list}) \
-				VALUES \
-					('%{Acct-Session-Id}', \
-					'%{Acct-Unique-Session-Id}', \
-					'%{SQL-User-Name}', \
-					'%{Realm}', \
-					'%{NAS-IP-Address}', \
-					'%{%{NAS-Port-ID}:-%{NAS-Port}}', \
-					'%{NAS-Port-Type}', \
-					FROM_UNIXTIME(%{integer:Event-Timestamp} - %{%{Acct-Session-Time}:-0}), \
-					FROM_UNIXTIME(%{integer:Event-Timestamp}), \
-					FROM_UNIXTIME(%{integer:Event-Timestamp}), \
-					'%{%{Acct-Session-Time}:-0}', \
-					'%{Acct-Authentic}', \
-					'', \
-					'%{Connect-Info}', \
-					'%{%{Acct-Input-Gigawords}:-0}' << 32 | '%{%{Acct-Input-Octets}:-0}', \
-					'%{%{Acct-Output-Gigawords}:-0}' << 32 | '%{%{Acct-Output-Octets}:-0}', \
-					'%{Called-Station-Id}', \
-					'%{Calling-Station-Id}', \
 					'%{Acct-Terminate-Cause}', \
-					'%{Service-Type}', \
-					'%{Framed-Protocol}', \
-					'%{Framed-IP-Address}', '%{control:PacketFence-Tenant-Id}')"
+					'%{Acct-Status-Type}', \
+					'%{control:PacketFence-Tenant-Id}')"
+
 		}
 	}
 }


### PR DESCRIPTION
# Description
Detect if PacketFence receive duplicates accounting stop and avoid insertion in the DB.

# Impacts
RADIUS authorize accounting


# Issue
Duplicate entries in the radacct_log table

# Delete branch after merge
YES

# NEWS file entries

## Enhancements
* Avoid duplicates accounting stop entries
