### PR TITLE
Make verify_chain working on Debian

### DIFF
--- a/lib/pf/ssl.pm
+++ b/lib/pf/ssl.pm
@@ -342,7 +342,7 @@ sub verify_chain {
     }
     write_file($tmpinter, $bundle);
 
-    my $result = `/bin/bash -c "echo '$cert_str' | openssl verify -verbose -CAfile <(cat /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem $tmpinter)"`;
+    my $result = `/bin/bash -c "echo '$cert_str' | openssl verify -verbose -CAfile <(cat $ca_bundle_file $tmpinter)"`;
     unlink $tmpinter;
 
     if($? != 0) {

--- a/lib/pf/ssl.pm
+++ b/lib/pf/ssl.pm
@@ -411,11 +411,11 @@ Set OS specific path for CA bundle file
 
 sub set_ca_bundle_path {
     if ($OS eq 'debian') {
-        get_logger->info("debian detected")
+        get_logger->info("debian detected");
         return '/etc/ssl/certs/ca-certificates.crt';
     }
     elsif ($OS eq 'rhel') {
-        get_logger->info("rhel detected")
+        get_logger->info("rhel detected");
         return '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem';
     }
 }

--- a/lib/pf/ssl.pm
+++ b/lib/pf/ssl.pm
@@ -38,9 +38,9 @@ use pf::file_paths qw(
     $radius_server_key
 );
 
-Readonly::Scalar our $OS_CA_CERT_FILE => get_ca_cert_file();
 Readonly::Scalar our $DEB_CA_CERT_FILE => '/etc/ssl/certs/ca-certificates.crt';
 Readonly::Scalar our $RHEL_CA_CERT_FILE => '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem';
+Readonly::Scalar our $OS_CA_CERT_FILE => get_ca_cert_file();
 
 =head2 certs_map
 

--- a/lib/pf/ssl.pm
+++ b/lib/pf/ssl.pm
@@ -22,6 +22,8 @@ use LWP::UserAgent;
 use pf::util;
 use pf::log;
 use pf::cluster;
+use pf::config qw($OS);
+use Readonly;
 
 use Crypt::OpenSSL::RSA;
 use Crypt::OpenSSL::X509;
@@ -35,6 +37,8 @@ use pf::file_paths qw(
     $radius_ca_cert
     $radius_server_key
 );
+
+Readonly::Scalar our $ca_bundle_file => set_ca_bundle_path();
 
 =head2 certs_map
 
@@ -397,6 +401,23 @@ sub install_to_file {
     }
 
     return @errors;
+}
+
+=head2 set_ca_bundle_path
+
+Set OS specific path for CA bundle file
+
+=cut
+
+sub set_ca_bundle_path {
+    if ($OS eq 'debian') {
+        get_logger->info("debian detected")
+        return '/etc/ssl/certs/ca-certificates.crt';
+    }
+    elsif ($OS eq 'rhel') {
+        get_logger->info("rhel detected")
+        return '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem';
+    }
 }
 
 =head1 AUTHOR


### PR DESCRIPTION
# Description
Path to OS CA certificates file was hard-coded into a bash call. This PR put CA certificates file in a constants depending on OS to make it working on Debian and RHEL systems.

# Impacts
Verification of SSL certificates chain.


# Issue
fixes #4736, related to #4739 

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* Verify SSL certificates chain on Debian
