### PR TITLE
Package correctly go and html directories in RPM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,10 +253,11 @@ html_install:
 	    install -v -m 0644 $$file $(DESTDIR)$(PF_PREFIX)/$$file ; \
 	done
 
-	# @echo "install $(SRC_HTML_PFAPPDIR) other dirs and files"
-	# for dir in $(pfapp_other_dirs); do \
-        #     install -v -d -m0755 $(DESTDIR)$(PF_PREFIX)/$$dir ; \
-	# done
-	# for file in $(pfapp_other_files); do \
-	#     install -v -m 0644 $$file $(DESTDIR)$(PF_PREFIX)/$$file ; \
-	# done
+	@echo "install $(SRC_HTML_PFAPPDIR_STATIC) other dirs and files"
+	for dir in $(pfapp_static_dir); do \
+            install -v -d -m0755 $(DESTDIR)$(PF_PREFIX)/$$dir ; \
+	done
+	for file in $(pfapp_static_files); do \
+	    install -v -m 0644 $$file $(DESTDIR)$(PF_PREFIX)/$$file ; \
+	done
+

--- a/Makefile
+++ b/Makefile
@@ -218,6 +218,7 @@ update_samsung_dns_filter:
 .PHONY: html_install
 
 # install -D will automatically create target directories
+# $$file in destination of install command contain relative path
 html_install:
 	@echo "create directories under $(DESTDIR)$(HTMLDIR)"
 	install -d -m0755 $(DESTDIR)$(HTML_PARKINGDIR)
@@ -240,7 +241,7 @@ html_install:
 	    install -v -m 0644 $$file -D $(DESTDIR)$(PF_PREFIX)/$$file ; \
 	done
 
-	@echo "install $(SRC_HTML_PFAPPDIR) without root dir"
+	@echo "install $(SRC_HTML_PFAPPDIR) without static and static.alt dir"
 	for file in $(pfapp_files); do \
 	    install -v -m 0644 $$file -D $(DESTDIR)$(PF_PREFIX)/$$file ; \
 	done
@@ -257,5 +258,7 @@ html_install:
 	for file in $(pfapp_bootstrap_files); do \
 	    install -v -m 0644 $$file -D $(DESTDIR)$(PF_PREFIX)/$$file ; \
 	done
-
+	@echo "install symlink"
+	cp -v --no-dereference $(SRC_HTML_PFAPPDIR_STATIC)/alt \
+	    $(DESTDIR)$(HTML_PFAPPDIR_STATIC)
 

--- a/Makefile
+++ b/Makefile
@@ -215,9 +215,9 @@ test:
 update_samsung_dns_filter:
 	bash /usr/local/pf/addons/update-samsung-dns-filter.sh
 
-.PHONY: pfappserver-install
+.PHONY: html_install
 
-pfappserver_install:
+html_install:
 	@echo "create directories under $(DESTDIR)$(HTMLDIR)"
 	install -d -m0755 $(DESTDIR)$(HTML_PARKINGDIR)
 	install -d -m0755 $(DESTDIR)$(HTML_COMMONDIR)

--- a/Makefile
+++ b/Makefile
@@ -255,9 +255,7 @@ html_install:
 	for file in $(pfapp_alt_files); do \
 	    install -v -m 0644 $$file -D $(DESTDIR)$(PF_PREFIX)/$$file ; \
 	done
-	for file in $(pfapp_bootstrap_files); do \
-	    install -v -m 0644 $$file -D $(DESTDIR)$(PF_PREFIX)/$$file ; \
-	done
+
 	@echo "install symlink"
 	cp -v --no-dereference $(SRC_HTML_PFAPPDIR_STATIC)/alt \
 	    $(DESTDIR)$(HTML_PFAPPDIR_STATIC)

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+include config.mk
 DOCBOOK_XSL := /usr/share/xml/docbook/stylesheet/docbook-xsl
 UNAME := $(shell uname -s)
 ifeq ($(UNAME),Darwin)
@@ -213,3 +214,25 @@ test:
 
 update_samsung_dns_filter:
 	bash /usr/local/pf/addons/update-samsung-dns-filter.sh
+
+.PHONY: pfappserver-install
+
+pfappserver_install:
+	@echo "create directories under $(DESTDIR)$(HTMLDIR)"
+	install -d -m0755 $(DESTDIR)$(HTML_PARKINGDIR)
+	install -d -m0755 $(DESTDIR)$(HTML_COMMONDIR)
+	install -d -m0755 $(DESTDIR)$(HTML_CPDIR)
+	install -d -m0755 $(DESTDIR)$(HTML_PFAPPDIR)
+
+	@echo "install html/parking files"
+	for file in $(parking_files); do \
+            install -v -m 0644 html/parking/$$file $(DESTDIR)$(HTML_PARKINGDIR)/ ; \
+	done
+
+	@echo "install html/common dirs and files"
+	for dir in $(common_dirs); do \
+            install -v -d -m0755 $(DESTDIR)$(PFPREFIX)/$$dir ; \
+	done
+	for file in $(common_files); do \
+	    install -v -m 0644 $$file $(DESTDIR)$(PFPREFIX)/$$file ; \
+	done

--- a/Makefile
+++ b/Makefile
@@ -217,6 +217,7 @@ update_samsung_dns_filter:
 
 .PHONY: html_install
 
+# install -D will automatically create target directories
 html_install:
 	@echo "create directories under $(DESTDIR)$(HTMLDIR)"
 	install -d -m0755 $(DESTDIR)$(HTML_PARKINGDIR)
@@ -226,38 +227,35 @@ html_install:
 
 	@echo "install $(SRC_HTML_PARKINGDIR) files"
 	for file in $(parking_files); do \
-            install -v -m 0644 $(SRC_HTML_PARKINGDIR)/$$file $(DESTDIR)$(HTML_PARKINGDIR)/ ; \
+            install -v -m 0644 $$file -D $(DESTDIR)$(PF_PREFIX)/$$file ; \
 	done
 
 	@echo "install $(SRC_HTML_COMMONDIR) dirs and files"
-	for dir in $(common_dirs); do \
-            install -v -d -m0755 $(DESTDIR)$(PF_PREFIX)/$$dir ; \
-	done
 	for file in $(common_files); do \
-	    install -v -m 0644 $$file $(DESTDIR)$(PF_PREFIX)/$$file ; \
+	    install -v -m 0644 $$file -D $(DESTDIR)$(PF_PREFIX)/$$file ; \
 	done
 
 	@echo "install $(SRC_HTML_CPDIR) dirs and files"
-	for dir in $(cp_dirs); do \
-            install -v -d -m0755 $(DESTDIR)$(PF_PREFIX)/$$dir ; \
-	done
 	for file in $(cp_files); do \
-	    install -v -m 0644 $$file $(DESTDIR)$(PF_PREFIX)/$$file ; \
+	    install -v -m 0644 $$file -D $(DESTDIR)$(PF_PREFIX)/$$file ; \
 	done
 
 	@echo "install $(SRC_HTML_PFAPPDIR) without root dir"
-	for dir in $(pfapp_dirs); do \
-            install -v -d -m0755 $(DESTDIR)$(PF_PREFIX)/$$dir ; \
-	done
 	for file in $(pfapp_files); do \
-	    install -v -m 0644 $$file $(DESTDIR)$(PF_PREFIX)/$$file ; \
+	    install -v -m 0644 $$file -D $(DESTDIR)$(PF_PREFIX)/$$file ; \
 	done
 
-	@echo "install $(SRC_HTML_PFAPPDIR_STATIC) other dirs and files"
-	for dir in $(pfapp_static_dir); do \
-            install -v -d -m0755 $(DESTDIR)$(PF_PREFIX)/$$dir ; \
-	done
+	@echo "install $(SRC_HTML_PFAPPDIR_STATIC) dirs and files"
 	for file in $(pfapp_static_files); do \
-	    install -v -m 0644 $$file $(DESTDIR)$(PF_PREFIX)/$$file ; \
+	    install -v -m 0644 $$file -D $(DESTDIR)$(PF_PREFIX)/$$file ; \
 	done
+
+	@echo "install $(SRC_HTML_PFAPPDIR_ALT) dirs and files"
+	for file in $(pfapp_alt_files); do \
+	    install -v -m 0644 $$file -D $(DESTDIR)$(PF_PREFIX)/$$file ; \
+	done
+	for file in $(pfapp_bootstrap_files); do \
+	    install -v -m 0644 $$file -D $(DESTDIR)$(PF_PREFIX)/$$file ; \
+	done
+
 

--- a/Makefile
+++ b/Makefile
@@ -224,15 +224,23 @@ pfappserver_install:
 	install -d -m0755 $(DESTDIR)$(HTML_CPDIR)
 	install -d -m0755 $(DESTDIR)$(HTML_PFAPPDIR)
 
-	@echo "install html/parking files"
+	@echo "install $(SRC_HTML_PARKINGDIR) files"
 	for file in $(parking_files); do \
-            install -v -m 0644 html/parking/$$file $(DESTDIR)$(HTML_PARKINGDIR)/ ; \
+            install -v -m 0644 $(SRC_HTML_PARKINGDIR)/$$file $(DESTDIR)$(HTML_PARKINGDIR)/ ; \
 	done
 
-	@echo "install html/common dirs and files"
+	@echo "install $(SRC_HTML_COMMONDIR) dirs and files"
 	for dir in $(common_dirs); do \
             install -v -d -m0755 $(DESTDIR)$(PFPREFIX)/$$dir ; \
 	done
 	for file in $(common_files); do \
+	    install -v -m 0644 $$file $(DESTDIR)$(PFPREFIX)/$$file ; \
+	done
+
+	@echo "install $(SRC_HTML_CPDIR) dirs and files"
+	for dir in $(cp_dirs); do \
+            install -v -d -m0755 $(DESTDIR)$(PFPREFIX)/$$dir ; \
+	done
+	for file in $(cp_files); do \
 	    install -v -m 0644 $$file $(DESTDIR)$(PFPREFIX)/$$file ; \
 	done

--- a/Makefile
+++ b/Makefile
@@ -245,10 +245,18 @@ pfappserver_install:
 	    install -v -m 0644 $$file $(DESTDIR)$(PFPREFIX)/$$file ; \
 	done
 
-	@echo "install $(SRC_HTML_PFAPPDIR) top dirs and files"
-	for dir in $(pfapp_top_dirs); do \
+	@echo "install $(SRC_HTML_PFAPPDIR) without root dir"
+	for dir in $(pfapp_dirs); do \
             install -v -d -m0755 $(DESTDIR)$(PFPREFIX)/$$dir ; \
 	done
-	for file in $(pfapp_top_files); do \
+	for file in $(pfapp_files); do \
 	    install -v -m 0644 $$file $(DESTDIR)$(PFPREFIX)/$$file ; \
 	done
+
+	# @echo "install $(SRC_HTML_PFAPPDIR) other dirs and files"
+	# for dir in $(pfapp_other_dirs); do \
+        #     install -v -d -m0755 $(DESTDIR)$(PFPREFIX)/$$dir ; \
+	# done
+	# for file in $(pfapp_other_files); do \
+	#     install -v -m 0644 $$file $(DESTDIR)$(PFPREFIX)/$$file ; \
+	# done

--- a/Makefile
+++ b/Makefile
@@ -231,32 +231,32 @@ html_install:
 
 	@echo "install $(SRC_HTML_COMMONDIR) dirs and files"
 	for dir in $(common_dirs); do \
-            install -v -d -m0755 $(DESTDIR)$(PFPREFIX)/$$dir ; \
+            install -v -d -m0755 $(DESTDIR)$(PF_PREFIX)/$$dir ; \
 	done
 	for file in $(common_files); do \
-	    install -v -m 0644 $$file $(DESTDIR)$(PFPREFIX)/$$file ; \
+	    install -v -m 0644 $$file $(DESTDIR)$(PF_PREFIX)/$$file ; \
 	done
 
 	@echo "install $(SRC_HTML_CPDIR) dirs and files"
 	for dir in $(cp_dirs); do \
-            install -v -d -m0755 $(DESTDIR)$(PFPREFIX)/$$dir ; \
+            install -v -d -m0755 $(DESTDIR)$(PF_PREFIX)/$$dir ; \
 	done
 	for file in $(cp_files); do \
-	    install -v -m 0644 $$file $(DESTDIR)$(PFPREFIX)/$$file ; \
+	    install -v -m 0644 $$file $(DESTDIR)$(PF_PREFIX)/$$file ; \
 	done
 
 	@echo "install $(SRC_HTML_PFAPPDIR) without root dir"
 	for dir in $(pfapp_dirs); do \
-            install -v -d -m0755 $(DESTDIR)$(PFPREFIX)/$$dir ; \
+            install -v -d -m0755 $(DESTDIR)$(PF_PREFIX)/$$dir ; \
 	done
 	for file in $(pfapp_files); do \
-	    install -v -m 0644 $$file $(DESTDIR)$(PFPREFIX)/$$file ; \
+	    install -v -m 0644 $$file $(DESTDIR)$(PF_PREFIX)/$$file ; \
 	done
 
 	# @echo "install $(SRC_HTML_PFAPPDIR) other dirs and files"
 	# for dir in $(pfapp_other_dirs); do \
-        #     install -v -d -m0755 $(DESTDIR)$(PFPREFIX)/$$dir ; \
+        #     install -v -d -m0755 $(DESTDIR)$(PF_PREFIX)/$$dir ; \
 	# done
 	# for file in $(pfapp_other_files); do \
-	#     install -v -m 0644 $$file $(DESTDIR)$(PFPREFIX)/$$file ; \
+	#     install -v -m 0644 $$file $(DESTDIR)$(PF_PREFIX)/$$file ; \
 	# done

--- a/Makefile
+++ b/Makefile
@@ -244,3 +244,11 @@ pfappserver_install:
 	for file in $(cp_files); do \
 	    install -v -m 0644 $$file $(DESTDIR)$(PFPREFIX)/$$file ; \
 	done
+
+	@echo "install $(SRC_HTML_PFAPPDIR) top dirs and files"
+	for dir in $(pfapp_top_dirs); do \
+            install -v -d -m0755 $(DESTDIR)$(PFPREFIX)/$$dir ; \
+	done
+	for file in $(pfapp_top_files); do \
+	    install -v -m 0644 $$file $(DESTDIR)$(PFPREFIX)/$$file ; \
+	done

--- a/config.mk
+++ b/config.mk
@@ -1,18 +1,34 @@
-GOVERSION = go1.13.1
-GOBINARIES = pfhttpd pfdhcp pfdns pfstats pfdetect
+#==============================================================================
+# CI
+#==============================================================================
+
+#
+# Packer
+#
 DOCKER_TAG = latest
 REGISTRY = docker.io
-
-### CI
 ANSIBLE_CENTOS_GROUP = devel_centos
 ANSIBLE_DEBIAN_GROUP = devel_debian
 ANSIBLE_RUBYGEMS_GROUP = devel_rubygems
 
-### PacketFence
+
+#==============================================================================
+# PacketFence application
+#==============================================================================
+
+#
+# Base directories
+#
 PREFIX = /usr/local
 PFPREFIX = $(PREFIX)/pf
 BINDIR = $(PFPREFIX)/bin
 SBINDIR = $(PFPREFIX)/sbin
+
+#
+# Golang
+#
+GOVERSION = go1.13.1
+GOBINARIES = pfhttpd pfdhcp pfdns pfstats pfdetect
 
 # SRC HTML dirs
 SRC_HTMLDIR = html

--- a/config.mk
+++ b/config.mk
@@ -2,8 +2,32 @@ GOVERSION = go1.13.1
 GOBINARIES = pfhttpd pfdhcp pfdns pfstats pfdetect
 DOCKER_TAG = latest
 REGISTRY = docker.io
-SBINDIR = /usr/local/pf/sbin
 
-ANSIBLE_CENTOS_GROUP=devel_centos
-ANSIBLE_DEBIAN_GROUP=devel_debian
-ANSIBLE_RUBYGEMS_GROUP=devel_rubygems
+### CI
+ANSIBLE_CENTOS_GROUP = devel_centos
+ANSIBLE_DEBIAN_GROUP = devel_debian
+ANSIBLE_RUBYGEMS_GROUP = devel_rubygems
+
+### PacketFence
+PREFIX = /usr/local
+PFPREFIX = $(PREFIX)/pf
+BINDIR = $(PFPREFIX)/bin
+SBINDIR = $(PFPREFIX)/sbin
+
+# HTML dirs
+HTMLDIR = $(PFPREFIX)/html
+HTML_CPDIR = $(HTMLDIR)/captive-portal
+HTML_COMMONDIR = $(HTMLDIR)/common
+HTML_PARKINGDIR = $(HTMLDIR)/parking
+HTML_PFAPPDIR = $(HTMLDIR)/pfappserver
+
+
+# HTML files
+parking_files = $(notdir $(wildcard ./html/parking/*))
+
+# '*' after dir name don't match current directory
+# exclude node_modules dir and subdirs
+common_dirs = $(shell find html/common/* ! -path "html/common/node_modules*" -type d)
+
+# exclude package.json and package-lock.json
+common_files = $(shell find html/common/* -type f -not -name "package*.json") 

--- a/config.mk
+++ b/config.mk
@@ -14,20 +14,31 @@ PFPREFIX = $(PREFIX)/pf
 BINDIR = $(PFPREFIX)/bin
 SBINDIR = $(PFPREFIX)/sbin
 
-# HTML dirs
+# SRC HTML dirs
+SRC_HTMLDIR = html
+SRC_HTML_CPDIR = $(SRC_HTMLDIR)/captive-portal
+SRC_HTML_COMMONDIR = $(SRC_HTMLDIR)/common
+SRC_HTML_PARKINGDIR = $(SRC_HTMLDIR)/parking
+SRC_HTML_PFAPPDIR = $(SRC_HTMLDIR)/pfappserver
+
+# Installed HTLML dirs
 HTMLDIR = $(PFPREFIX)/html
 HTML_CPDIR = $(HTMLDIR)/captive-portal
 HTML_COMMONDIR = $(HTMLDIR)/common
 HTML_PARKINGDIR = $(HTMLDIR)/parking
 HTML_PFAPPDIR = $(HTMLDIR)/pfappserver
 
+# parking files
+parking_files = $(notdir $(wildcard ./$(SRC_HTML_PARKINGDIR)/*))
 
-# HTML files
-parking_files = $(notdir $(wildcard ./html/parking/*))
-
+# common files and dirs
 # '*' after dir name don't match current directory
 # exclude node_modules dir and subdirs
-common_dirs = $(shell find html/common/* ! -path "html/common/node_modules*" -type d)
+common_dirs = $(shell find $(SRC_HTML_COMMONDIR)/* ! -path "$(SRC_HTML_COMMONDIR)/node_modules*" -type d)
 
 # exclude package.json and package-lock.json
-common_files = $(shell find html/common/* -type f -not -name "package*.json") 
+common_files = $(shell find $(SRC_HTML_COMMONDIR)/* -type f -not -name "package*.json") 
+
+# captive portal files and dirs
+cp_dirs = $(shell find $(SRC_HTML_CPDIR)/* -type d)
+cp_files = $(shell find $(SRC_HTML_CPDIR)/* -type f)

--- a/config.mk
+++ b/config.mk
@@ -56,11 +56,9 @@ parking_files = $(shell find $(SRC_HTML_PARKINGDIR)/* \
 
 # common files
 # '*' after dir name don't match current directory
-# exclude package.json and package-lock.json
 # exclude node_modules dir and subdirs
 common_files = $(shell find $(SRC_HTML_COMMONDIR)/* \
 	-type f \
-	-not -name "package*.json" \
 	-and -not -path "$(SRC_HTML_COMMONDIR)/node_modules/*")
 
 # captive portal files
@@ -80,14 +78,11 @@ pfapp_files = $(shell find $(SRC_HTML_PFAPPDIR)/* \
 
 pfapp_static_files = $(shell find $(SRC_HTML_PFAPPDIR_STATIC)/* \
 	-type f \
-	-not -name "package*.json" \
-	-and -not -name "bower.json" \
 	-and -not -path "$(SRC_HTML_PFAPPDIR_STATIC)/bower_components/*" \
 	-and -not -path "$(SRC_HTML_PFAPPDIR_STATIC)/node_modules/*")
 
 pfapp_alt_files = $(shell find $(SRC_HTML_PFAPPDIR_ALT)/* \
 	-type f \
-	-not -name "package*.json" \
 	-and -not -path "$(SRC_HTML_PFAPPDIR_ALT)/node_modules/*")
 
 pfapp_bootstrap_files = $(shell find $(SRC_HTML_PFAPPDIR_ALT)/node_modules/bootstrap/dist \

--- a/config.mk
+++ b/config.mk
@@ -69,13 +69,14 @@ cp_files = $(shell find $(SRC_HTML_CPDIR)/* \
 	-not -path "$(SRC_HTML_CPDIR)/content/node_modules*" \
 	-and -not -path "$(SRC_HTML_CPDIR)/t*")
 
-# pfappserver files without root
+# pfappserver files without static and static.alt
 pfapp_files = $(shell find $(SRC_HTML_PFAPPDIR)/* \
 	-type f \
 	-not -name "Changes" \
 	-not -path "$(SRC_HTML_PFAPPDIR)/root-custom*" \
 	-and -not -path "$(SRC_HTML_PFAPPDIR)/t*" \
-	-and -not -path "$(SRC_HTML_PFAPPDIR)/root*")
+	-and -not -path "$(SRC_HTML_PFAPPDIR_STATIC)*" \
+	-and -not -path "$(SRC_HTML_PFAPPDIR_ALT)*")
 
 pfapp_static_files = $(shell find $(SRC_HTML_PFAPPDIR_STATIC)/* \
 	-type f \
@@ -91,6 +92,3 @@ pfapp_alt_files = $(shell find $(SRC_HTML_PFAPPDIR_ALT)/* \
 
 pfapp_bootstrap_files = $(shell find $(SRC_HTML_PFAPPDIR_ALT)/node_modules/bootstrap/dist \
 	-type f)
-
-# node_modules (static), (static.alt)
-# node_modules (static), (static.alt)

--- a/config.mk
+++ b/config.mk
@@ -85,5 +85,3 @@ pfapp_alt_files = $(shell find $(SRC_HTML_PFAPPDIR_ALT)/* \
 	-type f \
 	-and -not -path "$(SRC_HTML_PFAPPDIR_ALT)/node_modules/*")
 
-pfapp_bootstrap_files = $(shell find $(SRC_HTML_PFAPPDIR_ALT)/node_modules/bootstrap/dist \
-	-type f)

--- a/config.mk
+++ b/config.mk
@@ -88,7 +88,7 @@ pfapp_static_files = $(shell find $(SRC_HTML_PFAPPDIR_STATIC)/* \
 pfapp_alt_files = $(shell find $(SRC_HTML_PFAPPDIR_ALT)/* \
 	-type f \
 	-not -name "package*.json" \
-	-and -not -path "$(SRC_HTML_PFAPPDIR_ALT)/node_modules*")
+	-and -not -path "$(SRC_HTML_PFAPPDIR_ALT)/node_modules/*")
 
 pfapp_bootstrap_files = $(shell find $(SRC_HTML_PFAPPDIR_ALT)/node_modules/bootstrap/dist \
 	-type f)

--- a/config.mk
+++ b/config.mk
@@ -20,6 +20,8 @@ SRC_HTML_CPDIR = $(SRC_HTMLDIR)/captive-portal
 SRC_HTML_COMMONDIR = $(SRC_HTMLDIR)/common
 SRC_HTML_PARKINGDIR = $(SRC_HTMLDIR)/parking
 SRC_HTML_PFAPPDIR = $(SRC_HTMLDIR)/pfappserver
+SRC_HTML_PFAPPDIR_STATIC = $(SRC_HTML_PFAPPDIR)/root/static
+SRC_HTML_PFAPPDIR_ALT = $(SRC_HTML_PFAPPDIR)/root/static.alt
 
 # Installed HTLML dirs
 HTMLDIR = $(PFPREFIX)/html
@@ -27,6 +29,8 @@ HTML_CPDIR = $(HTMLDIR)/captive-portal
 HTML_COMMONDIR = $(HTMLDIR)/common
 HTML_PARKINGDIR = $(HTMLDIR)/parking
 HTML_PFAPPDIR = $(HTMLDIR)/pfappserver
+HTML_PFAPPDIR_STATIC = $(HTML_PFAPPDIR)/root/static
+HTML_PFAPPDIR_ALT = $(HTML_PFAPPDIR)/root/static.alt
 
 # parking files
 parking_files = $(notdir $(wildcard ./$(SRC_HTML_PARKINGDIR)/*))
@@ -40,5 +44,13 @@ common_dirs = $(shell find $(SRC_HTML_COMMONDIR)/* ! -path "$(SRC_HTML_COMMONDIR
 common_files = $(shell find $(SRC_HTML_COMMONDIR)/* -type f -not -name "package*.json") 
 
 # captive portal files and dirs
-cp_dirs = $(shell find $(SRC_HTML_CPDIR)/* -type d)
+cp_dirs = $(shell find $(SRC_HTML_CPDIR)/* ! -path "$(SRC_HTML_CPDIR)/content/node_modules*" -type d)
 cp_files = $(shell find $(SRC_HTML_CPDIR)/* -type f)
+
+# pfappserver files and dirs
+# top level pfappserver
+pfapp_top_dirs = $(shell find $(SRC_HTML_PFAPPDIR)/* -maxdepth 0 -type d ! -path "html/pfappserver/root-custom*" -and ! -path "html/pfappserver/t*")
+pfapp_top_files = $(shell find $(SRC_HTML_PFAPPDIR)/* -maxdepth 0 -type f -not -name "Changes")
+
+# node_modules (static), (static.alt)
+# node_modules (static), (static.alt)

--- a/config.mk
+++ b/config.mk
@@ -36,8 +36,9 @@ SRC_HTML_CPDIR = $(SRC_HTMLDIR)/captive-portal
 SRC_HTML_COMMONDIR = $(SRC_HTMLDIR)/common
 SRC_HTML_PARKINGDIR = $(SRC_HTMLDIR)/parking
 SRC_HTML_PFAPPDIR = $(SRC_HTMLDIR)/pfappserver
-SRC_HTML_PFAPPDIR_STATIC = $(SRC_HTML_PFAPPDIR)/root/static
-SRC_HTML_PFAPPDIR_ALT = $(SRC_HTML_PFAPPDIR)/root/static.alt
+SRC_HTML_PFAPPDIR_ROOT = $(SRC_HTMLDIR)/pfappserver/root
+SRC_HTML_PFAPPDIR_STATIC = $(SRC_HTML_PFAPPDIR_ROOT)/static
+SRC_HTML_PFAPPDIR_ALT = $(SRC_HTML_PFAPPDIR_ROOT)/static.alt
 
 # Installed HTLML dirs
 HTMLDIR = $(PF_PREFIX)/html
@@ -45,8 +46,9 @@ HTML_CPDIR = $(HTMLDIR)/captive-portal
 HTML_COMMONDIR = $(HTMLDIR)/common
 HTML_PARKINGDIR = $(HTMLDIR)/parking
 HTML_PFAPPDIR = $(HTMLDIR)/pfappserver
-HTML_PFAPPDIR_STATIC = $(HTML_PFAPPDIR)/root/static
-HTML_PFAPPDIR_ALT = $(HTML_PFAPPDIR)/root/static.alt
+HTML_PFAPPDIR_ROOT = $(HTMLDIR)/pfappserver/root
+HTML_PFAPPDIR_STATIC = $(HTML_PFAPPDIR_ROOT)/static
+HTML_PFAPPDIR_ALT = $(HTML_PFAPPDIR_ROOT)/static.alt
 
 # parking files
 parking_files = $(notdir $(wildcard ./$(SRC_HTML_PARKINGDIR)/*))
@@ -54,21 +56,54 @@ parking_files = $(notdir $(wildcard ./$(SRC_HTML_PARKINGDIR)/*))
 # common files and dirs
 # '*' after dir name don't match current directory
 # exclude node_modules dir and subdirs
-common_dirs = $(shell find $(SRC_HTML_COMMONDIR)/* ! -path "$(SRC_HTML_COMMONDIR)/node_modules*" -type d)
+common_dirs = $(shell find $(SRC_HTML_COMMONDIR)/* \
+	-type d \
+	-not -path "$(SRC_HTML_COMMONDIR)/node_modules*")
 
 # exclude package.json and package-lock.json
-common_files = $(shell find $(SRC_HTML_COMMONDIR)/* -type f -not -name "package*.json") 
+common_files = $(shell find $(SRC_HTML_COMMONDIR)/* \
+	-type f \
+	-not -name "package*.json")
 
 # captive portal files and dirs
-cp_dirs = $(shell find $(SRC_HTML_CPDIR)/* ! -path "$(SRC_HTML_CPDIR)/content/node_modules*" -type d)
-cp_files = $(shell find $(SRC_HTML_CPDIR)/* -type f)
+cp_dirs = $(shell find $(SRC_HTML_CPDIR)/* \
+	-type d \
+	-not -path "$(SRC_HTML_CPDIR)/content/node_modules*" \
+	-and -not -path "$(SRC_HTML_CPDIR)/t*")
+
+cp_files = $(shell find $(SRC_HTML_CPDIR)/* \
+	-type f \
+	-not -path "$(SRC_HTML_CPDIR)/content/node_modules*" \
+	-and -not -path "$(SRC_HTML_CPDIR)/t*")
 
 # pfappserver files and dirs without root and useless dirs
-pfapp_dirs = $(shell find $(SRC_HTML_PFAPPDIR)/* -type d ! -path "html/pfappserver/root-custom*" -and ! -path "html/pfappserver/t*" -and ! -path "html/pfappserver/root*")
-pfapp_files = $(shell find $(SRC_HTML_PFAPPDIR)/* -type f -not -name "Changes" ! -path "html/pfappserver/root-custom*" -and ! -path "html/pfappserver/t*" -and ! -path "html/pfappserver/root*")
+pfapp_dirs = $(shell find $(SRC_HTML_PFAPPDIR)/* \
+	-type d \
+	-not -path "$(SRC_HTML_PFAPPDIR)/root-custom*" \
+	-and -not -path "$(SRC_HTML_PFAPPDIR)/t*" \
+	-and -not -path "$(SRC_HTML_PFAPPDIR)/root*")
 
-pfapp_other_dirs = $(shell find $(SRC_HTML_PFAPPDIR)/* -maxdepth 0 -type d ! -path "html/pfappserver/root-custom*" -and ! -path "html/pfappserver/t*")
-pfapp_other_files = $(shell find $(SRC_HTML_PFAPPDIR)/* -maxdepth 0 -type f -not -name "Changes")
+pfapp_files = $(shell find $(SRC_HTML_PFAPPDIR)/* \
+	-type f \
+	-not -name "Changes" \
+	-not -path "$(SRC_HTML_PFAPPDIR)/root-custom*" \
+	-and -not -path "$(SRC_HTML_PFAPPDIR)/t*" \
+	-and -not -path "$(SRC_HTML_PFAPPDIR)/root*")
+
+pfapp_static_dir = $(shell find $(SRC_HTML_PFAPPDIR_STATIC)/* \
+	-type d \
+	-not -path "$(SRC_HTML_PFAPPDIR_STATIC)/bower_components*" \
+	-and -not -path "$(SRC_HTML_PFAPPDIR_STATIC)/node_modules*")
+
+pfapp_static_files = $(shell find $(SRC_HTML_PFAPPDIR_STATIC)/* \
+	-type f \
+	-not -name "package*.json" \
+	-and -not -name "bower.json" \
+	-and -not -path "$(SRC_HTML_PFAPPDIR_STATIC)/bower_components*" \
+	-and -not -path "$(SRC_HTML_PFAPPDIR_STATIC)/node_modules*")
+
+# pfapp_alt_dir = $(shell find $(SRC_HTML_PFAPPDIR_ALT)/* -type d ! -path "html/pfappserver/root-custom*" -and ! -path "html/pfappserver/t*")
+# pfapp_alt_files = $(shell find $(SRC_HTML_PFAPPDIR_ALT)/* -type f -not -name "")
 
 # node_modules (static), (static.alt)
 # node_modules (static), (static.alt)

--- a/config.mk
+++ b/config.mk
@@ -47,10 +47,12 @@ common_files = $(shell find $(SRC_HTML_COMMONDIR)/* -type f -not -name "package*
 cp_dirs = $(shell find $(SRC_HTML_CPDIR)/* ! -path "$(SRC_HTML_CPDIR)/content/node_modules*" -type d)
 cp_files = $(shell find $(SRC_HTML_CPDIR)/* -type f)
 
-# pfappserver files and dirs
-# top level pfappserver
-pfapp_top_dirs = $(shell find $(SRC_HTML_PFAPPDIR)/* -maxdepth 0 -type d ! -path "html/pfappserver/root-custom*" -and ! -path "html/pfappserver/t*")
-pfapp_top_files = $(shell find $(SRC_HTML_PFAPPDIR)/* -maxdepth 0 -type f -not -name "Changes")
+# pfappserver files and dirs without root and useless dirs
+pfapp_dirs = $(shell find $(SRC_HTML_PFAPPDIR)/* -type d ! -path "html/pfappserver/root-custom*" -and ! -path "html/pfappserver/t*" -and ! -path "html/pfappserver/root*")
+pfapp_files = $(shell find $(SRC_HTML_PFAPPDIR)/* -type f -not -name "Changes" ! -path "html/pfappserver/root-custom*" -and ! -path "html/pfappserver/t*" -and ! -path "html/pfappserver/root*")
+
+pfapp_other_dirs = $(shell find $(SRC_HTML_PFAPPDIR)/* -maxdepth 0 -type d ! -path "html/pfappserver/root-custom*" -and ! -path "html/pfappserver/t*")
+pfapp_other_files = $(shell find $(SRC_HTML_PFAPPDIR)/* -maxdepth 0 -type f -not -name "Changes")
 
 # node_modules (static), (static.alt)
 # node_modules (static), (static.alt)

--- a/config.mk
+++ b/config.mk
@@ -59,29 +59,29 @@ parking_files = $(shell find $(SRC_HTML_PARKINGDIR)/* \
 # exclude node_modules dir and subdirs
 common_files = $(shell find $(SRC_HTML_COMMONDIR)/* \
 	-type f \
-	-and -not -path "$(SRC_HTML_COMMONDIR)/node_modules/*")
+	-not -path "$(SRC_HTML_COMMONDIR)/node_modules/*")
 
 # captive portal files
 cp_files = $(shell find $(SRC_HTML_CPDIR)/* \
 	-type f \
 	-not -path "$(SRC_HTML_CPDIR)/content/node_modules/*" \
-	-and -not -path "$(SRC_HTML_CPDIR)/t/*")
+	-not -path "$(SRC_HTML_CPDIR)/t/*")
 
 # pfappserver files without static and static.alt
 pfapp_files = $(shell find $(SRC_HTML_PFAPPDIR)/* \
 	-type f \
 	-not -name "Changes" \
 	-not -path "$(SRC_HTML_PFAPPDIR)/root-custom*" \
-	-and -not -path "$(SRC_HTML_PFAPPDIR)/t/*" \
-	-and -not -path "$(SRC_HTML_PFAPPDIR_STATIC)*" \
-	-and -not -path "$(SRC_HTML_PFAPPDIR_ALT)*")
+	-not -path "$(SRC_HTML_PFAPPDIR)/t/*" \
+	-not -path "$(SRC_HTML_PFAPPDIR_STATIC)*" \
+	-not -path "$(SRC_HTML_PFAPPDIR_ALT)*")
 
 pfapp_static_files = $(shell find $(SRC_HTML_PFAPPDIR_STATIC)/* \
 	-type f \
-	-and -not -path "$(SRC_HTML_PFAPPDIR_STATIC)/bower_components/*" \
-	-and -not -path "$(SRC_HTML_PFAPPDIR_STATIC)/node_modules/*")
+	-not -path "$(SRC_HTML_PFAPPDIR_STATIC)/bower_components/*" \
+	-not -path "$(SRC_HTML_PFAPPDIR_STATIC)/node_modules/*")
 
 pfapp_alt_files = $(shell find $(SRC_HTML_PFAPPDIR_ALT)/* \
 	-type f \
-	-and -not -path "$(SRC_HTML_PFAPPDIR_ALT)/node_modules/*")
+	-not -path "$(SRC_HTML_PFAPPDIR_ALT)/node_modules/*")
 

--- a/config.mk
+++ b/config.mk
@@ -1,4 +1,5 @@
 GOVERSION = go1.13.1
+GOBINARIES = pfhttpd pfdhcp pfdns pfstats pfdetect
 DOCKER_TAG = latest
 REGISTRY = docker.io
 SBINDIR = /usr/local/pf/sbin

--- a/config.mk
+++ b/config.mk
@@ -61,20 +61,20 @@ parking_files = $(shell find $(SRC_HTML_PARKINGDIR)/* \
 common_files = $(shell find $(SRC_HTML_COMMONDIR)/* \
 	-type f \
 	-not -name "package*.json" \
-	-and -not -path "$(SRC_HTML_COMMONDIR)/node_modules*")
+	-and -not -path "$(SRC_HTML_COMMONDIR)/node_modules/*")
 
 # captive portal files
 cp_files = $(shell find $(SRC_HTML_CPDIR)/* \
 	-type f \
-	-not -path "$(SRC_HTML_CPDIR)/content/node_modules*" \
-	-and -not -path "$(SRC_HTML_CPDIR)/t*")
+	-not -path "$(SRC_HTML_CPDIR)/content/node_modules/*" \
+	-and -not -path "$(SRC_HTML_CPDIR)/t/*")
 
 # pfappserver files without static and static.alt
 pfapp_files = $(shell find $(SRC_HTML_PFAPPDIR)/* \
 	-type f \
 	-not -name "Changes" \
 	-not -path "$(SRC_HTML_PFAPPDIR)/root-custom*" \
-	-and -not -path "$(SRC_HTML_PFAPPDIR)/t*" \
+	-and -not -path "$(SRC_HTML_PFAPPDIR)/t/*" \
 	-and -not -path "$(SRC_HTML_PFAPPDIR_STATIC)*" \
 	-and -not -path "$(SRC_HTML_PFAPPDIR_ALT)*")
 
@@ -82,8 +82,8 @@ pfapp_static_files = $(shell find $(SRC_HTML_PFAPPDIR_STATIC)/* \
 	-type f \
 	-not -name "package*.json" \
 	-and -not -name "bower.json" \
-	-and -not -path "$(SRC_HTML_PFAPPDIR_STATIC)/bower_components*" \
-	-and -not -path "$(SRC_HTML_PFAPPDIR_STATIC)/node_modules*")
+	-and -not -path "$(SRC_HTML_PFAPPDIR_STATIC)/bower_components/*" \
+	-and -not -path "$(SRC_HTML_PFAPPDIR_STATIC)/node_modules/*")
 
 pfapp_alt_files = $(shell find $(SRC_HTML_PFAPPDIR_ALT)/* \
 	-type f \

--- a/config.mk
+++ b/config.mk
@@ -65,6 +65,7 @@ common_files = $(shell find $(SRC_HTML_COMMONDIR)/* \
 cp_files = $(shell find $(SRC_HTML_CPDIR)/* \
 	-type f \
 	-not -path "$(SRC_HTML_CPDIR)/content/node_modules/*" \
+	-not -path "$(SRC_HTML_CPDIR)/profile-templates/*" \
 	-not -path "$(SRC_HTML_CPDIR)/t/*")
 
 # pfappserver files without static and static.alt

--- a/config.mk
+++ b/config.mk
@@ -20,9 +20,9 @@ ANSIBLE_RUBYGEMS_GROUP = devel_rubygems
 # Base directories
 #
 PREFIX = /usr/local
-PFPREFIX = $(PREFIX)/pf
-BINDIR = $(PFPREFIX)/bin
-SBINDIR = $(PFPREFIX)/sbin
+PF_PREFIX = $(PREFIX)/pf
+BINDIR = $(PF_PREFIX)/bin
+SBINDIR = $(PF_PREFIX)/sbin
 
 #
 # Golang
@@ -40,7 +40,7 @@ SRC_HTML_PFAPPDIR_STATIC = $(SRC_HTML_PFAPPDIR)/root/static
 SRC_HTML_PFAPPDIR_ALT = $(SRC_HTML_PFAPPDIR)/root/static.alt
 
 # Installed HTLML dirs
-HTMLDIR = $(PFPREFIX)/html
+HTMLDIR = $(PF_PREFIX)/html
 HTML_CPDIR = $(HTMLDIR)/captive-portal
 HTML_COMMONDIR = $(HTMLDIR)/common
 HTML_PARKINGDIR = $(HTMLDIR)/parking

--- a/config.mk
+++ b/config.mk
@@ -51,49 +51,31 @@ HTML_PFAPPDIR_STATIC = $(HTML_PFAPPDIR_ROOT)/static
 HTML_PFAPPDIR_ALT = $(HTML_PFAPPDIR_ROOT)/static.alt
 
 # parking files
-parking_files = $(notdir $(wildcard ./$(SRC_HTML_PARKINGDIR)/*))
+parking_files = $(shell find $(SRC_HTML_PARKINGDIR)/* \
+	-type f)
 
-# common files and dirs
+# common files
 # '*' after dir name don't match current directory
-# exclude node_modules dir and subdirs
-common_dirs = $(shell find $(SRC_HTML_COMMONDIR)/* \
-	-type d \
-	-not -path "$(SRC_HTML_COMMONDIR)/node_modules*")
-
 # exclude package.json and package-lock.json
+# exclude node_modules dir and subdirs
 common_files = $(shell find $(SRC_HTML_COMMONDIR)/* \
 	-type f \
-	-not -name "package*.json")
+	-not -name "package*.json" \
+	-and -not -path "$(SRC_HTML_COMMONDIR)/node_modules*")
 
-# captive portal files and dirs
-cp_dirs = $(shell find $(SRC_HTML_CPDIR)/* \
-	-type d \
-	-not -path "$(SRC_HTML_CPDIR)/content/node_modules*" \
-	-and -not -path "$(SRC_HTML_CPDIR)/t*")
-
+# captive portal files
 cp_files = $(shell find $(SRC_HTML_CPDIR)/* \
 	-type f \
 	-not -path "$(SRC_HTML_CPDIR)/content/node_modules*" \
 	-and -not -path "$(SRC_HTML_CPDIR)/t*")
 
-# pfappserver files and dirs without root and useless dirs
-pfapp_dirs = $(shell find $(SRC_HTML_PFAPPDIR)/* \
-	-type d \
-	-not -path "$(SRC_HTML_PFAPPDIR)/root-custom*" \
-	-and -not -path "$(SRC_HTML_PFAPPDIR)/t*" \
-	-and -not -path "$(SRC_HTML_PFAPPDIR)/root*")
-
+# pfappserver files without root
 pfapp_files = $(shell find $(SRC_HTML_PFAPPDIR)/* \
 	-type f \
 	-not -name "Changes" \
 	-not -path "$(SRC_HTML_PFAPPDIR)/root-custom*" \
 	-and -not -path "$(SRC_HTML_PFAPPDIR)/t*" \
 	-and -not -path "$(SRC_HTML_PFAPPDIR)/root*")
-
-pfapp_static_dir = $(shell find $(SRC_HTML_PFAPPDIR_STATIC)/* \
-	-type d \
-	-not -path "$(SRC_HTML_PFAPPDIR_STATIC)/bower_components*" \
-	-and -not -path "$(SRC_HTML_PFAPPDIR_STATIC)/node_modules*")
 
 pfapp_static_files = $(shell find $(SRC_HTML_PFAPPDIR_STATIC)/* \
 	-type f \
@@ -102,8 +84,13 @@ pfapp_static_files = $(shell find $(SRC_HTML_PFAPPDIR_STATIC)/* \
 	-and -not -path "$(SRC_HTML_PFAPPDIR_STATIC)/bower_components*" \
 	-and -not -path "$(SRC_HTML_PFAPPDIR_STATIC)/node_modules*")
 
-# pfapp_alt_dir = $(shell find $(SRC_HTML_PFAPPDIR_ALT)/* -type d ! -path "html/pfappserver/root-custom*" -and ! -path "html/pfappserver/t*")
-# pfapp_alt_files = $(shell find $(SRC_HTML_PFAPPDIR_ALT)/* -type f -not -name "")
+pfapp_alt_files = $(shell find $(SRC_HTML_PFAPPDIR_ALT)/* \
+	-type f \
+	-not -name "package*.json" \
+	-and -not -path "$(SRC_HTML_PFAPPDIR_ALT)/node_modules*")
+
+pfapp_bootstrap_files = $(shell find $(SRC_HTML_PFAPPDIR_ALT)/node_modules/bootstrap/dist \
+	-type f)
 
 # node_modules (static), (static.alt)
 # node_modules (static), (static.alt)

--- a/debian/rules
+++ b/debian/rules
@@ -182,7 +182,6 @@ install: build
 	done
 	#Golang binary
 	install -d -m0744 $(CURDIR)/debian/packetfence-golang-daemon$(PREFIX)/$(NAME)/sbin
-	#PATH=$$PATH:/usr/lib/go-1.7/bin && addons/packages/build-go.sh build $(CURDIR)/ $(CURDIR)/debian/packetfence-golang-daemon$(PREFIX)/$(NAME)/sbin $(CURDIR)/debian
 	make -C go all
 	make -C go DESTDIR=$(CURDIR)/debian/packetfence-golang-daemon copy
 

--- a/go/Makefile
+++ b/go/Makefile
@@ -66,11 +66,15 @@ test:
 	PFCONFIG_TESTING=y go test ./...
 
 .PHONY: all
-all: pfhttpd pfdhcp pfdns pfstats pfdetect
+all: $(GOBINARIES)
 
 .PHONY: copy
 copy:
-	cp -f pfhttpd pfdhcp pfdns pfstats pfdetect $(DESTDIR)$(SBINDIR)
+	cp -f $(GOBINARIES) $(DESTDIR)$(SBINDIR)
+
+.PHONY: clean
+clean:
+	rm -f $(GOBINARIES)
 
 .PHONY: clean-coredns-src
 clean-coredns-src:

--- a/rpm/packetfence.spec
+++ b/rpm/packetfence.spec
@@ -478,12 +478,14 @@ rm -rf %{buildroot}/usr/local/pf/docs/docbook
 rm -rf %{buildroot}/usr/local/pf/docs/fonts
 rm -rf %{buildroot}/usr/local/pf/docs/images
 rm -rf %{buildroot}/usr/local/pf/docs/api
-cp -r html %{buildroot}/usr/local/pf/
 
 # install Golang binaries
 %{__make} -C go DESTDIR=%{buildroot} copy
 # clean Golang binaries from build dir
 %{__make} -C go clean
+
+# install html stuff
+%{_make} DESTDIR=%{buildroot} pfappserver_install
 
 # install html and images dirs in pfappserver for embedded doc
 %{__install} -d -m0755 %{buildroot}/usr/local/pf/html/pfappserver/root/static/doc

--- a/rpm/packetfence.spec
+++ b/rpm/packetfence.spec
@@ -484,8 +484,8 @@ rm -rf %{buildroot}/usr/local/pf/docs/api
 # clean Golang binaries from build dir
 %{__make} -C go clean
 
-# install html stuff
-%{_make} DESTDIR=%{buildroot} pfappserver_install
+# install html directory
+%{_make} DESTDIR=%{buildroot} html_install
 
 # install html and images dirs in pfappserver for embedded doc
 %{__install} -d -m0755 %{buildroot}/usr/local/pf/html/pfappserver/root/static/doc

--- a/rpm/packetfence.spec
+++ b/rpm/packetfence.spec
@@ -1066,7 +1066,6 @@ fi
 %config(noreplace)      /usr/local/pf/html/common/styles.css.map
 %config(noreplace)      /usr/local/pf/html/common/styles-dark.css
                         /usr/local/pf/html/common/Gruntfile.js
-                        /usr/local/pf/html/common/package.json
                         /usr/local/pf/html/common/scss/*.scss
 # captive portal
 %dir                    /usr/local/pf/html/captive-portal
@@ -1113,8 +1112,6 @@ fi
 %config(noreplace)      /usr/local/pf/html/captive-portal/lib/captiveportal/View/MobileConfig.pm
 %dir                    /usr/local/pf/html/captive-portal/script
                         /usr/local/pf/html/captive-portal/script/*
-%dir                    /usr/local/pf/html/captive-portal/t
-                        /usr/local/pf/html/captive-portal/t/*
                         /usr/local/pf/html/captive-portal/content/PacketFenceAgent.apk
                         /usr/local/pf/html/captive-portal/content/sslinspection.js
 %dir                    /usr/local/pf/html/captive-portal/templates

--- a/rpm/packetfence.spec
+++ b/rpm/packetfence.spec
@@ -1055,23 +1055,29 @@ fi
 %exclude                /usr/local/pf/docs/*.fo
 %endif
 
-%dir                    /usr/local/pf/html/pfappserver/root/static/doc
-%doc                    /usr/local/pf/html/pfappserver/root/static/doc/*
+### html dir
 %dir                    /usr/local/pf/html
+# parking
+%dir                    /usr/local/pf/html/parking
+# common
+%dir                    /usr/local/pf/html/common
+                        /usr/local/pf/html/common/*
+%config(noreplace)      /usr/local/pf/html/common/styles.css
+%config(noreplace)      /usr/local/pf/html/common/styles.css.map
+%config(noreplace)      /usr/local/pf/html/common/styles-dark.css
+                        /usr/local/pf/html/common/Gruntfile.js
+                        /usr/local/pf/html/common/package.json
+                        /usr/local/pf/html/common/scss/*.scss
+# captive portal
 %dir                    /usr/local/pf/html/captive-portal
                         /usr/local/pf/html/captive-portal/Changes
                         /usr/local/pf/html/captive-portal/Makefile.PL
                         /usr/local/pf/html/captive-portal/README
 %config(noreplace)      /usr/local/pf/html/captive-portal/captiveportal.conf
                         /usr/local/pf/html/captive-portal/captiveportal.conf.example
-%config(noreplace)      /usr/local/pf/html/common/styles.css
-%config(noreplace)      /usr/local/pf/html/common/styles.css.map
-%config(noreplace)      /usr/local/pf/html/common/styles-dark.css
                         /usr/local/pf/html/captive-portal/content/countdown.min.js
                         /usr/local/pf/html/captive-portal/content/guest-management.js
-                        /usr/local/pf/html/common/Gruntfile.js
                         /usr/local/pf/html/captive-portal/content/captiveportal.js
-                        /usr/local/pf/html/common/package.json
                         /usr/local/pf/html/captive-portal/content/autosubmit.js
                         /usr/local/pf/html/captive-portal/content/timerbar.js
                         /usr/local/pf/html/captive-portal/content/ChilliLibrary.js
@@ -1087,9 +1093,7 @@ fi
                         /usr/local/pf/html/captive-portal/content/waiting.js
 %dir                    /usr/local/pf/html/captive-portal/content/images
                         /usr/local/pf/html/captive-portal/content/images/*
-%config(noreplace)      /usr/local/pf/html/common/scss/*.scss
 %dir                    /usr/local/pf/html/captive-portal/lib
-     
                         /usr/local/pf/html/captive-portal/lib/*
 %config(noreplace)      /usr/local/pf/html/captive-portal/lib/captiveportal/Controller/Activate/Email.pm
 %config(noreplace)      /usr/local/pf/html/captive-portal/lib/captiveportal/Controller/Authenticate.pm
@@ -1107,7 +1111,6 @@ fi
 %config(noreplace)      /usr/local/pf/html/captive-portal/lib/captiveportal/Model/Portal/Session.pm
 %config(noreplace)      /usr/local/pf/html/captive-portal/lib/captiveportal/View/HTML.pm
 %config(noreplace)      /usr/local/pf/html/captive-portal/lib/captiveportal/View/MobileConfig.pm
-
 %dir                    /usr/local/pf/html/captive-portal/script
                         /usr/local/pf/html/captive-portal/script/*
 %dir                    /usr/local/pf/html/captive-portal/t
@@ -1116,12 +1119,8 @@ fi
                         /usr/local/pf/html/captive-portal/content/sslinspection.js
 %dir                    /usr/local/pf/html/captive-portal/templates
                         /usr/local/pf/html/captive-portal/templates/*
-%dir                    /usr/local/pf/html/common
-                        /usr/local/pf/html/common/*
-                        /usr/local/pf/html/parking/back-on-network.html
-                        /usr/local/pf/html/parking/index.html
-                        /usr/local/pf/html/parking/max-attempts.html
-                        /usr/local/pf/html/pfappserver/
+# pfappserver dir
+%dir                    /usr/local/pf/html/pfappserver/
 %config(noreplace)      /usr/local/pf/html/pfappserver/pfappserver.conf
 %config(noreplace)      /usr/local/pf/html/pfappserver/lib/pfappserver/Controller/Admin.pm
 %config(noreplace)      /usr/local/pf/html/pfappserver/lib/pfappserver/Controller/Config/AdminRoles.pm
@@ -1148,6 +1147,10 @@ fi
 %config(noreplace)      /usr/local/pf/html/pfappserver/lib/pfappserver/Controller/Service.pm
 %config(noreplace)      /usr/local/pf/html/pfappserver/lib/pfappserver/Controller/User.pm
 %config(noreplace)      /usr/local/pf/html/pfappserver/lib/pfappserver/Controller/SecurityEvent.pm
+%dir                    /usr/local/pf/html/pfappserver/root/static/doc
+%doc                    /usr/local/pf/html/pfappserver/root/static/doc/*
+
+# lib dir
                         /usr/local/pf/lib/
 %dir                    /usr/local/pf/lib/pfconfig
                         /usr/local/pf/lib/pfconfig/*

--- a/rpm/packetfence.spec
+++ b/rpm/packetfence.spec
@@ -1056,17 +1056,18 @@ fi
 %endif
 
 ### html dir
+# %dir will add only html dir, not subdirectories or files
 %dir                    /usr/local/pf/html
-# parking
-%dir                    /usr/local/pf/html/parking
-# common
-%dir                    /usr/local/pf/html/common
-                        /usr/local/pf/html/common/*
+
+# parking dir and files below
+                        /usr/local/pf/html/parking
+
+# common dir and files below
+                        /usr/local/pf/html/common
 %config(noreplace)      /usr/local/pf/html/common/styles.css
 %config(noreplace)      /usr/local/pf/html/common/styles.css.map
 %config(noreplace)      /usr/local/pf/html/common/styles-dark.css
-                        /usr/local/pf/html/common/Gruntfile.js
-                        /usr/local/pf/html/common/scss/*.scss
+
 # captive portal
 %dir                    /usr/local/pf/html/captive-portal
                         /usr/local/pf/html/captive-portal/Changes
@@ -1090,10 +1091,10 @@ fi
                         /usr/local/pf/html/captive-portal/content/scan.js
                         /usr/local/pf/html/captive-portal/content/status.js
                         /usr/local/pf/html/captive-portal/content/waiting.js
-%dir                    /usr/local/pf/html/captive-portal/content/images
-                        /usr/local/pf/html/captive-portal/content/images/*
-%dir                    /usr/local/pf/html/captive-portal/lib
-                        /usr/local/pf/html/captive-portal/lib/*
+                        /usr/local/pf/html/captive-portal/content/PacketFenceAgent.apk
+                        /usr/local/pf/html/captive-portal/content/sslinspection.js
+                        /usr/local/pf/html/captive-portal/content/images
+                        /usr/local/pf/html/captive-portal/lib
 %config(noreplace)      /usr/local/pf/html/captive-portal/lib/captiveportal/Controller/Activate/Email.pm
 %config(noreplace)      /usr/local/pf/html/captive-portal/lib/captiveportal/Controller/Authenticate.pm
 %config(noreplace)      /usr/local/pf/html/captive-portal/lib/captiveportal/Controller/DeviceRegistration.pm
@@ -1110,14 +1111,10 @@ fi
 %config(noreplace)      /usr/local/pf/html/captive-portal/lib/captiveportal/Model/Portal/Session.pm
 %config(noreplace)      /usr/local/pf/html/captive-portal/lib/captiveportal/View/HTML.pm
 %config(noreplace)      /usr/local/pf/html/captive-portal/lib/captiveportal/View/MobileConfig.pm
-%dir                    /usr/local/pf/html/captive-portal/script
-                        /usr/local/pf/html/captive-portal/script/*
-                        /usr/local/pf/html/captive-portal/content/PacketFenceAgent.apk
-                        /usr/local/pf/html/captive-portal/content/sslinspection.js
-%dir                    /usr/local/pf/html/captive-portal/templates
-                        /usr/local/pf/html/captive-portal/templates/*
+                        /usr/local/pf/html/captive-portal/script
+                        /usr/local/pf/html/captive-portal/templates
 # pfappserver dir
-%dir                    /usr/local/pf/html/pfappserver/
+                        /usr/local/pf/html/pfappserver
 %config(noreplace)      /usr/local/pf/html/pfappserver/pfappserver.conf
 %config(noreplace)      /usr/local/pf/html/pfappserver/lib/pfappserver/Controller/Admin.pm
 %config(noreplace)      /usr/local/pf/html/pfappserver/lib/pfappserver/Controller/Config/AdminRoles.pm
@@ -1144,7 +1141,6 @@ fi
 %config(noreplace)      /usr/local/pf/html/pfappserver/lib/pfappserver/Controller/Service.pm
 %config(noreplace)      /usr/local/pf/html/pfappserver/lib/pfappserver/Controller/User.pm
 %config(noreplace)      /usr/local/pf/html/pfappserver/lib/pfappserver/Controller/SecurityEvent.pm
-%dir                    /usr/local/pf/html/pfappserver/root/static/doc
 %doc                    /usr/local/pf/html/pfappserver/root/static/doc/*
 
 # lib dir

--- a/rpm/packetfence.spec
+++ b/rpm/packetfence.spec
@@ -482,6 +482,8 @@ cp -r html %{buildroot}/usr/local/pf/
 
 # install Golang binaries
 %{__make} -C go DESTDIR=%{buildroot} copy
+# clean Golang binaries from build dir
+%{__make} -C go clean
 
 # install html and images dirs in pfappserver for embedded doc
 %{__install} -d -m0755 %{buildroot}/usr/local/pf/html/pfappserver/root/static/doc

--- a/rpm/packetfence.spec
+++ b/rpm/packetfence.spec
@@ -485,7 +485,7 @@ rm -rf %{buildroot}/usr/local/pf/docs/api
 %{__make} -C go clean
 
 # install html directory
-%{_make} DESTDIR=%{buildroot} html_install
+%{__make} DESTDIR=%{buildroot} html_install
 
 # install html and images dirs in pfappserver for embedded doc
 %{__install} -d -m0755 %{buildroot}/usr/local/pf/html/pfappserver/root/static/doc


### PR DESCRIPTION
# Description
- Remove Golang binaries in `go` dir for packaging
- Install only things necessary in `html` dir (removed artifcats created by several `make` commands)

# Impacts
- Golang installation in RPM packages
- Packaging of `html` dir in RPM packages

# Issue
fixes #4882 

# Delete branch after merge
YES
