### PR TITLE
CLI-Access connection profile filter.

### DIFF
--- a/html/pfappserver/root/static.alt/src/globals/configuration/pfConfiguration.js
+++ b/html/pfappserver/root/static.alt/src/globals/configuration/pfConfiguration.js
@@ -850,6 +850,34 @@ export const pfConfigurationConditions = {
       }
     }
   },
+  switch: {
+    value: 'switch',
+    text: i18n.t('Switch'),
+    types: [authenticationConditionType.SUBSTRING],
+    validators: {
+      operator: {
+        [i18n.t('Operator required.')]: required
+      },
+      value: {
+        [i18n.t('Value required.')]: required,
+        [i18n.t('Maximum 255 characters.')]: maxLength(255)
+      }
+    }
+  },
+  switch_group: {
+    value: 'switch_group',
+    text: i18n.t('Switch Group'),
+    types: [authenticationConditionType.SUBSTRING],
+    validators: {
+      operator: {
+        [i18n.t('Operator required.')]: required
+      },
+      value: {
+        [i18n.t('Value required.')]: required,
+        [i18n.t('Maximum 255 characters.')]: maxLength(255)
+      }
+    }
+  },
   'TLS-Cert-Common-Name': {
     value: 'TLS-Cert-Common-Name',
     text: i18n.t('TLS-Cert-Common-Name'),

--- a/html/pfappserver/root/static.alt/src/globals/configuration/pfConfiguration.js
+++ b/html/pfappserver/root/static.alt/src/globals/configuration/pfConfiguration.js
@@ -851,7 +851,7 @@ export const pfConfigurationConditions = {
     }
   },
   switch: {
-    value: 'switch',
+    value: 'switch_id',
     text: i18n.t('Switch'),
     types: [authenticationConditionType.SUBSTRING],
     validators: {

--- a/html/pfappserver/root/static.alt/src/globals/pfField.js
+++ b/html/pfappserver/root/static.alt/src/globals/pfField.js
@@ -131,7 +131,9 @@ pfFieldTypeValues[pfFieldType.CONNECTION_TYPE] = () => {
     { name: 'Ethernet-EAP', value: 'Ethernet-EAP' },
     { name: 'Ethernet-NoEAP', value: 'Ethernet-NoEAP' },
     { name: 'Wireless-Web-Auth', value: 'Wireless-Web-Auth' },
-    { name: 'Wireless-802.11-EAP', value: 'Wireless-802.11-EAP' }
+    { name: 'Wireless-802.11-EAP', value: 'Wireless-802.11-EAP' },
+    { name: 'VPN-Access', value: 'VPN-Access' },
+    { name: 'CLI-Access', value: 'CLI-Access' }
   ]
 }
 pfFieldTypeValues[pfFieldType.CONNECTION_SUB_TYPE] = () => {

--- a/lib/pf/Authentication/Source.pm
+++ b/lib/pf/Authentication/Source.pm
@@ -97,7 +97,7 @@ sub common_attributes {
           { value => 'computer_name', type => $Conditions::SUBSTRING },
           { value => "mac", type => $Conditions::SUBSTRING },
           { value => "realm", type => $Conditions::SUBSTRING },
-          { value => "switch", type => $Conditions::SUBSTRING },
+          { value => "switch_id", type => $Conditions::SUBSTRING },
           { value => "switch_group", type => $Conditions::SUBSTRING },
           ];
 }

--- a/lib/pf/Authentication/Source.pm
+++ b/lib/pf/Authentication/Source.pm
@@ -97,7 +97,9 @@ sub common_attributes {
           { value => 'computer_name', type => $Conditions::SUBSTRING },
           { value => "mac", type => $Conditions::SUBSTRING },
           { value => "realm", type => $Conditions::SUBSTRING },
-         ];
+          { value => "switch", type => $Conditions::SUBSTRING },
+          { value => "switch_group", type => $Conditions::SUBSTRING },
+          ];
 }
 
 =head2 authenticate

--- a/lib/pf/Connection.pm
+++ b/lib/pf/Connection.pm
@@ -117,6 +117,7 @@ sub backwardCompatibleToAttributes {
 
     if (lc($type) =~/^virtual/ ) {
             $self->transport("Virtual");
+            $self->isCLI($TRUE);
     }
 
     # We check if SNMP. If so, we return immediately while setting the flag

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -840,6 +840,7 @@ sub switch_access {
         user_name => $user_name,
         radius_request => $radius_request,
         switch_group => $switch->{_group},
+        switch_id => $switch->{_id},
     };
 
     my $options = {};

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -839,6 +839,7 @@ sub switch_access {
         realm => $realm,
         user_name => $user_name,
         radius_request => $radius_request,
+        switch_group => $switch->{_group},
     };
 
     my $options = {};

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -898,6 +898,10 @@ sub switch_access {
             $switch->synchronize_locationlog($port, undef, $mac,
                 $args->{'isPhone'} ? $VOIP : $NO_VOIP, $VIRTUAL_VPN, undef, $user_name, undef, $stripped_user_name, $realm, $args->{'user_role'}, $ifDesc
             );
+        } else {
+            my $profile = pf::Connection::ProfileFactory->instantiate("55:44:33:22:11:00",$options);
+            $args->{'profile'} = $profile;
+            @sources = $profile->getFilteredAuthenticationSources($args->{'stripped_user_name'}, $args->{'realm'});
         }
     }
     my ( $return, $message, $source_id, $extra ) = pf::authentication::authenticate( {
@@ -914,7 +918,10 @@ sub switch_access {
     if ($connection->isVPN()) {
         return $switch->returnAuthorizeVPN($args);
     } else {
-        my $matched = pf::authentication::match2($source_id, { username => $radius_request->{'User-Name'}, 'rule_class' => $Rules::ADMIN, 'context' => $pf::constants::realm::RADIUS_CONTEXT }, $extra);
+        my $merged = { %$options, %$args };
+        $merged->{'rule_class'} = $Rules::ADMIN;
+        $merged->{'context'} = $pf::constants::realm::RADIUS_CONTEXT;
+        my $matched = pf::authentication::match2($source_id, $merged, $extra);
         my $value = $matched->{values}{$Actions::SET_ACCESS_LEVEL} if $matched;
         if ($value) {
             my @values = split(',', $value);

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -900,7 +900,7 @@ sub switch_access {
                 $args->{'isPhone'} ? $VOIP : $NO_VOIP, $VIRTUAL_VPN, undef, $user_name, undef, $stripped_user_name, $realm, $args->{'user_role'}, $ifDesc
             );
         } else {
-            my $profile = pf::Connection::ProfileFactory->instantiate("55:44:33:22:11:00",$options);
+            my $profile = pf::Connection::ProfileFactory->instantiate("de:fa:ce:db:ab:e0",$options);
             $args->{'profile'} = $profile;
             @sources = $profile->getFilteredAuthenticationSources($args->{'stripped_user_name'}, $args->{'realm'});
         }


### PR DESCRIPTION
# Description
Added connection profile filter for CLI-Access.
Allow switch and switch_group in authentication/administration rules.

# Impacts
CLI-Access

# Delete branch after merge
YES
 | NO

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* New connection profile filter for CLI-Access. Switch and switch_group in authentication/administration rules.

