### PR TITLE
Pfappserver - User\Realm encoding

### DIFF
--- a/html/pfappserver/root/static.alt/src/views/Users/_api/index.js
+++ b/html/pfappserver/root/static.alt/src/views/Users/_api/index.js
@@ -1,5 +1,12 @@
 import apiCall from '@/utils/api'
 
+const encodePID = (pid) => {
+console.log('pid', pid)
+  // 1. replace '/' with '~'
+  // 2. encodeURI
+  return encodeURI(pid.replace('/', '~'))
+}
+
 export default {
   all: params => {
     if (params.sort) {
@@ -20,17 +27,17 @@ export default {
     })
   },
   user: pid => {
-    return apiCall.get(`user/${encodeURI(pid)}`).then(response => {
+    return apiCall.get(`user/${encodePID(pid)}`).then(response => {
       return response.data.item
     })
   },
   nodes: pid => {
-    return apiCall.get(`user/${encodeURI(pid)}/nodes`).then(response => {
+    return apiCall.get(`user/${encodePID(pid)}/nodes`).then(response => {
       return response.data.items
     })
   },
   securityEvents: pid => {
-    return apiCall.get(`user/${encodeURI(pid)}/security_events`).then(response => {
+    return apiCall.get(`user/${encodePID(pid)}/security_events`).then(response => {
       return response.data.items
     })
   },
@@ -42,7 +49,7 @@ export default {
   },
   updateUser: body => {
     const patch = body.quiet ? 'patchQuiet' : 'patch'
-    return apiCall[patch](`user/${encodeURI(body.pid)}`, body).then(response => {
+    return apiCall[patch](`user/${encodePID(body.pid)}`, body).then(response => {
       return response.data
     })
   },
@@ -51,13 +58,13 @@ export default {
   },
   createPassword: body => {
     const post = body.quiet ? 'postQuiet' : 'post'
-    return apiCall[post](`user/${encodeURI(body.pid)}/password`, body).then(response => {
+    return apiCall[post](`user/${encodePID(body.pid)}/password`, body).then(response => {
       return response.data
     })
   },
   updatePassword: body => {
     const patch = body.quiet ? 'patchQuiet' : 'patch'
-    return apiCall[patch](`user/${encodeURI(body.pid)}/password`, body).then(response => {
+    return apiCall[patch](`user/${encodePID(body.pid)}/password`, body).then(response => {
       return response.data
     })
   },
@@ -72,7 +79,7 @@ export default {
     })
   },
   unassignUserNodes: pid => {
-    return apiCall.post(`user/${encodeURI(pid)}/unassign_nodes`)
+    return apiCall.post(`user/${encodePID(pid)}/unassign_nodes`)
   },
   bulkRegisterNodes: body => {
     return apiCall.post(`users/bulk_register`, body).then(response => {

--- a/html/pfappserver/root/static.alt/src/views/Users/_api/index.js
+++ b/html/pfappserver/root/static.alt/src/views/Users/_api/index.js
@@ -1,9 +1,7 @@
 import apiCall from '@/utils/api'
 
 const encodePID = (pid) => {
-console.log('pid', pid)
-  // 1. replace '/' with '~'
-  // 2. encodeURI
+  // 1. replace '/' with '~' (caddy workaround), 2. encodeURI
   return encodeURI(pid.replace('/', '~'))
 }
 

--- a/html/pfappserver/root/static.alt/src/views/Users/_api/index.js
+++ b/html/pfappserver/root/static.alt/src/views/Users/_api/index.js
@@ -20,17 +20,17 @@ export default {
     })
   },
   user: pid => {
-    return apiCall.get(`user/${pid}`).then(response => {
+    return apiCall.get(`user/${encodeURI(pid)}`).then(response => {
       return response.data.item
     })
   },
   nodes: pid => {
-    return apiCall.get(`user/${pid}/nodes`).then(response => {
+    return apiCall.get(`user/${encodeURI(pid)}/nodes`).then(response => {
       return response.data.items
     })
   },
   securityEvents: pid => {
-    return apiCall.get(`user/${pid}/security_events`).then(response => {
+    return apiCall.get(`user/${encodeURI(pid)}/security_events`).then(response => {
       return response.data.items
     })
   },
@@ -42,7 +42,7 @@ export default {
   },
   updateUser: body => {
     const patch = body.quiet ? 'patchQuiet' : 'patch'
-    return apiCall[patch](`user/${body.pid}`, body).then(response => {
+    return apiCall[patch](`user/${encodeURI(body.pid)}`, body).then(response => {
       return response.data
     })
   },
@@ -51,13 +51,13 @@ export default {
   },
   createPassword: body => {
     const post = body.quiet ? 'postQuiet' : 'post'
-    return apiCall[post](`user/${body.pid}/password`, body).then(response => {
+    return apiCall[post](`user/${encodeURI(body.pid)}/password`, body).then(response => {
       return response.data
     })
   },
   updatePassword: body => {
     const patch = body.quiet ? 'patchQuiet' : 'patch'
-    return apiCall[patch](`user/${body.pid}/password`, body).then(response => {
+    return apiCall[patch](`user/${encodeURI(body.pid)}/password`, body).then(response => {
       return response.data
     })
   },
@@ -72,7 +72,7 @@ export default {
     })
   },
   unassignUserNodes: pid => {
-    return apiCall.post(`user/${pid}/unassign_nodes`)
+    return apiCall.post(`user/${encodeURI(pid)}/unassign_nodes`)
   },
   bulkRegisterNodes: body => {
     return apiCall.post(`users/bulk_register`, body).then(response => {

--- a/lib/pf/UnifiedApi/Controller/Crud.pm
+++ b/lib/pf/UnifiedApi/Controller/Crud.pm
@@ -245,7 +245,9 @@ Get id of current resource
 
 sub id {
     my ($self) = @_;
-    url_unescape($self->stash->{$self->url_param_name});
+    my $id = url_unescape($self->stash->{$self->url_param_name});
+    $id =~ s/~/\//g;
+    return $id;
 }
 
 sub create_error_msg {

--- a/lib/pf/UnifiedApi/Controller/Crud.pm
+++ b/lib/pf/UnifiedApi/Controller/Crud.pm
@@ -266,8 +266,9 @@ sub render_create {
     }
 
     my $id = $obj->{$self->primary_key};
-    $id =~ s#/#~#g;
-    $self->res->headers->location($self->make_location_url($id));
+    my $location_id = $id;
+    $location_id =~ s#/#~#g;
+    $self->res->headers->location($self->make_location_url($location_id));
     return $self->render(json => { id => $id , message => "'$id' created"}, status => $status);
 }
 

--- a/lib/pf/UnifiedApi/Controller/Crud.pm
+++ b/lib/pf/UnifiedApi/Controller/Crud.pm
@@ -245,9 +245,14 @@ Get id of current resource
 
 sub id {
     my ($self) = @_;
-    my $id = url_unescape($self->stash->{$self->url_param_name});
-    $id =~ s/~/\//g;
-    return $id;
+    return $self->escape_url_param($self->stash->{$self->url_param_name});
+}
+
+sub escape_url_param {
+    my ($self, $param) = @_;
+    $param = url_unescape($param);
+    $param =~ s/~/\//g;
+    return $param;
 }
 
 sub create_error_msg {
@@ -261,6 +266,7 @@ sub render_create {
     }
 
     my $id = $obj->{$self->primary_key};
+    $id =~ s#/#~#g;
     $self->res->headers->location($self->make_location_url($id));
     return $self->render(json => { id => $id , message => "'$id' created"}, status => $status);
 }

--- a/t/unittest/UnifiedApi/Controller/Users.t
+++ b/t/unittest/UnifiedApi/Controller/Users.t
@@ -32,7 +32,7 @@ my $t = Test::Mojo->new('pf::UnifiedApi');
 #This test will running last
 use Test::NoWarnings;
 my $batch = 5;
-plan tests => $batch * (2 + 2 * $batch) + 41;
+plan tests => $batch * (2 + 2 * $batch) + 42;
 
 my $base_url = "/api/v1/user";
 
@@ -44,7 +44,8 @@ my $base_url = "/api/v1/user";
     my $url = "$base_url/$id";
     $t->post_ok("/api/v1/users/" => json => { pid => $pid })
       ->status_is(201)
-      ->header_is(Location => $url);
+      ->header_is(Location => $url)
+      ->json_is("/id", $pid);
 
     my $location = $t->tx->res->headers->header('Location');
     $t->get_ok($location)

--- a/t/unittest/UnifiedApi/Controller/Users.t
+++ b/t/unittest/UnifiedApi/Controller/Users.t
@@ -32,7 +32,23 @@ my $t = Test::Mojo->new('pf::UnifiedApi');
 #This test will running last
 use Test::NoWarnings;
 my $batch = 5;
-plan tests => $batch * (2 + 2 * $batch) + 31;
+plan tests => $batch * (2 + 2 * $batch) + 36;
+
+{
+    my $n = ($$ + int(rand(999))) % 1000 ;
+    my $pid = sprintf("user_%03d/realm", $n);
+    my $id = $pid;
+    $id =~ s#/#~#g;
+    my $url = "/api/v1/user/$id";
+    $t->post_ok("/api/v1/users/" => json => { pid => $pid })
+      ->status_is(201)
+      ->header_is(Location => $url);
+
+    my $location = $t->tx->res->headers->header('Location');
+    $t->get_ok($location)
+      ->status_is(200);
+}
+
 my @persons;
 
 {


### PR DESCRIPTION
# Description
Adds encoding to API calls to allow backslash `\` in `pid` for `user\realm`.

# Impacts
Encodes /user API endpoints

# Issue
Fixes #4531 

# Delete branch after merge
YES

# Checklist
- [n/a] Document the feature
- [n/a] Add unit tests
- [n/a] Add acceptance tests (TestLink)

## Bug Fixes
* v9-gui: display user with REALM in pid (#4531)