### PR TITLE
[docs] Remove duplicated instructions for PacketFence cluster upgrade

### DIFF
--- a/UPGRADE.asciidoc
+++ b/UPGRADE.asciidoc
@@ -221,7 +221,7 @@ find /usr/local/pf -name \*.rpmnew
 
 The list of files returned are the new versions shipped with PacketFence.
 Compare them to your existing version and see if there are changes that should
-be merged into your existing configuration.  Then, once you are done make sure
+be merged into your existing configuration. Then, once you are done make sure
 to delete these files so that there is no confusion the next time you upgrade
 PacketFence.
 

--- a/UPGRADE.asciidoc
+++ b/UPGRADE.asciidoc
@@ -180,6 +180,32 @@ apt install fingerbank
 PacketFence and Fingerbank should now be upgraded. However, there may be extra
 steps required depending on the version you are upgrading from.
 
+==== Reboot after an upgrade
+
+If you reboot a standalone server or one server from a cluster after packages
+upgrade, make sure you set the systemd target to `multi-user.target` before rebooting:
+
+[source,bash]
+----
+systemctl set-default multi-user.target
+----
+
+Set it back to previous target after it boots up:
+
+.Cluster
+[source,bash]
+----
+systemctl set-default packetfence-cluster.target
+----
+
+.Standalone
+[source,bash]
+----
+systemctl set-default packetfence.target
+----
+
+This will make sure your services don't start up after the reboot.
+
 ==== New versions of configuration files
 
 You should take care to review any changes to configuration files and merge them if required. 

--- a/docs/PacketFence_Clustering_Guide.asciidoc
+++ b/docs/PacketFence_Clustering_Guide.asciidoc
@@ -1365,177 +1365,221 @@ WiFi controllers, etc.)
 
 
 
-Performing an upgrade on a cluster
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+=== Performing an upgrade on a cluster
+
 
 CAUTION: Performing a live upgrade on a PacketFence cluster is not a straightforward operation and should be done meticulously.
 
 In this procedure, the 3 nodes will be named A, B and C and they are in this order in `cluster.conf`.
 
-Backups
-^^^^^^^
+==== Backups
 
 First, ensure you have taken backups of your data. We highly encourage you to perform snapshots of all the virtual machines prior to the upgrade. You should also take a backup of the database and the `/usr/local/pf` directory using:
 
 * <<PacketFence_Upgrade_Guide.asciidoc#_database_backup,Database backup instructions>>
 * <<PacketFence_Upgrade_Guide.asciidoc#_packetfence_configurations_and_codebase_backup,PacketFence configurations and codebase backup instructions>>
 
-Disabling the auto-correction of configuration
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Disabling the auto-correction of configuration
+
 
 The PacketFence clustering stack has a mechanism that allows configuration conflicts to be handled accross the servers. This will come in conflict with your upgrade, so you should disable it.
 
-In order to do, so go in 'Configuration->System Configuration->Maintenance' and disable the 'Cluster Check' task.
+In order to do, so go in _Configuration->System Configuration->Maintenance_ and disable the _Cluster Check_ task.
 
 Once this is done, restart `pfmon` on all nodes using:
 
-  # /usr/local/pf/bin/pfcmd service pfmon restart
+[source,bash]
+----
+/usr/local/pf/bin/pfcmd service pfmon restart
+----
 
-Upgrading node C
-^^^^^^^^^^^^^^^^
+==== Upgrading node C
+
 
 In order to be able to work on node C, we first need to stop all the PacketFence application services on it.
 
-  # /usr/local/pf/bin/pfcmd service pf stop
+[source,bash]
+----
+/usr/local/pf/bin/pfcmd service pf stop
+----
   
 Due to disconnection issues with the systemd-logind service while yum is performing the update, you need to ensure the service is stopped disabled. The last command will then ensure your current process is removed out of the user-0.slice.
 
-  /usr/bin/systemctl stop systemd-logind
-  /usr/bin/systemctl --now mask systemd-logind
-  /usr/bin/systemctl daemon-reload
-  /bin/bash -c "/usr/bin/systemctl status user-0.slice | /usr/bin/grep -E -o '─[0-9]+' | /usr/bin/sed 's/─//g' | /usr/bin/xargs -I{} /bin/bash -c '/usr/bin/kill -0 {} > /dev/null 2>/dev/null && /usr/bin/echo {} > /sys/fs/cgroup/systemd/tasks'"
+[source,bash]
+----
+/usr/bin/systemctl stop systemd-logind
+/usr/bin/systemctl --now mask systemd-logind
+/usr/bin/systemctl daemon-reload
+/bin/bash -c "/usr/bin/systemctl status user-0.slice | /usr/bin/grep -E -o '─[0-9]+' | /usr/bin/sed 's/─//g' | /usr/bin/xargs -I{} /bin/bash -c '/usr/bin/kill -0 {} > /dev/null 2>/dev/null && /usr/bin/echo {} > /sys/fs/cgroup/systemd/tasks'"
+----
 
 Next, upgrade your operating system and PacketFence on node C:
 
-  # yum upgrade --enablerepo=packetfence
+[source,bash]
+----
+yum upgrade --enablerepo=packetfence
+----
 
 NOTE: If you reboot your server during this procedure, make sure you set the systemd target to multi-user (`systemctl set-default multi-user.target`) before rebooting and back to packetfence-cluster (`systemctl set-default packetfence-cluster.target`) after it boots up. This will make sure your services don't start up after the reboot.
 
 Now, make sure you follow the directives in the <<PacketFence_Upgrade_Guide.asciidoc#,upgrade guide>> as you would on a standalone server with the exception of the database schema updates.
 
-Migrating service on node C
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Migrating service on node C
+
 
 Node C should currently be running the latest version of PacketFence while A and B should still be running the older version and still be offering service. The database is also still being synced to node C via the `packetfence-mariadb` service.
 
 NOTE: The steps below will cause a temporary loss of service.
 
-Detach node C from the cluster
-++++++++++++++++++++++++++++++
+===== Detach node C from the cluster
+
 
 First, we need to tell A and B to ignore C in their cluster configuration. In order to do so, execute the following command **on A and B** while changing `node-C-hostname` with the actual hostname of node C:
 
-  # /usr/local/pf/bin/cluster/node node-C-hostname disable
+[source,bash]
+----
+/usr/local/pf/bin/cluster/node node-C-hostname disable
+----
 
 Once this is done proceed to restart the following services on nodes A and B **one at a time**. This will cause service failure during the restart on node A
 
- # For PF versions prior to 8.0
- /usr/local/pf/bin/pfcmd service haproxy restart
- /usr/local/pf/bin/pfcmd service keepalived restart
+.For PF versions prior to 8.0
+[source,bash]
+----
+/usr/local/pf/bin/pfcmd service haproxy restart
+/usr/local/pf/bin/pfcmd service keepalived restart
+----
 
- # For PF versions 8.0 and later
- /usr/local/pf/bin/pfcmd service radiusd restart
- /usr/local/pf/bin/pfcmd service pfdhcplistener restart
- /usr/local/pf/bin/pfcmd service haproxy-db restart
- /usr/local/pf/bin/pfcmd service haproxy-portal restart
- /usr/local/pf/bin/pfcmd service keepalived restart
-
+.For PF versions 8.0 and later
+[source,bash]
+----
+/usr/local/pf/bin/pfcmd service radiusd restart
+/usr/local/pf/bin/pfcmd service pfdhcplistener restart
+/usr/local/pf/bin/pfcmd service haproxy-db restart
+/usr/local/pf/bin/pfcmd service haproxy-portal restart
+/usr/local/pf/bin/pfcmd service keepalived restart
+----
 
 Then, we should tell C to ignore A and B in their cluster configuration. In order to do so, execute the following commands on node C while changing `node-A-hostname` and `node-B-hostname` by the hostname of nodes A and B respectively.
 
-  # systemctl start packetfence-config
-  # /usr/local/pf/bin/cluster/node node-A-hostname disable
-  # /usr/local/pf/bin/cluster/node node-B-hostname disable
+[source,bash]
+----
+systemctl start packetfence-config
+/usr/local/pf/bin/cluster/node node-A-hostname disable
+/usr/local/pf/bin/cluster/node node-B-hostname disable
+----
 
 Now restart `packetfence-mariadb` on node C:
 
-  # systemctl restart packetfence-mariadb
+[source,bash]
+----
+systemctl restart packetfence-mariadb
+----
 
 NOTE: From this moment on, you will lose the configuration changes and data changes that occur on nodes A and B.
 
 The commands above will make sure that nodes A and B will not be forwarding requests to C even if it is alive. Same goes for C which won't be sending traffic to A and B. This means A and B will continue to have the same database informations while C will start to diverge from it when it goes live. We'll make sure to reconcile this data afterwards.
 
-Complete upgrade of node C
-++++++++++++++++++++++++++
+===== Complete upgrade of node C
+
 
 From that moment node C is in standalone for its database. We can proceed to update the database schema so it matches the one of the latest version.
 In order to do so, upgrade the database schema using the instructions provided in <<PacketFence_Upgrade_Guide.asciidoc#,Upgrade guide>>.
 
-Stop service on nodes A and B
-+++++++++++++++++++++++++++++
+===== Stop service on nodes A and B
+
 
 Next, stop all application service on node A and B along with the database:
 
-  # /usr/local/pf/bin/pfcmd service pf stop
-  # systemctl stop packetfence-mariadb
+[source,bash]
+----
+/usr/local/pf/bin/pfcmd service pf stop
+systemctl stop packetfence-mariadb
+----
 
-Start service on node C
-+++++++++++++++++++++++
+===== Start service on node C
+
 
 Now, start the application service on node C
 
-  # /usr/local/pf/bin/pfcmd service pf start
+[source,bash]
+----
+/usr/local/pf/bin/pfcmd service pf start
+----
 
-Validate migration
-^^^^^^^^^^^^^^^^^^
+==== Validate migration
+
 
 You should now have full service on node C and should validate that all functionnalities are working as expected. Once you continue past this point, there will be no way to migrate back to nodes A and B in case of issues other than to use the snapshots taken prior to the upgrade.
 
-If all goes wrong
-+++++++++++++++++
+===== If all goes wrong
+
 
 If your migration to node C goes wrong, you can fail back to nodes A and B by stopping all services on node C and starting them on nodes A and B
 
-**On node C**
+.On node C
+[source,bash]
+----
+systemctl stop packetfence-mariadb
+/usr/local/pf/bin/pfcmd service pf stop
+----
 
-  # systemctl stop packetfence-mariadb
-  # /usr/local/pf/bin/pfcmd service pf stop
-
-**On nodes A and B**
-
-  # systemctl start packetfence-mariadb
-  # /usr/local/pf/bin/pfcmd service pf start
+.On nodes A and B
+[source,bash]
+----
+systemctl start packetfence-mariadb
+/usr/local/pf/bin/pfcmd service pf start
+----
 
 Once you are feeling confident to try your failover to node C again, you can do the exact opposite of the commands above to try your upgrade again.
 
-If all goes well
-++++++++++++++++
+===== If all goes well
+
 
 If you are happy about the state of your upgrade, you can continue on the steps below in order to complete the upgrade of the two remaining nodes.
 
-Upgrading nodes A and B
-^^^^^^^^^^^^^^^^^^^^^^^
+==== Upgrading nodes A and B
+
 
 Due to disconnection issues with the systemd-logind service while yum is performing the update, you need to ensure the service is stopped disabled. The last command will then ensure your current process is removed out of the user-0.slice.
 
-  /usr/bin/systemctl stop systemd-logind
-  /usr/bin/systemctl --now mask systemd-logind
-  /usr/bin/systemctl daemon-reload
-  /bin/bash -c "/usr/bin/systemctl status user-0.slice | /usr/bin/grep -E -o '─[0-9]+' | /usr/bin/sed 's/─//g' | /usr/bin/xargs -I{} /bin/bash -c '/usr/bin/kill -0 {} > /dev/null 2>/dev/null && /usr/bin/echo {} > /sys/fs/cgroup/systemd/tasks'"
+[source,bash]
+----
+/usr/bin/systemctl stop systemd-logind
+/usr/bin/systemctl --now mask systemd-logind
+/usr/bin/systemctl daemon-reload
+/bin/bash -c "/usr/bin/systemctl status user-0.slice | /usr/bin/grep -E -o '─[0-9]+' | /usr/bin/sed 's/─//g' | /usr/bin/xargs -I{} /bin/bash -c '/usr/bin/kill -0 {} > /dev/null 2>/dev/null && /usr/bin/echo {} > /sys/fs/cgroup/systemd/tasks'"
+----
 
 Next, upgrade your operating system and PacketFence on each server:
 
-  # yum upgrade --enablerepo=packetfence
+[source,bash]
+----
+yum upgrade --enablerepo=packetfence
+----
 
 NOTE: If you reboot your server during this procedure, make sure you set the systemd target to multi-user (`systemctl set-default multi-user.target`) before rebooting and back to packetfence-cluster (`systemctl set-default packetfence-cluster.target`) after it boots up. This will make sure your services don't start up after the reboot.
 
 You do not need to follow the upgrade procedure when upgrading these nodes. You should instead do a sync from node C on nodes A and B
 
-  # systemctl restart packetfence-config
-  # /usr/local/pf/bin/cluster/sync --from=192.168.1.5 --api-user=packet --api-password=fence
-  # /usr/local/pf/bin/pfcmd configreload hard
+[source,bash]
+----
+systemctl restart packetfence-config
+/usr/local/pf/bin/cluster/sync --from=192.168.1.5 --api-user=packet --api-password=fence
+/usr/local/pf/bin/pfcmd configreload hard
+----
 
 Where :
 
-* '192.168.1.5' is the management IP of node C
-* 'packet' is the webservices username ('Configuration->Webservices')
-* 'fence' is the webservices password ('Configuration->Webservices')
+* `_192.168.1.5_` is the management IP of node C
+* `_packet_` is the webservices username (_Configuration->Webservices_)
+* `_fence_` is the webservices password (_Configuration->Webservices_)
 
-Reintegrating nodes A and B
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+==== Reintegrating nodes A and B
 
-Optional step: Cleaning up data on node C
-+++++++++++++++++++++++++++++++++++++++++
+
+===== Optional step: Cleaning up data on node C
+
 
 When you will re-establish a cluster using node C in the steps below, your environment will be set in read-only mode for the duration of the database sync (which needs to be done from scratch).
 
@@ -1543,7 +1587,7 @@ This can take from a few minutes to an hour depending on your database size.
 
 We highly suggest you delete data from the following tables if you don't need it:
 
-* `radius_audit_log`: contains the data in 'Auditing->RADIUS Audit Log'
+* `radius_audit_log`: contains the data in _Auditing->RADIUS Audit Logs_
 * `ip4log_history`: Archiving data for the IPv4 history
 * `ip4log_archive`: Archiving data for the IPv4 history
 * `locationlog_archive`: Archiving data for the node location history
@@ -1552,68 +1596,97 @@ You can safely delete the data from all of these tables without affecting the fu
 
 In order to truncate a table:
 
-  # mysql -u root -p pf
-  MariaDB> truncate TABLE_NAME;
+[source,bash]
+----
+mysql -u root -p pf
+MariaDB> truncate TABLE_NAME;
+----
 
-Elect node C as database master
-+++++++++++++++++++++++++++++++
+===== Elect node C as database master
+
 
 In order for node C to be able to elect itself as database master, we must tell it there are other members in its cluster by re-enabling nodes A and B
 
-  # /usr/local/pf/bin/cluster/node node-A-hostname enable
-  # /usr/local/pf/bin/cluster/node node-B-hostname enable
+[source,bash]
+----
+/usr/local/pf/bin/cluster/node node-A-hostname enable
+/usr/local/pf/bin/cluster/node node-B-hostname enable
+----
 
 Next, enable node C on nodes A and B by executing the following command on the two servers:
 
-  # /usr/local/pf/bin/cluster/node node-C-hostname enable
+[source,bash]
+----
+/usr/local/pf/bin/cluster/node node-C-hostname enable
+----
 
 Now, stop `packetfence-mariadb` on node C, regenerate the MariaDB configuration and start it as a new master:
 
- # systemctl stop packetfence-mariadb
- # /usr/local/pf/bin/pfcmd generatemariadbconfig
- # /usr/local/pf/sbin/pf-mariadb --force-new-cluster
+[source,bash]
+----
+systemctl stop packetfence-mariadb
+/usr/local/pf/bin/pfcmd generatemariadbconfig
+/usr/local/pf/sbin/pf-mariadb --force-new-cluster
+----
 
-You should validate that you are able to connect to the MariaDB database even though it is in read-only mode using the MariaDB command line. If its not, make sure you check the MariaDB log (`/usr/local/pf/logs/mariadb_error.log`)
+You should validate that you are able to connect to the MariaDB database even
+though it is in read-only mode using the MariaDB command line. If its not,
+make sure you check the MariaDB log ([filename]`/usr/local/pf/logs/mariadb_error.log`)
 
-Sync nodes A and B
-++++++++++++++++++
+===== Sync nodes A and B
+
 
 On each of the servers you want to discard the data from, stop `packetfence-mariadb`, you must destroy all the data in `/var/lib/mysql` and start packetfence-mariadb so it resyncs its data from scratch.
 
-  # systemctl stop packetfence-mariadb
-  # rm -fr /var/lib/mysql/*
-  # systemctl start packetfence-mariadb
+[source,bash]
+----
+systemctl stop packetfence-mariadb
+rm -fr /var/lib/mysql/*
+systemctl start packetfence-mariadb
+----
 
-Should there be any issues during the sync, make sure you look into the MariaDB log (`/usr/local/pf/logs/mariadb_error.log`)
+Should there be any issues during the sync, make sure you look into the MariaDB log ([filename]`/usr/local/pf/logs/mariadb_error.log`)
 
-Once both nodes have completely synced (try connecting to it using the MariaDB command line), then you can break the cluster election command you have running on node C and start node C normally (using `systemctl start packetfence-mariadb`).
+Once both nodes have completely synced (try connecting to it using the MariaDB
+command line), then you can break the cluster election command you have
+running on node C and start node C normally (using `systemctl start
+packetfence-mariadb`).
 
-Start nodes A and B
-+++++++++++++++++++
+===== Start nodes A and B
+
 
 You can now safely start PacketFence on nodes A and B using:
 
-  # /usr/local/pf/bin/pfcmd service pf restart
+[source,bash]
+----
+/usr/local/pf/bin/pfcmd service pf restart
+----
 
-Restart node C
-^^^^^^^^^^^^^^
+==== Restart node C
+
 
 Now, you should restart PacketFence on node C so it becomes aware of its peers again.
 
-  # /usr/local/pf/bin/pfcmd service pf restart
+[source,bash]
+----
+/usr/local/pf/bin/pfcmd service pf restart
+----
 
 You should now have full service on all 3 nodes using the latest version of PacketFence.
 
-Reactivate the configuration conflict handling
-++++++++++++++++++++++++++++++++++++++++++++++
+===== Reactivate the configuration conflict handling
+
 
 Now that your cluster is back to a healthy state, you should reactivate the configuration conflict resolution.
 
-In order to do, so go in 'Configuration->System Configuration->Maintenance' and re-enable the 'Cluster Check' task.
+In order to do, so go in _Configuration->System Configuration->Maintenance_ and re-enable the _Cluster Check_ task.
 
 Once this is done, restart `pfmon` on all nodes using:
 
-  # /usr/local/pf/bin/pfcmd service pfmon restart
+[source,bash]
+----
+/usr/local/pf/bin/pfcmd service pfmon restart
+----
 
 MariaDB Galera cluster troubleshooting
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/PacketFence_Clustering_Guide.asciidoc
+++ b/docs/PacketFence_Clustering_Guide.asciidoc
@@ -1396,12 +1396,10 @@ Once this is done, restart `pfmon` on all nodes using:
 ==== Upgrading node C
 
 
-In order to be able to work on node C, we first need to stop all the PacketFence application services on it.
-
-[source,bash]
-----
-/usr/local/pf/bin/pfcmd service pf stop
-----
+In order to be able to work on node C, we first need to stop all the
+PacketFence application services on it, see
+<<PacketFence_Upgrade_Guide.asciidoc#_stop_all_packetfence_services,Stop all
+PacketFence services section>>.
   
 Due to disconnection issues with the systemd-logind service while yum is performing the update, you need to ensure the service is stopped disabled. The last command will then ensure your current process is removed out of the user-0.slice.
 
@@ -1486,14 +1484,16 @@ The commands above will make sure that nodes A and B will not be forwarding requ
 From that moment node C is in standalone for its database. We can proceed to update the database schema so it matches the one of the latest version.
 In order to do so, upgrade the database schema using the instructions provided in <<PacketFence_Upgrade_Guide.asciidoc#,Upgrade guide>>.
 
-===== Stop service on nodes A and B
+===== Stop services on nodes A and B
 
+Next, stop all application services on node A and B:
 
-Next, stop all application service on node A and B along with the database:
-
+* See <<PacketFence_Upgrade_Guide.asciidoc#_stop_all_packetfence_services,Stop all
+PacketFence services section>>
+* Stop database:
++
 [source,bash]
 ----
-/usr/local/pf/bin/pfcmd service pf stop
 systemctl stop packetfence-mariadb
 ----
 

--- a/docs/PacketFence_Clustering_Guide.asciidoc
+++ b/docs/PacketFence_Clustering_Guide.asciidoc
@@ -1401,24 +1401,7 @@ PacketFence application services on it, see
 <<PacketFence_Upgrade_Guide.asciidoc#_stop_all_packetfence_services,Stop all
 PacketFence services section>>.
   
-Due to disconnection issues with the systemd-logind service while yum is performing the update, you need to ensure the service is stopped disabled. The last command will then ensure your current process is removed out of the user-0.slice.
-
-[source,bash]
-----
-/usr/bin/systemctl stop systemd-logind
-/usr/bin/systemctl --now mask systemd-logind
-/usr/bin/systemctl daemon-reload
-/bin/bash -c "/usr/bin/systemctl status user-0.slice | /usr/bin/grep -E -o '─[0-9]+' | /usr/bin/sed 's/─//g' | /usr/bin/xargs -I{} /bin/bash -c '/usr/bin/kill -0 {} > /dev/null 2>/dev/null && /usr/bin/echo {} > /sys/fs/cgroup/systemd/tasks'"
-----
-
-Next, upgrade your operating system and PacketFence on node C:
-
-[source,bash]
-----
-yum upgrade --enablerepo=packetfence
-----
-
-NOTE: If you reboot your server during this procedure, make sure you set the systemd target to multi-user (`systemctl set-default multi-user.target`) before rebooting and back to packetfence-cluster (`systemctl set-default packetfence-cluster.target`) after it boots up. This will make sure your services don't start up after the reboot.
+Next, you can upgrade your operating system and/or PacketFence on node C by following instructions of <<PacketFence_Upgrade_Guide.asciidoc#_packages_upgrades,Packages upgrades section>>.
 
 Now, make sure you follow the directives in the <<PacketFence_Upgrade_Guide.asciidoc#,upgrade guide>> as you would on a standalone server with the exception of the database schema updates.
 
@@ -1540,27 +1523,12 @@ If you are happy about the state of your upgrade, you can continue on the steps 
 
 ==== Upgrading nodes A and B
 
+Next, you can upgrade your operating system and/or PacketFence on nodes A and B by
+following instructions of
+<<PacketFence_Upgrade_Guide.asciidoc#_packages_upgrades,Packages upgrades
+section>>.
 
-Due to disconnection issues with the systemd-logind service while yum is performing the update, you need to ensure the service is stopped disabled. The last command will then ensure your current process is removed out of the user-0.slice.
-
-[source,bash]
-----
-/usr/bin/systemctl stop systemd-logind
-/usr/bin/systemctl --now mask systemd-logind
-/usr/bin/systemctl daemon-reload
-/bin/bash -c "/usr/bin/systemctl status user-0.slice | /usr/bin/grep -E -o '─[0-9]+' | /usr/bin/sed 's/─//g' | /usr/bin/xargs -I{} /bin/bash -c '/usr/bin/kill -0 {} > /dev/null 2>/dev/null && /usr/bin/echo {} > /sys/fs/cgroup/systemd/tasks'"
-----
-
-Next, upgrade your operating system and PacketFence on each server:
-
-[source,bash]
-----
-yum upgrade --enablerepo=packetfence
-----
-
-NOTE: If you reboot your server during this procedure, make sure you set the systemd target to multi-user (`systemctl set-default multi-user.target`) before rebooting and back to packetfence-cluster (`systemctl set-default packetfence-cluster.target`) after it boots up. This will make sure your services don't start up after the reboot.
-
-You do not need to follow the upgrade procedure when upgrading these nodes. You should instead do a sync from node C on nodes A and B
+You do not need to follow the upgrade procedure when upgrading these nodes. You should instead do a sync from node C on nodes A and B:
 
 [source,bash]
 ----
@@ -1569,7 +1537,7 @@ systemctl restart packetfence-config
 /usr/local/pf/bin/pfcmd configreload hard
 ----
 
-Where :
+Where:
 
 * `_192.168.1.5_` is the management IP of node C
 * `_packet_` is the webservices username (_Configuration->Webservices_)

--- a/docs/PacketFence_Clustering_Guide.asciidoc
+++ b/docs/PacketFence_Clustering_Guide.asciidoc
@@ -1483,10 +1483,12 @@ systemctl stop packetfence-mariadb
 ===== Start service on node C
 
 
-Now, start the application service on node C
+Now, start the application service on node C:
 
 [source,bash]
 ----
+/usr/local/pf/bin/pfcmd fixpermissions
+/usr/local/pf/bin/pfcmd configreload hard
 /usr/local/pf/bin/pfcmd service pf start
 ----
 
@@ -1532,7 +1534,7 @@ You do not need to follow the upgrade procedure when upgrading these nodes. You 
 
 [source,bash]
 ----
-systemctl restart packetfence-config
+systemctl start packetfence-config
 /usr/local/pf/bin/cluster/sync --from=192.168.1.5 --api-user=packet --api-password=fence
 /usr/local/pf/bin/pfcmd configreload hard
 ----
@@ -1542,6 +1544,8 @@ Where:
 * `_192.168.1.5_` is the management IP of node C
 * `_packet_` is the webservices username (_Configuration->Webservices_)
 * `_fence_` is the webservices password (_Configuration->Webservices_)
+
+WARNING: Make sure you sync by hand any changes to configuration files on node C that are not synced.
 
 ==== Reintegrating nodes A and B
 

--- a/docs/PacketFence_Clustering_Guide.asciidoc
+++ b/docs/PacketFence_Clustering_Guide.asciidoc
@@ -1377,8 +1377,8 @@ Backups
 
 First, ensure you have taken backups of your data. We highly encourage you to perform snapshots of all the virtual machines prior to the upgrade. You should also take a backup of the database and the `/usr/local/pf` directory using:
 
-  # mysqldump --opt --routines -u root -p pf | gzip > /root/packetfence_db.sql.gz
-  # tar -C /usr/local -czf /root/packetfence.tar.gz pf --exclude='pf/logs' --exclude='pf/var'
+* <<PacketFence_Upgrade_Guide.asciidoc#_database_backup,Database backup instructions>>
+* <<PacketFence_Upgrade_Guide.asciidoc#_packetfence_configurations_and_codebase_backup,PacketFence configurations and codebase backup instructions>>
 
 Disabling the auto-correction of configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
# Description
* Use same instructions as for standalone upgrades for:
  * backups
  * stop services
  * package upgrades
using links to Upgrade guide.
* Add missing information in Upgrade guide.
* Apply asciidoctor conventions to "Performing an upgrade on a cluster" section

## Changed
* With this new instructions, `packetfence-config` is stopped before performing an upgrade on nodes in a cluster (before stopping all PF services).

# Impacts
- Cluster upgrade
- Documentation

# Delete branch after merge
YES
