### PR TITLE
optimize nt hash cache lookup

### DIFF
--- a/addons/packages/packetfence.spec
+++ b/addons/packages/packetfence.spec
@@ -93,7 +93,7 @@ Requires: httpd, mod_ssl
 Requires: mod_perl, mod_proxy_html
 requires: libapreq2
 Requires: redis
-Requires: freeradius >= 3.0.18-17, freeradius-mysql, freeradius-perl, freeradius-ldap, freeradius-utils, freeradius-redis, freeradius-rest, freeradius-radsniff >= 3.0.18-17
+Requires: freeradius >= 3.0.18-18, freeradius-mysql, freeradius-perl, freeradius-ldap, freeradius-utils, freeradius-redis, freeradius-rest, freeradius-radsniff >= 3.0.18-18
 Requires: make
 Requires: net-tools
 Requires: sscep

--- a/addons/packages/packetfence.spec
+++ b/addons/packages/packetfence.spec
@@ -93,7 +93,7 @@ Requires: httpd, mod_ssl
 Requires: mod_perl, mod_proxy_html
 requires: libapreq2
 Requires: redis
-Requires: freeradius >= 3.0.18, freeradius-mysql, freeradius-perl, freeradius-ldap, freeradius-utils, freeradius-redis, freeradius-rest, freeradius-radsniff >= 3.0.18
+Requires: freeradius >= 3.0.18-17, freeradius-mysql, freeradius-perl, freeradius-ldap, freeradius-utils, freeradius-redis, freeradius-rest, freeradius-radsniff >= 3.0.18-17
 Requires: make
 Requires: net-tools
 Requires: sscep

--- a/conf/chi.conf.defaults
+++ b/conf/chi.conf.defaults
@@ -157,3 +157,10 @@ storage=distributed
 #
 # The storage to use for the namespace
 storage=distributed
+
+[storage ntlm_cache_username_lookup]
+#
+# storage ntlm_cache_username_lookup.expires_in
+#
+# Amount of time from the current time to expire an entry
+expires_in=24h

--- a/conf/radiusd/packetfence-tunnel.example
+++ b/conf/radiusd/packetfence-tunnel.example
@@ -193,7 +193,7 @@ authenticate {
 		# In the event it fails, it will fallback to an ntlm_auth call below
 		if(&control:NT-Password && &control:NT-Password != "") {
 			update {
-				&control:PacketFence-NTCacheHash := "YES"
+				&control:PacketFence-NTCacheHash := 1
 			}
 			mschap_local {
 				reject = 2
@@ -201,7 +201,7 @@ authenticate {
 			if (reject || fail) {
 				packetfence-mschap-authenticate
 				update {
-					&control:PacketFence-NTCacheHash := "NO"
+					&control:PacketFence-NTCacheHash := 0
 				}
 			}
                         update control {

--- a/conf/radiusd/packetfence-tunnel.example
+++ b/conf/radiusd/packetfence-tunnel.example
@@ -192,11 +192,24 @@ authenticate {
 		# If there is already an NT-Password populated in the control, we'll try it
 		# In the event it fails, it will fallback to an ntlm_auth call below
 		if(&control:NT-Password && &control:NT-Password != "") {
+			update {
+				&control:PacketFence-NTCacheHash := "YES"
+			}
 			mschap_local {
 				reject = 2
 			}
 			if (reject || fail) {
 				packetfence-mschap-authenticate
+				update {
+					&control:PacketFence-NTCacheHash := "NO"
+				}
+			}
+                        update control {
+                            Cache-Status-Only = 'yes'
+                        }
+			PacketFence-NTCacheHash
+			if (notfound) {
+				PacketFence-NTCacheHash
 			}
 		}
 		else {
@@ -259,9 +272,15 @@ session {
 #  then update the inner-tunnel reply.
 post-auth {
 	packetfence-set-tenant-id
-        if !( ("%{client:shortname}" =~ /eduroam_tlrs/)  || (&request:PacketFence-SHortName && &request:PacketFence-ShortName =~ /eduroam_tlrs/)) {
-               rest
-        }
+	PacketFence-NTCacheHash
+	if (ok) {
+		update {
+			&request:PacketFence-NTCacheHash := &control:PacketFence-NTCacheHash
+		}
+	}
+	if !( ("%{client:shortname}" =~ /eduroam_tlrs/)  || (&request:PacketFence-SHortName && &request:PacketFence-ShortName =~ /eduroam_tlrs/)) {
+		rest
+	}
 	update {
 		&request:User-Password := "******"
 	}

--- a/lib/pf/CHI.pm
+++ b/lib/pf/CHI.pm
@@ -75,7 +75,7 @@ my $merger = Hash::Merge->new();
 $merger->specify_behavior(\%SPECS, 'PF_CHI_MERGE');
 $merger->set_behavior('PF_CHI_MERGE');
 
-our @CACHE_NAMESPACES = qw(configfilesdata configfiles httpd.admin httpd.portal pfdns switch.overlay ldap_auth fingerbank firewall_sso switch accounting clustering person_lookup route_int provisioning switch_distributed pfdhcp_api openvas_scans local_mac);
+our @CACHE_NAMESPACES = qw(configfilesdata configfiles httpd.admin httpd.portal pfdns switch.overlay ldap_auth fingerbank firewall_sso switch accounting clustering person_lookup route_int provisioning switch_distributed pfdhcp_api openvas_scans local_mac ntlm_cache_username_lookup);
 
 our $chi_default_config = pf::IniFiles->new( -file => $chi_defaults_config_file) or die "Cannot open $chi_defaults_config_file";
 

--- a/lib/pf/cmd/pf/cache.pm
+++ b/lib/pf/cmd/pf/cache.pm
@@ -26,6 +26,7 @@ Namespaces:
   switch
   switch.overlay
   local_mac
+  ntlm_cache_username_lookup
 
 Options:
 

--- a/lib/pf/domain/ntlm_cache.pm
+++ b/lib/pf/domain/ntlm_cache.pm
@@ -274,7 +274,7 @@ sub cache_user {
     my $source = getAuthenticationSource($config->{ntlm_cache_source});
     return ($FALSE, "Invalid LDAP source $config->{ntlm_cache_source}") unless(defined($source));
     my $cache_key = "$domain.$username";
-    my $user = $CHI_CACHE->get($cache_key);
+    my $user = get_from_cache($cache_key);
     unless($user){
         if($username =~ /^host\//) {
             ($username, my $msg) = $source->findAtttributeFrom("servicePrincipalName", $username, "sAMAccountName");
@@ -284,7 +284,7 @@ sub cache_user {
             ($username, my $msg) = $source->findAtttributeFrom($source->{'usernameattribute'}, $username, "sAMAccountName");
             return ($FALSE, $msg) unless($username);
         }
-        $CHI_CACHE->set($cache_key, $username);
+        set_to_cache($cache_key, $username);
 
     }
     if (defined($user)) {
@@ -379,6 +379,31 @@ sub insert_user_in_redis_cache {
     $logger->info("Inserting '$key' => '$nthash'");
     $redis->set($key, $nthash, 'EX', $config->{ntlm_cache_expiry});
 }
+
+=head2 get_from_cache
+
+Get the value from the key
+
+=cut
+
+sub get_from_cache {
+    my ($key) = @_;
+
+    return $CHI_CACHE->get($key);
+}
+
+=head2 set_to_cache
+
+Set the value associated to the key
+
+=cut
+
+sub set_to_cache {
+    my ($key, $value) = @_;
+
+    $CHI_CACHE->set($key,$value);
+}
+
 
 =head1 AUTHOR
 

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -27,6 +27,7 @@ use pf::constants;
 use pf::constants::trigger qw($TRIGGER_TYPE_ACCOUNTING);
 use pf::constants::role qw($VOICE_ROLE);
 use pf::constants::realm;
+use pf::constants::domain qw($NTLM_REDIS_CACHE_HOST $NTLM_REDIS_CACHE_PORT);
 use pf::error qw(is_error);
 use pf::config qw(
     $ROLE_API_LEVEL
@@ -70,6 +71,8 @@ use pf::role::pool;
 use pf::dal;
 use pf::security_event;
 use pf::constants::security_event qw($LOST_OR_STOLEN);
+use pf::Redis;
+use pf::CHI;
 
 our $VERSION = 1.03;
 
@@ -1019,10 +1022,20 @@ Handle NTLM caching if necessary
 
 sub handleNtlmCaching {
     my ($self, $radius_request) = @_;
+    my $logger = get_logger;
     my $domain = $radius_request->{"PacketFence-Domain"};
+    my $usedNtHash = $radius_request->{"PacketFence-NTCacheHash"};
+
     if($domain && isenabled($ConfigDomain{$domain}{ntlm_cache}) && isenabled($ConfigDomain{$domain}{ntlm_cache_on_connection})) {
-        my $client = pf::api::queue->new(queue => "general");
-        $client->notify("cache_user_ntlm", $domain, $radius_request->{"Stripped-User-Name"});
+        my $CHI_CACHE = pf::CHI->new( namespace => 'ntlm_cache_username_lookup' );
+        my $cache_key = "$domain.$radius_request->{'Stripped-User-Name'}";
+        my $username = $CHI_CACHE->get($cache_key);
+        if (defined($usedNtHash) && $usedNtHash && defined($username)) {
+            update_user_in_redis_cache($domain,$username);
+        } else {
+            my $client = pf::api::queue->new(queue => "general");
+            $client->notify("cache_user_ntlm", $domain, $radius_request->{"Stripped-User-Name"});
+        }
     }
 }
 
@@ -1128,6 +1141,29 @@ sub check_lost_stolen {
 
     if($is_lost_stolen) {
         pf::action::action_execute( $mac, $LOST_OR_STOLEN, "Endpoint has just connected on the network" );
+    }
+}
+
+=head2 update_user_in_redis_cache
+
+Update a user/NT hash combination inside redis for a given domain
+
+=cut
+
+sub update_user_in_redis_cache {
+    my ($domain, $user) = @_;
+    my $logger = get_logger;
+    my $config = $ConfigDomain{$domain};
+
+    # pf::Redis has a cache for the connection
+    my $redis = pf::Redis->new(server => "$NTLM_REDIS_CACHE_HOST:$NTLM_REDIS_CACHE_PORT", reconnect => 5);
+
+
+    my $key = "NTHASH:$domain:$user";
+    my $nthash = $redis->get($key);
+    if (defined($nthash)) {
+        $redis->set($key, $nthash, 'EX', $config->{ntlm_cache_expiry});
+        $logger->info("Updating '$key' => '$nthash'");
     }
 }
 

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -1026,14 +1026,15 @@ sub handleNtlmCaching {
     my $usedNtHash = $radius_request->{"PacketFence-NTCacheHash"};
 
     if($domain && isenabled($ConfigDomain{$domain}{ntlm_cache}) && isenabled($ConfigDomain{$domain}{ntlm_cache_on_connection})) {
-        my $cache_key = "$domain.$radius_request->{'Stripped-User-Name'}";
+        my $radius_username = $radius_request->{'Stripped-User-Name'} || $radius_request->{'User-Name'};
+        my $cache_key = "$domain.$radius_username";
         my $username = pf::domain::ntlm_cache::get_from_cache($cache_key);
         if (defined($usedNtHash) && $usedNtHash && defined($username)) {
             $self->update_user_in_redis_cache($domain,$username);
         }
         else {
             my $client = pf::api::queue->new(queue => "general");
-            $client->notify("cache_user_ntlm", $domain, $radius_request->{"Stripped-User-Name"});
+            $client->notify("cache_user_ntlm", $domain, $radius_username);
         }
     }
 }

--- a/raddb/dictionary.inverse
+++ b/raddb/dictionary.inverse
@@ -46,6 +46,7 @@ ATTRIBUTE       PacketFence-Proxied-From              30       string
 ATTRIBUTE       PacketFence-UserNameAttribute         31       string
 ATTRIBUTE       PacketFence-KeyBalanced               32       string
 ATTRIBUTE       PacketFence-Radius-Ip                 33       string
+ATTRIBUTE       PacketFence-NTCacheHash               34       string
 
 END-VENDOR      Inverse
 

--- a/raddb/mods-available/cache_password
+++ b/raddb/mods-available/cache_password
@@ -29,3 +29,14 @@ cache userprincipalname {
                 &reply:Class := "%{randstr:ssssssssssssssssssssssssssssssss}"
         }
 }
+
+cache PacketFence-NTCacheHash {
+
+        driver = "rlm_cache_rbtree"
+        key = "%{User-Name}"
+        ttl = 10
+        add_stats = no
+        update {
+                &control:PacketFence-NTCacheHash += &control:PacketFence-NTCacheHash
+        }
+}


### PR DESCRIPTION
# Description
Do no fork the secretdump.py file each time packetfence receive a radius request.
If radius is able to find the nt_hash in redis then extend the ttl.

# Impacts
- RADIUS authorize workflow


# NEW Package(s) required
Freeradius 

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* Optimize the nt_hash lookup on each radius request
