### PR TITLE
Added --allow-mschapv2 parameter for ntlm_auth call

### DIFF
--- a/UPGRADE.asciidoc
+++ b/UPGRADE.asciidoc
@@ -1923,6 +1923,19 @@ In order to upgrade the Admin rights, run the following commands
 Upgrading from a version prior to X.Y.Z
 ---------------------------------------
 
+ntlm_auth allow mschapv2 only
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To support ntlmv2 only in Active Directory ( 'Network Security: LAN Manager authentication level' setting changed to 'Send NTLMv2 Response Only. Refuse LM & NTLM') a configuration paramater has been added in the ntlm_auth call in FreeRADIUS (conf/radiusd/mschap.conf) --allow-mschapv2
+
+https://samba-technical.samba.narkive.com/2pdJidyq/pr-patch-added-msv1-0-allow-msvchapv2-flag-to-ntlm-auth
+
+If your Active Directory doesn't support that mode then feel free to remove this configuration parameter.
+
+
+Database schema
+^^^^^^^^^^^^^^^
+
 Changes have been made to the database schema. You will need to update it accordingly.
 An SQL upgrade script has been provided to upgrade the database from the X.X schema to X.Y.
 

--- a/UPGRADE.asciidoc
+++ b/UPGRADE.asciidoc
@@ -1923,16 +1923,6 @@ In order to upgrade the Admin rights, run the following commands
 Upgrading from a version prior to X.Y.Z
 ---------------------------------------
 
-ntlm_auth allow mschapv2 only
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-To support ntlmv2 only in Active Directory ( 'Network Security: LAN Manager authentication level' setting changed to 'Send NTLMv2 Response Only. Refuse LM & NTLM') a configuration paramater has been added in the ntlm_auth call in FreeRADIUS (conf/radiusd/mschap.conf) --allow-mschapv2
-
-https://samba-technical.samba.narkive.com/2pdJidyq/pr-patch-added-msv1-0-allow-msvchapv2-flag-to-ntlm-auth
-
-If your Active Directory doesn't support that mode then feel free to remove this configuration parameter.
-
-
 Database schema
 ^^^^^^^^^^^^^^^
 

--- a/conf/radiusd/mschap.conf.example
+++ b/conf/radiusd/mschap.conf.example
@@ -58,7 +58,7 @@ mschap {
     # Call ntlm_auth through the logging wrapper. Make sure to preserve the -- separator to distinguish between
     # the args to the wrapper and those to the ntlm_auth executable itself
     ntlm_auth = "/usr/local/pf/bin/ntlm_auth_wrapper -p %%statsd_port%% -- \
-         --request-nt-key  --username=%{%{control:AD-Samaccountname}:-%{%{Stripped-User-Name}:-%{mschap:User-Name:-None}}} --challenge=%{mschap:Challenge:-00} --nt-response=%{mschap:NT-Response:-00} --allow-mschapv2"
+         --request-nt-key  --username=%{%{control:AD-Samaccountname}:-%{%{Stripped-User-Name}:-%{mschap:User-Name:-None}}} --challenge=%{mschap:Challenge:-00} --nt-response=%{mschap:NT-Response:-00}"
 
 	# The default is to wait 10 seconds for ntlm_auth to
 	# complete.  This is a long time, and if it's taking that
@@ -242,7 +242,7 @@ mschap chrooted_mschap {
     # Call ntlm_auth through the logging wrapper. Make sure to preserve the -- separator to distinguish between
     # the args to the wrapper and those to the ntlm_auth executable itself
     ntlm_auth = "/usr/bin/sudo /usr/sbin/chroot /chroots/%{PacketFence-Domain} /usr/local/pf/bin/ntlm_auth_wrapper -p %%statsd_port%% -- \
-         --request-nt-key --username=%{%{control:AD-Samaccountname}:-%{%{Stripped-User-Name}:-%{mschap:User-Name:-None}}} --challenge=%{mschap:Challenge:-00} --nt-response=%{mschap:NT-Response:-00} --allow-mschapv2"
+         --request-nt-key --username=%{%{control:AD-Samaccountname}:-%{%{Stripped-User-Name}:-%{mschap:User-Name:-None}}} --challenge=%{mschap:Challenge:-00} --nt-response=%{mschap:NT-Response:-00} %{PacketFence-NTLMv2-Only}"
 
 	# The default is to wait 10 seconds for ntlm_auth to
 	# complete.  This is a long time, and if it's taking that
@@ -385,7 +385,7 @@ mschap chrooted_mschap_machine {
 
         require_strong = yes
         ntlm_auth = "/usr/bin/sudo /usr/sbin/chroot /chroots/%{PacketFence-Domain} /usr/local/pf/bin/ntlm_auth_wrapper -p %%statsd_port%% -- \
-             --request-nt-key --username=%{mschap:User-Name:-None} --challenge=%{mschap:Challenge:-00} --nt-response=%{mschap:NT-Response:-00} --allow-mschapv2"
+             --request-nt-key --username=%{mschap:User-Name:-None} --challenge=%{mschap:Challenge:-00} --nt-response=%{mschap:NT-Response:-00} %{PacketFence-NTLMv2-Only}"
 
 
         allow_retry = no
@@ -398,7 +398,7 @@ mschap mschap_machine {
         require_encryption = yes
         require_strong = yes
         ntlm_auth = "/usr/local/pf/bin/ntlm_auth_wrapper -p %%statsd_port%% -- \
-             --request-nt-key --username=%{mschap:User-Name:-None} --challenge=%{mschap:Challenge:-00} --nt-response=%{mschap:NT-Response:-00} --allow-mschapv2"
+             --request-nt-key --username=%{mschap:User-Name:-None} --challenge=%{mschap:Challenge:-00} --nt-response=%{mschap:NT-Response:-00} %{PacketFence-NTLMv2-Only}"
         allow_retry = no
 	ntlm_auth_timeout = 3
 }

--- a/conf/radiusd/mschap.conf.example
+++ b/conf/radiusd/mschap.conf.example
@@ -58,7 +58,7 @@ mschap {
     # Call ntlm_auth through the logging wrapper. Make sure to preserve the -- separator to distinguish between
     # the args to the wrapper and those to the ntlm_auth executable itself
     ntlm_auth = "/usr/local/pf/bin/ntlm_auth_wrapper -p %%statsd_port%% -- \
-         --request-nt-key  --username=%{%{control:AD-Samaccountname}:-%{%{Stripped-User-Name}:-%{mschap:User-Name:-None}}} --challenge=%{mschap:Challenge:-00} --nt-response=%{mschap:NT-Response:-00}"
+         --request-nt-key  --username=%{%{control:AD-Samaccountname}:-%{%{Stripped-User-Name}:-%{mschap:User-Name:-None}}} --challenge=%{mschap:Challenge:-00} --nt-response=%{mschap:NT-Response:-00} --allow-mschapv2"
 
 	# The default is to wait 10 seconds for ntlm_auth to
 	# complete.  This is a long time, and if it's taking that
@@ -242,7 +242,7 @@ mschap chrooted_mschap {
     # Call ntlm_auth through the logging wrapper. Make sure to preserve the -- separator to distinguish between
     # the args to the wrapper and those to the ntlm_auth executable itself
     ntlm_auth = "/usr/bin/sudo /usr/sbin/chroot /chroots/%{PacketFence-Domain} /usr/local/pf/bin/ntlm_auth_wrapper -p %%statsd_port%% -- \
-         --request-nt-key --username=%{%{control:AD-Samaccountname}:-%{%{Stripped-User-Name}:-%{mschap:User-Name:-None}}} --challenge=%{mschap:Challenge:-00} --nt-response=%{mschap:NT-Response:-00}"
+         --request-nt-key --username=%{%{control:AD-Samaccountname}:-%{%{Stripped-User-Name}:-%{mschap:User-Name:-None}}} --challenge=%{mschap:Challenge:-00} --nt-response=%{mschap:NT-Response:-00} --allow-mschapv2"
 
 	# The default is to wait 10 seconds for ntlm_auth to
 	# complete.  This is a long time, and if it's taking that
@@ -385,7 +385,7 @@ mschap chrooted_mschap_machine {
 
         require_strong = yes
         ntlm_auth = "/usr/bin/sudo /usr/sbin/chroot /chroots/%{PacketFence-Domain} /usr/local/pf/bin/ntlm_auth_wrapper -p %%statsd_port%% -- \
-             --request-nt-key --username=%{mschap:User-Name:-None} --challenge=%{mschap:Challenge:-00} --nt-response=%{mschap:NT-Response:-00}"	
+             --request-nt-key --username=%{mschap:User-Name:-None} --challenge=%{mschap:Challenge:-00} --nt-response=%{mschap:NT-Response:-00} --allow-mschapv2"
 
 
         allow_retry = no
@@ -398,7 +398,7 @@ mschap mschap_machine {
         require_encryption = yes
         require_strong = yes
         ntlm_auth = "/usr/local/pf/bin/ntlm_auth_wrapper -p %%statsd_port%% -- \
-             --request-nt-key --username=%{mschap:User-Name:-None} --challenge=%{mschap:Challenge:-00} --nt-response=%{mschap:NT-Response:-00}"	
+             --request-nt-key --username=%{mschap:User-Name:-None} --challenge=%{mschap:Challenge:-00} --nt-response=%{mschap:NT-Response:-00} --allow-mschapv2"
         allow_retry = no
 	ntlm_auth_timeout = 3
 }

--- a/html/pfappserver/lib/pfappserver/Form/Config/Domain.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Domain.pm
@@ -130,6 +130,14 @@ has_field 'registration' =>
              help => 'If this option is enabled, the device will be able to reach the Active Directory from the registration VLAN.' },
   );
 
+has_field 'ntlmv2_only' =>
+  (
+   type => 'Checkbox',
+   label => 'ntlmv2 only',
+   tags => { after_element => \&help,
+             help => 'If you enabled "Send NTLMv2 Response Only. Refuse LM & NTLM" (only allow ntlm v2) in Network Security: LAN Manager authentication level'},
+  );
+
 has_field 'ntlm_cache' =>
   (
    type => 'Toggle',

--- a/html/pfappserver/root/static.alt/src/globals/configuration/pfConfigurationDomains.js
+++ b/html/pfappserver/root/static.alt/src/globals/configuration/pfConfigurationDomains.js
@@ -224,6 +224,19 @@ export const pfConfigurationDomainViewFields = (context = {}) => {
           ]
         },
         {
+          label: i18n.t('ntlmv2 only'),
+          text: i18n.t('If you enabled "Send NTLMv2 Response Only. Refuse LM & NTLM" (only allow ntlm v2) in Network Security: LAN Manager authentication level'),
+          fields: [
+            {
+              key: 'ntlmv2_only',
+              component: pfFormRangeToggle,
+              attrs: {
+                values: { checked: '1', unchecked: '0' }
+              }
+            }
+          ]
+        },
+        {
           label: i18n.t('Allow on registration'),
           text: i18n.t('If this option is enabled, the device will be able to reach the Active Directory from the registration VLAN.'),
           fields: [

--- a/raddb/mods-config/attr_filter/packetfence-post-auth
+++ b/raddb/mods-config/attr_filter/packetfence-post-auth
@@ -38,4 +38,5 @@ DEFAULT
     PacketFence-Tenant-Id                 !* ANY,
     PacketFence-ShortName                 !* ANY,
     PacketFence-Proxied-From              !* ANY,
-    PacketFence-UserName                  !* ANY
+    PacketFence-UserName                  !* ANY,
+    PacketFence-NTLMv2-Only               !* ANY

--- a/raddb/mods-config/perl/packetfence-multi-domain.pm
+++ b/raddb/mods-config/perl/packetfence-multi-domain.pm
@@ -77,6 +77,8 @@ sub authorize {
         $RAD_REQUEST{"PacketFence-Domain"} = $realm_config->{domain};
     }
 
+    $RAD_REQUEST{"PacketFence-NTLMv2-Only"} = $realm_config->{ntlmv2_only} ? '--allow-mschapv2' : '',
+
     # If it doesn't go into any of the conditions above, then the behavior will be the same as before (non chrooted ntlm_auth)
     return $RADIUS::RLM_MODULE_UPDATED;
 }


### PR DESCRIPTION
# Description
Fix ntlm_auth when the ntlmv2 only support has been enabled in Active Directory.
https://samba-technical.samba.narkive.com/2pdJidyq/pr-patch-added-msv1-0-allow-msvchapv2-flag-to-ntlm-auth

# Impacts
802.1x with AD

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
## Enhancements
* Support for ntlmv2 only with active directory

