### PR TITLE
feature/return_rule_id_when_matching

### DIFF
--- a/lib/pf/Authentication/Source.pm
+++ b/lib/pf/Authentication/Source.pm
@@ -190,7 +190,7 @@ sub match {
         if ($self->match_rule($rule, $params, $extra)) {
             $logger->info("Matched rule (".$rule->{'id'}.") in source ".$self->id.", returning actions.");
             $self->postMatchProcessing;
-            return $rule->{'actions'};
+            return $rule;
         }
 
     } # foreach my $rule ( @{$self->{'rules'}} ) {

--- a/lib/pf/Authentication/Source/BlackholeSource.pm
+++ b/lib/pf/Authentication/Source/BlackholeSource.pm
@@ -84,13 +84,17 @@ sub available_actions {
 
 sub match {
     my ($self, $params) = @_;
-    return [ 
-        pf::Authentication::Action->new({
-            type    => $Actions::SET_ROLE,
-            value   => $REJECT_ROLE,
-            class   => pf::Authentication::Action->getRuleClassForAction($Actions::SET_ROLE),
-        }) 
-    ];
+    return pf::Authentication::Rule->new(
+        id => $self->id,
+        class => $Rules::AUTH,
+        actions => [
+            pf::Authentication::Action->new({
+                type    => $Actions::SET_ROLE,
+                value   => $REJECT_ROLE,
+                class   => pf::Authentication::Action->getRuleClassForAction($Actions::SET_ROLE),
+            })
+        ],
+    );
        
 }
 

--- a/lib/pf/Authentication/Source/HTTPSource.pm
+++ b/lib/pf/Authentication/Source/HTTPSource.pm
@@ -195,63 +195,52 @@ sub match {
         return undef;
     }
 
-    if (defined $result) {
-
-        my @actions = ();
-        my $action;
-
-        my $access_duration = $result->{'access_duration'};
-        if (defined $access_duration) {
-            $action =  pf::Authentication::Action->new({type => $Actions::SET_ACCESS_DURATION,
-                                                        value => $access_duration});
-            push(@actions, $action);
-        }
-
-        my $access_level = $result->{'access_level'};
-        if (defined $access_level ) {
-            $action =  pf::Authentication::Action->new({type => $Actions::SET_ACCESS_LEVEL,
-                                                        value => $access_level});
-            push(@actions, $action);
-        }
-
-        my $sponsor = $result->{'sponsor'};
-        if (defined($sponsor) && $sponsor == 1) {
-            $action =  pf::Authentication::Action->new({type => $Actions::MARK_AS_SPONSOR,
-                                                        value => 1});
-            push(@actions, $action);
-        }
-
-        my $unregdate = $result->{'unregdate'};
-        if (defined $unregdate) {
-            $action =  pf::Authentication::Action->new({type => $Actions::SET_UNREG_DATE,
-                                                        value => $unregdate});
-            push(@actions, $action);
-        }
-
-        my $category = $result->{'category'};
-        if (defined $category) {
-            $action =  pf::Authentication::Action->new({type => $Actions::SET_ROLE,
-                                                        value => $category});
-            push(@actions, $action);
-        }
-
-        my $time_balance = $result->{'time_balance'};
-        if (defined $time_balance) {
-            $action =  pf::Authentication::Action->new({type => $Actions::SET_TIME_BALANCE,
-                                                        value => $time_balance});
-            push(@actions, $action);
-        }
-
-        my $bandwidth_balance = $result->{'bandwidth_balance'};
-        if (defined $bandwidth_balance) {
-            $action =  pf::Authentication::Action->new({type => $Actions::SET_BANDWIDTH_BALANCE,
-                                                        value => $bandwidth_balance});
-            push(@actions, $action);
-        }
-        return \@actions;
+    if (!defined $result) {
+        return undef;
     }
 
-    return undef;
+    my @actions = ();
+
+    my $access_duration = $result->{'access_duration'};
+    if (defined $access_duration) {
+        push @actions, pf::Authentication::Action->new({type => $Actions::SET_ACCESS_DURATION, value => $access_duration});
+    }
+
+    my $access_level = $result->{'access_level'};
+    if (defined $access_level ) {
+        push @actions, pf::Authentication::Action->new({type => $Actions::SET_ACCESS_LEVEL, value => $access_level});
+    }
+
+    my $sponsor = $result->{'sponsor'};
+    if (defined($sponsor) && $sponsor == 1) {
+        push @actions, pf::Authentication::Action->new({type => $Actions::MARK_AS_SPONSOR, value => 1});
+    }
+
+    my $unregdate = $result->{'unregdate'};
+    if (defined $unregdate) {
+        push @actions, pf::Authentication::Action->new({type => $Actions::SET_UNREG_DATE, value => $unregdate});
+    }
+
+    my $category = $result->{'category'};
+    if (defined $category) {
+        push @actions, pf::Authentication::Action->new({type => $Actions::SET_ROLE, value => $category});
+    }
+
+    my $time_balance = $result->{'time_balance'};
+    if (defined $time_balance) {
+        push @actions, pf::Authentication::Action->new({type => $Actions::SET_TIME_BALANCE, value => $time_balance});
+    }
+
+    my $bandwidth_balance = $result->{'bandwidth_balance'};
+    if (defined $bandwidth_balance) {
+        push @actions, pf::Authentication::Action->new({type => $Actions::SET_BANDWIDTH_BALANCE, value => $bandwidth_balance});
+    }
+
+    return pf::Authentication::Rule->new(
+        id => "default",
+        class => $params->{rule_class},
+        actions => \@actions,
+    );
 }
 
 

--- a/lib/pf/Authentication/Source/SQLSource.pm
+++ b/lib/pf/Authentication/Source/SQLSource.pm
@@ -84,80 +84,74 @@ sub match {
     }
 
     # User is defined in SQL source, let's build the actions and return that
-    if (defined $result) {
-
-        my @actions = ();
-        my $action;
-
-        my $access_duration = $result->{'access_duration'};
-        if (defined $access_duration) {
-            $action = pf::Authentication::Action->new({
-                type    => $Actions::SET_ACCESS_DURATION,
-                value   => $access_duration,
-                class   => pf::Authentication::Action->getRuleClassForAction($Actions::SET_ACCESS_DURATION),
-            });
-            push(@actions, $action);
-        }
-
-        my $access_level = $result->{'access_level'};
-        if (defined $access_level ) {
-            $action = pf::Authentication::Action->new({
-                type    => $Actions::SET_ACCESS_LEVEL,
-                value   => $access_level,
-                class   => pf::Authentication::Action->getRuleClassForAction($Actions::SET_ACCESS_LEVEL),
-            });
-            push(@actions, $action);
-        }
-
-        my $sponsor = $result->{'sponsor'};
-        if ($sponsor == 1) {
-            $action = pf::Authentication::Action->new({
-                type    => $Actions::MARK_AS_SPONSOR,
-                value   => 1,
-                class   => pf::Authentication::Action->getRuleClassForAction($Actions::MARK_AS_SPONSOR),
-            });
-            push(@actions, $action);
-        }
-
-        my $unregdate = $result->{'unregdate'};
-        if (defined $unregdate) {
-            $action = pf::Authentication::Action->new({
-                type    => $Actions::SET_UNREG_DATE,
-                value   => $unregdate,
-                class   => pf::Authentication::Action->getRuleClassForAction($Actions::SET_UNREG_DATE),
-            });
-            push(@actions, $action);
-        }
-
-        my $category = $result->{'category'};
-        if (defined $category) {
-            $action = pf::Authentication::Action->new({
-                type    => $Actions::SET_ROLE,
-                value   => $category,
-                class   => pf::Authentication::Action->getRuleClassForAction($Actions::SET_ROLE),
-            });
-            push(@actions, $action);
-        }
-
-        my $time_balance = $result->{'time_balance'};
-        if (defined $time_balance) {
-            $action =  pf::Authentication::Action->new({type => $Actions::SET_TIME_BALANCE,
-                                                        value => $time_balance});
-            push(@actions, $action);
-        }
-
-        my $bandwidth_balance = $result->{'bandwidth_balance'};
-        if (defined $bandwidth_balance) {
-            $action =  pf::Authentication::Action->new({type => $Actions::SET_BANDWIDTH_BALANCE,
-                                                        value => $bandwidth_balance});
-            push(@actions, $action);
-        }
-
-
-        return \@actions;
+    if (!defined $result) {
+        return undef;
     }
 
-    return undef;
+    my @actions = ();
+    my $action;
+
+    my $access_duration = $result->{'access_duration'};
+    if (defined $access_duration) {
+        push @actions, pf::Authentication::Action->new({
+            type    => $Actions::SET_ACCESS_DURATION,
+            value   => $access_duration,
+            class   => pf::Authentication::Action->getRuleClassForAction($Actions::SET_ACCESS_DURATION),
+        });
+    }
+
+    my $access_level = $result->{'access_level'};
+    if (defined $access_level ) {
+        push @actions, pf::Authentication::Action->new({
+            type    => $Actions::SET_ACCESS_LEVEL,
+            value   => $access_level,
+            class   => pf::Authentication::Action->getRuleClassForAction($Actions::SET_ACCESS_LEVEL),
+        });
+    }
+
+    my $sponsor = $result->{'sponsor'};
+    if ($sponsor == 1) {
+        push @actions, pf::Authentication::Action->new({
+            type    => $Actions::MARK_AS_SPONSOR,
+            value   => 1,
+            class   => pf::Authentication::Action->getRuleClassForAction($Actions::MARK_AS_SPONSOR),
+        });
+    }
+
+    my $unregdate = $result->{'unregdate'};
+    if (defined $unregdate) {
+        push @actions, pf::Authentication::Action->new({
+            type    => $Actions::SET_UNREG_DATE,
+            value   => $unregdate,
+            class   => pf::Authentication::Action->getRuleClassForAction($Actions::SET_UNREG_DATE),
+        });
+    }
+
+    my $category = $result->{'category'};
+    if (defined $category) {
+        push @actions, pf::Authentication::Action->new({
+            type    => $Actions::SET_ROLE,
+            value   => $category,
+            class   => pf::Authentication::Action->getRuleClassForAction($Actions::SET_ROLE),
+        });
+    }
+
+    my $time_balance = $result->{'time_balance'};
+    if (defined $time_balance) {
+        push @actions, pf::Authentication::Action->new({type => $Actions::SET_TIME_BALANCE, value => $time_balance});
+    }
+
+    my $bandwidth_balance = $result->{'bandwidth_balance'};
+    if (defined $bandwidth_balance) {
+        push @actions, pf::Authentication::Action->new({type => $Actions::SET_BANDWIDTH_BALANCE, value => $bandwidth_balance});
+
+    }
+
+    return pf::Authentication::Rule->new(
+        id => "default",
+        class => $params->{rule_class},
+        actions => \@actions,
+    );
 }
 
 =head1 AUTHOR

--- a/lib/pf/pftest/authentication.pm
+++ b/lib/pf/pftest/authentication.pm
@@ -61,7 +61,7 @@ sub _run {
                 my $matched;
                 foreach my $class ( @Rules::CLASSES ) {
                     if( $matched = pf::authentication::match2([$source], {username => $user, rule_class => $class, context => $context})) {
-                        print $colors->{success},$indent ,"Matched against ",$source->id," for '$class' rules\n";
+                        print $colors->{success},$indent ,"Matched against ",$source->id," for '$class' rule $matched->{rule_id}\n";
                         {
                             local $indent = $indent x 2;
                             foreach my $action (@{$matched->{actions}}) {

--- a/t/unittest/authentication.t
+++ b/t/unittest/authentication.t
@@ -415,7 +415,8 @@ is_deeply(
         'values'    => {
             'set_role'       => 'default',
             'set_unreg_date' => '2038-01-01'
-        }
+        },
+        rule_id => 'match_test',
     },
    "potd match rule"
 );


### PR DESCRIPTION
Description
===========
Display the matching rule while running pftest

Impacts
=======
pftest and authentication match

Issue
=====
Fixes #4707

Delete branch after merge
=========================
NO

Checklist
=========
- [ ] Document the feature
- [x] Add unit tests
- [ ] Add acceptance tests (TestLink)


UPGRADE
=========
Any custom pf::Authentication::Source that overrides the match method.
Needs to return the matching pf::Authentication::Rule instead of the array of actions.
