### PR TITLE
Adapt build-go.sh script for CI

### DIFF
--- a/addons/packages/build-go.sh
+++ b/addons/packages/build-go.sh
@@ -51,9 +51,6 @@ else
   echo "Will place binaries in $BINDST"
 fi
 
-set -x
-
-
 if [ -z "$DEBPATH" ]; then
     export GOPATH=`mktemp -d`
 else

--- a/addons/packages/build-go.sh
+++ b/addons/packages/build-go.sh
@@ -75,14 +75,10 @@ export GOBIN="$GOPATH/bin"
 GOPATHPF="$GOPATH/src/github.com/inverse-inc/packetfence"
 
 if [ -d "$GOPATHPF" ]; then
-    echo "$GOPATHPF already exists with outdated go/ dir"
-    rsync -av go/ $GOPATHPF/go/
-    echo "Go dirs synchronized"
-    # refresh dependencies
-    cd $GOPATHPF/go
-    $GOPATH/bin/govendor sync -v
-    # change dir to use Makefile in build dir
-    #cd go/
+    echo "$GOPATHPF already exists"
+
+    # # change dir to use Makefile in build dir
+    cd go/
 else
     trap cleanup EXIT
     cd "$GOPATH"

--- a/addons/packages/build-go.sh
+++ b/addons/packages/build-go.sh
@@ -79,9 +79,10 @@ if [ -d "$GOPATHPF" ]; then
     rsync -av go/ $GOPATHPF/go/
     echo "Go dirs synchronized"
     # refresh dependencies
-    ( cd $GOPATHPF/go ; $GOPATH/bin/govendor sync )
+    cd $GOPATHPF/go
+    $GOPATH/bin/govendor sync -v
     # change dir to use Makefile in build dir
-    cd go/
+    #cd go/
 else
     trap cleanup EXIT
     cd "$GOPATH"


### PR DESCRIPTION
# Description
- Refactor `build-go.sh` script to use it inside a Docker images built with Packer (see #4686).
Assumptions in this case:
  * latest vendor dependencies have been moved to `$GOROOT` in Packer build
  * `govendor sync` has been done during Packer build
- Keep current Go builds unchanged

# Impacts
Golang builds

# Code / PR Dependencies
#4686 

# Delete branch after merge
YES