### PR TITLE
allow to force the access duration when using device registration

### DIFF
--- a/html/pfappserver/lib/pfappserver/Form/Config/SelfService.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/SelfService.pm
@@ -55,6 +55,19 @@ has_field 'device_registration_role' =>
              help => 'The role to assign to devices registered from the self-service portal. If none is specified, the role of the registrant is used.' },
   );
 
+has_field 'device_registration_access_duration' =>
+  (
+   type => 'Duration',
+   label => 'Access duration to assign',
+   default => {
+    interval => 0,
+    unit => 's',
+   },
+   options_method => \&options_roles,
+   tags => { after_element => \&help,
+             help => 'The access duration to assign to devices registered from the self-service portal. If zero is specified, the access duration of the registrant is used.' },
+  );
+
 has_field 'device_registration_allowed_devices' =>
   (
    type => 'FingerbankSelect',
@@ -79,7 +92,7 @@ has_block status_definition =>
 
 has_block device_registration_definition =>
   (
-   render_list => [ qw(device_registration_role device_registration_allowed_devices) ],
+   render_list => [ qw(device_registration_role device_registration_access_duration device_registration_allowed_devices) ],
   );
 
 =head2 options_roles

--- a/html/pfappserver/root/static.alt/src/globals/configuration/pfConfigurationSelfServices.js
+++ b/html/pfappserver/root/static.alt/src/globals/configuration/pfConfigurationSelfServices.js
@@ -164,6 +164,24 @@ export const pfConfigurationSelfServiceViewFields = (context = {}) => {
           ]
         },
         {
+          label: i18n.t('Access duration to assign'),
+          text: i18n.t(`The access duration to assign to devices registered from the self-service portal. If zero is specified, the access duration of the registrant is used.`),
+          fields: [
+            {
+              key: 'device_registration_access_duration.interval',
+              component: pfFormInput,
+              attrs: pfConfigurationAttributesFromMeta(meta, 'device_registration_access_duration.interval'),
+              validators: pfConfigurationValidatorsFromMeta(meta, 'device_registration_access_duration.interval', i18n.t('Interval'))
+            },
+            {
+              key: 'device_registration_access_duration.unit',
+              component: pfFormChosen,
+              attrs: pfConfigurationAttributesFromMeta(meta, 'device_registration_access_duration.unit'),
+              validators: pfConfigurationValidatorsFromMeta(meta, 'device_registration_access_duration.unit', i18n.t('Unit'))
+            }
+          ]
+        },
+        {
           label: i18n.t('Allowed OS'),
           text: i18n.t('List of OS which will be allowed to be register via the self service portal.'),
           fields: [

--- a/lib/pfconfig/namespaces/config/SelfService.pm
+++ b/lib/pfconfig/namespaces/config/SelfService.pm
@@ -19,6 +19,7 @@ use warnings;
 
 use pfconfig::namespaces::config;
 use pf::file_paths qw($self_service_config_file $self_service_default_config_file);
+use pf::util;
 
 use base 'pfconfig::namespaces::config';
 
@@ -46,6 +47,7 @@ sub build_child {
 sub cleanup_after_read {
     my ( $self, $id, $data ) = @_;
     $self->expand_list( $data, qw(device_registration_allowed_devices roles_allowed_to_unregister) );
+    $data->{device_registration_access_duration} = $data->{device_registration_access_duration} ? normalize_time($data->{device_registration_access_duration}) : 0;
 }
 
 =head1 AUTHOR


### PR DESCRIPTION
# Description
allow to force the access duration when using device registration

# Impacts
device registration

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
## New Features
* Allow to force the access duration when using device registration

