### PR TITLE
Realm match default

### DIFF
--- a/lib/pf/config/util.pm
+++ b/lib/pf/config/util.pm
@@ -415,10 +415,14 @@ Find sources for a specific realm
 
 sub get_realm_authentication_source {
     my ( $username, $realm, $sources ) = @_;
+    my $matched_realm = $realm;
+    $matched_realm //= 'null';
     my @found = grep { $_->realmIsAllowed($realm) } @{$sources};
-    if (@found == 0 && $realm ne 'default') {
+    if (@found == 0 && $realm ne 'default' && !(exists $pf::config::ConfigRealm{$realm})) {
+        $matched_realm = 'default';
         @found = grep { $_->realmIsAllowed('default') } @{$sources};
     }
+    get_logger->info("Used realm $realm is associated to the configured realm $matched_realm");
 
     return \@found;
 }

--- a/lib/pf/config/util.pm
+++ b/lib/pf/config/util.pm
@@ -415,7 +415,12 @@ Find sources for a specific realm
 
 sub get_realm_authentication_source {
     my ( $username, $realm, $sources ) = @_;
-    return [grep { $_->realmIsAllowed($realm) } @{$sources}];
+    my @found = grep { $_->realmIsAllowed($realm) } @{$sources};
+    if (@found == 0 && $realm ne 'default') {
+        @found = grep { $_->realmIsAllowed('default') } @{$sources};
+    }
+
+    return \@found;
 }
 
 =head2 filter_authentication_sources


### PR DESCRIPTION
# Description
If the realm is not defined in the configuration then packetfence use the default realm to match the sources associated on the portal.

# Impacts
Source selection

# Issue
Return the authentication sources where the default realm has been associated if the realm used by the connection contain a realm that is not defined in the configuration.

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Bug Fixes
* Return the authentication sources where the default realm has been associated if the realm used by the connection contain a realm that is not defined in the configuration.
