### PR TITLE
feature/pfperl-api-port

### DIFF
--- a/addons/upgrade/to-9.1-update-api.conf.sh
+++ b/addons/upgrade/to-9.1-update-api.conf.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+perl -pi -e's/127.0.0.1:8080/127.0.0.1:22224/' /usr/local/pf/conf/caddy-services/api.conf

--- a/conf/caddy-services/api.conf.example
+++ b/conf/caddy-services/api.conf.example
@@ -40,7 +40,7 @@
   }
   
   # Everything else goes to the Perl API
-  proxy /api/v1/ 127.0.0.1:8080 {
+  proxy /api/v1/ 127.0.0.1:22224 {
     transparent
     timeout 10m
   }

--- a/conf/systemd/packetfence-pfperl-api.service
+++ b/conf/systemd/packetfence-pfperl-api.service
@@ -5,7 +5,7 @@ Wants=packetfence-base.target packetfence-config.service packetfence-iptables.se
 
 [Service]
 Type=notify
-ExecStart=/usr/local/pf/sbin/pfperl-api prefork -m production -l http://127.0.0.1:8080 --pid-file /usr/local/pf/var/run/pfperl-api.pid
+ExecStart=/usr/local/pf/sbin/pfperl-api prefork -m production -l http://127.0.0.1:22224 --pid-file /usr/local/pf/var/run/pfperl-api.pid
 Slice=packetfence.slice
 Restart=on-failure
 KillMode=process

--- a/go/caddy/api-aaa/api-aaa.go
+++ b/go/caddy/api-aaa/api-aaa.go
@@ -101,7 +101,7 @@ func buildApiAAAHandler(ctx context.Context) (ApiAAAHandler, error) {
 		apiAAA.webservicesBackend.SetUser(pfconfigdriver.Config.PfConf.Webservices.User, pfconfigdriver.Config.PfConf.Webservices.Pass)
 	}
 
-	url, err := url.Parse("http://127.0.0.1:8080/api/v1/authentication/admin_authentication")
+	url, err := url.Parse("http://127.0.0.1:22224/api/v1/authentication/admin_authentication")
 	sharedutils.CheckError(err)
 	apiAAA.authentication.AddAuthenticationBackend(aaa.NewPfAuthenticationBackend(ctx, url, false))
 


### PR DESCRIPTION
Description
===========
Change pfperl-api port from 8080 to 22224 to avoid conflicts with 3rd party services.

Impacts
=======
pfperl-api

Issue
=====
Fixes #4231

Delete branch after merge
=========================
NO

Checklist
=========
- [ ] Document the feature
- [x] Add unit tests
- [ ] Add acceptance tests (TestLink)

Upgrade
=========

Run update /usr/local/pf/addons/upgrade/to-9.1-update-api.conf.sh