### PR TITLE
Feature/accounting triggers history

### DIFF
--- a/html/pfappserver/root/security_event/view.tt
+++ b/html/pfappserver/root/security_event/view.tt
@@ -86,6 +86,7 @@
               <select id="trigger_type" class="input-medium">
                 <option value=""></option>
                 [% FOREACH type IN trigger_types -%]
+                [% NEXT IF type == "recorded_accounting" %]
                 <option value="[% type | html %]">[% l(type) %]</option>
                 [% END -%]
               </select>

--- a/lib/pf/accounting_events_history.pm
+++ b/lib/pf/accounting_events_history.pm
@@ -113,7 +113,7 @@ sub latest_mac_history {
     }
 
     if($self->redis->hexists($latest, $mac)) {
-        return decode_json($self->redis->hget($latest, $mac));
+        return [ keys %{decode_json($self->redis->hget($latest, $mac))} ];
     }
     else {
         return [];

--- a/lib/pf/accounting_events_history.pm
+++ b/lib/pf/accounting_events_history.pm
@@ -1,5 +1,17 @@
 package pf::accounting_events_history;
 
+=head1 NAME
+
+pf::provisioner
+
+=cut
+
+=head1 DESCRIPTION
+
+Module to track historical accounting triggers
+
+=cut
+
 use Moo;
 use Data::UUID;
 use Time::HiRes qw(time);
@@ -35,12 +47,24 @@ has server => (
     default  => sub { "127.0.0.1:6379" },
 );
 
+=head2 prefix
+
+The prefix to use when storing data in redis hashes
+
+=cut
+
 has prefix => (
     is      => 'rw',
     default => sub { "accounting_events_history" },
 );
 
-sub set_name_prefix { "data-" }
+=head2 hash_name_prefix
+
+The prefix to use for the hash names
+
+=cut
+
+sub hash_name_prefix { "data-" }
 
 =head2 _build_redis
 
@@ -63,14 +87,32 @@ sub _build_redis {
     return pf::Redis->new(%args);
 }
 
+=head2 add_prefix
+
+Add the configured prefix to a key
+
+=cut
+
 sub add_prefix {
     return $_[0]->prefix.":".$_[1]
 }
+
+=head2 get_new_history_hash
+
+Get a history hash name that can be populated with new data
+
+=cut
 
 sub get_new_history_hash {
     my ($self) = @_;
     return $UUID_GENERATOR->create_str();
 }
+
+=head2 add_to_history_hash
+
+Add data to an uncommited history hash
+
+=cut
 
 sub add_to_history_hash {
     my ($self, $hash, $mac, $tid) = @_;
@@ -81,27 +123,50 @@ sub add_to_history_hash {
     $self->redis->hset($hash, $mac, encode_json($data));
 }
 
-#use pf::config::pfmon qw(%ConfigPfmon) ; print Dumper($ConfigPfmon{acct_maintenance}{interval})
+=head2 commit
+
+Commit a history hash by naming it so it can be viewed by all_history_hashes
+
+=cut
+
 sub commit {
     my ($self, $hash, $ttl) = @_;
-    my $set_name = $self->add_prefix($self->set_name_prefix . time . "-$hash");
-    $self->redis->rename($self->add_prefix($hash), $set_name);
-    $self->redis->expire($set_name, $ttl);
+    my $hash_name = $self->add_prefix($self->hash_name_prefix . time . "-$hash");
+    $self->redis->rename($self->add_prefix($hash), $hash_name);
+    $self->redis->expire($hash_name, $ttl);
 }
+
+=head2 all_history_hashes
+
+List all the commited history hashes
+
+=cut
 
 sub all_history_hashes {
     my ($self) = @_;
-    my $search = $self->add_prefix($self->set_name_prefix)."*";
+    my $search = $self->add_prefix($self->hash_name_prefix)."*";
     my @histories = $self->redis->keys($search);
     @histories = nsort @histories;
     return @histories;
 }
+
+=head2 latest_history_hash
+
+Get the name of the latest history hash
+
+=cut
 
 sub latest_history_hash {
     my ($self) = @_;
     my @histories = $self->all_history_hashes();
     return scalar(@histories) > 0 ? $histories[-1] : undef;
 }
+
+=head2 latest_mac_history
+
+The the accounting triggers history for a specific MAC address
+
+=cut
 
 sub latest_mac_history {
     my ($self, $mac) = @_;
@@ -120,11 +185,44 @@ sub latest_mac_history {
     }
 }
 
+=head2 flush_all
+
+Flush all the history hashes
+
+=cut
+
 sub flush_all {
     my ($self) = @_;
     my @previous = $self->all_history_hashes;
     return @previous ? $self->redis->del(@previous) : undef;
 }
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2019 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
 
 1;
 

--- a/lib/pf/accounting_events_history.pm
+++ b/lib/pf/accounting_events_history.pm
@@ -1,0 +1,130 @@
+package pf::accounting_events_history;
+
+use Moo;
+use Data::UUID;
+use Time::HiRes qw(time);
+use pf::Redis;
+use Sort::Naturally qw(nsort);
+use JSON::MaybeXS;
+use pf::log;
+
+my $UUID_GENERATOR = Data::UUID->new;
+
+
+=head2 redis
+
+The redis client to use
+
+=cut
+
+has redis => (
+    is      => 'rw',
+    builder => 1,
+    lazy    => 1,
+);
+
+=head2 server
+
+The server of the redis client
+
+=cut
+
+has server => (
+    is       => 'rw',
+    required => 1,
+    default  => sub { "127.0.0.1:6379" },
+);
+
+has prefix => (
+    is      => 'rw',
+    default => sub { "accounting_events_history" },
+);
+
+sub set_name_prefix { "data-" }
+
+=head2 _build_redis
+
+Build the redis client
+
+=cut
+
+sub _build_redis {
+    my ($self) = @_;
+    my %args;
+    my $server = $self->server;
+
+    #If there is a / then consider it unix socket
+    if ($server =~ m#/#) {
+        $args{sock} = $server;
+    }
+    else {
+        $args{server} = $server;
+    }
+    return pf::Redis->new(%args);
+}
+
+sub add_prefix {
+    return $_[0]->prefix.":".$_[1]
+}
+
+sub get_new_history_hash {
+    my ($self) = @_;
+    return $UUID_GENERATOR->create_str();
+}
+
+sub add_to_history_hash {
+    my ($self, $hash, $mac, $tid) = @_;
+    $hash = $self->add_prefix($hash);
+    my $data = $self->redis->hget($hash, $mac);
+    $data = $data ? decode_json($data) : {};
+    $data->{$tid} = 1;
+    $self->redis->hset($hash, $mac, encode_json($data));
+}
+
+#use pf::config::pfmon qw(%ConfigPfmon) ; print Dumper($ConfigPfmon{acct_maintenance}{interval})
+sub commit {
+    my ($self, $hash, $ttl) = @_;
+    my $set_name = $self->add_prefix($self->set_name_prefix . time . "-$hash");
+    $self->redis->rename($self->add_prefix($hash), $set_name);
+    $self->redis->expire($set_name, $ttl);
+}
+
+sub all_history_hashes {
+    my ($self) = @_;
+    my $search = $self->add_prefix($self->set_name_prefix)."*";
+    my @histories = $self->redis->keys($search);
+    @histories = nsort @histories;
+    return @histories;
+}
+
+sub latest_history_hash {
+    my ($self) = @_;
+    my @histories = $self->all_history_hashes();
+    return scalar(@histories) > 0 ? $histories[-1] : undef;
+}
+
+sub latest_mac_history {
+    my ($self, $mac) = @_;
+    my $latest = $self->latest_history_hash();
+
+    unless(defined($latest)) {
+        get_logger->warn("Unable to pull accounting history for device $mac. The history set doesn't exist yet.");
+        return undef;
+    }
+
+    if($self->redis->hexists($latest, $mac)) {
+        return decode_json($self->redis->hget($latest, $mac));
+    }
+    else {
+        return [];
+    }
+}
+
+sub flush_all {
+    my ($self) = @_;
+    my @previous = $self->all_history_hashes;
+    return @previous ? $self->redis->del(@previous) : undef;
+}
+
+1;
+

--- a/lib/pf/factory/condition/security_event.pm
+++ b/lib/pf/factory/condition/security_event.pm
@@ -30,7 +30,7 @@ sub factory_for {'pf::condition'};
 my $DEFAULT_CONDITION = 'key';
 
 our %TRIGGER_TYPE_TO_CONDITION_TYPE = (
-    'accounting'                => {type => 'equals',                   key  => 'last_accounting_id',      event => $TRUE},
+    'accounting'                => {type => 'equals',                   key  => 'last_accounting_id'},
     'recorded_accounting'       => {type => 'includes',                 key  => 'last_accounting_events'},
     'detect'                    => {type => 'equals',                   key  => 'last_detect_id',          event => $TRUE},
     'device'                    => {type => 'fingerbank::device_is_a',  key  => 'device_id'},

--- a/lib/pf/factory/condition/security_event.pm
+++ b/lib/pf/factory/condition/security_event.pm
@@ -31,6 +31,7 @@ my $DEFAULT_CONDITION = 'key';
 
 our %TRIGGER_TYPE_TO_CONDITION_TYPE = (
     'accounting'                => {type => 'equals',                   key  => 'last_accounting_id',      event => $TRUE},
+    'recorded_accounting'       => {type => 'includes',                 key  => 'last_accounting_events'},
     'detect'                    => {type => 'equals',                   key  => 'last_detect_id',          event => $TRUE},
     'device'                    => {type => 'fingerbank::device_is_a',  key  => 'device_id'},
     'dhcp_fingerprint'          => {type => 'equals',                   key  => 'dhcp_fingerprint_id'},
@@ -70,6 +71,11 @@ sub instantiate {
         my @triggers = split(/\s*&\s*/,$1);
         my @conditions;
         foreach my $sub_trigger (@triggers){
+            # In multi-trigger context, we use the recorded accounting triggers
+            if($sub_trigger =~ /^accounting::(.*)/) {
+                $sub_trigger = "recorded_accounting::$1";
+            }
+
             ($type,$data) = $class->getData($sub_trigger);
             my $subclass = $class->getModuleName($type);
             my $condition = $subclass->new($data);

--- a/lib/pf/security_event.pm
+++ b/lib/pf/security_event.pm
@@ -536,7 +536,7 @@ sub info_for_security_event_engine {
         return pf::fingerbank::mac_vendor_from_mac($mac);
     });
 
-    my $accounting_history = pf::accounting_events_history->new->latest_history_hash($mac);
+    my $accounting_history = pf::accounting_events_history->new->latest_mac_history($mac);
 
     my $info = {
       device_id => $device_id,

--- a/lib/pf/security_event.pm
+++ b/lib/pf/security_event.pm
@@ -536,6 +536,8 @@ sub info_for_security_event_engine {
         return pf::fingerbank::mac_vendor_from_mac($mac);
     });
 
+    my $accounting_history = pf::accounting_events_history->new->latest_history_hash($mac);
+
     my $info = {
       device_id => $device_id,
       dhcp_fingerprint_id => $results->{dhcp_fingerprint},
@@ -547,6 +549,7 @@ sub info_for_security_event_engine {
       user_agent_id => $results->{user_agent},
       last_switch => $node_info->{'last_switch'},
       role => $node_info->{category},
+      last_accounting_events => $accounting_history,
     };
 
     my $trigger_info = $pf::factory::condition::security_event::TRIGGER_TYPE_TO_CONDITION_TYPE{$type};

--- a/t/unittest/accounting_events_history.t
+++ b/t/unittest/accounting_events_history.t
@@ -1,0 +1,85 @@
+#!/usr/bin/perl -w
+
+use strict;
+use warnings;
+use diagnostics;
+
+use lib '/usr/local/pf/lib';
+BEGIN {
+    use lib qw(/usr/local/pf/t);
+    use test_paths;
+    use setup_test_config;
+    use pf::log;
+}
+
+use Test::More;
+use Test::Deep;
+use Config::IniFiles;
+
+use_ok('pf::accounting_events_history');
+
+my $history = pf::accounting_events_history->new();
+$history->flush_all();
+
+my $mac = "00:11:22:33:44:55";
+
+ok(!defined($history->latest_mac_history($mac)), "Undefined result when fetching on empty history");
+
+my $h = $history->get_new_history_hash();
+
+$history->add_to_history_hash($h, $mac, "TOT5BM");
+
+ok(!defined($history->latest_mac_history($mac)), "Data doesn't exist before its commited");
+
+$history->commit($h, 3600);
+
+ok(exists($history->latest_mac_history($mac)->{TOT5BM}), "Right result when fetching history");
+
+$h = $history->get_new_history_hash();
+
+$history->add_to_history_hash($h, $mac, "TOT10BM");
+
+ok(exists($history->latest_mac_history($mac)->{TOT5BM}), "Previous historical is provided before new data is commited");
+
+ok(!exists($history->latest_mac_history($mac)->{TOT10BM}), "New historical data isn't there before its commited");
+
+$history->commit($h, 3600);
+
+ok(!exists($history->latest_mac_history($mac)->{TOT5BM}), "Previous historical isn't there anymore after new one is commited");
+
+ok(exists($history->latest_mac_history($mac)->{TOT10BM}), "New historical data is there after its commited");
+
+$history->flush_all();
+
+ok(!defined($history->latest_mac_history($mac)), "Undefined result when fetching on flushed history");
+done_testing();
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2019 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;
+


### PR DESCRIPTION
# Description
Allow to search current accounting triggers when triggering another security event.
Makes the accounting triggers non-event (can be mixed with Suricata, nexpose, etc)

# Impacts
Security event engine
Accounting maintenance

# Fixes issue
fixes #4066

# Delete branch after merge
YES

