### PR TITLE
Reorganize UPGRADE.asciidoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -214,6 +214,7 @@ docs/docbook/xsl/import-fo.xsl
 docs/docbook/xsl/titlepage-fo.xsl
 docs/docbook/*.docbook
 docs/html/*.html
+docs/html/index.js
 
 # trap stats graphs
 # TODO we should move them under var/

--- a/UPGRADE.asciidoc
+++ b/UPGRADE.asciidoc
@@ -213,1116 +213,13 @@ systemctl restart packetfence-config
 /usr/local/pf/bin/pfcmd service pf restart
 ----
 
+== Upgrading from a version prior to 7.0.0
 
-Upgrading from a version prior to 4.0.0
----------------------------------------
-
-Upgrading an old version of PacketFence to v4 will be quite
-an endeavor. While it's entirely possible if done meticulously, we
-suggest you start from scratch and move your customizations and
-nodes information over to your new installation.
-
-Database schema update
-^^^^^^^^^^^^^^^^^^^^^^
-The temporary password table has been extended to include roles information.
-Moreover, an "admin" user is now automatically created. The default password
-is also "admin". Finally, a new table has been added for saved searches in the
-new Web administrative interface.
-
-  mysql -u root -p pf -v < /usr/local/pf/db/upgrade-3.6.1-4.0.0.sql
-
-Other important changes
-^^^^^^^^^^^^^^^^^^^^^^^
-
-PacketFence v4 received a major overhaul, especially regarding the authentication
-sources. Authentication modules found in `conf/authentication/` are no longer
-being used and have been replaced by the `conf/authentication.conf` file. While
-this file can be hand-edited, you should create your authentication sources
-and perform roles-mapping using the Configuation > Users > Sources page from
-PacketFence's Web administrative interface.
-
-Also, in PacketFence v4, the VLANs can be assigned in `conf/switches.conf` by constructing
-the parameter names from the VLAN names and the `Vlan` suffix. The VLAN names must match one
-of the default names (registration, isolation, macDetection, inline, and voice) or one of the
-defined roles. If you were using custom VLANs, you must create a new role per VLAN and assign
-them accordingly.
-
-Other key changes were done, such as:
-
-* moved remediation templates in `html/captive-portal/templates/violations` and converted them to Template Toolkit
-* dropped guests_admin_registration.category
-* dropped guests_self_registration.access_duration
-* dropped guests_self_registration.category
-* dropped guests_self_registration.sponsor_authentication
-* dropped guests_self_registration.sponsors_only_from_localdomain
-* dropped ports.listeners
-* dropped registration.auth and registration.default_auth
-* dropped registration.maxnodes
-* dropped registration.expire_* and registration.skip_*
-* dropped trapping.blacklist
-* dropped support for resetVlanAllPort in `bin/pfcmd_vlan`
-* dropped `sbin/pfredirect` binary
-* splitted the httpd services in three: httpd.admin, httpd.portal and httpd.webservices
-* domain-name is no longer required in each section of networks.conf
-
-For all parameters related to authentication (categories, access duration, sponsor authentication, etc.),
-you should now set proper actions in the `conf/authentication.conf` file.
-
-Finally, the `pf` must be sudoer access to the `/sbin/ip` (and others) binary. As root, please do:
-
-  echo "pf ALL=NOPASSWD: /sbin/iptables, /usr/sbin/ipset, /sbin/ip, /sbin/vconfig, /sbin/route, /sbin/service, /usr/bin/tee, /usr/local/pf/sbin/pfdhcplistener, /bin/kill, /usr/sbin/dhcpd, /usr/sbin/radiusd" >> /etc/sudoers
-
-
-
-
-Upgrading from a version prior to 4.0.1
----------------------------------------
-
-This release only fixes various bugs and doesn't need the database schema to be
-modified. Simply update the file /usr/local/pf/conf/currently-at to match the new
-release number.
-Upgrading from a version prior to 4.0.2
----------------------------------------
-
-This release only fixes various bugs and doesn't need the database schema to be
-modified. Simply update the file /usr/local/pf/conf/currently-at to match the new
-release number.
-
-LDAP SSL and STARTTLS is now correctly implemented.
-Make sure the server you specify in authentication.conf supports the encryption type 
-requested on the port configured. Failure to do so will break LDAP and Active Directory 
-authentication.
-
-Upgrading from a version prior to 4.0.3
----------------------------------------
-
-You need to downgrade the version of perl-Net-DNS and perl-Net-DNS-Nameserver to
-version 0.65-4 in order to fix the issue with pfdns crashing.
-
-Upgrading from a version prior to 4.0.4
----------------------------------------
-
-The parameter guest_self_reg in the profiles.conf file is no longer necessary.
-The self-registration is now automatically enabled if at least one external 
-authentication source is selected (Email, SMS, SponsorEmail, or Oauth2).
-
-Upgrading from a version prior to 4.0.5
----------------------------------------
-
-This release adds a new dependency on the Perl module Apache::SSLLookup. Once installed, 
-update the file /usr/local/pf/conf/currently-at to match the new release number.
-
-Upgrading from a version prior to 4.0.6
----------------------------------------
-
-Changes to authentication API
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The method pf::authentication::authenticate now expects an array of pf::authentication::Source objects
-instead of an array of source IDs.
-
-The methods getSourceByType, getInternalSources, and getExternalSources of the module pf::Portal::Profile
-now return pf::authentication::Source objects instead of source IDs.
-
-Upgrading from a version prior to 4.1.0
----------------------------------------
-
-Database schema update
-^^^^^^^^^^^^^^^^^^^^^^
-
-The category column in the temporary_password should not be mandatory.
-
-Also, the access_level of the temporary_password table is now a string instead of a bit string.
-
-Make sure you run the following to update your schema:
-
-  mysql -u root -p pf -v < /usr/local/pf/db/upgrade-4.0.0-4.1.0.sql
-
-Configuration changes
-^^^^^^^^^^^^^^^^^^^^^
-
-The parameters `trapping.redirecturl` and `trapping.always_use_redirecturl` from `pf.conf` (or `pf.conf.defaults`)
-were moved to the default portal profile in `profiles.conf`.
-
-The parameter `registration.range` has been deprecated. Make sure you remove it from your configuration file.
-
-The action `set_access_level` of authentication sources in `authentication.conf` must now match one of the admin roles
-defined in `adminroles.conf`. The previous level `4294967295` must be replaced by *ALL* and the level `0` by *NONE*.
-
-Adjust your configuration files accordingly.
-
-Once the configuration completed, update the file /usr/local/pf/conf/currently-at to match the new release number.
-
-Upgrading from a version prior to 4.2.0
----------------------------------------
-
-Database schema update
-^^^^^^^^^^^^^^^^^^^^^^
-
-The person table has many new columns that can be used for registration.
-
-The node table has new columns to store the time and bandwidth balances of a node.
-
-The node table has also a new column to keep the audit-session-id from the RADIUS request to use with the CoA.
-
-Added a new column config_timestamp in radius_nas table.
-
-The locationlog table has new columns to store the switch IP and MAC when using dynamic controllers.
-
-New table for inline (layer 3) accounting.
-
-New table for WRIX data.
-
-Make sure you run the following to update your schema:
-
-  mysql -u root -p pf -v < /usr/local/pf/db/upgrade-4.1.0-4.2.0.sql
-
-Configuration changes
-^^^^^^^^^^^^^^^^^^^^^
-
-The parameter `guests_self_registration.mandatory_fields` from `pf.conf` (or `pf.conf.defaults`) was moved to the
-default portal profile in `profiles.conf`.
-
-The parameters `registration.gaming_devices_registration` and `registration.gaming_devices_registration_role` are replaced
-with `registration.device_registration` and `registration.device_registration_role`.
-
-Adjust your configuration files accordingly.
-
-The captive portal has been rewritten using the Catalyst MVC framework. Any customization to the previous CGI scripts
-will need to be ported to the new architecture.
-
-Once the configuration completed, update the file /usr/local/pf/conf/currently-at to match the new release number.
-
-Upgrading from a version prior to 4.3.0
----------------------------------------
-
-Database schema update
-^^^^^^^^^^^^^^^^^^^^^^
-
-The person table has 2 new column to keep the portal and the source used to authenticate.
-
-The tables email_activation and sms_activation have been merged in a table named `activation`. It has an additional column to keep the portal used to register.
-
-Make sure you run the following to update your schema:
-
-  mysql -u root -p pf -v < /usr/local/pf/db/upgrade-4.2.0-4.3.0.sql
-
-Configuration changes
-^^^^^^^^^^^^^^^^^^^^^
-
-The parameters `VlanMap` and `RoleMap` have been added in `switches.conf`; be sure to add them in the [default] switch section.
-
-The OAuth passthroughs will not be activated unless `trapping.passthrough` in `pf.conf` is enabled. Make sure you enable it if you have OAuth authentication sources (Google, Facebook, Github, LinkedIn and Windows Live).
-
-Once the configuration is completed, update the file /usr/local/pf/conf/currently-at to match the new release number.
-
-Upgrading from a version prior to 4.4.0
----------------------------------------
-
-Database schema update
-^^^^^^^^^^^^^^^^^^^^^^
-
-Introduced the 'iplog_history' table for easier cleanup of the existing 'iplog' table.
-
-Make sure you run the following to update your schema:
-
-  mysql -u root -p pf -v < /usr/local/pf/db/upgrade-4.3.0-4.4.0.sql
-
-Cache serialization
-^^^^^^^^^^^^^^^^^^^
-
-The serialization of the objects in the cache changed, making all the previous cached objects invalid.
-With PacketFence completely stopped do :
-
-  rm -fr /usr/local/pf/var/cache/*
-
-Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 4.4.0).
-
-Upgrading from a version prior to 4.5.0
----------------------------------------
-
-Database schema update
-^^^^^^^^^^^^^^^^^^^^^^
-
-The class table has a new column delay_by.
-
-Make sure you run the following to update your schema:
-
-  mysql -u root -p pf -v < /usr/local/pf/db/upgrade-4.4.0-4.5.0.sql
-
-Violation configuration
-^^^^^^^^^^^^^^^^^^^^^^^
-
-A new parameter 'delay_by' has been introduced in the violation configuration. Make sure to add the following to the 'defaults' section of 'conf/violations.conf' to avoid any problem.
-
-delay_by=0s
-
-Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 4.5.0).
-
-Upgrading from a version prior to 4.6.0
----------------------------------------
-
-Database schema update
-^^^^^^^^^^^^^^^^^^^^^^
-
-The locationlog and locationlog_history table have 2 new columns stripped_user_name and realm.
-We added new INDEX on iplog, violation and locationlog tables.
-
-Make sure you run the following to update your schema:
-
-  mysql -u root -p pf -v < /usr/local/pf/db/upgrade-4.5.0-4.6.0.sql
-
-
-Violation template pages language handling
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Code to match violation template pages have been reworked. Make sure to lowercase FR to fr in french template files name.
-
-Realm configuration
-^^^^^^^^^^^^^^^^^^^
-
-Realm are now managed by Freeradius server so if your users authenticate with a username like username@acme.com then add the realm acme.com
-in the Radius Realms configuration menu and in your Active Directory source select 'Use stripped username'.
-
-Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 4.6.0).
-
-Upgrading from a version prior to 4.7.0
----------------------------------------
-
-Database schema update
-^^^^^^^^^^^^^^^^^^^^^^
-
-The 'node' table has a new column (machine_account).
-
-Make sure you run the following to update your schema:
-
-  mysql -u root -p pf -v < /usr/local/pf/db/upgrade-4.6.0-4.7.0.sql
-
-Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 4.7.0).
-
-Upgrading from a version prior to 5.0.0
----------------------------------------
-
-Upgrading a version of PacketFence older than 4.1 to v5 will be a complex undertaking.
-While it's entirely possible if done meticulously, we
-suggest you start from scratch and move your customizations and
-nodes information over to your new installation.
-
-Please note that the sections below are cumulative. That is to say, if you are upgrading from version 4.3 to version 5.0 you must apply in order all changes in between the two versions, including database schema changes.
-
-As always, taking a complete backup of your current installation is strongly recommended. 
-A backup should contain a copy of all PacketFence files as well as a copy of the database.
-You can take a backup of the pf directory with the following command:
-
-  tar -C /usr/local -czf /root/packetfence.tar.gz pf 
-
-A backup of the database can be taken using the procedure described in the next section.
-
-Database schema update
-^^^^^^^^^^^^^^^^^^^^^^
-
-Before making any changes to your database, ensure that you have a backup.
-A complete database backup can be taken using this command:
-
-  mysqldump --opt --routines -u root -p pf | gzip > /root/packetfence_db.sql.gz
-
-If your database is more than a few hundred megabytes, you may also want to consider using a tool such as Percona XtraBackup which makes for much faster restores than mysqldump.
-
-
-Multiple changes have been made to the database schema. You will need to update it accordingly.
-Since we will be dropping and recreating the 'iplog' table it is essential that you have a backup if you need the data it contains.
-
-Make sure you run the following to update your schema:
-
-  mysql -u root -p pf -v < /usr/local/pf/db/upgrade-4.7.0-5.0.0.sql
-
-Configuration changes
-^^^^^^^^^^^^^^^^^^^^^
-
-You must manually enter the MySQL password of the pf user in the conf/pfconfig.conf file.
-The MySQL password is saved in the conf/pf.conf file under the [database] section.
-Copy the following from conf/pf.conf to conf/pfconfig.conf: 
-
-  pass=$YOURPASSWORDHERE
-  
-
-Violations configuration
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-The violation triggers have been reworked for the new Fingerbank integration.
-We highly suggest you copy `conf/violations.conf.example` over `conf/violations.conf` and then reconfigure any violations you had before.
-
-Also, make sure you adjust the following triggers to their new ID (Can be found under 'Configuration->Fingerbank'):
-
-* `USERAGENT` becomes `user_agent`
-* `VENDORMAC` becomes `mac_vendor`
-
-The `OS` trigger has been deprecated over the new `dhcp_fingerprint` trigger. 
-You will need to adjust these triggers to the new ids as well as renaming them.
-
-iptables changes
-^^^^^^^^^^^^^^^^
-
-The iptables configuration file doesn't use the generated rules '%%input_mgmt_guest_rules%%' anymore. 
-Make sure you remove this line from conf/iptables.conf.
-
-Also a lot of additions were made to the iptables configuration file. 
-Make sure you add the new rules in conf/iptables.conf.example to your existing iptables file or execute the following command to replace the whole file.
-
-  cp /usr/local/pf/conf/iptables.conf.example /usr/local/pf/conf/iptables.conf
-
-Using EAP local authentication
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-If you are using EAP MS-CHAP local authentication, meaning your 802.1x connections authenticate against your local database, you will need to make sure you deactivate password encryption in the database.
-In the administration interface, go in 'Configuration -> Advanced' and set 'Database passwords hashing method' to `plaintext`
-
-Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 5.0.0).
-
-Upgrading from a version prior to 5.1.0
----------------------------------------
-
-Database schema update
-^^^^^^^^^^^^^^^^^^^^^^
-
-Multiple changes have been made to the database schema. You will need to update it accordingly.
-
-Make sure you run the following to update your schema:
-
-  mysql -u root -p pf -v < /usr/local/pf/db/upgrade-5.0.0-5.1.0.sql
-
-pfsetvlan and snmptrapd
-^^^^^^^^^^^^^^^^^^^^^^^
-
-These two services have been disabled by default. 
-If you are using SNMP traps enforcement on your switches (like port-security), make sure you re-enable them in 'Configuration->Services'.
-
-Active Directory domain join
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The Microsoft Active Directory domain join configuration is now part of PacketFence. 
-A migration script has been made so you can migrate an existing domain join into this configuration.
-Note that this step is not mandatory, as the old join method is still supported. But if you do
-not perform this step, you will not see its configuration from the PacketFence web administrative interface.
-
-Simply execute the following script and follow its instructions `/usr/local/pf/addons/AD/migrate.pl`
-
-Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 5.1.0).
-
-Upgrading from a version prior to 5.2.0
----------------------------------------
-
-Database schema update
-^^^^^^^^^^^^^^^^^^^^^^
-
-Multiple changes have been made to the database schema. You will need to update it accordingly.
-
-Make sure you run the following to update your schema:
-
-  mysql -u root -p pf -v < /usr/local/pf/db/upgrade-5.1.0-5.2.0.sql
-
-Database monitoring host
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-If you are using an Active/Active cluster, you will need to adjust the monitoring database host to point to your database as it is not forced anymore.
-
-In `conf/pf.conf` :
-
-----
-[monitoring]
-db_host=127.0.0.1
-----
-
-New 'portal' interface type
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-If you are using email registration, web-auth enforcement (external captive-portal), device registration feature, or anything that would require to access the captive portal from outside the registration/isolation VLANs, you might want (actually, you need otherwise it will no longer works!) to add the 'portal' type to the existing 'management' interface.
-
-In `conf/pf.conf` :
-
-----
-[interface eth42]
-type=management,portal
-----
-
-
-Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 5.2.0).
-
-Upgrading from a version prior to 5.3.0
----------------------------------------
-
-Database schema update
-^^^^^^^^^^^^^^^^^^^^^^
-
-Changes have been made to the database schema. You will need to update it accordingly.
-
-Make sure you run the following to update your schema:
-
-  mysql -u root -p pf -v < /usr/local/pf/db/upgrade-5.2.0-5.3.0.sql
-
-Debian and Ubuntu
-^^^^^^^^^^^^^^^^^
-
-A downgrade in a package version may cause an error when trying to upgrade.
-
-If you receive this error: 
-
-  The following packages have unmet dependencies:
-   packetfence : Depends: libhtml-formhandler-perl (= 0.40013-2) but 0.40050-2 is to be installed
-  E: Unable to correct problems, you have held broken packages.
-
-Run the following commands:
-
-  # dpkg -r --ignore-depends=packetfence   libhtml-formhandler-perl
-  # apt-get install  libhtml-formhandler-perl  libtemplate-autofilter-perl  libmoo-perl 
-  # apt-get install packetfence packetfence-config packetfence-pfcmd-suid libdist-checkconflicts-perl libimport-into-perl 
-
-Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 5.3.0).
-
-
-Upgrading from a version prior to 5.4.0
----------------------------------------
-
-Database schema update
-^^^^^^^^^^^^^^^^^^^^^^
-
-Changes have been made to the database schema. You will need to update it accordingly.
-
-Make sure you run the following to update your schema:
-
-  mysql -u root -p pf -v < /usr/local/pf/db/upgrade-5.3.0-5.4.0.sql
-
-Authentication sources rules rework
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Authentication sources rules have been reworked in a way to differentiate an 'authentication' rule and an 'administration' rule. Codewise, that means that codeflow will look into specific types of rules depending of the use case.
-
-Please take a minute or two to go through the existing rules for each of the authentication sources and make sure there is no 'administration' class actions into an 'authentication' class rule and vice versa, otherwise the "invalid" action will be ignored.
-
-Authentication sources rules structure is as follow:
-
-* 'authentication' rule class available actions:
-** Set role (set_role)
-** Set access duration (set_access_duration)
-** Set unregistration date (set_unreg_date)
-* 'administration' rule class available actions:
-** Set access level of Web admin (set_access_level)
-** Mark as sponsor (mark_as_sponsor)
-
-For example, if an existing rule is as follow:
-
-* Name: AllAdmins
-* Class: No class defined since the class attribute is new
-* Conditions: ...
-* Actions:
-** Set access level of Web admin -> ALL
-** Set role -> default
-** Set access duration -> 24H
-
-That existing rule will default to the 'authentication' class if none is being set. 
-If that's the case, the first action "Set access level of Web admin" will then be ignored.
-
-To replicate that existing rule with the new classes, you would have to create two separate rules, as follow:
-
-Rule for 'administration' purposes
-
-* Name: AllAdmins_admin 
-* Class: administration
-* Conditions: ...
-* Actions:
-** Set access level of Web admin -> ALL
-
-Rule for 'authentication' purposes
-
-* Name: AllAdmins_auth
-* Class: authentication
-* Conditions: ...
-* Actions:
-** Set role -> default
-** Set access duration -> 24H
-
-Configuration will be validated on every start / restart so that "bogus" authentication sources / rules can be identified.
-
-
-OAuth2 authentication sources changes
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The Facebook API now requires to specify the fields to be defined in the query.
-In all your facebook sources, change the parameter protected_resource_url to https://graph.facebook.com/me?fields=id,name,email,first_name,last_name
-
-Change the parameter scope to user,user:email in all your Github sources as PacketFence is now fetching the email address of the user when registering with Github.
-
-StatsD configuration changes
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-monitoring.statsd_host and monitoring.statsd_port have been removed from pf.conf. 
-If you have specified a specific host or port, remove them from your configuration and change them in /usr/local/pf/lib/pf/StatsD.pm
-
-Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 5.4.0).
-
-Upgrading from a version prior to 5.5.0
----------------------------------------
-
-Database schema update
-^^^^^^^^^^^^^^^^^^^^^^
-
-Changes have been made to the database schema. You will need to update it accordingly.
-
-Make sure you run the following to update your schema:
-
-  mysql -u root -p pf -v < /usr/local/pf/db/upgrade-5.4.0-5.5.0.sql
-
-VLAN Filter configuration changes
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The VLAN filter has been reworked to use a more generalized syntax to allow more complex filters to be created.
-
-This mean nested conditions no longer need to specify the attribute in the condition.
-
-So the following attribute
-
-   [condition]
-   filter=node_info
-   attribute=category
-   operator=is
-   value=default
-
-Should be rewritten as
-
-   [condition]
-   filter=node_info.category
-   operator=is
-   value=default
-
-The older syntax is still supported but will be deprecated in a future release.
-
-The operators match and match_not has changed their behavior.
-They will match (or not match) the exact string given in the condition.
-The following condition
-
-  [condition]
-  filter=node_info.computername
-  operator=match
-  value=^Bob
-
-Will match node_info.computername only if it contians '^Bob'.
-It will not match if node_info.computername start with 'Bob'
-
-If you need to use a regex then use the regex/regex_not operator.
-So the following condition should be changed from
-
-  [condition]
-  filter=node_info.mac
-  operator=match
-  value=^00:
-
-To the following
-
-  [condition]
-  filter=node_info.mac
-  operator=regex
-  value=^00:
-
-pf.conf configuration file changes
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The following parameters have been removed from pf.conf. Make sure to remove them from your file if configured.
-
-* alerting.wins_server
-* alerting.admin_netbiosname
-
-violations.conf configuration file changes
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Violations have been reworked and configuration changes are necessary in order to maintain functionnality.
-
-In violations.conf the following actions have been renamed, please update them accordingly.
-
-* trap -> reevaluate_access
-* email -> email_admin
-
-The following action have been removed from the violations :
-
-* popup
-
-Also in violations.conf, the parameter whitelisted_categories has been renamed into whitelisted_roles
-
-Billing configuration change
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The parameter `billing_engine` of the Portal Profiles has been deprecated.
-Remove it from all your profiles configuration in `/usr/local/pf/conf/profiles.conf`.
-
-The billing engine of PacketFence has been reworked completely.
-
-It will require to reconfigure existing billing providers from scratch as there is no retro-compatibility with the previous configuration.
-
-Please see the Administration Guide for details on how to configure the billing engine.
-
-Mod_qos configuration changes
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Mod_qos configuration has been moved from "services" to "captive_portal" section.
-Make sure to apply the appropriate changes if needed.
-
-Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 5.5.0).
-
-Upgrading from a version prior to 5.6.0
----------------------------------------
-
-Database schema update
-^^^^^^^^^^^^^^^^^^^^^^
-
-Changes have been made to the database schema. You will need to update it accordingly.
-
-Make sure you run the following to update your schema:
-
-  mysql -u root -p pf -v < /usr/local/pf/db/upgrade-5.5.0-5.6.0.sql
-
-Extension points changes
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-The file lib/pf/vlan/custom.pm has now been renamed to lib/pf/role/custom.pm.
-Most of the customizations that used to be made in vlan/custom.pm can now be handled by configuring a vlan filter.
-You should take a good look at your existing vlan/custom.pm and consider porting the changes to conf/vlan_filters.conf. 
-
-VLAN filters changes
-^^^^^^^^^^^^^^^^^^^^
-
-The scopes for the VLAN filters have changed.
-The following have been renamed according to these rules:
-
-NormalVlan          -> RegisteredRole
-RegistrationVlan    -> RegistrationRole 
-ViolationVlan       -> ViolationRole
-InlineVlan          -> InlineRole
-
-If you have defined any filters in /usr/local/pf/conf/vlan_filters.conf, make sure to rename all references to the left hand side with the new names on the right hand side.
-
-Default type for the switches
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The default type for the switches now needs to be set explicitly. Add the following line in the default section of `/usr/local/pf/conf/switches.conf`
-
-`type=Generic`
-
-Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 5.6.0).
-
-Upgrading from a version prior to 5.7.0
----------------------------------------
-
-Suricata violation trigger renaming
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-With the introduction of the ability to trigger a violation based on a MD5 hash detected by Suricata, a new trigger type has been introduced, requiring the modification of the actual 'suricata' trigger.
-Make sure to go through your violations configuration and change any 'suricata' trigger name for 'suricata_event'.
-
-Database schema update
-^^^^^^^^^^^^^^^^^^^^^^
-
-Changes have been made to the database schema. You will need to update it accordingly.
-
-Make sure you run the following to update your schema:
-
-  mysql -u root -p pf -v < /usr/local/pf/db/upgrade-5.6.0-5.7.0.sql
-
-Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 5.7.0).
-
-Upgrading from a version prior to 6.0.0
----------------------------------------
-
-Upgrading PacketFence from a version older than v6.0.0 will be a complex undertaking.
-While it's entirely possible if done meticulously, we
-suggest you start from scratch and move your customizations and
-nodes information over to your new installation.
-
-
-Devices parking
-^^^^^^^^^^^^^^^
-
-The new registration devices parking requires that you add the following violation in `/usr/local/pf/conf/violations.conf`
-
-  [1300003]
-  priority=1
-  desc=Parking violation
-  max_enable=3
-  grace=10m
-  actions=log,reevaluate_access
-  enabled=Y
-  auto_enable=Y
-  vlan=registration
-  trigger=Internal::parking_detected
-
-Chained authentication
-^^^^^^^^^^^^^^^^^^^^^^
-
-The chained source has been deprecated in favor of a fully customizable flow in the captive portal.
-
-Make sure you delete the source *BEFORE* upgrading your installation.
-
-Once you upgrade, configure a portal module for each of your sources and a chained one that contains both. Refer to the administration guide for a detailed example.
-
-Redesigned captive portal
-^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The parameter `mandatory_fields` of the Portal Profiles has been deprecated. Remove it from all the profiles in `profiles.conf`
-
-To configure mandatatory fields in the portal, refer to the 'Portal Modules' section of the Administration guide
-
-You need to add the `root_module` parameter to your default portal profile. In `profiles.conf` add `root_module=default_policy` to the default portal profile
-
-Changes to OAuth2 sources callback URL
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-All the OAuth2 sources you have configured (Facebook, Github, Google, LinkedIn ,Twitter, Windows Live) need to be adjusted as the redirect URL is now the same for all the types.
-
-In the admin interface change `Portal URL` from `https://YOUR_HOSTNAME/oauth2/SOURCE_TYPE` to `https://YOUR_HOSTNAME/oauth/callback` (where `SOURCE_TYPE` would be the lower case name of the source type). Note that this parameter is named `redirect_url` in the configuration file.
-
-Changes to Cisco Web auth
-^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Use the Cisco::Catalyst_2960 switch module instead of the Cisco::Catalyst_2960_http as switch type.
-
-Use the Cisco::WLC switch module instead of the Cisco::WLC_http as switch type.
-
-The portalURL configuration parameter is now configured per-role so make sure you have `http://ip_portal/$session_id` assigned to the registration role in the `Role by Web Auth URL` section of the switch configuration.
-
-See the Network Device configuration guide for additional details.
-
-SMS carrier database table
-^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Google Project Fi have been added as a supported carrier. Since an ID is hardcoded on creation of a new entry in the 'sms_carrier' database table, a manual intervention may be required in the case the database schema update fails.
-
-pf.conf configuration parameters
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-'expire' and 'maintenance' section have been reworked and 'expire' section is no longer a thing. Make sure to adjust configuration parameter accordingly if needed;
- 
-* expire.node is now maintenance.node_cleanup_window
-* expire.iplog is now maintenance.iplog_cleanup_window
-* expire.locationlog is now maintenance.locationlog_cleanup_window
-* expire.radius_audit_log is now maintenance.radius_audit_log_cleanup_window
-* expire.traplog is now maintenance.traplog_cleanup_window
-
-node category / role
-^^^^^^^^^^^^^^^^^^^^
-
-The 'REJECT' role is now a default standard role. If you already have such role, make sure no conflict exists.
-
-Also, add the following line to the default section of `switches.conf` :
-
-`REJECTVlan = -1`
-
-Changes to the generated smb.conf
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-If you have a domain configured directly in PacketFence (in 'Configuration->Domains'), you need to re-generate the associated configuration files as changes have been made to the samba configuration.
-
-Using the CLI `/usr/local/pf/bin/pfcmd generatedomainconfig` or in the admin interface in 'Configuration->Domains', click 'Refresh domain configuration'
-
-Upgrade from FreeRADIUS 2 to FreeRADIUS 3
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-PacketFence 6 relies on FreeRADIUS 3 rather that FreeRADIUS 2 as provided in PacketFence 5.
-The configuration files, directory layout and "unlang" directives have changed significantly.
-The packaging will automatically rename the existing raddb directory to raddb-pre6.
-All your existing configuration and certificates (if stored under raddb/certs) should be preserved but may need to be merged with the new raddb directory layout if you customized them.
-
-The configuration files under conf/radiusd/*.example have also changed.
-Make sure to compare them to your conf/radiusd/* files if you have any customizations, and merge any *.rpmnew files that may have been created by the packaging.
-
-The default location for the FreeRADIUS server certificates has changed from conf/ssl/ to raddb/certs/.
-The configuration of the certificates location is in conf/radiusd/eap.conf.
-You may point it to any valid certificate and key by setting the value of `certificate_file` and `private_key_file` respectively.
-It is not recommended to use the same server certificate for the HTTP services and the RADIUS server as the requirements for each are different.
-Reusing the same certificate will work, but you would be well advised to consider separate certificates.
-
-Finally, the database schema for the RADIUS accounting tables and stored procedures have changed.
-Make sure to apply the database changes as described in the following section.
-
-Database schema update
-^^^^^^^^^^^^^^^^^^^^^^
-
-Significant changes have been made to the database schema. You will need to update it accordingly.
-An SQL upgrade script has been provided to upgrade the database from the 5.7 schema to 6.0.
-
-Since the schema of the `radacct` table has been reworked, the script will rename the existing table to `radacct2` and insert it's content into the new `radacct` table.
-If your existing `radacct` table is large (as is sometimes the case), the operation may take a long time and consume a significant amount of disk space.
-Make sure to have plenty of both before running the upgrade script.
-
-You can estimate the size of the existing `radacct` table by running the following command:
-
-    mysql> SELECT table_name AS "Table", round(((data_length + index_length) / 1024 / 1024), 2) "Size in MB" FROM information_schema.TABLES WHERE table_schema = "pf" AND table_name = "radacct";
-
-You should have at least twice as much space as that table uses in the filesystem on which the MySQL data directory is mounted (usually /var/lib/mysql).
-
-If you do not have enough space or time, you may consider truncating the `radacct` table (or simply deleting some of the rows) before running the upgrade script.
-
-When ready, run the following to update your schema:
-
-  mysql -u root -p pf -v < /usr/local/pf/db/upgrade-5.7.0-6.0.0.sql
-
-Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 6.0.0).
-
-You will also want to drop the `radacct2` table from the database as it will no longer be needed.
-
-Upgrading from a version prior to 6.1.0
----------------------------------------
-
-Significant changes have been made to the database schema. You will need to update it accordingly.
-An SQL upgrade script has been provided to upgrade the database from the 6.0 schema to 6.1.
-
-To upgrade the database schema, run the following command: 
-
-  mysql -u root -p pf -v < /usr/local/pf/db/upgrade-6.0.0-6.1.0.sql
-
-Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 6.1.0).
-
-
-Dynamically created local secret
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The management IP(s) of PacketFence are now defined as switches with a forced RADIUS secret defined in /usr/local/pf/conf/local_secret. Make sure you reconfigure the secret in the file if necessary and that this file is synchronized on all your cluster members if that applies. Note that this doesn't affect the RADIUS secret you have configured for wireless controllers and switches. It only affects RADIUS requests that originate from the management IP(s)
-
-Changes to LinkedIn source
-^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-A change to the authorize URL of LinkedIn was made. Make sure to change the 'API Authorize Path' in all your LinkedIn source to `/uas/oauth2/authorization`.
-
-Upgrading from a version prior to 6.2.0
----------------------------------------
-
-Changes have been made to the database schema. You will need to update it accordingly.
-An SQL upgrade script has been provided to upgrade the database from the 6.1 schema to 6.2.
-
-To upgrade the database schema, run the following command: 
-
-  mysql -u root -p pf -v < /usr/local/pf/db/upgrade-6.1.0-6.2.0.sql
-
-Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 6.2.0).
-
-Upgrading from a version prior to 6.2.1
----------------------------------------
-
-Changes have been made to the httpd.admin configuration.
-Make sure you copy the conf/httpd.conf.d/httpd.admin.tt.example file over conf/httpd.conf.d/httpd.admin.tt.
-If you customized that file in any way, you will have to merge the changes.
-
-Restart the httpd.admin process once that is done by running 
-  /usr/local/pf/bin/pfcmd service httpd.admin restart
-
-Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 6.2.1).
-
-Upgrading from a version prior to 6.3.0
----------------------------------------
-
-Changes have been made to the database schema. You will need to update it accordingly.
-An SQL upgrade script has been provided to upgrade the database from the 6.2 schema to 6.3.
-
-To upgrade the database schema, run the following command: 
-
-  mysql -u root -p pf -v < /usr/local/pf/db/upgrade-6.2.0-6.3.0.sql
-
-Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 6.3.0).
-
-RADIUS configuration file changes
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The following file: /usr/local/pf/conf/radiusd/eap.conf was modified to use TemplateToolkit, you will need to replace it by /usr/local/pf/conf/radiusd/eap.conf.example, make sure to re-edit the new file and add your certificate if needed.
-
-Samba cache directory changed
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Rejoining the domains from PacketFence GUI is required. 
-
-Go under `Configuration->RADIUS->Domains` and click `Rejoin` for each domain configured.
-
-Configuration changes to the Provisioning and Scaning
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The configuration of the Scan engines and the Provisioners has been reworked to use the Fingerbank device IDs in the OS matching. `scan.conf` and `provisioning.conf` need to be migrated to use the new values. A migration script should be run `# /usr/local/pf/addons/upgrade/to-6.3-os-rewrite.pl` to migrate the configuration. This will output the migrated configuration in `/usr/local/pf/conf/provisioning.conf.new` and `/usr/local/pf/conf/scan.conf.new`. First run the script and then validate that their content is fine. Once that is done, copy the files over the original ones using : 
-
-```
-# cp /usr/local/pf/conf/provisioning.conf.new /usr/local/pf/conf/provisioning.conf
-# cp /usr/local/pf/conf/scan.conf.new /usr/local/pf/conf/scan.conf
-# /usr/local/pf/bin/pfcmd configreload hard
-```
-
-Fingerbank database moving to MySQL (optionnal but highly suggested)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The Fingerbank database can now be hosted in the same MySQL database PacketFence uses.
-
-In order to do so, you need to collect the database credentials from the PacketFence configuration:
-
-```
-# /usr/local/pf/bin/pfcmd pfconfig show resource::Database
-$VAR1 = {
-          'pass' => 'myPassword',
-          'db' => 'pf',
-          'user' => 'pf',
-          'port' => '3306',
-          'host' => 'localhost'
-        };
-```
-
-Now, you need to create the database and assign the proper rights to the user by executing the following commands:
-
-```
-# mysql -u root -p -e "CREATE DATABASE pf_fingerbank"
-# mysql -u root -p -e "GRANT ALL PRIVILEGES ON pf_fingerbank.* TO 'pf'@'%' IDENTIFIED BY 'myPassword'"
-# mysql -u root -p -e "GRANT ALL PRIVILEGES ON pf_fingerbank.* TO 'pf'@'localhost' IDENTIFIED BY 'myPassword'"
-```
-
-Replace `myPassword` by the password displayed (`pass`) when running the first command.
-
-Next, head to 'Configuration->Fingerbank Settings' in the web administration interface and configure the following parameters:
-
- * MySQL host : set this to the value of `host` you got from running the command above.
- * MySQL port : set this to the value of `port` you got from running the command above.
- * MySQL username : set this to the value of `user` you got from running the command above.
- * MySQL password : set this to the value of `pass` you got from running the command above.
- * MySQL database : set this to `pf_fingerbank`.
- 
-After saving those new parameters, at the top of the same page, click 'Initialize MySQL database' to start the import process. Once that is completed, you will receive an e-mail to the one configured for alerting and PacketFence will start using the MySQL backend for the Fingerbank database.
-
-Upgrading from a version prior to 6.4.0
----------------------------------------
-
-Database schema updates
-^^^^^^^^^^^^^^^^^^^^^^^
-
-Changes have been made to the database schema. You will need to update it accordingly.
-An SQL upgrade script has been provided to upgrade the database from the 6.3 schema to 6.4.
-
-To upgrade the database schema, run the following command: 
-
-  mysql -u root -p pf -v < /usr/local/pf/db/upgrade-6.3.0-6.4.0.sql
-
-
-Changes to web authentication configuration
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Rework of the external captive portal capabilities involves some significant changes in the switch modules configuration.
-Some switch modules have been moved to other ones and some others have been removed. Please adjust the configuration (type) accordingly within switches.conf.
-
- * AeroHIVE::AP_http -> AeroHIVE::AP
- * Meraki::AP_http -> Meraki::MR
- * Meraki::AP_http_V2 -> Meraki::MR_v2
- * Xirrus:AP_http -> Xirrus
-
-To instruct a switch module to perform external captive portal enforcement, a new switch configuration parameter have been added. Make sure to adjust the following parameter to your needs in switches.conf
-
-```
-ExternalPortalEnforcement = Y
-```
-
-External captive portal URLs have also changed. Change them accordingly depending on the type of equipment you use:
-
- * AeroHIVE: http://portal_IP/AeroHIVE::AP
- * Aruba: http://portal_IP/Aruba
- * Cisco Catalyst 2960: http://portal_IP/Cisco::Catalyst_2960
- * Cisco WLC: http://portal_IP/Cisco::WLC
- * CoovaChilli: http://portal_IP/CoovaChilli
- * Meraki: http://portal_IP/Meraki::MR
- * Ruckus: http://portal_IP/Ruckus
- * Xirrus: http://portal_IP/Xirrus
-
-Where portal_ip is the IP Address (or DNS name) of your captive portal as it was configured before
-
-
-Changes to WMI
-^^^^^^^^^^^^^^
-
-If you use WMI, you must modify conf/wmi.conf in order to make sure that a namespace parameter is defined for each rule. For example, you could have:
-
-```
-[SCCM]
-request=select * from Win32_Process where name='CcmExec.exe'
-action=[sccm]
-namespace=ROOT\cimv2
-on_tab=1
-```
-
-Changes to default cronjob
-^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Upon PacketFence installation, a default cronjob will be in /etc/cron.d/. You should make sure you do not invoke the /usr/local/pf/addons/backup-and-maintenance.sh
-script from any other cronjob.
-
-Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 6.4.0).
-
-
-Upgrading from a version prior to 6.5.0
----------------------------------------
-
-Database schema updates
-^^^^^^^^^^^^^^^^^^^^^^^
-
-Changes have been made to the database schema. You will need to update it accordingly.
-An SQL upgrade script has been provided to upgrade the database from the 6.4 schema to 6.5.
-
-To upgrade the database schema, run the following command: 
-
-  mysql -u root -p pf -v < /usr/local/pf/db/upgrade-6.4.0-6.5.0.sql
-
-
-Custom code warning
-^^^^^^^^^^^^^^^^^^^
-
-The method signature of pf::node::node_register has been modified. Make sure you adjust any custom code / external scripts to handle the new returned values.
-
-Switches Configuration
-^^^^^^^^^^^^^^^^^^^^^^
-You must rename "controllerPort" to "disconnectPort" in your switches.conf configuration file. You can automate this using:
-
-  cd /usr/local/pf
-  find . -name "switches.conf" -exec sed -i "s/controllerPort/disconnectPort/g" '{}' \;
-
-Eduroam
-^^^^^^^
-Eduroam authentication source is now an "exclusive" authentication source rather than an "external" one. That being said, make sure to adjust portal profile accordingly (an "exclusive" authentication source can be the only one configured in a portal profile).
-
-Improved Logging
-^^^^^^^^^^^^^^^^
-In order to be sure all your logging facilities use the new logging backend which ensures the processes will not die in case of a logging failure, you must execute the following command:
-
-  cd /usr/local/pf
-  find conf/log.conf.d/ -type f -exec sed -i.bak "s/Log::Log4perl::Appender::File/pf::log::FileAppender/g" {} \; ; find conf/log.conf.d/ -name '*.bak' -delete
-
-Email templates
-^^^^^^^^^^^^^^^
-
-The email templates have been moved from /usr/local/pf/conf/emails/ to /usr/local/pf/html/captive-portal/templates/emails/ as they are now configurable by portal profile. Also you can configure the language in which PacketFence should send emails to the administrator in the Advanced section of the configuration.
-
-Make sure you run the following command after upgrading:
-
-  /usr/local/pf/bin/pfcmd cache configfiles clear
-
-Violations
-^^^^^^^^^^
-When whitelisting roles in a violation, the registration role will now match unregistered devices where before it would never match. Make sure to go through violations that may include this role to make sure it is relevant.
-
-Database schema updates
-^^^^^^^^^^^^^^^^^^^^^^^
-The "configfile" and "traplog" database tables are now deprecated. If you wish to reclaim the disk space used by those two database tables, they should be manually removed.
-
-Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 6.5.0).
-
-
-Default RoleMap for the switches
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-If you were using the default 'RoleMap = Y' in the conf/switches.conf it's disabled by default now. You will need to put 'RoleMap = Y' under your switches or switch group configuration.
-
-Upgrading from a version prior to 7.0.0
----------------------------------------
 
 NOTE: You cannot upgrade from CentOS 6 or Debian Wheezy to PacketFence 7.0 and above
 
-Debian upgrade
-^^^^^^^^^^^^^^
+=== Debian upgrade
+
 
 The requirement for MariaDB 10.1 means that a simple "apt upgrade" will not be enough.
 You will need to help apt through the upgrade by manually removing some packages and installing some others.
@@ -1346,8 +243,8 @@ Finally, upgrade the rest of the packages
 
 Note that "full-upgrade" may also affect other packages you might have installed on the system if you had other software than PacketFence on it.
 
-MariaDB upgrade (CentOS + RHEL only)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+=== MariaDB upgrade (CentOS + RHEL only)
+
 
 Upgrading to PacketFence 7+ will install a more recent version of MariaDB than the one that is shipped with CentOS.
 
@@ -1376,8 +273,8 @@ Once done, restart the MariaDB service (managed by PacketFence)
 
   systemctl start packetfence-mariadb
 
-Database schema update (all Linux distributions)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+=== Database schema update (all Linux distributions)
+
 
 Changes have been made to the database schema. You will need to update it accordingly.
 An SQL upgrade script has been provided to upgrade the database from the 6.5 schema to 7.0.
@@ -1386,31 +283,31 @@ To upgrade the database schema, run the following command:
 
   mysql -u root -p pf -v < /usr/local/pf/db/upgrade-6.5.0-7.0.0.sql
 
-Systemd integration
-^^^^^^^^^^^^^^^^^^^
+=== Systemd integration
+
 
 All PacketFence services are managed individually via systemd unit files instead of one unit file (`packetfence.service`). When you updated the PacketFence package, it already set the system target to `packetfence.target`.
 
 If you are hosting the MySQL/MariaDB service on your PacketFence servers (it is by default), you should now manage the service via `packetfence-mariadb.service` instead of `mariadb.service`.
 The changes in the server startup will be done automatically by the packaging.
 
-Admin roles configuration
-^^^^^^^^^^^^^^^^^^^^^^^^^
+=== Admin roles configuration
+
 
 Given the portal profiles have now been renamed to connection profiles, you need to make sure any admin role that allowed portal profile Create/Read/Update/Delete operations is updated to be valid for connection profiles.
 
   cd /usr/local/pf
   sed -i "s/PORTAL_PROFILE/CONNECTION_PROFILE/g" conf/adminroles.conf
 
-PacketFence configuration
-^^^^^^^^^^^^^^^^^^^^^^^^^
+=== PacketFence configuration
+
 
 Multiple parameters inside `pf.conf` have been renamed for better clarity. Execute the following in order to migrate the parameters.
 
   /usr/local/pf/addons/upgrade/to-7.0-pf-conf-changes.pl
 
-Maintenance configuration
-^^^^^^^^^^^^^^^^^^^^^^^^^
+=== Maintenance configuration
+
 
 Maintenance related configuration for pfmon has been moved to a dedicated configuration file (`/usr/local/pf/conf/pfmon.conf`).
 
@@ -1418,8 +315,8 @@ In order to migrate your settings from `pf.conf` to `pfmon.conf`, run the follow
 
   /usr/local/pf/addons/upgrade/to-7.0-pf.conf-to-pfmon.conf.pl
 
-DHCP filters configuration
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+=== DHCP filters configuration
+
 
 Minor changes were made to the DHCP filters configuration (`/usr/local/pf/conf/dhcp_filters.conf`).
 
@@ -1432,8 +329,8 @@ In order to rename those in an automated way:
   sed -i "s/computer_name/computername/g" conf/dhcp_filters.conf
   sed -i "s/DhcpFingerbank/Fingerbank/g" conf/dhcp_filters.conf
 
-Roles configuration
-^^^^^^^^^^^^^^^^^^^
+=== Roles configuration
+
 
 The source of truth for roles is now in a configuration file (`/usr/local/pf/conf/roles.conf`) instead of being in the database. In order to pull the existing roles from your database into the configuration file, execute the following command:
 
@@ -1441,15 +338,15 @@ The source of truth for roles is now in a configuration file (`/usr/local/pf/con
 
 NOTE: The roles still exist in the database like before (node_category table), but their source of truth is now in the configuration file. Should you remove a role manually from `roles.conf`, it will *not* be removed from the database unless you manually go delete it from the database.
 
-pfdetect configuration
-^^^^^^^^^^^^^^^^^^^^^^
+=== pfdetect configuration
+
 
 New parameters have been introduced in `conf/pfdetect.conf`. Run the following script to migrate your configuration.
 
   /usr/local/pf/addons/upgrade/to-7.0-pfdetect-conf.pl
 
-LinkedIn Source changes
-^^^^^^^^^^^^^^^^^^^^^^^
+=== LinkedIn Source changes
+
 
 If you are using the LinkedIn OAuth2 source, a change has been made on their API, thus you will need to do the following:
 
@@ -1457,15 +354,15 @@ If you are using the LinkedIn OAuth2 source, a change has been made on their API
   sed -i "s/uas\/oauth2/oauth\/v2/g" conf/authentication.conf
 
 
-Logging service
-^^^^^^^^^^^^^^^
+=== Logging service
+
 
 Since all logging now goes through rsyslog, if you had edited the logging configuration (e.g. to forward logs to a centralized syslog server) make sure that the new logging rules in `/etc/rsyslog.d/packetfence.conf` do not conflict with your changes.
 
 Take a look at `/usr/local/pf/conf/log.conf` and `/usr/local/pf/conf/log.conf.d/*` for the detailed configuration of the PacketFence services.
 
-Redis Queue
-^^^^^^^^^^^
+=== Redis Queue
+
 
 Clear the redis queue to avoid old stale jobs from being processes.
 
@@ -1474,8 +371,8 @@ Clear the redis queue to avoid old stale jobs from being processes.
   redis-cli -p 6380 FLUSHALL
   systemctl stop packetfence-redis_queue
   
-SSL certificates
-^^^^^^^^^^^^^^^^
+=== SSL certificates
+
 
 Given that haproxy is now the termination point for the captive portal, any SSL configuration you have in `/usr/local/pf/conf/httpd.conf.d/ssl-certificates.conf` needs to be ported so that it works with haproxy.
 
@@ -1486,19 +383,18 @@ In order to do so:
   # cd /usr/local/pf/
   # cat /path/to/your/server.crt /path/to/your/intermediates.crt /path/to/your/server.key > /usr/local/pf/conf/ssl/server.pem
 
-Running 7.0+ in a cluster
-^^^^^^^^^^^^^^^^^^^^^^^^^
+=== Running 7.0+ in a cluster
+
 
 A complete re-visit of the database clustering stack was done in version 7.0. If you run your PacketFence installation in a cluster, make sure you read the following section.
 
-Active/Active clusters with Active/Passive DB (default before 7.0)
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+==== Active/Active clusters with Active/Passive DB (default before 7.0)
 
 We highly suggest you migrate your existing clustered installation using Corosync/Pacemaker to the new cluster stack of PacketFence that uses MariaDB Galera cluster. 
 The easiest way to perform this is to build new servers and port your configuration (by copying the configuration files) and your database (using mysqldump).
 There are ways to migrate the 2 existing nodes to a 3 nodes cluster but this is not covered in this guide.
 
-*Corosync adjustment*
+===== Corosync adjustment
 
 Note that you can safely keep your existing 2-node cluster with Corosync/Pacemaker in place and things will work like before.
 You will simply have to adjust your Corosync configuration so that MariaDB points to the packetfence-mariadb file instead of the mariadb unit.
@@ -1508,14 +404,14 @@ You will simply have to adjust your Corosync configuration so that MariaDB point
           op stop timeout=60s interval=0 \
           op monitor interval=20s timeout=30s
 	 
-*Disabling Galera cluster*
+===== Disabling Galera cluster
 
 You must then disable the MariaDB Galera cluster as a replication mechanism as you will still be using DRBD. In order to do so, add the following in `/usr/local/pf/conf/pf.conf`
 
   [active_active]
   galera_replication=disabled
  
-*IP address bind*
+===== IP address bind
 
 You must also instruct packetfence-mariadb to bind to the management IP address of the server manually.
 
@@ -1533,7 +429,7 @@ with:
 
 Where 1.2.3.4 is the management IP address of the server.
 
-*Disable packetfence-mariadb on boot*
+===== Disable packetfence-mariadb on boot
 
 Like in previous versions where mariadb shouldn't have been started on boot, now you must ensure its replacement (packetfence-mariadb) doesn't start on boot.
 
@@ -1545,13 +441,12 @@ Next, you must set the default target to packetfence-cluster:
 
   systemctl set-default packetfence-cluster.target
 
-Active/Active clusters with external DB
-+++++++++++++++++++++++++++++++++++++++
+==== Active/Active clusters with external DB
 
 No changes to your clustering stack is required when using an external database.
 
-Active/Passive clusters
-+++++++++++++++++++++++
+==== Active/Passive clusters
+
 
 CAUTION: You shouldn't be running active/passive clusters anymore. If you do, you're pretty much on your own for community support. Inverse provides professionnal services to help you maintain these clusters. If you intend to keep an active/passive cluster, we suggest you have deep knowledge of Corosync/Pacemaker and strong Linux skills.
 
@@ -1574,35 +469,35 @@ You should then change your Corosync configuration for MariaDB and PacketFence t
 	        op stop timeout=300s interval=0 \
 	        op monitor interval=300s timeout=300s
 
-Upgrading from a version prior to 7.1.0
----------------------------------------
+== Upgrading from a version prior to 7.1.0
 
-Multiple DNS servers per domain
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+=== Multiple DNS servers per domain
+
 
 The PacketFence Active Directory Domains integration now supports multiple DNS servers to be specified to find a DC. For this reason the parameter dns_server has been renamed to dns_servers in domain.conf. In order to automatically rename the parameters, run the following command:
 
     sed -i.bak "s/^dns_server/dns_servers/g" /usr/local/pf/conf/domain.conf
 
-Add default values to new auth source parameters
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+=== Add default values to new auth source parameters
+
 
     /usr/local/pf/addons/upgrade/to-7.1-authentication-conf.pl
 
-Fix the Ubiquiti typo
-^^^^^^^^^^^^^^^^^^^^^
+=== Fix the Ubiquiti typo
+
 
 In order to use the Ubiquiti switch module that has been renamed, run the following command:
 
     sed -i.bak "s/Ubiquity/Ubiquiti/g" /usr/local/pf/conf/switches.conf
 
-Instagram source changes
-^^^^^^^^^^^^^^^^^^^^^^^^
+=== Instagram source changes
+
 
 Due to a change in the API of Instagram please change the scope if you are using an Instagram OAuth2 source. Replace 'scope=email' by 'scope=basic' in conf/authentication.conf under the section '[Instagram Source]'.
 
-Database schema update (all Linux distributions)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+=== Database schema update (all Linux distributions)
+
 
 Changes have been made to the database schema. You will need to update it accordingly.
 An SQL upgrade script has been provided to upgrade the database from the 7.0 schema to 7.1.
@@ -1612,11 +507,11 @@ To upgrade the database schema, run the following command:
   mysql -u root -p pf -v < /usr/local/pf/db/upgrade-7.0.0-7.1.0.sql
 
 
-Upgrading from a version prior to 7.2.0
----------------------------------------
+== Upgrading from a version prior to 7.2.0
 
-Ability to «pin» a domain DC
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+=== Ability to «pin» a domain DC
+
 
 PacketFence is now able to instruct Samba to «pin» a DC for authentication or use all of them.
 You should instruct Samba to connect to all domain controllers by adding the following to each of your domains in domain.conf:
@@ -1629,16 +524,16 @@ And then regenerate the domain configuration:
   /usr/local/pf/bin/pfcmd configreload hard
   /usr/local/pf/bin/pfcmd generatedomainconfig
 
-Change to sponsor CC address
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+=== Change to sponsor CC address
+
 
 The CC address for sponsors is now BCC. In order to adjust the configuration, execute the following:
 
   cd /usr/local/pf
   sed -i "s/sponsorship_cc/sponsorship_bcc/g" conf/authentication.conf
 
-Changes to authentication sources codebase
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+=== Changes to authentication sources codebase
+
 
 Any custom authentication sources forms and templates would need to be copied to the new location.
 
@@ -1650,8 +545,8 @@ Forms
 /usr/local/pf/html/pfappserver/lib/pfappserver/Form/Config/Source
 
 
-Database schema update (all Linux distributions)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+=== Database schema update (all Linux distributions)
+
 
 Changes have been made to the database schema. You will need to update it accordingly.
 An SQL upgrade script has been provided to upgrade the database from the 7.1 schema to 7.2.
@@ -1660,24 +555,24 @@ To upgrade the database schema, run the following command:
 
   mysql -u root -p pf -v < /usr/local/pf/db/upgrade-7.1.0-7.2.0.sql
 
-Upgrading from a version prior to 7.3.0
----------------------------------------
+== Upgrading from a version prior to 7.3.0
 
-Device Registration
-^^^^^^^^^^^^^^^^^^^
+
+=== Device Registration
+
 
 You will need to remove anything related to [device_registration] in the conf/pf.conf file.
 Once done, you will need to reconfigure any device registration policy using the following instructions: https://packetfence.org/doc/PacketFence_Installation_Guide.html#_devices_registration
 
-Changes to `authentication.conf` and `domain.conf` regarding realms and source matching
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+=== Changes to `authentication.conf` and `domain.conf` regarding realms and source matching
+
 
 You have to run the following script to change the configuration:
 
   /usr/local/pf/addons/upgrade/to-7.3-authentication-conf.pl
 
-MariaDB database read-only mode
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+=== MariaDB database read-only mode
+
 
 There was, in some cases, an issue where the database cluster was put in a read-only mode which then prevent it to comes back gracefully.
 
@@ -1689,8 +584,8 @@ Ensure you merge changes in the galera section of `conf/mariadb/mariadb.conf.tt.
 Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 7.3.0).
 
 
-Database schema update (all Linux distributions)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+=== Database schema update (all Linux distributions)
+
 
 Changes have been made to the database schema. You will need to update it accordingly.
 An SQL upgrade script has been provided to upgrade the database from the 7.2 schema to 7.3.
@@ -1699,11 +594,11 @@ To upgrade the database schema, run the following command:
 
   mysql -u root -p pf -v < /usr/local/pf/db/upgrade-7.2.0-7.3.0.sql
 
-Upgrading from a version prior to 7.4.0
----------------------------------------
+== Upgrading from a version prior to 7.4.0
 
-New LinkedIn domain list
-^^^^^^^^^^^^^^^^^^^^^^^^
+
+=== New LinkedIn domain list
+
 
 If you use social login with LinkedIn OAuth2, you will need to adjust the list of domains that are passthroughs in the LinkedIn source.
 
@@ -1711,13 +606,13 @@ For all your LinkedIn sources, change the domains to:
 
   www.linkedin.com,api.linkedin.com,*.licdn.comlatform.linkedin.com
   
-Portal redirection timer
-^^^^^^^^^^^^^^^^^^^^^^^^
+=== Portal redirection timer
+
 
 The redirection timer configuration (length of the timer bar at the end of the portal) has been moved from the fencing section to the captive_portal section. More precisely, it has moved from `fencing.redirtimer` to `captive_portal.network_redirect_delay`.
 
-Database schema update (all Linux distributions)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+=== Database schema update (all Linux distributions)
+
 
 Changes have been made to the database schema. You will need to update it accordingly.
 An SQL upgrade script has been provided to upgrade the database from the 7.3 schema to 7.4.
@@ -1728,11 +623,11 @@ To upgrade the database schema, run the following command:
 
 Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 7.4.0).
 
-Upgrading from a version prior to 8.0.0
----------------------------------------
+== Upgrading from a version prior to 8.0.0
 
-Realms upgrade
-^^^^^^^^^^^^^^
+
+=== Realms upgrade
+
 
 The way PacketFence detects whether or not it should strip the realm out of a username when performing authentication and authorisation has been moved to the realms. Moreover, it is now configurable based on the context (login on the captive portal or administration interface, as well as when performing authorization in RADIUS 802.1x)
 
@@ -1740,8 +635,8 @@ In order to migrate your configuration, you can use the following script which w
 
  /usr/local/pf/addons/upgrade/to-8.0-authentication-conf.pl
 
-Fingerbank v2
-^^^^^^^^^^^^^
+=== Fingerbank v2
+
 
 *Device names*
 
@@ -1768,8 +663,8 @@ WARNING: Fingerbank v1 and v2 *do not* use the same infrastructure. The accounts
 
 If you manage a large scale environment, you'll want to make sure your account can perform an unlimited amount of API requests on Fingerbank so that device profiling works correctly in a consistent way. In order to obtain this, contact fingerbank@inverse.ca. Note that most Inverse customers are entitled to free unlimited usage of the Fingerbank Cloud API.
 
-Changes to the default switch roles
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+=== Changes to the default switch roles
+
 
 The default roles that were returned using "Role by Switch Role" have been removed. If you were relying on them to be returned in the RADIUS response, then you need to add them back in the default switch in the 'Roles' tab.
 
@@ -1783,8 +678,8 @@ The previous values were:
 
 This is should only be necessary if you are using ACL assignment on your switches and using the default names that were there in PacketFence before.
 
-Removal of the graphite database
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+=== Removal of the graphite database
+
 
 PacketFence doesn't use graphite anymore for its dashboard. It is recommended to delete the graphite database although this is purely optional.
 
@@ -1792,8 +687,8 @@ In order to do so, execute the following:
 
   mysql -u root -p -e "drop database pf_graphite"
 
-Changes to DNS filters
-^^^^^^^^^^^^^^^^^^^^^^
+=== Changes to DNS filters
+
 
 The $qname parameter need to be removed from dns_filters.conf 
 
@@ -1801,8 +696,8 @@ In order to do so, execute the following command:
 
   sed -i -e 's/\$qname//g' /usr/local/pf/conf/dns_filters.conf
 
-Database schema update (all Linux distributions)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+=== Database schema update (all Linux distributions)
+
 
 Changes have been made to the database schema. You will need to update it accordingly.
 An SQL upgrade script has been provided to upgrade the database from the 7.4 schema to 8.0.
@@ -1813,18 +708,18 @@ To upgrade the database schema, run the following command:
 
 Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 8.0.0).
 
-Upgrading from a version prior to 8.1.0 
----------------------------------------
+== Upgrading from a version prior to 8.1.0 
 
-Changes on unreg_on_accounting_stop parameter
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+=== Changes on unreg_on_accounting_stop parameter
+
 
 The global configuration parameter unreg_on_acct_stop has been moved in the connection profile.
 So if you enabled it then make sure to enable it now in the connection profile.
 
 
-Database schema update (all Linux distributions)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+=== Database schema update (all Linux distributions)
+
 
 Changes have been made to the database schema. You will need to update it accordingly.
 An SQL upgrade script has been provided to upgrade the database from the 7.4 schema to 8.0.
@@ -1835,17 +730,17 @@ To upgrade the database schema, run the following command:
 
 Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 8.1.0).
 
-Upgrading from a version prior to 8.2.0
----------------------------------------
+== Upgrading from a version prior to 8.2.0
 
-Queue Stats maintenance job removal
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+=== Queue Stats maintenance job removal
+
 The queue_stats maintenance job has been deprecated in favor of using pfstats. In order to remove configuration related to this maintenance job, run:
 
   /usr/local/pf/addons/upgrade/to-8.2-pfmon-conf.pl
 
-Upgrade pfdetect perl regex to the go RE2 regex
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+=== Upgrade pfdetect perl regex to the go RE2 regex
+
 The pfdetect was moved from perl to go so all rule regexes have to be converted to the RE2 regex syntax.
 RE2 is mostly is compatiable the perl regex syntax.
 More information on the RE2 syntax can be found here https://github.com/google/re2/wiki/Syntax.
@@ -1855,21 +750,21 @@ To upgrade the regex run:
 
 Any perl regex that cannnot be convert will be displayed and should be fixed.
 
-Upgrade realm.conf to be tenant aware
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+=== Upgrade realm.conf to be tenant aware
+
 
 The realms are now multi-tenant aware, in order to upgrade your configuration to have the existing realms use the default tenant, execute the following script:
 
   /usr/local/pf/addons/upgrade/to-8.2-realm-conf.pl
 
 
-The api_user table has been deprecated
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+=== The api_user table has been deprecated
+
 
 Any users in that were in the api_user table should be migrated to PacketFence local account (password table)
 
-Upgrade pf user privileges
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+=== Upgrade pf user privileges
+
 
 Starting from 8.2, stored routines will be dump *with* the PacketFence database.
 The user created at the installation ('pf' by default) in database need to
@@ -1879,14 +774,14 @@ To upgrade the privileges of that user, run the following command:
 
  /usr/local/pf/addons/upgrade/to-8.2-upgrade-pf-privileges.sh
 
-Update connection_type from WIRED_MAC_AUTH to Ethernet-NoEAP
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+=== Update connection_type from WIRED_MAC_AUTH to Ethernet-NoEAP
+
 We merged the WIRED_MAC_AUTH and Ethernet-NoEAP to Ethernet-NoEAP so the configuration needs to be updated, to do that run:
 
  sed -i "s/WIRED_MAC_AUTH/Ethernet-NoEAP/g" /usr/local/pf/conf/profiles.conf /usr/local/pf/conf/vlan_filters.conf /usr/local/pf/conf/radius_filters.conf /usr/local/pf/conf/switch_filters.conf /usr/local/pf/conf/authentication.conf
 
-Database schema
-^^^^^^^^^^^^^^^
+=== Database schema
+
 
 Changes have been made to the database schema. You will need to update it accordingly.
 An SQL upgrade script has been provided to upgrade the database from the 8.1 schema to 8.2.
@@ -1897,11 +792,11 @@ To upgrade the database schema, run the following command:
 
 Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 8.2.0).
 
-Upgrading from a version prior to 8.3.0
----------------------------------------
+== Upgrading from a version prior to 8.3.0
 
-Upgrade pf.conf to rename configuration parameters
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+=== Upgrade pf.conf to rename configuration parameters
+
 
 We moved radius_authentication_methods section to radius_configuration and moved all the radius configuration parameters in this new section.
 To upgrade your configuration execute the following script:
@@ -1909,8 +804,8 @@ To upgrade your configuration execute the following script:
   /usr/local/pf/addons/upgrade/to-8.3-rename-pf-conf-parameters.pl
 
 
-Upgrade authentication.conf to add searchattributes parameter
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+=== Upgrade authentication.conf to add searchattributes parameter
+
 
 We added a new parameter in AD and LDAP authentication sources to be able to do 802.1x authentication with any unique ldap attributes.
 This parameter "searchattributes" need to be added in the existing authentication sources.
@@ -1918,8 +813,8 @@ To apply this configuration execute the following script:
 
  /usr/local/pf/addons/upgrade/to-8.3-authentication-searchattributes.pl
 
-Adjustment to the encoding of the configuration files and templates
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+=== Adjustment to the encoding of the configuration files and templates
+
 
 Configuration and templates in the admin were previously being saved as latin1 instead of utf8.
 
@@ -1927,8 +822,8 @@ This script will convert all latin1 config file to utf8
 
   /usr/local/pf/addons/upgrade/to-8.3-conf-latin1-to-utf8.sh
 
-Database schema
-^^^^^^^^^^^^^^^
+=== Database schema
+
 
 Changes have been made to the database schema. You will need to update it accordingly.
 An SQL upgrade script has been provided to upgrade the database from the 8.2 schema to 8.3.
@@ -1939,16 +834,16 @@ To upgrade the database schema, run the following command:
 
 Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 8.3.0).
 
-Upgrading from a version prior to 9.0.0
----------------------------------------
+== Upgrading from a version prior to 9.0.0
 
-Support for Debian 8 dropped
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+=== Support for Debian 8 dropped
+
 
 Debian 8 will not be supported anymore for versions 9.0.0 and above. You should instead use Debian 9 now as it is currently the only supported Debian version.
 
-Necessity to use MariaDB
-^^^^^^^^^^^^^^^^^^^^^^^^
+=== Necessity to use MariaDB
+
 
 NOTE: This only applies to users using an external database server. If your database is hosted on the same server as PacketFence whether you are in cluster or standalone, this requires no attention.
 
@@ -1960,33 +855,33 @@ The recommended MariaDB version for PacketFence is currently 10.1.21
 
 A recent version of MySQL can also work but going forward, the only tested database engine will be MariaDB.
 
-Deprecate the classic dhcp filters
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+=== Deprecate the classic dhcp filters
+
 
 The previous dhcp filters engine has been deprecated in favor of the new one who is able to modify
 the dhcp answer on the fly.
 
-Violations have been renamed to Security Events
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+=== Violations have been renamed to Security Events
+
 
 The violations have been renamed to security events. In order to make the appropriate changes in your configuration, execute the following script:
 
   /usr/local/pf/addons/upgrade/to-9.0-security-events.sh
   
-Removed MAC detection setting
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+=== Removed MAC detection setting
+
 
 The MAC detection setting in the switches has been removed. In order to cleanup the switches configuration for the removal of this setting, execute the following script:
 
   /usr/local/pf/addons/upgrade/to-9.0-remove_mac_detection.sh
   
-Modifications to accounting cleanup
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+=== Modifications to accounting cleanup
+
 
 Accounting cleanup is now done via a pfmon task (acct_cleanup) instead of the database backup and maintenance script. Make sure you adjust the cleanup window in pfmon's configuration (Configuration->System Maintenance->Maintenance) if necessary. Also note that the default retention for the accounting data has been lowered to 1 day instead of 1 week like it was before.
 
-Admin roles configuration
-^^^^^^^^^^^^^^^^^^^^^^^^^
+=== Admin roles configuration
+
 
 In order to upgrade the Admin rights, run the following commands
 
@@ -1994,8 +889,8 @@ In order to upgrade the Admin rights, run the following commands
   sed -i "s/SERVICES/SERVICES_READ/g" /usr/local/pf/conf/adminroles.conf 
   sed -i "s/REPORTS/REPORTS_READ/g" /usr/local/pf/conf/adminroles.conf
 
-Database schema
-^^^^^^^^^^^^^^^
+=== Database schema
+
 
 Changes have been made to the database schema. You will need to update it accordingly.
 An SQL upgrade script has been provided to upgrade the database from the 8.3 schema to 9.0.
@@ -2007,33 +902,33 @@ To upgrade the database schema, run the following command:
 Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 9.0.0).
 
 
-Upgrading from a version prior to 9.1.0
----------------------------------------
+== Upgrading from a version prior to 9.1.0
 
-Now possible to disable a domain
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+=== Now possible to disable a domain
+
 
 In order to add the necessary enabled flag to your existing domains, run the following command:
 
   /usr/local/pf/addons/upgrade/to-9.1-add-domain-conf.pl
 
-pfperl-api port
-^^^^^^^^^^^^^^^
+=== pfperl-api port
+
 
 The port of the pfperl-api service has changed, in order to adjust the existing configuration, run the following command:
 
   /usr/local/pf/addons/upgrade/to-9.1-update-api.conf.sh
 
-Linkedin OAuth2
-^^^^^^^^^^^^^^^
+=== Linkedin OAuth2
+
 
 The LinkedIn API calls have changed drastically.
 On top of the new LinkedIn modules that are part of the update, you will need to change the following parameter in all your existing LinkedIn sources:
 
  API URL of logged user -> https://api.linkedin.com/v2/emailAddress?q=members&projection=(elements*(handle~))
 
-VLAN pool configuration
-^^^^^^^^^^^^^^^^^^^^^^^
+=== VLAN pool configuration
+
 
 The VLAN pool strategy configuration has been moved to the connection profiles.
 
@@ -2041,15 +936,15 @@ In order to migrate the current setting of pf.conf into profiles.conf, you will 
 
 	/usr/local/pf/addons/upgrade/to-9.1-move-vlan-pool-technique-parameter.pl
 
-Remove Useragent Triggers
-^^^^^^^^^^^^^^^^^^^^^^^^^
+=== Remove Useragent Triggers
+
 
 The useragent and user_agent security event triggers have been deprecated. Performing HTTP User-Agent based detection is extremelly inefficient given the very dynamic nature of HTTP User-Agents. You should instead be using the device trigger which leverages the device profiling performed by Fingerbank. In order to remove any existing useragent trigger, execute the following script:
 
    /usr/local/pf/addons/upgrade/to-9.1-security-events-remove-useragent.pl
 
-Database schema
-^^^^^^^^^^^^^^^
+=== Database schema
+
 
 Changes have been made to the database schema. You will need to update it accordingly.
 An SQL upgrade script has been provided to upgrade the database from the 9.0 schema to 9.1.
@@ -2133,3 +1028,7 @@ Once completed, update the file [filename]`/usr/local/pf/conf/currently-at` to m
 ----
 cat /usr/local/pf/conf/pf-release > /usr/local/pf/conf/currently-at
 ----
+
+== Archived upgrade notes
+
+include::{extra_path}upgrade-notes/archived_upgrade_notes.asciidoc[]

--- a/UPGRADE.asciidoc
+++ b/UPGRADE.asciidoc
@@ -7,6 +7,7 @@
 // to display images directly on GitHub
 ifdef::env-github[]
 :imagesdir: images
+:extra_path: docs/
 endif::[]
 
 ////
@@ -15,7 +16,7 @@ endif::[]
 
 ////
 
-include::includes/global-attributes.asciidoc[]
+include::{extra_path}includes/global-attributes.asciidoc[]
 
 == About this Guide
 

--- a/UPGRADE.asciidoc
+++ b/UPGRADE.asciidoc
@@ -55,8 +55,18 @@ You can take a backup of the pf directory with the following command:
 
 == Upgrade procedure
 
+=== Steps
 
-NOTE: These are general upgrade instructions. Make sure to go through (read) the upgrade instructions specific to the upgrade path taken since some steps may be required to be done *BEFORE* the packages upgrades.
+A PacketFence upgrade consists of following steps:
+
+. preliminary steps to run before packages upgrades
+. packages upgrades
+. configuration migrations
+. database schema upgrade
+
+IMPORTANT: Before starting packages upgrades, make sure to go through (read) the upgrade
+instructions specific to the upgrade path taken since some preliminary steps may be
+required to be done *BEFORE* the packages upgrades.
 
 === For a clustered environment
 

--- a/UPGRADE.asciidoc
+++ b/UPGRADE.asciidoc
@@ -61,6 +61,7 @@ tar -C /usr/local -czf /root/packetfence.tar.gz pf --exclude='pf/logs' --exclude
 
 == Upgrade procedure
 
+[#upgrade-steps]
 === Steps
 
 A PacketFence upgrade consists of following steps:
@@ -184,7 +185,8 @@ Debian installation system should have interactively asked for existing modified
 [#restart-services]
 === Restart all PacketFence services
 
-Once the additionnal steps below are completed, restart `packetfence-config` and `packetfence`:
+Once all <<upgrade-steps,steps of upgrade procedure>> are completed, restart
+`packetfence-config` and `packetfence` services:
 
 [source,bash]
 ----

--- a/UPGRADE.asciidoc
+++ b/UPGRADE.asciidoc
@@ -61,10 +61,14 @@ A PacketFence upgrade consists of following steps:
 
 . stop all PacketFence services (see <<stop-services>> section)
 . preliminary steps to run before packages upgrades (see sections for your upgrade path)
-. packages upgrades (see <<packages-upgrades>> section)
+. packages upgrades (see <<pkg-upgrades>> section)
 . configuration migrations (see sections for your upgrade path)
 . database schema upgrade (see sections for your upgrade path)
 . restart all PacketFence services (see <<restart-services>> section)
+
+Upgrade notes for a given upgrade path are cumulative. That is to say, if you
+are upgrading from version 7.0 to version 9.0 you must apply in order all
+changes in between the two versions, including database schema changes.
 
 IMPORTANT: Before starting packages upgrades, make sure to go through (read) the upgrade
 instructions specific to the upgrade path taken since some preliminary steps may be
@@ -94,63 +98,76 @@ instructions specific to the upgrade path taken since some preliminary steps may
 required to be done *BEFORE* the packages upgrades.
 
 [#pkg-upgrades-rpm]
-RHEL / CentOS based systems
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== RHEL / CentOS based systems
 
 Due to disconnection issues with the systemd-logind service while yum is performing the update, you need to ensure the service is stopped disabled. The last command will then ensure your current process is removed out of the user-0.slice.
 
-  /usr/bin/systemctl stop systemd-logind
-  /usr/bin/systemctl --now mask systemd-logind
-  /usr/bin/systemctl daemon-reload
-  /bin/bash -c "/usr/bin/systemctl status user-0.slice | /usr/bin/grep -E -o '─[0-9]+' | /usr/bin/sed 's/─//g' | /usr/bin/xargs -I{} /bin/bash -c '/usr/bin/kill -0 {} > /dev/null 2>/dev/null && /usr/bin/echo {} > /sys/fs/cgroup/systemd/tasks'"
-
-
-Run the following command to update PacketFence:
-
-  yum update packetfence packetfence-release --enablerepo=packetfence
-  
-Since PacketFence heavily relies on Fingerbank, it is recommended to make sure you are running the latest version:
-
-  yum update fingerbank --enablerepo=packetfence
-
-PacketFence and Fingerbank should now be upgraded. However, there may be extra steps required depending on the version you are upgrading from. Please review the following notes about upgrading from an older release.
-
-NOTE: Upgrade notes for a given upgrade path are cumulative. That is to say, if you are upgrading from version 5.3 to version 6.0 you must apply in order all changes in between the two versions, including database schema changes.
-
-Debian based systems
-^^^^^^^^^^^^^^^^^^^^
-
-  apt update
+[source,bash]
+----
+/usr/bin/systemctl stop systemd-logind
+/usr/bin/systemctl --now mask systemd-logind
+/usr/bin/systemctl daemon-reload
+/bin/bash -c "/usr/bin/systemctl status user-0.slice | /usr/bin/grep -E -o '─[0-9]+' | /usr/bin/sed 's/─//g' | /usr/bin/xargs -I{} /bin/bash -c '/usr/bin/kill -0 {} > /dev/null 2>/dev/null && /usr/bin/echo {} > /sys/fs/cgroup/systemd/tasks'"
+----
 
 Run the following command to update PacketFence:
 
-  apt install packetfence
+[source,bash]
+----
+yum update packetfence packetfence-release --enablerepo=packetfence
+----
 
 Since PacketFence heavily relies on Fingerbank, it is recommended to make sure you are running the latest version:
 
-  apt install fingerbank
+[source,bash]
+----
+yum update fingerbank --enablerepo=packetfence
+----
+
+PacketFence and Fingerbank should now be upgraded. However, there may be extra
+steps required depending on the version you are upgrading from. Please review
+the following notes about upgrading from an older release.
+
+==== Debian based systems
+
+Run the following command to update PacketFence:
+
+[source,bash]
+----
+apt update
+apt install packetfence
+----
+
+Since PacketFence heavily relies on Fingerbank, it is recommended to make sure you are running the latest version:
+
+[source,bash]
+----
+apt install fingerbank
+----
 
 PacketFence and Fingerbank should now be upgraded. However, there may be extra steps required depending on the version you are upgrading from. Please review the following notes about upgrading from an older release.
-
-NOTE: Upgrade notes for a given upgrade path are cumulative. That is to say, if you are upgrading from version 5.3 to version 6.0 you must apply in order all changes in between the two versions, including database schema changes.
 
 '''
 
 You should take care to review any changes to configuration files and merge them if required. 
 To find out which configuration files have changed run this command:
 
+==== New versions of configuration files
 
-RHEL / CentOS based systems
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+===== RHEL / CentOS based systems
 
-  find /usr/local/pf -name \*.rpmnew
+[source,bash]
+----
+find /usr/local/pf -name \*.rpmnew
+----
 
 The list of files returned are the new versions shipped with PacketFence.
-Compare them to your existing version and see if there are changes that should be merged into your existing configuration.
-Then, once you are done make sure to delete these files so that there is no confusion the next time you upgrade PacketFence.
+Compare them to your existing version and see if there are changes that should
+be merged into your existing configuration.  Then, once you are done make sure
+to delete these files so that there is no confusion the next time you upgrade
+PacketFence.
 
-Debian based systems
-^^^^^^^^^^^^^^^^^^^^
+===== Debian based systems
 
 Debian installation system should have interactively asked for existing modified files.
 

--- a/UPGRADE.asciidoc
+++ b/UPGRADE.asciidoc
@@ -62,6 +62,7 @@ NOTE: These are general upgrade instructions. Make sure to go through (read) the
 
 Please refer to the https://github.com/inverse-inc/packetfence/blob/stable/docs/PacketFence_Clustering_Guide.asciidoc[PacketFence Clustering Guide], more specifically the https://github.com/inverse-inc/packetfence/blob/stable/docs/PacketFence_Clustering_Guide.asciidoc#performing-an-upgrade-on-a-cluster[Perform an upgrade on a cluster] section.
 
+[#standalone]
 === For a standalone server
 
 It is recommended that you stop the currently running PacketFence services before proceeding any further.
@@ -74,6 +75,7 @@ systemctl stop packetfence-config
 ----
 
 
+[#standalone-rpm]
 RHEL / CentOS based systems
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -87,7 +89,7 @@ Due to disconnection issues with the systemd-logind service while yum is perform
 
 Run the following command to update PacketFence:
 
-  yum update packetfence --enablerepo=packetfence
+  yum update packetfence packetfence-release --enablerepo=packetfence
   
 Since PacketFence heavily relies on Fingerbank, it is recommended to make sure you are running the latest version:
 
@@ -2004,22 +2006,14 @@ Once completed, update the file /usr/local/pf/conf/currently-at to match the new
 == Upgrading from a version prior to X.Y.Z
 
 
-=== Merge of all RPM packages into one
+=== Merge of all RPM packages into one (RHEL / CentOS only)
 
 NOTE: This step need to be done *before* packages upgrade.
 
 Starting from now, PacketFence will be released as an unique RPM package for
-x86_64 architectures. To remove properly older RPM packages, you need to follow these steps:
+`x86_64` architectures. To remove properly older RPM packages, you need to follow these steps:
 
-. Stop services:
-+
-[source,bash]
-----
-/usr/local/pf/bin/pfcmd service pf stop
-systemctl stop packetfence-config
-----
-+
-
+. Follow instructions as mentioned in <<standalone,standalone server upgrade procedure section>> and stop before upgrading PacketFence packages using [command]`yum`
 . Uninstall old RPM without running post-uninstallation steps:
 +
 [source,bash]
@@ -2031,33 +2025,23 @@ rpm -e --nodeps --noscripts packetfence-remote-arp-sensor
 ----
 +
 
-. Update [package]`packetfence-release` and [package]`packetfence` packages:
+. Recopy previous [filename]`pfconfig.conf` filename to its original location:
 +
 [source,bash]
 ----
-yum update packetfence-release --enablerepo=packetfence
-yum update packetfence --enablerepo=packetfence
 mv -f /usr/local/pf/conf/pfconfig.conf.rpmsave /usr/local/pf/conf/pfconfig.conf
 ----
 +
 
-. Restart services:
-+
-[source,bash]
-----
-/usr/local/pf/bin/pfcmd fixpermissions
-/usr/local/pf/bin/pfcmd pfconfig clear_backend
-systemctl restart packetfence-config
-/usr/local/pf/bin/pfcmd configreload hard
-/usr/local/pf/bin/pfcmd service pf restart
-----
+. Upgrade PacketFence packages by following [command]`yum` instructions in <<standalone-rpm>> section
+. Continue upgrade procedure
 
-At the end of the process, you should have only one RPM package called
+At the end of upgrade procedure, you should have only one RPM package called
 [package]`packetfence`. If you previously installed
 [package]`packetfence-release` package in order to have PacketFence repository
 installed, this one has been upgraded to latest version.
 
-=== New GPG key for Debian installations
+=== New GPG key for Debian installations (Debian only)
 
 NOTE: This step need to be done *before* packages upgrade.
 

--- a/UPGRADE.asciidoc
+++ b/UPGRADE.asciidoc
@@ -2049,7 +2049,7 @@ In order to install new versions of Debian packages, you will need to add a new 
 
 [source,bash]
 ----
-curl -L https://inverse.ca/downloads/GPG_PUBLIC_KEY | sudo apt-key add -
+wget -O - https://inverse.ca/downloads/GPG_PUBLIC_KEY | sudo apt-key add -
 ----
 
 You can safely remove the oldest one:

--- a/UPGRADE.asciidoc
+++ b/UPGRADE.asciidoc
@@ -197,13 +197,6 @@ systemctl restart packetfence-config
 /usr/local/pf/bin/pfcmd service pf restart
 ----
 
-Don't forget to edit the [file]`/usr/local/pf/conf/currently-at` file to match the newly updated version:
-
-[source,bash]
-----
-cat /usr/local/pf/conf/pf-release > /usr/local/pf/conf/currently-at
-----
-
 
 Upgrading from a version prior to 4.0.0
 ---------------------------------------

--- a/UPGRADE.asciidoc
+++ b/UPGRADE.asciidoc
@@ -2111,4 +2111,9 @@ To upgrade the database schema, run the following command:
 mysql -u root -p pf -v < /usr/local/pf/db/upgrade-X.X.X-X.Y.Z.sql
 ----
 
-Once completed, update the file [filename]`/usr/local/pf/conf/currently-at` to match the new release number (PacketFence X.Y.Z).
+Once completed, update the file [filename]`/usr/local/pf/conf/currently-at` to match the new release number (PacketFence X.Y.Z):
+
+[source,bash]
+----
+cat /usr/local/pf/conf/pf-release > /usr/local/pf/conf/currently-at
+----

--- a/UPGRADE.asciidoc
+++ b/UPGRADE.asciidoc
@@ -136,12 +136,11 @@ yum update fingerbank --enablerepo=packetfence
 ----
 
 PacketFence and Fingerbank should now be upgraded. However, there may be extra
-steps required depending on the version you are upgrading from. Please review
-the following notes about upgrading from an older release.
+steps required depending on the version you are upgrading from.
 
 ==== Debian based systems
 
-Run the following command to update PacketFence:
+Run the following commands to update PacketFence:
 
 [source,bash]
 ----
@@ -156,16 +155,16 @@ Since PacketFence heavily relies on Fingerbank, it is recommended to make sure y
 apt install fingerbank
 ----
 
-PacketFence and Fingerbank should now be upgraded. However, there may be extra steps required depending on the version you are upgrading from. Please review the following notes about upgrading from an older release.
-
-'''
-
-You should take care to review any changes to configuration files and merge them if required. 
-To find out which configuration files have changed run this command:
+PacketFence and Fingerbank should now be upgraded. However, there may be extra
+steps required depending on the version you are upgrading from.
 
 ==== New versions of configuration files
 
+You should take care to review any changes to configuration files and merge them if required. 
+
 ===== RHEL / CentOS based systems
+
+To find out which configuration files have changed run following command:
 
 [source,bash]
 ----

--- a/UPGRADE.asciidoc
+++ b/UPGRADE.asciidoc
@@ -31,8 +31,8 @@ include::includes/license.asciidoc[]
 == General Upgrade Tips
 
 
-Database backup
-^^^^^^^^^^^^^^^
+=== Database backup
+
 
 Before making any changes to your database, ensure that you have a backup.
 A complete database backup can be taken using this command:
@@ -44,24 +44,24 @@ If your database is more than a few hundred megabytes, you may also want to cons
 It is also possible to simply backup the actual MySQL files themselves -- as long as the database is not currently running.
 To do so, stop MySQL and then copy all files under /var/lib/mysql to a secure directory.
 
-PacketFence configurations and codebase backup
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+=== PacketFence configurations and codebase backup
+
 
 Taking a complete backup of your current installation is strongly recommended.
 You can take a backup of the pf directory with the following command:
 
   tar -C /usr/local -czf /root/packetfence.tar.gz pf --exclude='pf/logs' --exclude='pf/var'
 
-Upgrade procedure
------------------
+== Upgrade procedure
+
 
 NOTE: These are general upgrade instructions. Make sure to go through (read) the upgrade instructions specific to the upgrade path taken since some steps may be required to be done *BEFORE* the packages upgrades.
 
-### For a clustered environment
+=== For a clustered environment
 
 Please refer to the https://github.com/inverse-inc/packetfence/blob/stable/docs/PacketFence_Clustering_Guide.asciidoc[PacketFence Clustering Guide], more specifically the https://github.com/inverse-inc/packetfence/blob/stable/docs/PacketFence_Clustering_Guide.asciidoc#performing-an-upgrade-on-a-cluster[Perform an upgrade on a cluster] section.
 
-### For a standalone server
+=== For a standalone server
 
 It is recommended that you stop the currently running PacketFence services before proceeding any further.
 To do so, run the following commands:
@@ -2011,14 +2011,16 @@ Starting from now, PacketFence will be released as an unique RPM package for
 x86_64 architectures. To remove properly older RPM packages, you need to follow these steps:
 
 . Stop services:
++
 [source,bash]
 ----
 /usr/local/pf/bin/pfcmd service pf stop
 systemctl stop packetfence-config
 ----
++
 
 . Uninstall old RPM without running post-uninstallation steps:
-
++
 [source,bash]
 ----
 rpm -e --nodeps --noscripts packetfence-config
@@ -2026,17 +2028,20 @@ rpm -e --nodeps --noscripts packetfence-config
 # run only if packetfence-remote-arp-sensor has been installed
 rpm -e --nodeps --noscripts packetfence-remote-arp-sensor
 ----
++
 
 . Update [package]`packetfence-release` and [package]`packetfence` packages:
-
++
 [source,bash]
 ----
 yum update packetfence-release --enablerepo=packetfence
 yum update packetfence --enablerepo=packetfence
 mv -f /usr/local/pf/conf/pfconfig.conf.rpmsave /usr/local/pf/conf/pfconfig.conf
 ----
++
 
 . Restart services:
++
 [source,bash]
 ----
 /usr/local/pf/bin/pfcmd fixpermissions

--- a/UPGRADE.asciidoc
+++ b/UPGRADE.asciidoc
@@ -136,9 +136,9 @@ Debian based systems
 
 Debian installation system should have interactively asked for existing modified files.
 
-'''
+=== Restart of services
 
-Once the additionnal steps below are completed, restart packetfence-config and packetfence
+Once the additionnal steps below are completed, restart `packetfence-config` and `packetfence`:
 
 [source,bash]
 ----
@@ -2050,6 +2050,12 @@ In order to install new versions of Debian packages, you will need to add a new 
 [source,bash]
 ----
 curl -L https://inverse.ca/downloads/GPG_PUBLIC_KEY | sudo apt-key add -
+----
+
+You can safely remove the oldest one:
+[source,bash]
+----
+sudo apt-key del FE9E84327B18FF82B0378B6719CDA6A9810273C4
 ----
 
 === Database schema

--- a/UPGRADE.asciidoc
+++ b/UPGRADE.asciidoc
@@ -66,15 +66,20 @@ tar -C /usr/local -czf /root/packetfence.tar.gz pf --exclude='pf/logs' --exclude
 A PacketFence upgrade consists of following steps:
 
 . stop all PacketFence services (see <<stop-services>> section)
-. preliminary steps to run before packages upgrades (see sections for your upgrade path)
+. preliminary step(s) to run before packages upgrades (see sections for your upgrade path)
 . packages upgrades (see <<pkg-upgrades>> section)
-. configuration migrations (see sections for your upgrade path)
-. database schema upgrade (see sections for your upgrade path)
+. configuration migration(s) (see sections for your upgrade path)
+. database schema upgrade(s) (see sections for your upgrade path)
 . restart all PacketFence services (see <<restart-services>> section)
 
 Upgrade notes for a given upgrade path are cumulative. That is to say, if you
-are upgrading from version 7.0 to version 9.0 you must apply in order all
-changes in between the two versions, including database schema changes.
+are upgrading from version 7.0 to version 9.0 you must apply in order all:
+
+. preliminary step(s) to run before packages upgrades
+. configuration migration(s)
+. database schema upgrade(s)
+
+in between the two versions.
 
 IMPORTANT: Before starting packages upgrades, make sure to go through (read) the upgrade
 instructions specific to the upgrade path taken since some preliminary steps may be

--- a/UPGRADE.asciidoc
+++ b/UPGRADE.asciidoc
@@ -112,16 +112,6 @@ required to be done *BEFORE* the packages upgrades.
 [#pkg-upgrades-rpm]
 ==== RHEL / CentOS based systems
 
-Due to disconnection issues with the systemd-logind service while yum is performing the update, you need to ensure the service is stopped disabled. The last command will then ensure your current process is removed out of the user-0.slice.
-
-[source,bash]
-----
-/usr/bin/systemctl stop systemd-logind
-/usr/bin/systemctl --now mask systemd-logind
-/usr/bin/systemctl daemon-reload
-/bin/bash -c "/usr/bin/systemctl status user-0.slice | /usr/bin/grep -E -o '─[0-9]+' | /usr/bin/sed 's/─//g' | /usr/bin/xargs -I{} /bin/bash -c '/usr/bin/kill -0 {} > /dev/null 2>/dev/null && /usr/bin/echo {} > /sys/fs/cgroup/systemd/tasks'"
-----
-
 Run the following command to update PacketFence:
 
 [source,bash]
@@ -138,6 +128,32 @@ yum update fingerbank --enablerepo=packetfence
 
 PacketFence and Fingerbank should now be upgraded. However, there may be extra
 steps required depending on the version you are upgrading from.
+
+===== Upgrade to RHEL / CentOS 7.7 before 9.1.0
+
+If you run a version prior to 9.1.0 and want to *only* upgrade your RHEL /
+CentOS system to 7.7, you will need to perform the following preliminary steps
+before you perform your OS update through [command]`yum`.
+
+.Disable `systemd-logind` service which is currently causing issues with the `systemctl isolate` command
+[source,bash]
+----
+/usr/bin/systemctl stop systemd-logind
+/usr/bin/systemctl --now mask systemd-logind
+/usr/bin/systemctl daemon-reload
+/bin/bash -c "/usr/bin/systemctl status user-0.slice | /usr/bin/grep -E -o '─[0-9]+' | /usr/bin/sed 's/─//g' | /usr/bin/xargs -I{} /bin/bash -c '/usr/bin/kill -0 {} > /dev/null 2>/dev/null && /usr/bin/echo {} > /sys/fs/cgroup/systemd/tasks'"
+----
+
+These commands prevent disconnection issues while [command]`yum` is performing
+the update. The last command ensures your current process is removed out of
+the `user-0.slice`.
+
+.Get latest version of [package]`ipset` package from packetfence repository
+[source,bash]
+----
+yum update ipset --enablerepo=packetfence
+----
+
 
 ==== Debian based systems
 

--- a/UPGRADE.asciidoc
+++ b/UPGRADE.asciidoc
@@ -59,21 +59,23 @@ You can take a backup of the pf directory with the following command:
 
 A PacketFence upgrade consists of following steps:
 
-. preliminary steps to run before packages upgrades
-. packages upgrades
-. configuration migrations
-. database schema upgrade
+. stop all PacketFence services (see <<stop-services>> section)
+. preliminary steps to run before packages upgrades (see sections for your upgrade path)
+. packages upgrades (see <<packages-upgrades>> section)
+. configuration migrations (see sections for your upgrade path)
+. database schema upgrade (see sections for your upgrade path)
+. restart all PacketFence services (see <<restart-services>> section)
 
 IMPORTANT: Before starting packages upgrades, make sure to go through (read) the upgrade
 instructions specific to the upgrade path taken since some preliminary steps may be
 required to be done *BEFORE* the packages upgrades.
 
-=== For a clustered environment
+==== Clustered environment: specific procedure
 
 Please refer to the https://github.com/inverse-inc/packetfence/blob/stable/docs/PacketFence_Clustering_Guide.asciidoc[PacketFence Clustering Guide], more specifically the https://github.com/inverse-inc/packetfence/blob/stable/docs/PacketFence_Clustering_Guide.asciidoc#performing-an-upgrade-on-a-cluster[Perform an upgrade on a cluster] section.
 
-[#standalone]
-=== For a standalone server
+[#stop-services]
+=== Stop all PacketFence services
 
 It is recommended that you stop the currently running PacketFence services before proceeding any further.
 To do so, run the following commands:
@@ -84,8 +86,14 @@ To do so, run the following commands:
 systemctl stop packetfence-config
 ----
 
+[#pkg-upgrades]
+=== Packages upgrades
 
-[#standalone-rpm]
+IMPORTANT: Again, before starting packages upgrades, make sure to go through (read) the upgrade
+instructions specific to the upgrade path taken since some preliminary steps may be
+required to be done *BEFORE* the packages upgrades.
+
+[#pkg-upgrades-rpm]
 RHEL / CentOS based systems
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -146,7 +154,8 @@ Debian based systems
 
 Debian installation system should have interactively asked for existing modified files.
 
-=== Restart of services
+[#restart-services]
+=== Restart all PacketFence services
 
 Once the additionnal steps below are completed, restart `packetfence-config` and `packetfence`:
 
@@ -2023,7 +2032,7 @@ NOTE: This step need to be done *before* packages upgrade.
 Starting from now, PacketFence will be released as an unique RPM package for
 `x86_64` architectures. To remove properly older RPM packages, you need to follow these steps:
 
-. Follow instructions as mentioned in <<standalone,standalone server upgrade procedure section>> and stop before upgrading PacketFence packages using [command]`yum`
+. Follow instructions mentioned in <<stop-services>> section and stop before starting packages upgrades
 . Uninstall old RPM without running post-uninstallation steps:
 +
 [source,bash]
@@ -2043,7 +2052,7 @@ mv -f /usr/local/pf/conf/pfconfig.conf.rpmsave /usr/local/pf/conf/pfconfig.conf
 ----
 +
 
-. Upgrade PacketFence packages by following [command]`yum` instructions in <<standalone-rpm>> section
+. Upgrade PacketFence packages by following instructions in <<pkg-upgrades-rpm,Packages upgrades>> section
 . Continue upgrade procedure
 
 At the end of upgrade procedure, you should have only one RPM package called
@@ -2075,6 +2084,9 @@ An SQL upgrade script has been provided to upgrade the database from the X.X sch
 
 To upgrade the database schema, run the following command:
 
-  mysql -u root -p pf -v < /usr/local/pf/db/upgrade-X.X.X-X.Y.Z.sql
+[source,bash]
+----
+mysql -u root -p pf -v < /usr/local/pf/db/upgrade-X.X.X-X.Y.Z.sql
+----
 
-Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence X.Y.Z).
+Once completed, update the file [filename]`/usr/local/pf/conf/currently-at` to match the new release number (PacketFence X.Y.Z).

--- a/UPGRADE.asciidoc
+++ b/UPGRADE.asciidoc
@@ -38,7 +38,10 @@ include::{extra_path}includes/license.asciidoc[]
 Before making any changes to your database, ensure that you have a backup.
 A complete database backup can be taken using this command:
 
-  mysqldump --opt --routines -u root -p pf | gzip > /root/packetfence_db.sql.gz
+[source,bash]
+----
+mysqldump --opt --routines -u root -p pf | gzip > /root/packetfence_db.sql.gz
+----
 
 If your database is more than a few hundred megabytes, you may also want to consider using a tool such as Percona XtraBackup which makes for much faster restores than mysqldump.
 
@@ -51,7 +54,10 @@ To do so, stop MySQL and then copy all files under /var/lib/mysql to a secure di
 Taking a complete backup of your current installation is strongly recommended.
 You can take a backup of the pf directory with the following command:
 
-  tar -C /usr/local -czf /root/packetfence.tar.gz pf --exclude='pf/logs' --exclude='pf/var'
+[source,bash]
+----
+tar -C /usr/local -czf /root/packetfence.tar.gz pf --exclude='pf/logs' --exclude='pf/var'
+----
 
 == Upgrade procedure
 

--- a/UPGRADE.asciidoc
+++ b/UPGRADE.asciidoc
@@ -1,17 +1,35 @@
-PacketFence Upgrade Guide
-=========================
+= PacketFence Upgrade Guide
 :encoding: UTF-8
 :lang: en
 :doctype: book
 :toc: left
 
-include::docs/includes/global-attributes.asciidoc[]
+// to display images directly on GitHub
+ifdef::env-github[]
+:imagesdir: images
+endif::[]
 
-http://www.packetfence.org/
+////
+
+    This file is part of the PacketFence project.
+
+////
+
+include::includes/global-attributes.asciidoc[]
+
+== About this Guide
+
+This guide covers procedures to upgrade PacketFence servers.
+
+include::includes/additional-info.asciidoc[]
+
+include::includes/commercial-support.asciidoc[]
+
+include::includes/license.asciidoc[]
 
 
-General Upgrade Tips
---------------------
+== General Upgrade Tips
+
 
 Database backup
 ^^^^^^^^^^^^^^^

--- a/UPGRADE.asciidoc
+++ b/UPGRADE.asciidoc
@@ -151,7 +151,7 @@ the `user-0.slice`.
 .Get latest version of [package]`ipset` package from packetfence repository
 [source,bash]
 ----
-yum update ipset --enablerepo=packetfence
+yum update ipset ipset-libs --enablerepo=packetfence
 ----
 
 

--- a/UPGRADE.asciidoc
+++ b/UPGRADE.asciidoc
@@ -9,7 +9,7 @@ ifdef::env-github[]
 :imagesdir: images
 :extra_path: docs/
 endif::[]
-
+:extra_path:
 ////
 
     This file is part of the PacketFence project.
@@ -22,11 +22,11 @@ include::{extra_path}includes/global-attributes.asciidoc[]
 
 This guide covers procedures to upgrade PacketFence servers.
 
-include::includes/additional-info.asciidoc[]
+include::{extra_path}includes/additional-info.asciidoc[]
 
-include::includes/commercial-support.asciidoc[]
+include::{extra_path}includes/commercial-support.asciidoc[]
 
-include::includes/license.asciidoc[]
+include::{extra_path}includes/license.asciidoc[]
 
 
 == General Upgrade Tips

--- a/docs/PacketFence_Clustering_Guide.asciidoc
+++ b/docs/PacketFence_Clustering_Guide.asciidoc
@@ -1387,7 +1387,7 @@ Next, upgrade your operating system and PacketFence on node C:
 
 NOTE: If you reboot your server during this procedure, make sure you set the systemd target to multi-user (`systemctl set-default multi-user.target`) before rebooting and back to packetfence-cluster (`systemctl set-default packetfence-cluster.target`) after it boots up. This will make sure your services don't start up after the reboot.
 
-Now, make sure you follow the directives in the upgrade guide (`UPGRADE.asciidoc`) as you would on a standalone server with the exception of the database schema updates.
+Now, make sure you follow the directives in the <<PacketFence_Upgrade_Guide.asciidoc#,upgrade guide>> as you would on a standalone server with the exception of the database schema updates.
 
 Migrating service on node C
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1435,7 +1435,7 @@ Complete upgrade of node C
 ++++++++++++++++++++++++++
 
 From that moment node C is in standalone for its database. We can proceed to update the database schema so it matches the one of the latest version.
-In order to do so, upgrade the database schema using the instructions provided in `UPGRADE.asciidoc`.
+In order to do so, upgrade the database schema using the instructions provided in <<PacketFence_Upgrade_Guide.asciidoc#,Upgrade guide>>.
 
 Stop service on nodes A and B
 +++++++++++++++++++++++++++++

--- a/docs/PacketFence_Clustering_Guide.asciidoc
+++ b/docs/PacketFence_Clustering_Guide.asciidoc
@@ -1,5 +1,4 @@
-Clustering Quick Installation Guide
-===================================
+= Clustering Quick Installation Guide
 :encoding: UTF-8
 :lang: en
 :doctype: book

--- a/docs/PacketFence_Installation_Guide.asciidoc
+++ b/docs/PacketFence_Installation_Guide.asciidoc
@@ -41,7 +41,7 @@ _Developer's Guide_ (pdf)::
   This is, at least, a partial file of PacketFence contributors.
 `NEWS.asciidoc`::
   Covers noteworthy features, improvements and bug fixes by release.
-`UPGRADE.asciidoc`::
+<<PacketFence_Upgrade_Guide.asciidoc#,Upgrade Guide>>::
   Covers compatibility related changes, manual instructions and general notes
   about upgrading.
 

--- a/docs/PacketFence_Installation_Guide.asciidoc
+++ b/docs/PacketFence_Installation_Guide.asciidoc
@@ -1,5 +1,4 @@
-Installation Guide
-==================
+= Installation Guide
 :encoding: UTF-8
 :lang: en
 :doctype: book

--- a/docs/PacketFence_Network_Devices_Configuration_Guide.asciidoc
+++ b/docs/PacketFence_Network_Devices_Configuration_Guide.asciidoc
@@ -1,5 +1,5 @@
-Network Devices Configuration Guide
-===================================
+= Network Devices Configuration Guide
+
 :encoding: UTF-8
 :lang: en
 :doctype: book

--- a/docs/PacketFence_Upgrade_Guide-docinfo.xml
+++ b/docs/PacketFence_Upgrade_Guide-docinfo.xml
@@ -1,0 +1,4 @@
+<copyright>
+  <year>2019</year>
+  <holder>Inverse inc.</holder>
+</copyright>

--- a/docs/PacketFence_Upgrade_Guide.asciidoc
+++ b/docs/PacketFence_Upgrade_Guide.asciidoc
@@ -1,0 +1,1 @@
+../UPGRADE.asciidoc

--- a/docs/upgrade-notes/archived_upgrade_notes.asciidoc
+++ b/docs/upgrade-notes/archived_upgrade_notes.asciidoc
@@ -1,0 +1,1102 @@
+
+=== Upgrading from a version prior to 4.0.0
+
+
+Upgrading an old version of PacketFence to v4 will be quite
+an endeavor. While it's entirely possible if done meticulously, we
+suggest you start from scratch and move your customizations and
+nodes information over to your new installation.
+
+==== Database schema update
+
+The temporary password table has been extended to include roles information.
+Moreover, an "admin" user is now automatically created. The default password
+is also "admin". Finally, a new table has been added for saved searches in the
+new Web administrative interface.
+
+  mysql -u root -p pf -v < /usr/local/pf/db/upgrade-3.6.1-4.0.0.sql
+
+==== Other important changes
+
+
+PacketFence v4 received a major overhaul, especially regarding the authentication
+sources. Authentication modules found in `conf/authentication/` are no longer
+being used and have been replaced by the `conf/authentication.conf` file. While
+this file can be hand-edited, you should create your authentication sources
+and perform roles-mapping using the Configuation > Users > Sources page from
+PacketFence's Web administrative interface.
+
+Also, in PacketFence v4, the VLANs can be assigned in `conf/switches.conf` by constructing
+the parameter names from the VLAN names and the `Vlan` suffix. The VLAN names must match one
+of the default names (registration, isolation, macDetection, inline, and voice) or one of the
+defined roles. If you were using custom VLANs, you must create a new role per VLAN and assign
+them accordingly.
+
+Other key changes were done, such as:
+
+* moved remediation templates in `html/captive-portal/templates/violations` and converted them to Template Toolkit
+* dropped guests_admin_registration.category
+* dropped guests_self_registration.access_duration
+* dropped guests_self_registration.category
+* dropped guests_self_registration.sponsor_authentication
+* dropped guests_self_registration.sponsors_only_from_localdomain
+* dropped ports.listeners
+* dropped registration.auth and registration.default_auth
+* dropped registration.maxnodes
+* dropped registration.expire_* and registration.skip_*
+* dropped trapping.blacklist
+* dropped support for resetVlanAllPort in `bin/pfcmd_vlan`
+* dropped `sbin/pfredirect` binary
+* splitted the httpd services in three: httpd.admin, httpd.portal and httpd.webservices
+* domain-name is no longer required in each section of networks.conf
+
+For all parameters related to authentication (categories, access duration, sponsor authentication, etc.),
+you should now set proper actions in the `conf/authentication.conf` file.
+
+Finally, the `pf` must be sudoer access to the `/sbin/ip` (and others) binary. As root, please do:
+
+  echo "pf ALL=NOPASSWD: /sbin/iptables, /usr/sbin/ipset, /sbin/ip, /sbin/vconfig, /sbin/route, /sbin/service, /usr/bin/tee, /usr/local/pf/sbin/pfdhcplistener, /bin/kill, /usr/sbin/dhcpd, /usr/sbin/radiusd" >> /etc/sudoers
+
+
+
+
+=== Upgrading from a version prior to 4.0.1
+
+
+This release only fixes various bugs and doesn't need the database schema to be
+modified. Simply update the file /usr/local/pf/conf/currently-at to match the new
+release number.
+=== Upgrading from a version prior to 4.0.2
+
+
+This release only fixes various bugs and doesn't need the database schema to be
+modified. Simply update the file /usr/local/pf/conf/currently-at to match the new
+release number.
+
+LDAP SSL and STARTTLS is now correctly implemented.
+Make sure the server you specify in authentication.conf supports the encryption type 
+requested on the port configured. Failure to do so will break LDAP and Active Directory 
+authentication.
+
+=== Upgrading from a version prior to 4.0.3
+
+
+You need to downgrade the version of perl-Net-DNS and perl-Net-DNS-Nameserver to
+version 0.65-4 in order to fix the issue with pfdns crashing.
+
+=== Upgrading from a version prior to 4.0.4
+
+
+The parameter guest_self_reg in the profiles.conf file is no longer necessary.
+The self-registration is now automatically enabled if at least one external 
+authentication source is selected (Email, SMS, SponsorEmail, or Oauth2).
+
+=== Upgrading from a version prior to 4.0.5
+
+
+This release adds a new dependency on the Perl module Apache::SSLLookup. Once installed, 
+update the file /usr/local/pf/conf/currently-at to match the new release number.
+
+=== Upgrading from a version prior to 4.0.6
+
+
+==== Changes to authentication API
+
+
+The method pf::authentication::authenticate now expects an array of pf::authentication::Source objects
+instead of an array of source IDs.
+
+The methods getSourceByType, getInternalSources, and getExternalSources of the module pf::Portal::Profile
+now return pf::authentication::Source objects instead of source IDs.
+
+=== Upgrading from a version prior to 4.1.0
+
+
+==== Database schema update
+
+
+The category column in the temporary_password should not be mandatory.
+
+Also, the access_level of the temporary_password table is now a string instead of a bit string.
+
+Make sure you run the following to update your schema:
+
+  mysql -u root -p pf -v < /usr/local/pf/db/upgrade-4.0.0-4.1.0.sql
+
+==== Configuration changes
+
+
+The parameters `trapping.redirecturl` and `trapping.always_use_redirecturl` from `pf.conf` (or `pf.conf.defaults`)
+were moved to the default portal profile in `profiles.conf`.
+
+The parameter `registration.range` has been deprecated. Make sure you remove it from your configuration file.
+
+The action `set_access_level` of authentication sources in `authentication.conf` must now match one of the admin roles
+defined in `adminroles.conf`. The previous level `4294967295` must be replaced by *ALL* and the level `0` by *NONE*.
+
+Adjust your configuration files accordingly.
+
+Once the configuration completed, update the file /usr/local/pf/conf/currently-at to match the new release number.
+
+=== Upgrading from a version prior to 4.2.0
+
+
+==== Database schema update
+
+
+The person table has many new columns that can be used for registration.
+
+The node table has new columns to store the time and bandwidth balances of a node.
+
+The node table has also a new column to keep the audit-session-id from the RADIUS request to use with the CoA.
+
+Added a new column config_timestamp in radius_nas table.
+
+The locationlog table has new columns to store the switch IP and MAC when using dynamic controllers.
+
+New table for inline (layer 3) accounting.
+
+New table for WRIX data.
+
+Make sure you run the following to update your schema:
+
+  mysql -u root -p pf -v < /usr/local/pf/db/upgrade-4.1.0-4.2.0.sql
+
+==== Configuration changes
+
+
+The parameter `guests_self_registration.mandatory_fields` from `pf.conf` (or `pf.conf.defaults`) was moved to the
+default portal profile in `profiles.conf`.
+
+The parameters `registration.gaming_devices_registration` and `registration.gaming_devices_registration_role` are replaced
+with `registration.device_registration` and `registration.device_registration_role`.
+
+Adjust your configuration files accordingly.
+
+The captive portal has been rewritten using the Catalyst MVC framework. Any customization to the previous CGI scripts
+will need to be ported to the new architecture.
+
+Once the configuration completed, update the file /usr/local/pf/conf/currently-at to match the new release number.
+
+=== Upgrading from a version prior to 4.3.0
+
+
+==== Database schema update
+
+
+The person table has 2 new column to keep the portal and the source used to authenticate.
+
+The tables email_activation and sms_activation have been merged in a table named `activation`. It has an additional column to keep the portal used to register.
+
+Make sure you run the following to update your schema:
+
+  mysql -u root -p pf -v < /usr/local/pf/db/upgrade-4.2.0-4.3.0.sql
+
+==== Configuration changes
+
+
+The parameters `VlanMap` and `RoleMap` have been added in `switches.conf`; be sure to add them in the [default] switch section.
+
+The OAuth passthroughs will not be activated unless `trapping.passthrough` in `pf.conf` is enabled. Make sure you enable it if you have OAuth authentication sources (Google, Facebook, Github, LinkedIn and Windows Live).
+
+Once the configuration is completed, update the file /usr/local/pf/conf/currently-at to match the new release number.
+
+=== Upgrading from a version prior to 4.4.0
+
+
+==== Database schema update
+
+
+Introduced the 'iplog_history' table for easier cleanup of the existing 'iplog' table.
+
+Make sure you run the following to update your schema:
+
+  mysql -u root -p pf -v < /usr/local/pf/db/upgrade-4.3.0-4.4.0.sql
+
+==== Cache serialization
+
+
+The serialization of the objects in the cache changed, making all the previous cached objects invalid.
+With PacketFence completely stopped do :
+
+  rm -fr /usr/local/pf/var/cache/*
+
+Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 4.4.0).
+
+=== Upgrading from a version prior to 4.5.0
+
+
+==== Database schema update
+
+
+The class table has a new column delay_by.
+
+Make sure you run the following to update your schema:
+
+  mysql -u root -p pf -v < /usr/local/pf/db/upgrade-4.4.0-4.5.0.sql
+
+==== Violation configuration
+
+
+A new parameter 'delay_by' has been introduced in the violation configuration. Make sure to add the following to the 'defaults' section of 'conf/violations.conf' to avoid any problem.
+
+delay_by=0s
+
+Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 4.5.0).
+
+=== Upgrading from a version prior to 4.6.0
+
+
+==== Database schema update
+
+
+The locationlog and locationlog_history table have 2 new columns stripped_user_name and realm.
+We added new INDEX on iplog, violation and locationlog tables.
+
+Make sure you run the following to update your schema:
+
+  mysql -u root -p pf -v < /usr/local/pf/db/upgrade-4.5.0-4.6.0.sql
+
+
+==== Violation template pages language handling
+
+
+Code to match violation template pages have been reworked. Make sure to lowercase FR to fr in french template files name.
+
+==== Realm configuration
+
+
+Realm are now managed by Freeradius server so if your users authenticate with a username like username@acme.com then add the realm acme.com
+in the Radius Realms configuration menu and in your Active Directory source select 'Use stripped username'.
+
+Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 4.6.0).
+
+=== Upgrading from a version prior to 4.7.0
+
+
+==== Database schema update
+
+
+The 'node' table has a new column (machine_account).
+
+Make sure you run the following to update your schema:
+
+  mysql -u root -p pf -v < /usr/local/pf/db/upgrade-4.6.0-4.7.0.sql
+
+Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 4.7.0).
+
+=== Upgrading from a version prior to 5.0.0
+
+
+Upgrading a version of PacketFence older than 4.1 to v5 will be a complex undertaking.
+While it's entirely possible if done meticulously, we
+suggest you start from scratch and move your customizations and
+nodes information over to your new installation.
+
+Please note that the sections below are cumulative. That is to say, if you are upgrading from version 4.3 to version 5.0 you must apply in order all changes in between the two versions, including database schema changes.
+
+As always, taking a complete backup of your current installation is strongly recommended. 
+A backup should contain a copy of all PacketFence files as well as a copy of the database.
+You can take a backup of the pf directory with the following command:
+
+  tar -C /usr/local -czf /root/packetfence.tar.gz pf 
+
+A backup of the database can be taken using the procedure described in the next section.
+
+==== Database schema update
+
+
+Before making any changes to your database, ensure that you have a backup.
+A complete database backup can be taken using this command:
+
+  mysqldump --opt --routines -u root -p pf | gzip > /root/packetfence_db.sql.gz
+
+If your database is more than a few hundred megabytes, you may also want to consider using a tool such as Percona XtraBackup which makes for much faster restores than mysqldump.
+
+
+Multiple changes have been made to the database schema. You will need to update it accordingly.
+Since we will be dropping and recreating the 'iplog' table it is essential that you have a backup if you need the data it contains.
+
+Make sure you run the following to update your schema:
+
+  mysql -u root -p pf -v < /usr/local/pf/db/upgrade-4.7.0-5.0.0.sql
+
+==== Configuration changes
+
+
+You must manually enter the MySQL password of the pf user in the conf/pfconfig.conf file.
+The MySQL password is saved in the conf/pf.conf file under the [database] section.
+Copy the following from conf/pf.conf to conf/pfconfig.conf: 
+
+  pass=$YOURPASSWORDHERE
+  
+
+==== Violations configuration
+
+
+The violation triggers have been reworked for the new Fingerbank integration.
+We highly suggest you copy `conf/violations.conf.example` over `conf/violations.conf` and then reconfigure any violations you had before.
+
+Also, make sure you adjust the following triggers to their new ID (Can be found under 'Configuration->Fingerbank'):
+
+* `USERAGENT` becomes `user_agent`
+* `VENDORMAC` becomes `mac_vendor`
+
+The `OS` trigger has been deprecated over the new `dhcp_fingerprint` trigger. 
+You will need to adjust these triggers to the new ids as well as renaming them.
+
+==== iptables changes
+
+
+The iptables configuration file doesn't use the generated rules '%%input_mgmt_guest_rules%%' anymore. 
+Make sure you remove this line from conf/iptables.conf.
+
+Also a lot of additions were made to the iptables configuration file. 
+Make sure you add the new rules in conf/iptables.conf.example to your existing iptables file or execute the following command to replace the whole file.
+
+  cp /usr/local/pf/conf/iptables.conf.example /usr/local/pf/conf/iptables.conf
+
+==== Using EAP local authentication
+
+
+If you are using EAP MS-CHAP local authentication, meaning your 802.1x connections authenticate against your local database, you will need to make sure you deactivate password encryption in the database.
+In the administration interface, go in 'Configuration -> Advanced' and set 'Database passwords hashing method' to `plaintext`
+
+Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 5.0.0).
+
+=== Upgrading from a version prior to 5.1.0
+
+
+==== Database schema update
+
+
+Multiple changes have been made to the database schema. You will need to update it accordingly.
+
+Make sure you run the following to update your schema:
+
+  mysql -u root -p pf -v < /usr/local/pf/db/upgrade-5.0.0-5.1.0.sql
+
+==== pfsetvlan and snmptrapd
+
+
+These two services have been disabled by default. 
+If you are using SNMP traps enforcement on your switches (like port-security), make sure you re-enable them in 'Configuration->Services'.
+
+==== Active Directory domain join
+
+
+The Microsoft Active Directory domain join configuration is now part of PacketFence. 
+A migration script has been made so you can migrate an existing domain join into this configuration.
+Note that this step is not mandatory, as the old join method is still supported. But if you do
+not perform this step, you will not see its configuration from the PacketFence web administrative interface.
+
+Simply execute the following script and follow its instructions `/usr/local/pf/addons/AD/migrate.pl`
+
+Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 5.1.0).
+
+=== Upgrading from a version prior to 5.2.0
+
+
+==== Database schema update
+
+
+Multiple changes have been made to the database schema. You will need to update it accordingly.
+
+Make sure you run the following to update your schema:
+
+  mysql -u root -p pf -v < /usr/local/pf/db/upgrade-5.1.0-5.2.0.sql
+
+==== Database monitoring host
+
+
+If you are using an Active/Active cluster, you will need to adjust the monitoring database host to point to your database as it is not forced anymore.
+
+In `conf/pf.conf` :
+
+----
+[monitoring]
+db_host=127.0.0.1
+----
+
+==== New 'portal' interface type
+
+
+If you are using email registration, web-auth enforcement (external captive-portal), device registration feature, or anything that would require to access the captive portal from outside the registration/isolation VLANs, you might want (actually, you need otherwise it will no longer works!) to add the 'portal' type to the existing 'management' interface.
+
+In `conf/pf.conf` :
+
+----
+[interface eth42]
+type=management,portal
+----
+
+
+Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 5.2.0).
+
+=== Upgrading from a version prior to 5.3.0
+
+
+==== Database schema update
+
+
+Changes have been made to the database schema. You will need to update it accordingly.
+
+Make sure you run the following to update your schema:
+
+  mysql -u root -p pf -v < /usr/local/pf/db/upgrade-5.2.0-5.3.0.sql
+
+==== Debian and Ubuntu
+
+
+A downgrade in a package version may cause an error when trying to upgrade.
+
+If you receive this error: 
+
+  The following packages have unmet dependencies:
+   packetfence : Depends: libhtml-formhandler-perl (= 0.40013-2) but 0.40050-2 is to be installed
+  E: Unable to correct problems, you have held broken packages.
+
+Run the following commands:
+
+  # dpkg -r --ignore-depends=packetfence   libhtml-formhandler-perl
+  # apt-get install  libhtml-formhandler-perl  libtemplate-autofilter-perl  libmoo-perl 
+  # apt-get install packetfence packetfence-config packetfence-pfcmd-suid libdist-checkconflicts-perl libimport-into-perl 
+
+Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 5.3.0).
+
+
+=== Upgrading from a version prior to 5.4.0
+
+
+==== Database schema update
+
+
+Changes have been made to the database schema. You will need to update it accordingly.
+
+Make sure you run the following to update your schema:
+
+  mysql -u root -p pf -v < /usr/local/pf/db/upgrade-5.3.0-5.4.0.sql
+
+==== Authentication sources rules rework
+
+
+Authentication sources rules have been reworked in a way to differentiate an 'authentication' rule and an 'administration' rule. Codewise, that means that codeflow will look into specific types of rules depending of the use case.
+
+Please take a minute or two to go through the existing rules for each of the authentication sources and make sure there is no 'administration' class actions into an 'authentication' class rule and vice versa, otherwise the "invalid" action will be ignored.
+
+Authentication sources rules structure is as follow:
+
+* 'authentication' rule class available actions:
+** Set role (set_role)
+** Set access duration (set_access_duration)
+** Set unregistration date (set_unreg_date)
+* 'administration' rule class available actions:
+** Set access level of Web admin (set_access_level)
+** Mark as sponsor (mark_as_sponsor)
+
+For example, if an existing rule is as follow:
+
+* Name: AllAdmins
+* Class: No class defined since the class attribute is new
+* Conditions: ...
+* Actions:
+** Set access level of Web admin -> ALL
+** Set role -> default
+** Set access duration -> 24H
+
+That existing rule will default to the 'authentication' class if none is being set. 
+If that's the case, the first action "Set access level of Web admin" will then be ignored.
+
+To replicate that existing rule with the new classes, you would have to create two separate rules, as follow:
+
+Rule for 'administration' purposes
+
+* Name: AllAdmins_admin 
+* Class: administration
+* Conditions: ...
+* Actions:
+** Set access level of Web admin -> ALL
+
+Rule for 'authentication' purposes
+
+* Name: AllAdmins_auth
+* Class: authentication
+* Conditions: ...
+* Actions:
+** Set role -> default
+** Set access duration -> 24H
+
+Configuration will be validated on every start / restart so that "bogus" authentication sources / rules can be identified.
+
+
+==== OAuth2 authentication sources changes
+
+
+The Facebook API now requires to specify the fields to be defined in the query.
+In all your facebook sources, change the parameter protected_resource_url to https://graph.facebook.com/me?fields=id,name,email,first_name,last_name
+
+Change the parameter scope to user,user:email in all your Github sources as PacketFence is now fetching the email address of the user when registering with Github.
+
+==== StatsD configuration changes
+
+
+monitoring.statsd_host and monitoring.statsd_port have been removed from pf.conf. 
+If you have specified a specific host or port, remove them from your configuration and change them in /usr/local/pf/lib/pf/StatsD.pm
+
+Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 5.4.0).
+
+=== Upgrading from a version prior to 5.5.0
+
+
+==== Database schema update
+
+
+Changes have been made to the database schema. You will need to update it accordingly.
+
+Make sure you run the following to update your schema:
+
+  mysql -u root -p pf -v < /usr/local/pf/db/upgrade-5.4.0-5.5.0.sql
+
+==== VLAN Filter configuration changes
+
+
+The VLAN filter has been reworked to use a more generalized syntax to allow more complex filters to be created.
+
+This mean nested conditions no longer need to specify the attribute in the condition.
+
+So the following attribute
+
+   [condition]
+   filter=node_info
+   attribute=category
+   operator=is
+   value=default
+
+Should be rewritten as
+
+   [condition]
+   filter=node_info.category
+   operator=is
+   value=default
+
+The older syntax is still supported but will be deprecated in a future release.
+
+The operators match and match_not has changed their behavior.
+They will match (or not match) the exact string given in the condition.
+The following condition
+
+  [condition]
+  filter=node_info.computername
+  operator=match
+  value=^Bob
+
+Will match node_info.computername only if it contians '^Bob'.
+It will not match if node_info.computername start with 'Bob'
+
+If you need to use a regex then use the regex/regex_not operator.
+So the following condition should be changed from
+
+  [condition]
+  filter=node_info.mac
+  operator=match
+  value=^00:
+
+To the following
+
+  [condition]
+  filter=node_info.mac
+  operator=regex
+  value=^00:
+
+==== pf.conf configuration file changes
+
+
+The following parameters have been removed from pf.conf. Make sure to remove them from your file if configured.
+
+* alerting.wins_server
+* alerting.admin_netbiosname
+
+==== violations.conf configuration file changes
+
+
+Violations have been reworked and configuration changes are necessary in order to maintain functionnality.
+
+In violations.conf the following actions have been renamed, please update them accordingly.
+
+* trap -> reevaluate_access
+* email -> email_admin
+
+The following action have been removed from the violations :
+
+* popup
+
+Also in violations.conf, the parameter whitelisted_categories has been renamed into whitelisted_roles
+
+==== Billing configuration change
+
+
+The parameter `billing_engine` of the Portal Profiles has been deprecated.
+Remove it from all your profiles configuration in `/usr/local/pf/conf/profiles.conf`.
+
+The billing engine of PacketFence has been reworked completely.
+
+It will require to reconfigure existing billing providers from scratch as there is no retro-compatibility with the previous configuration.
+
+Please see the Administration Guide for details on how to configure the billing engine.
+
+==== Mod_qos configuration changes
+
+
+Mod_qos configuration has been moved from "services" to "captive_portal" section.
+Make sure to apply the appropriate changes if needed.
+
+Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 5.5.0).
+
+=== Upgrading from a version prior to 5.6.0
+
+
+==== Database schema update
+
+
+Changes have been made to the database schema. You will need to update it accordingly.
+
+Make sure you run the following to update your schema:
+
+  mysql -u root -p pf -v < /usr/local/pf/db/upgrade-5.5.0-5.6.0.sql
+
+==== Extension points changes
+
+
+The file lib/pf/vlan/custom.pm has now been renamed to lib/pf/role/custom.pm.
+Most of the customizations that used to be made in vlan/custom.pm can now be handled by configuring a vlan filter.
+You should take a good look at your existing vlan/custom.pm and consider porting the changes to conf/vlan_filters.conf. 
+
+==== VLAN filters changes
+
+
+The scopes for the VLAN filters have changed.
+The following have been renamed according to these rules:
+
+NormalVlan          -> RegisteredRole
+RegistrationVlan    -> RegistrationRole 
+ViolationVlan       -> ViolationRole
+InlineVlan          -> InlineRole
+
+If you have defined any filters in /usr/local/pf/conf/vlan_filters.conf, make sure to rename all references to the left hand side with the new names on the right hand side.
+
+==== Default type for the switches
+
+
+The default type for the switches now needs to be set explicitly. Add the following line in the default section of `/usr/local/pf/conf/switches.conf`
+
+`type=Generic`
+
+Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 5.6.0).
+
+=== Upgrading from a version prior to 5.7.0
+
+
+==== Suricata violation trigger renaming
+
+
+With the introduction of the ability to trigger a violation based on a MD5 hash detected by Suricata, a new trigger type has been introduced, requiring the modification of the actual 'suricata' trigger.
+Make sure to go through your violations configuration and change any 'suricata' trigger name for 'suricata_event'.
+
+==== Database schema update
+
+
+Changes have been made to the database schema. You will need to update it accordingly.
+
+Make sure you run the following to update your schema:
+
+  mysql -u root -p pf -v < /usr/local/pf/db/upgrade-5.6.0-5.7.0.sql
+
+Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 5.7.0).
+
+=== Upgrading from a version prior to 6.0.0
+
+
+Upgrading PacketFence from a version older than v6.0.0 will be a complex undertaking.
+While it's entirely possible if done meticulously, we
+suggest you start from scratch and move your customizations and
+nodes information over to your new installation.
+
+
+==== Devices parking
+
+
+The new registration devices parking requires that you add the following violation in `/usr/local/pf/conf/violations.conf`
+
+  [1300003]
+  priority=1
+  desc=Parking violation
+  max_enable=3
+  grace=10m
+  actions=log,reevaluate_access
+  enabled=Y
+  auto_enable=Y
+  vlan=registration
+  trigger=Internal::parking_detected
+
+==== Chained authentication
+
+
+The chained source has been deprecated in favor of a fully customizable flow in the captive portal.
+
+Make sure you delete the source *BEFORE* upgrading your installation.
+
+Once you upgrade, configure a portal module for each of your sources and a chained one that contains both. Refer to the administration guide for a detailed example.
+
+==== Redesigned captive portal
+
+
+The parameter `mandatory_fields` of the Portal Profiles has been deprecated. Remove it from all the profiles in `profiles.conf`
+
+To configure mandatatory fields in the portal, refer to the 'Portal Modules' section of the Administration guide
+
+You need to add the `root_module` parameter to your default portal profile. In `profiles.conf` add `root_module=default_policy` to the default portal profile
+
+==== Changes to OAuth2 sources callback URL
+
+
+All the OAuth2 sources you have configured (Facebook, Github, Google, LinkedIn ,Twitter, Windows Live) need to be adjusted as the redirect URL is now the same for all the types.
+
+In the admin interface change `Portal URL` from `https://YOUR_HOSTNAME/oauth2/SOURCE_TYPE` to `https://YOUR_HOSTNAME/oauth/callback` (where `SOURCE_TYPE` would be the lower case name of the source type). Note that this parameter is named `redirect_url` in the configuration file.
+
+==== Changes to Cisco Web auth
+
+
+Use the Cisco::Catalyst_2960 switch module instead of the Cisco::Catalyst_2960_http as switch type.
+
+Use the Cisco::WLC switch module instead of the Cisco::WLC_http as switch type.
+
+The portalURL configuration parameter is now configured per-role so make sure you have `http://ip_portal/$session_id` assigned to the registration role in the `Role by Web Auth URL` section of the switch configuration.
+
+See the Network Device configuration guide for additional details.
+
+==== SMS carrier database table
+
+
+Google Project Fi have been added as a supported carrier. Since an ID is hardcoded on creation of a new entry in the 'sms_carrier' database table, a manual intervention may be required in the case the database schema update fails.
+
+==== pf.conf configuration parameters
+
+
+'expire' and 'maintenance' section have been reworked and 'expire' section is no longer a thing. Make sure to adjust configuration parameter accordingly if needed;
+ 
+* expire.node is now maintenance.node_cleanup_window
+* expire.iplog is now maintenance.iplog_cleanup_window
+* expire.locationlog is now maintenance.locationlog_cleanup_window
+* expire.radius_audit_log is now maintenance.radius_audit_log_cleanup_window
+* expire.traplog is now maintenance.traplog_cleanup_window
+
+==== node category / role
+
+
+The 'REJECT' role is now a default standard role. If you already have such role, make sure no conflict exists.
+
+Also, add the following line to the default section of `switches.conf` :
+
+`REJECTVlan = -1`
+
+==== Changes to the generated smb.conf
+
+
+If you have a domain configured directly in PacketFence (in 'Configuration->Domains'), you need to re-generate the associated configuration files as changes have been made to the samba configuration.
+
+Using the CLI `/usr/local/pf/bin/pfcmd generatedomainconfig` or in the admin interface in 'Configuration->Domains', click 'Refresh domain configuration'
+
+==== Upgrade from FreeRADIUS 2 to FreeRADIUS 3
+
+
+PacketFence 6 relies on FreeRADIUS 3 rather that FreeRADIUS 2 as provided in PacketFence 5.
+The configuration files, directory layout and "unlang" directives have changed significantly.
+The packaging will automatically rename the existing raddb directory to raddb-pre6.
+All your existing configuration and certificates (if stored under raddb/certs) should be preserved but may need to be merged with the new raddb directory layout if you customized them.
+
+The configuration files under conf/radiusd/*.example have also changed.
+Make sure to compare them to your conf/radiusd/* files if you have any customizations, and merge any *.rpmnew files that may have been created by the packaging.
+
+The default location for the FreeRADIUS server certificates has changed from conf/ssl/ to raddb/certs/.
+The configuration of the certificates location is in conf/radiusd/eap.conf.
+You may point it to any valid certificate and key by setting the value of `certificate_file` and `private_key_file` respectively.
+It is not recommended to use the same server certificate for the HTTP services and the RADIUS server as the requirements for each are different.
+Reusing the same certificate will work, but you would be well advised to consider separate certificates.
+
+Finally, the database schema for the RADIUS accounting tables and stored procedures have changed.
+Make sure to apply the database changes as described in the following section.
+
+==== Database schema update
+
+
+Significant changes have been made to the database schema. You will need to update it accordingly.
+An SQL upgrade script has been provided to upgrade the database from the 5.7 schema to 6.0.
+
+Since the schema of the `radacct` table has been reworked, the script will rename the existing table to `radacct2` and insert it's content into the new `radacct` table.
+If your existing `radacct` table is large (as is sometimes the case), the operation may take a long time and consume a significant amount of disk space.
+Make sure to have plenty of both before running the upgrade script.
+
+You can estimate the size of the existing `radacct` table by running the following command:
+
+    mysql> SELECT table_name AS "Table", round(((data_length + index_length) / 1024 / 1024), 2) "Size in MB" FROM information_schema.TABLES WHERE table_schema = "pf" AND table_name = "radacct";
+
+You should have at least twice as much space as that table uses in the filesystem on which the MySQL data directory is mounted (usually /var/lib/mysql).
+
+If you do not have enough space or time, you may consider truncating the `radacct` table (or simply deleting some of the rows) before running the upgrade script.
+
+When ready, run the following to update your schema:
+
+  mysql -u root -p pf -v < /usr/local/pf/db/upgrade-5.7.0-6.0.0.sql
+
+Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 6.0.0).
+
+You will also want to drop the `radacct2` table from the database as it will no longer be needed.
+
+=== Upgrading from a version prior to 6.1.0
+
+
+Significant changes have been made to the database schema. You will need to update it accordingly.
+An SQL upgrade script has been provided to upgrade the database from the 6.0 schema to 6.1.
+
+To upgrade the database schema, run the following command: 
+
+  mysql -u root -p pf -v < /usr/local/pf/db/upgrade-6.0.0-6.1.0.sql
+
+Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 6.1.0).
+
+
+==== Dynamically created local secret
+
+
+The management IP(s) of PacketFence are now defined as switches with a forced RADIUS secret defined in /usr/local/pf/conf/local_secret. Make sure you reconfigure the secret in the file if necessary and that this file is synchronized on all your cluster members if that applies. Note that this doesn't affect the RADIUS secret you have configured for wireless controllers and switches. It only affects RADIUS requests that originate from the management IP(s)
+
+==== Changes to LinkedIn source
+
+
+A change to the authorize URL of LinkedIn was made. Make sure to change the 'API Authorize Path' in all your LinkedIn source to `/uas/oauth2/authorization`.
+
+=== Upgrading from a version prior to 6.2.0
+
+
+Changes have been made to the database schema. You will need to update it accordingly.
+An SQL upgrade script has been provided to upgrade the database from the 6.1 schema to 6.2.
+
+To upgrade the database schema, run the following command: 
+
+  mysql -u root -p pf -v < /usr/local/pf/db/upgrade-6.1.0-6.2.0.sql
+
+Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 6.2.0).
+
+=== Upgrading from a version prior to 6.2.1
+
+
+Changes have been made to the httpd.admin configuration.
+Make sure you copy the conf/httpd.conf.d/httpd.admin.tt.example file over conf/httpd.conf.d/httpd.admin.tt.
+If you customized that file in any way, you will have to merge the changes.
+
+Restart the httpd.admin process once that is done by running 
+  /usr/local/pf/bin/pfcmd service httpd.admin restart
+
+Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 6.2.1).
+
+=== Upgrading from a version prior to 6.3.0
+
+
+Changes have been made to the database schema. You will need to update it accordingly.
+An SQL upgrade script has been provided to upgrade the database from the 6.2 schema to 6.3.
+
+To upgrade the database schema, run the following command: 
+
+  mysql -u root -p pf -v < /usr/local/pf/db/upgrade-6.2.0-6.3.0.sql
+
+Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 6.3.0).
+
+==== RADIUS configuration file changes
+
+
+The following file: /usr/local/pf/conf/radiusd/eap.conf was modified to use TemplateToolkit, you will need to replace it by /usr/local/pf/conf/radiusd/eap.conf.example, make sure to re-edit the new file and add your certificate if needed.
+
+==== Samba cache directory changed
+
+
+Rejoining the domains from PacketFence GUI is required. 
+
+Go under `Configuration->RADIUS->Domains` and click `Rejoin` for each domain configured.
+
+==== Configuration changes to the Provisioning and Scaning
+
+
+The configuration of the Scan engines and the Provisioners has been reworked to use the Fingerbank device IDs in the OS matching. `scan.conf` and `provisioning.conf` need to be migrated to use the new values. A migration script should be run `# /usr/local/pf/addons/upgrade/to-6.3-os-rewrite.pl` to migrate the configuration. This will output the migrated configuration in `/usr/local/pf/conf/provisioning.conf.new` and `/usr/local/pf/conf/scan.conf.new`. First run the script and then validate that their content is fine. Once that is done, copy the files over the original ones using : 
+
+```
+# cp /usr/local/pf/conf/provisioning.conf.new /usr/local/pf/conf/provisioning.conf
+# cp /usr/local/pf/conf/scan.conf.new /usr/local/pf/conf/scan.conf
+# /usr/local/pf/bin/pfcmd configreload hard
+```
+
+==== Fingerbank database moving to MySQL (optionnal but highly suggested)
+
+
+The Fingerbank database can now be hosted in the same MySQL database PacketFence uses.
+
+In order to do so, you need to collect the database credentials from the PacketFence configuration:
+
+```
+# /usr/local/pf/bin/pfcmd pfconfig show resource::Database
+$VAR1 = {
+          'pass' => 'myPassword',
+          'db' => 'pf',
+          'user' => 'pf',
+          'port' => '3306',
+          'host' => 'localhost'
+        };
+```
+
+Now, you need to create the database and assign the proper rights to the user by executing the following commands:
+
+```
+# mysql -u root -p -e "CREATE DATABASE pf_fingerbank"
+# mysql -u root -p -e "GRANT ALL PRIVILEGES ON pf_fingerbank.* TO 'pf'@'%' IDENTIFIED BY 'myPassword'"
+# mysql -u root -p -e "GRANT ALL PRIVILEGES ON pf_fingerbank.* TO 'pf'@'localhost' IDENTIFIED BY 'myPassword'"
+```
+
+Replace `myPassword` by the password displayed (`pass`) when running the first command.
+
+Next, head to 'Configuration->Fingerbank Settings' in the web administration interface and configure the following parameters:
+
+ * MySQL host : set this to the value of `host` you got from running the command above.
+ * MySQL port : set this to the value of `port` you got from running the command above.
+ * MySQL username : set this to the value of `user` you got from running the command above.
+ * MySQL password : set this to the value of `pass` you got from running the command above.
+ * MySQL database : set this to `pf_fingerbank`.
+ 
+After saving those new parameters, at the top of the same page, click 'Initialize MySQL database' to start the import process. Once that is completed, you will receive an e-mail to the one configured for alerting and PacketFence will start using the MySQL backend for the Fingerbank database.
+
+=== Upgrading from a version prior to 6.4.0
+
+
+==== Database schema updates
+
+
+Changes have been made to the database schema. You will need to update it accordingly.
+An SQL upgrade script has been provided to upgrade the database from the 6.3 schema to 6.4.
+
+To upgrade the database schema, run the following command: 
+
+  mysql -u root -p pf -v < /usr/local/pf/db/upgrade-6.3.0-6.4.0.sql
+
+
+==== Changes to web authentication configuration
+
+
+Rework of the external captive portal capabilities involves some significant changes in the switch modules configuration.
+Some switch modules have been moved to other ones and some others have been removed. Please adjust the configuration (type) accordingly within switches.conf.
+
+ * AeroHIVE::AP_http -> AeroHIVE::AP
+ * Meraki::AP_http -> Meraki::MR
+ * Meraki::AP_http_V2 -> Meraki::MR_v2
+ * Xirrus:AP_http -> Xirrus
+
+To instruct a switch module to perform external captive portal enforcement, a new switch configuration parameter have been added. Make sure to adjust the following parameter to your needs in switches.conf
+
+```
+ExternalPortalEnforcement = Y
+```
+
+External captive portal URLs have also changed. Change them accordingly depending on the type of equipment you use:
+
+ * AeroHIVE: http://portal_IP/AeroHIVE::AP
+ * Aruba: http://portal_IP/Aruba
+ * Cisco Catalyst 2960: http://portal_IP/Cisco::Catalyst_2960
+ * Cisco WLC: http://portal_IP/Cisco::WLC
+ * CoovaChilli: http://portal_IP/CoovaChilli
+ * Meraki: http://portal_IP/Meraki::MR
+ * Ruckus: http://portal_IP/Ruckus
+ * Xirrus: http://portal_IP/Xirrus
+
+Where portal_ip is the IP Address (or DNS name) of your captive portal as it was configured before
+
+
+==== Changes to WMI
+
+
+If you use WMI, you must modify conf/wmi.conf in order to make sure that a namespace parameter is defined for each rule. For example, you could have:
+
+```
+[SCCM]
+request=select * from Win32_Process where name='CcmExec.exe'
+action=[sccm]
+namespace=ROOT\cimv2
+on_tab=1
+```
+
+==== Changes to default cronjob
+
+
+Upon PacketFence installation, a default cronjob will be in /etc/cron.d/. You should make sure you do not invoke the /usr/local/pf/addons/backup-and-maintenance.sh
+script from any other cronjob.
+
+Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 6.4.0).
+
+
+=== Upgrading from a version prior to 6.5.0
+
+
+==== Database schema updates
+
+
+Changes have been made to the database schema. You will need to update it accordingly.
+An SQL upgrade script has been provided to upgrade the database from the 6.4 schema to 6.5.
+
+To upgrade the database schema, run the following command: 
+
+  mysql -u root -p pf -v < /usr/local/pf/db/upgrade-6.4.0-6.5.0.sql
+
+
+==== Custom code warning
+
+
+The method signature of pf::node::node_register has been modified. Make sure you adjust any custom code / external scripts to handle the new returned values.
+
+==== Switches Configuration
+
+You must rename "controllerPort" to "disconnectPort" in your switches.conf configuration file. You can automate this using:
+
+  cd /usr/local/pf
+  find . -name "switches.conf" -exec sed -i "s/controllerPort/disconnectPort/g" '{}' \;
+
+==== Eduroam
+
+Eduroam authentication source is now an "exclusive" authentication source rather than an "external" one. That being said, make sure to adjust portal profile accordingly (an "exclusive" authentication source can be the only one configured in a portal profile).
+
+==== Improved Logging
+
+In order to be sure all your logging facilities use the new logging backend which ensures the processes will not die in case of a logging failure, you must execute the following command:
+
+  cd /usr/local/pf
+  find conf/log.conf.d/ -type f -exec sed -i.bak "s/Log::Log4perl::Appender::File/pf::log::FileAppender/g" {} \; ; find conf/log.conf.d/ -name '*.bak' -delete
+
+==== Email templates
+
+
+The email templates have been moved from /usr/local/pf/conf/emails/ to /usr/local/pf/html/captive-portal/templates/emails/ as they are now configurable by portal profile. Also you can configure the language in which PacketFence should send emails to the administrator in the Advanced section of the configuration.
+
+Make sure you run the following command after upgrading:
+
+  /usr/local/pf/bin/pfcmd cache configfiles clear
+
+==== Violations
+
+When whitelisting roles in a violation, the registration role will now match unregistered devices where before it would never match. Make sure to go through violations that may include this role to make sure it is relevant.
+
+==== Database schema updates
+
+The "configfile" and "traplog" database tables are now deprecated. If you wish to reclaim the disk space used by those two database tables, they should be manually removed.
+
+Once completed, update the file /usr/local/pf/conf/currently-at to match the new release number (PacketFence 6.5.0).
+
+
+==== Default RoleMap for the switches
+
+
+If you were using the default 'RoleMap = Y' in the conf/switches.conf it's disabled by default now. You will need to put 'RoleMap = Y' under your switches or switch group configuration.


### PR DESCRIPTION
# Description
- Add `UPGRADE.asciidoc` to list of your guides using a symlink to keep `UPGRADE.asciidoc` at root of source tree: I'm not sure that's a good idea.

Making a symlink from root source tree to `docs/PacketFence_Upgrade_Guide.asciidoc` doesn't display correctly document in GitHub.

- Improve upgrade steps for 9.2
- Archive old upgrade instructions (before 7.X.X) to a subfolder of `docs/`
- Reference new guide in other guides
- Reorganize document to:
  - clarify steps to run/not run
  - remove useless things

=> Cross references will not work in PDF.

# Impacts
Direct links to specific section in UPGRADE.asciidoc.

# Code / PR Dependencies
Pull request opened here : https://git.inverse.ca/inverse/website-packetfence/pulls/2 to display new guides in official website.

# Delete branch after merge
YES

# NEWS file entries
## Enhancements
* Upgrade Guide has been overhauled

