### PR TITLE
feature/remove_currently_at

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,9 +139,6 @@ conf/local_secret:
 conf/unified_api_system_pass:
 	date +%s | sha256sum | base64 | head -c 32 > /usr/local/pf/conf/unified_api_system_pass
 
-conf/currently-at: conf/pf-release
-	cat conf/pf-release > conf/currently-at
-
 bin/pfcmd: src/pfcmd.c
 	$(CC) -O2 -g -std=c99  -Wall $< -o $@
 

--- a/addons/dev-helpers/setup-dev-env.sh
+++ b/addons/dev-helpers/setup-dev-env.sh
@@ -19,7 +19,6 @@ cp ../pf-pkg/conf/pf.conf conf/
 cp ../pf-pkg/conf/pfconfig.conf conf/
 # to keep iptables rule for vagrant management
 cp ../pf-pkg/conf/iptables.conf conf/
-make conf/currently-at
 
 log_section "Build docs"
 make html/pfappserver/root/static/doc

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1249,6 +1249,13 @@ description=<<EOT
 Execution timeout for pfperl-api
 EOT
 
+[advanced.configurator]
+type=toggle
+options=enabled|disabled
+description=<<EOT
+Enable the Configurator and the Configurator API
+EOT
+
 [provisioning.autoconfig]
 type=toggle
 options=enabled|disabled

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -909,6 +909,11 @@ statsd_listen_port = 8125
 # Execution timeout for pfperl-api
 pfperl_api_timeout = 600
 
+# advanced.configurator
+#
+# Enable the Configurator and the Configurator API
+configurator = enabled
+
 [provisioning]
 #
 # provisioning.autoconfig

--- a/docs/PacketFence_Clustering_Guide.asciidoc
+++ b/docs/PacketFence_Clustering_Guide.asciidoc
@@ -383,10 +383,6 @@ Now restart PacketFence *on all servers*:
 
   # /usr/local/pf/bin/pfcmd service pf restart
 
-Disable the access to the configurator by setting the `currently-at` file on each server:
-
-  # /usr/local/pf/bin/pfcmd version > /usr/local/pf/conf/currently-at
-
 Next, make sure to join domains through 'Configuration/Policies And Access Control/Domains/Active Directory Domains' on each node.
 
 You should now reboot *each server one by one* waiting for the one you rebooted to come back online before proceeding to the next one. After each reboot, ensure the database sync is fine by performing the checks outlined in "Checking the MariaDB sync".

--- a/docs/PacketFence_Installation_Guide.asciidoc
+++ b/docs/PacketFence_Installation_Guide.asciidoc
@@ -285,8 +285,6 @@ Once all services are started, you will automatically be redirected to the
 PacketFence's web admin interface. It is located at
 https://@ip_of_packetfence:1443/admin. Open that link and log in using the username/password specified in Step 5.
 
-PacketFence's configurator also creates the file `/usr/local/pf/conf/currently-at` to prevent new access to configurator.
-
 Connecting PacketFence to Microsoft Active Directory
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/html/pfappserver/lib/pfappserver/Model/Configurator.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Configurator.pm
@@ -19,17 +19,14 @@ use Readonly;
 use namespace::autoclean;
 
 use pf::log;
-use pf::config;
+use pf::config qw(%Config);
 use pf::file_paths qw($install_dir $conf_dir);
 use pf::error;
 use pf::util;
 use Perl::Version;
+use pf::ConfigStore::Pf;
 
 extends 'Catalyst::Model';
-
-Readonly::Scalar our $CONFIGURATION => 'configuration';
-Readonly::Scalar our $INSTALLATION => 'installation';
-Readonly::Scalar our $UPGRADE => 'upgrade';
 
 =head1 METHODS
 
@@ -54,70 +51,23 @@ sub checkForRootUser {
     return 1;
 }
 
-=item checkForUpgrade
+=item isEnabled
 
 =cut
 
-sub checkForUpgrade {
+sub isEnabled {
     my ( $self ) = @_;
-    my $logger = get_logger();
-
-    my $filehandler;
-
-    if ( !(-e "$install_dir/conf/currently-at") ) {
-        return $INSTALLATION;
-    }
-
-    open( $filehandler, '<', "$install_dir/conf/currently-at" );
-    chomp (my $currently_at = <$filehandler>);
-    close( $filehandler );
-
-    open( $filehandler, '<', "$install_dir/conf/pf-release" );
-    chomp(my $pf_release = <$filehandler>);
-    close( $filehandler );
-    $logger->info("Currently at $currently_at, running release $pf_release");
-
-    if ( (!$currently_at) || ($currently_at eq $pf_release) ) {
-        $logger->info("Configuration process");
-        return $CONFIGURATION;
-    } else {
-        $currently_at =~ s/PacketFence //;
-        $currently_at =~ s/-/_/;
-        $pf_release =~ s/PacketFence //;
-        $pf_release =~ s/-/_/;
-        if ($currently_at =~ Perl::Version::MATCH) {
-            my $current_version = Perl::Version->new($currently_at);
-            my $release_version = Perl::Version->new($pf_release);
-            if($current_version->revision < $release_version->revision || $current_version->version < $release_version->version) {
-                $logger->info("Upgrade process");
-                return $UPGRADE;
-            } else {
-                $logger->info("Minor Change");
-                return $CONFIGURATION;
-            }
-        } else {
-            return $INSTALLATION;
-        }
-    }
+    return isenabled($Config{advanced}{configurator});
 }
 
-=item upate_currently_at
+=item disableConfigurator
 
 =cut
 
-sub update_currently_at {
-    my ( $self ) = @_;
-    my $logger = get_logger();
-
-    open PFRELEASE, '<', "$conf_dir/pf-release";
-    my @pfrelease  = <PFRELEASE>;
-    close PFRELEASE;
-
-    open CURRENTLYAT, '>', "$conf_dir/currently-at";
-    print CURRENTLYAT @pfrelease;
-    close CURRENTLYAT;
-
-    return $STATUS::OK;
+sub disableConfigurator {
+    my $cs = pf::ConfigStore::Pf->new;
+    $cs->update(advanced => {configurator => "disabled"});
+    return $cs->commit();
 }
 
 =back

--- a/html/pfappserver/lib/pfappserver/PacketFence/Controller/Configurator.pm
+++ b/html/pfappserver/lib/pfappserver/PacketFence/Controller/Configurator.pm
@@ -82,8 +82,7 @@ Configurator controller dispatcher
 sub object :Chained('/') :PathPart('configurator') :CaptureArgs(0) {
     my ( $self, $c ) = @_;
 
-    $c->stash->{installation_type} = $c->model('Configurator')->checkForUpgrade();
-    if ($c->stash->{installation_type} eq $pfappserver::Model::Configurator::CONFIGURATION) {
+    if (!$c->model('Configurator')->isEnabled()) {
         my $admin_url = $c->uri_for($c->controller('Admin')->action_for('index'));
         $c->log->info("Redirecting to admin interface $admin_url");
         $c->response->redirect($admin_url);
@@ -510,7 +509,7 @@ sub services :Chained('object') :PathPart('services') :Args(0) {
         } else {
             my ($HTTP_CODE, $services) = $c->model('Services')->status(1);
             if( all { $_->{status} ne '0' } @{ $services->{services} } ) {
-                $c->model('Configurator')->update_currently_at();
+                $c->model('Configurator')->disableConfigurator();
             }
             $c->controller('Service')->_process_model_results_as_json($c, $HTTP_CODE, $services);
         }

--- a/html/pfappserver/lib/pfappserver/PacketFence/Controller/Root.pm
+++ b/html/pfappserver/lib/pfappserver/PacketFence/Controller/Root.pm
@@ -52,15 +52,14 @@ The root page (/)
 
 sub index :Path :Args(0) {
     my ( $self, $c ) = @_;
-    my $installation_type = $c->model('Configurator')->checkForUpgrade();
-    if ($installation_type ne $pfappserver::Model::Configurator::INSTALLATION) {
+    if ($c->model('Configurator')->isEnabled()) {
+        # Redirect to the configurator
+        $c->response->redirect($c->uri_for($c->controller('Configurator')->action_for('index')));
+    } else {
         # Redirect to the admin interface
         my $admin_url = $c->uri_for($c->controller('Admin')->action_for('index'));
         $c->log->info("Redirecting to admin interface $admin_url");
         $c->response->redirect($admin_url);
-    } else {
-        # Redirect to the configurator
-        $c->response->redirect($c->uri_for($c->controller('Configurator')->action_for('index')));
     }
     $c->detach();
 }

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_config/advanced.js
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_config/advanced.js
@@ -61,6 +61,19 @@ export const view = (form = {}, meta = {}) => {
           ]
         },
         {
+          label: i18n.t('Configurator'),
+          text: i18n.t('Enable the Configurator and the Configurator API.'),
+          cols: [
+            {
+              namespace: 'configurator',
+              component: pfFormRangeToggle,
+              attrs: {
+                values: { checked: 'enabled', unchecked: 'disabled' }
+              }
+            }
+          ]
+        },
+        {
           label: i18n.t('CSP headers for Admin'),
           text: i18n.t('(Experimental) Enforce Content-Security-Policy (CSP) HTTP response header in admin interface.'),
           cols: [


### PR DESCRIPTION
Description
===========
Remove the need for the currently_at file

Impacts
=======
The configurator 

NEWS file entries
=======================
Enhancements
-------------
* Showing the configurator is now configurable.

UPGRADE file entries
=======================
The file /usr/local/pf/conf/currently-at is no longer needed it can be removed.
```rm -rf /usr/local/pf/conf/currently-at```