### PR TITLE
Unreg on accounting stop only if autoregister enabled

### DIFF
--- a/lib/pf/Connection/Profile.pm
+++ b/lib/pf/Connection/Profile.pm
@@ -680,6 +680,17 @@ sub unregOnAcctStop {
     return isenabled($self->{'_unreg_on_acct_stop'});
 }
 
+=item autoRegister
+
+is autoregister enabled
+
+=cut
+
+sub autoRegister {
+    my ($self) = @_;
+    return isenabled($self->{'_autoregister'});
+}
+
 sub TO_JSON {
     return {%{$_[0]}};
 }

--- a/lib/pf/api.pm
+++ b/lib/pf/api.pm
@@ -1497,7 +1497,7 @@ sub handle_accounting_metadata : Public {
 
     if ($acct_status_type == $ACCOUNTING::STOP) {
         my $profile_name = pf::Connection::ProfileFactory->get_profile_name($mac);
-        if (pf::util::isenabled($pf::config::Profiles_Config{$profile_name}{unreg_on_acct_stop})) {
+        if (pf::util::isenabled($pf::config::Profiles_Config{$profile_name}{unreg_on_acct_stop}) && pf::util::isenabled($pf::config::Profiles_Config{$profile_name}{autoregister})) {
             $logger->info("Unregistering $mac on Accounting-Stop");
             $client->notify("deregister_node", mac => $mac);
         }


### PR DESCRIPTION
# Description
Unregegister the device on accounting stop only if the device has been autoregistered

# Impacts
- RADIUS authorize workflow

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
## Enhancements
* Only unregister the device if the device has been automatically registered
