### PR TITLE
feature/domain_filtering_for_email_sources

### DIFF
--- a/docs/PacketFence_Installation_Guide.asciidoc
+++ b/docs/PacketFence_Installation_Guide.asciidoc
@@ -513,6 +513,43 @@ When no condition is defined, the rule will be considered as a catch-all. When a
 
 In the previous section, you configured two authentication sources: Microsoft Active Directory and the Null sources. They were both catch-all sources.
 
+Email Authentication for Guests
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This section will show you how to allow guests to register endpoints using their email address. PacketFence sends a PIN code to the guest's email address. That code will then be required to complete the registration process.
+
+Adding Email Authentication Source
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+From 'Configuration->Policies and Access Control->Authentication Sources', click 'Add source->External->Email'. As 'Name' and 'Description', specify 'email-source'.
+
+Additional options available
+
+ * email_activation_timeout - This is the delay given to a guest who registered by email confirmation to log into his email and click the activation link.
+ * allow_localdomain - Accept self-registration from email address within the local domain
+ * activation_domain - Set this value if you want to change the hostname in the validation link. Changing this requires to restart haproxy to be fully effective.
+ * allowed_domains - A comma-separated list of domains that are allowed for email registration. Allowed domains are checked after banned domains.
+ * banned_domains - A comma-separated list of domains that are banned for email registration. Banned domains are checked before allowed domains.
+
+Then add an 'Authentication Rules' with name 'catchall' with no condition and with the following two 'Actions':
+
+[options="compact"]
+ * Role - guest
+ * Access duration - 12 hours
+
+Click on 'Save' to save the new authentication source.
+
+Configuring the Connection Profile
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Now let's add our new Email-based authentication source to our guests captive portal. From 'Configuration->Policies and Access Control->Connection Profiles', click on the 'guest' profile that we previously created. In the 'Sources', click on the '(+)' button and add the newly created Email source, 'email-source'. Save the changes by clicking on the 'Save' button.
+
+NOTE: You can preview at any time the portal associated with connection profile by clicking on the 'Preview' button.
+
+Testing
+^^^^^^^
+
+Unplug and unregister your endpoint. Reconnect the endpoint - you should see the captive portal with the new Email-based registration option.
+
 Adding SMS Authentication for Guests
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/html/pfappserver/lib/pfappserver/Base/Form/Role/EmailFiltering.pm
+++ b/html/pfappserver/lib/pfappserver/Base/Form/Role/EmailFiltering.pm
@@ -1,0 +1,76 @@
+package pfappserver::Base::Form::Role::EmailFiltering;
+
+=head1 NAME
+
+pfappserver::Base::Form::Role::EmailFiltering -
+
+=head1 DESCRIPTION
+
+pfappserver::Base::Form::Role::EmailFiltering
+
+=cut
+
+use strict;
+use warnings;
+use HTML::FormHandler::Moose::Role;
+with 'pfappserver::Base::Form::Role::Help';
+
+has_field 'allow_localdomain' =>
+  (
+   type => 'Toggle',
+   checkbox_value => 'yes',
+   unchecked_value => 'no',
+   label => 'Allow Local Domain',
+   default => 'yes',
+   tags => { after_element => \&help,
+             help => 'Accept self-registration with email address from the local domain' },
+  );
+
+has_field 'banned_domains' =>
+  (
+    type  => 'TextArea',
+    label => 'Comma-separated list of Banned Domains',
+    tags => {
+        after_element => \&help,
+        help => 'A comma-separated list of domains that are banned for email registration. Wildcards are accepted (*pfdemo.org). Banned domains are checked before allowed domains.'
+    },
+  );
+
+has_field 'allowed_domains' =>
+  (
+    type  => 'TextArea',
+    label => 'Comma-separated list of Allowed Domains',
+    tags => {
+        after_element => \&help,
+        help => 'A comma-separated list of domains that are allowed for email registration. Wildcards are accepted (*pfdemo.org). Allowed domains are checked after banned domains.',
+    },
+  );
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2018 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source/Email.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source/Email.pm
@@ -12,8 +12,11 @@ Form definition to create or update an Email-verified user source.
 
 use HTML::FormHandler::Moose;
 extends 'pfappserver::Form::Config::Source';
-with 'pfappserver::Base::Form::Role::Help';
-with 'pfappserver::Base::Form::Role::SourceLocalAccount';
+with qw(
+  pfappserver::Base::Form::Role::Help
+  pfappserver::Base::Form::Role::SourceLocalAccount
+  pfappserver::Base::Form::Role::EmailFiltering
+);
 
 use pf::Authentication::Source::EmailSource;
 use pfappserver::Form::Field::Duration;
@@ -37,37 +40,6 @@ has_field 'activation_domain' =>
     tags => {
         after_element => \&help,
         help => 'Set this value if you want to change the hostname in the validation link. Changing this requires to restart haproxy to be fully effective.',
-    },
-  );
-
-has_field 'allow_localdomain' =>
-  (
-   type => 'Toggle',
-   checkbox_value => 'yes',
-   unchecked_value => 'no',
-   label => 'Allow Local Domain',
-   default => pf::Authentication::Source::EmailSource->meta->get_attribute('allow_localdomain')->default,
-   tags => { after_element => \&help,
-             help => 'Accept self-registration with email address from the local domain' },
-  );
-
-has_field 'banned_domains' =>
-  (
-    type  => 'TextArea',
-    label => 'Comma-separated list of Banned Domains',
-    tags => {
-        after_element => \&help,
-        help => 'A comma-separated list of domains that are banned for email registration. Wildcards are accepted (*pfdemo.org). Banned domains are checked before allowed domains.'
-    },
-  );
-
-has_field 'allowed_domains' =>
-  (
-    type  => 'TextArea',
-    label => 'Comma-separated list of Allowed Domains',
-    tags => {
-        after_element => \&help,
-        help => 'A comma-separated list of domains that are allowed for email registration. Wildcards are accepted (*pfdemo.org). Allowed domains are checked after banned domains.',
     },
   );
 
@@ -95,4 +67,5 @@ USA.
 =cut
 
 __PACKAGE__->meta->make_immutable unless $ENV{"PF_SKIP_MAKE_IMMUTABLE"};
+
 1;

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source/Email.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source/Email.pm
@@ -51,6 +51,18 @@ has_field 'activation_domain' =>
     },
   );
 
+has_field 'allowed_domains' =>
+  (
+   'type' => 'Text',
+    label => 'Comma seperated list of Allowed Domains',
+  );
+
+has_field 'banned_domains' =>
+  (
+   'type' => 'Text',
+    label => 'Comma seperated list of Banned Domains',
+  );
+
 =head1 COPYRIGHT
 
 Copyright (C) 2005-2018 Inverse inc.

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source/Email.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source/Email.pm
@@ -53,13 +53,13 @@ has_field 'activation_domain' =>
 
 has_field 'allowed_domains' =>
   (
-   'type' => 'Text',
+   'type' => 'TextArea',
     label => 'Comma-separated list of Allowed Domains',
   );
 
 has_field 'banned_domains' =>
   (
-   'type' => 'Text',
+   'type' => 'TextArea',
     label => 'Comma-separated list of Banned Domains',
   );
 

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source/Email.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source/Email.pm
@@ -54,13 +54,13 @@ has_field 'activation_domain' =>
 has_field 'allowed_domains' =>
   (
    'type' => 'Text',
-    label => 'Comma-seperated list of Allowed Domains',
+    label => 'Comma-separated list of Allowed Domains',
   );
 
 has_field 'banned_domains' =>
   (
    'type' => 'Text',
-    label => 'Comma-seperated list of Banned Domains',
+    label => 'Comma-separated list of Banned Domains',
   );
 
 =head1 COPYRIGHT

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source/Email.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source/Email.pm
@@ -55,12 +55,20 @@ has_field 'allowed_domains' =>
   (
    'type' => 'TextArea',
     label => 'Comma-separated list of Allowed Domains',
+    tags => {
+        after_element => \&help,
+        help => 'A comma-separated list of domains that are allowed for email registration. Allowed domains are checked after banned domains.',
+    },
   );
 
 has_field 'banned_domains' =>
   (
    'type' => 'TextArea',
     label => 'Comma-separated list of Banned Domains',
+    tags => {
+        after_element => \&help,
+        help => 'A comma-separated list of domains that are banned for email registration. Banned domains are checked before allowed domains.'
+    },
   );
 
 =head1 COPYRIGHT

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source/Email.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source/Email.pm
@@ -53,7 +53,7 @@ has_field 'activation_domain' =>
 
 has_field 'allowed_domains' =>
   (
-   'type' => 'TextArea',
+    type  => 'TextArea',
     label => 'Comma-separated list of Allowed Domains',
     tags => {
         after_element => \&help,
@@ -63,7 +63,7 @@ has_field 'allowed_domains' =>
 
 has_field 'banned_domains' =>
   (
-   'type' => 'TextArea',
+    type  => 'TextArea',
     label => 'Comma-separated list of Banned Domains',
     tags => {
         after_element => \&help,

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source/Email.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source/Email.pm
@@ -29,17 +29,6 @@ has_field 'email_activation_timeout' =>
              help => 'This is the delay given to a guest who registered by email confirmation to log into his email and click the activation link.' },
   );
 
-has_field 'allow_localdomain' =>
-  (
-   type => 'Toggle',
-   checkbox_value => 'yes',
-   unchecked_value => 'no',
-   label => 'Allow Local Domain',
-   default => pf::Authentication::Source::EmailSource->meta->get_attribute('allow_localdomain')->default,
-   tags => { after_element => \&help,
-             help => 'Accept self-registration with email address from the local domain' },
-  );
-
 has_field 'activation_domain' =>
   (
    type => 'Text',
@@ -49,6 +38,17 @@ has_field 'activation_domain' =>
         after_element => \&help,
         help => 'Set this value if you want to change the hostname in the validation link. Changing this requires to restart haproxy to be fully effective.',
     },
+  );
+
+has_field 'allow_localdomain' =>
+  (
+   type => 'Toggle',
+   checkbox_value => 'yes',
+   unchecked_value => 'no',
+   label => 'Allow Local Domain',
+   default => pf::Authentication::Source::EmailSource->meta->get_attribute('allow_localdomain')->default,
+   tags => { after_element => \&help,
+             help => 'Accept self-registration with email address from the local domain' },
   );
 
 has_field 'banned_domains' =>

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source/Email.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source/Email.pm
@@ -54,13 +54,13 @@ has_field 'activation_domain' =>
 has_field 'allowed_domains' =>
   (
    'type' => 'Text',
-    label => 'Comma seperated list of Allowed Domains',
+    label => 'Comma-seperated list of Allowed Domains',
   );
 
 has_field 'banned_domains' =>
   (
    'type' => 'Text',
-    label => 'Comma seperated list of Banned Domains',
+    label => 'Comma-seperated list of Banned Domains',
   );
 
 =head1 COPYRIGHT

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source/Email.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source/Email.pm
@@ -51,23 +51,23 @@ has_field 'activation_domain' =>
     },
   );
 
-has_field 'allowed_domains' =>
-  (
-    type  => 'TextArea',
-    label => 'Comma-separated list of Allowed Domains',
-    tags => {
-        after_element => \&help,
-        help => 'A comma-separated list of domains that are allowed for email registration. Allowed domains are checked after banned domains.',
-    },
-  );
-
 has_field 'banned_domains' =>
   (
     type  => 'TextArea',
     label => 'Comma-separated list of Banned Domains',
     tags => {
         after_element => \&help,
-        help => 'A comma-separated list of domains that are banned for email registration. Banned domains are checked before allowed domains.'
+        help => 'A comma-separated list of domains that are banned for email registration. Wildcards are accepted (*pfdemo.org). Banned domains are checked before allowed domains.'
+    },
+  );
+
+has_field 'allowed_domains' =>
+  (
+    type  => 'TextArea',
+    label => 'Comma-separated list of Allowed Domains',
+    tags => {
+        after_element => \&help,
+        help => 'A comma-separated list of domains that are allowed for email registration. Wildcards are accepted (*pfdemo.org). Allowed domains are checked after banned domains.',
     },
   );
 

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source/SponsorEmail.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source/SponsorEmail.pm
@@ -12,8 +12,11 @@ Form definition to create or update an guest-sponsored user source.
 
 use HTML::FormHandler::Moose;
 extends 'pfappserver::Form::Config::Source';
-with 'pfappserver::Base::Form::Role::Help';
-with 'pfappserver::Base::Form::Role::SourceLocalAccount';
+with qw(
+  pfappserver::Base::Form::Role::Help
+  pfappserver::Base::Form::Role::SourceLocalAccount
+  pfappserver::Base::Form::Role::EmailFiltering
+);
 
 use pfappserver::Form::Field::Duration;
 use pf::Authentication::Source::SponsorEmailSource;
@@ -38,37 +41,6 @@ has_field 'activation_domain' =>
     tags => {
         after_element => \&help,
         help => 'Set this value if you want to change the hostname in the validation link. Changing this requires to restart haproxy to be fully effective.',
-    },
-  );
-
-has_field 'allow_localdomain' =>
-  (
-   type => 'Toggle',
-   checkbox_value => 'yes',
-   unchecked_value => 'no',
-   label => 'Allow Local Domain',
-   default => pf::Authentication::Source::SponsorEmailSource->meta->get_attribute('allow_localdomain')->default,
-   tags => { after_element => \&help,
-             help => 'Accept self-registration with email address from the local domain' },
-  );
-
-has_field 'banned_domains' =>
-  (
-    type  => 'TextArea',
-    label => 'Comma-separated list of Banned Domains',
-    tags => {
-        after_element => \&help,
-        help => 'A comma-separated list of domains that are banned for email registration. Wildcards are accepted (*pfdemo.org). Banned domains are checked before allowed domains.'
-    },
-  );
-
-has_field 'allowed_domains' =>
-  (
-    type  => 'TextArea',
-    label => 'Comma-separated list of Allowed Domains',
-    tags => {
-        after_element => \&help,
-        help => 'A comma-separated list of domains that are allowed for email registration. Wildcards are accepted (*pfdemo.org). Allowed domains are checked after banned domains.',
     },
   );
 

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source/SponsorEmail.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source/SponsorEmail.pm
@@ -19,16 +19,6 @@ use pfappserver::Form::Field::Duration;
 use pf::Authentication::Source::SponsorEmailSource;
 
 # Form fields
-has_field 'allow_localdomain' =>
-  (
-   type => 'Toggle',
-   checkbox_value => 'yes',
-   unchecked_value => 'no',
-   label => 'Allow Local Domain',
-   default => pf::Authentication::Source::SponsorEmailSource->meta->get_attribute('allow_localdomain')->default,
-   tags => { after_element => \&help,
-             help => 'Accept self-registration with email address from the local domain' },
-  );
 
 has_field 'email_activation_timeout' =>
   (
@@ -48,6 +38,37 @@ has_field 'activation_domain' =>
     tags => {
         after_element => \&help,
         help => 'Set this value if you want to change the hostname in the validation link. Changing this requires to restart haproxy to be fully effective.',
+    },
+  );
+
+has_field 'allow_localdomain' =>
+  (
+   type => 'Toggle',
+   checkbox_value => 'yes',
+   unchecked_value => 'no',
+   label => 'Allow Local Domain',
+   default => pf::Authentication::Source::SponsorEmailSource->meta->get_attribute('allow_localdomain')->default,
+   tags => { after_element => \&help,
+             help => 'Accept self-registration with email address from the local domain' },
+  );
+
+has_field 'banned_domains' =>
+  (
+    type  => 'TextArea',
+    label => 'Comma-separated list of Banned Domains',
+    tags => {
+        after_element => \&help,
+        help => 'A comma-separated list of domains that are banned for email registration. Wildcards are accepted (*pfdemo.org). Banned domains are checked before allowed domains.'
+    },
+  );
+
+has_field 'allowed_domains' =>
+  (
+    type  => 'TextArea',
+    label => 'Comma-separated list of Allowed Domains',
+    tags => {
+        after_element => \&help,
+        help => 'A comma-separated list of domains that are allowed for email registration. Wildcards are accepted (*pfdemo.org). Allowed domains are checked after banned domains.',
     },
   );
 

--- a/lib/pf/Authentication/EmailFilteringRole.pm
+++ b/lib/pf/Authentication/EmailFilteringRole.pm
@@ -43,8 +43,8 @@ around BUILDARGS => sub {
     }
 
     for my $f (qw(allowed_domains banned_domains)) {
-        next unless $hash{$f};
-        $hash{$f} = [ map { split(/\r?\n/) } expand_csv($hash{$f})];
+        next unless exists $hash{$f};
+        $hash{$f} = [ map { split(/\r?\n/) } expand_csv($hash{$f} // '')];
     }
 
     my $args = $class->$orig(\%hash);

--- a/lib/pf/Authentication/EmailFilteringRole.pm
+++ b/lib/pf/Authentication/EmailFilteringRole.pm
@@ -1,0 +1,178 @@
+package pf::Authentication::EmailFilteringRole;
+
+=head1 NAME
+
+pf::Authentication::EmailFilteringRole -
+
+=head1 DESCRIPTION
+
+pf::Authentication::EmailFilteringRole
+
+=cut
+
+use strict;
+use warnings;
+use Moose::Role;
+use pf::util qw(expand_csv isenabled);
+use pf::constants qw($TRUE $FALSE);
+use pf::config qw(%Config);
+use List::MoreUtils qw(any);
+
+has 'allowed_domains' => (isa => 'Maybe[ArrayRef[Str]]', is => 'rw');
+has 'banned_domains' => (isa => 'Maybe[ArrayRef[Str]]', is => 'rw');
+has 'allow_localdomain' => (isa => 'Str', is => 'rw', default => 'yes');
+
+=head2 BUILDARGS
+
+BUILDARGS
+
+=cut
+
+around BUILDARGS => sub {
+    my $orig  = shift;
+    my $class = shift;
+    my %hash;
+    if (@_ == 1) {
+        if (ref($_[0]) ne 'HASH') {
+            return $class->$orig(@_);
+        }
+
+        %hash = %{$_[0]};
+    } else {
+        %hash = @_;
+    }
+
+    for my $f (qw(allowed_domains banned_domains)) {
+        next unless $hash{$f};
+        $hash{$f} = [ map { split(/\r?\n/) } expand_csv($hash{$f})];
+    }
+
+    my $args = $class->$orig(\%hash);
+    return $args;
+};
+
+
+=head2 isEmailAllowed
+
+checks if email is allowed
+
+=cut
+
+sub isEmailAllowed {
+    my ($self, $email) = @_;
+    $email = lc($email);
+    if (any {$email =~ $_} $self->banned_email_regexes) {
+        return $FALSE;
+    }
+
+    my @allowed = $self->allowed_email_regexes;
+    if (@allowed) {
+        return (any {$email =~ $_} @allowed) ? $TRUE : $FALSE;
+    }
+
+    return $TRUE;
+}
+
+=head2 banned_email_regexes
+
+banned email regexes
+
+=cut
+
+sub banned_email_regexes {
+    my ($self) = @_;
+    my @banned = make_email_regexes($self->banned_domains);
+    if (!isenabled($self->allow_localdomain)) {
+        push @banned, localdomain_regexes();
+    }
+
+    return @banned;
+}
+
+=head2 allowed_email_regexes
+
+allowed email regexes
+
+=cut
+
+sub allowed_email_regexes {
+    my ($self) = @_;
+    my @allowed = make_email_regexes($self->allowed_domains);
+    if (@allowed && isenabled($self->allow_localdomain)) {
+        push @allowed, localdomain_regexes();
+    }
+
+    return @allowed;
+}
+
+=head2 localdomain_regexes
+
+Return list of email regexes for matching the the local domain
+
+=cut
+
+sub localdomain_regexes {
+    my $domain = lc($Config{general}{domain});
+    return make_email_regexes([$domain,"*.$domain"]);
+}
+
+=head2 make_email_regexes
+
+Create an array of email regexes from a list of domain wildcards
+
+=cut
+
+sub make_email_regexes {
+    my ($domain_wildcards) = @_;
+    return map { make_email_regex($_) } @{$domain_wildcards // []};
+}
+
+=head2 make_email_regex
+
+Make an email regex from a domain wildcard
+
+=cut
+
+sub make_email_regex {
+    my ($domain_wildcard) = @_;
+    local $_;
+    $domain_wildcard = lc($domain_wildcard);
+    if ($domain_wildcard =~ /\*/) {
+        $domain_wildcard =~ s/\./\\./g;
+        $domain_wildcard =~ s/\*/\.\*/g;
+        $domain_wildcard = "\@$domain_wildcard\$";
+        return qr/$domain_wildcard/;
+    }
+
+    return qr/@\Q$domain_wildcard\E$/;
+}
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2018 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;
+

--- a/lib/pf/Authentication/Source/EmailSource.pm
+++ b/lib/pf/Authentication/Source/EmailSource.pm
@@ -228,6 +228,7 @@ Make an email regex from a domain wildcard
 sub make_email_regex {
     my ($domain_wildcard) = @_;
     local $_;
+    $domain_wildcard = lc($domain_wildcard);
     if ($domain_wildcard =~ /\*/) {
         $domain_wildcard =~ s/\./\\./g;
         $domain_wildcard =~ s/\*/\.\*/g;

--- a/lib/pf/Authentication/Source/EmailSource.pm
+++ b/lib/pf/Authentication/Source/EmailSource.pm
@@ -9,53 +9,21 @@ pf::Authentication::Source::EmailSource
 =cut
 
 use pf::Authentication::constants;
-use pf::config qw(%Config);
 use pf::constants qw($TRUE $FALSE);
 use pf::constants::authentication::messages;
 use pf::log;
-use List::MoreUtils qw(any);
-use pf::util;
 
 use Moose;
 extends 'pf::Authentication::Source';
-with 'pf::Authentication::CreateLocalAccountRole';
+with qw(
+    pf::Authentication::CreateLocalAccountRole
+    pf::Authentication::EmailFilteringRole
+);
 
 has '+class' => (default => 'external');
 has '+type' => (default => 'Email');
-has 'allow_localdomain' => (isa => 'Str', is => 'rw', default => 'yes');
 has 'email_activation_timeout' => (isa => 'Str', is => 'rw', default => '10m');
 has 'activation_domain' => (isa => 'Maybe[Str]', is => 'rw');
-has 'allowed_domains' => (isa => 'Maybe[ArrayRef[Str]]', is => 'rw');
-has 'banned_domains' => (isa => 'Maybe[ArrayRef[Str]]', is => 'rw');
-
-=head2 BUILDARGS
-
-BUILDARGS
-
-=cut
-
-around BUILDARGS => sub {
-    my $orig  = shift;
-    my $class = shift;
-    my %hash;
-    if (@_ == 1) {
-        if (ref($_[0]) ne 'HASH') {
-            return $class->$orig(@_);
-        }
-
-        %hash = %{$_[0]};
-    } else {
-        %hash = @_;
-    }
-
-    for my $f (qw(allowed_domains banned_domains)) {
-        next unless $hash{$f};
-        $hash{$f} = [ map { split(/\r?\n/) } expand_csv($hash{$f})];
-    }
-
-    my $args = $class->$orig(\%hash);
-    return $args;
-};
 
 =head2 dynamic_routing_module
 
@@ -143,101 +111,6 @@ sub authenticate {
     return $TRUE;
 }
 
-
-=head2 isEmailAllowed
-
-checks if email is allowed
-
-=cut
-
-sub isEmailAllowed {
-    my ($self, $email) = @_;
-    $email = lc($email);
-    if (any {$email =~ $_} $self->banned_email_regexes) {
-        return $FALSE;
-    }
-
-    my @allowed = $self->allowed_email_regexes;
-    if (@allowed) {
-        return (any {$email =~ $_} @allowed) ? $TRUE : $FALSE;
-    }
-
-    return $TRUE;
-}
-
-=head2 banned_email_regexes
-
-banned email regexes
-
-=cut
-
-sub banned_email_regexes {
-    my ($self) = @_;
-    my @banned = make_email_regexes($self->banned_domains);
-    if (!isenabled($self->allow_localdomain)) {
-        push @banned, localdomain_regexes();
-    }
-
-    return @banned;
-}
-
-=head2 allowed_email_regexes
-
-allowed email regexes
-
-=cut
-
-sub allowed_email_regexes {
-    my ($self) = @_;
-    my @allowed = make_email_regexes($self->allowed_domains);
-    if (@allowed && isenabled($self->allow_localdomain)) {
-        push @allowed, localdomain_regexes();
-    }
-
-    return @allowed;
-}
-
-=head2 localdomain_regexes
-
-Return list of email regexes for matching the the local domain
-
-=cut
-
-sub localdomain_regexes {
-    my $domain = lc($Config{general}{domain});
-    return make_email_regexes([$domain,"*.$domain"]);
-}
-
-=head2 make_email_regexes
-
-Create an array of email regexes from a list of domain wildcards
-
-=cut
-
-sub make_email_regexes {
-    my ($domain_wildcards) = @_;
-    return map { make_email_regex($_) } @{$domain_wildcards // []};
-}
-
-=head2 make_email_regex
-
-Make an email regex from a domain wildcard
-
-=cut
-
-sub make_email_regex {
-    my ($domain_wildcard) = @_;
-    local $_;
-    $domain_wildcard = lc($domain_wildcard);
-    if ($domain_wildcard =~ /\*/) {
-        $domain_wildcard =~ s/\./\\./g;
-        $domain_wildcard =~ s/\*/\.\*/g;
-        $domain_wildcard = "\@$domain_wildcard\$";
-        return qr/$domain_wildcard/;
-    }
-
-    return qr/@\Q$domain_wildcard\E$/;
-}
 
 =head1 AUTHOR
 

--- a/lib/pf/Authentication/Source/EmailSource.pm
+++ b/lib/pf/Authentication/Source/EmailSource.pm
@@ -125,7 +125,7 @@ isEmailAllowed
 sub isEmailAllowed {
     my ($self, $email) = @_;
     $email = lc($email);
-    my @banned = $self->domains_regexes($self->banned_domains);
+    my @banned = make_domains_regexes($self->banned_domains);
     if (!isenabled($self->allow_localdomain)) {
         push @banned, localdomain_regexes();
     }
@@ -134,7 +134,7 @@ sub isEmailAllowed {
         return $FALSE;
     }
 
-    my @allowed = $self->domains_regexes($self->allowed_domains);
+    my @allowed = make_domains_regexes($self->allowed_domains);
     if (@allowed && isenabled($self->allow_localdomain)) {
         push @allowed, localdomain_regexes();
     }
@@ -146,17 +146,35 @@ sub isEmailAllowed {
     return $TRUE;
 }
 
+=head2 localdomain_regexes
+
+Return list of regexes for matching the the local domain
+
+=cut
+
 sub localdomain_regexes {
     my $domain = $Config{general}{domain};
-    return (make_regex("$domain"), make_regex("*.$domain"));
+    return make_domains_regexes([$domain,"*.$domain"]);
 }
 
-sub domains_regexes {
-    my ($self, $domains) = @_;
-    return map { make_regex($_) } @{$domains // []};
+=head2 make_domains_regexes
+
+Create a domain regexes from a list of domains
+
+=cut
+
+sub make_domains_regexes {
+    my ($domains) = @_;
+    return map { make_domain_regex($_) } @{$domains // []};
 }
 
-sub make_regex {
+=head2 make_domain_regex
+
+Make the regex from a domain
+
+=cut
+
+sub make_domain_regex {
     my ($d) = @_;
     local $_;
     if ($d =~ /\*/) {

--- a/lib/pf/Authentication/Source/EmailSource.pm
+++ b/lib/pf/Authentication/Source/EmailSource.pm
@@ -136,7 +136,7 @@ sub authenticate {
     my ( $self, $username, $password ) = @_;
     if (!$self->isEmailAllowed($username)) {
         my $logger = get_logger();
-        $logger->warn("Failed to authenticate using EmailSource ($self->{id}) with PID '$username'");
+        $logger->warn("EmailSource ($self->{id}) failed to authenticate PID '$username' is banned");
         return ($FALSE, $pf::constants::authentication::messages::EMAIL_UNAUTHORIZED);
     }
 

--- a/lib/pf/Authentication/Source/EmailSource.pm
+++ b/lib/pf/Authentication/Source/EmailSource.pm
@@ -118,7 +118,7 @@ sub authenticate {
 
 =head2 isEmailAllowed
 
-isEmailAllowed
+checks if email is allowed
 
 =cut
 

--- a/lib/pf/Authentication/Source/EmailSource.pm
+++ b/lib/pf/Authentication/Source/EmailSource.pm
@@ -13,6 +13,7 @@ use pf::config qw(%Config);
 use pf::constants qw($TRUE $FALSE);
 use pf::constants::authentication::messages;
 use pf::log;
+use List::MoreUtils qw(any);
 use pf::util;
 
 use Moose;
@@ -24,7 +25,7 @@ has '+type' => (default => 'Email');
 has 'allow_localdomain' => (isa => 'Str', is => 'rw', default => 'yes');
 has 'email_activation_timeout' => (isa => 'Str', is => 'rw', default => '10m');
 has 'activation_domain' => (isa => 'Maybe[Str]', is => 'rw');
-has 'allowed_domains' => (isa => 'Maybe[Str]', is => 'rw');
+has 'allowed_domains' => (isa => 'Maybe[ArrayRef[Str]]', is => 'rw');
 
 =head2 dynamic_routing_module
 
@@ -129,11 +130,11 @@ isEmailAllowed
 sub isEmailAllowed {
     my ($self, $email) = @_;
     my $allowed_domains = $self->allowed_domains;
-    unless ($allowed_domains) {
+    if (!defined $allowed_domains || @$allowed_domains == 0) {
         return $TRUE;
     }
 
-    return ($email =~ /\Q$allowed_domains\E$/)  ? $TRUE :  $FALSE;
+    return (any {$email =~ /\Q$_\E$/} @$allowed_domains)  ? $TRUE :  $FALSE;
 }
 
 =head1 AUTHOR

--- a/lib/pf/Authentication/Source/EmailSource.pm
+++ b/lib/pf/Authentication/Source/EmailSource.pm
@@ -24,6 +24,7 @@ has '+type' => (default => 'Email');
 has 'allow_localdomain' => (isa => 'Str', is => 'rw', default => 'yes');
 has 'email_activation_timeout' => (isa => 'Str', is => 'rw', default => '10m');
 has 'activation_domain' => (isa => 'Maybe[Str]', is => 'rw');
+has 'allowed_domains' => (isa => 'Maybe[Str]', is => 'rw');
 
 =head2 dynamic_routing_module
 
@@ -118,6 +119,22 @@ sub authenticate {
     return $TRUE;
 }
 
+
+=head2 isEmailAllowed
+
+isEmailAllowed
+
+=cut
+
+sub isEmailAllowed {
+    my ($self, $email) = @_;
+    my $allowed_domains = $self->allowed_domains;
+    unless ($allowed_domains) {
+        return $TRUE;
+    }
+
+    return ($email =~ /\Q$allowed_domains\E$/)  ? $TRUE :  $FALSE;
+}
 
 =head1 AUTHOR
 

--- a/lib/pf/Authentication/Source/SponsorEmailSource.pm
+++ b/lib/pf/Authentication/Source/SponsorEmailSource.pm
@@ -18,11 +18,13 @@ use pf::log;
 use pf::util;
 
 extends 'pf::Authentication::Source';
-with 'pf::Authentication::CreateLocalAccountRole';
+with qw(
+    pf::Authentication::CreateLocalAccountRole
+    pf::Authentication::EmailFilteringRole
+);
 
 has '+class' => (default => 'external');
 has '+type' => (default => 'SponsorEmail');
-has 'allow_localdomain' => (isa => 'Str', is => 'rw', default => 'yes');
 has 'activation_domain' => (isa => 'Maybe[Str]', is => 'rw');
 has 'sponsorship_bcc' => (isa => 'Maybe[Str]', is => 'rw');
 has 'email_activation_timeout' => (isa => 'Str', is => 'rw', default => '30m');

--- a/lib/pf/ConfigStore/Source.pm
+++ b/lib/pf/ConfigStore/Source.pm
@@ -129,13 +129,13 @@ sub cleanupAfterRead {
             $item->{message} = $self->join_options($item->{message});
         }
     }
-    $self->expand_list($item, $self->_fields_expanded($item);
+    $self->expand_list($item, $self->_fields_expanded($item));
 }
 
 
 sub cleanupBeforeCommit {
     my ($self, $id, $item) = @_;
-    $self->flatten_list($item, $self->_fields_expanded($item);
+    $self->flatten_list($item, $self->_fields_expanded($item));
 }
 
 before rewriteConfig => sub {

--- a/lib/pf/ConfigStore/Source.pm
+++ b/lib/pf/ConfigStore/Source.pm
@@ -35,7 +35,6 @@ _fields_expanded
 our %TYPE_TO_EXPANDED_FIELDS = (
     SMS => [qw(sms_carriers)],
     Eduroam => [qw(local_realm reject_realm)],
-    Email => [qw(allowed_domains banned_domains)],
 );
 
 sub _fields_expanded {
@@ -122,19 +121,44 @@ sub cleanupAfterRead {
         $rule->{conditions} = [delete @$rule{@conditions_keys}];
         push @{$item->{"${class}_rules"}}, $rule;
     }
+    my $type = $item->{type};
 
-    if ($item->{type} eq 'SMS' || $item->{type} eq "Twilio") {
+    if ($type eq 'SMS' || $type eq "Twilio") {
         # This can be an array if it's fresh out of the file. We make it separated by newlines so it works fine the frontend
         if(ref($item->{message}) eq 'ARRAY'){
             $item->{message} = $self->join_options($item->{message});
         }
     }
+
+    if ($type eq 'Email') {
+        for my $f (qw(allowed_domains banned_domains)) {
+            next unless exists $item->{$f};
+            my $val =  $item->{$f};
+            if (ref($val) eq 'ARRAY') {
+                $item->{$f} = $self->join_options($val);
+            }
+        }
+    }
+
     $self->expand_list($item, $self->_fields_expanded($item));
 }
 
 
 sub cleanupBeforeCommit {
     my ($self, $id, $item) = @_;
+    if ($item->{type} eq 'Email') {
+        for my $f (qw(allowed_domains banned_domains)) {
+            next unless exists $item->{$f};
+            my $val =  $item->{$f};
+            next unless defined $val;
+            if (ref($val) eq 'ARRAY') {
+                $item->{$f} = [ map { my $a = $_; $a =~ s/\r//sg;$a } @$val ];
+            } else {
+                $val =~ s/\r//sg;
+            }
+        }
+    }
+
     $self->flatten_list($item, $self->_fields_expanded($item));
 }
 
@@ -146,8 +170,8 @@ before rewriteConfig => sub {
 
 
 sub join_options {
-    my ($self,$options) = @_;
-    return join("\n",@$options);
+    my ($self, $options) = @_;
+    return join("\n", @$options);
 }
 
 __PACKAGE__->meta->make_immutable unless $ENV{"PF_SKIP_MAKE_IMMUTABLE"};

--- a/lib/pf/constants/authentication/messages.pm
+++ b/lib/pf/constants/authentication/messages.pm
@@ -25,7 +25,7 @@ Readonly our $AUTH_FAIL_MSG => 'Invalid login or password';
 Readonly our $AUTH_SUCCESS_MSG => 'Authentication successful.';
 Readonly our $INVALID_EMAIL_MSG => 'Invalid e-mail address';
 Readonly our $LOCALDOMAIN_EMAIL_UNAUTHORIZED => "You can't register as a guest with this corporate email address. Please register as a regular user using your email address instead.";
-Readonly our $EMAIL_UNAUTHORIZED => "Cannot register with this email address.";
+Readonly our $EMAIL_UNAUTHORIZED => "Cannot register with this email address: unallowed domain.";
 
 =head1 AUTHOR
 

--- a/lib/pf/constants/authentication/messages.pm
+++ b/lib/pf/constants/authentication/messages.pm
@@ -17,7 +17,7 @@ use warnings;
 use Readonly;
 use base qw(Exporter);
 our @EXPORT = qw(
-  $COMMUNICATION_ERROR_MSG $AUTH_FAIL_MSG $AUTH_SUCCESS_MSG $INVALID_EMAIL_MSG $LOCALDOMAIN_EMAIL_UNAUTHORIZED
+  $COMMUNICATION_ERROR_MSG $AUTH_FAIL_MSG $AUTH_SUCCESS_MSG $INVALID_EMAIL_MSG $LOCALDOMAIN_EMAIL_UNAUTHORIZED $EMAIL_UNAUTHORIZED
 );
 
 Readonly our $COMMUNICATION_ERROR_MSG => 'Unable to validate credentials at the moment';
@@ -25,6 +25,7 @@ Readonly our $AUTH_FAIL_MSG => 'Invalid login or password';
 Readonly our $AUTH_SUCCESS_MSG => 'Authentication successful.';
 Readonly our $INVALID_EMAIL_MSG => 'Invalid e-mail address';
 Readonly our $LOCALDOMAIN_EMAIL_UNAUTHORIZED => "You can't register as a guest with this corporate email address. Please register as a regular user using your email address instead.";
+Readonly our $EMAIL_UNAUTHORIZED => "Cannot register with this email address.";
 
 =head1 AUTHOR
 

--- a/lib/pfconfig/namespaces/config/Authentication.pm
+++ b/lib/pfconfig/namespaces/config/Authentication.pm
@@ -171,7 +171,7 @@ sub newAuthenticationSource {
 
 sub cleanup_after_read {
     my ( $self, $id, $data ) = @_;
-    $self->expand_list( $data, qw(realms local_realm reject_realm) );
+    $self->expand_list( $data, qw(realms local_realm reject_realm allowed_domains) );
 }
 
 =head1 AUTHOR

--- a/lib/pfconfig/namespaces/config/Authentication.pm
+++ b/lib/pfconfig/namespaces/config/Authentication.pm
@@ -171,7 +171,7 @@ sub newAuthenticationSource {
 
 sub cleanup_after_read {
     my ( $self, $id, $data ) = @_;
-    $self->expand_list( $data, qw(realms local_realm reject_realm allowed_domains) );
+    $self->expand_list( $data, qw(realms local_realm reject_realm allowed_domains banned_domains) );
 }
 
 =head1 AUTHOR

--- a/lib/pfconfig/namespaces/config/Authentication.pm
+++ b/lib/pfconfig/namespaces/config/Authentication.pm
@@ -171,7 +171,7 @@ sub newAuthenticationSource {
 
 sub cleanup_after_read {
     my ( $self, $id, $data ) = @_;
-    $self->expand_list( $data, qw(realms local_realm reject_realm allowed_domains banned_domains) );
+    $self->expand_list( $data, qw(realms local_realm reject_realm) );
 }
 
 =head1 AUTHOR

--- a/t/data/authentication.conf
+++ b/t/data/authentication.conf
@@ -155,6 +155,20 @@ bob.com,zoz.com
 aoa.com
 EOT
 
+[email_uppercase_allowed]
+description=Email/sponsor-based registration
+email_activation_timeout=10m
+type=Email
+allow_localdomain=1
+allowed_domains=BOB.com
+
+[email_uppercase_banned]
+description=Email/sponsor-based registration
+email_activation_timeout=10m
+type=Email
+allow_localdomain=1
+banned_domains=ZOZ.com
+
 [LDAP0]
 description=pf-test
 password=

--- a/t/data/authentication.conf
+++ b/t/data/authentication.conf
@@ -169,6 +169,20 @@ type=Email
 allow_localdomain=1
 banned_domains=ZOZ.com
 
+[sponsor_uppercase_allowed]
+description=Email/sponsor-based registration
+email_activation_timeout=10m
+type=SponsorEmail
+allow_localdomain=1
+allowed_domains=BOB.com
+
+[sponsor_uppercase_banned]
+description=Email/sponsor-based registration
+email_activation_timeout=10m
+type=SponsorEmail
+allow_localdomain=1
+banned_domains=ZOZ.com
+
 [LDAP0]
 description=pf-test
 password=

--- a/t/data/authentication.conf
+++ b/t/data/authentication.conf
@@ -119,6 +119,26 @@ class=administration
 match=all
 action0=mark_as_sponsor=1
 
+[email2]
+description=Email/sponsor-based registration
+email_activation_timeout=10m
+type=Email
+allow_localdomain=1
+banned_domains=zoz.com
+
+[email3]
+description=Email/sponsor-based registration
+email_activation_timeout=10m
+type=Email
+allow_localdomain=1
+
+[email4]
+description=Email/sponsor-based registration
+email_activation_timeout=10m
+type=Email
+allow_localdomain=1
+allowed_domains=*bob.com
+
 [LDAP0]
 description=pf-test
 password=

--- a/t/data/authentication.conf
+++ b/t/data/authentication.conf
@@ -139,6 +139,12 @@ type=Email
 allow_localdomain=1
 allowed_domains=*bob.com
 
+[email5]
+description=Email/sponsor-based registration
+email_activation_timeout=10m
+type=Email
+allow_localdomain=0
+
 [LDAP0]
 description=pf-test
 password=

--- a/t/data/authentication.conf
+++ b/t/data/authentication.conf
@@ -104,6 +104,7 @@ description=Email/sponsor-based registration
 email_activation_timeout=10m
 type=Email
 allow_localdomain=1
+allowed_domains=bob.com
 
 [email rule catchall_Auth]
 description=

--- a/t/data/authentication.conf
+++ b/t/data/authentication.conf
@@ -145,6 +145,16 @@ email_activation_timeout=10m
 type=Email
 allow_localdomain=0
 
+[email6]
+description=Email/sponsor-based registration
+email_activation_timeout=10m
+type=Email
+allow_localdomain=0
+allowed_domains=<<EOT
+bob.com,zoz.com
+aoa.com
+EOT
+
 [LDAP0]
 description=pf-test
 password=

--- a/t/unittest/Authentication/Source/EmailSource.t
+++ b/t/unittest/Authentication/Source/EmailSource.t
@@ -1,0 +1,64 @@
+#!/usr/bin/perl
+
+=head1 NAME
+
+EmailSource
+
+=head1 DESCRIPTION
+
+unit test for EmailSource
+
+=cut
+
+use strict;
+use warnings;
+#
+use lib '/usr/local/pf/lib';
+
+BEGIN {
+    #include test libs
+    use lib qw(/usr/local/pf/t);
+    #Module for overriding configuration paths
+    use setup_test_config;
+}
+
+use Test::More tests => 3;
+use pf::authentication;
+
+#This test will running last
+use Test::NoWarnings;
+
+my $source = getAuthenticationSource('email');
+
+ok($source->isEmailAllowed('j@bob.com'), "Email is allowed");
+ok(!$source->isEmailAllowed('j@bobby.com'), "Email is not allowed");
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2018 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;
+

--- a/t/unittest/Authentication/Source/EmailSource.t
+++ b/t/unittest/Authentication/Source/EmailSource.t
@@ -29,21 +29,21 @@ my $local_email2 = "j\@a.$Config{general}{domain}";
 our @TESTS = (
     {
         name => 'email',
-        allowed => [qw(j@bob.com), $local_email1, $local_email2],
+        allowed => [qw(j@bob.com k@BOB.com), $local_email1, $local_email2],
         banned => [qw(j@bbob.com j@bobby.com)],
     },
     {
         name => 'email2',
-        allowed => [qw(j@zozz.com), $local_email1, $local_email2],
+        allowed => [qw(j@zozz.com j@ZoZz.com), $local_email1, $local_email2],
         banned => [qw(j@zoz.com)],
     },
     {
         name => 'email3',
-        allowed => [qw(j@zozz.com j@zoz.com), $local_email1, $local_email2],
+        allowed => [qw(j@zozz.com j@zoz.com j@ZoZ.com j@ZOZZ.com), $local_email1, $local_email2],
     },
     {
         name => 'email4',
-        allowed => [qw(j@bob.com j@bbob.com), $local_email1, $local_email2],
+        allowed => [qw(j@bob.com j@bbob.com j@BOB.COM j@BBOB.COM), $local_email1, $local_email2],
         banned => [qw(j@zoz.com j@bob.comm)],
     },
     {
@@ -63,9 +63,9 @@ use pf::authentication;
 use Test::NoWarnings;
 use List::Util qw(sum);
 
-my $tests = sum 1, map { ( scalar @{$_->{allowed} // []}, scalar @{$_->{banned} // []}) } @TESTS;
+my $test_count = sum 1, map { ( scalar @{$_->{allowed} // []}, scalar @{$_->{banned} // []}) } @TESTS;
 
-plan tests => $tests;
+plan tests => $test_count;
 
 for my $test (@TESTS) {
     my $name = $test->{name};

--- a/t/unittest/Authentication/Source/EmailSource.t
+++ b/t/unittest/Authentication/Source/EmailSource.t
@@ -64,6 +64,16 @@ our @TESTS = (
         allowed => [qw(j@zozz.com j@ZoZz.com), $local_email1, $local_email2],
         banned => [qw(j@zoz.com j@ZOZ.com)],
     },
+    {
+        name => 'sponsor_uppercase_allowed',
+        allowed => [qw(j@bob.com k@BOB.com), $local_email1, $local_email2],
+        banned => [qw(j@bbob.com j@bobby.com)],
+    },
+    {
+        name => 'sponsor_uppercase_banned',
+        allowed => [qw(j@zozz.com j@ZoZz.com), $local_email1, $local_email2],
+        banned => [qw(j@zoz.com j@ZOZ.com)],
+    },
 );
 
 use Test::More;

--- a/t/unittest/Authentication/Source/EmailSource.t
+++ b/t/unittest/Authentication/Source/EmailSource.t
@@ -50,6 +50,10 @@ our @TESTS = (
         name => 'email5',
         banned => [$local_email1, $local_email2],
     },
+    {
+        name => 'email6',
+        allowed => [qw(j@bob.com j@zoz.com j@aoa.com)],
+    },
 );
 
 use Test::More;

--- a/t/unittest/Authentication/Source/EmailSource.t
+++ b/t/unittest/Authentication/Source/EmailSource.t
@@ -35,7 +35,7 @@ our @TESTS = (
     {
         name => 'email2',
         allowed => [qw(j@zozz.com j@ZoZz.com), $local_email1, $local_email2],
-        banned => [qw(j@zoz.com)],
+        banned => [qw(j@zoz.com j@ZOZ.com)],
     },
     {
         name => 'email3',
@@ -53,6 +53,16 @@ our @TESTS = (
     {
         name => 'email6',
         allowed => [qw(j@bob.com j@zoz.com j@aoa.com)],
+    },
+    {
+        name => 'email_uppercase_allowed',
+        allowed => [qw(j@bob.com k@BOB.com), $local_email1, $local_email2],
+        banned => [qw(j@bbob.com j@bobby.com)],
+    },
+    {
+        name => 'email_uppercase_banned',
+        allowed => [qw(j@zozz.com j@ZoZz.com), $local_email1, $local_email2],
+        banned => [qw(j@zoz.com j@ZOZ.com)],
     },
 );
 


### PR DESCRIPTION
Description
===========
Allow to filter email domains that can be used for the email source

Impacts
=======
EmailSource and the portal email source workflow


Checklist
=======
- [x] Document the feature
- [X] Add unit tests
- [x] Add acceptance tests (TestLink)

NEWS file entries
=================

Enhancements
------------
* Email Source can have banned and allowed email domains