### PR TITLE
Additional Daemon dns and dhcp

### DIFF
--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -752,7 +752,7 @@ EOT
 
 [interface.type]
 type=multi
-options=internal|management|managed|monitor|dhcplistener|dhcp-listener|high-availability|portal|radius|dhcpd|dns
+options=internal|management|managed|monitor|dhcplistener|dhcp-listener|high-availability|portal|radius|dhcp|dns
 description=<<EOT
 Describes type of the named interface.
  * "internal" describes interfaces where PacketFence will enforce network access.
@@ -762,8 +762,8 @@ Describes type of the named interface.
  * "high-availability" is for an interface between two PacketFence servers dedicated to high-availability (drbd, corosync).
  * "portal" interface have the captive-portal running on them without the need of having any enforcement mechanism.
  * "radius" interface have the radius running (auth, acct, cli)
- * "dhcpd" interface have the pfdhcp running.
- * "dns" interface have the pfdns running
+ * "dhcp" interface have the pfdhcp daemon running.
+ * "dns" interface have the pfdns daemon running
 EOT
 
 [interface.enforcement]

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -752,7 +752,7 @@ EOT
 
 [interface.type]
 type=multi
-options=internal|management|managed|monitor|dhcplistener|dhcp-listener|high-availability|portal|radius
+options=internal|management|managed|monitor|dhcplistener|dhcp-listener|high-availability|portal|radius|dhcpd|dns
 description=<<EOT
 Describes type of the named interface.
  * "internal" describes interfaces where PacketFence will enforce network access.
@@ -762,6 +762,8 @@ Describes type of the named interface.
  * "high-availability" is for an interface between two PacketFence servers dedicated to high-availability (drbd, corosync).
  * "portal" interface have the captive-portal running on them without the need of having any enforcement mechanism.
  * "radius" interface have the radius running (auth, acct, cli)
+ * "dhcpd" interface have the pfdhcp running.
+ * "dns" interface have the pfdns running
 EOT
 
 [interface.enforcement]

--- a/conf/iptables.conf.example
+++ b/conf/iptables.conf.example
@@ -21,7 +21,7 @@
 -A input-management-if --protocol tcp --match tcp --dport %%web_admin_port%% --jump ACCEPT
 # Webservices
 -A input-management-if --protocol tcp --match tcp --dport %%webservices_port%% --jump ACCEPT
-# AAA 
+# AAA
 -A input-management-if --protocol tcp --match tcp --dport %%aaa_port%% --jump ACCEPT
 # Unified API
 -A input-management-if --protocol tcp --match tcp --dport %%unifiedapi_port%% --jump ACCEPT
@@ -89,16 +89,16 @@
 -A input-dns-if --protocol tcp --match tcp --dport 53 --jump ACCEPT
 -A input-dns-if --protocol udp --match udp --dport 53 --jump ACCEPT
 
-:input-dhcpd-if - [0:0]
--A input-dhcpd-if --protocol udp --match udp --dport 67  --jump ACCEPT
--A input-dhcpd-if --protocol tcp --match tcp --dport 67  --jump ACCEPT
+:input-dhcp-if - [0:0]
+-A input-dhcp-if --protocol udp --match udp --dport 67  --jump ACCEPT
+-A input-dhcp-if --protocol tcp --match tcp --dport 67  --jump ACCEPT
 
 
 :input-internal-vlan-if - [0:0]
 # DNS
 -A input-internal-vlan-if --protocol tcp --match tcp --dport 53  --jump ACCEPT
 -A input-internal-vlan-if --protocol udp --match udp --dport 53  --jump ACCEPT
-# HTTP (captive-portal) 
+# HTTP (captive-portal)
 -A input-internal-vlan-if --protocol tcp --match tcp --dport 80  --jump ACCEPT
 -A input-internal-vlan-if --protocol tcp --match tcp --dport 443 --jump ACCEPT
 -A input-internal-vlan-if --protocol tcp --match tcp --dport 647 --jump ACCEPT
@@ -114,7 +114,7 @@
 # DHCP
 -A input-internal-isol_vlan-if --protocol udp --match udp --dport 67  --jump ACCEPT
 -A input-internal-isol_vlan-if --protocol tcp --match tcp --dport 67  --jump ACCEPT
-# HTTP (captive-portal) 
+# HTTP (captive-portal)
 -A input-internal-isol_vlan-if --protocol tcp --match tcp --dport 80  --jump ACCEPT
 -A input-internal-isol_vlan-if --protocol tcp --match tcp --dport 443 --jump ACCEPT
 -A input-internal-isol_vlan-if --protocol tcp --match tcp --dport 647 --jump ACCEPT
@@ -126,7 +126,7 @@
 # DNS
 -A input-internal-inline-if --protocol tcp --match tcp --dport 53  --jump ACCEPT
 -A input-internal-inline-if --protocol udp --match udp --dport 53  --jump ACCEPT
-# HTTP (captive-portal) 
+# HTTP (captive-portal)
 # prevent registered users from reaching it
 # TODO: Must work in dispatcher and Catalyst to redirect registered client out of the portal
 #-A input-internal-inline-if --protocol tcp --match tcp --dport 80  --match mark --mark 0x1 --jump DROP
@@ -226,7 +226,7 @@ COMMIT
 # - allowing through instead of doing NAT (make sure you have the proper return route)
 # - traffic out on some interface other than management
 # - overloading on multiple IP addresses
-# Comment the next two lines and do it here on the POSTROUTING chain. 
+# Comment the next two lines and do it here on the POSTROUTING chain.
 # Make sure to adjust the FORWARD rules also to allow traffic back-in.
 %%nat_postrouting_vlan%%
 
@@ -235,4 +235,3 @@ COMMIT
 #
 %%domain_postrouting%%
 COMMIT
-

--- a/conf/iptables.conf.example
+++ b/conf/iptables.conf.example
@@ -85,6 +85,15 @@
 -A input-radius-if --protocol tcp --match tcp --dport 2083 --jump ACCEPT
 %%eduroam_radius_listening%%
 
+:input-dns-if - [0:0]
+-A input-dns-if --protocol tcp --match tcp --dport 53 --jump ACCEPT
+-A input-dns-if --protocol udp --match udp --dport 53 --jump ACCEPT
+
+:input-dhcpd-if - [0:0]
+-A input-dhcpd-if --protocol udp --match udp --dport 67  --jump ACCEPT
+-A input-dhcpd-if --protocol tcp --match tcp --dport 67  --jump ACCEPT
+
+
 :input-internal-vlan-if - [0:0]
 # DNS
 -A input-internal-vlan-if --protocol tcp --match tcp --dport 53  --jump ACCEPT

--- a/go/coredns/plugin/pfdns/pfdns.go
+++ b/go/coredns/plugin/pfdns/pfdns.go
@@ -410,6 +410,9 @@ func (pf *pfdns) detectVIP() error {
 	var interfaces pfconfigdriver.ListenInts
 	pfconfigdriver.FetchDecodeSocket(ctx, &interfaces)
 
+	var DNSinterfaces pfconfigdriver.DNSInts
+	pfconfigdriver.FetchDecodeSocket(ctx, &DNSinterfaces)
+
 	var keyConfNet pfconfigdriver.PfconfigKeys
 	keyConfNet.PfconfigNS = "config::Network"
 	keyConfNet.PfconfigHostnameOverlay = "yes"
@@ -418,7 +421,7 @@ func (pf *pfdns) detectVIP() error {
 	var keyConfCluster pfconfigdriver.NetInterface
 	keyConfCluster.PfconfigNS = "config::Pf(CLUSTER," + pfconfigdriver.FindClusterName(ctx) + ")"
 
-	for _, v := range interfaces.Element {
+	for _, v := range append(interfaces.Element, DNSinterfaces.Element...) {
 
 		keyConfCluster.PfconfigHashNS = "interface " + v
 		pfconfigdriver.FetchDecodeSocket(ctx, &keyConfCluster)

--- a/go/coredns/plugin/pfdns/pfdns.go
+++ b/go/coredns/plugin/pfdns/pfdns.go
@@ -421,7 +421,7 @@ func (pf *pfdns) detectVIP() error {
 	var keyConfCluster pfconfigdriver.NetInterface
 	keyConfCluster.PfconfigNS = "config::Pf(CLUSTER," + pfconfigdriver.FindClusterName(ctx) + ")"
 
-	for _, v := range append(interfaces.Element, DNSinterfaces.Element...) {
+	for _, v := range sharedutils.RemoveDuplicates(append(interfaces.Element, DNSinterfaces.Element...)) {
 
 		keyConfCluster.PfconfigHashNS = "interface " + v
 		pfconfigdriver.FetchDecodeSocket(ctx, &keyConfCluster)

--- a/go/dhcp/config.go
+++ b/go/dhcp/config.go
@@ -72,7 +72,7 @@ func (d *Interfaces) readConfig() {
 	pfconfigdriver.FetchDecodeSocket(ctx, &keyConfNet)
 
 	wg := &sync.WaitGroup{}
-	for _, v := range append(interfaces.Element, DHCPinterfaces.Element...) {
+	for _, v := range sharedutils.RemoveDuplicates(append(interfaces.Element, DHCPinterfaces.Element...)) {
 
 		eth, err := net.InterfaceByName(v)
 

--- a/go/dhcp/config.go
+++ b/go/dhcp/config.go
@@ -62,6 +62,9 @@ func (d *Interfaces) readConfig() {
 	var interfaces pfconfigdriver.ListenInts
 	pfconfigdriver.FetchDecodeSocket(ctx, &interfaces)
 
+	var DHCPinterfaces pfconfigdriver.DHCPInts
+	pfconfigdriver.FetchDecodeSocket(ctx, &DHCPinterfaces)
+
 	var keyConfNet pfconfigdriver.PfconfigKeys
 	keyConfNet.PfconfigNS = "config::Network"
 	keyConfNet.PfconfigHostnameOverlay = "yes"
@@ -69,7 +72,7 @@ func (d *Interfaces) readConfig() {
 	pfconfigdriver.FetchDecodeSocket(ctx, &keyConfNet)
 
 	wg := &sync.WaitGroup{}
-	for _, v := range interfaces.Element {
+	for _, v := range append(interfaces.Element, DHCPinterfaces.Element...) {
 
 		eth, err := net.InterfaceByName(v)
 

--- a/go/dhcp/main.go
+++ b/go/dhcp/main.go
@@ -89,7 +89,7 @@ func main() {
 		var interfaces pfconfigdriver.ListenInts
 		pfconfigdriver.FetchDecodeSocket(ctx, &interfaces)
 		for {
-			DHCPConfig.detectVIP(append(interfaces.Element, DHCPinterfaces.Element...))
+			DHCPConfig.detectVIP(sharedutils.RemoveDuplicates(append(interfaces.Element, DHCPinterfaces.Element...)))
 
 			time.Sleep(3 * time.Second)
 		}

--- a/go/dhcp/main.go
+++ b/go/dhcp/main.go
@@ -84,10 +84,12 @@ func main() {
 	VIPIp = make(map[string]net.IP)
 
 	go func() {
+		var DHCPinterfaces pfconfigdriver.DHCPInts
+		pfconfigdriver.FetchDecodeSocket(ctx, &DHCPinterfaces)
 		var interfaces pfconfigdriver.ListenInts
 		pfconfigdriver.FetchDecodeSocket(ctx, &interfaces)
 		for {
-			DHCPConfig.detectVIP(interfaces)
+			DHCPConfig.detectVIP(append(interfaces.Element, DHCPinterfaces.Element...))
 
 			time.Sleep(3 * time.Second)
 		}

--- a/go/dhcp/utils.go
+++ b/go/dhcp/utils.go
@@ -115,12 +115,12 @@ func InterfaceScopeFromMac(MAC string) string {
 }
 
 // Detect the vip on each interfaces
-func (d *Interfaces) detectVIP(interfaces pfconfigdriver.ListenInts) {
+func (d *Interfaces) detectVIP(interfaces []string) {
 
 	var keyConfCluster pfconfigdriver.NetInterface
 	keyConfCluster.PfconfigNS = "config::Pf(CLUSTER," + pfconfigdriver.FindClusterName(ctx) + ")"
 
-	for _, v := range interfaces.Element {
+	for _, v := range interfaces {
 		keyConfCluster.PfconfigHashNS = "interface " + v
 		pfconfigdriver.FetchDecodeSocket(ctx, &keyConfCluster)
 		// Nothing in keyConfCluster.Ip so we are not in cluster mode

--- a/go/pfconfigdriver/structs.go
+++ b/go/pfconfigdriver/structs.go
@@ -219,7 +219,7 @@ type ListenInts struct {
 type DHCPInts struct {
 	StructConfig
 	PfconfigMethod          string `val:"element"`
-	PfconfigNS              string `val:"interfaces::dhcpd_ints"`
+	PfconfigNS              string `val:"interfaces::dhcp_ints"`
 	PfconfigArray           string `val:"yes"`
 	PfconfigHostnameOverlay string `val:"yes"`
 	Element                 []string

--- a/go/pfconfigdriver/structs.go
+++ b/go/pfconfigdriver/structs.go
@@ -51,6 +51,7 @@ type configStruct struct {
 	Interfaces struct {
 		ListenInts        ListenInts
 		ManagementNetwork ManagementNetwork
+		DHCPInts          DHCPInts
 	}
 	PfConf struct {
 		General       PfConfGeneral
@@ -209,6 +210,15 @@ type ListenInts struct {
 	StructConfig
 	PfconfigMethod          string `val:"element"`
 	PfconfigNS              string `val:"interfaces::listen_ints"`
+	PfconfigArray           string `val:"yes"`
+	PfconfigHostnameOverlay string `val:"yes"`
+	Element                 []string
+}
+
+type DHCPInts struct {
+	StructConfig
+	PfconfigMethod          string `val:"element"`
+	PfconfigNS              string `val:"interfaces::dhcpd_ints"`
 	PfconfigArray           string `val:"yes"`
 	PfconfigHostnameOverlay string `val:"yes"`
 	Element                 []string

--- a/go/pfconfigdriver/structs.go
+++ b/go/pfconfigdriver/structs.go
@@ -52,6 +52,7 @@ type configStruct struct {
 		ListenInts        ListenInts
 		ManagementNetwork ManagementNetwork
 		DHCPInts          DHCPInts
+		DNSInts           DNSInts
 	}
 	PfConf struct {
 		General       PfConfGeneral
@@ -219,6 +220,15 @@ type DHCPInts struct {
 	StructConfig
 	PfconfigMethod          string `val:"element"`
 	PfconfigNS              string `val:"interfaces::dhcpd_ints"`
+	PfconfigArray           string `val:"yes"`
+	PfconfigHostnameOverlay string `val:"yes"`
+	Element                 []string
+}
+
+type DNSInts struct {
+	StructConfig
+	PfconfigMethod          string `val:"element"`
+	PfconfigNS              string `val:"interfaces::dns_ints"`
 	PfconfigArray           string `val:"yes"`
 	PfconfigHostnameOverlay string `val:"yes"`
 	Element                 []string

--- a/go/sharedutils/util.go
+++ b/go/sharedutils/util.go
@@ -268,6 +268,7 @@ func CleanIP(s string) (string, error) {
 	}
 }
 
+// Remove duplicates elements in an array
 func RemoveDuplicates(elements []string) []string {
 	// Use map to record duplicates as we find them.
 	encountered := map[string]bool{}

--- a/go/sharedutils/util.go
+++ b/go/sharedutils/util.go
@@ -10,11 +10,11 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
 	"unicode"
-	"regexp"
 
 	"github.com/cevaris/ordered_map"
 	"github.com/kr/pretty"
@@ -266,4 +266,23 @@ func CleanIP(s string) (string, error) {
 	} else {
 		return ip.String(), nil
 	}
+}
+
+func RemoveDuplicates(elements []string) []string {
+	// Use map to record duplicates as we find them.
+	encountered := map[string]bool{}
+	result := []string{}
+
+	for v := range elements {
+		if encountered[elements[v]] == true {
+			// Do not add duplicate.
+		} else {
+			// Record this element as an encountered element.
+			encountered[elements[v]] = true
+			// Append to result slice.
+			result = append(result, elements[v])
+		}
+	}
+	// Return the new slice.
+	return result
 }

--- a/go/sharedutils/util.go
+++ b/go/sharedutils/util.go
@@ -268,7 +268,7 @@ func CleanIP(s string) (string, error) {
 	}
 }
 
-// Remove duplicates elements in an array
+// RemoveDuplicates function remove duplicates elements in an array
 func RemoveDuplicates(elements []string) []string {
 	// Use map to record duplicates as we find them.
 	encountered := map[string]bool{}

--- a/go/sharedutils/util.go
+++ b/go/sharedutils/util.go
@@ -274,9 +274,7 @@ func RemoveDuplicates(elements []string) []string {
 	result := []string{}
 
 	for v := range elements {
-		if encountered[elements[v]] == true {
-			// Do not add duplicate.
-		} else {
+		if encountered[elements[v]] != true {
 			// Record this element as an encountered element.
 			encountered[elements[v]] = true
 			// Append to result slice.

--- a/html/pfappserver/lib/pfappserver/Form/Interface.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Interface.pm
@@ -140,7 +140,7 @@ sub options_additional_listening_daemons {
     my $self = shift;
 
     return map { { value => $_, label => $_ } }
-        qw(portal radius);
+        qw(portal radius dhcpd dns);
 }
 
 =head2 validate
@@ -177,6 +177,24 @@ sub validate {
         my %daemons = map { $_ => 1 } @{$self->value->{additional_listening_daemons}};
         if ( exists($daemons{'radius'}) ) {
             my $index = firstidx { $_ eq 'radius' } @{$self->value->{additional_listening_daemons}};
+            splice @{$self->value->{additional_listening_daemons}}, $index, 1;
+        }
+    }
+    # Remove double dns type if exist
+    @types = qw(dns);
+    if ( defined $self->value->{type} && any { $_ eq $self->value->{type} } @types ) {
+        my %daemons = map { $_ => 1 } @{$self->value->{additional_listening_daemons}};
+        if ( exists($daemons{'dns'}) ) {
+            my $index = firstidx { $_ eq 'dns' } @{$self->value->{additional_listening_daemons}};
+            splice @{$self->value->{additional_listening_daemons}}, $index, 1;
+        }
+    }
+    # Remove double radius type if exist
+    @types = qw(dhcpd);
+    if ( defined $self->value->{type} && any { $_ eq $self->value->{type} } @types ) {
+        my %daemons = map { $_ => 1 } @{$self->value->{additional_listening_daemons}};
+        if ( exists($daemons{'dhcpd'}) ) {
+            my $index = firstidx { $_ eq 'dhcpd' } @{$self->value->{additional_listening_daemons}};
             splice @{$self->value->{additional_listening_daemons}}, $index, 1;
         }
     }

--- a/html/pfappserver/lib/pfappserver/Form/Interface.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Interface.pm
@@ -68,7 +68,7 @@ has_field 'dns' =>
              help => 'The primary DNS server of your network.' },
   );
 
-has_field 'dhcpd_enabled' => 
+has_field 'dhcpd_enabled' =>
    (
     type => 'Toggle',
     checkbox_value => 1,
@@ -76,7 +76,7 @@ has_field 'dhcpd_enabled' =>
     label => 'Enable DHCP Server',
    );
 
-has_field 'high_availability' => 
+has_field 'high_availability' =>
    (
     type => 'Toggle',
     checkbox_value => 1,
@@ -140,7 +140,7 @@ sub options_additional_listening_daemons {
     my $self = shift;
 
     return map { { value => $_, label => $_ } }
-        qw(portal radius dhcpd dns);
+        qw(portal radius dhcp dns);
 }
 
 =head2 validate
@@ -152,9 +152,9 @@ Force DNS to be defined when the 'inline' type is selected
 sub validate {
     my $self = shift;
 
-    if (defined $self->value->{type} &&  
-        ( $self->value->{type} eq 'inlinel2' or 
-          $self->value->{type} eq 'inline' ) 
+    if (defined $self->value->{type} &&
+        ( $self->value->{type} eq 'inlinel2' or
+          $self->value->{type} eq 'inline' )
         ) {
         unless ($self->value->{dns}) {
             $self->field('dns')->add_error('Please specify your DNS server.');
@@ -189,12 +189,12 @@ sub validate {
             splice @{$self->value->{additional_listening_daemons}}, $index, 1;
         }
     }
-    # Remove double radius type if exist
-    @types = qw(dhcpd);
+    # Remove double dhcp type if exist
+    @types = qw(dhcp);
     if ( defined $self->value->{type} && any { $_ eq $self->value->{type} } @types ) {
         my %daemons = map { $_ => 1 } @{$self->value->{additional_listening_daemons}};
-        if ( exists($daemons{'dhcpd'}) ) {
-            my $index = firstidx { $_ eq 'dhcpd' } @{$self->value->{additional_listening_daemons}};
+        if ( exists($daemons{'dhcp'}) ) {
+            my $index = firstidx { $_ eq 'dhcp' } @{$self->value->{additional_listening_daemons}};
             splice @{$self->value->{additional_listening_daemons}}, $index, 1;
         }
     }

--- a/html/pfappserver/lib/pfappserver/Model/Interface.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Interface.pm
@@ -463,7 +463,7 @@ sub getType {
         # rely on pf.conf's info
         else {
             $type = $interface->{type};
-            if ($type !~ /radius/i && $type !~ /portal/i) {
+            if ($type !~ /radius/i && $type !~ /portal/i && $type !~ /dns/i && $type !~ /dhcpd/i) {
                 $type = ($type =~ /management|managed/i) ? 'management' : 'other';
             }
         }
@@ -507,7 +507,7 @@ sub setType {
                                     $self->_prepare_interface_for_pfconf($interface, $interface_ref, $type));
 
         # Update networks.conf
-        if ( $type =~ /management|portal|^radius$/ ) {
+        if ( $type =~ /management|portal|^radius$|dhcpd|dns/ ) {
             # management interfaces must not appear in networks.conf
             $models->{network}->remove($interface_ref->{network}) if ($interface_ref->{network});
         }
@@ -740,6 +740,14 @@ sub _prepare_interface_for_pfconf {
     }
     elsif ($type =~ /^portal$/i) {
         $int_config_ref->{'type'} = 'portal';
+        $int_config_ref->{'enforcement'} = undef;
+    }
+    elsif ($type =~ /^dhcpd$/i) {
+        $int_config_ref->{'type'} = 'dhcpd';
+        $int_config_ref->{'enforcement'} = undef;
+    }
+    elsif ($type =~ /^dns$/i) {
+        $int_config_ref->{'type'} = 'dns';
         $int_config_ref->{'enforcement'} = undef;
     }
     else {

--- a/html/pfappserver/lib/pfappserver/Model/Interface.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Interface.pm
@@ -463,7 +463,7 @@ sub getType {
         # rely on pf.conf's info
         else {
             $type = $interface->{type};
-            if ($type !~ /radius/i && $type !~ /portal/i && $type !~ /dns/i && $type !~ /dhcpd/i) {
+            if ($type !~ /radius/i && $type !~ /portal/i && $type !~ /dns/i && $type !~ /dhcp/i) {
                 $type = ($type =~ /management|managed/i) ? 'management' : 'other';
             }
         }
@@ -507,7 +507,7 @@ sub setType {
                                     $self->_prepare_interface_for_pfconf($interface, $interface_ref, $type));
 
         # Update networks.conf
-        if ( $type =~ /management|portal|^radius$|dhcpd|dns/ ) {
+        if ( $type =~ /management|portal|^radius$|dhcp|dns/ ) {
             # management interfaces must not appear in networks.conf
             $models->{network}->remove($interface_ref->{network}) if ($interface_ref->{network});
         }
@@ -548,7 +548,7 @@ sub setType {
         }
     }
     $logger->debug("Committing changes to $interface interface");
-    
+
     ($status, $status_msg) = $models->{network}->commit();
     if(is_error($status)) {
         return ($status, $status_msg);
@@ -742,8 +742,8 @@ sub _prepare_interface_for_pfconf {
         $int_config_ref->{'type'} = 'portal';
         $int_config_ref->{'enforcement'} = undef;
     }
-    elsif ($type =~ /^dhcpd$/i) {
-        $int_config_ref->{'type'} = 'dhcpd';
+    elsif ($type =~ /^dhcp$/i) {
+        $int_config_ref->{'type'} = 'dhcp';
         $int_config_ref->{'enforcement'} = undef;
     }
     elsif ($type =~ /^dns$/i) {

--- a/html/pfappserver/lib/pfappserver/PacketFence/Controller/Interface.pm
+++ b/html/pfappserver/lib/pfappserver/PacketFence/Controller/Interface.pm
@@ -248,10 +248,10 @@ sub view :Chained('object') :PathPart('read') :Args(0) :AdminRole('INTERFACES_RE
             $interface_ref->{$interface}->{'type'} =~ s/,radius//;
         }
     }
-    if ( $interface_ref->{$interface}->{'type'} =~ 'dhcpd') {
-        if ($interface_ref->{$interface}->{'type'} !~ /^dhcpd/i ) {
-            push @{$interface_ref->{$interface}->{'additional_listening_daemons'}}, "dhcpd";
-            $interface_ref->{$interface}->{'type'} =~ s/,dhcpd//;
+    if ( $interface_ref->{$interface}->{'type'} =~ 'dhcp') {
+        if ($interface_ref->{$interface}->{'type'} !~ /^dhcp/i ) {
+            push @{$interface_ref->{$interface}->{'additional_listening_daemons'}}, "dhcp";
+            $interface_ref->{$interface}->{'type'} =~ s/,dhcp//;
         }
     }
     if ( $interface_ref->{$interface}->{'type'} =~ 'dns') {

--- a/html/pfappserver/lib/pfappserver/PacketFence/Controller/Interface.pm
+++ b/html/pfappserver/lib/pfappserver/PacketFence/Controller/Interface.pm
@@ -248,6 +248,18 @@ sub view :Chained('object') :PathPart('read') :Args(0) :AdminRole('INTERFACES_RE
             $interface_ref->{$interface}->{'type'} =~ s/,radius//;
         }
     }
+    if ( $interface_ref->{$interface}->{'type'} =~ 'dhcpd') {
+        if ($interface_ref->{$interface}->{'type'} !~ /^dhcpd/i ) {
+            push @{$interface_ref->{$interface}->{'additional_listening_daemons'}}, "dhcpd";
+            $interface_ref->{$interface}->{'type'} =~ s/,dhcpd//;
+        }
+    }
+    if ( $interface_ref->{$interface}->{'type'} =~ 'dns') {
+        if ($interface_ref->{$interface}->{'type'} !~ /^dns/i ) {
+            push @{$interface_ref->{$interface}->{'additional_listening_daemons'}}, "dns";
+            $interface_ref->{$interface}->{'type'} =~ s/,dns//;
+        }
+    }
 
     # Build form
     my $form = pfappserver::Form::Interface->new(ctx => $c,

--- a/lib/pf/config.pm
+++ b/lib/pf/config.pm
@@ -109,7 +109,7 @@ use pf::util;
 our (
     @listen_ints, @dhcplistener_ints, @ha_ints, $monitor_int,
     @internal_nets, @routed_isolation_nets, @routed_registration_nets, @inline_nets, @portal_ints,@radius_ints,
-    @inline_enforcement_nets, @vlan_enforcement_nets, $management_network,
+    @inline_enforcement_nets, @vlan_enforcement_nets, $management_network, @dhcpd_ints, @dns_ints,
 #pf.conf.default variables
     %Default_Config,
 #pf.conf variables
@@ -182,7 +182,7 @@ BEGIN {
     @EXPORT_OK = qw(
         @listen_ints @dhcplistener_ints @ha_ints $monitor_int
         @internal_nets @routed_isolation_nets @routed_registration_nets @inline_nets $management_network @portal_ints @radius_ints
-        @inline_enforcement_nets @vlan_enforcement_nets
+        @inline_enforcement_nets @vlan_enforcement_nets @dhcpd_ints @dns_ints
         $IPTABLES_MARK_UNREG $IPTABLES_MARK_REG $IPTABLES_MARK_ISOLATION
         %mark_type_to_str %mark_type
         $MAC $PORT $SSID $ALWAYS
@@ -250,6 +250,8 @@ tie @inline_enforcement_nets, 'pfconfig::cached_array', "interfaces::inline_enfo
 tie @internal_nets, 'pfconfig::cached_array', "interfaces::internal_nets($host_id)";
 tie @portal_ints, 'pfconfig::cached_array', "interfaces::portal_ints($host_id)";
 tie @radius_ints, 'pfconfig::cached_array', "interfaces::radius_ints($host_id)";
+tie @dhcpd_ints, 'pfconfig::cached_array', "interfaces::dhcpd_ints($host_id)";
+tie @dns_ints, 'pfconfig::cached_array', "interfaces::dns_ints($host_id)";
 tie @vlan_enforcement_nets, 'pfconfig::cached_array', "interfaces::vlan_enforcement_nets($host_id)";
 tie $management_network, 'pfconfig::cached_scalar', "interfaces::management_network($host_id)";
 tie $monitor_int, 'pfconfig::cached_scalar', "interfaces::monitor_int($host_id)";

--- a/lib/pf/config.pm
+++ b/lib/pf/config.pm
@@ -109,7 +109,7 @@ use pf::util;
 our (
     @listen_ints, @dhcplistener_ints, @ha_ints, $monitor_int,
     @internal_nets, @routed_isolation_nets, @routed_registration_nets, @inline_nets, @portal_ints,@radius_ints,
-    @inline_enforcement_nets, @vlan_enforcement_nets, $management_network, @dhcpd_ints, @dns_ints,
+    @inline_enforcement_nets, @vlan_enforcement_nets, $management_network, @dhcp_ints, @dns_ints,
 #pf.conf.default variables
     %Default_Config,
 #pf.conf variables
@@ -182,7 +182,7 @@ BEGIN {
     @EXPORT_OK = qw(
         @listen_ints @dhcplistener_ints @ha_ints $monitor_int
         @internal_nets @routed_isolation_nets @routed_registration_nets @inline_nets $management_network @portal_ints @radius_ints
-        @inline_enforcement_nets @vlan_enforcement_nets @dhcpd_ints @dns_ints
+        @inline_enforcement_nets @vlan_enforcement_nets @dhcp_ints @dns_ints
         $IPTABLES_MARK_UNREG $IPTABLES_MARK_REG $IPTABLES_MARK_ISOLATION
         %mark_type_to_str %mark_type
         $MAC $PORT $SSID $ALWAYS
@@ -250,7 +250,7 @@ tie @inline_enforcement_nets, 'pfconfig::cached_array', "interfaces::inline_enfo
 tie @internal_nets, 'pfconfig::cached_array', "interfaces::internal_nets($host_id)";
 tie @portal_ints, 'pfconfig::cached_array', "interfaces::portal_ints($host_id)";
 tie @radius_ints, 'pfconfig::cached_array', "interfaces::radius_ints($host_id)";
-tie @dhcpd_ints, 'pfconfig::cached_array', "interfaces::dhcpd_ints($host_id)";
+tie @dhcp_ints, 'pfconfig::cached_array', "interfaces::dhcp_ints($host_id)";
 tie @dns_ints, 'pfconfig::cached_array', "interfaces::dns_ints($host_id)";
 tie @vlan_enforcement_nets, 'pfconfig::cached_array', "interfaces::vlan_enforcement_nets($host_id)";
 tie $management_network, 'pfconfig::cached_scalar', "interfaces::management_network($host_id)";

--- a/lib/pf/iptables.pm
+++ b/lib/pf/iptables.pm
@@ -53,7 +53,7 @@ use pf::config qw(
     is_inline_enforcement_enabled
     is_type_inline
     @radius_ints
-    @dhcpd_ints
+    @dhcp_ints
     @dns_ints
 );
 use pf::file_paths qw($generated_conf_dir $conf_dir);
@@ -69,7 +69,7 @@ use pf::ConfigStore::Domain;
 Readonly our $FW_FILTER_INPUT_MGMT      => 'input-management-if';
 Readonly our $FW_FILTER_INPUT_PORTAL    => 'input-portal-if';
 Readonly our $FW_FILTER_INPUT_RADIUS    => 'input-radius-if';
-Readonly our $FW_FILTER_INPUT_DHCPD     => 'input-dhcpd-if';
+Readonly our $FW_FILTER_INPUT_DHCP      => 'input-dhcp-if';
 Readonly our $FW_FILTER_INPUT_DNS       => 'input-dns-if';
 
 Readonly my $FW_TABLE_FILTER => 'filter';
@@ -251,7 +251,7 @@ sub generate_filter_if_src_to_chain {
                 $rules_forward .= "-A FORWARD --in-interface $dev --jump $FW_FILTER_FORWARD_INT_VLAN\n";
                 $rules_forward .= "-A FORWARD --out-interface $dev --jump $FW_FILTER_FORWARD_INT_VLAN\n";
             }
-            if ($isolation_passthrough_enabled && ($type eq $pf::config::NET_TYPE_VLAN_ISOL)) { 
+            if ($isolation_passthrough_enabled && ($type eq $pf::config::NET_TYPE_VLAN_ISOL)) {
                 $rules_forward .= "-A FORWARD --in-interface $dev --jump $FW_FILTER_FORWARD_INT_ISOL_VLAN\n";
                 $rules_forward .= "-A FORWARD --out-interface $dev --jump $FW_FILTER_FORWARD_INT_ISOL_VLAN\n";
             }
@@ -293,10 +293,10 @@ sub generate_filter_if_src_to_chain {
         $rules .= "-A INPUT --in-interface $dev -p vrrp -j ACCEPT\n";
         $rules .= "-A INPUT --in-interface $dev --jump $FW_FILTER_INPUT_RADIUS\n";
     }
-    # 'dhcpd' interfaces handling
-    foreach my $dhcpd_interface ( @dhcpd_ints ) {
-        my $dev = $dhcpd_interface->tag("int");
-        $rules .= "-A INPUT --in-interface $dev --jump $FW_FILTER_INPUT_DHCPD\n";
+    # 'dhcp' interfaces handling
+    foreach my $dhcp_interface ( @dhcp_ints ) {
+        my $dev = $dhcp_interface->tag("int");
+        $rules .= "-A INPUT --in-interface $dev --jump $FW_FILTER_INPUT_DHCP\n";
     }
     # 'dns' interfaces handling
     foreach my $dns_interface ( @dns_ints ) {

--- a/lib/pf/iptables.pm
+++ b/lib/pf/iptables.pm
@@ -53,6 +53,8 @@ use pf::config qw(
     is_inline_enforcement_enabled
     is_type_inline
     @radius_ints
+    @dhcpd_ints
+    @dns_ints
 );
 use pf::file_paths qw($generated_conf_dir $conf_dir);
 use pf::util;
@@ -67,6 +69,8 @@ use pf::ConfigStore::Domain;
 Readonly our $FW_FILTER_INPUT_MGMT      => 'input-management-if';
 Readonly our $FW_FILTER_INPUT_PORTAL    => 'input-portal-if';
 Readonly our $FW_FILTER_INPUT_RADIUS    => 'input-radius-if';
+Readonly our $FW_FILTER_INPUT_DHCPD     => 'input-dhcpd-if';
+Readonly our $FW_FILTER_INPUT_DNS       => 'input-dns-if';
 
 Readonly my $FW_TABLE_FILTER => 'filter';
 Readonly my $FW_TABLE_MANGLE => 'mangle';
@@ -288,6 +292,16 @@ sub generate_filter_if_src_to_chain {
         $rules .= "-A INPUT --in-interface $dev -d 224.0.0.0/8 -j ACCEPT\n";
         $rules .= "-A INPUT --in-interface $dev -p vrrp -j ACCEPT\n";
         $rules .= "-A INPUT --in-interface $dev --jump $FW_FILTER_INPUT_RADIUS\n";
+    }
+    # 'dhcpd' interfaces handling
+    foreach my $dhcpd_interface ( @dhcpd_ints ) {
+        my $dev = $dhcpd_interface->tag("int");
+        $rules .= "-A INPUT --in-interface $dev --jump $FW_FILTER_INPUT_DHCPD\n";
+    }
+    # 'dns' interfaces handling
+    foreach my $dns_interface ( @dns_ints ) {
+        my $dev = $dns_interface->tag("int");
+        $rules .= "-A INPUT --in-interface $dev --jump $FW_FILTER_INPUT_DNS\n";
     }
 
     # management interface handling

--- a/lib/pf/pfcmd/checkup.pm
+++ b/lib/pf/pfcmd/checkup.pm
@@ -220,7 +220,7 @@ sub interfaces_defined {
             }
         }
 
-        my $int_types = qr/(?:internal|management|managed|monitor|dhcplistener|dhcp-listener|high-availability|portal|radius)/;
+        my $int_types = qr/(?:internal|management|managed|monitor|dhcplistener|dhcp-listener|high-availability|portal|radius|dhcpd|dns)/;
         if (defined($int_conf{'type'}) && $int_conf{'type'} !~ /$int_types/) {
             add_problem( $FATAL, "invalid network type $int_conf{'type'} for $interface" );
         }

--- a/lib/pf/pfcmd/checkup.pm
+++ b/lib/pf/pfcmd/checkup.pm
@@ -220,7 +220,7 @@ sub interfaces_defined {
             }
         }
 
-        my $int_types = qr/(?:internal|management|managed|monitor|dhcplistener|dhcp-listener|high-availability|portal|radius|dhcpd|dns)/;
+        my $int_types = qr/(?:internal|management|managed|monitor|dhcplistener|dhcp-listener|high-availability|portal|radius|dhcp|dns)/;
         if (defined($int_conf{'type'}) && $int_conf{'type'} !~ /$int_types/) {
             add_problem( $FATAL, "invalid network type $int_conf{'type'} for $interface" );
         }
@@ -1257,7 +1257,7 @@ sub cluster {
     my $int_cs = pf::ConfigStore::Interface->new;
     my @ints = @{$int_cs->readAll('name')};
     my @servers = @pf::cluster::cluster_servers;
- 
+
     my $hostname_map = pfconfig::namespaces::resource::clusters_hostname_map->new->build();
     my $cluster_name = $hostname_map->{$pf::cluster::host_id};
 

--- a/lib/pfconfig/namespaces/interfaces.pm
+++ b/lib/pfconfig/namespaces/interfaces.pm
@@ -40,7 +40,7 @@ sub init {
         vlan_enforcement_nets   => [],
         portal_ints             => [],
         radius_ints             => [],
-        dhcpd_ints              => [],
+        dhcp_ints              => [],
         dns_ints                => [],
 	monitor_int             => '',
         management_network      => '',
@@ -53,10 +53,10 @@ sub init {
         'interfaces::portal_ints',             'interfaces::inline_nets',
         'interfaces::routed_isolation_nets',   'interfaces::routed_registration_nets',
         'interfaces::radius_ints',             'resource::network_config',
-        'interfaces::dhcpd_ints',              'interfaces::dns_ints',
+        'interfaces::dhcp_ints',               'interfaces::dns_ints',
     ];
     if($host_id){
-        @{$self->{child_resources}} = map { "$_($host_id)" } @{$self->{child_resources}}; 
+        @{$self->{child_resources}} = map { "$_($host_id)" } @{$self->{child_resources}};
     }
 
     $self->{config_resource} = pfconfig::namespaces::config::Pf->new( $self->{cache}, $host_id );
@@ -105,7 +105,7 @@ sub build {
         }
 
         die "Missing mandatory element ip or netmask on interface $int"
-            if ( $type =~ /internal|managed|management|portal|radius|dhcpd|dns/ && !defined($int_obj) );
+            if ( $type =~ /internal|managed|management|portal|radius|dhcp|dns/ && !defined($int_obj) );
 
         foreach my $type ( split( /\s*,\s*/, $type ) ) {
             if ( $type eq 'internal' ) {
@@ -155,8 +155,8 @@ sub build {
             elsif ( $type eq 'dns' ) {
                 push @{ $self->{_interfaces}->{dns_ints} }, $int if ( $int !~ /:\d+$/ )
             }
-            elsif ( $type eq 'dhcpd' ) {
-                push @{ $self->{_interfaces}->{dhcpd_ints} }, $int if ( $int !~ /:\d+$/ )
+            elsif ( $type eq 'dhcp' ) {
+                push @{ $self->{_interfaces}->{dhcp_ints} }, $int if ( $int !~ /:\d+$/ )
             }
         }
     }
@@ -221,4 +221,3 @@ USA.
 # vim: set shiftwidth=4:
 # vim: set expandtab:
 # vim: set backspace=indent,eol,start:
-

--- a/lib/pfconfig/namespaces/interfaces.pm
+++ b/lib/pfconfig/namespaces/interfaces.pm
@@ -40,7 +40,9 @@ sub init {
         vlan_enforcement_nets   => [],
         portal_ints             => [],
         radius_ints             => [],
-        monitor_int             => '',
+        dhcpd_ints              => [],
+        dns_ints                => [],
+	monitor_int             => '',
         management_network      => '',
     };
     $self->{child_resources} = [
@@ -51,6 +53,7 @@ sub init {
         'interfaces::portal_ints',             'interfaces::inline_nets',
         'interfaces::routed_isolation_nets',   'interfaces::routed_registration_nets',
         'interfaces::radius_ints',             'resource::network_config',
+        'interfaces::dhcpd_ints',              'interfaces::dns_ints',
     ];
     if($host_id){
         @{$self->{child_resources}} = map { "$_($host_id)" } @{$self->{child_resources}}; 
@@ -102,7 +105,7 @@ sub build {
         }
 
         die "Missing mandatory element ip or netmask on interface $int"
-            if ( $type =~ /internal|managed|management|portal|radius/ && !defined($int_obj) );
+            if ( $type =~ /internal|managed|management|portal|radius|dhcpd|dns/ && !defined($int_obj) );
 
         foreach my $type ( split( /\s*,\s*/, $type ) ) {
             if ( $type eq 'internal' ) {
@@ -148,6 +151,14 @@ sub build {
             elsif ( $type eq 'radius' ) {
                 $int_obj->tag( "vip", $self->_fetch_virtual_ip( $int, $interface ) );
                 push @{ $self->{_interfaces}->{radius_ints} }, $int_obj;
+            }
+            elsif ( $type eq 'dns' ) {
+                $int_obj->tag( "vip", $self->_fetch_virtual_ip( $int, $interface ) );
+                push @{ $self->{_interfaces}->{dns_ints} }, $int_obj;
+            }
+            elsif ( $type eq 'dhcpd' ) {
+                $int_obj->tag( "vip", $self->_fetch_virtual_ip( $int, $interface ) );
+                push @{ $self->{_interfaces}->{dhcpd_ints} }, $int_obj;
             }
 
         }

--- a/lib/pfconfig/namespaces/interfaces.pm
+++ b/lib/pfconfig/namespaces/interfaces.pm
@@ -153,14 +153,11 @@ sub build {
                 push @{ $self->{_interfaces}->{radius_ints} }, $int_obj;
             }
             elsif ( $type eq 'dns' ) {
-                $int_obj->tag( "vip", $self->_fetch_virtual_ip( $int, $interface ) );
-                push @{ $self->{_interfaces}->{dns_ints} }, $int_obj;
+                push @{ $self->{_interfaces}->{dns_ints} }, $int if ( $int !~ /:\d+$/ )
             }
             elsif ( $type eq 'dhcpd' ) {
-                $int_obj->tag( "vip", $self->_fetch_virtual_ip( $int, $interface ) );
-                push @{ $self->{_interfaces}->{dhcpd_ints} }, $int_obj;
+                push @{ $self->{_interfaces}->{dhcpd_ints} }, $int if ( $int !~ /:\d+$/ )
             }
-
         }
     }
 

--- a/lib/pfconfig/namespaces/interfaces/dhcp_ints.pm
+++ b/lib/pfconfig/namespaces/interfaces/dhcp_ints.pm
@@ -1,14 +1,14 @@
-package pfconfig::namespaces::interfaces::dhcpd_ints;
+package pfconfig::namespaces::interfaces::dhcp_ints;
 
 =head1 NAME
 
-pfconfig::namespaces::interfaces::dhcpd_ints
+pfconfig::namespaces::interfaces::dhcp_ints
 
 =cut
 
 =head1 DESCRIPTION
 
-Return all the interfaces where pfdhcpd must run
+Return all the interfaces where pfdhcpd daemon must run
 
 =cut
 
@@ -25,7 +25,7 @@ sub init {
 sub build {
     my ($self) = @_;
     my $interfaces = $self->{_interfaces};
-    return $interfaces->{dhcpd_ints} // [];
+    return $interfaces->{dhcp_ints} // [];
 }
 
 

--- a/lib/pfconfig/namespaces/interfaces/dhcpd_ints.pm
+++ b/lib/pfconfig/namespaces/interfaces/dhcpd_ints.pm
@@ -1,0 +1,63 @@
+package pfconfig::namespaces::interfaces::dhcpd_ints;
+
+=head1 NAME
+
+pfconfig::namespaces::interfaces::dhcpd_ints
+
+=cut
+
+=head1 DESCRIPTION
+
+Return all the interfaces where pfdhcpd must run
+
+=cut
+
+use strict;
+use warnings;
+
+use base 'pfconfig::namespaces::interfaces';
+
+sub init {
+    my ($self, $host_id) = @_;
+    $self->{_interfaces} = defined($host_id) ? $self->{cache}->get_cache("interfaces($host_id)") : $self->{cache}->get_cache("interfaces");
+}
+
+sub build {
+    my ($self) = @_;
+    my $interfaces = $self->{_interfaces};
+    return $interfaces->{dhcpd_ints} // [];
+}
+
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2018 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;
+
+# vim: set shiftwidth=4:
+# vim: set expandtab:
+# vim: set backspace=indent,eol,start:

--- a/lib/pfconfig/namespaces/interfaces/dhcpd_ints.pm
+++ b/lib/pfconfig/namespaces/interfaces/dhcpd_ints.pm
@@ -35,7 +35,7 @@ Inverse inc. <info@inverse.ca>
 
 =head1 COPYRIGHT
 
-Copyright (C) 2005-2018 Inverse inc.
+Copyright (C) 2005-2019 Inverse inc.
 
 =head1 LICENSE
 

--- a/lib/pfconfig/namespaces/interfaces/dns_ints.pm
+++ b/lib/pfconfig/namespaces/interfaces/dns_ints.pm
@@ -35,7 +35,7 @@ Inverse inc. <info@inverse.ca>
 
 =head1 COPYRIGHT
 
-Copyright (C) 2005-2018 Inverse inc.
+Copyright (C) 2005-2019 Inverse inc.
 
 =head1 LICENSE
 

--- a/lib/pfconfig/namespaces/interfaces/dns_ints.pm
+++ b/lib/pfconfig/namespaces/interfaces/dns_ints.pm
@@ -1,0 +1,64 @@
+package pfconfig::namespaces::interfaces::dns_ints;
+
+=head1 NAME
+
+pfconfig::namespaces::interfaces::dns_ints
+
+=cut
+
+=head1 DESCRIPTION
+
+Return all the interfaces where pfdns must run
+
+=cut
+
+use strict;
+use warnings;
+
+use base 'pfconfig::namespaces::interfaces';
+
+sub init {
+    my ($self, $host_id) = @_;
+    $self->{_interfaces} = defined($host_id) ? $self->{cache}->get_cache("interfaces($host_id)") : $self->{cache}->get_cache("interfaces");
+}
+
+sub build {
+    my ($self) = @_;
+    my $interfaces = $self->{_interfaces};
+    return $interfaces->{dns_ints} // [];
+}
+
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2018 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;
+
+# vim: set shiftwidth=4:
+# vim: set expandtab:
+# vim: set backspace=indent,eol,start:
+


### PR DESCRIPTION
# Description
Enable dns/dhcp daemon on a specific network interface (like portal) 

# Impacts
DHCP/DNS

# Delete branch after merge
YES

# Checklist
- [n/a] Document the feature
- [n/a] Add unit tests
- [n/a] Add acceptance tests (TestLink)

# NEWS file entries
## New Features
* DHCP and DNS services can be enabled on a specific interface.

