### PR TITLE
Pfappserver add defaults to source rules

### DIFF
--- a/html/pfappserver/root/static.alt/src/components/pfFieldRule.vue
+++ b/html/pfappserver/root/static.alt/src/components/pfFieldRule.vue
@@ -129,11 +129,16 @@ export default {
     disabled: {
       type: Boolean,
       default: false
+    },
+    default: {
+      type: Object,
+      default: () => {
+        return { id: null, description: null, match: 'all', actions: [], conditions: [] }
+      }
     }
   },
   data () {
     return {
-      default:              { id: null, description: null, match: 'all', actions: [], conditions: [] }, // default value
       uuid:                 uuidv4(), // unique id for multiple instances of this component
       actionValidations:    {}, // overloaded from actions (pf-form-fields) child component
       conditionValidations: {} // overloaded from conditions (pf-form-fields) child component

--- a/html/pfappserver/root/static.alt/src/globals/configuration/pfConfigurationAuthenticationSources.js
+++ b/html/pfappserver/root/static.alt/src/globals/configuration/pfConfigurationAuthenticationSources.js
@@ -224,6 +224,13 @@ export const pfConfigurationAuthenticationSourceFields = {
             field: {
               component: pfFieldRule,
               attrs: {
+                default: {
+                  id: null,
+                  description: null,
+                  match: 'all',
+                  actions: [ { type: 'set_access_level', value: null } ],
+                  conditions: []
+                },
                 matchLabel: i18n.t('Select rule match'),
                 actions: {
                   component: pfFieldTypeValue,
@@ -416,6 +423,13 @@ export const pfConfigurationAuthenticationSourceFields = {
             field: {
               component: pfFieldRule,
               attrs: {
+                default: {
+                  id: null,
+                  description: null,
+                  match: 'all',
+                  actions: [ { type: 'set_role', value: 'default' } ],
+                  conditions: []
+                },
                 matchLabel: i18n.t('Select rule match'),
                 actions: {
                   component: pfFieldTypeValue,


### PR DESCRIPTION
# Description
- Adds defaults to authentication rules
- Adds defaults to administration rules

# Impacts
Will automatically chose default actions when creating a new rule in administration rules or authentication rules 

# Issue
fixes #4546 

# Delete branch after merge
YES

# Checklist
- [n/a] Document the feature
- [n/a] Add unit tests
- [n/a] Add acceptance tests (TestLink)

## Bug Fixes
* v9-gui: default actions when creating rules (#4546)