### PR TITLE
issue with winbindd

### DIFF
--- a/sbin/winbindd-wrapper
+++ b/sbin/winbindd-wrapper
@@ -211,7 +211,7 @@ sub run_winbindd {
         ) or die("winbindd-wrapper could not set SIGCHLD handler: $!");
         $IS_CHILD = 1;
         Log::Log4perl::MDC->put('tid', $$);
-        unless(exec("sudo chroot $chroot_path $binary -s $config_file -l $log_directory --foreground")) {
+        unless(exec("sudo chroot $chroot_path $binary -s $config_file -l $log_directory --foreground --no-process-group")) {
             $logger->error("Failed to start the winbindd process $id");
             exit 1;
         }


### PR DESCRIPTION
# Description
Describe what the new code is used for.
We had an issue with winbindd. The --no-process-group fixed this issue and the service is running now.
# Impacts
Describe what to reviewer should look at. Will also help for testing purposes.
winbindd

# Issue
  /usr/sbin/winbindd  -s /etc/samba/AD.conf --foreground
[2019/01/24 17:03:31.299176,  0] ../lib/util/become_daemon.c:124(exit_daemon)
  exit_daemon: STATUS=daemon failed to start: Failed to create session, error code 1

# Delete branch after merge
YES 

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)