### PR TITLE
Pfappserver - append "-copy" to id on clone

### DIFF
--- a/html/pfappserver/root/static.alt/src/views/Configuration/_components/AdminRoleView.vue
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_components/AdminRoleView.vue
@@ -123,6 +123,7 @@ export default {
         if (this.id) {
           // existing
           this.$store.dispatch(`${this.storeName}/getAdminRole`, this.id).then(form => {
+            if (this.isClone) form.id = `${form.id}-${this.$i18n.t('copy')}`
             this.form = form
           })
         } else {

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_components/AuthenticationSourceView.vue
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_components/AuthenticationSourceView.vue
@@ -127,6 +127,7 @@ export default {
         this.$store.dispatch(`${this.storeName}/optionsById`, this.id).then(options => {
           this.options = options
           this.$store.dispatch(`${this.storeName}/getAuthenticationSource`, this.id).then(form => {
+            if (this.isClone) form.id = `${form.id}-${this.$i18n.t('copy')}`
             this.form = form
             this.sourceType = form.type
           })

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_components/BillingTierView.vue
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_components/BillingTierView.vue
@@ -126,6 +126,7 @@ export default {
         if (this.id) {
           // existing
           this.$store.dispatch(`${this.storeName}/getBillingTier`, this.id).then(form => {
+            if (this.isClone) form.id = `${form.id}-${this.$i18n.t('copy')}`
             this.form = form
           })
         } else {

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_components/ConnectionProfileView.vue
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_components/ConnectionProfileView.vue
@@ -156,6 +156,7 @@ export default {
         if (this.id) {
           // existing
           this.$store.dispatch(`${this.storeName}/getConnectionProfile`, this.id).then(form => {
+            if (this.isClone) form.id = `${form.id}-${this.$i18n.t('copy')}`
             this.form = form
           })
         } else {

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_components/DeviceRegistrationView.vue
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_components/DeviceRegistrationView.vue
@@ -123,6 +123,7 @@ export default {
         if (this.id) {
           // existing
           this.$store.dispatch(`${this.storeName}/getDeviceRegistration`, this.id).then(form => {
+            if (this.isClone) form.id = `${form.id}-${this.$i18n.t('copy')}`
             this.form = form
           })
         } else {

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_components/DomainView.vue
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_components/DomainView.vue
@@ -124,6 +124,7 @@ export default {
         if (this.id) {
           // existing
           this.$store.dispatch(`${this.storeName}/getDomain`, this.id).then(form => {
+            if (this.isClone) form.id = `${form.id}-${this.$i18n.t('copy')}`
             this.form = form
           })
         } else {

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_components/FingerbankCombinationView.vue
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_components/FingerbankCombinationView.vue
@@ -121,6 +121,7 @@ export default {
       if (this.id) {
         // existing
         this.$store.dispatch(`${this.storeName}/getCombination`, this.id).then(form => {
+          if (this.isClone) form.id = `${form.id}-${this.$i18n.t('copy')}`
           this.form = form
         })
       }

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_components/FingerbankDeviceView.vue
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_components/FingerbankDeviceView.vue
@@ -121,6 +121,7 @@ export default {
       if (this.id) {
         // existing
         this.$store.dispatch(`${this.storeName}/getDevice`, this.id).then(form => {
+          if (this.isClone) form.id = `${form.id}-${this.$i18n.t('copy')}`
           this.form = form
         })
       }

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_components/FingerbankDhcpFingerprintView.vue
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_components/FingerbankDhcpFingerprintView.vue
@@ -121,6 +121,7 @@ export default {
       if (this.id) {
         // existing
         this.$store.dispatch(`${this.storeName}/getDhcpFingerprint`, this.id).then(form => {
+          if (this.isClone) form.id = `${form.id}-${this.$i18n.t('copy')}`
           this.form = form
         })
       }

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_components/FingerbankDhcpVendorView.vue
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_components/FingerbankDhcpVendorView.vue
@@ -121,6 +121,7 @@ export default {
       if (this.id) {
         // existing
         this.$store.dispatch(`${this.storeName}/getDhcpVendor`, this.id).then(form => {
+          if (this.isClone) form.id = `${form.id}-${this.$i18n.t('copy')}`
           this.form = form
         })
       }

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_components/FingerbankDhcpv6EnterpriseView.vue
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_components/FingerbankDhcpv6EnterpriseView.vue
@@ -121,6 +121,7 @@ export default {
       if (this.id) {
         // existing
         this.$store.dispatch(`${this.storeName}/getDhcpv6Enterprise`, this.id).then(form => {
+          if (this.isClone) form.id = `${form.id}-${this.$i18n.t('copy')}`
           this.form = form
         })
       }

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_components/FingerbankDhcpv6FingerprintView.vue
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_components/FingerbankDhcpv6FingerprintView.vue
@@ -121,6 +121,7 @@ export default {
       if (this.id) {
         // existing
         this.$store.dispatch(`${this.storeName}/getDhcpv6Fingerprint`, this.id).then(form => {
+          if (this.isClone) form.id = `${form.id}-${this.$i18n.t('copy')}`
           this.form = form
         })
       }

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_components/FingerbankMacVendorView.vue
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_components/FingerbankMacVendorView.vue
@@ -121,6 +121,7 @@ export default {
       if (this.id) {
         // existing
         this.$store.dispatch(`${this.storeName}/getMacVendor`, this.id).then(form => {
+          if (this.isClone) form.id = `${form.id}-${this.$i18n.t('copy')}`
           this.form = form
         })
       }

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_components/FingerbankUserAgentView.vue
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_components/FingerbankUserAgentView.vue
@@ -121,6 +121,7 @@ export default {
       if (this.id) {
         // existing
         this.$store.dispatch(`${this.storeName}/getUserAgent`, this.id).then(form => {
+          if (this.isClone) form.id = `${form.id}-${this.$i18n.t('copy')}`
           this.form = form
         })
       }

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_components/FirewallView.vue
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_components/FirewallView.vue
@@ -127,6 +127,7 @@ export default {
         this.$store.dispatch(`${this.storeName}/optionsById`, this.id).then(options => {
           this.options = options
           this.$store.dispatch(`${this.storeName}/getFirewall`, this.id).then(form => {
+            if (this.isClone) form.id = `${form.id}-${this.$i18n.t('copy')}`
             this.form = form
             this.firewallType = form.type
           })

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_components/FloatingDeviceView.vue
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_components/FloatingDeviceView.vue
@@ -123,6 +123,7 @@ export default {
         if (this.id) {
           // existing
           this.$store.dispatch(`${this.storeName}/getFloatingDevice`, this.id).then(form => {
+            if (this.isClone) form.id = `${form.id}-${this.$i18n.t('copy')}`
             this.form = form
           })
         } else {

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_components/PkiProviderView.vue
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_components/PkiProviderView.vue
@@ -127,6 +127,7 @@ export default {
         this.$store.dispatch(`${this.storeName}/optionsById`, this.id).then(options => {
           this.options = options
           this.$store.dispatch(`${this.storeName}/getPkiProvider`, this.id).then(form => {
+            if (this.isClone) form.id = `${form.id}-${this.$i18n.t('copy')}`
             this.form = form
             this.providerType = form.type
           })

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_components/PortalModuleView.vue
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_components/PortalModuleView.vue
@@ -128,6 +128,7 @@ export default {
         this.$store.dispatch(`${this.storeName}/optionsById`, this.id).then(options => {
           this.options = options
           this.$store.dispatch(`${this.storeName}/getPortalModule`, this.id).then(form => {
+            if (this.isClone) form.id = `${form.id}-${this.$i18n.t('copy')}`
             this.form = form
             this.moduleType = form.type
           })

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_components/ProvisioningView.vue
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_components/ProvisioningView.vue
@@ -127,6 +127,7 @@ export default {
         this.$store.dispatch(`${this.storeName}/optionsById`, this.id).then(options => {
           this.options = options
           this.$store.dispatch(`${this.storeName}/getProvisioning`, this.id).then(form => {
+            if (this.isClone) form.id = `${form.id}-${this.$i18n.t('copy')}`
             this.form = form
             this.provisioningType = form.type
           })

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_components/RealmView.vue
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_components/RealmView.vue
@@ -122,6 +122,7 @@ export default {
         if (this.id) {
           // existing
           this.$store.dispatch(`${this.storeName}/getRealm`, this.id).then(form => {
+            if (this.isClone) form.id = `${form.id}-${this.$i18n.t('copy')}`
             this.form = form
           })
         } else {

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_components/RoleView.vue
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_components/RoleView.vue
@@ -121,6 +121,7 @@ export default {
         if (this.id) {
           // existing
           this.$store.dispatch(`${this.storeName}/getRole`, this.id).then(form => {
+            if (this.isClone) form.id = `${form.id}-${this.$i18n.t('copy')}`
             this.form = form
           })
         } else {

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_components/ScanEngineView.vue
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_components/ScanEngineView.vue
@@ -127,6 +127,7 @@ export default {
         this.$store.dispatch(`${this.storeName}/optionsById`, this.id).then(options => {
           this.options = options
           this.$store.dispatch(`${this.storeName}/getScanEngine`, this.id).then(form => {
+            if (this.isClone) form.id = `${form.id}-${this.$i18n.t('copy')}`
             this.form = form
             this.scanType = form.type
           })

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_components/SecurityEventView.vue
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_components/SecurityEventView.vue
@@ -106,6 +106,7 @@ export default {
       if (this.id) {
         // existing
         promise = this.$store.dispatch(`${this.storeName}/getSecurityEvent`, this.id).then(form => {
+          if (this.isClone) form.id = `${form.id}-${this.$i18n.t('copy')}`
           this.form = form
           return form
         })

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_components/SwitchGroupView.vue
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_components/SwitchGroupView.vue
@@ -126,6 +126,7 @@ export default {
         if (this.id) {
           // existing
           this.$store.dispatch(`${this.storeName}/getSwitchGroup`, this.id).then(form => {
+            if (this.isClone) form.id = `${form.id}-${this.$i18n.t('copy')}`
             this.form = form
           })
         } else {

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_components/SwitchView.vue
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_components/SwitchView.vue
@@ -130,6 +130,7 @@ export default {
         this.$store.dispatch(`${this.storeName}/optionsById`, this.id).then(options => {
           this.options = options
           this.$store.dispatch(`${this.storeName}/getSwitch`, this.id).then(form => {
+            if (this.isClone) form.id = `${form.id}-${this.$i18n.t('copy')}`
             this.form = form
             this.switchGroup = form.group
           })

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_components/SyslogForwarderView.vue
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_components/SyslogForwarderView.vue
@@ -127,6 +127,7 @@ export default {
         this.$store.dispatch(`${this.storeName}/optionsById`, this.id).then(options => {
           this.options = options
           this.$store.dispatch(`${this.storeName}/getSyslogForwarder`, this.id).then(form => {
+            if (this.isClone) form.id = `${form.id}-${this.$i18n.t('copy')}`
             this.form = form
             this.syslogForwarderType = form.type
           })

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_components/SyslogParserView.vue
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_components/SyslogParserView.vue
@@ -141,6 +141,7 @@ export default {
         this.$store.dispatch(`${this.storeName}/optionsById`, this.id).then(options => {
           this.options = options
           this.$store.dispatch(`${this.storeName}/getSyslogParser`, this.id).then(form => {
+            if (this.isClone) form.id = `${form.id}-${this.$i18n.t('copy')}`
             this.form = form
             this.syslogParserType = form.type
           })

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_components/WmiRuleView.vue
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_components/WmiRuleView.vue
@@ -122,6 +122,7 @@ export default {
         if (this.id) {
           // existing
           this.$store.dispatch(`${this.storeName}/getWmiRule`, this.id).then(form => {
+            if (this.isClone) form.id = `${form.id}-${this.$i18n.t('copy')}`
             this.form = form
           })
         } else {

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_components/WrixLocationView.vue
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_components/WrixLocationView.vue
@@ -4,8 +4,8 @@
     :disabled="isLoading"
     :isDeletable="isDeletable"
     :form="getForm"
-    :model="wrixLocation"
-    :vuelidate="$v.wrixLocation"
+    :model="form"
+    :vuelidate="$v.form"
     :isNew="isNew"
     :isClone="isClone"
     @validations="setValidations($event)"
@@ -23,7 +23,7 @@
       </h4>
     </template>
     <template slot="footer">
-      <b-card-footer @mouseenter="$v.wrixLocation.$touch()">
+      <b-card-footer @mouseenter="$v.form.$touch()">
         <pf-button-save :disabled="invalidForm" :isLoading="isLoading">
           <template v-if="isNew">{{ $t('Create') }}</template>
           <template v-else-if="isClone">{{ $t('Clone') }}</template>
@@ -82,13 +82,13 @@ export default {
   },
   data () {
     return {
-      wrixLocation: defaults(this), // will be overloaded with the data from the store
-      wrixLocationValidations: {} // will be overloaded with data from the pfConfigView,
+      form: defaults(this), // will be overloaded with the data from the store
+      formValidations: {} // will be overloaded with data from the pfConfigView,
     }
   },
   validations () {
     return {
-      wrixLocation: this.wrixLocationValidations
+      form: this.formValidations
     }
   },
   computed: {
@@ -105,7 +105,7 @@ export default {
       }
     },
     isDeletable () {
-      if (this.isNew || this.isClone || ('not_deletable' in this.wrixLocation && this.wrixLocation.not_deletable)) {
+      if (this.isNew || this.isClone || ('not_deletable' in this.form && this.form.not_deletable)) {
         return false
       }
       return true
@@ -120,17 +120,17 @@ export default {
     },
     create (event) {
       const ctrlKey = this.ctrlKey
-      this.$store.dispatch(`${this.storeName}/createWrixLocation`, this.wrixLocation).then(response => {
+      this.$store.dispatch(`${this.storeName}/createWrixLocation`, this.form).then(response => {
         if (ctrlKey) { // [CTRL] key pressed
           this.close()
         } else {
-          this.$router.push({ name: 'wrixLocation', params: { id: this.wrixLocation.id } })
+          this.$router.push({ name: 'wrixLocation', params: { id: this.form.id } })
         }
       })
     },
     save (event) {
       const ctrlKey = this.ctrlKey
-      this.$store.dispatch(`${this.storeName}/updateWrixLocation`, this.wrixLocation).then(response => {
+      this.$store.dispatch(`${this.storeName}/updateWrixLocation`, this.form).then(response => {
         if (ctrlKey) { // [CTRL] key pressed
           this.close()
         }
@@ -142,16 +142,14 @@ export default {
       })
     },
     setValidations (validations) {
-      this.$set(this, 'wrixLocationValidations', validations)
+      this.$set(this, 'formValidations', validations)
     }
   },
   created () {
     if (this.id) {
-      this.$store.dispatch(`${this.storeName}/getWrixLocation`, this.id).then(data => {
-        this.wrixLocation = Object.assign({}, data)
-        if (this.isClone) {
-          this.wrixLocation.id = null
-        }
+      this.$store.dispatch(`${this.storeName}/getWrixLocation`, this.id).then(form => {
+        if (this.isClone) form.id = `${form.id}-${this.$i18n.t('copy')}`
+        this.form = form
       })
     }
   },


### PR DESCRIPTION
# Description
Automatically append "-copy" suffix to the form `id` on clone.

# Impacts
When cloning the id will have "-copy" appended to it in all configuration sections, expect interfaces and l2_networks (routed).

# Issue
Fixes #4468

# Delete branch after merge
YES

# Checklist
- [n/a] Document the feature
- [n/a] Add unit tests
- [n/a] Add acceptance tests (TestLink)

## Bug Fixes
Fixes #4468
