### PR TITLE
[ci] deploy packetfence-release rpm with a fixed name

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -150,7 +150,7 @@ variables:
   dependencies:
     - sign_dev_and_release
   variables:
-    #DEPLOY_USER: see GitLab variables
+    DEPLOY_USER: root
     DEB_DEPLOY_DIR: ${CI_ENVIRONMENT_NAME}
     DEPLOY_UPDATE: "/builds/bin/ci-repo-deploy deb ${CI_ENVIRONMENT_NAME}"
   script:
@@ -165,7 +165,7 @@ variables:
   dependencies:
     - sign_dev_and_release
   variables:
-    #DEPLOY_USER: see GitLab variables
+    DEPLOY_USER: root
     RPM_DEPLOY_DIR: ${CI_ENVIRONMENT_NAME}
     DEPLOY_SRPMS: "no"
     DEPLOY_UPDATE: "/builds/bin/ci-repo-deploy rpm ${CI_ENVIRONMENT_NAME}"
@@ -181,6 +181,7 @@ variables:
   dependencies:
     - sign_dev_and_release
   variables:
+    DEPLOY_USER: reposync
     DEPLOY_HOST: web.inverse.ca
   environment:
     name: ${PKG_DEST_NAME}
@@ -432,7 +433,6 @@ post_upload_rpm_packetfence-release_dev:
     - .job_dev_triggers
   variables:
     PKG_DEST_NAME: packetfence-release-7.devel.noarch.rpm
-    DEPLOY_USER: reposync
 
 post_upload_rpm_packetfence-release_release:
   extends:
@@ -440,4 +440,3 @@ post_upload_rpm_packetfence-release_release:
     - .job_release_triggers
   variables:
     PKG_DEST_NAME: packetfence-release-7.stable.noarch.rpm
-    DEPLOY_USER: reposync

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -176,12 +176,11 @@ variables:
     - inverse
     - shell
 
-.deploy_rpm_packetfence-release_job:
+.post_upload_rpm_packetfence-release_job:
   stage: post_upload
   dependencies:
     - sign_dev_and_release
   variables:
-    DEPLOY_USER: reposync
     DEPLOY_HOST: web.inverse.ca
   environment:
     name: ${PKG_DEST_NAME}
@@ -427,16 +426,18 @@ deploy_maintenance:
 # we deploy packetfence-release RPM with
 # a fixed name *outside* a RPM repo
 # for first installation
-deploy_rpm_packetfence-release_dev:
+post_upload_rpm_packetfence-release_dev:
   extends:
-    - .deploy_rpm_packetfence-release_job
+    - .post_upload_rpm_packetfence-release_job
     - .job_dev_triggers
   variables:
     PKG_DEST_NAME: packetfence-release-7.devel.noarch.rpm
+    DEPLOY_USER: reposync
 
-deploy_rpm_packetfence-release_release:
+post_upload_rpm_packetfence-release_release:
   extends:
-    - .deploy_rpm_packetfence-release_job
+    - .post_upload_rpm_packetfence-release_job
     - .job_release_triggers
   variables:
     PKG_DEST_NAME: packetfence-release-7.stable.noarch.rpm
+    DEPLOY_USER: reposync

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,6 +17,7 @@ stages:
   - publish
   - install
   - upload
+  - post_upload
 
 ################################################################################
 # VARIABLES
@@ -173,6 +174,21 @@ variables:
   # run job on runners tag with inverse AND shell
   tags:
     - inverse
+    - shell
+
+.deploy_rpm_packetfence-release_job:
+  stage: post_upload
+  dependencies:
+    - sign_dev_and_release
+  variables:
+    DEPLOY_USER: reposync
+    DEPLOY_HOST: web.inverse.ca
+  environment:
+    name: ${PKG_DEST_NAME}
+    url: ${PUBLIC_REPO_URL}/RHEL7
+  script:
+    - ./${UPLOAD_DIR}/deploy-artifacts.sh packetfence-release
+  tags:
     - shell
 
 .rpm_script:
@@ -404,3 +420,23 @@ deploy_maintenance:
   environment:
     name: maintenance
     url: ${PUBLIC_REPO_URL}/${CI_ENVIRONMENT_NAME}
+
+########################################
+# POST_UPLOAD JOBS
+########################################
+# we deploy packetfence-release RPM with
+# a fixed name *outside* a RPM repo
+# for first installation
+deploy_rpm_packetfence-release_dev:
+  extends:
+    - .deploy_rpm_packetfence-release_job
+    - .job_dev_triggers
+  variables:
+    PKG_DEST_NAME: packetfence-release-7.devel.noarch.rpm
+
+deploy_rpm_packetfence-release_release:
+  extends:
+    - .deploy_rpm_packetfence-release_job
+    - .job_release_triggers
+  variables:
+    PKG_DEST_NAME: packetfence-release-7.stable.noarch.rpm

--- a/addons/ZEN-vagrant-builder/installer/install-pf.sh
+++ b/addons/ZEN-vagrant-builder/installer/install-pf.sh
@@ -3,7 +3,7 @@
 echo "nameserver 8.8.8.8" > /etc/resolv.conf
 
 # Install the PacketFence repos
-yum localinstall http://packetfence.org/downloads/PacketFence/RHEL7/`uname -i`/RPMS/packetfence-release-1.2-6.el7.centos.noarch.rpm -y
+yum localinstall http://packetfence.org/downloads/PacketFence/RHEL7/packetfence-release-7.stable.rpm -y
 
 # Update the release to be sure we run its latest version
 yum update packetfence-release --enablerepo=packetfence -y

--- a/ci/lib/upload/deploy-artifacts.sh
+++ b/ci/lib/upload/deploy-artifacts.sh
@@ -84,6 +84,19 @@ maint_deploy() {
         || die "scp failed"
 }
 
+packetfence_release_centos7_deploy() {
+    src_dir="$RPM_RESULT_DIR/7"
+    dst_repo="$PUBLIC_REPO_BASE_DIR/RHEL7"
+    dst_dir="$DEPLOY_USER@$DEPLOY_HOST:$dst_repo"
+    pf_release_rpm_file=$(basename $(ls $RPM_RESULT_DIR/7/packetfence-release*))
+    pkg_dest_name=${PKG_DEST_NAME:-"packetfence-release-7.${CI_COMMIT_REF_SLUG}.noarch.rpm"}
+    declare -p src_dir dst_dir pf_release_rpm_file pkg_dest_name
+
+    echo "scp: ${src_dir}/${pf_release_rpm_file} -> ${dst_dir}/${pkg_dest_name}"
+    scp "${src_dir}/${pf_release_rpm_file}" "${dst_dir}/${pkg_dest_name}" \
+        || die "scp failed"
+}
+
 log_section "Display artifacts"
 tree ${RESULT_DIR}
 
@@ -92,5 +105,6 @@ case $1 in
     rpm) rpm_deploy ;;
     deb) deb_deploy ;;
     maintenance) maint_deploy ;;
+    packetfence-release) packetfence_release_centos7_deploy ;;
     *)   die "Wrong argument"
 esac

--- a/docs/PacketFence_Installation_Guide.asciidoc
+++ b/docs/PacketFence_Installation_Guide.asciidoc
@@ -226,7 +226,7 @@ In order to use the PacketFence repository:
 
 [source,bash]
 ----
-yum localinstall http://packetfence.org/downloads/PacketFence/RHEL7/`uname -i`/RPMS/packetfence-release-1.2-7.el7.centos.noarch.rpm
+yum localinstall http://packetfence.org/downloads/PacketFence/RHEL7/packetfence-release-7.stable.noarch.rpm
 ----
 
 Once the repository is defined, you can install PacketFence with all its

--- a/docs/pki/packetfence.asciidoc
+++ b/docs/pki/packetfence.asciidoc
@@ -84,7 +84,7 @@ Once the repository is defined, you can install packetfence-pki using:
 Installing on RHEL or CentOS requires the packetfence and packetfence-extra repositories.
 Install them first and then install the packetfence-pki package itself.
 
- yum localinstall http://inverse.ca/downloads/PacketFence/CentOS6/x86_64/RPMS/packetfence-release-1-2.centos6.noarch.rpm
+ yum localinstall http://packetfence.org/downloads/PacketFence/RHEL7/packetfence-release-7.stable.noarch.rpm
  yum install packetfence-pki --enablerepo=packetfence-extra, packetfence
 
 


### PR DESCRIPTION
# Description
Deploy `packetfence-release` RPM built in pipeline with a fixed name:
- `packetfence-release-7.devel.noarch.rpm` (devel pipeline)
- `packetfence-release-7.stable.noarch.rpm` (release pipeline)

under https://packetfence.org/downloads/PacketFence/RHEL7 (outside a RPM repository) to simplify [installation instructions](https://github.com/inverse-inc/packetfence/blob/devel/docs/PacketFence_Installation_Guide.asciidoc#rhel--centos).

**Important**:  `packetfence-release` RPM will continue to be deploy in RPMS repositories. Job done here is only to simplify installation instructions and tests.

[Pipeline triggered](https://gitlab.com/inverse-inc/packetfence/pipelines/95315784)

# Impacts
* Installation instructions
* Pipelines.
* ZEN builds

# Delete branch after merge
YES