### PR TITLE
feature/cisco-avpair-as-array

### DIFF
--- a/lib/pf/Switch.pm
+++ b/lib/pf/Switch.pm
@@ -3666,6 +3666,33 @@ sub setCurrentTenant {
     pf::dal->set_tenant($self->{_TenantId});
 }
 
+=head2 getCiscoAvPairAttribute
+
+getCiscoAvPairAttribute
+
+=cut
+
+sub getCiscoAvPairAttribute {
+    my ($self, $radius_request, $attr) = @_;
+    my $logger = $self->logger;
+    my $avpair = listify($radius_request->{'Cisco-AVPair'} // []);
+    foreach my $ciscoAVPair (@{$avpair}) {
+        $logger->trace("Cisco-AVPair: $ciscoAVPair $attr");
+        if ($ciscoAVPair =~ /^\Q$attr\E=(.*)$/ig) {
+            return $1;
+        } else {
+            $logger->info("Unable to extract $attr of Cisco-AVPair: $ciscoAVPair");
+        }
+    }
+
+    $logger->warn(
+        "Unable to extract $attr for module " . ref($self) . ". SSID-based VLAN assignments won't work. "
+        . "Make sure you enable Vendor Specific Attributes (VSA) on the AP if you want them to work."
+    );
+
+    return ;
+}
+
 =back
 
 =head1 AUTHOR

--- a/lib/pf/Switch/Cisco/Aironet.pm
+++ b/lib/pf/Switch/Cisco/Aironet.pm
@@ -203,34 +203,7 @@ Overriding default extractSsid because on Aironet AP SSID is in the Cisco-AVPair
 # Same as in pf::Switch::Cisco::Aironet_WDS. Please keep both in sync. Once Moose push in a role.
 sub extractSsid {
     my ($self, $radius_request) = @_;
-    my $logger = $self->logger;
-
-    if (defined($radius_request->{'Cisco-AVPair'})) {
-        if (ref($radius_request->{'Cisco-AVPair'}) eq 'ARRAY') {
-            foreach my $ciscoAVPair (@{$radius_request->{'Cisco-AVPair'}}) {
-                $logger->trace("Cisco-AVPair: ".$ciscoAVPair);
-
-                if ($ciscoAVPair =~ /^ssid=(.*)$/) { # ex: Cisco-AVPair = "ssid=PacketFence-Secure"
-                    return $1;
-                } else {
-                    $logger->info("Unable to extract SSID of Cisco-AVPair: ".$ciscoAVPair);
-                }
-            }
-        } else {
-            if ($radius_request->{'Cisco-AVPair'} =~ /^ssid=(.*)$/) { # ex: Cisco-AVPair = "ssid=PacketFence-Secure"
-                return $1;
-            } else {
-                $logger->info("Unable to extract SSID of Cisco-AVPair: ".$radius_request->{'Cisco-AVPair'});
-
-            }
-        }
-    }
-
-    $logger->warn(
-        "Unable to extract SSID for module " . ref($self) . ". SSID-based VLAN assignments won't work. "
-        . "Make sure you enable Vendor Specific Attributes (VSA) on the AP if you want them to work."
-    );
-    return;
+    return $self->getCiscoAvPairAttribute($radius_request, 'ssid');
 }
 
 =item deauthTechniques

--- a/lib/pf/Switch/Cisco/Aironet_WDS.pm
+++ b/lib/pf/Switch/Cisco/Aironet_WDS.pm
@@ -200,34 +200,7 @@ Overriding default extractSsid because on Aironet AP SSID is in the Cisco-AVPair
 # Same as in pf::Switch::Cisco::Aironet. Please keep both in sync. Once Moose push in a role.
 sub extractSsid {
     my ($self, $radius_request) = @_;
-    my $logger = $self->logger;
-
-    if (defined($radius_request->{'Cisco-AVPair'})) {
-        if (ref($radius_request->{'Cisco-AVPair'}) eq 'ARRAY') {
-            foreach my $ciscoAVPair (@{$radius_request->{'Cisco-AVPair'}}) {
-                $logger->trace("Cisco-AVPair: ".$ciscoAVPair);
-
-                if ($ciscoAVPair =~ /^ssid=(.*)$/) { # ex: Cisco-AVPair = "ssid=PacketFence-Secure"
-                    return $1;
-                } else {
-                    $logger->info("Unable to extract SSID of Cisco-AVPair: ".$ciscoAVPair);
-                }
-            }
-        } else {
-            if ($radius_request->{'Cisco-AVPair'} =~ /^ssid=(.*)$/) { # ex: Cisco-AVPair = "ssid=PacketFence-Secure"
-                return $1;
-            } else {
-                $logger->info("Unable to extract SSID of Cisco-AVPair: ".$radius_request->{'Cisco-AVPair'});
-
-            }
-        }
-    }
-
-    $logger->warn(
-        "Unable to extract SSID for module " . ref($self) . ". SSID-based VLAN assignments won't work. "
-        . "Make sure you enable Vendor Specific Attributes (VSA) on the AP if you want them to work."
-    );
-    return;
+    return $self->getCiscoAvPairAttribute($radius_request, 'ssid');
 }
 
 =item deauthTechniques

--- a/lib/pf/Switch/Cisco/WLC.pm
+++ b/lib/pf/Switch/Cisco/WLC.pm
@@ -593,13 +593,8 @@ sub parseRequest {
     my $port            = $radius_request->{'NAS-Port'};
     my $eap_type        = ( exists($radius_request->{'EAP-Type'}) ? $radius_request->{'EAP-Type'} : 0 );
     my $nas_port_id     = ( defined($radius_request->{'NAS-Port-Id'}) ? $radius_request->{'NAS-Port-Id'} : undef );
+    my $session_id = $switch->getCiscoAvPairAttribute($radius_request, 'audit-session-id');
 
-    my $session_id;
-    if (defined($radius_request->{'Cisco-AVPair'})) {
-        if ($radius_request->{'Cisco-AVPair'} =~ /audit-session-id=(.*)/ig ) {
-            $session_id =$1;
-        }
-    }
     return ($nas_port_type, $eap_type, $client_mac, $port, $user_name, $nas_port_id, $session_id, $nas_port_id);
 }
 

--- a/lib/pf/Switch/Meraki/MR_v2.pm
+++ b/lib/pf/Switch/Meraki/MR_v2.pm
@@ -155,13 +155,8 @@ sub parseRequest {
     my $port            = $radius_request->{'NAS-Port'};
     my $eap_type        = ( exists($radius_request->{'EAP-Type'}) ? $radius_request->{'EAP-Type'} : 0 );
     my $nas_port_id     = ( defined($radius_request->{'NAS-Port-Id'}) ? $radius_request->{'NAS-Port-Id'} : undef );
+    my $session_id = $self->getCiscoAvPairAttribute($radius_request, "audit-session-id");
 
-    my $session_id;
-    if (defined($radius_request->{'Cisco-AVPair'})) {
-        if ($radius_request->{'Cisco-AVPair'} =~ /audit-session-id=(.*)/ig ) {
-            $session_id =$1;
-        }
-    }
     return ($nas_port_type, $eap_type, $client_mac, $port, $user_name, $nas_port_id, $session_id, $nas_port_id);
 }
 

--- a/lib/pf/Switch/Meraki/MS220_8.pm
+++ b/lib/pf/Switch/Meraki/MS220_8.pm
@@ -95,13 +95,7 @@ sub parseRequest {
     my $port            = $radius_request->{'NAS-Port'};
     my $eap_type        = ( exists($radius_request->{'EAP-Type'}) ? $radius_request->{'EAP-Type'} : 0 );
     my $nas_port_id     = ( defined($radius_request->{'NAS-Port-Id'}) ? $radius_request->{'NAS-Port-Id'} : undef );
-
-    my $session_id;
-    if (defined($radius_request->{'Cisco-AVPair'})) {
-        if ($radius_request->{'Cisco-AVPair'} =~ /audit-session-id=(.*)/ig ) {
-            $session_id =$1;
-        }
-    }
+    my $session_id = $self->getCiscoAvPairAttribute($radius_request, "audit-session-id");
     return ($nas_port_type, $eap_type, $client_mac, $port, $user_name, $nas_port_id, $session_id, $nas_port_id);
 }
 

--- a/lib/pf/radius/rest.pm
+++ b/lib/pf/radius/rest.pm
@@ -21,6 +21,10 @@ use Apache2::Const -compile =>
 use pf::api::error;
 use pf::radius::constants;
 
+my %ALLOWED_MULTIPLE = (
+    'Cisco-AVPair' => undef
+);
+
 =head2 format_response
 
 Format a PacketFence RADIUS response to the format expected by the FreeRADIUS REST module
@@ -67,7 +71,7 @@ sub format_request {
     my ($request) = @_;
     # transform the request according to what radius_authorize expects
     my %remapped_radius_request = map {
-        $_ => $request->{$_}->{value}->[0];
+        $_ => ( exists $ALLOWED_MULTIPLE{$_} ) ? $request->{$_}{value} : $request->{$_}{value}[0]
     } keys %{$request};
     return \%remapped_radius_request;
 }


### PR DESCRIPTION
Description
===========
Allow Cisco-AVPair to be an array

Impacts
=======
pf::Switch and radius

Delete branch after merge
=========================
NO

Checklist
=========
- [ ] Document the feature
- [x] Add unit tests
- [ ] Add acceptance tests (TestLink)