### PR TITLE
Feature/eduroam non email formated username

### DIFF
--- a/conf/radiusd/eduroam.example
+++ b/conf/radiusd/eduroam.example
@@ -73,7 +73,7 @@ authorize {
 %%local_realm%%
         }
         else {
-                reject
+%%local_realm_exception%%
         }
 	#
 	#  This module takes care of EAP-MD5, EAP-TLS, and EAP-LEAP

--- a/lib/pf/services/manager/radiusd_child.pm
+++ b/lib/pf/services/manager/radiusd_child.pm
@@ -372,6 +372,7 @@ EOT
         %tags = ();
         $tags{'template'} = "$conf_dir/raddb/sites-available/eduroam";
         $tags{'local_realm'} = '';
+        $tags{'local_realm_exception'} = '';
         $tags{'eduroam_post_auth'} = '';
         $tags{'local_realm_acct'} = '        if (User-Name =~ /@/) {';
         my $found_acct = $FALSE;

--- a/lib/pf/services/manager/radiusd_child.pm
+++ b/lib/pf/services/manager/radiusd_child.pm
@@ -421,6 +421,19 @@ EOT
                 }
             }
 EOT
+            $tags{'local_realm_exception'} .= '            if ( ';
+            $tags{'local_realm_exception'} .=  join(' || ', @local_realms);
+            $tags{'local_realm_exception'} .= ' ) {'."\n";
+            $tags{'local_realm_exception'} .= <<"EOT";
+                update control {
+                    Proxy-To-Realm := "packetfence"
+                }
+            } else {
+                reject
+            }
+EOT
+        } else {
+            $tags{'local_realm_exception'} .= 'reject';
         }
         if ($found_acct) {
             $tags{'local_realm_acct'} .= '        }';


### PR DESCRIPTION
# Description
Allow local domain to authenticate through eduroam even if the username is not in email format.


# Impacts
Eduroam

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* Local realm can authenticate even if the username format is not in email format (eduroam)
