### PR TITLE
Fix pfdhcp duplicates with big registration/inline network + pfstats call

### DIFF
--- a/go/dhcp/api.go
+++ b/go/dhcp/api.go
@@ -172,6 +172,27 @@ func handleStats(res http.ResponseWriter, req *http.Request) {
 	return
 }
 
+func handleDuplicates(res http.ResponseWriter, req *http.Request) {
+	vars := mux.Vars(req)
+
+	if h, ok := intNametoInterface[vars["int"]]; ok {
+		stat := h.handleApiReq(ApiReq{Req: "duplicates", NetInterface: vars["int"], NetWork: vars["network"]})
+
+		outgoingJSON, err := json.Marshal(stat)
+
+		if err != nil {
+			unifiedapierrors.Error(res, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		fmt.Fprint(res, string(outgoingJSON))
+		return
+	}
+
+	unifiedapierrors.Error(res, "Interface not found", http.StatusNotFound)
+	return
+}
+
 func handleDebug(res http.ResponseWriter, req *http.Request) {
 	vars := mux.Vars(req)
 
@@ -316,6 +337,43 @@ func (h *Interface) handleAPIReq(Request APIReq) interface{} {
 	var stats []Stats
 
 	// Send back stats
+	if Request.Req == "duplicates" {
+		for _, v := range h.network {
+
+			var Members []Node
+			var Macs []string
+			id, _ := GlobalTransactionLock.Lock()
+			members := v.dhcpHandler.hwcache.Items()
+			GlobalTransactionLock.Unlock(id)
+			var Count int
+			Count = 0
+			for i, item := range members {
+				Count++
+				result := make(net.IP, 4)
+				binary.BigEndian.PutUint32(result, binary.BigEndian.Uint32(v.dhcpHandler.start.To4())+uint32(item.Object.(int)))
+				_, mac, _ := v.dhcpHandler.available.GetMACIndex(uint64(item.Object.(int)))
+				error := "0"
+				if i != mac {
+					error = "1"
+				}
+				Macs = append(Macs, i)
+				Members = append(Members, Node{IP: result.String(), Mac: i, Pool: mac, Error: error, EndsAt: time.Unix(0, item.Expiration)})
+			}
+			inPoolNotInCache, DuplicateInPool := v.dhcpHandler.available.GetIssues(Macs)
+			var DupInPool map[string]string
+			DupInPool = make(map[string]string)
+			for key, val := range DuplicateInPool {
+				result2 := make(net.IP, 4)
+				binary.BigEndian.PutUint32(result2, binary.BigEndian.Uint32(v.dhcpHandler.start.To4())+uint32(key))
+				DupInPool[result2.String()] = val
+			}
+
+			stats = append(stats, Stats{EthernetName: Request.NetInterface, Net: v.network.String(), Category: v.dhcpHandler.role, Members: Members, Size: v.dhcpHandler.leaseRange, InPoolNotInCache: inPoolNotInCache, DuplicateInPool: DupInPool})
+		}
+		return stats
+	}
+
+	// Send back stats
 	if Request.Req == "stats" {
 		for _, v := range h.network {
 			ipv4Addr, _, erro := net.ParseCIDR(Request.NetWork + "/32")
@@ -361,14 +419,6 @@ func (h *Interface) handleAPIReq(Request APIReq) interface{} {
 				Macs = append(Macs, i)
 				Members = append(Members, Node{IP: result.String(), Mac: i, Pool: mac, Error: error, EndsAt: time.Unix(0, item.Expiration)})
 			}
-			inPoolNotInCache, DuplicateInPool := v.dhcpHandler.available.GetIssues(Macs)
-			var DupInPool map[string]string
-			DupInPool = make(map[string]string)
-			for key, val := range DuplicateInPool {
-				result2 := make(net.IP, 4)
-				binary.BigEndian.PutUint32(result2, binary.BigEndian.Uint32(v.dhcpHandler.start.To4())+uint32(key))
-				DupInPool[result2.String()] = val
-			}
 			_, reserved := IPsFromRange(v.dhcpHandler.ipReserved)
 			if reserved != 1 {
 				Count = Count + reserved
@@ -385,7 +435,7 @@ func (h *Interface) handleAPIReq(Request APIReq) interface{} {
 				Status = "Calculated available IP " + strconv.Itoa(v.dhcpHandler.leaseRange-Count) + " is different than what we have available in the pool " + strconv.Itoa(availableCount)
 			}
 
-			stats = append(stats, Stats{EthernetName: Request.NetInterface, Net: v.network.String(), Free: availableCount, Category: v.dhcpHandler.role, Options: Options, Members: Members, Status: Status, Size: v.dhcpHandler.leaseRange, Used: usedCount, PercentFree: percentfree, PercentUsed: percentused, InPoolNotInCache: inPoolNotInCache, DuplicateInPool: DupInPool})
+			stats = append(stats, Stats{EthernetName: Request.NetInterface, Net: v.network.String(), Free: availableCount, Category: v.dhcpHandler.role, Options: Options, Members: Members, Status: Status, Size: v.dhcpHandler.leaseRange, Used: usedCount, PercentFree: percentfree, PercentUsed: percentused})
 		}
 		return stats
 	}

--- a/go/dhcp/api.go
+++ b/go/dhcp/api.go
@@ -176,7 +176,7 @@ func handleDuplicates(res http.ResponseWriter, req *http.Request) {
 	vars := mux.Vars(req)
 
 	if h, ok := intNametoInterface[vars["int"]]; ok {
-		stat := h.handleApiReq(ApiReq{Req: "duplicates", NetInterface: vars["int"], NetWork: vars["network"]})
+		stat := h.handleAPIReq(APIReq{Req: "duplicates", NetInterface: vars["int"], NetWork: vars["network"]})
 
 		outgoingJSON, err := json.Marshal(stat)
 
@@ -356,7 +356,7 @@ func extractMembers(v Network) ([]Node, []string, int) {
 	return Members, Macs, Count
 }
 
-func (h *Interface) handleApiReq(Request ApiReq) interface{} {
+func (h *Interface) handleAPIReq(Request APIReq) interface{} {
 	var stats []Stats
 
 	if Request.Req == "duplicates" {

--- a/go/dhcp/config.go
+++ b/go/dhcp/config.go
@@ -231,7 +231,7 @@ func (d *Interfaces) readConfig() {
 							DHCPScope.leaseRange = dhcp.IPRange(ip, ips)
 							algorithm, _ := strconv.Atoi(ConfNet.Algorithm)
 							// Initialize dhcp pool
-							available := pool.NewDHCPPool(uint64(dhcp.IPRange(ip, ips)), algorithm)
+							available := pool.NewDHCPPool(ctx, uint64(dhcp.IPRange(ip, ips)), algorithm)
 
 							DHCPScope.available = available
 
@@ -295,7 +295,8 @@ func (d *Interfaces) readConfig() {
 						algorithm, _ := strconv.Atoi(ConfNet.Algorithm)
 
 						// Initialize dhcp pool
-						available := pool.NewDHCPPool(uint64(dhcp.IPRange(net.ParseIP(ConfNet.DhcpStart), net.ParseIP(ConfNet.DhcpEnd))), algorithm)
+						available := pool.NewDHCPPool(ctx, uint64(dhcp.IPRange(net.ParseIP(ConfNet.DhcpStart), net.ParseIP(ConfNet.DhcpEnd))), algorithm)
+						available := pool.NewDHCPPool(uint64(dhcp.IPRange(net.ParseIP(ConfNet.DhcpStart), net.ParseIP(ConfNet.DhcpEnd))), ctx)
 						DHCPScope.available = available
 
 						// Initialize hardware cache

--- a/go/dhcp/config.go
+++ b/go/dhcp/config.go
@@ -296,7 +296,6 @@ func (d *Interfaces) readConfig() {
 
 						// Initialize dhcp pool
 						available := pool.NewDHCPPool(ctx, uint64(dhcp.IPRange(net.ParseIP(ConfNet.DhcpStart), net.ParseIP(ConfNet.DhcpEnd))), algorithm)
-						available := pool.NewDHCPPool(uint64(dhcp.IPRange(net.ParseIP(ConfNet.DhcpStart), net.ParseIP(ConfNet.DhcpEnd))), ctx)
 						DHCPScope.available = available
 
 						// Initialize hardware cache

--- a/go/dhcp/config.go
+++ b/go/dhcp/config.go
@@ -231,7 +231,7 @@ func (d *Interfaces) readConfig() {
 							DHCPScope.leaseRange = dhcp.IPRange(ip, ips)
 							algorithm, _ := strconv.Atoi(ConfNet.Algorithm)
 							// Initialize dhcp pool
-							available := pool.NewDHCPPool(ctx, uint64(dhcp.IPRange(ip, ips)), algorithm)
+							available := pool.NewDHCPPool(ctx, uint64(dhcp.IPRange(ip, ips)), algorithm, StatsdClient)
 
 							DHCPScope.available = available
 
@@ -295,7 +295,7 @@ func (d *Interfaces) readConfig() {
 						algorithm, _ := strconv.Atoi(ConfNet.Algorithm)
 
 						// Initialize dhcp pool
-						available := pool.NewDHCPPool(ctx, uint64(dhcp.IPRange(net.ParseIP(ConfNet.DhcpStart), net.ParseIP(ConfNet.DhcpEnd))), algorithm)
+						available := pool.NewDHCPPool(ctx, uint64(dhcp.IPRange(net.ParseIP(ConfNet.DhcpStart), net.ParseIP(ConfNet.DhcpEnd))), algorithm, StatsdClient)
 						DHCPScope.available = available
 
 						// Initialize hardware cache

--- a/go/dhcp/main.go
+++ b/go/dhcp/main.go
@@ -333,7 +333,7 @@ func (I *Interface) ServeDHCP(ctx context.Context, p dhcp.Packet, msgType dhcp.M
 			GlobalTransactionLock.Unlock(id)
 			return answer
 		}
-		GlobalTransactionCache.Set(cacheKey, 1, time.Duration(1)*time.Second)
+		GlobalTransactionCache.Set(cacheKey, 3, time.Duration(1)*time.Second)
 		GlobalTransactionLock.Unlock(id)
 
 		prettyType := "DHCP" + strings.ToUpper(msgType.String())

--- a/go/dhcp/main.go
+++ b/go/dhcp/main.go
@@ -394,7 +394,7 @@ func (I *Interface) ServeDHCP(ctx context.Context, p dhcp.Packet, msgType dhcp.M
 					handler.hwcache.Delete(p.CHAddr().String())
 
 					// Reserve the ip
-					err, returnedMac = handler.available.ReserveIPIndex(uint64(x.(int)), p.CHAddr().String())
+					returnedMac, err = handler.available.ReserveIPIndex(uint64(x.(int)), p.CHAddr().String())
 					if err != nil {
 						log.LoggerWContext(ctx).Error(err.Error())
 					}
@@ -440,7 +440,7 @@ func (I *Interface) ServeDHCP(ctx context.Context, p dhcp.Packet, msgType dhcp.M
 					} else if err == nil && returnedMac == FreeMac {
 						log.LoggerWContext(ctx).Debug("The IP asked by the device is available in the pool")
 						// The ip is free use it
-						err, returnedMac = handler.available.ReserveIPIndex(uint64(element), p.CHAddr().String())
+						returnedMac, err = handler.available.ReserveIPIndex(uint64(element), p.CHAddr().String())
 						// Reserve the ip
 						if err != nil {
 							log.LoggerWContext(ctx).Error(err.Error())

--- a/go/dhcp/main.go
+++ b/go/dhcp/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/inverse-inc/packetfence/go/sharedutils"
 	"github.com/inverse-inc/packetfence/go/timedlock"
 	dhcp "github.com/krolaw/dhcp4"
+	statsd "gopkg.in/alexcesaro/statsd.v2"
 )
 
 // DHCPConfig global var
@@ -64,10 +65,13 @@ var webservices pfconfigdriver.PfConfWebservices
 
 var intNametoInterface map[string]*Interface
 
-// FreeMac global var
+// StatsdClient global var
+var StatsdClient *statsd.Client
+
+// FreeMac global constant
 const FreeMac = "00:00:00:00:00:00"
 
-// FakeMac global var
+// FakeMac global constant
 const FakeMac = "ff:ff:ff:ff:ff:ff"
 
 func main() {
@@ -119,6 +123,27 @@ func main() {
 			DHCPConfig.detectVIP(sharedutils.RemoveDuplicates(append(interfaces.Element, intDhcp...)))
 
 			time.Sleep(3 * time.Second)
+		}
+	}()
+
+	go func() {
+		var err error
+		var connected bool
+
+		for !connected {
+			var keyConfAdvanced pfconfigdriver.PfConfAdvanced
+			keyConfAdvanced.PfconfigNS = "config::Pf"
+			keyConfAdvanced.PfconfigHostnameOverlay = "yes"
+			pfconfigdriver.FetchDecodeSocket(ctx, &keyConfAdvanced)
+			Options := statsd.Address("localhost:" + keyConfAdvanced.StatsdListenPort)
+
+			StatsdClient, err = statsd.New(Options)
+			if err != nil {
+				log.LoggerWContext(ctx).Error("Error while creating statsd client: " + err.Error())
+				time.Sleep(1 * time.Second)
+			} else {
+				connected = true
+			}
 		}
 	}()
 

--- a/go/dhcp/main.go
+++ b/go/dhcp/main.go
@@ -176,7 +176,7 @@ func main() {
 	router.HandleFunc("/api/v1/dhcp/stats/{int:.*}/{network:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}", handleStats).Methods("GET")
 	router.HandleFunc("/api/v1/dhcp/stats/{int:.*}", handleStats).Methods("GET")
 	router.HandleFunc("/api/v1/dhcp/debug/{int:.*}/{role:(?:[^/]*)}", handleDebug).Methods("GET")
-	router.HandleFunc("/api/v1/dhcp/detectduplicates/{int:.*}", handleDuplicates).Methods("GET")
+	router.HandleFunc("/api/v1/dhcp/detect_duplicates/{int:.*}", handleDuplicates).Methods("GET")
 	router.HandleFunc("/api/v1/dhcp/options/network/{network:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}", handleOverrideNetworkOptions).Methods("POST")
 	router.HandleFunc("/api/v1/dhcp/options/network/{network:(?:[0-9]{1,3}.){3}(?:[0-9]{1,3})}", handleRemoveNetworkOptions).Methods("DELETE")
 	router.HandleFunc("/api/v1/dhcp/options/mac/{mac:(?:[0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}}", handleOverrideOptions).Methods("POST")
@@ -359,7 +359,7 @@ func (I *Interface) ServeDHCP(ctx context.Context, p dhcp.Packet, msgType dhcp.M
 				// Test if we find the the mac address at the index
 				_, returnedMac, err := handler.available.GetMACIndex(uint64(x.(int)))
 				if err != nil {
-					log.LoggerWContext(ctx).Debug(err.Error())
+					log.LoggerWContext(ctx).Error(err.Error())
 				}
 				if returnedMac == p.CHAddr().String() {
 					free = x.(int)
@@ -371,7 +371,7 @@ func (I *Interface) ServeDHCP(ctx context.Context, p dhcp.Packet, msgType dhcp.M
 					// Reserve the ip
 					err, returnedMac = handler.available.ReserveIPIndex(uint64(x.(int)), p.CHAddr().String())
 					if err != nil {
-						log.LoggerWContext(ctx).Debug(err.Error())
+						log.LoggerWContext(ctx).Error(err.Error())
 					}
 					if err == nil && returnedMac == p.CHAddr().String() {
 						free = x.(int)
@@ -407,7 +407,7 @@ func (I *Interface) ServeDHCP(ctx context.Context, p dhcp.Packet, msgType dhcp.M
 					// Test if we find the the mac address at the index
 					_, returnedMac, err := handler.available.GetMACIndex(uint64(element))
 					if err != nil {
-						log.LoggerWContext(ctx).Debug(err.Error())
+						log.LoggerWContext(ctx).Error(err.Error())
 					}
 					if err == nil && returnedMac == p.CHAddr().String() {
 						log.LoggerWContext(ctx).Debug("The IP asked by the device is available in the pool")
@@ -418,7 +418,7 @@ func (I *Interface) ServeDHCP(ctx context.Context, p dhcp.Packet, msgType dhcp.M
 						err, returnedMac = handler.available.ReserveIPIndex(uint64(element), p.CHAddr().String())
 						// Reserve the ip
 						if err != nil {
-							log.LoggerWContext(ctx).Debug(err.Error())
+							log.LoggerWContext(ctx).Error(err.Error())
 							// The ip is not available
 							firstTry = false
 							goto retry

--- a/go/dhcp/pool/pool.go
+++ b/go/dhcp/pool/pool.go
@@ -35,7 +35,7 @@ type DHCPPool struct {
 }
 
 // NewDHCPPool constructor
-func NewDHCPPool(capacity uint64, context context.Context) *DHCPPool {
+func NewDHCPPool(context context.Context, capacity uint64, algorithm int) *DHCPPool {
 	log.SetProcessName("pfdhcp")
 	ctx := log.LoggerNewContext(context)
 	d := &DHCPPool{

--- a/go/dhcp/pool/pool_test.go
+++ b/go/dhcp/pool/pool_test.go
@@ -3,15 +3,17 @@ package pool
 import (
 	"context"
 	"github.com/inverse-inc/packetfence/go/log"
+	statsd "gopkg.in/alexcesaro/statsd.v2"
 	"testing"
 )
 
 var ctx = log.LoggerNewContext(context.Background())
+var StatsdClient, _ = statsd.New()
 
 func TestReserveIPIndex(t *testing.T) {
 	cap := uint64(5)
 	algo := Random
-	dp := NewDHCPPool(ctx, cap, algo)
+	dp := NewDHCPPool(ctx, cap, algo, StatsdClient)
 
 	var err error
 
@@ -54,7 +56,7 @@ func TestReserveIPIndex(t *testing.T) {
 func TestFreeIPIndex(t *testing.T) {
 	cap := uint64(5)
 	algo := Random
-	dp := NewDHCPPool(ctx, cap, algo)
+	dp := NewDHCPPool(ctx, cap, algo, StatsdClient)
 
 	var err error
 	mac := "00:11:22:33:44:55"
@@ -100,7 +102,7 @@ func TestFreeIPIndex(t *testing.T) {
 func TestGetFreeIPIndex(t *testing.T) {
 	cap := uint64(1000)
 	algo := Random
-	dp := NewDHCPPool(ctx, cap, algo)
+	dp := NewDHCPPool(ctx, cap, algo, StatsdClient)
 
 	var err error
 	mac := "00:11:22:33:44:55"
@@ -140,7 +142,7 @@ func TestGetFreeIPIndex(t *testing.T) {
 	// No two pool orders should be the same when getting IPs
 	// This has a very minimal chance of failing even if the code works
 	// If it does, go buy yourself a 6/49
-	dp2 := NewDHCPPool(ctx, cap, algo)
+	dp2 := NewDHCPPool(ctx, cap, algo, StatsdClient)
 
 	order2 := []uint64{}
 
@@ -166,7 +168,7 @@ func TestGetFreeIPIndex(t *testing.T) {
 func TestFreeIPsRemaining(t *testing.T) {
 	cap := uint64(1000)
 	algo := Random
-	dp := NewDHCPPool(ctx, cap, algo)
+	dp := NewDHCPPool(ctx, cap, algo, StatsdClient)
 
 	var expected uint64
 	var got uint64
@@ -215,7 +217,7 @@ func TestFreeIPsRemaining(t *testing.T) {
 func TestCapacity(t *testing.T) {
 	cap := uint64(1000)
 	algo := Random
-	dp := NewDHCPPool(ctx, cap, algo)
+	dp := NewDHCPPool(ctx, cap, algo, StatsdClient)
 
 	if dp.Capacity() != cap {
 		t.Error("Pool capacity not equal the one provided at instantiation")

--- a/go/dhcp/pool/pool_test.go
+++ b/go/dhcp/pool/pool_test.go
@@ -1,13 +1,17 @@
 package pool
 
 import (
+	"context"
+	"github.com/inverse-inc/packetfence/go/log"
 	"testing"
 )
+
+var ctx = log.LoggerNewContext(context.Background())
 
 func TestReserveIPIndex(t *testing.T) {
 	cap := uint64(5)
 	algo := Random
-	dp := NewDHCPPool(cap, algo)
+	dp := NewDHCPPool(ctx, cap, algo)
 
 	var err error
 
@@ -50,7 +54,7 @@ func TestReserveIPIndex(t *testing.T) {
 func TestFreeIPIndex(t *testing.T) {
 	cap := uint64(5)
 	algo := Random
-	dp := NewDHCPPool(cap, algo)
+	dp := NewDHCPPool(ctx, cap, algo)
 
 	var err error
 	mac := "00:11:22:33:44:55"
@@ -96,7 +100,7 @@ func TestFreeIPIndex(t *testing.T) {
 func TestGetFreeIPIndex(t *testing.T) {
 	cap := uint64(1000)
 	algo := Random
-	dp := NewDHCPPool(cap, algo)
+	dp := NewDHCPPool(ctx, cap, algo)
 
 	var err error
 	mac := "00:11:22:33:44:55"
@@ -136,7 +140,7 @@ func TestGetFreeIPIndex(t *testing.T) {
 	// No two pool orders should be the same when getting IPs
 	// This has a very minimal chance of failing even if the code works
 	// If it does, go buy yourself a 6/49
-	dp2 := NewDHCPPool(cap, algo)
+	dp2 := NewDHCPPool(ctx, cap, algo)
 
 	order2 := []uint64{}
 
@@ -162,7 +166,7 @@ func TestGetFreeIPIndex(t *testing.T) {
 func TestFreeIPsRemaining(t *testing.T) {
 	cap := uint64(1000)
 	algo := Random
-	dp := NewDHCPPool(cap, algo)
+	dp := NewDHCPPool(ctx, cap, algo)
 
 	var expected uint64
 	var got uint64
@@ -211,7 +215,7 @@ func TestFreeIPsRemaining(t *testing.T) {
 func TestCapacity(t *testing.T) {
 	cap := uint64(1000)
 	algo := Random
-	dp := NewDHCPPool(cap, algo)
+	dp := NewDHCPPool(ctx, cap, algo)
 
 	if dp.Capacity() != cap {
 		t.Error("Pool capacity not equal the one provided at instantiation")

--- a/go/dhcp/pool/pool_test.go
+++ b/go/dhcp/pool/pool_test.go
@@ -2,9 +2,10 @@ package pool
 
 import (
 	"context"
+	"testing"
+
 	"github.com/inverse-inc/packetfence/go/log"
 	statsd "gopkg.in/alexcesaro/statsd.v2"
-	"testing"
 )
 
 var ctx = log.LoggerNewContext(context.Background())
@@ -25,7 +26,7 @@ func TestReserveIPIndex(t *testing.T) {
 
 	// Try to reserve all the IPs
 	for i := uint64(0); i < dp.capacity; i++ {
-		err, returnedMac := dp.ReserveIPIndex(i, mac)
+		returnedMac, err := dp.ReserveIPIndex(i, mac)
 		if err != nil {
 			t.Error("Got an error and shouldn't have gotten one", err)
 		}
@@ -39,14 +40,14 @@ func TestReserveIPIndex(t *testing.T) {
 	}
 
 	// Try to reserve an IP again
-	err, _ = dp.ReserveIPIndex(3, mac)
+	_, err = dp.ReserveIPIndex(3, mac)
 
 	if err == nil {
 		t.Error("Didn't get an error when trying to double-reserve an IP")
 	}
 
 	// Try to reserve an IP outside the capacity
-	err, _ = dp.ReserveIPIndex(cap, mac)
+	_, err = dp.ReserveIPIndex(cap, mac)
 
 	if err == nil {
 		t.Error("Didn't get an error when trying to reserve an IP outside the capacity")


### PR DESCRIPTION
# Description
Moved duplicates detection in his own func to avoid lock on the dhcp pool by the pfstats call.
Lock of the pool generated duplicates reservation in the dhcp pool.

# Impacts
DHCP Server

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Bug Fixes
* Fix duplicates reservation in the dhcp pool caused by a big registration/inline network and pfstats call

