### PR TITLE
add requested host in haproxy's portal config file

### DIFF
--- a/lib/pf/services/manager/haproxy_portal.pm
+++ b/lib/pf/services/manager/haproxy_portal.pm
@@ -101,6 +101,7 @@ EOT
             $tags{'http'} .= <<"EOT";
 frontend portal-http-$cluster_ip
         bind $cluster_ip:80
+        capture request header Host len 40
         stick-table type ip size 1m expire 10s store gpc0,http_req_rate(10s)
         tcp-request connection track-sc1 src
         http-request lua.change_host
@@ -124,6 +125,7 @@ EOT
 
 frontend portal-https-$cluster_ip
         bind $cluster_ip:443 ssl no-sslv3 crt /usr/local/pf/conf/ssl/server.pem
+        capture request header Host len 40
         stick-table type ip size 1m expire 10s store gpc0,http_req_rate(10s)
         tcp-request connection track-sc1 src
         http-request lua.change_host
@@ -171,6 +173,7 @@ EOT
                 $tags{'http'} .= <<"EOT";
 frontend portal-http-$cluster_ipv6
         bind $cluster_ipv6:80
+        capture request header Host len 40
         stick-table type ipv6 size 1m expire 10s store gpc0,http_req_rate(10s)
         tcp-request connection track-sc1 src
         http-request lua.change_host
@@ -188,6 +191,7 @@ frontend portal-http-$cluster_ipv6
 
 frontend portal-https-$cluster_ipv6
         bind $cluster_ipv6:443 ssl no-sslv3 crt /usr/local/pf/conf/ssl/server.pem
+        capture request header Host len 40
         stick-table type ipv6 size 1m expire 10s store gpc0,http_req_rate(10s)
         tcp-request connection track-sc1 src
         http-request lua.change_host


### PR DESCRIPTION
# Descriptio
Add additional logging in haproxy that shows the "Host" header in haproxy's log files. This can greatly help identify missing "passthrough exceptions"  for the walled garden or needed for Google/Facebook/etc OAuth logins as we can see both the URL and HOST of the request that hit the portal instead of the passthrough.

# Impacts
HA proxy module in portal. haproxy log files have additional strings but log filters / syslog configuration does not need updating.

# Checklist
(REQUIRED) - [yes, no or n/a]
- [no] Document the feature
- [n/a] Add unit tests
- [n/a] Add acceptance tests (TestLink)

# NEWS file entries
(REQUIRED, but may be optional...)
## New Features
Not Applicable

## Enhancements
* Better logging for  haproxy-portal that allows to identify missing passthroughs

