### PR TITLE
Add radius disconnect for wired port on Aruba AP

### DIFF
--- a/lib/pf/Switch/Aruba.pm
+++ b/lib/pf/Switch/Aruba.pm
@@ -88,12 +88,12 @@ TODO: this list is incomplete
 # CAPABILITIES
 # access technology supported
 use pf::SwitchSupports qw(
-     RoleBasedEnforcement
-     WirelessDot1x
-     WirelessMacAuth
-     ExternalPortal
-     WiredMacAuth
-     WiredDot1x
+    RoleBasedEnforcement
+    WirelessDot1x
+    WirelessMacAuth
+    ExternalPortal
+    WiredMacAuth
+    WiredDot1x
  );
 
 # inline capabilities

--- a/lib/pf/Switch/Aruba.pm
+++ b/lib/pf/Switch/Aruba.pm
@@ -87,12 +87,14 @@ TODO: this list is incomplete
 
 # CAPABILITIES
 # access technology supported
-sub supportsRoleBasedEnforcement { return $TRUE; }
-sub supportsWirelessDot1x { return $TRUE; }
-sub supportsWirelessMacAuth { return $TRUE; }
-sub supportsExternalPortal { return $TRUE; }
-sub supportsWiredMacAuth { return $TRUE; }
-sub supportsWiredDot1x { return $TRUE; }
+use pf::SwitchSupports qw(
+     RoleBasedEnforcement
+     WirelessDot1x
+     WirelessMacAuth
+     ExternalPortal
+     WiredMacAuth
+     WiredDot1x
+ );
 
 # inline capabilities
 sub inlineCapabilities { return ($MAC,$SSID); }

--- a/lib/pf/Switch/Aruba.pm
+++ b/lib/pf/Switch/Aruba.pm
@@ -94,7 +94,7 @@ use pf::SwitchSupports qw(
     ExternalPortal
     WiredMacAuth
     WiredDot1x
- );
+);
 
 # inline capabilities
 sub inlineCapabilities { return ($MAC,$SSID); }

--- a/lib/pf/Switch/Aruba.pm
+++ b/lib/pf/Switch/Aruba.pm
@@ -669,7 +669,7 @@ Inverse inc. <info@inverse.ca>
 
 =head1 COPYRIGHT
 
-Copyright (C) 2005-2018 Inverse inc.
+Copyright (C) 2005-2020 Inverse inc.
 
 =head1 LICENSE
 

--- a/lib/pf/Switch/Aruba.pm
+++ b/lib/pf/Switch/Aruba.pm
@@ -75,7 +75,6 @@ sub description { 'Aruba Networks' }
 use pf::roles::custom;
 use pf::accounting qw(node_accounting_current_sessionid);
 use pf::util::radius qw(perform_coa perform_disconnect);
-use pf::node qw(node_attributes);
 
 =head1 SUBROUTINES
 
@@ -533,7 +532,6 @@ sub radiusDisconnect {
         my $role = $roleResolver->getRoleForNode($mac, $self);
 
         my $acctsessionid = node_accounting_current_sessionid($mac);
-        my $node_info = node_attributes($mac);
         # transforming MAC to the expected format 00-11-22-33-CA-FE
         $mac = uc($mac);
         $mac =~ s/:/-/g;


### PR DESCRIPTION
# Description
Add radius disconnect for wired port on Aruba AP

# Impacts
Aruba Wireless switch module

# Delete branch after merge
YES 

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
Add radius disconnect for wired port on Aruba AP