### PR TITLE
Return the portal ip if the fqdn match with one of the portal fqdn

### DIFF
--- a/conf/pfdns.conf.example
+++ b/conf/pfdns.conf.example
@@ -21,6 +21,13 @@ proxy . /etc/resolv.conf
     }
     # Anything not handled by pfdns will be resolved normally
 [% domain %]
+
+    # This configuration will check in the /etc/hosts and if the fqdn match it will return the corresponding ip.
+    # If it doesn't match then it will continue
+    #hosts {
+    #    fallthrough
+    #}
+
 [% inline %]
 
     # Default to system resolv.conf file

--- a/conf/pfdns.conf.example
+++ b/conf/pfdns.conf.example
@@ -24,9 +24,9 @@ proxy . /etc/resolv.conf
 
     # This configuration will check in the /etc/hosts and if the fqdn match it will return the corresponding ip.
     # If it doesn't match then it will continue
-    #hosts {
-    #    fallthrough
-    #}
+    hosts {
+        fallthrough
+    }
 
 [% inline %]
 

--- a/go/coredns/plugin/pfdns/pfdns.go
+++ b/go/coredns/plugin/pfdns/pfdns.go
@@ -289,7 +289,7 @@ func (pf *pfdns) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 					log.LoggerWContext(ctx).Error(fmt.Sprintf("error getting node status %s %s\n", mac, err))
 				}
 				// Defer to the proxy middleware if the device is registered
-				if status == "reg" && !security_event && category != "REJECT" {
+				if status == "reg" && !securityEvent && category != "REJECT" {
 					var found bool
 					found = false
 					for i := 0; i <= len(pf.PortalFQDN); i++ {

--- a/go/coredns/plugin/pfdns/pfdns.go
+++ b/go/coredns/plugin/pfdns/pfdns.go
@@ -289,9 +289,25 @@ func (pf *pfdns) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 					log.LoggerWContext(ctx).Error(fmt.Sprintf("error getting node status %s %s\n", mac, err))
 				}
 				// Defer to the proxy middleware if the device is registered
-				if status == "reg" && !securityEvent && category != "REJECT" {
-					log.LoggerWContext(ctx).Debug(srcIP + " : " + mac + " serve dns " + state.QName())
-					return pf.Next.ServeDNS(ctx, w, r)
+				if status == "reg" && !security_event && category != "REJECT" {
+					var found bool
+					found = false
+					for i := 0; i <= len(pf.PortalFQDN); i++ {
+						if found {
+							break
+						}
+						for c, d := range pf.PortalFQDN[i] {
+							if c.Contains(bIP) {
+								if d.MatchString(state.QName()) {
+									found = true
+								}
+							}
+						}
+					}
+					if !found {
+						log.LoggerWContext(ctx).Debug(srcIP + " : " + mac + " serve dns " + state.QName())
+						return pf.Next.ServeDNS(ctx, w, r)
+					}
 				} else if status == "reg" && category == "REJECT" {
 					rr, _ = dns.NewRR("30 IN A 127.0.0.1")
 					a.Answer = []dns.RR{rr}


### PR DESCRIPTION
# Description
Return the portal ip if the qname match a portal fqdn defined in the configuration. (for inline and reg devices). It help when you do email registration and you need to hit the portal once registered.

# Impacts
pfdns

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* Inline setup, reg device, return the portal ip if the qname match one of the portal fqdn
