### PR TITLE
Feature/inline detection mecanism bypass passthrough

### DIFF
--- a/go/coredns/plugin/pfdns/pfdns.go
+++ b/go/coredns/plugin/pfdns/pfdns.go
@@ -354,7 +354,12 @@ func (pf *pfdns) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 					if d.MatchString(state.QName()) {
 						rr.(*dns.A).Hdr = dns.RR_Header{Name: state.QName(), Rrtype: dns.TypeA, Class: state.QClass(), Ttl: 60}
 					} else {
-						rr.(*dns.A).Hdr = dns.RR_Header{Name: state.QName(), Rrtype: dns.TypeA, Class: state.QClass(), Ttl: 15}
+						var ttl uint32
+						ttl = 15
+						if PortalDetection {
+							ttl = 5
+						}
+						rr.(*dns.A).Hdr = dns.RR_Header{Name: state.QName(), Rrtype: dns.TypeA, Class: state.QClass(), Ttl: ttl}
 					}
 					found = true
 					break
@@ -393,7 +398,12 @@ func (pf *pfdns) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 					if d.MatchString(state.QName()) {
 						rr.(*dns.AAAA).Hdr = dns.RR_Header{Name: state.QName(), Rrtype: dns.TypeAAAA, Class: state.QClass(), Ttl: 60}
 					} else {
-						rr.(*dns.AAAA).Hdr = dns.RR_Header{Name: state.QName(), Rrtype: dns.TypeAAAA, Class: state.QClass(), Ttl: 15}
+						var ttl uint32
+						ttl = 15
+						if PortalDetection {
+							ttl = 5
+						}
+						rr.(*dns.AAAA).Hdr = dns.RR_Header{Name: state.QName(), Rrtype: dns.TypeAAAA, Class: state.QClass(), Ttl: ttl}
 					}
 					found = true
 					break

--- a/go/coredns/plugin/pfdns/pfdns.go
+++ b/go/coredns/plugin/pfdns/pfdns.go
@@ -354,12 +354,7 @@ func (pf *pfdns) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 					if d.MatchString(state.QName()) {
 						rr.(*dns.A).Hdr = dns.RR_Header{Name: state.QName(), Rrtype: dns.TypeA, Class: state.QClass(), Ttl: 60}
 					} else {
-						var ttl uint32
-						ttl = 15
-						if PortalDetection {
-							ttl = 5
-						}
-						rr.(*dns.A).Hdr = dns.RR_Header{Name: state.QName(), Rrtype: dns.TypeA, Class: state.QClass(), Ttl: ttl}
+						rr.(*dns.A).Hdr = dns.RR_Header{Name: state.QName(), Rrtype: dns.TypeA, Class: state.QClass(), Ttl: 15}
 					}
 					found = true
 					break
@@ -398,12 +393,7 @@ func (pf *pfdns) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 					if d.MatchString(state.QName()) {
 						rr.(*dns.AAAA).Hdr = dns.RR_Header{Name: state.QName(), Rrtype: dns.TypeAAAA, Class: state.QClass(), Ttl: 60}
 					} else {
-						var ttl uint32
-						ttl = 15
-						if PortalDetection {
-							ttl = 5
-						}
-						rr.(*dns.AAAA).Hdr = dns.RR_Header{Name: state.QName(), Rrtype: dns.TypeAAAA, Class: state.QClass(), Ttl: ttl}
+						rr.(*dns.AAAA).Hdr = dns.RR_Header{Name: state.QName(), Rrtype: dns.TypeAAAA, Class: state.QClass(), Ttl: 15}
 					}
 					found = true
 					break

--- a/go/httpdispatcher/proxy.go
+++ b/go/httpdispatcher/proxy.go
@@ -545,7 +545,7 @@ func (p *Proxy) nodeStatus(ctx context.Context, mac string) bool {
 	status := false
 	var Status string
 	err := p.Nodedb.QueryRow(mac).Scan(&Status)
-	if err != nil {
+	if err == nil {
 		if Status == "reg" {
 			status = true
 		}

--- a/go/httpdispatcher/proxy.go
+++ b/go/httpdispatcher/proxy.go
@@ -532,7 +532,7 @@ func (p *Proxy) handleDetectionMechanismRegister(ctx context.Context, w http.Res
 		MAC, err := p.IP2Mac(ctx, ipAddress)
 
 		if err == nil {
-			if p.nodeStatus(ctx, MAC) && passThrough.checkDetectionMechanisms(ctx, fqdn) {
+			if p.nodeIsReg(ctx, MAC) && passThrough.checkDetectionMechanisms(ctx, fqdn) {
 				log.LoggerWContext(ctx).Info("Device register and match the portal detection mechanism for " + MAC)
 				p.reverse(ctx, w, r, r.Host)
 			}
@@ -541,7 +541,7 @@ func (p *Proxy) handleDetectionMechanismRegister(ctx context.Context, w http.Res
 }
 
 // nodeStatus search for status of the device
-func (p *Proxy) nodeStatus(ctx context.Context, mac string) bool {
+func (p *Proxy) nodeIsReg(ctx context.Context, mac string) bool {
 	status := false
 	var Status string
 	err := p.Nodedb.QueryRow(mac).Scan(&Status)

--- a/go/httpdispatcher/proxy.go
+++ b/go/httpdispatcher/proxy.go
@@ -32,6 +32,7 @@ type Proxy struct {
 	ParkingSecurityEvent *sql.Stmt // prepared statement for security_event
 	IP4log               *sql.Stmt // prepared statement for ip4log queries
 	IP6log               *sql.Stmt // prepared statement for ip6log queries
+	Nodedb               *sql.Stmt // prepared statement for node queries
 	Db                   *sql.DB
 	apiClient            *unifiedapiclient.Client
 	ShowParkingPortal    bool
@@ -256,6 +257,12 @@ func (p *Proxy) Configure(ctx context.Context) {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "httpd.dispatcher: database security_event prepared statement error: %s", err)
 	}
+
+	p.Nodedb, err = p.Db.Prepare("select node.status from node where mac = ?")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "httpd.dispatcher: database nodedb prepared statement error: %s", err)
+	}
+
 	p.apiClient = unifiedapiclient.NewFromConfig(ctx)
 
 	pfconfigdriver.PfconfigPool.AddStruct(ctx, &pfconfigdriver.Config.PfConf.Parking)
@@ -465,17 +472,7 @@ func (p *Proxy) handleParking(ctx context.Context, w http.ResponseWriter, r *htt
 
 	rgx, _ := regexp.Compile("/common")
 
-	fwdAddress := r.Header.Get("X-Forwarded-For")
-	if fwdAddress != "" {
-
-		ipAddress = fwdAddress
-
-		// If we got an array... grab the first IP
-		ips := strings.Split(fwdAddress, ", ")
-		if len(ips) > 1 {
-			ipAddress = ips[0]
-		}
-	}
+	ipAddress = p.getIP(ctx, r)
 
 	if ipAddress != "" {
 		MAC, err := p.IP2Mac(ctx, ipAddress)
@@ -525,6 +522,54 @@ func (p *Proxy) detectPortalURL(r *http.Request) (bool, url.URL) {
 		}
 	}
 	return found, PortalURL
+}
+
+func (p *Proxy) handleDetectionMechanismRegister(ctx context.Context, w http.ResponseWriter, r *http.Request, fqdn string) {
+	var ipAddress string
+	ipAddress = p.getIP(ctx, r)
+
+	if ipAddress != "" {
+		MAC, err := p.IP2Mac(ctx, ipAddress)
+
+		if err == nil {
+			if p.nodeStatus(ctx, MAC) && passThrough.checkDetectionMechanisms(ctx, fqdn) {
+				log.LoggerWContext(ctx).Info("Device register and match the portal detection mechanism for " + MAC)
+				p.reverse(ctx, w, r, r.Host)
+			}
+		}
+	}
+}
+
+// nodeStatus search for status of the device
+func (p *Proxy) nodeStatus(ctx context.Context, mac string) bool {
+	status := false
+	var Status string
+	err := p.Nodedb.QueryRow(mac).Scan(&Status)
+	if err != nil {
+		if Status == "reg" {
+			status = true
+		}
+	}
+
+	return status
+}
+
+func (p *Proxy) getIP(ctx context.Context, r *http.Request) string {
+
+	var ipAddress string
+
+	fwdAddress := r.Header.Get("X-Forwarded-For")
+	if fwdAddress != "" {
+
+		ipAddress = fwdAddress
+
+		// If we got an array... grab the first IP
+		ips := strings.Split(fwdAddress, ", ")
+		if len(ips) > 1 {
+			ipAddress = ips[0]
+		}
+	}
+	return ipAddress
 }
 
 func (p *Proxy) reverse(ctx context.Context, w http.ResponseWriter, r *http.Request, host string) {


### PR DESCRIPTION
# Description
If the device is reg and it try to hit a captive portal url detection then the dispatcher will proxy the request and the device will think that it have internet access.
It happen in inline setup when the device cache the dns request and still think that the captive portal url detection match with the ip of the portal

# Impacts
Portal detection

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
## Enhancements
* Proxy the captive portal detection url when the device is reg
