### PR TITLE
adjust lookup order of fingerbank devices classes

### DIFF
--- a/lib/pf/fingerbank.pm
+++ b/lib/pf/fingerbank.pm
@@ -324,7 +324,8 @@ sub find_device_class {
     my $logger = get_logger;
     my $result = cache()->compute("pf::fingerbank::find_device_class($top_level_parent,$device_name)", sub {
         my $timer = pf::StatsD::Timer->new({level => 7, stat => "pf::fingerbank::find_device_class::cache-compute"});
-        while (my ($k, $other_device_id) = each(%fingerbank::Constant::DEVICE_CLASS_IDS)) {
+        foreach my $k (@fingerbank::Constant::DEVICE_CLASS_LOOKUP_ORDER) {
+            my $other_device_id = $fingerbank::Constant::DEVICE_CLASS_IDS{$k};
             $logger->debug("Checking if device $device_name is a $other_device_id");
             my $is_a = fingerbank::Model::Device->is_a($device_name, $other_device_id);
             if(!defined($is_a)) {


### PR DESCRIPTION
# Description
Use precise lookup order for Fingerbank device class

# Impacts
Fingerbank device class computing

# Code / PR Dependencies
Depends on fingerbank/fingerbank-perl-client that contains 62a6acdf04c81c12a742cfda8d65d316dfaba045 and 132c5fc2a35a13d002f41fe160a65229d227b769

# NEW Package(s) required
The fingerbank package that will contain the 2 commits above

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
## Enhancements
* Adjust Fingerbank device class lookup ordering for added precision of the device class
