### PR TITLE
Randomize the key balanced 

### DIFF
--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1607,6 +1607,13 @@ description=<<EOT
 Treat OCSP response errors as 'soft' failures and still accept the certificate.
 EOT
 
+[radius_configuration.forward_key_balanced]
+type=toggle
+options=enabled|disabled
+description=<<EOT
+Send in the proxy request the attribute PacketFence-KeyBalanced to randomize the load balance in the next PacketFence RADIUS server
+EOT
+
 [pfdhcp.ip2mac_lookup]
 type=toggle
 options=enabled|disabled

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1611,7 +1611,8 @@ EOT
 type=toggle
 options=enabled|disabled
 description=<<EOT
-Send in the proxy request the attribute PacketFence-KeyBalanced to randomize the load balance in the next PacketFence RADIUS server
+Send in the proxy request the attribute PacketFence-KeyBalanced to randomize the load balance in the next PacketFence RADIUS server.
+Useful when you have multiple radius servers chained like 1-2-2 the default modulo result will be the same on each server.
 EOT
 
 [pfdhcp.ip2mac_lookup]

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -1197,6 +1197,10 @@ ocsp_timeout = 0
 #
 # Treat OCSP response errors as 'soft' failures and still accept the certificate.
 ocsp_softfail = no
+# radius_configuration.forward_key_balanced
+#
+# Send in the proxy request the attribute PacketFence-KeyBalanced to randomize the load balance in the next PacketFence RADIUS server
+PacketFence-KeyBalanced=disabled
 
 [pfdhcp]
 #

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -1200,7 +1200,7 @@ ocsp_softfail = no
 # radius_configuration.forward_key_balanced
 #
 # Send in the proxy request the attribute PacketFence-KeyBalanced to randomize the load balance in the next PacketFence RADIUS server
-PacketFence-KeyBalanced=disabled
+forward_key_balanced=disabled
 
 [pfdhcp]
 #

--- a/conf/radiusd/packetfence-cluster.example
+++ b/conf/radiusd/packetfence-cluster.example
@@ -44,8 +44,8 @@ server pf.cluster {
         }
 
         authorize {
+                packetfence-balanced-key-policy
                 update control {
-                        Load-Balance-Key := "%{Calling-Station-Id}"
                         Proxy-To-Realm := "packetfence"
                 }
                 if(!NAS-IP-Address || NAS-IP-Address == "0.0.0.0"){

--- a/conf/radiusd/packetfence-pre-proxy.example
+++ b/conf/radiusd/packetfence-pre-proxy.example
@@ -1,0 +1,38 @@
+#
+#       Configuration file for the rlm_attr_filter module.
+#       Please see rlm_attr_filter(5) manpage for more information.
+#
+#       $Id: afd89473dc50e4ff62389e35e5cb73b512e9d352 $
+#
+#       This configuration file is used to remove all of the PacketFence attributes
+#       in the proxy request.
+#
+DEFAULT
+    %%PacketFence-KeyBalanced%%
+    PacketFence-RPC-Server                !* ANY,
+    PacketFence-RPC-Port                  !* ANY,
+    PacketFence-RPC-User                  !* ANY,
+    PacketFence-RPC-Pass                  !* ANY,
+    PacketFence-RPC-Proto                 !* ANY,
+    PacketFence-Mac                       !* ANY,
+    PacketFence-UserName                  !* ANY,
+    PacketFence-Switch-Id                 !* ANY,
+    PacketFence-Switch-Mac                !* ANY,
+    PacketFence-Switch-Ip-Address         !* ANY,
+    PacketFence-Eap-Type                  !* ANY,
+    PacketFence-Connection-Type           !* ANY,
+    PacketFence-Source                    !* ANY,
+    PacketFence-SSID                      !* ANY,
+    PacketFence-IsPhone                   !* ANY,
+    PacketFence-AutoReg                   !* ANY,
+    PacketFence-Role                      !* ANY,
+    PacketFence-Status                    !* ANY,
+    PacketFence-IfIndex                   !* ANY,
+    PacketFence-Profile                   !* ANY,
+    PacketFence-Domain                    !* ANY,
+    PacketFence-Computer-Name             !* ANY,
+    PacketFence-Handled                   !* ANY,
+    PacketFence-Request-Time              !* ANY,
+    PacketFence-Authorization-Status      !* ANY,
+    PacketFence-Tenant-Id                 !* ANY
+

--- a/conf/radiusd/packetfence.example
+++ b/conf/radiusd/packetfence.example
@@ -406,6 +406,7 @@ post-auth {
 #  Only a few modules currently have this method.
 #
 pre-proxy {
+	attr_filter.packetfence_pre_proxy
 	%%pre_proxy_filter%%
 }
 

--- a/conf/radiusd/packetfence.example
+++ b/conf/radiusd/packetfence.example
@@ -23,9 +23,9 @@ authorize {
 		&control:PacketFence-RPC-Proto = ${rpc_proto}
 		&control:Tmp-Integer-0 := "%l"
 		&control:PacketFence-Request-Time := 0
-		&control:Load-Balance-Key := "%{Calling-Station-ID} %{User-Name}"
 	}
 	packetfence-set-realm-if-machine
+	packetfence-balanced-key-policy
 	packetfence-set-tenant-id
 	rewrite_calling_station_id
 	rewrite_called_station_id
@@ -203,6 +203,7 @@ authenticate {
 preacct {
 	preprocess
 	packetfence-set-realm-if-machine
+	packetfence-balanced-key-policy
 	packetfence-set-tenant-id
 	set_calling_station_id
 	rewrite_calling_station_id

--- a/lib/pf/services/manager/radiusd_child.pm
+++ b/lib/pf/services/manager/radiusd_child.pm
@@ -762,6 +762,14 @@ nostrip
 EOT
     }
     parse_template( \%tags, "$conf_dir/radiusd/proxy.conf.loadbalancer", "$install_dir/raddb/proxy.conf.loadbalancer" );
+
+    if(isenabled($Config{radius_configuration}{forward_key_balanced})){
+	   $tags{'PacketFence-KeyBalanced'} = "PacketFence-KeyBalanced                !* ANY,";
+    } else {
+        $tags{'PacketFence-KeyBalanced'} = "";
+    }
+
+    parse_template( \%tags, "$conf_dir/radiusd/packetfence-pre-proxy", "$install_dir/raddb/mods-config/attr_filter/packetfence-pre-proxy" );
 }
 
 =head2 generate_radiusd_cluster

--- a/raddb/dictionary.inverse
+++ b/raddb/dictionary.inverse
@@ -44,6 +44,7 @@ ATTRIBUTE       PacketFence-Tenant-Id                 28       integer
 ATTRIBUTE       PacketFence-ShortName                 29       string
 ATTRIBUTE       PacketFence-Proxied-From              30       string 
 ATTRIBUTE       PacketFence-UserNameAttribute         31       string
+ATTRIBUTE       PacketFence-KeyBalanced               32       string
 
 END-VENDOR      Inverse
 

--- a/raddb/mods-available/attr_filter
+++ b/raddb/mods-available/attr_filter
@@ -58,3 +58,14 @@ attr_filter attr_filter.packetfence_post_auth {
 	relaxed = yes
 	filename = ${modconfdir}/${.:name}/packetfence-post-auth
 }
+
+# Delete all PacketFence specific attributes from the reply
+#
+attr_filter attr_filter.packetfence_pre_proxy {
+        key = "%{User-Name}"
+        # relaxed means that we allow attributes that do not match the filters
+        # otherwise they would be filtered out.
+        relaxed = yes
+        filename = ${modconfdir}/${.:name}/packetfence-pre-proxy
+}
+

--- a/raddb/policy.d/packetfence
+++ b/raddb/policy.d/packetfence
@@ -209,3 +209,19 @@ packetfence-control-ntlm-failure {
   }
 }
 
+last-regexp = '(.*)(.)'
+
+packetfence-balanced-key-policy {
+    if (&PacketFence-KeyBalanced && (&PacketFence-KeyBalanced =~ /^${policy.last-regexp}$/i)) {
+        update {
+            &request:PacketFence-KeyBalanced := "%{md5:%{2}%{1}}"
+            &control:Load-Balance-Key := "%{md5:%{2}%{1}}"
+        }
+    }
+    else {
+        update {
+            &request:PacketFence-KeyBalanced := "%{md5:%{Calling-Station-Id}%{User-Name}}"
+            &control:Load-Balance-Key := "%{md5:%{Calling-Station-Id}%{User-Name}}"
+        }
+    }
+}


### PR DESCRIPTION
# Description
Randomize the key balanced calculation algorithm.
Let's say you have 1 internal server that proxy to 2 radius server then proxy to 2 others then with the modulo calculation the first proxy servers will always send the request to an only one server.
This code will allow to randomize the KeyBalanced attribute to load-balance (50/50) to the next servers.

# Impacts
Radius Proxy flow

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* Randomize KeyBalanced to randomize the load balance in Freeradius Proxy.
