### PR TITLE
Fix realm attribute on machine authentication

### DIFF
--- a/conf/radiusd/packetfence-tunnel.example
+++ b/conf/radiusd/packetfence-tunnel.example
@@ -20,13 +20,14 @@ server packetfence-tunnel {
 #  Make *sure* that 'preprocess' comes before any realm if you
 #  need to setup hints for the remote radius server
 authorize {
-    # TTLS does not send an EAP-Message to be parsed so the eap module
-    # cannot assign the EAP-Type
-    if ( outer.EAP-Type == TTLS) {
-        update request {
-            &EAP-Type := TTLS
-        }
+  # TTLS does not send an EAP-Message to be parsed so the eap module
+  # cannot assign the EAP-Type
+  if ( outer.EAP-Type == TTLS) {
+    update request {
+      &EAP-Type := TTLS
     }
+  }
+  packetfence-set-realm-if-machine
 	packetfence-set-tenant-id
 	#
 	#  Take a User-Name, and perform some checks on it, for spaces and other
@@ -111,7 +112,7 @@ authorize {
 	# Check if PacketFence local (SQL) authentication is enabled.
 	# Run the packetfence-local-auth policy if it is.
 	rewrite_called_station_id
-    
+
 	# Uncomment the following line to enable local PEAP authentication
 	# packetfence-local-auth
 
@@ -468,7 +469,7 @@ authorize {
 	# Check if PacketFence local (SQL) authentication is enabled.
 	# Run the packetfence-local-auth policy if it is.
 	rewrite_called_station_id
-    
+
 	# Uncomment the following line to enable local PEAP authentication
 	# packetfence-local-auth
 

--- a/conf/radiusd/packetfence-tunnel.example
+++ b/conf/radiusd/packetfence-tunnel.example
@@ -20,14 +20,14 @@ server packetfence-tunnel {
 #  Make *sure* that 'preprocess' comes before any realm if you
 #  need to setup hints for the remote radius server
 authorize {
-  # TTLS does not send an EAP-Message to be parsed so the eap module
-  # cannot assign the EAP-Type
-  if ( outer.EAP-Type == TTLS) {
-    update request {
-      &EAP-Type := TTLS
-    }
-  }
-  packetfence-set-realm-if-machine
+	# TTLS does not send an EAP-Message to be parsed so the eap module
+	# cannot assign the EAP-Type
+	if ( outer.EAP-Type == TTLS) {
+		update request {
+			&EAP-Type := TTLS
+		}
+	}
+	packetfence-set-realm-if-machine
 	packetfence-set-tenant-id
 	#
 	#  Take a User-Name, and perform some checks on it, for spaces and other

--- a/conf/radiusd/packetfence.example
+++ b/conf/radiusd/packetfence.example
@@ -25,6 +25,7 @@ authorize {
 		&control:PacketFence-Request-Time := 0
 		&control:Load-Balance-Key := "%{Calling-Station-ID} %{User-Name}"
 	}
+	packetfence-set-realm-if-machine
 	packetfence-set-tenant-id
 	rewrite_calling_station_id
 	rewrite_called_station_id

--- a/conf/radiusd/packetfence.example
+++ b/conf/radiusd/packetfence.example
@@ -202,6 +202,7 @@ authenticate {
 #
 preacct {
 	preprocess
+	packetfence-set-realm-if-machine
 	packetfence-set-tenant-id
 	set_calling_station_id
 	rewrite_calling_station_id

--- a/raddb/policy.d/packetfence
+++ b/raddb/policy.d/packetfence
@@ -33,6 +33,15 @@ packetfence-local-auth {
 
 }
 
+#Set the realm if it's machine authentication
+packetfence-set-realm-if-machine {
+    if (User-Name =~ /host\/([a-z0-9\-_]*)[\.](.*)/i) {
+        update {
+            &request:Realm := "%{2}"
+        }
+    }
+}
+
 #Update the PacketFence-Tenant-Id defaulting to the default tenant_id
 packetfence-set-tenant-id {
     if(!NAS-IP-Address || NAS-IP-Address == "0.0.0.0"){


### PR DESCRIPTION
# Description
In the case of a machine authentication PacketFence detect the realm in multidomain but never set the realm in the radius request.
Used unlang do detect machine authentication and set the realm

# Impacts
- RADIUS authorize workflow

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
## Bug Fixes
* Set the realm in the radius request when it's machine authentication

