### PR TITLE
Use rsyslog.service in place syslog.service in Debian

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -116,8 +116,8 @@ install: build
 #endif
 	install -d -m0700 $(CURDIR)/debian/packetfence/etc/default
 	# copy the rsyslog systemd drop in
-	install -d -m0755 $(CURDIR)/debian/packetfence/etc/systemd/system/syslog.service.d/
-	install -m0600 $(CURDIR)/packetfence.rsyslog-drop-in.service  $(CURDIR)/debian/packetfence/etc/systemd/system/syslog.service.d/packetfence.conf
+	install -d -m0755 $(CURDIR)/debian/packetfence/etc/systemd/system/rsyslog.service.d/
+	install -m0600 $(CURDIR)/packetfence.rsyslog-drop-in.service  $(CURDIR)/debian/packetfence/etc/systemd/system/rsyslog.service.d/packetfence.conf
 	#Sudoer
 	install -oroot -groot -d -m0750 $(CURDIR)/debian/packetfence/etc/sudoers.d
 	install -oroot -groot -m0440 $(CURDIR)/debian/packetfence.sudoers $(CURDIR)/debian/packetfence/etc/sudoers.d/packetfence


### PR DESCRIPTION
# Description
Fix rsyslog configuration for PacketFence in Debian.

# Impacts
Logs files for all daemons

# NEW Package(s) required
`packetfence` Debian package

# Issue
#3469 

# Delete branch after merge
YES

# NEWS file entries

## Bug Fixes
* Logs permissions and configuration for Debian (#3469)

