### PR TITLE
Juniper EX2300 Multidomain authentication

### DIFF
--- a/lib/pf/Switch/Juniper/EX2300.pm
+++ b/lib/pf/Switch/Juniper/EX2300.pm
@@ -46,6 +46,23 @@ Send a Disconnect request to disconnect a mac
 
 =cut
 
+=head2 getVoipVsa
+
+Get Voice over IP RADIUS Vendor Specific Attribute (VSA).
+For now it returns the voiceVlan untagged since Juniper supports multiple untagged VLAN in the same interface
+
+=cut
+
+sub getVoipVsa{
+    my ($self) = @_;
+    my $logger = $self->logger;
+    my $voiceVlan = $self->{'_voiceVlan'};
+    
+    $logger->info("Accepting phone with Access-Accept on voiceVlan $voiceVlan");
+    
+    return ('Juniper-VoIP-Vlan' => $voiceVlan);
+}
+
 sub radiusDisconnect {
     my ($self, $mac, $add_attributes_ref) = @_;
     my $logger = $self->logger;

--- a/lib/pf/Switch/Juniper/EX2300.pm
+++ b/lib/pf/Switch/Juniper/EX2300.pm
@@ -60,7 +60,12 @@ sub getVoipVsa{
     
     $logger->info("Accepting phone with Access-Accept on voiceVlan $voiceVlan");
     
-    return ('Juniper-VoIP-Vlan' => $voiceVlan);
+    return (
+        'Tunnel-Medium-Type' => $RADIUS::ETHERNET,
+        'Tunnel-Type' => $RADIUS::VLAN,
+        'Tunnel-Private-Group-ID' => "$voiceVlan",
+        'Juniper-VoIP-Vlan' => "$voiceVlan",
+    );
 }
 
 sub radiusDisconnect {

--- a/lib/pf/Switch/Juniper/EX2300.pm
+++ b/lib/pf/Switch/Juniper/EX2300.pm
@@ -60,12 +60,7 @@ sub getVoipVsa{
     
     $logger->info("Accepting phone with Access-Accept on voiceVlan $voiceVlan");
     
-    return (
-        'Tunnel-Medium-Type' => $RADIUS::ETHERNET,
-        'Tunnel-Type' => $RADIUS::VLAN,
-        'Tunnel-Private-Group-ID' => "$voiceVlan",
-        'Juniper-VoIP-Vlan' => "$voiceVlan",
-    );
+    return ('Juniper-VoIP-Vlan' => $voiceVlan);
 }
 
 sub radiusDisconnect {

--- a/lib/pf/util/dictionary
+++ b/lib/pf/util/dictionary
@@ -281,4 +281,5 @@ VENDOR          Juniper                         2636
 #       Standard attribute
 #
 
-VENDORATTR      Juniper                         Juniper-AV-Pair 52      string
+VENDORATTR      Juniper                         Juniper-VoIP-Vlan  49      string
+VENDORATTR      Juniper                         Juniper-AV-Pair    52      string


### PR DESCRIPTION
# Description
Starting with Junos OS Release 18.3R1, multidomain authentication is supported on EX Series switches. Multidomain authentication is an extension of multiple supplicant mode for 802.1X authentication, and allows one VoIP client and multiple data clients to authenticate to different VLANs while on the same port.

# Impacts
Voice VLAN

# Delete branch after merge
YES

# Checklist
- [ yes] Document the feature
- [ yes] Add unit tests
- [ no] Add acceptance tests (TestLink)

# NEWS file entries
## Enhancements
* Juniper EX2300 Multidomain authentication
