### PR TITLE
eduroam local realm proxy

### DIFF
--- a/conf/radiusd/eduroam-cluster.example
+++ b/conf/radiusd/eduroam-cluster.example
@@ -29,8 +29,6 @@ server eduroam.cluster {
         authorize {
             suffix
             ntdomain
-            %%reject_realm%%
-            %%local_realm%%
             if(!NAS-IP-Address || NAS-IP-Address == "0.0.0.0"){
                     update request {
                             NAS-IP-Address := "%{Packet-Src-IP-Address}"

--- a/conf/radiusd/eduroam.example
+++ b/conf/radiusd/eduroam.example
@@ -335,6 +335,7 @@ post-auth {
 	#update {
 	#	&reply: += &session-state:
 	#}
+%%eduroam_post_auth%%
 	if (Realm == "eduroam") {
 		# Update the realm in the request so its consistent with the logic that will be performed in httpd.aaa
 		update request {

--- a/conf/radiusd/eduroam.example
+++ b/conf/radiusd/eduroam.example
@@ -273,7 +273,7 @@ accounting {
     packetfence-set-tenant-id
 	rewrite_calling_station_id
 	rewrite_called_station_id
-
+%%local_realm_acct%%
 	#
 	#  If you receive stop packets with zero session length,
 	#  they will NOT be logged in the database.  The SQL module

--- a/conf/radiusd/proxy.conf.inc.example
+++ b/conf/radiusd/proxy.conf.inc.example
@@ -2,4 +2,6 @@
 
 %%config%%
 
+%%eduroam_config%%
+
 %%radius_sources%%

--- a/html/pfappserver/lib/pfappserver/Form/Config/Realm.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Realm.pm
@@ -127,6 +127,86 @@ has_field 'radius_acct_proxy_type' =>
              help => 'Home server pool type' },
   );
 
+has_field 'eduroam_options' =>
+  (
+   type => 'TextArea',
+   label => 'Eduroam Realm Options',
+   required => 0,
+   tags => { after_element => \&help,
+             help => 'You can add FreeRADIUS options in the realm definition' },
+  );
+
+has_field 'eduroam_radius_auth' =>
+  (
+   type => 'Select',
+   multiple => 1,
+   label => 'Eduroam RADIUS AUTH',
+   options_method => \&options_radius,
+   element_class => ['chzn-select'],
+   element_attr => {'data-placeholder' => 'Click to select a RADIUS Server'},
+   tags => { after_element => \&help,
+             help => 'The RADIUS Server(s) to proxy authentication' },
+  );
+
+has_field 'eduroam_radius_auth_proxy_type' =>
+  (
+   type => 'Select',
+   label => 'type',
+   required => 1,
+   options =>
+   [
+    { value => 'keyed-balance', label => 'Keyed Balance' },
+    { value => 'fail-over', label => 'Fail Over' },
+    { value => 'load-balance', label => 'Load Balance' },
+    { value => 'client-balance', label => 'Client Balance' },
+    { value => 'client-port-balance', label => 'Client Port Balance' },
+   ],
+   default => 'keyed-balance',
+   tags => { after_element => \&help,
+             help => 'Home server pool type' },
+  );
+
+  has_field 'eduroam_radius_auth_compute_in_pf' =>
+  (
+   type => 'Toggle',
+   checkbox_value => "enabled",
+   unchecked_value => "disabled",
+   default => "enabled",
+   label => 'Authorize from PacketFence',
+   tags => { after_element => \&help,
+             help => 'Should we forward the request to PacketFence to have a dynamic answer or do we use the remote proxy server answered attributes ?' },
+  );
+
+has_field 'eduroam_radius_acct' =>
+  (
+   type => 'Select',
+   multiple => 1,
+   label => 'Eduroam RADIUS ACCT',
+   options_method => \&options_radius,
+   element_class => ['chzn-select'],
+   element_attr => {'data-placeholder' => 'Click to select a RADIUS Server'},
+   tags => { after_element => \&help,
+             help => 'The RADIUS Server(s) to proxy accounting' },
+  );
+
+has_field 'eduroam_radius_acct_proxy_type' =>
+  (
+   type => 'Select',
+   label => 'type',
+   required => 1,
+   options =>
+   [
+    { value => 'keyed-balance', label => 'Keyed Balance' },
+    { value => 'fail-over', label => 'Fail Over' },
+    { value => 'load-balance', label => 'Load Balance' },
+    { value => 'client-balance', label => 'Client Balance' },
+    { value => 'client-port-balance', label => 'Client Port Balance' },
+   ],
+   default => 'load-balance',
+   tags => { after_element => \&help,
+             help => 'Home server pool type' },
+  );
+
 has_field 'radius_strip_username' =>
   (
    type => 'Toggle',

--- a/html/pfappserver/root/config/realm/view.tt
+++ b/html/pfappserver/root/config/realm/view.tt
@@ -23,6 +23,15 @@
         [% form.field('radius_acct').render | none %]
         [% form.field('radius_acct_proxy_type').render | none %]
         </div>
+        <h2 style="text-align: center;"><span>Freeradius Eduroam Proxy Configuration</span></h2>
+        <div class="card-block">
+        [% form.field('eduroam_options').render | none %]
+        [% form.field('eduroam_radius_auth').render | none %]
+        [% form.field('eduroam_radius_auth_proxy_type').render | none %]
+        [% form.field('eduroam_radius_auth_compute_in_pf').render | none %]
+        [% form.field('eduroam_radius_acct').render | none %]
+        [% form.field('eduroam_radius_acct_proxy_type').render | none %]
+        </div>
         <h2 style="text-align: center;"><span>Stripping Configuration</span></h2>
         <div class="card-block">
         [% form.field('portal_strip_username').render | none %]

--- a/html/pfappserver/root/static.alt/src/globals/configuration/pfConfigurationRealms.js
+++ b/html/pfappserver/root/static.alt/src/globals/configuration/pfConfigurationRealms.js
@@ -232,6 +232,82 @@ export const pfConfigurationRealmViewFields = (context = {}) => {
           ]
         },
         {
+          label: i18n.t('Freeradius Eduroam Proxy Configuration'), labelSize: 'lg'
+        },
+        {
+          label: i18n.t('Eduroam Realm Options'),
+          text: i18n.t('You can add Eduroam FreeRADIUS options in the realm definition.'),
+          fields: [
+            {
+              key: 'eduroam_options',
+              component: pfFormTextarea,
+              attrs: pfConfigurationAttributesFromMeta(meta, 'eduroam_options'),
+              validators: pfConfigurationValidatorsFromMeta(meta, 'eduroam_options', 'Realm options')
+            }
+          ]
+        },
+        {
+          label: i18n.t('Eduroam RADIUS AUTH'),
+          text: i18n.t('The RADIUS Server(s) to proxy authentication.'),
+          fields: [
+            {
+              key: 'eduroam_radius_auth',
+              component: pfFormChosen,
+              attrs: pfConfigurationAttributesFromMeta(meta, 'radius_auth'),
+              validators: pfConfigurationValidatorsFromMeta(meta, 'radius_auth', 'RADIUS AUTH')
+            }
+          ]
+        },
+        {
+          label: i18n.t('Type'),
+          text: i18n.t('Home server pool type.'),
+          fields: [
+            {
+              key: 'eduroam_radius_auth_proxy_type',
+              component: pfFormChosen,
+              attrs: pfConfigurationAttributesFromMeta(meta, 'eduroam_radius_auth_proxy_type'),
+              validators: pfConfigurationValidatorsFromMeta(meta, 'eduroam_radius_auth_proxy_type', 'Type')
+            }
+          ]
+        },
+        {
+          label: i18n.t('Authorize from PacketFence'),
+          text: i18n.t('Should we forward the request to PacketFence to have a dynamic answer or do we use the remote proxy server answered attributes?'),
+          fields: [
+            {
+              key: 'eduroam_radius_auth_compute_in_pf',
+              component: pfFormRangeToggle,
+              attrs: {
+                values: { checked: 'enabled', unchecked: 'disabled' }
+              }
+            }
+          ]
+        },
+        {
+          label: i18n.t('Eduroam RADIUS ACCT'),
+          text: i18n.t('The RADIUS Server(s) to proxy accounting.'),
+          fields: [
+            {
+              key: 'eduroam_radius_acct_chosen',
+              component: pfFormChosen,
+              attrs: pfConfigurationAttributesFromMeta(meta, 'radius_auth'),
+              validators: pfConfigurationValidatorsFromMeta(meta, 'radius_auth', 'RADIUS ACCT')
+            }
+          ]
+        },
+        {
+          label: i18n.t('Type'),
+          text: i18n.t('Home server pool type.'),
+          fields: [
+            {
+              key: 'eduroam_radius_acct_proxy_type',
+              component: pfFormChosen,
+              attrs: pfConfigurationAttributesFromMeta(meta, 'eduroam_radius_acct_proxy_type'),
+              validators: pfConfigurationValidatorsFromMeta(meta, 'eduroam_radius_acct_proxy_type', 'Type')
+            }
+          ]
+        },
+        {
           label: i18n.t('Stripping Configuration'), labelSize: 'lg'
         },
         {

--- a/lib/pf/services/manager/radiusd_child.pm
+++ b/lib/pf/services/manager/radiusd_child.pm
@@ -368,30 +368,45 @@ EOT
         %tags = ();
         $tags{'template'} = "$conf_dir/raddb/sites-available/eduroam";
         $tags{'local_realm'} = '';
+        $tags{'local_realm_acct'} = '        if (User-Name =~ /@/) {';
+        my $found_acct = $FALSE;
         my @realms;
+        $tags{'local_realm'} .= << "EOT";
+            update control {
+                Proxy-To-Realm := "eduroam"
+            }
+EOT
         foreach my $realm ( @{$eduroam_authentication_source[0]{'local_realm'}} ) {
-             push (@realms, "Realm == \"$realm\"");
-        }
-        if (@realms) {
-            $tags{'local_realm'} .= '            if ( ';
-            $tags{'local_realm'} .=  join(' || ', @realms);
-            $tags{'local_realm'} .= ' ) {'."\n";
-            $tags{'local_realm'} .= <<"EOT";
+            if ($pf::config::ConfigRealm{$realm}->{'eduroam_radius_auth'} ) {
+                $tags{'local_realm'} .= '            if ( Realm == "'.$realm.'" ) {'."\n";
+                $tags{'local_realm'} .= <<"EOT";
                 update control {
-                    Proxy-To-Realm := "packetfence"
-                }
-            } else {
-                update control {
-                    Proxy-To-Realm := "eduroam"
+                    Proxy-To-Realm := "eduroam.$realm"
                 }
             }
 EOT
-        } else {
-        $tags{'local_realm'} = << "EOT";
+            } else {
+                $tags{'local_realm'} = << "EOT";
                 update control {
                     Proxy-To-Realm := "eduroam"
                 }
 EOT
+            }
+            if ($pf::config::ConfigRealm{$realm}->{'eduroam_radius_acct'} ) {
+                $found_acct = $TRUE;
+                $tags{'local_realm_acct'} .= '            if ( Realm == "'.$realm.'" ) {'."\n";
+                $tags{'local_realm_acct'} .= <<"EOT";
+                update control {
+                    Proxy-To-Realm := "eduroam.$realm"
+                }
+            }
+EOT
+            }
+        }
+        if ($found_acct) {
+            $tags{'local_realm_acct'} .= '        }';
+        } else {
+            $tags{'local_realm_acct'} = '';
         }
         $tags{'reject_realm'} = '';
         my @reject_realms;
@@ -687,6 +702,68 @@ EOT
 }
 EOT
         }
+        # Generate Eduroam realms config
+	my $eduroam_options = $pf::config::ConfigRealm{$realm}->{'eduroam_options'} || '';
+        $tags{'eduroam_config'} .= <<"EOT";
+realm eduroam.$realm {
+$eduroam_options
+EOT
+        if ($pf::config::ConfigRealm{$realm}->{'eduroam_radius_auth'} ) {
+            $tags{'eduroam_config'} .= <<"EOT";
+auth_pool = eduroam_auth_pool_$realm
+EOT
+        }
+        if ($pf::config::ConfigRealm{$realm}->{'eduroam_radius_acct'}) {
+            $tags{'eduroam_config'} .= <<"EOT";
+acct_pool = eduroam_acct_pool_$realm
+EOT
+        }
+        if($pf::config::ConfigRealm{$realm}->{'eduroam_radius_auth'} || $pf::config::ConfigRealm{$realm}->{'eduroam_radius_acct'}) {
+            $tags{'eduroam_config'} .= <<"EOT";
+}
+
+EOT
+        }
+        if ($pf::config::ConfigRealm{$realm}->{'eduroam_radius_auth'} ) {
+            $tags{'eduroam_config'} .= <<"EOT";
+home_server_pool eduroam_auth_pool_$realm {
+type = $pf::config::ConfigRealm{$realm}->{'eduroam_radius_auth_proxy_type'}
+EOT
+            push(@radius_sources, split(',',$pf::config::ConfigRealm{$realm}->{'eduroam_radius_auth'}));
+            foreach my $radius (split(',',$pf::config::ConfigRealm{$realm}->{'eduroam_radius_auth'})) {
+
+                $tags{'eduroam_config'} .= <<"EOT";
+home_server = $radius
+EOT
+            }
+            $tags{'eduroam_config'} .= <<"EOT";
+}
+
+EOT
+        }
+        if ($pf::config::ConfigRealm{$realm}->{'eduroam_radius_acct'}) {
+            $tags{'eduroam_config'} .= <<"EOT";
+home_server_pool eduroam_acct_pool_$realm {
+type = $pf::config::ConfigRealm{$realm}->{'eduroam_radius_acct_proxy_type'}
+EOT
+            push(@radius_sources,split(',',$pf::config::ConfigRealm{$realm}->{'eduroam_radius_acct'}));
+            foreach my $radius (split(',',$pf::config::ConfigRealm{$realm}->{'eduroam_radius_acct'})) {
+
+                $tags{'eduroam_config'} .= <<"EOT";
+home_server = $radius
+EOT
+            }
+            $tags{'eduroam_config'} .= <<"EOT";
+}
+
+EOT
+        }
+         if(!$pf::config::ConfigRealm{$realm}->{'eduroam_radius_auth'} && !$pf::config::ConfigRealm{$realm}->{'eduroam_radius_acct'}) {
+            $tags{'eduroam_config'} .= <<"EOT";
+}
+
+EOT
+        }
     }
     foreach my $radius (uniq @radius_sources) {
         my $source = pf::authentication::getAuthenticationSource($radius);
@@ -850,48 +927,6 @@ EOT
         home_server =  eduroam$i.cluster
 EOT
                 $i++;
-            }
-            $tags{'local_realm'} = '';
-            my @realms;
-            foreach my $realm ( @{$eduroam_authentication_source[0]{'local_realm'}} ) {
-                 push (@realms, "Realm == \"$realm\"");
-            }
-            if (@realms) {
-                $tags{'local_realm'} .= 'if ( ';
-                $tags{'local_realm'} .=  join(' || ', @realms);
-                $tags{'local_realm'} .= ' ) {'."\n";
-                $tags{'local_realm'} .= <<"EOT";
-                update control {
-                    Proxy-To-Realm := "packetfence"
-                }
-            } else {
-                update control {
-                    Load-Balance-Key := "%{Calling-Station-Id}"
-                    Proxy-To-Realm := "eduroam.cluster"
-                }
-            }
-EOT
-            } else {
-$tags{'local_realm'} = << "EOT";
-                    update control {
-                        Load-Balance-Key := "%{Calling-Station-Id}"
-                        Proxy-To-Realm := "eduroam.cluster"
-                    }
-EOT
-            }
-            $tags{'reject_realm'} = '';
-            my @reject_realms;
-            foreach my $reject_realm ( @{$eduroam_authentication_source[0]{'reject_realm'}} ) {
-                 push (@reject_realms, "Realm == \"$reject_realm\"");
-            }
-            if (@reject_realms) {
-                $tags{'reject_realm'} .= 'if ( ';
-                $tags{'reject_realm'} .=  join(' || ', @reject_realms);
-                $tags{'reject_realm'} .= ' ) {'."\n";
-                $tags{'reject_realm'} .= <<"EOT";
-                reject
-            }
-EOT
             }
             parse_template( \%tags, "$conf_dir/radiusd/eduroam-cluster", "$install_dir/raddb/sites-enabled/eduroam-cluster" );
         } else {


### PR DESCRIPTION
# Description
Added the way to proxy eduroam local realm to another radius server (like nps)

# Impacts
- RADIUS eduroam workflow

# Delete branch after merge
(REQUIRED)
YES | NO

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
## New Features
* Added a way to forward eduroam local realm to a define radius server instead of packetfence.
