### PR TITLE
feature/delay_ldap_connection

### DIFF
--- a/lib/pf/Authentication/Source/LDAPSource.pm
+++ b/lib/pf/Authentication/Source/LDAPSource.pm
@@ -333,12 +333,15 @@ sub _match_in_subclass {
     my $timer = pf::StatsD::Timer->new({ 'stat' => "${timer_stat_prefix}",  level => 6});
 
     my $cached_connection = $self->_cached_connection;
+    my ($connection, $LDAPServer, $LDAPServerPort);
     unless ( $cached_connection ) {
-        return undef;
+        ($connection, $LDAPServer, $LDAPServerPort) = $self->_connect();
+        if (! defined($connection)) {
+            return undef;
+        }
+
+        $self->_cached_connection([$connection, $LDAPServer, $LDAPServerPort]);
     }
-    my ( $connection, $LDAPServer, $LDAPServerPort ) = @$cached_connection;
-
-
 
     my @attributes = map { $_->{'attribute'} } @{$own_conditions};
     my $result = do {
@@ -588,22 +591,6 @@ sub postMatchProcessing {
         my ( $connection, $LDAPServer, $LDAPServerPort ) = @$cached_connection;
         $self->_cached_connection(undef);
     }
-}
-
-=head2 preMatchProcessing
-
-Setup any resouces need for matching
-
-=cut
-
-sub preMatchProcessing {
-    my ($self) = @_;
-    my ( $connection, $LDAPServer, $LDAPServerPort ) = $self->_connect();
-    if (! defined($connection)) {
-        return undef;
-    }
-
-    $self->_cached_connection([$connection, $LDAPServer, $LDAPServerPort]);
 }
 
 =head2 _makefilter

--- a/lib/pf/Authentication/Source/LDAPSource.pm
+++ b/lib/pf/Authentication/Source/LDAPSource.pm
@@ -333,15 +333,16 @@ sub _match_in_subclass {
     my $timer = pf::StatsD::Timer->new({ 'stat' => "${timer_stat_prefix}",  level => 6});
 
     my $cached_connection = $self->_cached_connection;
-    my ($connection, $LDAPServer, $LDAPServerPort);
     unless ( $cached_connection ) {
-        ($connection, $LDAPServer, $LDAPServerPort) = $self->_connect();
+        my ($connection, $LDAPServer, $LDAPServerPort) = $self->_connect();
         if (! defined($connection)) {
             return undef;
         }
 
-        $self->_cached_connection([$connection, $LDAPServer, $LDAPServerPort]);
+        $cached_connection = [$connection, $LDAPServer, $LDAPServerPort];
+        $self->_cached_connection($cached_connection);
     }
+    my ( $connection, $LDAPServer, $LDAPServerPort ) = @$cached_connection;
 
     my @attributes = map { $_->{'attribute'} } @{$own_conditions};
     my $result = do {


### PR DESCRIPTION
Description
===========
Avoid connecting to LDAP for _match_in_subclass if the match was already cached

Impacts
=======
LDAP matching

Delete branch after merge
=========================
NO

Checklist
=========
- [ ] Document the feature
- [x] Add unit tests
- [ ] Add acceptance tests (TestLink)