### PR TITLE
Don't call sudo to run scripts from security events

### DIFF
--- a/UPGRADE.asciidoc
+++ b/UPGRADE.asciidoc
@@ -1026,6 +1026,16 @@ cat /usr/local/pf/conf/pf-release > /usr/local/pf/conf/currently-at
 
 == Upgrading from a version prior to X.Y.Z
 
+=== Execute script action doesn't use sudo anymore
+
+Execute script action in security events doesn't use [command]`sudo` anymore to run scripts.
+Consequently, you should ensure that `pf` user is:
+
+* able to read and execute these scripts
+* able to run commands inside these scripts (without `sudo`)
+
+=== Database schema
+
 Changes have been made to the database schema. You will need to update it accordingly.
 An SQL upgrade script has been provided to upgrade the database from the X.X schema to X.Y.
 

--- a/html/pfappserver/root/static.alt/src/components/pfFormSecurityEventActions.vue
+++ b/html/pfappserver/root/static.alt/src/components/pfFormSecurityEventActions.vue
@@ -91,7 +91,7 @@
       <b-col>
           <pf-form-input class="my-1"
             v-model="value.external_command"
-            :text="$t('You can use the following variables in your script launch command:<ul><li><b>$mac:</b> MAC address of the endpoint</li><li><b>$ip:</b> IP address of the endpoint</li><li><b>$vid:</b> ID of the security event</li></ul>')"></pf-form-input>
+            :text="$t('Script need to be readable and executable by pf user. You can use the following variables in your script launch command:<ul><li><b>$mac:</b> MAC address of the endpoint</li><li><b>$ip:</b> IP address of the endpoint</li><li><b>$vid:</b> ID of the security event</li></ul>')"></pf-form-input>
       </b-col>
     </b-row>
 

--- a/lib/pf/action.pm
+++ b/lib/pf/action.pm
@@ -185,7 +185,7 @@ sub action_api {
     }
     $logger->warn($return);
 
-    my $cmd = "sudo $return 2>&1";
+    my $cmd = "$return 2>&1";
 
     my @lines  = pf_run($cmd);
     return;


### PR DESCRIPTION
# Description
Don't call sudo to run scripts from security events

# Impacts
Execute action in security events

# Issue
fixes #4988 

# Delete branch after merge
YES

# NEWS file entries
## Enhancements
* Allow to run any script from a security event without a modification of sudoers file

# UPGRADE file entries
See commits.
