### PR TITLE
Moved vlan_pool_technique configuration parameter to the connection profile

### DIFF
--- a/addons/upgrade/to-9.1-move-vlan-pool-technique-parameter.pl
+++ b/addons/upgrade/to-9.1-move-vlan-pool-technique-parameter.pl
@@ -1,0 +1,71 @@
+#!/usr/bin/perl
+
+=head1 NAME
+
+addons/upgrade/to-9.1-move-vlan-pool-technique-parameter.pl
+
+=cut
+
+=head1 DESCRIPTION
+
+Move vlan_pool_technique parameter in profiles.conf
+
+=cut
+
+use strict;
+use warnings;
+use lib qw(/usr/local/pf/lib);
+use pf::IniFiles;
+use pf::file_paths qw($pf_config_file $pf_default_file $profiles_default_config_file);
+use pf::util;
+run_as_pf();
+
+my $ini_default = pf::IniFiles->new(-file => $pf_default_file, -allowempty => 1);
+my $ini = pf::IniFiles->new(-file => $pf_config_file, -allowempty => 1);
+my $profiles = pf::IniFiles->new(-file => $profiles_default_config_file, -allowempty => 1);
+if ($ini) {
+    if ($ini->exists('advanced', 'vlan_pool_technique')) {
+        my $val = $ini->val('advanced', 'vlan_pool_technique');
+        $ini->delval('advanced', 'vlan_pool_technique');
+        $profiles->newval('default', 'vlan_pool_technique', $val);
+    } elsif ($ini_default->exists('advanced', 'vlan_pool_technique')) {
+        my $val = $ini_default->val('advanced', 'vlan_pool_technique');
+        $ini_default->delval('advanced', 'vlan_pool_technique');
+        $profiles->newval('default', 'vlan_pool_technique', $val);
+    }
+
+
+    $ini->DeleteSection();
+    $ini->RewriteConfig();
+    $ini_default->DeleteSection();
+    $ini_default->RewriteConfig();
+    $profiles->RewriteConfig();
+}
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2019 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1211,14 +1211,6 @@ description=<<EOT
 Ability to manage all active devices from a same switch port
 EOT
 
-[advanced.vlan_pool_technique]
-type=toggle
-options=round_robbin|username_hash|random
-description=<<EOT
-The algorithm used to calculate the VLAN in a VLAN pool.
-EOT
-guide_anchor=_introduction_to_role_based_access_control
-
 [advanced.active_directory_os_join_check_bypass]
 type=toggle
 options=enabled|disabled

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -877,11 +877,6 @@ source_to_send_sms_when_creating_users=
 # Ability to manage all active devices from a same switch port
 multihost=disabled
 #
-# advanced.vlan_pool_technique
-#
-# The algorithm used to calculate the VLAN in a VLAN pool.
-vlan_pool_technique = username_hash
-#
 # active_directory_os_join_check_bypass
 #
 # Enable to bypass the operating system domain join verification.

--- a/conf/profiles.conf.defaults
+++ b/conf/profiles.conf.defaults
@@ -33,3 +33,4 @@ unreg_on_acct_stop=disabled
 network_logoff=disabled
 network_logoff_popup=disabled
 dot1x_unset_on_unmatch=disabled
+vlan_pool_technique=username_hash

--- a/docs/api/spec/components/schemas/configbase.yaml
+++ b/docs/api/spec/components/schemas/configbase.yaml
@@ -229,11 +229,6 @@ ConfigBase:
         description: Use the information included in the accounting to update the
           iplog
         type: string
-      vlan_pool_technique:
-        description: 'The algorithm used to calculate the VLAN in a VLAN pool. <a
-          target="_blank" href="/static/doc/PacketFence_Installation_Guide.html#_roles_management"><i
-          class="icon-question-circle-o"></i></a> '
-        type: string
     type: object
   - properties:
       access_duration_choices:

--- a/docs/api/spec/components/schemas/configconnectionprofile.yaml
+++ b/docs/api/spec/components/schemas/configconnectionprofile.yaml
@@ -151,6 +151,11 @@ ConfigConnectionProfile:
       description: This activates automatic deregistation of devices for the profile
         if PacketFence receives a RADIUS accounting stop.
       type: string
+    vlan_pool_technique:
+      description: 'The algorithm used to calculate the VLAN in a VLAN pool. <a
+        target="_blank" href="/static/doc/PacketFence_Installation_Guide.html#_roles_management"><i
+        class="icon-question-circle-o"></i></a> '
+      type: string
   required:
   - id
   - root_module

--- a/docs/api/spec/openapi.json
+++ b/docs/api/spec/openapi.json
@@ -716,10 +716,6 @@
                      "update_iplog_with_accounting" : {
                         "description" : "Use the information included in the accounting to update the iplog",
                         "type" : "string"
-                     },
-                     "vlan_pool_technique" : {
-                        "description" : "The algorithm used to calculate the VLAN in a VLAN pool. <a target=\"_blank\" href=\"/static/doc/PacketFence_Installation_Guide.html#_roles_management\"><i class=\"icon-question-circle-o\"></i></a> ",
-                        "type" : "string"
                      }
                   },
                   "type" : "object"
@@ -1799,6 +1795,10 @@
                },
                "unreg_on_acct_stop" : {
                   "description" : "This activates automatic deregistation of devices for the profile if PacketFence receives a RADIUS accounting stop.",
+                  "type" : "string"
+               },
+               "vlan_pool_technique" : {
+                  "description" : "The algorithm used to calculate the VLAN in a VLAN pool. <a target=\"_blank\" href=\"/static/doc/PacketFence_Installation_Guide.html#_roles_management\"><i class=\"icon-question-circle-o\"></i></a> ",
                   "type" : "string"
                }
             },

--- a/docs/api/spec/openapi.yaml
+++ b/docs/api/spec/openapi.yaml
@@ -587,11 +587,6 @@ components:
             description: Use the information included in the accounting to update
               the iplog
             type: string
-          vlan_pool_technique:
-            description: 'The algorithm used to calculate the VLAN in a VLAN pool.
-              <a target="_blank" href="/static/doc/PacketFence_Installation_Guide.html#_roles_management"><i
-              class="icon-question-circle-o"></i></a> '
-            type: string
         type: object
       - properties:
           access_duration_choices:
@@ -1526,6 +1521,11 @@ components:
         unreg_on_acct_stop:
           description: This activates automatic deregistation of devices for the profile
             if PacketFence receives a RADIUS accounting stop.
+          type: string
+        vlan_pool_technique:
+          description: 'The algorithm used to calculate the VLAN in a VLAN pool.
+            <a target="_blank" href="/static/doc/PacketFence_Installation_Guide.html#_roles_management"><i
+            class="icon-question-circle-o"></i></a> '
           type: string
       required:
       - id

--- a/go/pfconfigdriver/structs.go
+++ b/go/pfconfigdriver/structs.go
@@ -450,7 +450,6 @@ type PfConfAdvanced struct {
 	AdminCspSecurityHeaders          string   `json:"admin_csp_security_headers"`
 	Multihost                        string   `json:"multihost"`
 	SsoOnAccessReevaluation          string   `json:"sso_on_access_reevaluation"`
-	VlanPoolTechnique                string   `json:"vlan_pool_technique"`
 	DisablePfDomainAuth              string   `json:"disable_pf_domain_auth"`
 	TimingStatsLevel                 string   `json:"timing_stats_level"`
 	SsoOnDhcp                        string   `json:"sso_on_dhcp"`

--- a/html/pfappserver/lib/pfappserver/Form/Config/ProfileCommon.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/ProfileCommon.pm
@@ -27,6 +27,7 @@ use pf::ConfigStore::DeviceRegistration;
 use pf::ConfigStore::PortalModule;
 use pf::web::constants;
 use pf::constants::Connection::Profile;
+use pf::constants::role qw( $POOL_USERNAMEHASH $POOL_RANDOM $POOL_ROUND_ROBBIN );
 use pfappserver::Form::Field::Duration;
 use pfappserver::Base::Form;
 with 'pfappserver::Base::Form::Role::Help';
@@ -41,7 +42,7 @@ The main definition block
 
 has_block 'definition' =>
   (
-    render_list => [qw(id description root_module preregistration autoregister reuse_dot1x_credentials dot1x_recompute_role_from_portal dot1x_unset_on_unmatch dpsk default_psk_key unreg_on_acct_stop)],
+    render_list => [qw(id description root_module preregistration autoregister reuse_dot1x_credentials dot1x_recompute_role_from_portal dot1x_unset_on_unmatch dpsk default_psk_key unreg_on_acct_stop vlan_pool_technique)],
   );
 
 =head2 captive_portal
@@ -526,6 +527,25 @@ has_field 'access_registration_when_registered' =>
              help => 'This allows already registered users to be able to re-register their device by first accessing the status page and then accessing the portal. This is useful to allow users to extend their access even though they are already registered.' },
   );
 
+=head2 vlan_pool
+
+Control the vlan pool technique you want to use
+
+=cut
+
+has_field 'vlan_pool_technique' =>
+  (
+   type => 'Select',
+   multiple => 0,
+   required => 1,
+   label => 'Vlan Pool Technique',
+   options_method => \&options_vlan_pool,
+   element_class => ['chzn-select'],
+   default => "round_robbin",
+   tags => { after_element => \&help,
+             help => 'The Vlan Pool Technique to use' },
+  );
+
 =head1 METHODS
 
 =head2 options_locale
@@ -597,6 +617,18 @@ sub options_root_module {
     my $cs = pf::ConfigStore::PortalModule->new;
     return map { $_->{type} eq "Root" ? { value => $_->{id}, label => $_->{description} } : () } @{$cs->readAll("id")};
 }
+
+=head2 options_vlan_pool
+
+Returns the list of the vlan pool technique
+
+=cut
+
+sub options_vlan_pool {
+
+    return map{ { value => $_, label => $_ } } ( $POOL_ROUND_ROBBIN, $POOL_RANDOM, $POOL_USERNAMEHASH );
+}
+
 
 =head2 validate
 

--- a/html/pfappserver/root/static.alt/src/globals/configuration/pfConfigurationAdvanced.js
+++ b/html/pfappserver/root/static.alt/src/globals/configuration/pfConfigurationAdvanced.js
@@ -269,18 +269,6 @@ export const pfConfigurationAdvancedViewFields = (context = {}) => {
           ]
         },
         {
-          label: i18n.t('VLAN pool technique'),
-          text: i18n.t('The algorithm used to calculate the VLAN in a VLAN pool.'),
-          fields: [
-            {
-              key: 'vlan_pool_technique',
-              component: pfFormChosen,
-              attrs: pfConfigurationAttributesFromMeta(meta, 'vlan_pool_technique'),
-              validators: pfConfigurationValidatorsFromMeta(meta, 'vlan_pool_technique', i18n.t('Algorithm'))
-            }
-          ]
-        },
-        {
           label: i18n.t('Disable OS AD join check'),
           text: i18n.t('Enable to bypass the operating system domain join verification.'),
           fields: [

--- a/html/pfappserver/root/static.alt/src/globals/configuration/pfConfigurationConnectionProfiles.js
+++ b/html/pfappserver/root/static.alt/src/globals/configuration/pfConfigurationConnectionProfiles.js
@@ -537,6 +537,18 @@ export const pfConfigurationConnectionProfileViewFields = (context = {}) => {
           ]
         },
         {
+          label: i18n.t('VLAN pool technique'),
+          text: i18n.t('The algorithm used to calculate the VLAN in a VLAN pool.'),
+          fields: [
+            {
+              key: 'vlan_pool_technique',
+              component: pfFormChosen,
+              attrs: pfConfigurationAttributesFromMeta(meta, 'vlan_pool_technique'),
+              validators: pfConfigurationValidatorsFromMeta(meta, 'vlan_pool_technique', i18n.t('Algorithm'))
+            }
+          ]
+        },
+        {
           if: !isDefault,
           label: i18n.t('Filters'),
           fields: [

--- a/lib/pf/constants/role.pm
+++ b/lib/pf/constants/role.pm
@@ -31,6 +31,7 @@ our @EXPORT_OK = qw(
     $REJECT_ROLE
     $POOL_USERNAMEHASH
     $POOL_RANDOM
+    $POOL_ROUND_ROBBIN
 );
 
 our %EXPORT_TAGS = (
@@ -74,6 +75,7 @@ Constant used in the pool code
 
 Readonly::Scalar our $POOL_USERNAMEHASH  => 'username_hash';
 Readonly::Scalar our $POOL_RANDOM  => 'random';
+Readonly::Scalar our $POOL_ROUND_ROBBIN => 'round_robbin';
 
 =head1 AUTHOR
 

--- a/lib/pf/role/pool.pm
+++ b/lib/pf/role/pool.pm
@@ -53,10 +53,10 @@ sub getVlanFromPool {
     return $args->{'vlan'} if $self->rangeValidator($args->{'vlan'});
     my $range = Number::Range->new($args->{'vlan'});
     my $vlan;
-    if ($Config{advanced}{vlan_pool_technique} eq $POOL_USERNAMEHASH) {
+    if ($args->{'profile'}->{'_vlan_pool_technique'} eq $POOL_USERNAMEHASH ) {
         $logger->trace("Use $POOL_USERNAMEHASH algorithm for VLAN pool");
         $vlan = $self->getVlanByUsername($args, $range);
-    } elsif ($Config{advanced}{vlan_pool_technique} eq $POOL_RANDOM) {
+    } elsif ($args->{'profile'}->{'_vlan_pool_technique'} eq $POOL_RANDOM) {
         $logger->trace("Use $POOL_RANDOM algorithm for VLAN pool");
         $vlan = $self->getRandomVlanInPool($args, $range);
     } else {


### PR DESCRIPTION
# Description
Move vlan_pool_technique configuration parameter in connection profile

# Impacts
Vlan Pool

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* Moved vlan_pool_technique configuration parameter to the connection profile

# UPGRADE file entries
* you need to run to-9.1-move-vlan-pool-technique-parameter.pl script to move the configuration parameter from pf.conf.defaults/pf.conf to profiles.conf.defaults
