### PR TITLE
Interfaces&dhcpD

### DIFF
--- a/html/pfappserver/lib/pfappserver/Form/Interface.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Interface.pm
@@ -140,7 +140,7 @@ sub options_additional_listening_daemons {
     my $self = shift;
 
     return map { { value => $_, label => $_ } }
-        qw(portal radius dhcp dns);
+        qw(portal radius dhcp dns dhcp-listener);
 }
 
 =head2 validate
@@ -152,52 +152,33 @@ Force DNS to be defined when the 'inline' type is selected
 sub validate {
     my $self = shift;
 
-    if (defined $self->value->{type} &&
-        ( $self->value->{type} eq 'inlinel2' or
-          $self->value->{type} eq 'inline' )
-        ) {
+    if (defined $self->value->{type} && ( $self->value->{type} eq 'inlinel2' or $self->value->{type} eq 'inline' ) ) {
         unless ($self->value->{dns}) {
             $self->field('dns')->add_error('Please specify your DNS server.');
         }
     }
 
-    # Remove 'portal' additional listening daemon on already enabled httpd.portal interfaces
-    # TODO: Make a list of interface type rather than this ugly "or" - dwuelfrath@inverse.ca 2015.06.11
-    my @types = qw(vlan-registration vlan-isolation dns-enforcement inline inlinel2 portal);
-    if ( defined $self->value->{type} && any { $_ eq $self->value->{type} } @types ) {
-        my %daemons = map { $_ => 1 } @{$self->value->{additional_listening_daemons}};
-        if ( exists($daemons{'portal'}) ) {
-            my $index = firstidx { $_ eq 'portal' } @{$self->value->{additional_listening_daemons}};
-            splice @{$self->value->{additional_listening_daemons}}, $index, 1;
+    sub deDup {
+        my $self = shift;
+        my $daemonN = shift;
+        if ( defined $self->value->{type} && any { $_ eq $self->value->{type} } @_ ) {
+            my %daemons = map { $_ => 1 } @{$self->value->{additional_listening_daemons}};
+            if ( exists($daemons{$daemonN}) ) {
+                my $index = firstidx { $_ eq $daemonN } @{$self->value->{additional_listening_daemons}};
+                splice @{$self->value->{additional_listening_daemons}}, $index, 1;
+            }
         }
     }
-    # Remove double radius type if exist
-    @types = qw(radius);
-    if ( defined $self->value->{type} && any { $_ eq $self->value->{type} } @types ) {
-        my %daemons = map { $_ => 1 } @{$self->value->{additional_listening_daemons}};
-        if ( exists($daemons{'radius'}) ) {
-            my $index = firstidx { $_ eq 'radius' } @{$self->value->{additional_listening_daemons}};
-            splice @{$self->value->{additional_listening_daemons}}, $index, 1;
-        }
-    }
-    # Remove double dns type if exist
-    @types = qw(dns);
-    if ( defined $self->value->{type} && any { $_ eq $self->value->{type} } @types ) {
-        my %daemons = map { $_ => 1 } @{$self->value->{additional_listening_daemons}};
-        if ( exists($daemons{'dns'}) ) {
-            my $index = firstidx { $_ eq 'dns' } @{$self->value->{additional_listening_daemons}};
-            splice @{$self->value->{additional_listening_daemons}}, $index, 1;
-        }
-    }
-    # Remove double dhcp type if exist
-    @types = qw(dhcp);
-    if ( defined $self->value->{type} && any { $_ eq $self->value->{type} } @types ) {
-        my %daemons = map { $_ => 1 } @{$self->value->{additional_listening_daemons}};
-        if ( exists($daemons{'dhcp'}) ) {
-            my $index = firstidx { $_ eq 'dhcp' } @{$self->value->{additional_listening_daemons}};
-            splice @{$self->value->{additional_listening_daemons}}, $index, 1;
-        }
-    }
+
+    $self->deDup('portal',qw(vlan-registration vlan-isolation dns-enforcement inline inlinel2 portal));
+
+    $self->deDup('radius',qw(radius));
+
+    $self->deDup('dns',qw(dns));
+
+    $self->deDup('dhcp',qw(dhcp));
+
+    $self->deDup('dhcp-listener',qw(dhcp-listener));
 }
 
 =head1 COPYRIGHT

--- a/html/pfappserver/lib/pfappserver/Form/Interface.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Interface.pm
@@ -143,6 +143,25 @@ sub options_additional_listening_daemons {
         qw(portal radius dhcp dns dhcp-listener);
 }
 
+=head2 deDup
+
+checks for duplicates types
+
+=cut
+
+
+sub deDup {
+        my $self = shift;
+        my $daemonN = shift;
+        if ( defined $self->value->{type} && any { $_ eq $self->value->{type} } @_ ) {
+            my %daemons = map { $_ => 1 } @{$self->value->{additional_listening_daemons}};
+            if ( exists($daemons{$daemonN}) ) {
+                my $index = firstidx { $_ eq $daemonN } @{$self->value->{additional_listening_daemons}};
+                splice @{$self->value->{additional_listening_daemons}}, $index, 1;
+            }
+        }
+    }
+
 =head2 validate
 
 Force DNS to be defined when the 'inline' type is selected
@@ -158,18 +177,6 @@ sub validate {
         }
     }
 
-    sub deDup {
-        my $self = shift;
-        my $daemonN = shift;
-        if ( defined $self->value->{type} && any { $_ eq $self->value->{type} } @_ ) {
-            my %daemons = map { $_ => 1 } @{$self->value->{additional_listening_daemons}};
-            if ( exists($daemons{$daemonN}) ) {
-                my $index = firstidx { $_ eq $daemonN } @{$self->value->{additional_listening_daemons}};
-                splice @{$self->value->{additional_listening_daemons}}, $index, 1;
-            }
-        }
-    }
-
     $self->deDup('portal',qw(vlan-registration vlan-isolation dns-enforcement inline inlinel2 portal));
 
     $self->deDup('radius',qw(radius));
@@ -179,6 +186,7 @@ sub validate {
     $self->deDup('dhcp',qw(dhcp));
 
     $self->deDup('dhcp-listener',qw(dhcp-listener));
+
 }
 
 =head1 COPYRIGHT

--- a/html/pfappserver/lib/pfappserver/Model/Config/System.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Config/System.pm
@@ -70,6 +70,9 @@ sub getInterfaceForGateway {
 
         my $network = $interfaces_ref->{$interface}->{'network'};
         my $netmask = $interfaces_ref->{$interface}->{'netmask'};
+
+        next if(!defined($network) or !defined($netmask));
+
         my $subnet  = new Net::Netmask($network, $netmask);
 
         return $interface if ( $subnet->match($gateway) );

--- a/html/pfappserver/lib/pfappserver/Model/Interface.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Interface.pm
@@ -493,9 +493,6 @@ sub setType {
     my $type = $interface_ref->{type} || 'none';
     my ($status, $network_ref, $status_msg);
 
-    # we ignore interface type 'Other' (it basically means unsupported in configurator)
-    return if ( $type =~ /^other$/i );
-
     # we delete interface type 'None'
     if ( $type =~ /^none$/i && !$interface_ref->{high_availability} ) {
         $logger->debug("Deleting $interface interface");

--- a/html/pfappserver/root/static.alt/src/globals/configuration/pfConfigurationInterfaces.js
+++ b/html/pfappserver/root/static.alt/src/globals/configuration/pfConfigurationInterfaces.js
@@ -34,7 +34,8 @@ export const pfCongigurationInterfaceDaemons = [
   { value: 'dhcp', text: 'dhcp' },
   { value: 'dns', text: 'dns' },
   { value: 'portal', text: 'portal' },
-  { value: 'radius', text: 'radius' }
+  { value: 'radius', text: 'radius' },
+  { value: 'dhcp-listener', text: 'dhcp-listener' }
 
 ]
 


### PR DESCRIPTION
# Description

This pull requests fixes multiple bugs:

Added to the interfaces config in the admin UI the ability to select the "dhcp-listener" Daemon and by that allowing the iplog to continuously update

Remove the same checks again & again for duplicates types to a single routine .

Added a safety check ("next if(!defined($network) or !defined($netmask));") to avoid error when calling "new Net::Netmask($network, $netmask);" when the interface is missing netmask || network like the case of a physical interface with multiple vlans.

Removed the "return if ( $type =~ /^other$/i );" to solve the following scenario:

add an extra listening daemon for an interface with type = Other
If we will try to remove the extra listening daemon it will fail because of that irrelevant return statment
