### PR TITLE
Added internal event on production network versus managed network

### DIFF
--- a/lib/pf/constants/trigger.pm
+++ b/lib/pf/constants/trigger.pm
@@ -80,6 +80,8 @@ our $TRIGGER_MAP = {
     "connection_type_change" => "Connection transport changed",
     "parking_detected" => "Parking detected",
     "node_discovered" => "Node discovered",
+    "new_dhcp_info_from_managed_network" => "DHCP packet received from managed network",
+    "new_dhcp_info_from_production_network" => "DHCP packet received from production network",
   },
   $TRIGGER_TYPE_PROVISIONER => {
     $TRIGGER_ID_PROVISIONER => "Check status",


### PR DESCRIPTION
# Description
Added internal trigger to enable only a violation on a managed network (like registration/isolation) or on a production network.

# Impacts
Security event

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
## New Features
* Internal security event to trigger on managed network only or production network only
