### PR TITLE
Move accounting cleanup to pfmon

### DIFF
--- a/addons/backup-and-maintenance.sh
+++ b/addons/backup-and-maintenance.sh
@@ -92,12 +92,6 @@ fi
 # Is the database running on the current server and should we be running a backup ?
 if [ $SHOULD_BACKUP -eq 1 ] && { [ -f /var/run/mysqld/mysqld.pid ] || [ -f /var/run/mariadb/mariadb.pid ] || [ -f /var/lib/mysql/`hostname`.pid ]; }; then
 
-    /usr/local/pf/addons/database-cleaner.pl --table=radacct --date-field=acctupdatetime --older-than="1 WEEK" --update --update-field=acctstoptime
-
-    /usr/local/pf/addons/database-cleaner.pl --table=radacct --date-field=acctstarttime --older-than="1 WEEK" --additionnal-condition="acctstoptime IS NOT NULL"
-    
-    /usr/local/pf/addons/database-cleaner.pl --table=radacct_log --date-field=timestamp --older-than="1 WEEK"
-
     /usr/local/pf/addons/database-cleaner.pl --table=locationlog_archive --date-field=end_time --older-than="1 MONTH"
     
     # Check to see if Percona XtraBackup is installed

--- a/conf/pfmon.conf.defaults
+++ b/conf/pfmon.conf.defaults
@@ -619,7 +619,7 @@ description=Controls the cleanup of the accounting tables (raddact and radacct_l
 #
 # status
 #
-# If the task auth_log_cleanup is enabled
+# If the task acct_cleanup is enabled
 status=enabled
 #
 # interval
@@ -634,11 +634,11 @@ batch=100
 #
 # timeout
 #
-# How long a auth_log_cleanup job can run
+# How long a acct_cleanup job can run
 timeout=10s
 #
 # window
 #
-# How long to keep a auth_log_cleanup entry before deleting it
+# How long to keep a acct_cleanup entry before deleting it
 window=1D
 

--- a/conf/pfmon.conf.defaults
+++ b/conf/pfmon.conf.defaults
@@ -640,5 +640,5 @@ timeout=10s
 # window
 #
 # How long to keep a auth_log_cleanup entry before deleting it
-window=1W
+window=1D
 

--- a/conf/pfmon.conf.defaults
+++ b/conf/pfmon.conf.defaults
@@ -605,3 +605,40 @@ status=enabled
 # At which interval to run the password of the day pfmon task
 interval=60s
 
+[acct_cleanup]
+#
+# type
+#
+# The type of task to perform
+type=acct_cleanup
+#
+# description
+#
+# The description of task to perform
+description=Controls the cleanup of the accounting tables (raddact and radacct_log). Entries older than the window will be removed from the table.
+#
+# status
+#
+# If the task auth_log_cleanup is enabled
+status=enabled
+#
+# interval
+#
+# At which interval to run the auth log cleanup pfmon task
+interval=60s
+#
+# batch
+#
+# How many auth_log_cleanup entries to clean up in one run
+batch=100
+#
+# timeout
+#
+# How long a auth_log_cleanup job can run
+timeout=10s
+#
+# window
+#
+# How long to keep a auth_log_cleanup entry before deleting it
+window=1W
+

--- a/conf/pfmon.conf.defaults
+++ b/conf/pfmon.conf.defaults
@@ -629,7 +629,7 @@ interval=60s
 #
 # batch
 #
-# How many auth_log_cleanup entries to clean up in one run
+# How many acct_cleanup entries to clean up in one run
 batch=100
 #
 # timeout

--- a/lib/pf/accounting.pm
+++ b/lib/pf/accounting.pm
@@ -656,13 +656,13 @@ sub _db_items {
     return @{$iter->all(undef) // []};
 }
 
-=head2 accounting_cleanup
+=head2 cleanup
 
 Perform cleanup of the accounting tables
 
 =cut
 
-sub accounting_cleanup {
+sub cleanup {
     my $timer = pf::StatsD::Timer->new( { sample_rate => 0.2 } );
     my ( $expire_seconds, $batch, $time_limit ) = @_;
     my $logger = get_logger();

--- a/lib/pf/accounting.pm
+++ b/lib/pf/accounting.pm
@@ -656,6 +656,69 @@ sub _db_items {
     return @{$iter->all(undef) // []};
 }
 
+=head2 accounting_cleanup
+
+Perform cleanup of the accounting tables
+
+=cut
+
+sub accounting_cleanup {
+    my $timer = pf::StatsD::Timer->new( { sample_rate => 0.2 } );
+    my ( $expire_seconds, $batch, $time_limit ) = @_;
+    my $logger = get_logger();
+    $logger->debug( sub { "calling accounting_cleanup with time=$expire_seconds batch=$batch timelimit=$time_limit"; });
+
+    if ( $expire_seconds eq "0" ) {
+        $logger->debug("Not deleting because the window is 0");
+        return;
+    }
+    my $now        = pf::dal->now();
+
+    # Close old un-updated sessions
+    my %params = (
+        -set => { 
+            acctstoptime => \"NOW()",
+        },
+        -where => {
+            acctupdatetime => {
+                "<" => \[ 'DATE_SUB(?, INTERVAL ? SECOND)', $now, $expire_seconds ]
+            },
+            acctstoptime => undef,
+        },
+        -limit => $batch,
+        -no_auto_tenant_id => 1,
+    );
+    pf::dal::radacct->batch_update(\%params, $time_limit);
+
+    # Cleanup the radacct table
+    %params = (
+        -where => {
+            acctstarttime => {
+                "<" => \[ 'DATE_SUB(?, INTERVAL ? SECOND)', $now, $expire_seconds ]
+            },
+            acctstoptime => { "!=", undef },
+        },
+        -limit => $batch,
+        -no_auto_tenant_id => 1,
+    );
+    pf::dal::radacct->batch_remove(\%params, $time_limit);
+
+    # Cleanup the radacct_log table
+    %params = (
+        -where => {
+            timestamp => {
+                "<" => \[ 'DATE_SUB(?, INTERVAL ? SECOND)', $now, $expire_seconds ]
+            },
+        },
+        -limit => $batch,
+        -no_auto_tenant_id => 1,
+    );
+    pf::dal::radacct_log->batch_remove(\%params, $time_limit);
+
+
+    return;
+}
+
 =back
 
 =head1 AUTHOR

--- a/lib/pf/dal.pm
+++ b/lib/pf/dal.pm
@@ -1173,6 +1173,31 @@ sub batch_remove {
 }
 
 
+=head2 batch_update
+
+Batch update rows
+
+=cut
+
+sub batch_update {
+    my ($proto, $params, $time_limit) = @_;
+    my $logger = get_logger();
+    $logger->debug("calling batch_update with timelimit=$time_limit");
+    my $start_time = time;
+    my $end_time;
+    my $rows_updated = 0;
+    my $table = $proto->table;
+    while (1) {
+        my ($status, $rows) = $proto->update_items(%$params);
+        $end_time = time;
+        $rows_updated+=$rows if $rows > 0;
+        $logger->trace( sub { "updated $rows_updated entries from $table for batch_update ($start_time $end_time) " });
+        last if $rows <= 0 || (( $end_time - $start_time) > $time_limit );
+    }
+    $logger->info("updated $rows_updated entries from $table for batch_update ($start_time $end_time) ");
+    return $STATUS::OK, $rows_updated;
+}
+
 =head1 AUTHOR
 
 Inverse inc. <info@inverse.ca>

--- a/lib/pf/pfmon/task/acct_cleanup.pm
+++ b/lib/pf/pfmon/task/acct_cleanup.pm
@@ -1,0 +1,65 @@
+package pf::pfmon::task::acct_cleanup;
+
+=head1 NAME
+
+pf::pfmon::task::acct_cleanup - class for pfmon task accounting cleanup
+
+=cut
+
+=head1 DESCRIPTION
+
+pf::pfmon::task::acct_cleanup
+
+=cut
+
+use strict;
+use warnings;
+use Moose;
+use pf::accounting;
+extends qw(pf::pfmon::task);
+
+has 'batch' => ( is => 'rw');
+has 'timeout' => ( is => 'rw', isa => 'PfInterval', coerce => 1 );
+has 'window' => ( is => 'rw', isa => 'PfInterval', coerce => 1 );
+
+=head2 run
+
+run the auth log cleanup task
+
+=cut
+
+sub run {
+    my ($self) = @_;
+    my $window = $self->window;
+    pf::accounting::cleanup($window, $self->batch, $self->timeout) if $self->window;
+}
+
+=head1 AUTHOR
+
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2019 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;


### PR DESCRIPTION
# Description
Move accounting cleanup to pfmon and cleanup accounting data after a day

# Impacts
Accounting cleanup

# Issue
fixes #3062

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [n/a] Document the feature
- [n/a] Add unit tests
- [X] Add acceptance tests (TestLink)

# NEWS file entries
## Enhancements
* Cleanup of the accounting tables (radacct and radacct_log) is now done via pfmon instead of the database-backup-and-maintenance.sh script

# UPGRADE file entries

## Modifications to accounting cleanup

Accounting cleanup is now done via a pfmon task (acct_cleanup) instead of the database backup and maintenance script. Make sure you adjust the cleanup window in pfmon's configuration (Configuration->System Maintenance->Maintenance) if necessary. Also note that the default retention for the accounting data has been lowered to 1 day instead of 1 week like it was before.