### PR TITLE
[packer] support docker multi-tags

### DIFF
--- a/ci/packer/Makefile
+++ b/ci/packer/Makefile
@@ -4,24 +4,44 @@
 # - command variables (make VAR=VALUE target)
 
 include ../../config.mk
+
+#==============================================================================
+# Packer command line variables
+#==============================================================================
 ACTIVE_BUILDS = 'pfbuild-centos-7,pfbuild-stretch'
+
 # workaround for https://github.com/hashicorp/packer/issues/7904
 PARALLEL = false
 
+# by default, we make only *one* docker tag and skip
+# this docker-extra-tag post-processor
+PACKER_EXTRA_ARG = '-except=docker-extra-tag'
+
+#==============================================================================
+# Targets
+#==============================================================================
+
 .PHONY: all
 all: pfbuild
+
+# Environment variables are mentioned before 'packer build' commands to
+# - display their values when running in CI (be careful with secret variables)
+# - avoid passing each variable on CLI when running outside CI
 
 .PHONY: pfbuild
 pfbuild:
 	packer validate $@.json
 	DOCKER_TAG=$(DOCKER_TAG) \
+	DOCKER_EXTRA_TAG=$(DOCKER_EXTRA_TAG) \
 	GOVERSION=$(GOVERSION) \
 	REGISTRY=$(REGISTRY) \
+	REGISTRY_USER=$(REGISTRY_USER) \
 	ANSIBLE_CENTOS_GROUP=$(ANSIBLE_CENTOS_GROUP) \
 	ANSIBLE_DEBIAN_GROUP=$(ANSIBLE_DEBIAN_GROUP) \
 	ANSIBLE_RUBYGEMS_GROUP=$(ANSIBLE_RUBYGEMS_GROUP) \
 	packer build \
 	-only=$(ACTIVE_BUILDS) \
+	$(PACKER_EXTRA_ARG) \
 	-parallel=$(PARALLEL) $@.json
 
 .PHONY: variables

--- a/ci/packer/pfbuild.json
+++ b/ci/packer/pfbuild.json
@@ -17,8 +17,8 @@
         "docker_tag": "{{env `DOCKER_TAG`}}",
         "docker_user": "{{env `REGISTRY_USER`}}",
         "docker_password": "{{env `REGISTRY_PASSWORD`}}",
-        "docker_registry": "{{env `REGISTRY`}}"
-
+        "docker_registry": "{{env `REGISTRY`}}",
+        "docker_extra_tag": "{{env `DOCKER_EXTRA_TAG`}}"
     },
     "builders": [
         {
@@ -134,6 +134,13 @@
                 "tag": "{{user `docker_tag`}}"
             },
             {
+                "type": "docker-tag",
+                "name": "docker-extra-tag",
+                "only": ["{{user `builder_prefix`}}-centos-7"],
+                "repository": "{{user `docker_user`}}/{{user `builder_prefix`}}-centos-7",
+                "tag": "{{ user `docker_extra_tag`}}"
+            },
+            {
                 "type": "docker-push",
                 "only": ["{{user `builder_prefix`}}-centos-7"],
                 "login": true,
@@ -150,6 +157,13 @@
                 "tag": "{{user `docker_tag`}}"
             },
             {
+                "type": "docker-tag",
+                "name": "docker-extra-tag",
+                "only": ["{{user `builder_prefix`}}-stretch"],
+                "repository": "{{user `docker_user`}}/{{user `builder_prefix`}}-debian-stretch",
+                "tag": "{{ user `docker_extra_tag`}}"
+            },
+            {
                 "type": "docker-push",
                 "only": ["{{user `builder_prefix`}}-stretch"],
                 "login": true,
@@ -164,6 +178,13 @@
                 "only": ["{{user `builder_prefix`}}-buster"],
                 "repository": "{{user `docker_user`}}/{{user `builder_prefix`}}-debian-buster",
                 "tag": "{{user `docker_tag`}}"
+            },
+            {
+                "type": "docker-tag",
+                "name": "docker-extra-tag",
+                "only": ["{{user `builder_prefix`}}-buster"],
+                "repository": "{{user `docker_user`}}/{{user `builder_prefix`}}-debian-buster",
+                "tag": "{{ user `docker_extra_tag`}}"
             },
             {
                 "type": "docker-push",

--- a/config.mk
+++ b/config.mk
@@ -6,7 +6,9 @@
 # Packer
 #
 DOCKER_TAG = latest
+DOCKER_EXTRA_TAG = extra-tag
 REGISTRY = docker.io
+REGISTRY_USER = inverseinc
 ANSIBLE_CENTOS_GROUP = devel_centos
 ANSIBLE_DEBIAN_GROUP = devel_debian
 ANSIBLE_RUBYGEMS_GROUP = devel_rubygems


### PR DESCRIPTION
# Description
- Multi-tag a Docker image if `DOCKER_EXTRA_TAG` is set *and* if `PACKER_EXTRA_ARG` set to null

Needed to tag a Docker image release with two tags: `maintenance/X.X` and `vX.X.X`

- Add `REGISTRY_USER` environment variable to simplify test outside CI

# Impacts
Build of Docker images

# Delete branch after merge
YES

- [Pipeline triggered](https://gitlab.com/inverse-inc/packetfence/-/jobs/345562346) without default values : work as expected
- [Pipeline triggered](https://gitlab.com/inverse-inc/packetfence/-/jobs/345586558) with PACKER_EXTRA_ARG as empty value: in progress