### PR TITLE
Fix logic with authorize source

### DIFF
--- a/conf/profiles.conf.defaults
+++ b/conf/profiles.conf.defaults
@@ -19,6 +19,7 @@ login_attempt_limit=0
 root_module=default_policy
 billing_tiers=
 dot1x_recompute_role_from_portal=enabled
+mac_auth_recompute_role_from_portal=disabled
 preregistration=disabled
 autoregister=disabled
 scans=

--- a/docs/api/spec/components/schemas/configconnectionprofile.yaml
+++ b/docs/api/spec/components/schemas/configconnectionprofile.yaml
@@ -51,6 +51,10 @@ ConfigConnectionProfile:
       description: When enabled, PacketFence will not use the role initialy computed
         on the portal but will use the dot1x username to recompute the role.
       type: string
+    mac_auth_recompute_role_from_portal:
+      description: When enabled, PacketFence will not use the role initialy computed
+        on the portal but will use an authorize source if defined to recompute the role.
+      type: string
     dot1x_unset_on_unmatch:
       description: When enabled, PacketFence will unset the role of the device if no
         authentication sources returned one.

--- a/docs/api/spec/openapi.json
+++ b/docs/api/spec/openapi.json
@@ -1691,6 +1691,10 @@
                   "description" : "When enabled, PacketFence will not use the role initialy computed on the portal but will use the dot1x username to recompute the role.",
                   "type" : "string"
                },
+               "mac_auth_recompute_role_from_portal" : {
+                   "description" : "When enabled, PacketFence will not use the role initialy computed on the portal but will use an authorized source if defined to recompute the role.",
+                   "type" : "string"
+               },
                "dot1x_unset_on_unmatch" : {
                   "description" : "When enabled, PacketFence will unset the role of the device if no authentication sources returned one.",
                   "type" : "string"

--- a/docs/api/spec/openapi.yaml
+++ b/docs/api/spec/openapi.yaml
@@ -1419,6 +1419,10 @@ components:
           description: When enabled, PacketFence will not use the role initialy computed
             on the portal but will use the dot1x username to recompute the role.
           type: string
+        mac_auth_recompute_role_from_portal:
+          description: When enabled, PacketFence will not use the role initialy computed
+            on the portal but will use an authorized source if defined to recompute the role.
+          type: string
         dot1x_unset_on_unmatch:
           description: When enabled, PacketFence will unset the role of the device
             if no authentication sources returned one.

--- a/html/pfappserver/lib/pfappserver/Form/Config/Profile.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Profile.pm
@@ -135,7 +135,7 @@ The main definition block
 
 has_block 'definition' =>
   (
-    render_list => [qw(id description status root_module preregistration autoregister reuse_dot1x_credentials dot1x_recompute_role_from_portal dot1x_unset_on_unmatch dpsk default_psk_key unreg_on_acct_stop)],
+    render_list => [qw(id description status root_module preregistration autoregister reuse_dot1x_credentials dot1x_recompute_role_from_portal mac_auth_recompute_role_from_portal dot1x_unset_on_unmatch dpsk default_psk_key unreg_on_acct_stop)],
   );
 
 

--- a/html/pfappserver/lib/pfappserver/Form/Config/ProfileCommon.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/ProfileCommon.pm
@@ -43,7 +43,7 @@ The main definition block
 
 has_block 'definition' =>
   (
-    render_list => [qw(id description root_module preregistration autoregister reuse_dot1x_credentials dot1x_recompute_role_from_portal dot1x_unset_on_unmatch dpsk default_psk_key unreg_on_acct_stop vlan_pool_technique)],
+    render_list => [qw(id description root_module preregistration autoregister reuse_dot1x_credentials dot1x_recompute_role_from_portal mac_auth_recompute_role_from_portal dot1x_unset_on_unmatch dpsk default_psk_key unreg_on_acct_stop vlan_pool_technique)],
   );
 
 =head2 captive_portal
@@ -361,6 +361,20 @@ has_field 'dot1x_recompute_role_from_portal' =>
              help => 'When enabled, PacketFence will not use the role initialy computed on the portal but will use the dot1x username to recompute the role.' },
   );
 
+=head2 mac_auth_recompute_role_from_portal
+
+=cut
+
+has_field 'mac_auth_recompute_role_from_portal' =>
+  (
+    type => 'Checkbox',
+    checkbox_value => 'enabled',
+    unchecked_value => 'disabled',
+    default => 'disabled',
+    tags => { after_element => \&help,
+             help => 'When enabled, PacketFence will not use the role initialy computed on the portal but will use an authorized source if defined to recompute the role.' },
+  );
+  
 =head2 dot1x_unset_on_unmatch
 
 =cut

--- a/html/pfappserver/root/static.alt/src/globals/configuration/pfConfigurationConnectionProfiles.js
+++ b/html/pfappserver/root/static.alt/src/globals/configuration/pfConfigurationConnectionProfiles.js
@@ -486,6 +486,19 @@ export const pfConfigurationConnectionProfileViewFields = (context = {}) => {
           ]
         },
         {
+          label: i18n.t('MAC Auth recompute role from portal'),
+          text: i18n.t('When enabled, PacketFence will not use the role initialy computed on the portal but will use an authorized source if defined to recompute the role.'),
+          fields: [
+            {
+              key: 'mac_auth_recompute_role_from_portal',
+              component: pfFormToggle,
+              attrs: {
+                values: { checked: 'enabled', unchecked: 'disabled' }
+              }
+            }
+          ]
+        },
+        {
           label: i18n.t('Dot1x unset on unmatch'),
           text: i18n.t('When enabled, PacketFence will unset the role of the device if no authentication sources returned one.'),
           fields: [

--- a/lib/pf/Connection/Profile.pm
+++ b/lib/pf/Connection/Profile.pm
@@ -506,6 +506,17 @@ sub dot1xRecomputeRoleFromPortal {
     return $self->{'_dot1x_recompute_role_from_portal'};
 }
 
+=item macAuthRecomputeRoleFromPortal
+
+Reuse the mac address on a authorize source when authenticating
+
+=cut
+
+sub macAuthRecomputeRoleFromPortal {
+    my ($self) = @_;
+    return $self->{'_mac_auth_recompute_role_from_portal'};
+}
+
 =item dot1xUnsetOnUnmatch
 
 On autoreg if no authentication source return a role then unset the current node one

--- a/lib/pf/pfcmd/checkup.pm
+++ b/lib/pf/pfcmd/checkup.pm
@@ -984,7 +984,7 @@ sub connection_profiles {
         billing_tiers|description|sources|redirecturl|always_use_redirecturl|
         allowed_devices|allow_android_devices|
         reuse_dot1x_credentials|provisioners|filter_match_style|sms_pin_retry_limit|
-        sms_request_limit|login_attempt_limit|block_interval|dot1x_recompute_role_from_portal|dot1x_unset_on_unmatch|scan|root_module|preregistration|autoregister|access_registration_when_registered|self_service|
+        sms_request_limit|login_attempt_limit|block_interval|dot1x_recompute_role_from_portal|mac_auth_recompute_role_from_portal|dot1x_unset_on_unmatch|scan|root_module|preregistration|autoregister|access_registration_when_registered|self_service|
         dpsk|default_psk_key|status|unreg_on_acct_stop|vlan_pool_technique)/x;
     my $validator = pf::validation::profile_filters->new;
 

--- a/lib/pf/role.pm
+++ b/lib/pf/role.pm
@@ -406,10 +406,14 @@ sub getRegisteredRole {
                 $role = $args->{'node_info'}->{'category'};
                 @sources = ();
             }
-        } else {
-            $logger->info("Connection type is MAC-AUTH. Getting role from node_info or Authorization source" );
-            @sources = grep {uc($_->{'type'}) eq "AUTHORIZATION"} @sources;
-        }
+        } elsif ( ( ($args->{'connection_type'} & $WIRED_MAC_AUTH) == $WIRED_MAC_AUTH ) || ( ($args->{'connection_type'} & $WIRELESS_MAC_AUTH) == $WIRELESS_MAC_AUTH ) ) {
+		if ( isdisables($profile->macAuthRecomputeRoleFromPortal) ||  $args->{'autoreg'} == 1) {
+                    $logger->info("Connection type is MAC-AUTH. Getting role from node_info or Authorization source" );
+                    @sources = grep {uc($_->{'type'}) eq "AUTHORIZATION"} @sources;
+		} else {
+                    @sources = ();
+                }
+	}
         if (@sources) {
             my $stripped_user = '';
             $stripped_user = $args->{'stripped_user_name'} if(defined($args->{'stripped_user_name'}));

--- a/lib/pf/role.pm
+++ b/lib/pf/role.pm
@@ -407,13 +407,14 @@ sub getRegisteredRole {
                 @sources = ();
             }
         } elsif ( ( ($args->{'connection_type'} & $WIRED_MAC_AUTH) == $WIRED_MAC_AUTH ) || ( ($args->{'connection_type'} & $WIRELESS_MAC_AUTH) == $WIRELESS_MAC_AUTH ) ) {
-		if ( isdisables($profile->macAuthRecomputeRoleFromPortal) ||  $args->{'autoreg'} == 1) {
-                    $logger->info("Connection type is MAC-AUTH. Getting role from node_info or Authorization source" );
-                    @sources = grep {uc($_->{'type'}) eq "AUTHORIZATION"} @sources;
-		} else {
+                if ( isdisabled($profile->macAuthRecomputeRoleFromPortal) ||  $args->{'autoreg'} == 1) {
+                    $logger->info("Connection type is MAC-AUTH. Getting role from node_info" );
                     @sources = ();
+                } else {
+                    $logger->info("Connection type is MAC-AUTH. Getting role from Authorization source" );
+                    @sources = grep {uc($_->{'type'}) eq "AUTHORIZATION"} @sources;
                 }
-	}
+        }
         if (@sources) {
             my $stripped_user = '';
             $stripped_user = $args->{'stripped_user_name'} if(defined($args->{'stripped_user_name'}));

--- a/t/unittest/UnifiedApi/GenerateSpec.t
+++ b/t/unittest/UnifiedApi/GenerateSpec.t
@@ -223,6 +223,10 @@ cmp_deeply(
                     type => 'string',
                     description => 'When enabled, PacketFence will not use the role initialy computed on the portal but will use the dot1x username to recompute the role.',
                 },
+                'mac_auth_recompute_role_from_portal' => {
+                    type => 'string',
+                    description => 'When enabled, PacketFence will not use the role initialy computed on the portal but will use an authorized source if defined to recompute the role.',
+                },
                 'filter' => {
                     type => 'array',
                     description => 'Filters',


### PR DESCRIPTION
# Description
If a connection profile contain no sources and if an authorization source is define in the config then the code will use this authorization to recompute the role.

# Impacts
Mac auth

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Bug Fixes
* Fix logic for mac-auth when there is a authorize source defined in the config.
