### PR TITLE
Added a flag in node_cleanup task to bypass voip devices

### DIFF
--- a/conf/pfmon.conf.defaults
+++ b/conf/pfmon.conf.defaults
@@ -339,7 +339,11 @@ delete_window=0D
 #
 # How long to keep an inactive node before unregistering it
 unreg_window=0D
-
+#
+# voip
+#
+# Enable voip device cleanup
+voip=enabled
 
 [nodes_maintenance]
 #

--- a/html/pfappserver/lib/pfappserver/Form/Config/Pfmon/node_cleanup.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Pfmon/node_cleanup.pm
@@ -31,6 +31,15 @@ has_field 'delete_window' => (
              help => 'How long can an unregistered node be inactive on the network before being deleted.<br>This shouldn\'t be used if you are using port-security' },
 );
 
+has_field 'voip' =>  (
+   type => 'Toggle',
+   checkbox_value => 'enabled',
+   unchecked_value => 'disabled',
+   default_method => \&default_field_method,
+    tags => { after_element => \&help,
+             help => 'Enable voip device cleanup' },
+);
+
 =head2 default_type
 
 default value of type
@@ -43,7 +52,7 @@ sub default_type {
 
 has_block  definition =>
   (
-    render_list => [qw(type status interval unreg_window delete_window)],
+    render_list => [qw(type status voip interval unreg_window delete_window)],
   );
 
 

--- a/lib/pf/node.pm
+++ b/lib/pf/node.pm
@@ -851,7 +851,7 @@ Cleanup nodes that should be deleted or unregistered based on the maintenance pa
 
 sub node_cleanup {
     my $timer = pf::StatsD::Timer->new;
-    my ($delete_time, $unreg_time) = @_;
+    my ($delete_time, $unreg_time,$voip) = @_;
     my $logger = get_logger();
     $logger->debug("calling node_cleanup with delete_time=$delete_time unreg_time=$unreg_time");
     
@@ -859,8 +859,10 @@ sub node_cleanup {
         foreach my $row ( node_expire_lastseen($delete_time) ) {
             my $mac = $row->{'mac'};
             my $tenant_id = $row->{'tenant_id'};
+            if (isdisabled($voip) && $row->{'voip'} eq 'yes') {
+                next;
+            }
             $logger->info("mac $mac not seen for $delete_time seconds, deleting");
-
             require pf::locationlog;
             pf::locationlog::locationlog_update_end_mac($mac, $tenant_id);
             node_delete($mac, $tenant_id);
@@ -875,6 +877,9 @@ sub node_cleanup {
         foreach my $row ( node_unreg_lastseen($unreg_time) ) {
             my $mac = $row->{'mac'};
             my $tenant_id = $row->{'tenant_id'};
+            if (isdisabled($voip) && $row->{'voip'} eq 'yes') {
+                next;
+            }
             $logger->info("mac $mac not seen for $unreg_time seconds, unregistering");
             pf::dal->set_tenant($tenant_id);
             node_deregister($mac);

--- a/lib/pf/node.pm
+++ b/lib/pf/node.pm
@@ -40,6 +40,7 @@ use pf::config qw(
     %Config
     $INLINE
     %connection_type_to_str
+    $VOIP
 );
 
 use constant NODE => 'node';
@@ -859,7 +860,7 @@ sub node_cleanup {
         foreach my $row ( node_expire_lastseen($delete_time) ) {
             my $mac = $row->{'mac'};
             my $tenant_id = $row->{'tenant_id'};
-            if (isdisabled($voip) && $row->{'voip'} eq 'yes') {
+            if (isdisabled($voip) && $row->{'voip'} eq $VOIP) {
                 next;
             }
             $logger->info("mac $mac not seen for $delete_time seconds, deleting");
@@ -877,7 +878,7 @@ sub node_cleanup {
         foreach my $row ( node_unreg_lastseen($unreg_time) ) {
             my $mac = $row->{'mac'};
             my $tenant_id = $row->{'tenant_id'};
-            if (isdisabled($voip) && $row->{'voip'} eq 'yes') {
+            if (isdisabled($voip) && $row->{'voip'} eq $VOIP) {
                 next;
             }
             $logger->info("mac $mac not seen for $unreg_time seconds, unregistering");

--- a/lib/pf/pfmon/task/node_cleanup.pm
+++ b/lib/pf/pfmon/task/node_cleanup.pm
@@ -22,6 +22,8 @@ has 'delete_window' => ( is => 'rw', isa => 'PfInterval', coerce => 1 );
 
 has 'unreg_window' => ( is => 'rw', isa => 'PfInterval', coerce => 1 );
 
+has 'voip' => (is => 'ro', isa => 'Str');
+
 =head2 run
 
 run the node cleanup task
@@ -30,7 +32,7 @@ run the node cleanup task
 
 sub run {
     my ($self) = @_;
-    node_cleanup($self->delete_window, $self->unreg_window);
+    node_cleanup($self->delete_window, $self->unreg_window, $self->voip);
 }
 
 =head1 AUTHOR


### PR DESCRIPTION
# Description
Bypass voip devices in node_cleanup.

# Impacts
pfmon node_cleanup task

# Delete branch after merge
YES

# Checklist
- [n/a] Document the feature
- [n/a] Add unit tests
- [n/a] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* Voip configuration parameter in node_cleanup task to bypass voip devices
