### PR TITLE
Fix EX2300 CoA Port Bounce

### DIFF
--- a/lib/pf/Switch/Juniper/EX2300.pm
+++ b/lib/pf/Switch/Juniper/EX2300.pm
@@ -125,12 +125,12 @@ sub setAdminStatus {
     
     if (!$mac) {
         $logger->info("Can't find MAC address in the locationlog... we won't perform port bounce");
-        return 1;
+        return $TRUE;
     }
 
     if ( !$self->isProductionMode() ) {
         $logger->info("Switch not in production mode... we won't perform port bounce");
-        return 1;
+        return $TRUE;
     }
 
     if (!defined($self->{'_radiusSecret'})) {


### PR DESCRIPTION
# Description
Override bouncePort, because  setAdminStatus is called two times in Switch.pm.
Replaced locationlog_view_open_switchport and added a check for VoIP nodes.

# Impacts
EX2300 CoA Port Bounce

# Delete branch after merge
YES

# Checklist
- [n/a ] Document the feature
- [n/a ] Add unit tests
- [ n/a] Add acceptance tests (TestLink)
