### PR TITLE
Added exception when the dns request is for a portal detection url

### DIFF
--- a/go/coredns/plugin/pfdns/pfdns.go
+++ b/go/coredns/plugin/pfdns/pfdns.go
@@ -30,27 +30,27 @@ import (
 )
 
 type pfdns struct {
-	RedirectIP        net.IP
-	Db                *sql.DB
-	IP4log            *sql.Stmt // prepared statement for ip4log queries
-	IP6log            *sql.Stmt // prepared statement for ip6log queries
-	Nodedb            *sql.Stmt // prepared statement for node table queries
-	SecurityEvent     *sql.Stmt // prepared statement for security_event
-	Bh                bool      //  whether blackholing is enabled or not
-	BhIP              net.IP
-	BhCname           string
-	Next              plugin.Handler
-	Webservices       pfconfigdriver.PfConfWebservices
-	FqdnPort          map[*regexp.Regexp][]string
-	FqdnIsolationPort map[*regexp.Regexp][]string
-	FqdnDomainPort    map[*regexp.Regexp][]string
-	Network           map[*net.IPNet]net.IP
-	NetworkType       map[*net.IPNet]string
-	DNSFilter         *cache.Cache
-	IpsetCache        *cache.Cache
-	apiClient         *unifiedapiclient.Client
-	refreshLauncher   *sync.Once
-	PortalFQDN        map[int]map[*net.IPNet]*regexp.Regexp
+	RedirectIP          net.IP
+	Db                  *sql.DB
+	IP4log              *sql.Stmt // prepared statement for ip4log queries
+	IP6log              *sql.Stmt // prepared statement for ip6log queries
+	Nodedb              *sql.Stmt // prepared statement for node table queries
+	SecurityEvent       *sql.Stmt // prepared statement for security_event
+	Bh                  bool      //  whether blackholing is enabled or not
+	BhIP                net.IP
+	BhCname             string
+	Next                plugin.Handler
+	Webservices         pfconfigdriver.PfConfWebservices
+	FqdnPort            map[*regexp.Regexp][]string
+	FqdnIsolationPort   map[*regexp.Regexp][]string
+	FqdnDomainPort      map[*regexp.Regexp][]string
+	Network             map[*net.IPNet]net.IP
+	NetworkType         map[*net.IPNet]string
+	DNSFilter           *cache.Cache
+	IpsetCache          *cache.Cache
+	apiClient           *unifiedapiclient.Client
+	refreshLauncher     *sync.Once
+	PortalFQDN          map[int]map[*net.IPNet]*regexp.Regexp
 	mutex               sync.Mutex
 	detectionmechanisms []*regexp.Regexp
 }
@@ -751,4 +751,4 @@ func (pf *pfdns) checkDetectionMechanisms(ctx context.Context, e string) bool {
 		}
 	}
 	return false
-
+}

--- a/go/coredns/plugin/pfdns/setup.go
+++ b/go/coredns/plugin/pfdns/setup.go
@@ -73,6 +73,10 @@ func setuppfdns(c *caddy.Controller) error {
 		return c.Errf("pfdns: unable to initialize Portal FQDN")
 	}
 
+	if err := pf.MakeDetectionMecanism(); err != nil {
+		return c.Errf("pfdns: unable to initialize Detection Mecanism List")
+	}
+
 	// Initialize dns filter cache
 	pf.DNSFilter = cache.New(300*time.Second, 10*time.Second)
 

--- a/go/coredns/plugin/pfdns/setup.go
+++ b/go/coredns/plugin/pfdns/setup.go
@@ -73,7 +73,7 @@ func setuppfdns(c *caddy.Controller) error {
 		return c.Errf("pfdns: unable to initialize Portal FQDN")
 	}
 
-	if err := pf.MakeDetectionMecanism(); err != nil {
+	if err := pf.MakeDetectionMecanism(ctx); err != nil {
 		return c.Errf("pfdns: unable to initialize Detection Mecanism List")
 	}
 


### PR DESCRIPTION
# Description
Added an exception when the dns request concern a fqdn for portal detection mechanism.

# Impacts
DNS

# Issue
- When a google oauth authentication source the domain *.gstatic.com is configured for dns bypass but the portal detection fqdn is connectivitycheck.gstatic.com and pfdns return the real ip address instead of the portal one.

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* Exception for portal detecion url in pfdns
