### PR TITLE
Add switch module to manage PICOS boxes

### DIFF
--- a/docs/PacketFence_Network_Devices_Configuration_Guide.asciidoc
+++ b/docs/PacketFence_Network_Devices_Configuration_Guide.asciidoc
@@ -4187,7 +4187,7 @@ Notes
 * **SNMP is not supported yet**
 * **Port Security is not supported**
 
-For interfaces with MAC Authentication, perform:
+For interfaces with MAC Authentication, perform the following:
 
   set interface gigabit-ethernet ge-1/1/25 family ethernet-switching port-mode trunk
   set protocols dot1x interface ge-1/1/25 auth-mode mac-radius
@@ -4197,24 +4197,28 @@ For interfaces with MAC Authentication, perform:
 For interfaces with 802.1X, perform:
 
   set interface gigabit-ethernet ge-1/1/4 family ethernet-switching port-mode trunk
-  set protocols dot1x interface ge-1/1/4 dynamic-vlan-enable true
+  set protocols dot1x interface ge-1/1/4 auth-mode dot1x
   set protocols dot1x interface ge-1/1/4 dynamic-vlan-enable true
   set protocols dot1x traceoptions interface ge-1/1/4 flag all disable false
-
+  
 Global configuration:
 
+  set protocols dot1x aaa radius nas-ip 10.10.51.169
   set protocols dot1x aaa radius authentication server-ip 192.168.1.5 shared-key useStrongerSecret
   set protocols dot1x aaa radius dynamic-author client 192.168.1.5 shared-key useStrongerSecret
   set protocols dot1x traceoptions interface ge-1/1/4 flag all disable false
-  set protocols dot1x traceoptions flag radius
-  set protocols dot1x traceoptions flag packet disable false
-  set vlan-interface loopback address 10.10.51.169 prefix-length 32
+  set protocols dot1x traceoptions flag radius disable false
   set vlans vlan-id 10
   set vlans vlan-id 20
   set vlans vlan-id 30
+  commit
 
 * `10.10.51.169` is the switch IP
-* Create VLAN(s) on the switch as per requirements
+* For interfaces where auth-mode is unknown, use the following command
+    set protocols dot1x interface ge-1/1/12 auth-mode dot1x-mac-radius
+  This allows the switch to first try 802.1X and if there is no response from the client then fallback to MAC Authentication.
+* Create VLAN(s) on the switch as per your requirements
+* Please note that traceoptions are only for debugging
 
 SMC
 ~~~

--- a/docs/PacketFence_Network_Devices_Configuration_Guide.asciidoc
+++ b/docs/PacketFence_Network_Devices_Configuration_Guide.asciidoc
@@ -4174,6 +4174,48 @@ Port  Trunk  Security
   24         Enabled
 -----
 
+Pica8
+~~~~~
+
+PacketFence supports Pica8 switches without VoIP using CoA to:
+
+* bounce-host-port
+* reauthenticate-host
+
+Notes
+
+* **SNMP is not supported yet**
+* **Port Security is not supported**
+
+For interfaces with MAC Authentication, perform:
+
+  set interface gigabit-ethernet ge-1/1/25 family ethernet-switching port-mode trunk
+  set protocols dot1x interface ge-1/1/25 auth-mode mac-radius
+  set protocols dot1x interface ge-1/1/25 dynamic-vlan-enable true
+  set protocols dot1x traceoptions interface ge-1/1/25 flag all disable false
+
+For interfaces with 802.1X, perform:
+
+  set interface gigabit-ethernet ge-1/1/4 family ethernet-switching port-mode trunk
+  set protocols dot1x interface ge-1/1/4 dynamic-vlan-enable true
+  set protocols dot1x interface ge-1/1/4 dynamic-vlan-enable true
+  set protocols dot1x traceoptions interface ge-1/1/4 flag all disable false
+
+Global configuration:
+
+  set protocols dot1x aaa radius authentication server-ip 192.168.1.5 shared-key useStrongerSecret
+  set protocols dot1x aaa radius dynamic-author client 192.168.1.5 shared-key useStrongerSecret
+  set protocols dot1x traceoptions interface ge-1/1/4 flag all disable false
+  set protocols dot1x traceoptions flag radius
+  set protocols dot1x traceoptions flag packet disable false
+  set vlan-interface loopback address 10.10.51.169 prefix-length 32
+  set vlans vlan-id 10
+  set vlans vlan-id 20
+  set vlans vlan-id 30
+
+* `10.10.51.169` is the switch IP
+* Create VLAN(s) on the switch as per requirements
+
 SMC
 ~~~
 

--- a/lib/pf/Switch/Pica8.pm
+++ b/lib/pf/Switch/Pica8.pm
@@ -61,10 +61,6 @@ use pf::config qw(
     $WIRED_802_1X
     $WIRED_MAC_AUTH
 );
-use pf::config qw(
-    $WIRED_802_1X
-    $WIRED_MAC_AUTH
-);
 
 =head1 SUBROUTINES
 
@@ -81,6 +77,7 @@ sub supportsWiredDot1x { return $TRUE; }
 sub supportsWiredMacAuth { return $TRUE; }
 sub supportsRadiusDynamicVlanAssignment { return $TRUE; }
 sub supportsRoleBasedEnforcement { return $TRUE; }
+sub supportsExternalPortal { return $TRUE; }
 
 =item setAdminStatus - bounce host port with radius CoA technique
 

--- a/lib/pf/Switch/Pica8.pm
+++ b/lib/pf/Switch/Pica8.pm
@@ -1,0 +1,319 @@
+package pf::Switch::Pica8;
+
+=head1 NAME
+
+pf::Switch::Pica8
+
+=head1 SYNOPSIS
+
+Implements switch module to manage white box switches on which PICOS NOS can be installed.
+The module supports RADIUS MAB + 802.1x for wired networks.
+
+=head1 STATUS
+
+Developed and tested on HPE AL 6900 running PICOS release 2.11.16 or later.
+
+=over
+
+=item Supports
+
+This module only supports Wired Networks.
+The Port Bounce feature is only supported for WIRED_802_1X; it is not supported for WIRED_MAC_AUTH connection type.
+
+=over
+
+=item Reauthentication and port bounce with RADIUS Change of Authorization (CoA) (RFC3576)
+
+=back
+
+=back
+
+=head1 BUGS AND LIMITATIONS
+
+Port bounce only works with WIRED_802_1X, SNMP is not yet supported. Port security is also not currently supported.
+
+=over
+
+Works only with PICOS release 2.11.16 or later.
+
+=back
+
+=cut
+
+use strict;
+use warnings;
+
+use base ('pf::Switch');
+use pf::log;
+use Try::Tiny;
+use pf::Switch::constants;
+use pf::util;
+use pf::util::radius qw(perform_coa);
+use pf::web::util;
+use pf::radius::constants;
+use pf::constants;
+use pf::config;
+use pf::locationlog;
+use pf::config qw(
+    $ROLE_API_LEVEL
+    $MAC
+    $PORT
+    $WIRED_802_1X
+    $WIRED_MAC_AUTH
+);
+use pf::config qw(
+    $WIRED_802_1X
+    $WIRED_MAC_AUTH
+);
+
+=head1 SUBROUTINES
+
+=over
+
+=cut
+
+# Description
+sub description { return "Pica8" }
+
+# CAPABILITIES
+# access technology supported
+sub supportsWiredDot1x { return $TRUE; }
+sub supportsWiredMacAuth { return $TRUE; }
+sub supportsRadiusDynamicVlanAssignment { return $TRUE; }
+sub supportsRoleBasedEnforcement { return $TRUE; }
+
+=item setAdminStatus - bounce host port with radius CoA technique
+
+=cut
+
+sub setAdminStatus {
+    my ( $self, $ifIndex ) = @_;
+    my $logger = $self->logger;
+
+    #We need to fetch the MAC on the ifIndex in order to bounce host port with CoA, only MAC works with CoA!
+    my @locationlog = locationlog_view_open_switchport_no_VoIP( $self->{_ip}, $ifIndex );
+    my $mac = $locationlog[0]->{'mac'};
+
+    #Port bounce with CoA is not supported for WIRED_MAC_AUTH connection type.
+    if ($locationlog[0]->{'connection_type'} eq 'WIRED_MAC_AUTH') {
+    $logger->info("Port bounce for this connection type is not supported");
+        return 1;
+    }
+
+    if ( !$self->isProductionMode() ) {
+        $logger->info("Switch not in production mode... we won't perform port bounce");
+        return 1;
+    }
+
+    if (!defined($self->{'_radiusSecret'})) {
+        $logger->warn(
+            "Unable to perform RADIUS CoA-Request on $self->{'_id'}: RADIUS Shared Secret not configured"
+        );
+        return;
+    }
+
+    $logger->info("boucing MAC $mac using RADIUS CoA-Request method");
+
+    # translating to expected format 00-11-22-33-CA-FE
+    $mac = uc($mac);
+    $mac =~ s/:/-/g;
+
+    my $response;
+    my $send_disconnect_to = $self->{'_controllerIp'} || $self->{'_ip'};
+    try {
+        my $connection_info = {
+            nas_ip => $send_disconnect_to,
+            secret => $self->{'_radiusSecret'},
+            LocalAddr => $self->deauth_source_ip($send_disconnect_to),
+        };
+
+        $response = perform_coa( $connection_info,
+            {
+                'Acct-Terminate-Cause' => 'Admin-Reset',
+                'NAS-IP-Address' => $self->{'_switchIp'},
+                'Calling-Station-Id' => $mac,
+            },
+            [{ 'vendor' => 'Pica8', 'attribute' => 'Pica8-AVPair', 'value' => 'subscriber:command=bounce-host-port' }],
+        );
+    } catch {
+        chomp;
+        $logger->warn("Unable to perform RADIUS CoA-Request: $_");
+        $logger->error("Wrong RADIUS secret or unreachable network device...") if ($_ =~ /^Timeout/);
+    };
+    return if (!defined($response));
+
+    return $TRUE if ($response->{'Code'} eq 'CoA-ACK');
+
+    $logger->warn(
+        "Unable to perform RADIUS CoA-Request."
+        . ( defined($response->{'Code'}) ? " $response->{'Code'}" : 'no RADIUS code' ) . ' received'
+        . ( defined($response->{'Error-Cause'}) ? " with Error-Cause: $response->{'Error-Cause'}." : '' )
+    );
+    return;
+}
+
+=item bouncePort
+
+Performs a shut / no-shut on the port.
+Usually used to force the operating system to do a new DHCP Request after a VLAN change.
+
+=cut
+
+sub bouncePort {
+    my ($self, $ifIndex) = @_;
+
+    $self->setAdminStatus( $ifIndex );
+
+    return $TRUE;
+}
+
+=head2 deauthenticateMacRadius
+
+Method to deauth a wired node with CoA.
+
+=cut
+
+sub deauthenticateMacRadius {
+    my ($self, $ifIndex,$mac) = @_;
+    my $logger = $self->logger;
+
+    # perform CoA
+    $self->radiusDisconnect($mac ,{ 'Acct-Terminate-Cause' => 'Admin-Reset'});
+}
+
+=head2 radiusDisconnect
+
+Send a CoA to disconnect a MAC
+
+=cut
+
+sub radiusDisconnect {
+    my ($self, $mac, $add_attributes_ref) = @_;
+    my $logger = $self->logger;
+
+    # initialize
+    $add_attributes_ref = {} if (!defined($add_attributes_ref));
+
+    if (!defined($self->{'_radiusSecret'})) {
+        $logger->warn(
+            "Unable to perform RADIUS CoA-Request on (".$self->{'_id'}."): RADIUS Shared Secret not configured"
+        );
+        return;
+    }
+
+    $logger->info("deauthenticating");
+
+    my $send_disconnect_to = $self->{'_ip'};
+    # allowing client code to override where we connect with NAS-IP-Address
+    $send_disconnect_to = $add_attributes_ref->{'NAS-IP-Address'}
+        if (defined($add_attributes_ref->{'NAS-IP-Address'}));
+
+    my $response;
+    try {
+        my $connection_info = {
+            nas_ip => $send_disconnect_to,
+            secret => $self->{'_radiusSecret'},
+            LocalAddr => $self->deauth_source_ip($send_disconnect_to),
+        };
+
+        $logger->debug("network device (".$self->{'_id'}.") supports roles. Evaluating role to be returned");
+
+        # transforming MAC to the expected format 00-11-22-33-CA-FE
+        $mac = uc($mac);
+        $mac =~ s/:/-/g;
+        # Standard Attributes
+
+        my $attributes_ref = {
+            'Calling-Station-Id' => $mac,
+            'NAS-IP-Address' => $send_disconnect_to,
+        };
+
+        # merging additional attributes provided by caller to the standard attributes
+        $attributes_ref = { %$attributes_ref, %$add_attributes_ref };
+        $response = perform_coa($connection_info, $attributes_ref,
+            [{'vendor' => 'Pica8', 'attribute' => 'Pica8-AVPair', 'value' => 'subscriber:command=reauthenticate'},
+             {'vendor' => 'Pica8', 'attribute' => 'Pica8-AVPair', 'value' => 'subscriber:reauthenticate-type=last'}
+            ]);
+    } catch {
+        chomp;
+        $logger->warn("Unable to perform RADIUS CoA-Request on (".$self->{'_id'}.") : $_");
+        $logger->error("Wrong RADIUS secret or unreachable network device (".$self->{'_id'}.") ...")
+            if ($_ =~ /^Timeout/);
+    };
+    return if (!defined($response));
+
+    return $TRUE if ( ($response->{'Code'} eq 'Disconnect-ACK') || ($response->{'Code'} eq 'CoA-ACK') );
+
+    $logger->warn(
+        "Unable to perform RADIUS Disconnect-Request on (".$self->{'_id'}.")."
+        . ( defined($response->{'Code'}) ? " $response->{'Code'}" : 'no RADIUS code' ) . ' received'
+        . ( defined($response->{'Error-Cause'}) ? " with Error-Cause: $response->{'Error-Cause'}." : '' )
+    );
+    return;
+}
+
+=head2 wiredeauthTechniques
+
+Return the reference to the deauth technique or the default deauth technique.
+
+=cut
+
+sub wiredeauthTechniques {
+    my ($self, $method, $connection_type) = @_;
+    my $logger = $self->logger;
+    if ($connection_type == $WIRED_802_1X) {
+        my $default = $SNMP::RADIUS;
+        my %tech = (
+            $SNMP::RADIUS => 'deauthenticateMacRadius',
+        );
+
+        if (!defined($method) || !defined($tech{$method})) {
+            $method = $default;
+        }
+        return $method,$tech{$method};
+    }
+    if ($connection_type == $WIRED_MAC_AUTH) {
+        my $default = $SNMP::RADIUS;
+        my %tech = (
+            $SNMP::RADIUS => 'deauthenticateMacRadius',
+        );
+
+        if (!defined($method) || !defined($tech{$method})) {
+            $method = $default;
+        }
+        return $method,$tech{$method};
+    }
+}
+
+=head1 AUTHOR
+
+Amjad Ali <ali.amjad@pica8.com>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2009-2018 Pica8, Inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;
+
+# vim: set shiftwidth=4:
+# vim: set expandtab:
+# vim: set backspace=indent,eol,start:

--- a/lib/pf/util/dictionary
+++ b/lib/pf/util/dictionary
@@ -255,3 +255,16 @@ VENDOR          Cisco                           9
 VENDORATTR      Cisco                           Cisco-AVPair    1       string
 VENDORATTR      Cisco                           Cisco-NAS-Port  2       string
 
+#
+# Pica8 RADIUS attributes
+# For general information please visit:
+# http://www.pica8.com
+#
+
+VENDOR          Pica8                           35098
+
+#
+#       Standard attribute
+#
+
+VENDORATTR      Pica8                           Pica8-AVPair    1       string


### PR DESCRIPTION
# Description

Implements module to manage white box switches on which PICOS NOS can be installed.

The module supports RADIUS MAB + 802.1x for wired networks.

# Impacts
- RADIUS authorize workflow

# Delete branch after merge
YES

# NEWS file entries
* Add module to manage PICOS white box switches.

## Enhancements
* Add module to manage PICOS white box switches, supporting RADIUS MAB + 802.1x for wired networks.