### PR TITLE
fix snmp error

### DIFF
--- a/lib/pf/task/pfsnmp.pm
+++ b/lib/pf/task/pfsnmp.pm
@@ -14,6 +14,7 @@ pf::task::pfsnmp
 
 use strict;
 use warnings;
+use base 'pf::task';
 use pf::log;
 use pf::SwitchFactory;
 use pf::role::custom;

--- a/lib/pf/task/pfsnmp_parsing.pm
+++ b/lib/pf/task/pfsnmp_parsing.pm
@@ -14,6 +14,7 @@ pf::task::pfsnmp_parsing
 
 use strict;
 use warnings;
+use base 'pf::task';
 use pf::log;
 use pf::Redis;
 use pf::SwitchFactory;


### PR DESCRIPTION
# Description
Fix the following error:
 ERROR: [mac:unknown] Can't locate object method "new" via package "pf::task::pfsnmp_parsing" at /usr/local/pf/lib/pf/pfqueue/consumer/redis.pm line 133.

AND

ERROR: [mac:unknown] Can't locate object method "new" via package "pf::task::pfsnmp" at /usr/local/pf/lib/pf/pfqueue/consumer/redis.pm line 133.
