### PR TITLE
Debian9: fix permissions on server.key

### DIFF
--- a/debian/packetfence.postinst
+++ b/debian/packetfence.postinst
@@ -74,6 +74,7 @@ case "$1" in
         #Make ssl certificate
         cd /usr/local/pf
         make conf/ssl/server.pem
+        chown pf $PACKETFENCE/conf/ssl/server.key
 
 
         # Create server local RADIUS secret


### PR DESCRIPTION
# Description
Set correct rights on server.key under Debian

# Impacts
Built-in SSL certificates in Debian (captive portal and web admin)

# Issue
fixes #4393

# Delete branch after merge
YES
