### PR TITLE
Reduce cache duration to 60s, cache mac + qname, return 127.0.0.1 for reg deviced in REJECT role

### DIFF
--- a/go/coredns/plugin/pfdns/pfdns.go
+++ b/go/coredns/plugin/pfdns/pfdns.go
@@ -116,6 +116,8 @@ func (pf *pfdns) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 	mac, err := pf.Ip2Mac(ctx, srcIP, ipVersion)
 	if err != nil {
 		log.LoggerWContext(ctx).Error(fmt.Sprintf("ERROR cannot find mac for ip %s\n", srcIP))
+	} else {
+		mac = "00:00:00:00:00:00"
 	}
 
 	// Domain bypass
@@ -219,17 +221,26 @@ func (pf *pfdns) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 			switch Type {
 			case "dnsenforcement", "inline":
 				var status = "unreg"
-				err = pf.Nodedb.QueryRow(mac, 1).Scan(&status)
+				var category string
+				err = pf.Nodedb.QueryRow(mac, 1).Scan(&status, &category)
 				if err != nil {
 					log.LoggerWContext(ctx).Error(fmt.Sprintf("error getting node status %s %s\n", mac, err))
 				}
 				// Defer to the proxy middleware if the device is registered
-				if status == "reg" && !violation {
+				if status == "reg" && !violation && category != "REJECT" {
 					log.LoggerWContext(ctx).Debug(srcIP + " : " + mac + " serve dns " + state.QName())
 					return pf.Next.ServeDNS(ctx, w, r)
 				}
+				if status == "reg" && category == "REJECT" {
+					rr, _ = dns.NewRR("30 IN A 127.0.0.1")
+					a.Answer = []dns.RR{rr}
+					log.LoggerWContext(ctx).Debug("REJECT " + mac + " IP " + srcIP + " Query " + state.QName())
+					state.SizeAndDo(a)
+					w.WriteMsg(a)
+					return 0, nil
+				}
 			}
-			answer, found := pf.DNSFilter.Get(state.QName())
+			answer, found := pf.DNSFilter.Get(mac + state.QName())
 			if found && answer != "null" {
 				log.LoggerWContext(ctx).Debug("Get answer from the cache for " + state.QName())
 				rr, _ = dns.NewRR(answer.(string))
@@ -241,7 +252,7 @@ func (pf *pfdns) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 					"mac":      mac,
 				})
 				if err != nil {
-					pf.DNSFilter.Set(state.QName(), "null", cache.DefaultExpiration)
+					pf.DNSFilter.Set(mac+state.QName(), "null", cache.DefaultExpiration)
 					break
 				}
 				var answer string
@@ -252,7 +263,7 @@ func (pf *pfdns) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 					}
 				}
 				log.LoggerWContext(ctx).Debug("Get answer from pffilter for " + state.QName())
-				pf.DNSFilter.Set(state.QName(), answer, cache.DefaultExpiration)
+				pf.DNSFilter.Set(mac+state.QName(), answer, cache.DefaultExpiration)
 				rr, _ = dns.NewRR(answer)
 			}
 
@@ -546,7 +557,7 @@ func (pf *pfdns) DbInit() error {
 		return err
 	}
 
-	pf.Nodedb, err = pf.Db.Prepare("select status from node where mac = ? AND tenant_id = ?")
+	pf.Nodedb, err = pf.Db.Prepare("select node.status IF(ISNULL(nc.name), '', nc.name) as category from node LEFT JOIN node_category as nc on node.category_id = nc.category_id where mac = ? AND tenant_id = ?")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "pfdns: database nodedb prepared statement error: %s", err)
 		return err

--- a/go/coredns/plugin/pfdns/setup.go
+++ b/go/coredns/plugin/pfdns/setup.go
@@ -73,7 +73,7 @@ func setuppfdns(c *caddy.Controller) error {
 	}
 
 	// Initialize dns filter cache
-	pf.DNSFilter = cache.New(60*time.Second, 10*time.Second)
+	pf.DNSFilter = cache.New(300*time.Second, 10*time.Second)
 
 	pf.IpsetCache = cache.New(1*time.Hour, 10*time.Second)
 

--- a/go/coredns/plugin/pfdns/setup.go
+++ b/go/coredns/plugin/pfdns/setup.go
@@ -73,7 +73,7 @@ func setuppfdns(c *caddy.Controller) error {
 	}
 
 	// Initialize dns filter cache
-	pf.DNSFilter = cache.New(300*time.Second, 10*time.Second)
+	pf.DNSFilter = cache.New(60*time.Second, 10*time.Second)
 
 	pf.IpsetCache = cache.New(1*time.Hour, 10*time.Second)
 


### PR DESCRIPTION
# Description
DNS Filter cache adjustement
Return 127.0.0.1 for devices with REJECT role (dns enforcement , Inline)

# Impacts
DNS Flow

# Issue
fixes #3785

# Delete branch after merge
YES

# NEWS file entries

## Bug Fixes
* Fixes mac filtered lookups are cached (#3785)
