### PR TITLE
allow to skip management node in portal load-balancing

### DIFF
--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1349,6 +1349,16 @@ description=<<EOT
 Centralize the deauthentication to the management node of the cluster.
 EOT
 
+[active_active.portal_on_management]
+type=toggle
+options=enabled|disabled
+description=<<EOT
+Process captive portal requests on the management server (the current load balancer).
+Disabling it will make the management server only proxy requests to other servers.
+Useful if your load balancer cannot handle both tasks.
+Changing this requires to restart haproxy-portal.
+EOT
+
 [active_active.auth_on_management]
 type=toggle
 options=enabled|disabled

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1356,7 +1356,7 @@ description=<<EOT
 Process captive portal requests on the management server (the current load balancer).
 Disabling it will make the management server only proxy requests to other servers.
 Useful if your load balancer cannot handle both tasks.
-Changing this requires to restart haproxy-portal.
+Changing this requires to restart the haproxy-portal service.
 EOT
 
 [active_active.auth_on_management]

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -1003,7 +1003,7 @@ centralized_deauth=enabled
 # Process captive portal requests on the management server (the current load balancer).
 # Disabling it will make the management server only proxy requests to other servers.
 # Useful if your load balancer cannot handle both tasks.
-# Changing this requires to restart haproxy-portal.
+# Changing this requires to restart the haproxy-portal service.
 portal_on_management=enabled
 #
 # active_active.auth_on_management

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -998,6 +998,14 @@ dns_on_vip_only=disabled
 # Centralize the deauthentication to the management node of the cluster.
 centralized_deauth=enabled
 #
+# active_active.portal_on_management
+#
+# Process captive portal requests on the management server (the current load balancer).
+# Disabling it will make the management server only proxy requests to other servers.
+# Useful if your load balancer cannot handle both tasks.
+# Changing this requires to restart haproxy-portal.
+portal_on_management=enabled
+#
 # active_active.auth_on_management
 #
 # Process RADIUS authentication requests on the management server (the current load balancer).

--- a/html/pfappserver/lib/pfappserver/I18N/en.po
+++ b/html/pfappserver/lib/pfappserver/I18N/en.po
@@ -9692,6 +9692,10 @@ msgid "active_active"
 msgstr "Active Active"
 
 # conf/documentation.conf
+msgid "active_active.portal_on_management"
+msgstr "Captive-portal on management"
+
+# conf/documentation.conf
 msgid "active_active.auth_on_management"
 msgstr "RADIUS authentication on management"
 

--- a/html/pfappserver/lib/pfappserver/I18N/en.po
+++ b/html/pfappserver/lib/pfappserver/I18N/en.po
@@ -9693,7 +9693,7 @@ msgstr "Active Active"
 
 # conf/documentation.conf
 msgid "active_active.portal_on_management"
-msgstr "Captive-portal on management"
+msgstr "Captive portal on management"
 
 # conf/documentation.conf
 msgid "active_active.auth_on_management"

--- a/lib/pf/services/manager/haproxy_portal.pm
+++ b/lib/pf/services/manager/haproxy_portal.pm
@@ -75,6 +75,7 @@ sub generateConfig {
             push @backend_ip, '127.0.0.1' if !@backend_ip;
             my $backend_ip_config = '';
             foreach my $back_ip ( @backend_ip ) {
+                next if($back_ip eq $cfg->{ip} && isdisabled($Config{active_active}{portal_on_management}));
 
                 $backend_ip_config .= <<"EOT";
         server $back_ip $back_ip:80 check
@@ -89,6 +90,7 @@ EOT
             push @backend_ip, '127.0.0.1' if !@backend_ip;
             my $backend_ip_config = '';
             foreach my $back_ip ( @backend_ip ) {
+                next if($back_ip eq $cfg->{ip} && isdisabled($Config{active_active}{portal_on_management}));
 
                 $backend_ip_config .= <<"EOT";
         server $back_ip $back_ip:80 check


### PR DESCRIPTION
# Description
allow to skip management node in portal load-balancing

# Impacts
haproxy-portal

# Delete branch after merge
YES

# NEWS file entries
## Enhancements
* Allow to skip management node in portal load-balancing when running in a cluster
