### PR TITLE
Feature/no empty fields portal

### DIFF
--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication.pm
@@ -325,6 +325,12 @@ sub prompt_fields {
     my ($self, $args) = @_;
     $args //= {};
     my %saved_fields = %{$self->app->session->{saved_fields}} if (defined ($self->app->session->{saved_fields}) );
+
+    if($self->with_aup && scalar(@{$self->required_fields}) == 1) {
+        get_logger->debug("Only AUP is required, will not prompt for any fields");
+        $args->{aup_only} = $TRUE;
+    }
+
     $self->render($self->signup_template, {
         previous_request => $self->app->request->parameters(),
         fields => $self->merged_fields,

--- a/html/captive-portal/templates/signin.html
+++ b/html/captive-portal/templates/signin.html
@@ -10,7 +10,7 @@
     </div>
 
       [% IF aup_only %]
-      <script src="/common/aup-autosubmit.js">
+      <script src="/common/aup-autosubmit.js"></script>
       [% END %]
 
     [% END %]

--- a/html/captive-portal/templates/signin.html
+++ b/html/captive-portal/templates/signin.html
@@ -8,6 +8,11 @@
     <div class="c-card u-padding u-padding@tablet u-padding-top-none">
         [% form.get_field('aup').render | none %]
     </div>
+
+      [% IF aup_only %]
+      <script src="/common/aup-autosubmit.js">
+      [% END %]
+
     [% END %]
 
     <div class="c-card[% IF fields.exists('aup') %] c-card--hidden c-card--disabled[% END %] o-layout o-layout--center u-padding">

--- a/html/common/aup-autosubmit.js
+++ b/html/common/aup-autosubmit.js
@@ -1,6 +1,6 @@
 $('label[for="aup"]').closest('div').click(function(e) {
   e.preventDefault();
   $('#aup').attr('checked', 'checked');
-  $(this).closest('form').submit(); 
+  $('#button').click();
   return false;
 });

--- a/html/common/aup-autosubmit.js
+++ b/html/common/aup-autosubmit.js
@@ -1,0 +1,6 @@
+$('label[for="aup"]').closest('div').click(function(e) {
+  e.preventDefault();
+  $('#aup').attr('checked', 'checked');
+  $(this).closest('form').submit(); 
+  return false;
+});


### PR DESCRIPTION
# Description
Do not prompt user to press continue after AUP when there are no fields to prompt (like null auth without email)

# Impacts
Portal authentication

# Delete branch after merge
YES

# NEWS file entries
## Enhancements
* Do not prompt user to press continue after AUP when there are no fields to prompt
