### PR TITLE
Update path to route binary

### DIFF
--- a/lib/pf/services/manager/routes.pm
+++ b/lib/pf/services/manager/routes.pm
@@ -131,7 +131,7 @@ sub isAlive {
         }
     }
     my $routes_applied = $FALSE;
-    $routes_applied = defined(pf_run("route | grep ".$route_exist)) if ($route_exist);
+    $routes_applied = defined(pf_run("/sbin/route | grep ".$route_exist)) if ($route_exist);
     $routes_applied = $TRUE if (-f "$install_dir/var/routes_applied");
     return (defined($pid) && $routes_applied);
 }


### PR DESCRIPTION
# Description
On Debian stretch, `route` binary is located in `/sbin` which is not part of the `PATH` for `pf` user

# Impacts
Detection of running state for `routes` service on Debian.

# NEW Package(s) required
YES

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* 

