### PR TITLE
Disable AD join os check option

### DIFF
--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1204,6 +1204,13 @@ The algorithm used to calculate the VLAN in a VLAN pool.
 EOT
 guide_anchor=_introduction_to_role_based_access_control
 
+[advanced.active_directory_os_join_check_bypass]
+type=toggle
+options=enabled|disabled
+description=<<EOT
+Ability to disable the check if the os has been join to a domain.
+EOT
+
 [provisioning.autoconfig]
 type=toggle
 options=enabled|disabled

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1208,7 +1208,7 @@ guide_anchor=_introduction_to_role_based_access_control
 type=toggle
 options=enabled|disabled
 description=<<EOT
-Ability to disable the check if the os has been join to a domain.
+Enable to bypass the operating system domain join verification.
 EOT
 
 [provisioning.autoconfig]

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -874,8 +874,9 @@ vlan_pool_technique = username_hash
 #
 # active_directory_os_join_check_bypass
 #
-# Ability to disable the check if the os has been join to a domain.
-active_directory_os_join_check_bypass=disable
+# Enable to bypass the operating system domain join verification.
+active_directory_os_join_check_bypass=disabled
+
 [provisioning]
 #
 # provisioning.autoconfig

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -871,7 +871,11 @@ multihost=disabled
 #
 # The algorithm used to calculate the VLAN in a VLAN pool.
 vlan_pool_technique = username_hash
-
+#
+# active_directory_os_join_check_bypass
+#
+# Ability to disable the check if the os has been join to a domain.
+active_directory_os_join_check_bypass=disable
 [provisioning]
 #
 # provisioning.autoconfig

--- a/html/pfappserver/lib/pfappserver/I18N/en.po
+++ b/html/pfappserver/lib/pfappserver/I18N/en.po
@@ -9814,7 +9814,7 @@ msgstr "VLAN pool technique"
 
 # conf/documentation.conf
 msgid "advanced.active_directory_os_join_check_bypass"
-msgstr "Disable AS AD join"
+msgstr "Disable OS AD join check"
 
 # conf/documentation.conf
 msgid "alerting"

--- a/html/pfappserver/lib/pfappserver/I18N/en.po
+++ b/html/pfappserver/lib/pfappserver/I18N/en.po
@@ -9813,6 +9813,10 @@ msgid "advanced.vlan_pool_technique"
 msgstr "VLAN pool technique"
 
 # conf/documentation.conf
+msgid "advanced.active_directory_os_join_check_bypass"
+msgstr "Disable AS AD join"
+
+# conf/documentation.conf
 msgid "alerting"
 msgstr "Alerting"
 

--- a/html/pfappserver/lib/pfappserver/PacketFence/Controller/Config/Domain.pm
+++ b/html/pfappserver/lib/pfappserver/PacketFence/Controller/Config/Domain.pm
@@ -16,7 +16,7 @@ use namespace::autoclean;
 
 use pf::util;
 use pf::domain;
-use pf::config qw(%ConfigDomain);
+use pf::config qw(%ConfigDomain %Config);
 
 BEGIN {
     extends 'pfappserver::Base::Controller';
@@ -88,7 +88,7 @@ after list => sub {
     $c->log->debug("Checking if user can edit the domain config");
     # we block the editing if the user has an OS configuration and no configured domains
     # this means he hasn't gone through the migration script
-    $c->stash->{block_edit} = ( pf::domain::has_os_configuration() && !keys(%ConfigDomain) );
+    $c->stash->{block_edit} = ( ( pf::domain::has_os_configuration() && !keys(%ConfigDomain) ) || isdisabled($Config{'advanced'}{'active_directory_os_join_check_bypass'}) );
 };
 
 =head2 after view


### PR DESCRIPTION
# Description
Even if the server is already joined to a domain (from the system) this option permit to bypass the check and allow the join through the admin gui.

# Impacts
AD Join

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* Disable AD join os check option
