### PR TITLE
Lower ttl to 5 seconds if the fqdn match with a captive portal detection host

### DIFF
--- a/go/coredns/plugin/pfdns/pfdns.go
+++ b/go/coredns/plugin/pfdns/pfdns.go
@@ -355,7 +355,12 @@ func (pf *pfdns) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 					if d.MatchString(state.QName()) {
 						rr.(*dns.A).Hdr = dns.RR_Header{Name: state.QName(), Rrtype: dns.TypeA, Class: state.QClass(), Ttl: 60}
 					} else {
-						rr.(*dns.A).Hdr = dns.RR_Header{Name: state.QName(), Rrtype: dns.TypeA, Class: state.QClass(), Ttl: 15}
+						var ttl uint32
+						ttl = 15
+						if PortalDetection {
+							ttl = 5
+						}
+						rr.(*dns.A).Hdr = dns.RR_Header{Name: state.QName(), Rrtype: dns.TypeA, Class: state.QClass(), Ttl: ttl}
 					}
 					found = true
 					break
@@ -384,7 +389,12 @@ func (pf *pfdns) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 					if d.MatchString(state.QName()) {
 						rr.(*dns.AAAA).Hdr = dns.RR_Header{Name: state.QName(), Rrtype: dns.TypeAAAA, Class: state.QClass(), Ttl: 60}
 					} else {
-						rr.(*dns.AAAA).Hdr = dns.RR_Header{Name: state.QName(), Rrtype: dns.TypeAAAA, Class: state.QClass(), Ttl: 15}
+						var ttl uint32
+						ttl = 15
+						if PortalDetection {
+							ttl = 5
+						}
+						rr.(*dns.AAAA).Hdr = dns.RR_Header{Name: state.QName(), Rrtype: dns.TypeAAAA, Class: state.QClass(), Ttl: ttl}
 					}
 					found = true
 					break


### PR DESCRIPTION
# Description
Force the ttl to 5 seconds for captive portal detection host

# Impacts
dns

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
## Enhancements
* Set TTL to 5 seconds when the host match with a captive portal detection host
