### PR TITLE
Remove Jessie and update docs for Stretch

### DIFF
--- a/docs/PacketFence_Clustering_Guide.asciidoc
+++ b/docs/PacketFence_Clustering_Guide.asciidoc
@@ -19,7 +19,7 @@ This guide has been created to give a quick start to install active/active clust
 Assumptions
 -----------
 * You have at least three (3) installed PacketFence (v7+) servers
-* The servers are running one of RHEL / CentOS 7 / Debian Jessie
+* The servers are running one of RHEL / CentOS 7 / Debian 9
 * The servers have identical identifiers for network interfaces (e.g. eth0)
 * The servers network interfaces are on the same layer 2 network
 * The servers must have IPv6 disabled.
@@ -49,12 +49,15 @@ Disable Percona repositories, so that installing software from that repository r
   # sed -i 's/enabled = 1/enabled = 0/g' /etc/yum.repos.d/percona-release.repo
   # yum install percona-xtrabackup socat --enablerepo=percona-release-x86_64
 
-On Debian:
-
-  # wget https://repo.percona.com/apt/percona-release_0.1-4.$(lsb_release -sc)_all.deb
-  # dpkg -i percona-release_0.1-4.$(lsb_release -sc)_all.deb
-  # apt-get update
-  # apt-get -y install percona-xtrabackup-24
+.On Debian:
+[source,bash]
+----
+apt-get install lsb-release
+wget https://repo.percona.com/apt/percona-release_0.1-4.$(lsb_release -sc)_all.deb
+dpkg -i percona-release_0.1-4.$(lsb_release -sc)_all.deb
+apt-get update
+apt-get -y install percona-xtrabackup-24
+----
 
 For the next steps, you want to make sure that you didn't configure anything in `/usr/local/pf/conf/cluster.conf`. If you already did, comment all the configuration in the file and do a configreload (`/usr/local/pf/bin/pfcmd configreload hard`).
 

--- a/docs/PacketFence_Installation_Guide.asciidoc
+++ b/docs/PacketFence_Installation_Guide.asciidoc
@@ -173,8 +173,8 @@ Regarding SELinux or AppArmor, even if they may be wanted by some
 organizations, PacketFence will not work properly if SELinux or AppArmor are
 enabled. You will need to explicitly disable SELinux from the
 `/etc/selinux/config` file and reboot the machine. For AppArmor, you need to
-follow instructions
-link:https://wiki.debian.org/AppArmor/HowToUse#Disable_AppArmor[on Debian wiki]
+follow instructions on
+link:https://wiki.debian.org/AppArmor/HowToUse#Disable_AppArmor[Debian wiki].
 
 Regarding resolvconf, you can remove the symlink to that file and simply create the `/etc/resolv.conf` file with the content you want.
 
@@ -5113,7 +5113,7 @@ Debian
 
 ----
 apt-get install uuid-runtime
-/usr/local/pf/addons/monit/monitoring-scripts/update.sh 
+/usr/local/pf/addons/monit/monitoring-scripts/update.sh
 ----
 
 Ensure the script outputs: `Update completed successfully`

--- a/docs/PacketFence_Installation_Guide.asciidoc
+++ b/docs/PacketFence_Installation_Guide.asciidoc
@@ -89,7 +89,6 @@ PacketFence supports the following operating systems on the x86_64 architecture:
 [options="compact"]
 * Red Hat Enterprise Linux 7.x Server
 * Community ENTerprise Operating System (CentOS) 7.x
-* Debian 8.0 (Jessie)
 * Debian 9.0 (Stretch)
 
 Make sure that you can install additional packages from your standard distribution. For example, if you are using Red Hat Enterprise Linux, you have to be subscribed to the Red Hat Network before continuing with the PacketFence software installation.
@@ -164,18 +163,18 @@ Make sure your system is up to date and your yum or apt-get database is updated.
 
 On a Debian system, do:
 
-  apt-get update
-  apt-get upgrade
+[source,bash]
+----
+apt-get update
+apt-get upgrade
+----
 
 Regarding SELinux or AppArmor, even if they may be wanted by some
 organizations, PacketFence will not work properly if SELinux or AppArmor are
 enabled. You will need to explicitly disable SELinux from the
 `/etc/selinux/config` file and reboot the machine. For AppArmor, you need to
-execute the following commands:
-
-  update-rc.d -f apparmor stop
-  update-rc.d -f apparmor teardown
-  update-rc.d -f apparmor remove
+follow instructions
+link:https://wiki.debian.org/AppArmor/HowToUse#Disable_AppArmor[on Debian wiki]
 
 Regarding resolvconf, you can remove the symlink to that file and simply create the `/etc/resolv.conf` file with the content you want.
 
@@ -219,19 +218,25 @@ server, DHCP server, RADIUS server) using:
 Debian
 ++++++
 
-In order to use the repository, create a file named `/etc/apt/sources.list.d/packetfence.list`:
+In order to use the repository, create a file named [filename]`/etc/apt/sources.list.d/packetfence.list`:
 
-   echo 'deb http://inverse.ca/downloads/PacketFence/debian jessie jessie' \
-   > /etc/apt/sources.list.d/packetfence.list
+[source,bash]
+----
+echo 'deb http://inverse.ca/downloads/PacketFence/debian stretch stretch' > \
+/etc/apt/sources.list.d/packetfence.list
+----
 
 Once the repository is defined, you can install PacketFence with all its
 dependencies, and the required external services (Database
 server, DHCP server, RADIUS server) using:
 
-  sudo apt-key adv --keyserver keys.gnupg.net \
-  --recv-key 0xFE9E84327B18FF82B0378B6719CDA6A9810273C4
-  sudo apt-get update
-  sudo apt-get install packetfence
+[source,bash]
+----
+sudo apt-key adv --keyserver keys.gnupg.net \
+--recv-key 0xFE9E84327B18FF82B0378B6719CDA6A9810273C4
+sudo apt-get update
+sudo apt-get install packetfence
+----
 
 Getting Started
 ---------------
@@ -3843,15 +3848,10 @@ Additional Packages
 
 In order to use this cache, you will need to install additional packages available from the packetfence-extra repository. These packages will allow PacketFence to query your Active Directory for the NT hash of the users.
 
-CentOS:
-```
-yum install python2-impacket --enablerepo=packetfence-extra
-```
+CentOS: [command]`yum install python2-impacket --enablerepo=packetfence-extra`
 
-Debian:
-```
-apt-get install python-impacket
-```
+Debian: [command]`apt-get install python-impacket`
+
 
 PacketFence Configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/PacketFence_Installation_Guide.asciidoc
+++ b/docs/PacketFence_Installation_Guide.asciidoc
@@ -5396,7 +5396,7 @@ Next, apply the innodb log:
 
 We will now stop MariaDB, move the existing data directory and replace it by the data that was extracted:
 
-NOTE: On Debian the service will be called `mysql` and on CentOS 7 `mariadb`. Make sure you adjust the commands above to your environment.
+NOTE: Make sure you adjust the commands above to your environment.
 
   # service packetfence-mariadb stop
   # mv /var/lib/mysql /var/lib/mysql.bak

--- a/docs/pki/packetfence.asciidoc
+++ b/docs/pki/packetfence.asciidoc
@@ -21,7 +21,7 @@ Installation
 Install the PKI
 +++++++++++++++
 
-NOTE: The PacketFence PKI application is available on the PacketFence repository as the package "packetfence-pki". This is available for CentOS 6, CentOS 7 and Debian 9.
+NOTE: The PacketFence PKI application is available on the PacketFence repository as the package "packetfence-pki". This is available for CentOS 6, CentOS 7 and Debian 7 and Debian 8.
 
 PacketFence PKI can be installed on a standalone machine or on the PacketFence server itself.
 Communication between the PKI and PacketFence proper will take place over a REST API over port 9393.

--- a/docs/pki/packetfence.asciidoc
+++ b/docs/pki/packetfence.asciidoc
@@ -21,7 +21,7 @@ Installation
 Install the PKI
 +++++++++++++++
 
-NOTE: The PacketFence PKI application is available on the PacketFence repository as the package "packetfence-pki". This is available for CentOS 6, CentOS 7 and Debian 7 and Debian 8.
+NOTE: The PacketFence PKI application is available on the PacketFence repository as the package "packetfence-pki". This is available for CentOS 6, CentOS 7 and Debian 9.
 
 PacketFence PKI can be installed on a standalone machine or on the PacketFence server itself.
 Communication between the PKI and PacketFence proper will take place over a REST API over port 9393.


### PR DESCRIPTION
# Description
Update PacketFence documentation to reflect changes on Debian support

# Impacts
PacketFence installation on Debian systems

# Issue
fixes #4315

# Delete branch after merge
YES

# NEWS file entries
## New Features
* Debian 9 support as a replacement for Debian 8

# UPGRADE file entries
Debian 8 is no longer supported starting from PacketFence v9. You need to upgrade your whole distribution before upgrading PacketFence.