### PR TITLE
Deprecate 'AUTO-REGISTERED' string in node notes

### DIFF
--- a/lib/pf/role.pm
+++ b/lib/pf/role.pm
@@ -547,7 +547,6 @@ sub getNodeInfoForAutoReg {
     # we do not set a default VLAN here so that node_register will set the default normalVlan from switches.conf
     my %node_info = (
         pid             => $args->{node_info}->{pid},
-        notes           => 'AUTO-REGISTERED',
         status          => 'reg',
         auto_registered => 1, # tells node_register to autoreg
         autoreg         => 'yes',


### PR DESCRIPTION
# Description
Same as title

# Impacts
unknown

# Issue
fixes #4718

# Delete branch after merge
YES

# Checklist
- [n/a] Document the feature
- [n/a] Add unit tests
- [n/a] Add acceptance tests (TestLink)

## Enhancements
* Don't squash node notes when re-registered

## Bug Fixes
* Auto-register overwrites note for nodes (#4718)