### PR TITLE
fix update email_pattern for Freedom

### DIFF
--- a/db/pf-schema-X.Y.Z.sql
+++ b/db/pf-schema-X.Y.Z.sql
@@ -553,7 +553,7 @@ VALUES
     (100122, 'Koodo Mobile', '%s@msg.koodomobile.com', now()),
     (100123, 'Chatr', '%s@pcs.rogers.com', now()),
     (100124, 'Eastlink', '%s@txt.eastlink.ca', now()),
-    (100125, 'Freedom', 'txt.freedommobile.ca', now()),
+    (100125, 'Freedom', '%s@txt.freedommobile.ca', now()),
     (100126, 'PC Mobile', '%s@msg.telus.com', now()),
     (100127, 'TBayTel', '%s@pcs.rogers.com', now()),
     (100128, 'Google Project Fi', '%s@msg.fi.google.com', now());

--- a/db/upgrade-X.X.X-X.Y.Z.sql
+++ b/db/upgrade-X.X.X-X.Y.Z.sql
@@ -364,4 +364,11 @@ BEGIN
 END /
 DELIMITER ;
 
+--
+-- Update Freedom mobile's email pattern
+--
+
+UPDATE sms_carrier SET email_pattern="%s@txt.freedommobile.ca" WHERE id=100125;
+
+
 INSERT INTO pf_version (id, version) VALUES (@VERSION_INT, CONCAT_WS('.', @MAJOR_VERSION, @MINOR_VERSION, @SUBMINOR_VERSION));


### PR DESCRIPTION
# Description
fix update email_pattern for Freedom

# Impacts
- DB schema
- PF upgrade to 8.3

# Issue
fixes #3872 

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* Wrong email_pattern in sms_carrier table for Freedom Mobile