### PR TITLE
NOT READY: Add message authenticator capability for CoA + Disconnect

### DIFF
--- a/lib/pf/Switch/Cisco/Catalyst_2960.pm
+++ b/lib/pf/Switch/Cisco/Catalyst_2960.pm
@@ -405,6 +405,8 @@ sub radiusDisconnect {
             nas_ip => $send_disconnect_to,
             secret => $self->{'_radiusSecret'},
             LocalAddr => $self->deauth_source_ip($send_disconnect_to),
+            #TODO: remove this as a default or make this configurable in the switch config
+            add_message_authenticator => $TRUE,
         };
 
         $logger->debug("network device (".$self->{'_id'}.") supports roles. Evaluating role to be returned");

--- a/lib/pf/util/dictionary
+++ b/lib/pf/util/dictionary
@@ -49,6 +49,7 @@ ATTRIBUTE	CHAP-Challenge				60	octets
 ATTRIBUTE	NAS-Port-Type				61	integer
 ATTRIBUTE	Port-Limit				62	integer
 ATTRIBUTE	Login-LAT-Port				63	string
+ATTRIBUTE Message-Authenticator 80 octets
 
 #
 #	Integer Translations

--- a/lib/pf/util/radius.pm
+++ b/lib/pf/util/radius.pm
@@ -38,6 +38,7 @@ BEGIN {
     @EXPORT_OK = qw(perform_disconnect perform_coa perform_rsso);
 }
 
+use pf::constants qw($TRUE);
 use Net::Radius::Packet;
 use Net::Radius::Dictionary;
 use IO::Select;
@@ -116,6 +117,11 @@ sub perform_dynauth {
     # avoids unnecessary warnings
     $radius_request->set_authenticator("");
 
+    use Data::Dumper ; print Dumper($radius_request->authenticator());
+    $radius_request->set_attr("Message-Authenticator", pack("H*", "0" x 32));
+    
+    use Data::Dumper ; print Dumper($radius_request->attr("Message-Authenticator"));
+
     # pushing attributes
     # TODO deal with attribute merging
     foreach my $attr (keys %$attributes) {
@@ -128,9 +134,20 @@ sub perform_dynauth {
     foreach my $vsa_ref (@$vsa) {
         $radius_request->set_vsattr($vsa_ref->{'vendor'}, $vsa_ref->{'attribute'}, $vsa_ref->{'value'});
     }
+    use File::Slurp qw(write_file);
+
+    my $packet_data = auth_resp($radius_request->pack(), $connection_info->{'secret'});
+    write_file("/tmp/packet-before.raw", $packet_data);
+
+    use Digest::HMAC_MD5 qw(hmac_md5 hmac_md5_hex);
+    my $auth_radius_request = Net::Radius::Packet->new($dictionary, $packet_data);
+    $auth_radius_request->set_attr("Message-Authenticator", hmac_md5($packet_data, $connection_info->{'secret'}), $TRUE);
+
+    my $signed_packet_data = $auth_radius_request->pack();
+    write_file("/tmp/packet.raw", $signed_packet_data);
 
     # applying shared-secret signing then send
-    $socket->send(auth_resp($radius_request->pack(), $connection_info->{'secret'}));
+    $socket->send($signed_packet_data);
 
     # Listen for the response.
     # Using IO::Select because otherwise we can't do timeout without using alarm()


### PR DESCRIPTION
# Description
Adds the ability to include a message authenticator during a RADIUS CoA or Disconnect

# Impacts
RADIUS CoA + Disconnect

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
## Enhancements
* Added the ability to include a Message-Authenticator during a RADIUS CoA or RADIUS Disconnect request
