### PR TITLE
Install images with all subdirectories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,21 @@ html/pfappserver/root/static/doc:
 docs/html/index.js: $(HTML)
 	find $$(dirname "$@") -type f  -iname  '*.html' -and -not -iname '*template*' -printf "{\"name\":\"%f\", \"size\":%s, \"last_modifed\" : %T@}\n" | jq -s '{ items: [ .[] |  {name, size, last_modifed : (.last_modifed*1000 | floor)} ] }' > $@
 
+.PHONY: images
+
+images:
+	@echo "install images dir and all subdirectories"
+	for subdir in `find docs/images/* -type d -printf "%f\n"` ; do \
+		install -d -m0755 $(DESTDIR)/usr/local/pf/html/pfappserver/root/static/images/$$subdir ; \
+		for img in `find docs/images/$$subdir -type f`; do \
+			install -m0644 $$img $(DESTDIR)/usr/local/pf/html/pfappserver/root/static/images/$$subdir ; \
+		done \
+	done
+	@echo "install only images at depth0 in images/ directory"
+	for img in `find docs/images/* -maxdepth 0 -type f`; do \
+		install -m0644 $$img $(DESTDIR)/usr/local/pf/html/pfappserver/root/static/images/ ; \
+	done
+
 .PHONY: html
 
 html: $(HTML) docs/html/index.js

--- a/addons/packages/packetfence.spec
+++ b/addons/packages/packetfence.spec
@@ -575,10 +575,9 @@ for i in `find docs/html "(" -name "*.html" -or -name "*.js" ")"  -type f`; do \
 	%{__install} -m0644 $i $RPM_BUILD_ROOT/usr/local/pf/html/pfappserver/root/static/doc/; \
 done
 
-%{__install} -d -m0755 $RPM_BUILD_ROOT/usr/local/pf/html/pfappserver/root/static/images
-for i in `find * -path 'docs/images/*' -type f`; do \
-	%{__install} -m0644 $i $RPM_BUILD_ROOT/usr/local/pf/html/pfappserver/root/static/images/; \
-done
+# images
+%{__make} DESTDIR=%{buildroot} images
+
 
 cp -r lib $RPM_BUILD_ROOT/usr/local/pf/
 cp -r go $RPM_BUILD_ROOT/usr/local/pf/

--- a/debian/rules
+++ b/debian/rules
@@ -151,11 +151,9 @@ install: build
 	for i in `find "docs/html" "(" -name "*.html" -or -iname "*.js" ")" -type f`; do \
 		install -m0644 $$i $(CURDIR)/debian/packetfence-doc$(PREFIX)/$(NAME)/html/pfappserver/root/static/doc/; \
 	done
+	# images
+	make DESTDIR=$(CURDIR)/debian/packetfence-doc images
 
-	install -d -m0755 $(CURDIR)/debian/packetfence-doc$(PREFIX)/$(NAME)/html/pfappserver/root/static/images
-	for i in `find * -path 'docs/images/*' -type f`; do \
-		install -m0644 $$i $(CURDIR)/debian/packetfence-doc$(PREFIX)/$(NAME)/html/pfappserver/root/static/images/; \
-	done
 	#Portal javascript/css
 	rm -f $(CURDIR)/debian/packetfence$(PREFIX)/$(NAME)/html/common/styles.css
 	rm -f $(CURDIR)/debian/packetfence$(PREFIX)/$(NAME)/html/common/styles.css.map


### PR DESCRIPTION
# Description
Add a dedicated `make` target to install images the same way between CentOS and Debian.

# Impacts
CentOS and Debian packages.

# Issue
fixes #4761 

# Delete branch after merge
YES
