### PR TITLE
Add copyright without year to avoid useless rpmnew or dpkg-dist files

### DIFF
--- a/conf/I18N/api/en.po
+++ b/conf/I18N/api/en.po
@@ -1,5 +1,6 @@
+# Copyright (C) Inverse inc.
 # English translations for PacketFence package.
-# Copyright (C) 2005-2019 Inverse inc.
+#
 # This file is distributed under the same license as the PacketFence package.
 #
 msgid ""

--- a/conf/I18N/api/fr.po
+++ b/conf/I18N/api/fr.po
@@ -1,5 +1,6 @@
+# Copyright (C) Inverse inc.
 # English translations for PacketFence package.
-# Copyright (C) 2005-2019 Inverse inc.
+#
 # This file is distributed under the same license as the PacketFence package.
 # 
 # Translators:

--- a/conf/adminroles.conf.example
+++ b/conf/adminroles.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Node Manager]
 actions=NODES_READ,NODES_CREATE,NODES_UPDATE,NODES_DELETE,SECURITY_EVENTS_READ,SWITCHES_READ,DHCP_OPTION_82_READ
 description=Nodes management

--- a/conf/apache_filters.conf.defaults
+++ b/conf/apache_filters.conf.defaults
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 # Refuse empty user agent
 # Define the test
 [empty_ua_get]

--- a/conf/apache_filters.conf.example
+++ b/conf/apache_filters.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 # filter can be:
 #
 #     user_agent

--- a/conf/authentication.conf.example
+++ b/conf/authentication.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [local]
 description=Local Users
 type=SQL

--- a/conf/caddy-services/api.conf.example
+++ b/conf/caddy-services/api.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 0.0.0.0:9999 {
   tls /usr/local/pf/conf/ssl/server.crt /usr/local/pf/conf/ssl/server.key
 

--- a/conf/caddy-services/httpdispatcher.conf
+++ b/conf/caddy-services/httpdispatcher.conf
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 :8888 {
   logger {
     level INFO

--- a/conf/caddy-services/httpdispatcher.conf.example
+++ b/conf/caddy-services/httpdispatcher.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 :8888 {
   logger {
     level INFO

--- a/conf/caddy-services/pfipset.conf.example
+++ b/conf/caddy-services/pfipset.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 :22223 {
   bind 127.0.0.1
   

--- a/conf/caddy-services/pfsso.conf.example
+++ b/conf/caddy-services/pfsso.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 :8777 {
   bind 127.0.0.1
 

--- a/conf/chi.conf.defaults
+++ b/conf/chi.conf.defaults
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [storage DEFAULT]
 #
 # storage DEFAULT.storage

--- a/conf/chi.conf.example
+++ b/conf/chi.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 # Look in /usr/local/pf/conf/chi.conf.defaults
 # for allowed parameters 
 # Also look in the CHI and the CHI::Driver::<Class>

--- a/conf/cluster.conf.example
+++ b/conf/cluster.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 # Cluster configuration file for active/active
 # This file will have it deactivated by default
 # To activate the active/active mode, set a management IP in the cluster section

--- a/conf/dhcp_filters.conf.example
+++ b/conf/dhcp_filters.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 # Dhcp FILTERS configuration
 # ==========================
 #

--- a/conf/dhcp_fingerprints.conf
+++ b/conf/dhcp_fingerprints.conf
@@ -1,7 +1,8 @@
+# Copyright (C) Inverse inc.
 # dhcp_fingerprints.conf  Version 6.8.2  Date 20140609
 #
 # FingerBank - DHCP fingerprint / signature database
-# Copyright (C) 2005-2019 Inverse inc.
+#
 #
 # The FingerBank database is made available under the Open Database License. 
 # See LICENSE.odbl-10.txt for the full text or 

--- a/conf/dns_filters.conf.defaults
+++ b/conf/dns_filters.conf.defaults
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [akamaihd_net]
 filter = qname
 operator = regex

--- a/conf/dns_filters.conf.example
+++ b/conf/dns_filters.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 # DNS filter configuration
 #
 # you can trigger rule in pfdns on specific scope (registration, isolation, inline, dnsenforcement)

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [general.domain]
 type=text
 description=<<EOT

--- a/conf/domain.conf.example
+++ b/conf/domain.conf.example
@@ -1,1 +1,2 @@
+# Copyright (C) Inverse inc.
 

--- a/conf/firewall_sso.conf.example
+++ b/conf/firewall_sso.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 #[192.168.1.254]
 #type=FortiGate
 #password=s3cr3t

--- a/conf/floating_network_device.conf.example
+++ b/conf/floating_network_device.conf.example
@@ -1,5 +1,6 @@
+# Copyright (C) Inverse inc.
 #
-# Copyright (C) 2005-2019 Inverse inc.
+#
 #
 # See the enclosed file COPYING for license information (GPL).
 # If you did not receive this file, see

--- a/conf/haproxy-db.conf.example
+++ b/conf/haproxy-db.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 global
   external-check
   user haproxy

--- a/conf/haproxy-portal.conf.example
+++ b/conf/haproxy-portal.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 global
   external-check
   user haproxy

--- a/conf/httpd.conf.d/log.conf
+++ b/conf/httpd.conf.d/log.conf
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 LogFormat "%{User-agent}i" agent
 LogFormat "%h %l %u %t \"%r\" %>s %b" common
 LogFormat "%h %l %u %t \"%r\" %>s %O %I %D \"%{Referer}i\" \"%{User-Agent}i\" \"%{Host}i\"" combined

--- a/conf/httpd.conf.d/ssl-certificates.conf.example
+++ b/conf/httpd.conf.d/ssl-certificates.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 # Apache SSL certificates configuration
 # This file is manipulated on PacketFence's startup before being given to Apache
 SSLCertificateFile %%install_dir%%/conf/ssl/server.crt

--- a/conf/iptables.conf.example
+++ b/conf/iptables.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 # iptables template
 # This file is manipulated on PacketFence's startup before being given to iptables
 *filter

--- a/conf/keepalived.conf.example
+++ b/conf/keepalived.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 global_defs {
    notification_email {
     %%emailaddr%%

--- a/conf/locale/de/LC_MESSAGES/packetfence.po
+++ b/conf/locale/de/LC_MESSAGES/packetfence.po
@@ -1,5 +1,6 @@
+# Copyright (C) Inverse inc.
 # English translations for PacketFence package.
-# Copyright (C) 2005-2019 Inverse inc.
+#
 # This file is distributed under the same license as the PacketFence package.
 # 
 # Translators:

--- a/conf/locale/en/LC_MESSAGES/packetfence.po
+++ b/conf/locale/en/LC_MESSAGES/packetfence.po
@@ -1,5 +1,6 @@
+# Copyright (C) Inverse inc.
 # English translations for PacketFence package.
-# Copyright (C) 2005-2019 Inverse inc.
+#
 # This file is distributed under the same license as the PacketFence package.
 #
 msgid ""

--- a/conf/locale/es/LC_MESSAGES/packetfence.po
+++ b/conf/locale/es/LC_MESSAGES/packetfence.po
@@ -1,5 +1,6 @@
+# Copyright (C) Inverse inc.
 # English translations for PacketFence package.
-# Copyright (C) 2005-2019 Inverse inc.
+#
 # This file is distributed under the same license as the PacketFence package.
 # 
 # Translators:

--- a/conf/locale/fr/LC_MESSAGES/packetfence.po
+++ b/conf/locale/fr/LC_MESSAGES/packetfence.po
@@ -1,5 +1,6 @@
+# Copyright (C) Inverse inc.
 # English translations for PacketFence package.
-# Copyright (C) 2005-2018 Inverse inc.
+#
 # This file is distributed under the same license as the PacketFence package.
 # 
 # Translators:

--- a/conf/locale/he_IL/LC_MESSAGES/packetfence.po
+++ b/conf/locale/he_IL/LC_MESSAGES/packetfence.po
@@ -1,5 +1,6 @@
+# Copyright (C) Inverse inc.
 # English translations for PacketFence package.
-# Copyright (C) 2005-2019 Inverse inc.
+#
 # This file is distributed under the same license as the PacketFence package.
 # 
 # Translators:

--- a/conf/locale/it/LC_MESSAGES/packetfence.po
+++ b/conf/locale/it/LC_MESSAGES/packetfence.po
@@ -1,5 +1,6 @@
+# Copyright (C) Inverse inc.
 # English translations for PacketFence package.
-# Copyright (C) 2005-2019 Inverse inc.
+#
 # This file is distributed under the same license as the PacketFence package.
 # 
 # Translators:

--- a/conf/locale/nl/LC_MESSAGES/packetfence.po
+++ b/conf/locale/nl/LC_MESSAGES/packetfence.po
@@ -1,5 +1,6 @@
+# Copyright (C) Inverse inc.
 # English translations for PacketFence package.
-# Copyright (C) 2005-2019 Inverse inc.
+#
 # This file is distributed under the same license as the PacketFence package.
 # 
 # Translators:

--- a/conf/locale/pl_PL/LC_MESSAGES/packetfence.po
+++ b/conf/locale/pl_PL/LC_MESSAGES/packetfence.po
@@ -1,5 +1,6 @@
+# Copyright (C) Inverse inc.
 # English translations for PacketFence package.
-# Copyright (C) 2005-2019 Inverse inc.
+#
 # This file is distributed under the same license as the PacketFence package.
 # 
 # Translators:

--- a/conf/locale/pt_BR/LC_MESSAGES/packetfence.po
+++ b/conf/locale/pt_BR/LC_MESSAGES/packetfence.po
@@ -1,5 +1,6 @@
+# Copyright (C) Inverse inc.
 # English translations for PacketFence package.
-# Copyright (C) 2005-2018 Inverse inc.
+#
 # This file is distributed under the same license as the PacketFence package.
 # 
 # Translators:

--- a/conf/log.conf.d/httpd.aaa.conf.example
+++ b/conf/log.conf.d/httpd.aaa.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 ### httpd.aaa logger ###
 log4perl.rootLogger = INFO, HTTPD_AAA
 

--- a/conf/log.conf.d/httpd.admin.conf.example
+++ b/conf/log.conf.d/httpd.admin.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 ### httpd.admin logger ###
 log4perl.rootLogger = INFO, HTTPD_ADMIN
 

--- a/conf/log.conf.d/httpd.collector.conf.example
+++ b/conf/log.conf.d/httpd.collector.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 ### httpd.collector logger ###
 log4perl.rootLogger = INFO, HTTPD_COLLECTOR
 

--- a/conf/log.conf.d/httpd.portal.conf.example
+++ b/conf/log.conf.d/httpd.portal.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 ### httpd.portal logger ###
 log4perl.rootLogger = INFO, HTTPD_PORTAL
 

--- a/conf/log.conf.d/httpd.proxy.conf.example
+++ b/conf/log.conf.d/httpd.proxy.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 ### httpd.proxy logger ###
 log4perl.rootLogger = INFO, HTTPD_PROXY
 

--- a/conf/log.conf.d/httpd.webservices.conf.example
+++ b/conf/log.conf.d/httpd.webservices.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 ### httpd.webservices logger ###
 log4perl.rootLogger = INFO, HTTPD_WEBSERVICES
 

--- a/conf/log.conf.d/pfbandwidthd.conf.example
+++ b/conf/log.conf.d/pfbandwidthd.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 ### pfbandwidthd logger ###
 log4perl.rootLogger = INFO, PFBANDWIDTHD
 

--- a/conf/log.conf.d/pfconfig.conf.example
+++ b/conf/log.conf.d/pfconfig.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 ### pfdns logger ###
 log4perl.rootLogger = ERROR, PFCONFIG
 

--- a/conf/log.conf.d/pfdetect.conf.example
+++ b/conf/log.conf.d/pfdetect.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 ## Update Log level for pfdetect
 ##
 LOG_LEVEL=INFO

--- a/conf/log.conf.d/pfdhcplistener.conf.example
+++ b/conf/log.conf.d/pfdhcplistener.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 ### pfdhcplistener logger ###
 log4perl.rootLogger = INFO, PFDHCPLISTENER
 

--- a/conf/log.conf.d/pfdns.conf.example
+++ b/conf/log.conf.d/pfdns.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 ### pfdns logger ###
 log4perl.rootLogger = INFO, PFDNS
 

--- a/conf/log.conf.d/pffilter.conf.example
+++ b/conf/log.conf.d/pffilter.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 ### pffilter logger ###
 log4perl.rootLogger = INFO, PFFILTER
 

--- a/conf/log.conf.d/pfmon.conf.example
+++ b/conf/log.conf.d/pfmon.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 ### pfmon logger ###
 log4perl.rootLogger = INFO, PFMON
 

--- a/conf/log.conf.d/pfperl-api.conf.example
+++ b/conf/log.conf.d/pfperl-api.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 ### pfdetect logger ###
 log4perl.rootLogger = INFO, PFUNIFIEDAPI
 

--- a/conf/log.conf.d/pfqueue.conf.example
+++ b/conf/log.conf.d/pfqueue.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 ### pfqueue logger ###
 log4perl.rootLogger = INFO, QUEUE_SYSLOG
 

--- a/conf/log.conf.d/rlm_perl.conf.example
+++ b/conf/log.conf.d/rlm_perl.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 ### rlm_perl logger ###
 log4perl.rootLogger = INFO, RLM_PERL
 

--- a/conf/log.conf.d/winbindd-wrapper.conf.example
+++ b/conf/log.conf.d/winbindd-wrapper.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 ### winbindd-wrapper logger ###
 log4perl.rootLogger = INFO, WINBINDD_WRAPPER
 

--- a/conf/log.conf.example
+++ b/conf/log.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 ### Root/Parent (PacketFence) logger ###
 # Will log everything (even categories defined to log in another appender) unless 
 # specified using the additivity parameter

--- a/conf/mariadb/mariadb.conf.tt.example
+++ b/conf/mariadb/mariadb.conf.tt.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 #
 # These groups are read by MariaDB server.
 # Use it for options that only the server (but not clients) should see

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [general]
 #
 # general.domain

--- a/conf/pfconfig.conf.example
+++ b/conf/pfconfig.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [general]
 backend=mysql
 

--- a/conf/pfdetect.conf.example
+++ b/conf/pfdetect.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 # This example below will create a pfdetect parser on /usr/local/pf/var/alert that will listen for Snort alerts
 # /usr/local/pf/var/alert must be a FIFO (use mkfifo to create it)
 #[snort]

--- a/conf/pfdhcp.conf.example
+++ b/conf/pfdhcp.conf.example
@@ -1,1 +1,2 @@
+# Copyright (C) Inverse inc.
 LOG_LEVEL=INFO

--- a/conf/pfdns.conf.example
+++ b/conf/pfdns.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 .:54 {
     logger {
       level INFO

--- a/conf/pfmon.conf.defaults
+++ b/conf/pfmon.conf.defaults
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 #The default for maintenance tasks
 
 [acct_maintenance]

--- a/conf/pfqueue.conf.defaults
+++ b/conf/pfqueue.conf.defaults
@@ -1,5 +1,6 @@
+# Copyright (C) Inverse inc.
 #
-# Copyright (C) 2005-2019 Inverse inc.
+#
 #
 # See the enclosed file COPYING for license information (GPL).
 # If you did not receive this file, see

--- a/conf/pfqueue.conf.example
+++ b/conf/pfqueue.conf.example
@@ -1,5 +1,6 @@
+# Copyright (C) Inverse inc.
 #
-# Copyright (C) 2005-2019 Inverse inc.
+#
 #
 # See the enclosed file COPYING for license information (GPL).
 # If you did not receive this file, see

--- a/conf/portal_modules.conf.defaults
+++ b/conf/portal_modules.conf.defaults
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [default_policy]
 description=Default portal policy
 type=Root

--- a/conf/profiles.conf.defaults
+++ b/conf/profiles.conf.defaults
@@ -1,5 +1,6 @@
+# Copyright (C) Inverse inc.
 #
-# Copyright (C) 2005-2019 Inverse inc.
+#
 #
 # See the enclosed file COPYING for license information (GPL).
 # If you did not receive this file, see

--- a/conf/profiles.conf.example
+++ b/conf/profiles.conf.example
@@ -1,5 +1,6 @@
+# Copyright (C) Inverse inc.
 #
-# Copyright (C) 2005-2019 Inverse inc.
+#
 #
 # See the enclosed file COPYING for license information (GPL).
 # If you did not receive this file, see

--- a/conf/provisioning.conf.example
+++ b/conf/provisioning.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [android]
 type=android
 description=android provisioner

--- a/conf/radius_filters.conf.example
+++ b/conf/radius_filters.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 # Radius filter configuration
 # 
 # you are able to rewrite the radius answer based on attributes values, by default the radius filter

--- a/conf/radiusd/acct.conf.example
+++ b/conf/radiusd/acct.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 
 pidfile = [% pid_file %]
 

--- a/conf/radiusd/auth.conf.example
+++ b/conf/radiusd/auth.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 
 pidfile = [% pid_file %]
 

--- a/conf/radiusd/cli.conf.example
+++ b/conf/radiusd/cli.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 pidfile = %%pid_file%%
 
 $INCLUDE radiusd.conf

--- a/conf/radiusd/eap.conf.example
+++ b/conf/radiusd/eap.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 # -*- text -*-
 ##
 ##  eap.conf -- Configuration for EAP types (PEAP, TTLS, etc.)

--- a/conf/radiusd/eduroam.conf.example
+++ b/conf/radiusd/eduroam.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 
 pidfile = %%pid_file%%
 

--- a/conf/radiusd/ldap_packetfence.conf.example
+++ b/conf/radiusd/ldap_packetfence.conf.example
@@ -1,1 +1,2 @@
+# Copyright (C) Inverse inc.
 %%servers%%

--- a/conf/radiusd/load_balancer.conf.example
+++ b/conf/radiusd/load_balancer.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 
 pidfile = %%pid_file%%
 

--- a/conf/radiusd/mschap.conf.example
+++ b/conf/radiusd/mschap.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 # -*- text -*-
 #
 #  $Id: 4673fa7f9fd1d9931fcf1e4e1cdd9bb656b1d434 $

--- a/conf/radiusd/radiusd.conf.example
+++ b/conf/radiusd/radiusd.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 # -*- text -*-
 ##
 ## radiusd.conf	-- FreeRADIUS server configuration file - 3.0.11

--- a/conf/radiusd/radiusd_loadbalancer.conf.example
+++ b/conf/radiusd/radiusd_loadbalancer.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 # -*- text -*-
 ##
 ## radiusd.conf	-- FreeRADIUS server configuration file - 3.0.11

--- a/conf/radiusd/rest.conf.example
+++ b/conf/radiusd/rest.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 rest {
 	#
 	#  This subsection configures the tls related items

--- a/conf/radiusd/sql.conf.example
+++ b/conf/radiusd/sql.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 # -*- text -*-
 ##
 ## sql.conf -- SQL modules

--- a/conf/realm.conf.defaults
+++ b/conf/realm.conf.defaults
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [1 DEFAULT]
 admin_strip_username=disabled
 radius_strip_username=disabled

--- a/conf/redis_cache.conf.example
+++ b/conf/redis_cache.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 # Redis configuration file example
 
 # Note on units: when memory size is needed, it is possible to specify

--- a/conf/redis_ntlm_cache.conf.example
+++ b/conf/redis_ntlm_cache.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 # Redis configuration file example
 
 # Note on units: when memory size is needed, it is possible to specify

--- a/conf/redis_queue.conf.example
+++ b/conf/redis_queue.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 # Redis configuration file example
 
 # Note on units: when memory size is needed, it is possible to specify

--- a/conf/report.conf.defaults
+++ b/conf/report.conf.defaults
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [authentications]
 type=builtin
 description= All Authentications

--- a/conf/roles.conf.defaults
+++ b/conf/roles.conf.defaults
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [default]
 max_nodes_per_pid=0
 notes=Placeholder role/category, feel free to edit

--- a/conf/security_events.conf.defaults
+++ b/conf/security_events.conf.defaults
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 # Most of the snort rules are from Emerging Threats (http://www.emergingthreats.net/)
 #
 # In order to use different rulesets, please point the variable snort_rules,

--- a/conf/security_events.conf.example
+++ b/conf/security_events.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 # Most of the snort rules are from Emerging Threats (http://www.emergingthreats.net/)
 #
 # In order to use different rulesets, please point the variable snort_rules,

--- a/conf/self_service.conf.defaults
+++ b/conf/self_service.conf.defaults
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [default]
 description=default
 device_registration_allowed_devices=

--- a/conf/snmptrapd.conf.example
+++ b/conf/snmptrapd.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 %%snmpTrapdAddr%%
 %%userLines%%
 %%authLines%%

--- a/conf/stats.conf.defaults
+++ b/conf/stats.conf.defaults
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [metric 'redis queue stats count']
 type=api
 statsd_type=gauge

--- a/conf/switch_filters.conf.example
+++ b/conf/switch_filters.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 # SWITCH FILTERS configuration
 # ============================
 #

--- a/conf/switches.conf.defaults
+++ b/conf/switches.conf.defaults
@@ -1,5 +1,6 @@
+# Copyright (C) Inverse inc.
 #
-# Copyright (C) 2005-2019 Inverse inc.
+#
 #
 # See the enclosed file COPYING for license information (GPL).
 # If you did not receive this file, see

--- a/conf/switches.conf.example
+++ b/conf/switches.conf.example
@@ -1,5 +1,6 @@
+# Copyright (C) Inverse inc.
 #
-# Copyright (C) 2005-2019 Inverse inc.
+#
 #
 # See the enclosed file COPYING for license information (GPL).
 # If you did not receive this file, see

--- a/conf/syslog.conf.defaults
+++ b/conf/syslog.conf.defaults
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [local]
 type=file
 logs=ALL

--- a/conf/systemd/packetfence-api-frontend.service
+++ b/conf/systemd/packetfence-api-frontend.service
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=PacketFence API frontend Service
 Wants=packetfence-base.target packetfence-config.service packetfence-iptables.service

--- a/conf/systemd/packetfence-base.slice
+++ b/conf/systemd/packetfence-base.slice
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=The PacketFence base resource control slice
 Before=slices.target

--- a/conf/systemd/packetfence-base.target
+++ b/conf/systemd/packetfence-base.target
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=PacketFence Base target
 Requires=multi-user.target

--- a/conf/systemd/packetfence-cluster.target
+++ b/conf/systemd/packetfence-cluster.target
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=PacketFence Cluster target
 Requires=packetfence.target

--- a/conf/systemd/packetfence-config.service
+++ b/conf/systemd/packetfence-config.service
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=PacketFence Config Service
 After=network.target packetfence-redis-cache.service

--- a/conf/systemd/packetfence-haproxy-db.service
+++ b/conf/systemd/packetfence-haproxy-db.service
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=PacketFence HAProxy Load Balancer for connecting to clustered databases
 Before=packetfence-httpd.portal.service packetfence-httpd.admin.service 

--- a/conf/systemd/packetfence-haproxy-portal.service
+++ b/conf/systemd/packetfence-haproxy-portal.service
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=PacketFence HAProxy Load Balancer for the captive portal
 Before=packetfence-httpd.portal.service packetfence-httpd.admin.service 

--- a/conf/systemd/packetfence-httpd.aaa.service
+++ b/conf/systemd/packetfence-httpd.aaa.service
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=PacketFence AAA Apache HTTP Server 
 Documentation=man:httpd(8)

--- a/conf/systemd/packetfence-httpd.admin.service
+++ b/conf/systemd/packetfence-httpd.admin.service
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=PacketFence Administration  Apache HTTP Server 
 Documentation=man:httpd(8)

--- a/conf/systemd/packetfence-httpd.collector.service
+++ b/conf/systemd/packetfence-httpd.collector.service
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=PacketFence Collector  Apache HTTP Server 
 Documentation=man:httpd(8)

--- a/conf/systemd/packetfence-httpd.dispatcher.service
+++ b/conf/systemd/packetfence-httpd.dispatcher.service
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=PacketFence HTTP Dispatcher
 Wants=packetfence-base.target packetfence-config.service packetfence-iptables.service

--- a/conf/systemd/packetfence-httpd.portal.service
+++ b/conf/systemd/packetfence-httpd.portal.service
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=PacketFence Captive Portal Apache HTTP Server 
 Documentation=man:httpd(8)

--- a/conf/systemd/packetfence-httpd.proxy.service
+++ b/conf/systemd/packetfence-httpd.proxy.service
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=PacketFence Proxy  Apache HTTP Server 
 Documentation=man:httpd(8)

--- a/conf/systemd/packetfence-httpd.webservices.service
+++ b/conf/systemd/packetfence-httpd.webservices.service
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=PacketFence Webservices Apache HTTP Server 
 Documentation=man:httpd(8)

--- a/conf/systemd/packetfence-iptables.service
+++ b/conf/systemd/packetfence-iptables.service
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=PacketFence Iptables configuration
 Wants=packetfence-base.target packetfence-config.service

--- a/conf/systemd/packetfence-keepalived.service
+++ b/conf/systemd/packetfence-keepalived.service
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=PacketFence LVS and VRRP High Availability Monitor
 After=packetfence.target packetfence-haproxy-db.service

--- a/conf/systemd/packetfence-mariadb.service
+++ b/conf/systemd/packetfence-mariadb.service
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=PacketFence MariaDB instance
 After=syslog.target

--- a/conf/systemd/packetfence-netdata.service
+++ b/conf/systemd/packetfence-netdata.service
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=Real time performance monitoring 
 Wants=packetfence-base.target packetfence-config.service packetfence-iptables.service

--- a/conf/systemd/packetfence-pfbandwidthd.service
+++ b/conf/systemd/packetfence-pfbandwidthd.service
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=PacketFence pfbandwidthd Service
 Wants=packetfence-base.target packetfence-config.service packetfence-iptables.service

--- a/conf/systemd/packetfence-pfdetect.service
+++ b/conf/systemd/packetfence-pfdetect.service
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=PacketFence pfdetect Service
 Wants=packetfence-base.target packetfence-config.service packetfence-iptables.service

--- a/conf/systemd/packetfence-pfdhcp.service
+++ b/conf/systemd/packetfence-pfdhcp.service
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=PacketFence GO DHCPv4 Server Daemon
 Wants=packetfence-base.target packetfence-config.service packetfence-iptables.service

--- a/conf/systemd/packetfence-pfdhcplistener.service
+++ b/conf/systemd/packetfence-pfdhcplistener.service
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=PacketFence DHCP Listener Service
 Wants=packetfence-pfqueue.service

--- a/conf/systemd/packetfence-pfdns.service
+++ b/conf/systemd/packetfence-pfdns.service
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=PacketFence GO DNS Server Daemon
 Wants=packetfence-base.target packetfence-config.service packetfence-iptables.service

--- a/conf/systemd/packetfence-pffilter.service
+++ b/conf/systemd/packetfence-pffilter.service
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=PacketFence pffilter Service
 Wants=packetfence-base.target packetfence-config.service packetfence-iptables.service

--- a/conf/systemd/packetfence-pfipset.service
+++ b/conf/systemd/packetfence-pfipset.service
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=PacketFence Ipset Daemon
 Wants=packetfence-base.target packetfence-config.service packetfence-iptables.service

--- a/conf/systemd/packetfence-pfmon.service
+++ b/conf/systemd/packetfence-pfmon.service
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=PacketFence pfmon Service
 Wants=packetfence-base.target packetfence-config.service packetfence-iptables.service

--- a/conf/systemd/packetfence-pfperl-api.service
+++ b/conf/systemd/packetfence-pfperl-api.service
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=PacketFence Unified API
 After=packetfence-base.target

--- a/conf/systemd/packetfence-pfqueue.service
+++ b/conf/systemd/packetfence-pfqueue.service
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=PacketFence pfqueue Service
 Wants=packetfence-redis_queue.service

--- a/conf/systemd/packetfence-pfsso.service
+++ b/conf/systemd/packetfence-pfsso.service
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=PacketFence PFSSO Service
 Wants=packetfence-base.target packetfence-config.service packetfence-iptables.service

--- a/conf/systemd/packetfence-pfstats.service
+++ b/conf/systemd/packetfence-pfstats.service
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=PacketFence Stats daemon
 Requires=packetfence-netdata.service

--- a/conf/systemd/packetfence-radiusd-acct.service
+++ b/conf/systemd/packetfence-radiusd-acct.service
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=PacketFence FreeRADIUS multi-protocol accounting server
 Documentation=man:radiusd(8) man:radiusd.conf(5) http://wiki.freeradius.org/ http://networkradius.com/doc/

--- a/conf/systemd/packetfence-radiusd-auth.service
+++ b/conf/systemd/packetfence-radiusd-auth.service
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=PacketFence FreeRADIUS authentication multi-protocol authentication server
 Documentation=man:radiusd(8) man:radiusd.conf(5) http://wiki.freeradius.org/ http://networkradius.com/doc/

--- a/conf/systemd/packetfence-radiusd-cli.service
+++ b/conf/systemd/packetfence-radiusd-cli.service
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=PacketFence FreeRADIUS multi-protocol CLI authentication server
 Documentation=man:radiusd(8) man:radiusd.conf(5) http://wiki.freeradius.org/ http://networkradius.com/doc/

--- a/conf/systemd/packetfence-radiusd-eduroam.service
+++ b/conf/systemd/packetfence-radiusd-eduroam.service
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=PacketFence FreeRADIUS multi-protocol EDUROAM authentication server
 Documentation=man:radiusd(8) man:radiusd.conf(5) http://wiki.freeradius.org/ http://networkradius.com/doc/

--- a/conf/systemd/packetfence-radiusd-load_balancer.service
+++ b/conf/systemd/packetfence-radiusd-load_balancer.service
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=PacketFence FreeRADIUS multi-protocol proxy load-balancer server
 Documentation=man:radiusd(8) man:radiusd.conf(5) http://wiki.freeradius.org/ http://networkradius.com/doc/

--- a/conf/systemd/packetfence-radsniff.service
+++ b/conf/systemd/packetfence-radsniff.service
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=PacketFence radsniff Service
 After=packetfence-pfstats.service

--- a/conf/systemd/packetfence-redis-cache.service
+++ b/conf/systemd/packetfence-redis-cache.service
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=PacketFence Redis Cache Service
 After=network.target

--- a/conf/systemd/packetfence-redis_ntlm_cache.service
+++ b/conf/systemd/packetfence-redis_ntlm_cache.service
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=PacketFence Redis NTLM authenticaton caching Service
 Wants=packetfence-base.target packetfence-config.service packetfence-iptables.service

--- a/conf/systemd/packetfence-redis_queue.service
+++ b/conf/systemd/packetfence-redis_queue.service
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=PacketFence Redis Queue Service
 Wants=packetfence-base.target packetfence-config.service packetfence-iptables.service

--- a/conf/systemd/packetfence-routes.service
+++ b/conf/systemd/packetfence-routes.service
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=PacketFence static routes configuration
 Wants=packetfence-config.service

--- a/conf/systemd/packetfence-snmptrapd.service
+++ b/conf/systemd/packetfence-snmptrapd.service
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=PacketFence Simple Network Management Protocol (SNMP) Trap Daemon.
 After=packetfence-base.target

--- a/conf/systemd/packetfence-tc.service
+++ b/conf/systemd/packetfence-tc.service
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=PacketFence Traffic Shaping configuration
 Wants=packetfence-config.service

--- a/conf/systemd/packetfence-tracking-config.path
+++ b/conf/systemd/packetfence-tracking-config.path
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=PacketFence Configuration Change Tracking
 Documentation=http://packetfence.org

--- a/conf/systemd/packetfence-tracking-config.service
+++ b/conf/systemd/packetfence-tracking-config.service
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=PacketFence Configuration Change Tracking
 Documentation=http://packetfence.org

--- a/conf/systemd/packetfence-winbindd.service
+++ b/conf/systemd/packetfence-winbindd.service
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=PacketFence SAMBA winbind Service
 Wants=packetfence-base.target packetfence-config.service packetfence-iptables.service

--- a/conf/systemd/packetfence.slice
+++ b/conf/systemd/packetfence.slice
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=The PacketFence resource control slice
 Before=slices.target

--- a/conf/systemd/packetfence.target
+++ b/conf/systemd/packetfence.target
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [Unit]
 Description=PacketFence target
 Wants=packetfence-base.target

--- a/conf/template_switches.conf.defaults
+++ b/conf/template_switches.conf.defaults
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 # Do not edit file
 # Changes will be lost on upgrade
 

--- a/conf/ui.conf
+++ b/conf/ui.conf
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 [ui]
 display=status,person,node,violation,scan,administration,configuration
 status=Status

--- a/conf/vlan_filters.conf.defaults
+++ b/conf/vlan_filters.conf.defaults
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 # defaults PacketFence's rules for PacketFence
 
 # This rules are predefined in PacketFence and disconnect device that coming from a secure connection to an open one.

--- a/conf/vlan_filters.conf.example
+++ b/conf/vlan_filters.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 
 # VLAN FILTERS configuration
 # ==========================

--- a/conf/wmi.conf.example
+++ b/conf/wmi.conf.example
@@ -1,3 +1,4 @@
+# Copyright (C) Inverse inc.
 # Detect installed software and trigger a security event
 [Software_Installed]
 namespace=ROOT\cimv2


### PR DESCRIPTION
# Description
Add copyright without year to avoid useless rpmnew or dpkg-dist files each yearly upgrade

# Impacts
Package upgrade.

# Issue
fixes #4986 

# Delete branch after merge
YES

# NEWS files entries
## Enhancements
* All configuration files have a copyright without year to avoid useless rpmnew or dpkg-dist files each yearly upgrade