### PR TITLE
Fix sql request to detect the tenant id

### DIFF
--- a/raddb/policy.d/packetfence
+++ b/raddb/policy.d/packetfence
@@ -35,16 +35,21 @@ packetfence-local-auth {
 
 #Update the PacketFence-Tenant-Id defaulting to the default tenant_id
 packetfence-set-tenant-id {
+    if(!NAS-IP-Address || NAS-IP-Address == "0.0.0.0"){
+        update request {
+            NAS-IP-Address := "%{Packet-Src-IP-Address}"
+        }
+    }
     if ( "%{%{control:PacketFence-Tenant-Id}:-0}" == "0") {
         update control {
-                &PacketFence-Tenant-Id = "%{sql: SELECT IFNULL((SELECT tenant_id FROM radius_nas WHERE nasname = '%{Packet-Src-IP-Address}'), 0)}"
+            &PacketFence-Tenant-Id = "%{sql: SELECT IFNULL((SELECT tenant_id FROM radius_nas WHERE nasname = '%{NAS-IP-Address}'), 0)}"
         }
 
     }
 
     if ( &control:PacketFence-Tenant-Id == 0 ) {
         update control {
-            &PacketFence-Tenant-Id := "%{sql: SELECT IFNULL((SELECT tenant_id from radius_nas WHERE start_ip <= INET_ATON('%{Packet-Src-IP-Address}') and INET_ATON('%{Packet-Src-IP-Address}') <= end_ip order by range_length limit 1), 1)}"
+            &PacketFence-Tenant-Id := "%{sql: SELECT IFNULL((SELECT tenant_id from radius_nas WHERE start_ip <= INET_ATON('%{NAS-IP-Address}') and INET_ATON('%{NAS-IP-Address}') <= end_ip order by range_length limit 1), 1)}"
         }
     }
 }


### PR DESCRIPTION
# Description
Use the NAS-IP-Address attribute instead of the source ip address.
In case of a cluster the sql request try to find the tenant id of the management vip address, because it never exist then for each radius request we do 2 sql request for nothing.

# Impacts
- RADIUS flow

# Issue
Too many request in the db that never return a result.

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Bug Fixes
* Reduce the stress on the db from radius
