### PR TITLE
Migrate to go mod for Golang binaries

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -69,7 +69,7 @@ all: pfhttpd pfdhcp pfdns pfstats pfdetect
 
 .PHONY: copy
 copy:
-	cp -f pfhttpd pfdhcp pfdns pfstats pfdetect $(SBINDIR)
+	cp -f pfhttpd pfdhcp pfdns pfstats pfdetect $(DESTDIR)$(SBINDIR)
 
 .PHONY: clean-coredns-src
 clean-coredns-src:


### PR DESCRIPTION
# Description
This migrates to `go mod` + Golang 1.13 for all our Golang binaries.
Ignore the branch name, I'm not upgrading caddy in this PR to keep it !@lzammit (lean)

# Impacts
All our golang binaries (pfdns, pfdetect, pfdhcp, pfhttpd, pfdns)

# Delete branch after merge
NO

