### PR TITLE
feature/profile_warn_on_old_files

### DIFF
--- a/lib/pf/UnifiedApi/Controller/Config.pm
+++ b/lib/pf/UnifiedApi/Controller/Config.pm
@@ -393,7 +393,12 @@ sub create {
     return unless($self->commit($cs));
     $self->stash( $self->primary_key => $id );
     $self->res->headers->location($self->make_location_url($id));
-    $self->render(status => 201, json => { id => $id, message => "'$id' created" });
+    $self->render(status => 201, json => $self->create_response($id));
+}
+
+sub create_response {
+    my ($self, $id) = @_;
+    return { id => $id, message => "'$id' created" };
 }
 
 sub commit {

--- a/lib/pf/UnifiedApi/Controller/Config/ConnectionProfiles.pm
+++ b/lib/pf/UnifiedApi/Controller/Config/ConnectionProfiles.pm
@@ -561,7 +561,7 @@ sub create_response {
         };
         if ($count) {
             $resp->{warnings} = [
-                { messgae => "There are $count files in profile template please review", id => $id},
+                { message => "There are $count files in profile template please review", id => $id},
             ];
         }
     }

--- a/lib/pf/UnifiedApi/Controller/Config/ConnectionProfiles.pm
+++ b/lib/pf/UnifiedApi/Controller/Config/ConnectionProfiles.pm
@@ -542,6 +542,33 @@ sub cached_form_key {
     return $id eq 'default' ? 'cached_form_default' : 'cached_form'
 }
 
+=head2 create_response
+
+create_response
+
+=cut
+
+sub create_response {
+    my ($self, $id) = @_;
+    my $resp = $self->SUPER::create_response($id);
+    my $path = profileFilePath($self->id, '');
+    if (-e -d $path) {
+        my $count = do {
+            opendir(my $dh, $path);
+            my $c =()= readdir($dh);
+            closedir($dh);
+            $c -= 2
+        };
+        if ($count) {
+            $resp->{warnings} = [
+                { messgae => "There are $count files in profile template please review", id => $id},
+            ];
+        }
+    }
+
+    return $resp;
+}
+
 =head1 AUTHOR
 
 Inverse inc. <info@inverse.ca>


### PR DESCRIPTION
Description
===========
Warn when a directory already exists when creating a profile.

Issue
=====
Fixes #793

Delete branch after merge
=========================
NO

Checklist
=========
- [ ] Document the feature
- [x] Add unit tests
- [ ] Add acceptance tests (TestLink)