### PR TITLE
Use access duration choices for password rotation period

### DIFF
--- a/addons/upgrade/to-9.2-update-potd.pl
+++ b/addons/upgrade/to-9.2-update-potd.pl
@@ -1,0 +1,86 @@
+#!/usr/bin/perl
+
+=head1 NAME
+
+Move password_rotation value from Potd source to guests_admin_registration.access_duration_choices 
+
+=cut
+
+=head1 DESCRIPTION
+
+Moved password_rotation value to guests_admin_registration.access_duration_choices
+
+=cut
+
+use strict;
+use warnings;
+use lib qw(/usr/local/pf/lib);
+use List::MoreUtils qw(uniq);
+use pf::IniFiles;
+use pf::file_paths qw($authentication_config_file $pf_config_file $pf_default_file);
+use pf::authentication;
+
+exit 0 unless -e $authentication_config_file;
+exit 0 unless -e $pf_config_file;
+exit 0 unless -e $pf_default_file;
+
+my $iniauth =
+  pf::IniFiles->new( -file => $authentication_config_file, -allowempty => 1 );
+
+my $config = 
+  pf::IniFiles->new(-file => $pf_config_file, -allowempty => 1 );
+
+my $default_pf_config = 
+  pf::IniFiles->new(-file => $pf_default_file, -allowempty => 1);
+
+my $access_duration_choices;
+my @access_duration;
+
+if ($config->exists('guests_admin_registration', 'access_duration_choices')) {
+    $access_duration_choices = $config->val('guests_admin_registration', 'access_duration_choices');
+} else {
+    $access_duration_choices = $default_pf_config->val('guests_admin_registration', 'access_duration_choices');
+}
+
+for my $authsection ( $iniauth->Sections() ) {
+    next if $authsection =~ / /;
+    if ( defined($iniauth->val($authsection, 'type')) && $iniauth->val($authsection, 'type') eq 'Potd') {
+        if (defined($iniauth->val( $authsection, 'password_rotation'))) {
+            push @access_duration, $iniauth->val( $authsection, 'password_rotation');
+        }
+    }
+}
+
+if (scalar(@access_duration) > 0 ) {
+    $access_duration_choices .= ",". join(',', uniq(@access_duration));
+    $access_duration_choices = join(',', uniq(split(',',$access_duration_choices)));
+    $config->newval('guests_admin_registration', 'access_duration_choices', $access_duration_choices);
+    $config->RewriteConfig();
+}
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2019 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source/Potd.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source/Potd.pm
@@ -11,7 +11,9 @@ Form definition to create or update a potd user source.
 =cut
 
 use pf::person;
+use pf::config qw(%Config);
 use HTML::FormHandler::Moose;
+use pfappserver::Base::Form::Authentication::Action;
 use pf::Authentication::Source::PotdSource;
 extends 'pfappserver::Form::Config::Source';
 with qw(
@@ -47,10 +49,13 @@ has_field 'id' =>
 
 has_field 'password_rotation' =>
   (
-   type => 'Duration',
-   label => 'Password Rotation Period',
-   required => 1,
-   default => pfappserver::Form::Field::Duration->duration_inflate(pf::Authentication::Source::PotdSource->meta->get_attribute('password_rotation')->default),
+   type => 'Select',
+   label => 'Password rotation',
+   localize_labels => 1,
+   options_method => \&pfappserver::Base::Form::Authentication::Action::options_durations,
+   default_method => sub { $Config{'guests_admin_registration'}{'default_access_duration'} },
+   element_class => ['chzn-select', 'input-xxlarge'],
+   element_attr => {'data-placeholder' => 'Click to add a duration'},
    tags => { after_element => \&help,
              help => 'Period of time after the password must be rotated.' },
   );

--- a/html/pfappserver/root/static.alt/src/globals/configuration/pfConfigurationAuthenticationSources.js
+++ b/html/pfappserver/root/static.alt/src/globals/configuration/pfConfigurationAuthenticationSources.js
@@ -1167,20 +1167,14 @@ export const pfConfigurationAuthenticationSourceFields = {
   },
   password_rotation: ({ options: { meta = {} } } = {}) => {
     return {
-      label: i18n.t('Password Rotation Period'),
+      label: i18n.t('Password rotation duration'),
       text: i18n.t('Period of time after the password must be rotated.'),
       fields: [
         {
-          key: 'password_rotation.interval',
-          component: pfFormInput,
-          attrs: pfConfigurationAttributesFromMeta(meta, 'password_rotation.interval'),
-          validators: pfConfigurationValidatorsFromMeta(meta, 'password_rotation.interval', i18n.t('Interval'))
-        },
-        {
-          key: 'password_rotation.unit',
+          key: 'password_rotation',
           component: pfFormChosen,
-          attrs: pfConfigurationAttributesFromMeta(meta, 'password_rotation.unit'),
-          validators: pfConfigurationValidatorsFromMeta(meta, 'password_rotation.unit', i18n.t('Unit'))
+          attrs: pfConfigurationAttributesFromMeta(meta, 'password_rotation'),
+          validators: pfConfigurationValidatorsFromMeta(meta, 'password_rotation', i18n.t('Duration'))
         }
       ]
     }

--- a/lib/pf/pfmon/task/password_of_the_day.pm
+++ b/lib/pf/pfmon/task/password_of_the_day.pm
@@ -49,10 +49,10 @@ sub run {
         }
         my $password = pf::password::view($source->{id});
         if(defined($password)){
-            my $valid_from = $password->{valid_from};
-            $valid_from = DateTime::Format::MySQL->parse_datetime($valid_from);
-            $valid_from->set_time_zone("local");
-            if ( ($now->epoch - $valid_from->epoch) > pf::util::normalize_time($source->{password_rotation})) {
+            my $expiration = $password->{expiration};
+            $expiration = DateTime::Format::MySQL->parse_datetime($expiration);
+            $expiration->set_time_zone("local");
+            if ( $now->epoch > $expiration->epoch) {
                 $new_password = pf::password::generate($source->{id},[{type => 'valid_from', value => $now},{type => 'expiration', value => pf::config::access_duration($source->{password_rotation})}],undef,'0',$source);
                 $self->send_email(pid => $source->{id},password => $new_password, email => $source->{password_email_update}, expiration => pf::config::access_duration($source->{password_rotation}));
             }


### PR DESCRIPTION
# Description
Use the access duration configuration in the password of the day rotation field.
It add the way to choose a rotation based on the beginning  of the period + a duration (like each day at 6am).

# Impacts
Password of the day source

# Issue
fixes #3761

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Bug Fixes
* Rotate on a precise day instead of duration (#3761)

# UPGRADE file entries
Run addons/upgrade/to-9.2-update-potd.pl