### PR TITLE
Enable CoA in inline

### DIFF
--- a/html/pfappserver/lib/pfappserver/Form/Config/Network/Routed.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Network/Routed.pm
@@ -79,6 +79,14 @@ has_field 'nat_enabled' => (
     label => 'Enable NATting',
 );
 
+has_field 'coa' => (
+    type => 'Toggle',
+    checkbox_value => "enabled",
+    unchecked_value => "disabled",
+    default => "disabled",
+    label => 'Enable CoA',
+);
+
 has_field 'dhcpd' =>
   (
    type => 'Toggle',

--- a/html/pfappserver/lib/pfappserver/Form/Interface.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Interface.pm
@@ -110,6 +110,13 @@ has_field 'reg_network' =>
              help => 'When split network by role is enabled then this network will be used as the registration network (example: 192.168.0.1/24).' },
   );
 
+has_field 'coa' => (
+    type => 'Toggle',
+    checkbox_value => "enabled",
+    unchecked_value => "disabled",
+    default => "disabled",
+    label => 'Enable CoA',
+);
 
 =head2 options_type
 

--- a/html/pfappserver/lib/pfappserver/Model/Interface.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Interface.pm
@@ -271,6 +271,7 @@ sub get {
                 $result->{"$interface"}->{'dhcpd_enabled'} = $network->{dhcpd};
                 $result->{"$interface"}->{'nat_enabled'} = $network->{nat_enabled};
                 $result->{"$interface"}->{'split_network'} = $network->{split_network};
+                $result->{"$interface"}->{'coa'} = $network->{coa};
                 $result->{"$interface"}->{'reg_network'} = $network->{reg_network};
                 $result->{"$interface"}->{'network_iseditable'} = $TRUE;
             }
@@ -546,6 +547,7 @@ sub setType {
             $network_ref->{dhcpd} = isenabled($interface_ref->{'dhcpd_enabled'}) ? 'enabled' : 'disabled';
             $network_ref->{nat_enabled} = isenabled($interface_ref->{'nat_enabled'}) ? 'enabled' : 'disabled';
             $network_ref->{split_network} = isenabled($interface_ref->{'split_network'}) ? 'enabled' : 'disabled';
+            $network_ref->{coa} = isenabled($interface_ref->{'coa'}) ? 'enabled' : 'disabled';
             $network_ref->{reg_network} = $interface_ref->{'reg_network'};
             $network_ref->{dhcp_start} = Net::Netmask->new(@{$interface_ref}{qw(ipaddress netmask)})->nth(10);
             $network_ref->{dhcp_end} = Net::Netmask->new(@{$interface_ref}{qw(ipaddress netmask)})->nth(-10);

--- a/html/pfappserver/root/static.alt/src/globals/configuration/pfConfigurationInterfaces.js
+++ b/html/pfappserver/root/static.alt/src/globals/configuration/pfConfigurationInterfaces.js
@@ -457,6 +457,20 @@ export const pfConfigurationInterfaceViewFields = (context = {}) => {
           ]
         },
         {
+          if: ['inlinel2'].includes(form.type),
+          label: i18n.t('Enable CoA'),
+          text: i18n.t('This will try to send a CoA to the equipment to reevaluate the access.'),
+          fields: [
+            {
+              key: 'coa',
+              component: pfFormRangeToggle,
+              attrs: {
+                values: { checked: 'enabled', unchecked: 'disabled' }
+              }
+            }
+          ]
+        },
+        {
           if: ['none', 'management'].includes(form.type),
           label: i18n.t('High availability'),
           fields: [

--- a/html/pfappserver/root/static.alt/src/globals/configuration/pfConfigurationInterfaces.js
+++ b/html/pfappserver/root/static.alt/src/globals/configuration/pfConfigurationInterfaces.js
@@ -459,7 +459,7 @@ export const pfConfigurationInterfaceViewFields = (context = {}) => {
         {
           if: ['inlinel2'].includes(form.type),
           label: i18n.t('Enable CoA'),
-          text: i18n.t('This will try to send a CoA to the equipment to reevaluate the access.'),
+          text: i18n.t('Enabling this will send a CoA request to the equipment to reevaluate network access of endpoints.'),
           fields: [
             {
               key: 'coa',

--- a/html/pfappserver/root/static.alt/src/globals/configuration/pfConfigurationRoutedNetworks.js
+++ b/html/pfappserver/root/static.alt/src/globals/configuration/pfConfigurationRoutedNetworks.js
@@ -182,6 +182,20 @@ export const pfConfigurationRoutedNetworkViewFields = (context = {}) => {
           ]
         },
         {
+          if: form.type === 'inlinel3',
+          label: i18n.t('Enable CoA'),
+          text: i18n.t('This will try to send a CoA to the equipment to reevaluate the access.'),
+          fields: [
+            {
+              key: 'coa',
+              component: pfFormRangeToggle,
+              attrs: {
+                values: { checked: 'enabled', unchecked: 'disabled' }
+              }
+            }
+          ]
+        },
+        {
           label: null, /* no label */
           fields: [
             {

--- a/html/pfappserver/root/static.alt/src/globals/configuration/pfConfigurationRoutedNetworks.js
+++ b/html/pfappserver/root/static.alt/src/globals/configuration/pfConfigurationRoutedNetworks.js
@@ -184,7 +184,7 @@ export const pfConfigurationRoutedNetworkViewFields = (context = {}) => {
         {
           if: form.type === 'inlinel3',
           label: i18n.t('Enable CoA'),
-          text: i18n.t('This will try to send a CoA to the equipment to reevaluate the access.'),
+          text: i18n.t('Enabling this will send a CoA request to the equipment to reevaluate network access of endpoints.'),
           fields: [
             {
               key: 'coa',

--- a/lib/pf/UnifiedApi/Controller/Config/Interfaces.pm
+++ b/lib/pf/UnifiedApi/Controller/Config/Interfaces.pm
@@ -38,6 +38,7 @@ my %FIELDS = (
     split_network => undef,
     vip => undef,
     vlan => undef,
+    coa => undef,
 );
 
 my %FIELDS_TO_REMOVE_FROM_UPDATE = (

--- a/lib/pf/ipset.pm
+++ b/lib/pf/ipset.pm
@@ -47,7 +47,6 @@ use pf::constants::parking qw($PARKING_IPSET_NAME);
 use pf::constants::node qw($STATUS_UNREGISTERED);
 use pf::api::unifiedapiclient;
 use pf::config::cluster;
-use pf::locationlog qw(locationlog_last_entry_non_inline_mac);
 
 Readonly my $FW_TABLE_FILTER => 'filter';
 Readonly my $FW_TABLE_MANGLE => 'mangle';
@@ -420,10 +419,6 @@ sub update_node {
                         "role_id" => "".$id,
                         "ip"      => $srcip
                     });
-                }
-                if (isenabled($ConfigNetworks{$network}{'coa'})) {
-                   my $locationlog = locationlog_last_entry_non_inline_mac($srcmac);
-		   pf::node::_vlan_reevaluation($srcmac, $locationlog);
                 }
             }
 

--- a/lib/pf/locationlog.pm
+++ b/lib/pf/locationlog.pm
@@ -54,7 +54,8 @@ BEGIN {
         locationlog_set_session
         locationlog_get_session
         locationlog_last_entry_mac
-        
+        locationlog_last_entry_non_inline_mac
+
         locationlog_unique_ssids
     );
 }
@@ -63,6 +64,8 @@ use pf::config qw(
     $WIRED
     $NO_VOIP
     $VOIP
+    $INLINE
+    %connection_type_to_str
 );
 use pf::db;
 use pf::dal;
@@ -603,6 +606,25 @@ sub locationlog_unique_ssids {
         },
         -order_by => 'ssid',
     });
+}
+
+=item locationlog_last_entry_non_inline_mac
+
+Return the last locationlog entry for a mac that is not inline even if it's open or close.
+
+=cut
+
+sub locationlog_last_entry_non_inline_mac {
+   my ($mac) = @_;
+   $mac = clean_mac($mac);
+   return _db_item({
+       -where => {
+           mac => $mac,
+           connection_type => { "!=" => $connection_type_to_str{$INLINE} },
+       },
+       -order_by => { -desc => 'start_time' },
+       -limit => 1,
+   });
 }
 
 =back


### PR DESCRIPTION
# Description
Let's say you have an ssid where you configured mac-auth but the target vlan where the device will stand is a inline vlan.
So in this case the location log will contain a mac-auth and an inline entry for the same device.
When packetfence will try to reevaluate the access it will change the ipset set and will not try to deauth the device from the network.

This PR add the ability to send a CoA to the network equipment and to update the ipset.

# Impacts
Inline setup

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* Make CoA available for inline setup when there is a mix between radius and inline
