### PR TITLE
Add anchors and links on section titles in HTML doc

### DIFF
--- a/docs/includes/global-attributes.asciidoc
+++ b/docs/includes/global-attributes.asciidoc
@@ -16,5 +16,7 @@
 :release_version: 8.2.0
 // set imagesdir for all asciidoc files
 :imagesdir: images
+:sectanchors:
+:sectlinks:
 
 // vim: set syntax=asciidoc tabstop=2 shiftwidth=2 expandtab:


### PR DESCRIPTION
# Description
- `sectanchors`: display clickable anchors in front of section titles to get easy references
- `sectlinks`: make section titles clickable to bookmark

# Impacts
- Built-in HTML docs
- Official HTML docs on packetfence.org website

# Delete branch after merge
YES

# NEWS file entries

## Enhancements
* Add anchors and links on section titles in HTML doc
