### PR TITLE
Added a violation trigger only from a network managed by packetfence

### DIFF
--- a/lib/pf/constants/trigger.pm
+++ b/lib/pf/constants/trigger.pm
@@ -63,6 +63,7 @@ Readonly::Scalar our $TRIGGER_MAP => {
     "hostname_change" => "Hostname changed",
     "parking_detected" => "Parking detected",
     "node_discovered" => "Node discovered",
+    "new_dhcp_info_from_managed_network" => "DHCP packet received from managed network",
   },
   $TRIGGER_TYPE_PROVISIONER => {
     $TRIGGER_ID_PROVISIONER => "Check status",

--- a/lib/pf/dhcp/processor_v4.pm
+++ b/lib/pf/dhcp/processor_v4.pm
@@ -326,6 +326,15 @@ sub parse_dhcp_request {
     }
     # We call the parking on all DHCPREQUEST since the actions have to be done on all servers and all servers receive the DHCPREQUEST
     else {
+        my $apiclient = pf::client::getClient;
+
+        my %violation_data = (
+            'mac'   => $client_mac,
+            'tid'   => 'new_dhcp_info_from_managed_network',
+            'type'  => 'internal',
+        );
+        $apiclient->notify('trigger_violation', %violation_data);
+
         $self->checkForParking($client_mac, $client_ip);
     }
 
@@ -386,6 +395,7 @@ sub parse_dhcp_ack {
     # Packet also has to be valid
     if( $self->pf_is_dhcp($client_ip) || 
         isenabled $Config{network}{force_listener_update_on_ack} ){
+
         $self->processIPTasks( (client_mac => $client_mac, client_ip => $client_ip, lease_length => $lease_length) );
         if ($self->{is_inline_vlan}) {
             $self->apiClient->notify('synchronize_locationlog',$self->{interface_ip},$self->{interface_ip},undef, $NO_PORT, $self->{interface_vlan}, $dhcp->{'chaddr'}, $NO_VOIP, $INLINE, $self->{inline_sub_connection_type});


### PR DESCRIPTION
# Description
Only trigger a violation based on a network managed by PacketFence.

# Impacts
Violation

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* Added a way to trigger a violation only from a network managed by PacketFence
