### PR TITLE
fixes to LinkedIn for their API v2

### DIFF
--- a/addons/packages/packetfence.spec
+++ b/addons/packages/packetfence.spec
@@ -167,7 +167,7 @@ Requires: perl(Net::Cisco::MSE::REST)
 # We would need to port to the new 3.x API (tracked by #1313)
 Requires: perl(Net::Appliance::Session) = 1.36
 Requires: perl(Net::SSH2) >= 0.63
-Requires: perl(Net::OAuth2) >= 0.57
+Requires: perl(Net::OAuth2) >= 0.65
 # Required by configurator script, pf::config
 Requires: perl(Net::Interface)
 Requires: perl(Net::Netmask)

--- a/debian/control
+++ b/debian/control
@@ -123,7 +123,7 @@ Depends: ${misc:Depends}, vlan,
  liblog-any-adapter-perl,
  liblog-any-adapter-log4perl-perl,
 # oauth2
- libnet-oauth2-perl (>=0.57),
+ libnet-oauth2-perl (>=0.65),
 # used by Captive Portal authentication modules
  libauthen-radius-perl (>=0.24), libauthen-krb5-simple-perl,
 # used by bin/pftest

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/OAuth/LinkedIn.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/OAuth/LinkedIn.pm
@@ -13,7 +13,9 @@ LinkedIn OAuth module
 use Moose;
 extends 'captiveportal::DynamicRouting::Module::Authentication::OAuth';
 
-has '+token_scheme' => (default => 'uri-query:oauth2_access_token');
+use JSON::MaybeXS;
+
+has '+token_scheme' => (default => 'auth-header:Bearer');
 
 has '+source' => (isa => 'pf::Authentication::Source::LinkedInSource');
 
@@ -25,9 +27,8 @@ The e-mail is returned as a quoted string
 
 sub _decode_response {
     my ($self, $response) = @_;
-    my $pid = $response->content();
-    $pid =~ s/"//g;
-    return {email => $pid};
+    my $response = decode_json($response->content());
+    return {email => $response->{elements}->[0]->{'handle~'}->{emailAddress}};
 }
 
 =head1 AUTHOR

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source/LinkedIn.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source/LinkedIn.pm
@@ -93,6 +93,16 @@ has_field 'domains' =>
    tags => { after_element => \&help,
              help => 'Comma separated list of domains that will be resolve with the correct IP addresses.' },
   );
+has_field 'scope' =>
+  (
+   type => 'Text',
+   label => 'Scope',
+   required => 1,
+   default => pf::Authentication::Source::LinkedInSource->meta->get_attribute('scope')->default,
+   element_class => ['input-xlarge'],
+   tags => { after_element => \&help,
+             help => 'The permissions the application requests.' },
+  );
 
 =head1 COPYRIGHT
 

--- a/html/pfappserver/root/static.alt/src/globals/configuration/pfConfigurationAuthenticationSources.js
+++ b/html/pfappserver/root/static.alt/src/globals/configuration/pfConfigurationAuthenticationSources.js
@@ -2416,6 +2416,7 @@ export const pfConfigurationAuthenticationSourceViewFields = (context) => {
             pfConfigurationAuthenticationSourceFields.authorize_path(context),
             { ...pfConfigurationAuthenticationSourceFields.access_token_path(context), ...{ label: i18n.t('API Token Path') } }, // re-label
             pfConfigurationAuthenticationSourceFields.access_token_param(context),
+            pfConfigurationAuthenticationSourceFields.access_scope(context),
             { ...pfConfigurationAuthenticationSourceFields.protected_resource_url(context), ...{ label: i18n.t('API URL of logged user') } }, // re-label
             pfConfigurationAuthenticationSourceFields.redirect_url(context),
             pfConfigurationAuthenticationSourceFields.domains(context),

--- a/lib/pf/Authentication/Source/LinkedInSource.pm
+++ b/lib/pf/Authentication/Source/LinkedInSource.pm
@@ -23,9 +23,10 @@ has 'site' => (isa => 'Str', is => 'rw', default => 'https://www.linkedin.com');
 has 'authorize_path' => (isa => 'Str', is => 'rw', default => '/oauth/v2/authorization');
 has 'access_token_path' => (isa => 'Str', is => 'rw', default => '/oauth/v2/accessToken');
 has 'access_token_param' => (isa => 'Str', is => 'rw', default => 'code');
-has 'protected_resource_url' => (isa => 'Str', is => 'rw', default => 'https://api.linkedin.com/v1/people/~/email-address');
+has 'protected_resource_url' => (isa => 'Str', is => 'rw', default => 'https://api.linkedin.com/v2/emailAddress?q=members&projection=(elements*(handle~))');
 has 'redirect_url' => (isa => 'Str', is => 'rw', required => 1, default => 'https://<hostname>/oauth2/callback');
 has 'domains' => (isa => 'Str', is => 'rw', required => 1, default => 'www.linkedin.com,api.linkedin.com,*.licdn.com,platform.linkedin.com');
+has 'scope' => (isa => 'Str', is => 'rw', default => 'r_emailaddress,r_liteprofile');
 
 =head2 dynamic_routing_module
 


### PR DESCRIPTION
# Description
Adjust our codebase to support LinkedIn API v2 (v1 doesn't work anymore)

# Impacts
LinkedIn OAuth flow

# NEW Package(s) required
A perl-Net-OAuth2 v0.64 + the following commit https://github.com/julsemaan/perl5-Net-OAuth2/commit/2fe7042aeea92dd14830ff19f5a99a0874090490

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
## Bug Fixes
* Fixed LinkedIn social login integration due to deprecated API calls from LinkedIn

# UPGRADE file entries

The LinkedIn API calls have changed drastically. On top of the new LinkedIn modules that are part of the update, you will need to change the following parameter in all your existing LinkedIn sources: `API URL of logged user` -> `https://api.linkedin.com/v2/emailAddress?q=members&projection=(elements*(handle~))`
