### PR TITLE
Feature/local account module

### DIFF
--- a/conf/portal_modules.conf.defaults
+++ b/conf/portal_modules.conf.defaults
@@ -1,7 +1,7 @@
 [default_policy]
 description=Default portal policy
 type=Root
-modules=default_registration_policy,default_provisioning_policy
+modules=default_registration_policy,default_show_local_account,default_provisioning_policy
 
 [default_pending_policy]
 modules=default_provisioning_policy
@@ -45,3 +45,10 @@ multi_source_object_classes=pf::Authentication::Source::BlackholeSource
 description=Default Provisioning policy
 type=Provisioning
 skipable=disabled
+
+[default_show_local_account]
+skipable=1
+actions=
+template=account.html
+type=ShowLocalAccount
+description=Show local account

--- a/html/captive-portal/lib/captiveportal/DynamicRouting/Module/ShowLocalAccount.pm
+++ b/html/captive-portal/lib/captiveportal/DynamicRouting/Module/ShowLocalAccount.pm
@@ -1,0 +1,46 @@
+package captiveportal::DynamicRouting::Module::ShowLocalAccount;
+use Moose;
+
+BEGIN { extends 'captiveportal::PacketFence::DynamicRouting::Module::ShowLocalAccount'; }
+
+=head1 NAME
+
+captiveportal::DynamicRouting::Module::ShowLocalAccount - Controller to show local account for captiveportal
+
+=head1 DESCRIPTION
+
+[enter your description here]
+
+=cut
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2018 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+__PACKAGE__->meta->make_immutable unless $ENV{"PF_SKIP_MAKE_IMMUTABLE"};
+
+1;
+

--- a/html/captive-portal/lib/captiveportal/DynamicRouting/Module/ShowLocalAccount.pm
+++ b/html/captive-portal/lib/captiveportal/DynamicRouting/Module/ShowLocalAccount.pm
@@ -19,7 +19,7 @@ Inverse inc. <info@inverse.ca>
 
 =head1 COPYRIGHT
 
-Copyright (C) 2005-2018 Inverse inc.
+Copyright (C) 2005-2019 Inverse inc.
 
 =head1 LICENSE
 

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Root.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Root.pm
@@ -339,13 +339,12 @@ Show the account details created in the pre-registration
 
 sub show_preregistration_account {
     my ($self) = @_;
-    if(my $account = $self->app->session->{local_account_info}){
-        $self->render("account.html", {account => $account, title => "Account created"});
-    }
-    else {
-        get_logger->warn("No created account found. Continuing normal portal flow");
-        $self->SUPER::execute_child();
-    }
+    captiveportal::DynamicRouting::Module::ShowLocalAccount->new(
+        id => "__TMP_ShowLocalAccount_Module__", 
+        parent => $self, 
+        app => $self->app, 
+        skipable => $FALSE
+    )->execute();
 }
 
 =head2 record_destination_url

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/ShowLocalAccount.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/ShowLocalAccount.pm
@@ -1,0 +1,67 @@
+package captiveportal::PacketFence::DynamicRouting::Module::ShowLocalAccount;
+
+=head1 NAME
+
+DynamicRouting::Module::ShowLocalAccount
+
+=head1 DESCRIPTION
+
+Module to show a message to the user
+
+=cut
+
+use Moose;
+extends 'captiveportal::DynamicRouting::Module';
+
+has 'template' => (is => 'rw', default => sub {'account.html'});
+
+has 'skipable' => (is => 'rw', default => sub {1});
+
+=head2 execute_child
+
+Display the message to the user and handle the continue if applicable
+
+=cut
+
+sub execute_child {
+    my ($self) = @_;
+    if(my $account = $self->app->session->{local_account_info}){
+        $self->render("account.html", {account => $account, title => "Account created", skipable => $self->skipable});
+    }
+    else {
+        get_logger->warn("No created account found. Continuing normal portal flow");
+        $self->done();
+    }
+}
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2018 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+__PACKAGE__->meta->make_immutable unless $ENV{"PF_SKIP_MAKE_IMMUTABLE"};
+
+1;
+

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/ShowLocalAccount.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/ShowLocalAccount.pm
@@ -25,7 +25,10 @@ Display the message to the user and handle the continue if applicable
 
 sub execute_child {
     my ($self) = @_;
-    if(my $account = $self->app->session->{local_account_info}){
+    if($self->app->request->param('next') && $self->skipable){
+        $self->done();
+    }
+    elsif(my $account = $self->app->session->{local_account_info}){
         $self->render("account.html", {account => $account, title => "Account created", skipable => $self->skipable});
     }
     else {

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/ShowLocalAccount.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/ShowLocalAccount.pm
@@ -6,7 +6,7 @@ DynamicRouting::Module::ShowLocalAccount
 
 =head1 DESCRIPTION
 
-Module to show a message to the user
+Module to show a Local Account Information to the user
 
 =cut
 
@@ -45,7 +45,7 @@ Inverse inc. <info@inverse.ca>
 
 =head1 COPYRIGHT
 
-Copyright (C) 2005-2018 Inverse inc.
+Copyright (C) 2005-2019 Inverse inc.
 
 =head1 LICENSE
 

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/ShowLocalAccount.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/ShowLocalAccount.pm
@@ -13,6 +13,8 @@ Module to show a message to the user
 use Moose;
 extends 'captiveportal::DynamicRouting::Module';
 
+use pf::log;
+
 has 'template' => (is => 'rw', default => sub {'account.html'});
 
 has 'skipable' => (is => 'rw', default => sub {1});
@@ -32,7 +34,7 @@ sub execute_child {
         $self->render("account.html", {account => $account, title => "Account created", skipable => $self->skipable});
     }
     else {
-        get_logger->warn("No created account found. Continuing normal portal flow");
+        get_logger->debug("No created account found. Continuing normal portal flow");
         $self->done();
     }
 }

--- a/html/captive-portal/templates/account.html
+++ b/html/captive-portal/templates/account.html
@@ -42,6 +42,14 @@
       [% END %]
       [% END %]
     </ul>
+      
+    <div class="o-layout__item u-1/1 u-margin-bottom">
+      [% IF skipable %]
+      <a href="/captive-portal?next=next" class="c-btn c-btn--tertiary u-margin-top">
+        [% i18n("Continue") %]
+      </a>
+      [% END %]
+    </div>
   </div>
 
 </div>

--- a/html/pfappserver/lib/pfappserver/Form/Config/PortalModule/ShowLocalAccount.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/PortalModule/ShowLocalAccount.pm
@@ -1,0 +1,79 @@
+package pfappserver::Form::Config::PortalModule::ShowLocalAccount;
+
+=head1 NAME
+
+pfappserver::Form::Config::PortalModule:Choice
+
+=head1 DESCRIPTION
+
+Form definition to create or update a choice portal module.
+
+=cut
+
+use HTML::FormHandler::Moose;
+extends 'pfappserver::Form::Config::PortalModule';
+with 'pfappserver::Base::Form::Role::Help';
+
+use captiveportal::DynamicRouting::Module::ShowLocalAccount;
+sub for_module {'captiveportal::PacketFence::DynamicRouting::Module::ShowLocalAccount'}
+## Definition
+
+has_field 'skipable' =>
+  (
+   type => 'Toggle',
+   label => 'Skippable',
+   unchecked_value => '0',
+   checkbox_value => '1',
+   tags => { after_element => \&help,
+             help => 'Whether or not, this message can be skipped' },
+  );
+
+has_field 'template' =>
+  (
+   type => 'Text',
+   label => 'Template',
+   tags => { after_element => \&help,
+             help => 'The template to use to display the message' },
+  );
+
+sub child_definition {
+    return qw(template skipable);
+}
+
+sub BUILD {
+    my ($self) = @_;
+    $self->field('template')->default($self->for_module->meta->find_attribute_by_name('template')->default->());
+    $self->field('skipable')->default($self->for_module->meta->find_attribute_by_name('skipable')->default->());
+}
+
+=over
+
+=back
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2018 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+__PACKAGE__->meta->make_immutable unless $ENV{"PF_SKIP_MAKE_IMMUTABLE"};
+1;
+
+

--- a/html/pfappserver/lib/pfappserver/Form/Config/PortalModule/ShowLocalAccount.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/PortalModule/ShowLocalAccount.pm
@@ -2,11 +2,11 @@ package pfappserver::Form::Config::PortalModule::ShowLocalAccount;
 
 =head1 NAME
 
-pfappserver::Form::Config::PortalModule:Choice
+pfappserver::Form::Config::PortalModule:ShowLocalAccount
 
 =head1 DESCRIPTION
 
-Form definition to create or update a choice portal module.
+Form definition to create or update a show local account module.
 
 =cut
 
@@ -52,7 +52,7 @@ sub BUILD {
 
 =head1 COPYRIGHT
 
-Copyright (C) 2005-2018 Inverse inc.
+Copyright (C) 2005-2019 Inverse inc.
 
 =head1 LICENSE
 


### PR DESCRIPTION
# Description
Display local account details even when not in preregistration

# Impacts
Captive portal registration

# Issue
fixes #3615 

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [no] Document the feature
- [n/a] Add unit tests
- [yes] Add acceptance tests (TestLink)

# NEWS file entries
## Enhancements
* Display local account in the captive portal during registration if applicable (#3615)
