### PR TITLE
Make pf-maint.pl proxy ready

### DIFF
--- a/addons/pf-maint.pl
+++ b/addons/pf-maint.pl
@@ -40,6 +40,8 @@ use Pod::Usage;
 use IO::Handle;
 use Term::ReadKey;
 use IO::Interactive qw(is_interactive);
+# use CONNECT method to deal with proxy, see #3425
+$ENV{PERL_NET_HTTPS_SSL_SOCKET_CLASS} = "Net::SSL";
 our $GITHUB_USER = 'inverse-inc';
 our $GITHUB_REPO = 'packetfence';
 our $PF_DIR      = $ENV{PF_DIR} || '/usr/local/pf';


### PR DESCRIPTION
# Description
`pf-maint.pl` can now retrieve proxies URL from environment variables on CentOS 7

# Impacts
`pf-maint.pl` script

# Issue
fixes #3425 

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* `pf-maint.pl` doesn't take *_proxy environment variables into account (#3425)