### PR TITLE
Make MySQL upgrade script echo comments and safely re-runnable

### DIFF
--- a/db/upgrade-X.X.X-X.Y.Z.sql
+++ b/db/upgrade-X.X.X-X.Y.Z.sql
@@ -1,11 +1,11 @@
---                                                                                                                     
+--
 -- PacketFence SQL schema upgrade from 9.1.0 to 9.1.9
---                                                                                                                     
-                                                                                                                       
+--
+
 
 --
--- Setting the major/minor/sub-minor version of the DB                                                                 
---                                                                                                                     
+-- Setting the major/minor/sub-minor version of the DB
+--
 
 SET @MAJOR_VERSION = 9;
 SET @MINOR_VERSION = 1;
@@ -16,45 +16,46 @@ SET @SUBMINOR_VERSION = 9;
 SET @PREV_MAJOR_VERSION = 9;
 SET @PREV_MINOR_VERSION = 1;
 SET @PREV_SUBMINOR_VERSION = 0;
-                                                                                                                       
 
---                                                                                                                     
+
+--
 -- The VERSION_INT to ensure proper ordering of the version in queries
---                                                                                                                     
+--
 
-SET @VERSION_INT = @MAJOR_VERSION << 16 | @MINOR_VERSION << 8 | @SUBMINOR_VERSION;                                     
+SET @VERSION_INT = @MAJOR_VERSION << 16 | @MINOR_VERSION << 8 | @SUBMINOR_VERSION;
 
-SET @PREV_VERSION_INT = @PREV_MAJOR_VERSION << 16 | @PREV_MINOR_VERSION << 8 | @PREV_SUBMINOR_VERSION;                 
+SET @PREV_VERSION_INT = @PREV_MAJOR_VERSION << 16 | @PREV_MINOR_VERSION << 8 | @PREV_SUBMINOR_VERSION;
 
-DROP PROCEDURE IF EXISTS ValidateVersion;                                                                              
+DROP PROCEDURE IF EXISTS ValidateVersion;
 --
 -- Updating to current version
---  
+--
 DELIMITER //
 CREATE PROCEDURE ValidateVersion()
-BEGIN                                                                                                                  
+BEGIN
     DECLARE PREVIOUS_VERSION int(11);
     DECLARE PREVIOUS_VERSION_STRING varchar(11);
     DECLARE _message varchar(255);
-    SELECT id, version INTO PREVIOUS_VERSION, PREVIOUS_VERSION_STRING FROM pf_version ORDER BY id DESC LIMIT 1;        
-              
-      IF PREVIOUS_VERSION != @PREV_VERSION_INT THEN                                                                    
-        SELECT CONCAT('PREVIOUS VERSION ', PREVIOUS_VERSION_STRING, ' DOES NOT MATCH ', CONCAT_WS('.', @PREV_MAJOR_VERSION, @PREV_MINOR_VERSION, @PREV_SUBMINOR_VERSION)) INTO _message;
-        SIGNAL SQLSTATE VALUE '99999'                                                                                  
-              SET MESSAGE_TEXT = _message;                                                                             
-      END IF;                                                                                                          
-END
-//                                                                                                                     
+    SELECT id, version INTO PREVIOUS_VERSION, PREVIOUS_VERSION_STRING FROM pf_version ORDER BY id DESC LIMIT 1;
 
-DELIMITER ;                                                                                                            
-call ValidateVersion;                                                                                                  
+      IF PREVIOUS_VERSION != @PREV_VERSION_INT THEN
+        SELECT CONCAT('PREVIOUS VERSION ', PREVIOUS_VERSION_STRING, ' DOES NOT MATCH ', CONCAT_WS('.', @PREV_MAJOR_VERSION, @PREV_MINOR_VERSION, @PREV_SUBMINOR_VERSION)) INTO _message;
+        SIGNAL SQLSTATE VALUE '99999'
+              SET MESSAGE_TEXT = _message;
+      END IF;
+END
+//
+
+DELIMITER ;
+\! echo "Checking PacketFence schema version...";
+-- call ValidateVersion;
 DROP PROCEDURE IF EXISTS ValidateVersion;
 
 --
 -- Table structure for table `admin_api_audit_log`
 --
-
-CREATE TABLE `admin_api_audit_log` (
+\! echo "Creating table 'admin_api_audit_log'...";
+CREATE TABLE IF NOT EXISTS `admin_api_audit_log` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `tenant_id` int(11) NOT NULL DEFAULT '1',
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
@@ -75,7 +76,10 @@ CREATE TABLE `admin_api_audit_log` (
 --
 -- Add an index on ssid on the locationlog
 --
+\! echo "Adding index 'locationlog_ssid' to 'locationlog' table...";
+ALTER TABLE locationlog ADD INDEX IF NOT EXISTS `locationlog_ssid` (`ssid`);
 
-ALTER TABLE locationlog ADD INDEX `locationlog_ssid` (`ssid`);
+\! echo "Incrementing PacketFence schema version...";
+INSERT IGNORE INTO pf_version (id, version) VALUES (@VERSION_INT, CONCAT_WS('.', @MAJOR_VERSION, @MINOR_VERSION, @SUBMINOR_VERSION));
 
-INSERT INTO pf_version (id, version) VALUES (@VERSION_INT, CONCAT_WS('.', @MAJOR_VERSION, @MINOR_VERSION, @SUBMINOR_VERSION)); 
+\! echo "Upgrade completed successfully.";

--- a/db/upgrade-X.X.X-X.Y.Z.sql
+++ b/db/upgrade-X.X.X-X.Y.Z.sql
@@ -48,7 +48,7 @@ END
 
 DELIMITER ;
 \! echo "Checking PacketFence schema version...";
--- call ValidateVersion;
+call ValidateVersion;
 DROP PROCEDURE IF EXISTS ValidateVersion;
 
 --


### PR DESCRIPTION
# Description
- Outputs text during processing
- Is now re-runnable, with the exception of the pf_version check.

# Issue
#4892 

# Delete branch after merge
YES

# Checklist
- [n/a] Document the feature
- [ ] Add unit tests
- [n/a] Add acceptance tests (TestLink)

## Enhancements
* MySQL upgrade scripts outputs comments during processing, now uses `INSERT IGNORE` and `CREATE IF NOT EXISTS`.

## Bug Fixes
* MySQL schema upgrade statements should be re-runnable. (#4892)