### PR TITLE
Adjust backup-and-maintenance.sh for locationlog_history table

### DIFF
--- a/addons/backup-and-maintenance.sh
+++ b/addons/backup-and-maintenance.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 #
-# Backup of PF tree and database
+# Backup of $PF_DIRECTORY and $DB_NAME
 #
-# - compressed PF tree to $BACKUP_DIRECTORY, rotate and clean
+# - compressed $PF_DIRECTORY to $BACKUP_DIRECTORY, rotate and clean
 # - compressed mysqldump to $BACKUP_DIRECTORY, rotate and clean
 #
 # Copyright (C) 2005-2019 Inverse inc.

--- a/addons/backup-and-maintenance.sh
+++ b/addons/backup-and-maintenance.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
 #
-# Database maintenance and backup
+# Backup of PF tree and database
 #
-# - Move entries older than a month from locationlog to locationlog_archive
-# - Optimize tables on sunday
+# - compressed PF tree to $BACKUP_DIRECTORY, rotate and clean
 # - compressed mysqldump to $BACKUP_DIRECTORY, rotate and clean
-# - archive locationlog_archive entries older than a year the first day of each month
 #
 # Copyright (C) 2005-2019 Inverse inc.
 #
@@ -13,7 +11,6 @@
 #
 # Licensed under the GPL
 #
-# Installation: make sure you have locationlog_archive (based on locationlog) and edit DB_PWD to fit your password.
 
 NB_DAYS_TO_KEEP_DB=7
 NB_DAYS_TO_KEEP_FILES=7
@@ -113,8 +110,6 @@ should_backup(){
 }
 
 backup_db(){
-    /usr/local/pf/addons/database-cleaner.pl --table=locationlog_archive --date-field=end_time --older-than="1 MONTH"
-
     # Check to see if Percona XtraBackup is installed
     if hash innobackupex 2>/dev/null; then
         echo -e "Percona XtraBackup is available. Will proceed using it for DB backup to avoid locking tables and easier recovery process. \n"
@@ -159,7 +154,7 @@ backup_db(){
         else
             find $BACKUP_DIRECTORY -name "$BACKUP_DB_FILENAME-*.sql.gz" -mtime +$NB_DAYS_TO_KEEP_DB -delete
             current_filename=$BACKUP_DIRECTORY/$BACKUP_DB_FILENAME-`date +%F_%Hh%M`.sql.gz
-            mysqldump --opt --routines -h $DB_HOST -u $DB_USER -p$DB_PWD $DB_NAME --ignore-table=$DB_NAME.locationlog_archive --ignore-table=$DB_NAME.iplog_archive | gzip > ${current_filename}
+            mysqldump --opt --routines -h $DB_HOST -u $DB_USER -p$DB_PWD $DB_NAME --ignore-table=$DB_NAME.locationlog_history --ignore-table=$DB_NAME.iplog_archive | gzip > ${current_filename}
             BACKUPRC=$?
             if (( $BACKUPRC > 0 )); then 
                 echo "mysqldump returned  error code: $?" >&2

--- a/docs/PacketFence_Clustering_Guide.asciidoc
+++ b/docs/PacketFence_Clustering_Guide.asciidoc
@@ -1562,7 +1562,7 @@ We highly suggest you delete data from the following tables if you don't need it
 * `radius_audit_log`: contains the data in _Auditing->RADIUS Audit Logs_
 * `ip4log_history`: Archiving data for the IPv4 history
 * `ip4log_archive`: Archiving data for the IPv4 history
-* `locationlog_archive`: Archiving data for the node location history
+* `locationlog_history`: Archiving data for the node location history
 
 You can safely delete the data from all of these tables without affecting the functionnalities as they are used for reporting and archiving purposes. Deleting the data from these tables can make the sync process considerably faster.
 

--- a/docs/PacketFence_Installation_Guide.asciidoc
+++ b/docs/PacketFence_Installation_Guide.asciidoc
@@ -4302,15 +4302,6 @@ We recommend that you run the http://mysqltuner.com/[MySQL Tuner] on your databa
 
   # /usr/local/pf/bin/pftest mysql
 
-Keeping Tables Small
-^^^^^^^^^^^^^^^^^^^^
-
-Over time, some of the tables will grow large and this will drag down performance (this is especially true on a wireless setup).
-
-One such table is the `locationlog` table. We recommend that closed entries in this table be moved to the archive table `locationlog_archive` after some time. A closed record is one where the `end_time` field is set to a date (strictly speaking it is when `end_time` is not null and not equals to 0).
-
-We provide a script called `backup-and-maintenance.sh` located in `addons/` that performs this cleanup in addition to optimize tables on Sunday and daily backups.
-
 Avoid "Too many connections" problems
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
# Description
- Exclude `locationlog_history` from `mysqldump`
- Remove call to `database-cleaner.pl` because `pfmon` already do the job
- Update docs

# Impacts
- `backup-and-maintenance.sh` script

# Issue
fixes #5076 

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* Adjust backup-and-maintenance.sh for `locationlog_history` table (#5076)
