### PR TITLE
fix/i18n_translation_utf8

### DIFF
--- a/addons/upgrade/to-8.3-conf-latin1-to-utf8.sh
+++ b/addons/upgrade/to-8.3-conf-latin1-to-utf8.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
-
-find /usr/local/pf/conf -type f -print0 | while read -d $'\0' file; do 
+PF_DIR="/usr/local/pf"
+find "$PF_DIR/html/captive-portal/profile-templates" "$PF_DIR/conf" -type f -print0 | while read -d $'\0' file; do
     if file --mime-encoding  "$file" | grep -q iso-8859-1  ;then
         echo "converting $file from iso-8859-1 to utf-8" 
         iconv --from-code=iso-8859-1 --to-code=utf-8 "$file" -o "$file"
    fi
 done
+echo "Finished converting files"

--- a/addons/upgrade/to-8.3-conf-latin1-to-utf8.sh
+++ b/addons/upgrade/to-8.3-conf-latin1-to-utf8.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+find /usr/local/pf/conf -type f -print0 | while read -d $'\0' file; do 
+    if file --mime-encoding  "$file" | grep -q iso-8859-1  ;then
+        echo "converting $file from iso-8859-1 to utf-8" 
+        iconv --from-code=iso-8859-1 --to-code=utf-8 "$file" -o "$file"
+   fi
+done

--- a/html/captive-portal/lib/captiveportal.pm
+++ b/html/captive-portal/lib/captiveportal.pm
@@ -26,7 +26,6 @@ use Catalyst qw/
   Session::Store::CHI
   Session::State::MAC
   StackTrace
-  Unicode::Encoding
   /;
 
 use Try::Tiny;

--- a/html/pfappserver/lib/pfappserver.pm
+++ b/html/pfappserver/lib/pfappserver.pm
@@ -28,7 +28,6 @@ use Catalyst qw/
     Session::Store::CHI
     Session::State::Cookie
     StackTrace
-    Unicode::Encoding
 /;
 
 use Try::Tiny;

--- a/lib/pf/config/util.pm
+++ b/lib/pf/config/util.pm
@@ -190,13 +190,13 @@ sub send_email {
         To          => $email,
         Bcc         => $data->{'bcc'} || '',
         Subject     => $subject,
+        Encoding    => 'base64',
         Template    => "emails-$template.html",
         TmplOptions => \%TmplOptions,
         TmplParams  => \%vars,
-        TmplUpgrade => 1,
         ( $data->{'from'} ? ( From => $data->{'from'} ) : () ),
     );
-    $msg->attr( "Content-Type" => "text/html; charset=UTF-8;" );
+    $msg->attr( "Content-Type" => "text/html; charset=UTF-8" );
     return send_mime_lite($msg);
 }
 

--- a/lib/pf/web.pm
+++ b/lib/pf/web.pm
@@ -80,7 +80,6 @@ sub i18n {
     }
 
     my $result = gettext($msgid);
-    utf8::decode($result);
     return $result;
 }
 
@@ -90,7 +89,6 @@ sub ni18n {
     my $category = shift;
 
     my $result = ngettext($singular, $plural, $category);
-    utf8::decode($result);
     return $result;
 }
 
@@ -106,7 +104,6 @@ sub i18n_format {
     my ($msgid, @args) = @_;
 
     my $result = gettext($msgid);
-    utf8::decode($result);
     $result = sprintf($result, @args);
     return $result;
 }


### PR DESCRIPTION
Description
===========
Fix utf8 encoding in templates and saving files

Impacts
=======
The portal, admin, email templates

Delete branch after merge
=========================
NO

UPGRADE file entries
====================

We had an issue where configuration we being saved as latin1 instead of utf8.

This script will convert all latin1 config file to utf8

addons/upgrade/to-8.3-conf-latin1-to-utf8.sh