### PR TITLE
Feature/api frontend token expiration++

### DIFF
--- a/go/api-frontend/aaa/authentication.go
+++ b/go/api-frontend/aaa/authentication.go
@@ -65,11 +65,19 @@ func (tam *TokenAuthenticationMiddleware) Login(ctx context.Context, username, p
 }
 
 func (tam *TokenAuthenticationMiddleware) BearerRequestIsAuthorized(ctx context.Context, r *http.Request) (bool, error) {
-	authHeader := r.Header.Get("Authorization")
-	token := strings.TrimPrefix(authHeader, "Bearer ")
+	token := tam.tokenFromRequest(ctx, r)
 	return tam.IsAuthenticated(ctx, token)
+}
+
+func (tam *TokenAuthenticationMiddleware) tokenFromRequest(ctx context.Context, r *http.Request) string {
+	authHeader := r.Header.Get("Authorization")
+	return strings.TrimPrefix(authHeader, "Bearer ")
 }
 
 func (tam *TokenAuthenticationMiddleware) IsAuthenticated(ctx context.Context, token string) (bool, error) {
 	return tam.tokenBackend.TokenIsValid(token), nil
+}
+
+func (tam *TokenAuthenticationMiddleware) TouchTokenInfo(ctx context.Context, r *http.Request) {
+	tam.tokenBackend.TouchTokenInfo(tam.tokenFromRequest(ctx, r))
 }

--- a/go/api-frontend/aaa/authentication_test.go
+++ b/go/api-frontend/aaa/authentication_test.go
@@ -11,7 +11,7 @@ import (
 func TestTokenAuthenticationMiddlewareIsAuthenticated(t *testing.T) {
 	ctx := log.LoggerNewContext(context.Background())
 
-	backend := NewMemTokenBackend(1 * time.Second)
+	backend := NewMemTokenBackend(1*time.Second, 1*time.Second)
 	tam := NewTokenAuthenticationMiddleware(backend)
 	token := "t-to-the-o-to-the-ken"
 
@@ -45,7 +45,7 @@ func TestTokenAuthenticationMiddlewareIsAuthenticated(t *testing.T) {
 func TestTokenAuthenticationMiddlewareLogin(t *testing.T) {
 	ctx := log.LoggerNewContext(context.Background())
 
-	backend := NewMemTokenBackend(1 * time.Second)
+	backend := NewMemTokenBackend(1*time.Second, 1*time.Second)
 	tam := NewTokenAuthenticationMiddleware(backend)
 
 	tam.AddAuthenticationBackend(NewMemAuthenticationBackend(

--- a/go/api-frontend/aaa/authentication_test.go
+++ b/go/api-frontend/aaa/authentication_test.go
@@ -40,6 +40,48 @@ func TestTokenAuthenticationMiddlewareIsAuthenticated(t *testing.T) {
 		t.Error("Expired token is still seen as valid")
 	}
 
+	// Test token expiration extension and max expiration
+	backend = NewMemTokenBackend(1*time.Second, 5*time.Second)
+	tam = NewTokenAuthenticationMiddleware(backend)
+
+	backend.StoreTokenInfo(token, &TokenInfo{})
+
+	res, _ = tam.IsAuthenticated(ctx, token)
+
+	if !res {
+		t.Error("Valid token wasn't seen as authenticated")
+	}
+
+	time.Sleep(2 * time.Second)
+
+	res, _ = tam.IsAuthenticated(ctx, token)
+
+	if res {
+		t.Error("Expired token is still seen as valid")
+	}
+
+	// Store a new token to start another expiration timer
+	backend.StoreTokenInfo(token, &TokenInfo{})
+
+	// Touch the token info for 2 seconds and test it after to ensure its still valid
+	for i := 0; i < 20; i++ {
+		backend.TouchTokenInfo(token)
+	}
+
+	res, _ = tam.IsAuthenticated(ctx, token)
+
+	if !res {
+		t.Error("Valid token wasn't seen as authenticated")
+	}
+
+	time.Sleep(5 * time.Second)
+
+	res, _ = tam.IsAuthenticated(ctx, token)
+
+	if res {
+		t.Error("Expired token is still seen as valid")
+	}
+
 }
 
 func TestTokenAuthenticationMiddlewareLogin(t *testing.T) {

--- a/go/api-frontend/aaa/authorization.go
+++ b/go/api-frontend/aaa/authorization.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/inverse-inc/packetfence/go/log"
 )
@@ -108,7 +109,7 @@ func (tam *TokenAuthorizationMiddleware) BearerRequestIsAuthorized(ctx context.C
 	token := tam.TokenFromBearerRequest(ctx, r)
 	xptid := r.Header.Get("X-PacketFence-Tenant-Id")
 
-	tokenInfo := tam.tokenBackend.TokenInfoForToken(token)
+	tokenInfo, _ := tam.tokenBackend.TokenInfoForToken(token)
 
 	if tokenInfo == nil {
 		return false, errors.New("Invalid token info")
@@ -244,11 +245,11 @@ func (tam *TokenAuthorizationMiddleware) isAuthorizedConfigNamespace(ctx context
 	}
 }
 
-func (tam *TokenAuthorizationMiddleware) GetTokenInfoFromBearerRequest(ctx context.Context, r *http.Request) *TokenInfo {
+func (tam *TokenAuthorizationMiddleware) GetTokenInfoFromBearerRequest(ctx context.Context, r *http.Request) (*TokenInfo, time.Time) {
 	token := tam.TokenFromBearerRequest(ctx, r)
 	return tam.GetTokenInfo(ctx, token)
 }
 
-func (tam *TokenAuthorizationMiddleware) GetTokenInfo(ctx context.Context, token string) *TokenInfo {
+func (tam *TokenAuthorizationMiddleware) GetTokenInfo(ctx context.Context, token string) (*TokenInfo, time.Time) {
 	return tam.tokenBackend.TokenInfoForToken(token)
 }

--- a/go/api-frontend/aaa/authorization_test.go
+++ b/go/api-frontend/aaa/authorization_test.go
@@ -13,7 +13,7 @@ import (
 func TestTokenAuthorizationMiddlewareIsAuthorized(t *testing.T) {
 	ctx := log.LoggerNewContext(context.Background())
 
-	m := NewTokenAuthorizationMiddleware(NewMemTokenBackend(1 * time.Second))
+	m := NewTokenAuthorizationMiddleware(NewMemTokenBackend(1*time.Second, 1*time.Second))
 
 	var res bool
 	var err error
@@ -201,7 +201,7 @@ func TestTokenAuthorizationMiddlewareIsAuthorized(t *testing.T) {
 func TestTokenAuthorizationMiddlewareBearerRequestIsAuthorized(t *testing.T) {
 	ctx := log.LoggerNewContext(context.Background())
 
-	backend := NewMemTokenBackend(1 * time.Second)
+	backend := NewMemTokenBackend(1*time.Second, 1*time.Second)
 	m := NewTokenAuthorizationMiddleware(backend)
 
 	token := "wow-such-beauty-token"
@@ -331,7 +331,7 @@ func addBearerTokenToTestRequest(r *http.Request, token string, tenantId int) {
 func BenchmarkIsAuthorizedAdminActionsStatic(b *testing.B) {
 	ctx := log.LoggerNewContext(context.Background())
 
-	m := NewTokenAuthorizationMiddleware(NewMemTokenBackend(1 * time.Second))
+	m := NewTokenAuthorizationMiddleware(NewMemTokenBackend(1*time.Second, 1*time.Second))
 	for n := 0; n < b.N; n++ {
 		m.isAuthorizedAdminActions(ctx, "GET", "/api/v1/nodes", map[string]bool{"NODES_READ": true})
 	}
@@ -340,7 +340,7 @@ func BenchmarkIsAuthorizedAdminActionsStatic(b *testing.B) {
 func BenchmarkIsAuthorizedAdminActionsDynamic(b *testing.B) {
 	ctx := log.LoggerNewContext(context.Background())
 
-	m := NewTokenAuthorizationMiddleware(NewMemTokenBackend(1 * time.Second))
+	m := NewTokenAuthorizationMiddleware(NewMemTokenBackend(1*time.Second, 1*time.Second))
 	for n := 0; n < b.N; n++ {
 		m.isAuthorizedAdminActions(ctx, "GET", "/api/v1/node/00:11:22:33:44:55", map[string]bool{"NODES_READ": true})
 	}

--- a/go/api-frontend/aaa/mem_token_backend_test.go
+++ b/go/api-frontend/aaa/mem_token_backend_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestMemTokenBackend(t *testing.T) {
-	b := NewMemTokenBackend(1 * time.Second)
+	b := NewMemTokenBackend(1*time.Second, 1*time.Second)
 	token := "my-beautiful-token"
 
 	if b.TokenIsValid(token) {

--- a/go/api-frontend/aaa/token_backend.go
+++ b/go/api-frontend/aaa/token_backend.go
@@ -1,6 +1,10 @@
 package aaa
 
-import "github.com/inverse-inc/packetfence/go/pfconfigdriver"
+import (
+	"time"
+
+	"github.com/inverse-inc/packetfence/go/pfconfigdriver"
+)
 
 type TokenBackend interface {
 	AdminActionsForToken(token string) map[string]bool
@@ -8,6 +12,7 @@ type TokenBackend interface {
 	TokenInfoForToken(token string) *TokenInfo
 	StoreTokenInfo(token string, ti *TokenInfo) error
 	TokenIsValid(token string) bool
+	TouchTokenInfo(token string)
 }
 
 const (
@@ -19,6 +24,8 @@ type TokenInfo struct {
 	AdminRoles map[string]bool
 	TenantId   int
 	Username   string
+	ExpiresAt  time.Time
+	CreatedAt  time.Time
 }
 
 func (ti *TokenInfo) AdminActions() map[string]bool {

--- a/go/api-frontend/aaa/token_backend.go
+++ b/go/api-frontend/aaa/token_backend.go
@@ -9,7 +9,7 @@ import (
 type TokenBackend interface {
 	AdminActionsForToken(token string) map[string]bool
 	TenantIdForToken(token string) int
-	TokenInfoForToken(token string) *TokenInfo
+	TokenInfoForToken(token string) (*TokenInfo, time.Time)
 	StoreTokenInfo(token string, ti *TokenInfo) error
 	TokenIsValid(token string) bool
 	TouchTokenInfo(token string)
@@ -24,7 +24,6 @@ type TokenInfo struct {
 	AdminRoles map[string]bool
 	TenantId   int
 	Username   string
-	ExpiresAt  time.Time
 	CreatedAt  time.Time
 }
 

--- a/go/caddy/api-aaa/api-aaa.go
+++ b/go/caddy/api-aaa/api-aaa.go
@@ -73,7 +73,7 @@ func buildApiAAAHandler(ctx context.Context) (ApiAAAHandler, error) {
 	pfconfigdriver.PfconfigPool.AddStruct(ctx, &pfconfigdriver.Config.UnifiedApiSystemUser)
 	pfconfigdriver.PfconfigPool.AddStruct(ctx, &pfconfigdriver.Config.AdminRoles)
 
-	tokenBackend := aaa.NewMemTokenBackend(15*time.Minute, 12*time.Hour)
+	tokenBackend := aaa.NewMemTokenBackend(1*time.Minute, 2*time.Minute)
 	apiAAA.authentication = aaa.NewTokenAuthenticationMiddleware(tokenBackend)
 
 	// Backend for the system Unified API user
@@ -153,7 +153,7 @@ func (h ApiAAAHandler) handleTokenInfo(w http.ResponseWriter, r *http.Request, p
 	ctx := r.Context()
 	defer statsd.NewStatsDTiming(ctx).Send("api-aaa.token_info")
 
-	info := h.authorization.GetTokenInfoFromBearerRequest(ctx, r)
+	info, expiration := h.authorization.GetTokenInfoFromBearerRequest(ctx, r)
 
 	if info != nil {
 		// We'll want to render the roles as an array, not as a map
@@ -162,7 +162,7 @@ func (h ApiAAAHandler) handleTokenInfo(w http.ResponseWriter, r *http.Request, p
 			AdminRoles:   make([]string, len(info.AdminRoles)),
 			TenantId:     info.TenantId,
 			Username:     info.Username,
-			ExpiresAt:    info.ExpiresAt,
+			ExpiresAt:    expiration,
 		}
 
 		i := 0

--- a/go/caddy/api-aaa/api-aaa.go
+++ b/go/caddy/api-aaa/api-aaa.go
@@ -73,7 +73,7 @@ func buildApiAAAHandler(ctx context.Context) (ApiAAAHandler, error) {
 	pfconfigdriver.PfconfigPool.AddStruct(ctx, &pfconfigdriver.Config.UnifiedApiSystemUser)
 	pfconfigdriver.PfconfigPool.AddStruct(ctx, &pfconfigdriver.Config.AdminRoles)
 
-	tokenBackend := aaa.NewMemTokenBackend(1*time.Minute, 2*time.Minute)
+	tokenBackend := aaa.NewMemTokenBackend(15*time.Minute, 12*time.Hour)
 	apiAAA.authentication = aaa.NewTokenAuthenticationMiddleware(tokenBackend)
 
 	// Backend for the system Unified API user


### PR DESCRIPTION
# Description
Default API token expiration is now 15 minutes, can be extended to 12 hours (extended on each usage other than a login and a token info)

# Impacts
API frontend

# Issue
fixes #4109

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [n/a] Document the feature
- [X] Add unit tests
- [n/a] Add acceptance tests (TestLink)

# NEWS file entries
## Enhancements
* Reworked API tokens so they are valid for 15 minutes with extendable access for up to 12 hours
