### PR TITLE
bugfix

### DIFF
--- a/html/pfappserver/root/static.alt/src/components/pfMixinSearchable.js
+++ b/html/pfappserver/root/static.alt/src/components/pfMixinSearchable.js
@@ -90,7 +90,7 @@ export default {
     searchFields () {
       return [...(new Set([ // unique array
         ...this.searchableOptions.defaultSortKeys, // always include default keys
-        ...this.visibleColumns.map(column => column.key)
+        ...this.visibleColumns.filter(column => !column.exclude).map(column => column.key)
       ]))]
     },
     items () {

--- a/html/pfappserver/root/static.alt/src/views/Nodes/_components/NodesSearch.vue
+++ b/html/pfappserver/root/static.alt/src/views/Nodes/_components/NodesSearch.vue
@@ -459,6 +459,7 @@ export default {
           label: this.$i18n.t('Actions'),
           sortable: false,
           visible: true,
+          exclude: true,
           locked: true,
           formatter: (value, key, item) => {
             return item.mac


### PR DESCRIPTION
# Description

* Fixes the bug that was introduced by this commit: f04c27763d0c53a265b4904cdce6d6be9a1e736e
by removing the filter method the "actions" key was added to the "fields" param for this api endpoint : 
"/api/v1/nodes" which resulted in an error and the entire node search ui breakage .