### PR TITLE
Fix management of child processes by winbindd-wrapper

### DIFF
--- a/sbin/winbindd-wrapper
+++ b/sbin/winbindd-wrapper
@@ -232,6 +232,8 @@ sub child_sighandler {
         last unless $child > 0;
         my $id = delete $CHILDREN{$child};
         if($running) {
+            get_logger->error("winbindd process failed for domain $id. Will try to start the process again.");
+            sleep 5;
             run_winbindd($id);
         }
     }


### PR DESCRIPTION
# Description
Rate limit the frequency at which failed winbindd processes are started.
Also this PR will contain a fix for childs that mysteriously stop being managed by packetfence-winbindd leading to an infinite restart loop

# Impacts
winbindd wrapper

# Issue
fixes #3950 (not now, but that is the hope)

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

To come later