### PR TITLE
Unset the role on autoreg if no authentication source return a role

### DIFF
--- a/conf/profiles.conf.defaults
+++ b/conf/profiles.conf.defaults
@@ -32,3 +32,4 @@ status=enabled
 unreg_on_acct_stop=disabled
 network_logoff=disabled
 network_logoff_popup=disabled
+dot1x_unset_on_unmatch=disabled

--- a/docs/api/spec/components/schemas/configconnectionprofile.yaml
+++ b/docs/api/spec/components/schemas/configconnectionprofile.yaml
@@ -51,6 +51,10 @@ ConfigConnectionProfile:
       description: When enabled, PacketFence will not use the role initialy computed
         on the portal but will use the dot1x username to recompute the role.
       type: string
+    dot1x_unset_on_unmatch:
+      description: When enabled, PacketFence will unset the role of the device if no
+        authentication sources returned one.
+      type: string
     dpsk:
       description: This enables the Dynamic PSK feature on this connection profile.
         It means that the RADIUS server will answer requests with specific attributes

--- a/html/pfappserver/lib/pfappserver/Form/Config/Profile.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Profile.pm
@@ -135,7 +135,7 @@ The main definition block
 
 has_block 'definition' =>
   (
-    render_list => [qw(id description status root_module preregistration autoregister reuse_dot1x_credentials dot1x_recompute_role_from_portal dpsk default_psk_key unreg_on_acct_stop)],
+    render_list => [qw(id description status root_module preregistration autoregister reuse_dot1x_credentials dot1x_recompute_role_from_portal dot1x_unset_on_unmatch dpsk default_psk_key unreg_on_acct_stop)],
   );
 
 

--- a/html/pfappserver/lib/pfappserver/Form/Config/ProfileCommon.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/ProfileCommon.pm
@@ -41,7 +41,7 @@ The main definition block
 
 has_block 'definition' =>
   (
-    render_list => [qw(id description root_module preregistration autoregister reuse_dot1x_credentials dot1x_recompute_role_from_portal dpsk default_psk_key unreg_on_acct_stop)],
+    render_list => [qw(id description root_module preregistration autoregister reuse_dot1x_credentials dot1x_recompute_role_from_portal dot1x_unset_on_unmatch dpsk default_psk_key unreg_on_acct_stop)],
   );
 
 =head2 captive_portal
@@ -355,6 +355,20 @@ has_field 'dot1x_recompute_role_from_portal' =>
     default => 'enabled',
     tags => { after_element => \&help,
              help => 'When enabled, PacketFence will not use the role initialy computed on the portal but will use the dot1x username to recompute the role.' },
+  );
+
+=head2 dot1x_unset_on_unmatch
+
+=cut
+
+has_field 'dot1x_unset_on_unmatch' =>
+  (
+    type => 'Checkbox',
+    checkbox_value => 'enabled',
+    unchecked_value => 'disabled',
+    default => 'disabled',
+    tags => { after_element => \&help,
+             help => 'When enabled, PacketFence will unset the role of the device if no authentication sources returned one.' },
   );
 
 =head2 block_interval

--- a/lib/pf/Connection/Profile.pm
+++ b/lib/pf/Connection/Profile.pm
@@ -506,6 +506,17 @@ sub dot1xRecomputeRoleFromPortal {
     return $self->{'_dot1x_recompute_role_from_portal'};
 }
 
+=item dot1xUnsetOnUnmatch
+
+On autoreg if no authentication source return a role then unset the current node one
+
+=cut
+
+sub dot1xUnsetOnUnmatch {
+    my ($self) = @_;
+    return $self->{'_dot1x_unset_on_unmatch'};
+}
+
 =item getScans
 
 Returns the Scans IDs for the profile

--- a/lib/pf/role.pm
+++ b/lib/pf/role.pm
@@ -594,12 +594,14 @@ sub getNodeInfoForAutoReg {
         $node_info{'time_balance'} = pf::util::normalize_time($time_balance) if (defined($time_balance));
         $node_info{'bandwidth_balance'} = pf::util::unpretty_bandwidth($bandwidth_balance) if (defined($bandwidth_balance));
 
-        pf::person::person_modify($args->{'user_name'},
-            'source'  => $source,
-            'portal'  => $profile->getName,
-        );
-        # Trigger a person lookup for 802.1x users
-        pf::lookup::person::async_lookup_person($args->{'user_name'}, $source, $pf::constants::realm::RADIUS_CONTEXT);
+        if ($source) {
+            pf::person::person_modify($args->{'user_name'},
+                'source'  => $source,
+                'portal'  => $profile->getName,
+            );
+            # Trigger a person lookup for 802.1x users
+            pf::lookup::person::async_lookup_person($args->{'user_name'}, $source, $pf::constants::realm::RADIUS_CONTEXT);
+        }
 
         if (defined $unregdate) {
             $node_info{'unregdate'} = $unregdate;
@@ -608,6 +610,9 @@ sub getNodeInfoForAutoReg {
             }
             %node_info = (%node_info, (source  => $source, portal => $profile->getName));
         }
+	if (!defined($role) && isenabled($profile->dot1xUnsetOnUnmatch)) {
+	    %node_info = (%node_info, (category => ''));
+	}
         $node_info{'pid'} = $args->{'user_name'};
     }
 

--- a/lib/pf/role.pm
+++ b/lib/pf/role.pm
@@ -610,9 +610,9 @@ sub getNodeInfoForAutoReg {
             }
             %node_info = (%node_info, (source  => $source, portal => $profile->getName));
         }
-	if (!defined($role) && isenabled($profile->dot1xUnsetOnUnmatch)) {
-	    %node_info = (%node_info, (category => ''));
-	}
+        if (!defined($role) && isenabled($profile->dot1xUnsetOnUnmatch)) {
+            %node_info = (%node_info, (category => ''));
+        }
         $node_info{'pid'} = $args->{'user_name'};
     }
 

--- a/t/unittest/UnifiedApi/GenerateSpec.t
+++ b/t/unittest/UnifiedApi/GenerateSpec.t
@@ -185,6 +185,10 @@ cmp_deeply(
                         description => 'Billing tier',
                     },
                 },
+                "dot1x_unset_on_unmatch" => {
+                    type => 'string',
+                    description => "When enabled, PacketFence will unset the role of the device if no authentication sources returned one.",
+                },
                 'block_interval' => {
                     type => 'object',
                     description => 'The amount of time a user is blocked after reaching the defined limit for login, sms request and sms pin retry.',


### PR DESCRIPTION
# Description
Specific case when you do autoregistration with 802.1x then if the device already have a role and if the authentication source return nothing then packetfence give the role of the device.
This new configuration parameter unset the role if the source return nothing.

# Impacts
- RADIUS 802.1x authorize workflow with autoreg

# Delete branch after merge
YES

# Checklist
- [ n/a] Document the feature
- [ n/a] Add unit tests
- [ n/a] Add acceptance tests (TestLink)

# NEWS file entries
## Enhancements
* Handle the case when 802.1x + autoreg and the device already have a role.
