### PR TITLE
centralize the firewall SSO on the management node

### DIFF
--- a/lib/pf/firewallsso.pm
+++ b/lib/pf/firewallsso.pm
@@ -55,7 +55,7 @@ sub do_sso {
     my $username = $node->{pid};
     my ($stripped_username, $realm) = pf::util::strip_username($username);
 
-    pf::api::unifiedapiclient->new->call("POST", "/api/v1/firewall_sso/".lc($postdata{method}), {
+    pf::api::unifiedapiclient->management_client->call("POST", "/api/v1/firewall_sso/".lc($postdata{method}), {
         ip                => $postdata{ip},
         mac               => $mac,
         # All values must be string for pfsso


### PR DESCRIPTION
# Description
Centralize firewall SSO on the management node of the cluster

# Impacts
firewall SSO

# Issue
fixes #2932

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
## Enhancements
* Firewall SSO is now performed centrally on the management node of a cluster