### PR TITLE
Vagrant: add an Active Directory server in environment

### DIFF
--- a/addons/vagrant/Vagrantfile
+++ b/addons/vagrant/Vagrantfile
@@ -7,24 +7,18 @@ require 'yaml'
 # Read YAML file with box details
 inventory = YAML.load_file('inventory/hosts')
 
-Vagrant.configure("2") do |pfservers|
+Vagrant.configure("2") do |config|
 
-  ## Global settings for pfservers
+  ## Global settings for config
   # disable synced folders
-  pfservers.vm.synced_folder ".", "/vagrant", disabled: true
+  config.vm.synced_folder ".", "/vagrant", disabled: true
   
   # use same private key on all machines
-  pfservers.ssh.insert_key = false
+  config.ssh.insert_key = false
 
-  # provisionners
-  # Sync timezone with host
-  pfservers.vm.provision "shell", inline: "sudo rm /etc/localtime && sudo ln -s /usr/share/zoneinfo/#{inventory['all']['vars']['tz']} /etc/localtime", run: "always"
-
-  # Allow SSH as root with insecure_private_key
-  pfservers.vm.provision "ssh", type:"shell", inline: "sudo mkdir -p /root/.ssh && sudo cp /home/vagrant/.ssh/authorized_keys /root/.ssh/"
-
-  # Provision with ansible
-  pfservers.vm.provision "ansible" do |ansible|
+  # common Ansible provisionner for all hosts
+  # filtering is done using 'hosts' directive in site.yml
+  config.vm.provision "ansible" do |ansible|
     ansible.playbook = "site.yml"
     ansible.config_file = "ansible.cfg"
     ansible.inventory_path = "inventory"
@@ -33,41 +27,11 @@ Vagrant.configure("2") do |pfservers|
     ansible.verbose = ENV['VAGRANT_ANSIBLE_VERBOSE'] || false
   end
 
-  # Use to run only tasks tagged "install" in site.yml
-  pfservers.vm.provision "config", type:"ansible", run:"never" do |config|
-    config.playbook = "site.yml"
-    config.config_file = "ansible.cfg"
-    config.inventory_path = "inventory"
-    config.tags = "install"
-    # only for debug
-    config.verbose = ENV['VAGRANT_ANSIBLE_VERBOSE'] || false
-  end
-
-  # Use to run only tasks tagged "upgrade" in site.yml
-  pfservers.vm.provision "upgrade", type:"ansible", run:"never" do |config|
-    config.playbook = "site.yml"
-    config.config_file = "ansible.cfg"
-    config.inventory_path = "inventory"
-    config.tags = "upgrade"
-    # only for debug
-    config.verbose = ENV['VAGRANT_ANSIBLE_VERBOSE'] || false
-  end
-
-  pfservers.vm.provision "api_config", type:"ansible", run:"never" do |config|
-    config.playbook = "site.yml"
-    config.config_file = "ansible.cfg"
-    config.inventory_path = "inventory"
-    config.tags = "install"
-    config.start_at_task = "include api_config tasks"
-    # only for debug
-    config.verbose = ENV['VAGRANT_ANSIBLE_VERBOSE'] || false
-  end
-
   # loop on **all** host(s) in pfservers group in inventory to create VM(s)
   inventory['all']['children']['pfservers']['children'].each do |groups, hosts|
     hosts['hosts'].each do |server, details|
       # don't start automatically virtual machines
-      pfservers.vm.define server, autostart: false do |srv|
+      config.vm.define server, autostart: false do |srv|
         srv.vm.box = details['box']
         srv.vm.hostname = server
 
@@ -96,19 +60,54 @@ Vagrant.configure("2") do |pfservers|
           v.cpus = details['cpus']
           v.memory = details['memory']
         end
+
+        # provisionners
+        # Sync timezone with host
+        srv.vm.provision "shell", inline: "sudo rm /etc/localtime && sudo ln -s /usr/share/zoneinfo/#{inventory['all']['vars']['tz']} /etc/localtime", run: "always"
+
+        # Allow SSH as root with insecure_private_key
+        srv.vm.provision "ssh", type:"shell", inline: "sudo mkdir -p /root/.ssh && sudo cp /home/vagrant/.ssh/authorized_keys /root/.ssh/"
+
+        # Use to run only tasks tagged "install" in site.yml
+        srv.vm.provision "config", type:"ansible", run:"never" do |config|
+          config.playbook = "site.yml"
+          config.config_file = "ansible.cfg"
+          config.inventory_path = "inventory"
+          config.tags = "install"
+          # only for debug
+          config.verbose = ENV['VAGRANT_ANSIBLE_VERBOSE'] || false
+        end
+
+        # Use to run only tasks tagged "upgrade" in site.yml
+        srv.vm.provision "upgrade", type:"ansible", run:"never" do |config|
+          config.playbook = "site.yml"
+          config.config_file = "ansible.cfg"
+          config.inventory_path = "inventory"
+          config.tags = "upgrade"
+          # only for debug
+          config.verbose = ENV['VAGRANT_ANSIBLE_VERBOSE'] || false
+        end
+
+        srv.vm.provision "api_config", type:"ansible", run:"never" do |config|
+          config.playbook = "site.yml"
+          config.config_file = "ansible.cfg"
+          config.inventory_path = "inventory"
+          config.tags = "install"
+          config.start_at_task = "include api_config tasks"
+          # only for debug
+          config.verbose = ENV['VAGRANT_ANSIBLE_VERBOSE'] || false
+        end
       end
     end
   end
+  # loop on all pfservers in *dev* group in inventory
   inventory['all']['children']['pfservers']['children']['dev']['hosts'].each do |server,details|
-    pfservers.vm.define server do |srv|
+    config.vm.define server do |srv|
       # we mount test dir and local repo in VM
       # override to avoid issue with symlink without referent
       # see https://github.com/hashicorp/vagrant/issues/5471
       srv.vm.synced_folder "../../t", "/src/t", type: "rsync", rsync__args: ["--verbose", "--archive", "--delete", "-z"]
       srv.vm.synced_folder "../../public", "/src/public", type: "rsync", rsync__args: ["--verbose", "--archive", "--delete", "-z"]
-
-      # provisioner for dev machines
-      #srv.vm.provision "setup-dev-env", type: "shell", path: "../dev-helpers/setup-dev-env.sh"
 
       # reset communicator to make /etc/environment variables available for next scripts
       srv.vm.provision "reset", type: "shell" do |config|
@@ -121,6 +120,31 @@ Vagrant.configure("2") do |pfservers|
           PERL_UNIT_TESTS: ENV['PERL_UNIT_TESTS'] || "yes",
           GOLANG_UNIT_TESTS: ENV['GOLANG_UNIT_TESTS'] || "yes"
         }
+      end
+    end
+  end
+
+  inventory['all']['children']['winservers']['hosts'].each do |server,details|
+    config.vm.define server do |srv|
+      srv.vm.box = details['box']
+      srv.vm.hostname = server
+
+      # mgmt
+      # libvirt__forward_mode: "route" mean:
+      # Allow inbound, but only to our expected subnet. Allow outbound, but
+      # only from our expected subnet. Allow traffic between guests. Deny
+      # all other inbound. Deny all other outbound.
+      srv.vm.network "private_network", ip: details['mgmt_ip'], netmask: details['mgmt_netmask'], libvirt__dhcp_enabled: false, libvirt__forward_mode: "route"
+
+      srv.vm.provider "libvirt" do |v|
+        v.random_hostname = true
+        v.cpus = details['cpus']
+        v.memory = details['memory']
+      end
+
+      srv.vm.provider "virtualbox" do |v|
+        v.cpus = details['cpus']
+        v.memory = details['memory']
       end
     end
   end

--- a/addons/vagrant/Vagrantfile
+++ b/addons/vagrant/Vagrantfile
@@ -125,7 +125,7 @@ Vagrant.configure("2") do |config|
   end
 
   inventory['all']['children']['winservers']['hosts'].each do |server,details|
-    config.vm.define server do |srv|
+    config.vm.define server, autostart: false do |srv|
       srv.vm.box = details['box']
       srv.vm.hostname = server
 

--- a/addons/vagrant/inventory/group_vars/all/common.yml
+++ b/addons/vagrant/inventory/group_vars/all/common.yml
@@ -1,0 +1,3 @@
+---
+# common variables to be available for all VM and also for Venom
+dns_domain: 'example.lan'

--- a/addons/vagrant/inventory/group_vars/stable_and_nightly/packetfence_install__api_calls.yml
+++ b/addons/vagrant/inventory/group_vars/stable_and_nightly/packetfence_install__api_calls.yml
@@ -3,7 +3,7 @@ packetfence_install__config_base_guests_admin_registration:
   access_duration_choices: '10m,20m'
 packetfence_install__config_base_general:
   hostname: pf
-  domain: example.lan
+  domain: '{{ dns_domain }}'
   dhcpservers: 10.0.0.1,192.168.122.1
   timezone: "{{ ansible_date_time['tz'] }}"
 packetfence_install__config_base_alerting:

--- a/addons/vagrant/inventory/group_vars/winservers/ansible.yml
+++ b/addons/vagrant/inventory/group_vars/winservers/ansible.yml
@@ -4,4 +4,6 @@ ansible_password: vagrant
 ansible_connection: winrm
 ansible_port: 5986
 ansible_winrm_transport: basic
+# require pywinrm > 0.3.0 to be take into account by Vagrant
+# see https://github.com/hashicorp/vagrant/issues/10444
 ansible_winrm_server_cert_validation: ignore

--- a/addons/vagrant/inventory/group_vars/winservers/ansible.yml
+++ b/addons/vagrant/inventory/group_vars/winservers/ansible.yml
@@ -1,0 +1,7 @@
+---
+ansible_user: vagrant
+ansible_password: vagrant
+ansible_connection: winrm
+ansible_port: 5986
+ansible_winrm_transport: basic
+ansible_winrm_server_cert_validation: ignore

--- a/addons/vagrant/inventory/group_vars/winservers/domain_account.yml
+++ b/addons/vagrant/inventory/group_vars/winservers/domain_account.yml
@@ -1,0 +1,5 @@
+---
+packetfence_domain_account: 'packetfence'
+
+# be careful with password restrictions
+packetfence_domain_password: 'P@ck3tF3nc3pass'

--- a/addons/vagrant/inventory/group_vars/winservers/domain_account.yml
+++ b/addons/vagrant/inventory/group_vars/winservers/domain_account.yml
@@ -1,5 +1,6 @@
 ---
 packetfence_domain_account: 'packetfence'
+packetfence_domain_email: 'packetfence@{{ domain_setup__domain_name }}'
 
 # be careful with password restrictions
 packetfence_domain_password: 'P@ck3tF3nc3pass'

--- a/addons/vagrant/inventory/group_vars/winservers/domain_setup.yml
+++ b/addons/vagrant/inventory/group_vars/winservers/domain_setup.yml
@@ -1,0 +1,5 @@
+---
+domain_setup_domain_name: '{{ dns_domain }}'
+domain_setup_safe_mode_password: VagrantPass1
+domain_setup_username: vagrant-domain
+domain_setup_password: VagrantPass1

--- a/addons/vagrant/inventory/group_vars/winservers/domain_setup.yml
+++ b/addons/vagrant/inventory/group_vars/winservers/domain_setup.yml
@@ -1,5 +1,5 @@
 ---
-domain_setup_domain_name: '{{ dns_domain }}'
-domain_setup_safe_mode_password: VagrantPass1
-domain_setup_username: vagrant-domain
-domain_setup_password: VagrantPass1
+domain_setup__domain_name: '{{ dns_domain }}'
+domain_setup__safe_mode_password: VagrantPass1
+domain_setup__username: vagrant-domain
+domain_setup__password: VagrantPass1

--- a/addons/vagrant/inventory/hosts
+++ b/addons/vagrant/inventory/hosts
@@ -4,6 +4,15 @@
 # also use as a Ansible inventory file to provision VMs
 all:
   children:
+    winservers:
+      hosts:
+        ad:
+          box: jborean93/WindowsServer2016
+          mgmt_ip: 172.17.1.100
+          mgmt_netmask: 255.255.255.0
+          ansible_host:  "{{ mgmt_ip }}"
+          cpus: 1
+          memory: 2048
     stable_and_nightly:
       children:
         stable:
@@ -160,5 +169,6 @@ all:
               ansible_host: "{{ mgmt_ip }}"
               cpus: 1
               memory: 8192
+
   vars:
     tz: Etc/UTC

--- a/addons/vagrant/requirements.yml
+++ b/addons/vagrant/requirements.yml
@@ -6,5 +6,5 @@ roles:
 collections:
   - name: inverse_inc.packetfence
   - name: debops.debops
-#  - name: inverse_inc.windows
+  - name: inverse_inc.windows
 

--- a/addons/vagrant/requirements.yml
+++ b/addons/vagrant/requirements.yml
@@ -6,4 +6,5 @@ roles:
 collections:
   - name: inverse_inc.packetfence
   - name: debops.debops
+#  - name: inverse_inc.windows
 

--- a/addons/vagrant/site.yml
+++ b/addons/vagrant/site.yml
@@ -71,3 +71,4 @@
     - role: packetfence_go
       tags: go
 
+- import_playbook: winservers.yml

--- a/addons/vagrant/winservers.yml
+++ b/addons/vagrant/winservers.yml
@@ -27,8 +27,8 @@
 - name: create Domain Controller and set AD CS
   hosts: ad
   gather_facts: no
-  # collections:
-  #   - inverse_inc.windows
+  collections:
+    - inverse_inc.windows
 
   roles:
 

--- a/addons/vagrant/winservers.yml
+++ b/addons/vagrant/winservers.yml
@@ -1,0 +1,47 @@
+---
+# This playbook comes from https://github.com/jborean93/ansible-windows
+- name: get network adapter information for each host
+  hosts: winservers
+  gather_facts: no
+
+  tasks:
+  - name: make absolutely sure the connection is active
+    wait_for_connection:
+
+  - name: get network connection name for private adapter
+    win_shell: |
+      foreach ($instance in (Get-CimInstance -ClassName Win32_NetworkAdapter -Filter "Netenabled='True'")) {
+          $instance_config = Get-CimInstance -ClassName WIn32_NetworkAdapterConfiguration -Filter "Index = '$($instance.Index)'"
+          if ($instance_config.IPAddress -contains "{{ ansible_host }}") {
+              $instance.NetConnectionID
+          }
+      }
+    changed_when: false
+    register: network_connection_name_register
+
+  - name: "fail if we didn't get a network connection name"
+    fail:
+      msg: Failed to get the network connection name
+    when: network_connection_name_register.stdout_lines|count != 1
+
+- name: create Domain Controller and set AD CS
+  hosts: ad
+  gather_facts: no
+  # collections:
+  #   - inverse_inc.windows
+
+  roles:
+
+  - name: domain_setup
+    vars:
+      domain_setup__network_name: '{{ network_connection_name_register.stdout_lines[0] }}'
+
+  - name: adcs_enrollment
+
+  post_tasks:
+  - name: create local file based on the certificate chain PEM content
+    copy:
+      content: '{{ out_adcs_enrollment_chain_thumbprint }}'
+      dest: ca_chain.pem
+    delegate_to: localhost
+    run_once: yes    

--- a/addons/vagrant/winservers.yml
+++ b/addons/vagrant/winservers.yml
@@ -58,6 +58,7 @@
       description: 'packetfence Domain Users Account'
       password: '{{ packetfence_domain_password }}'
       password_never_expires: yes
+      email: '{{ packetfence_domain_email }}'
       groups:
         - Domain Users
       state: present

--- a/addons/vagrant/winservers.yml
+++ b/addons/vagrant/winservers.yml
@@ -45,3 +45,19 @@
       dest: ca_chain.pem
     delegate_to: localhost
     run_once: yes    
+
+- name: Create a domain user account
+  hosts: ad
+  gather_facts: no
+
+  tasks:
+  - name: Create a packetfence domain account
+    win_domain_user:
+      name: '{{ packetfence_domain_account }}'
+      upn: '{{ packetfence_domain_account }}@{{ domain_setup__domain_name }}'
+      description: 'packetfence Domain Users Account'
+      password: '{{ packetfence_domain_password }}'
+      password_never_expires: yes
+      groups:
+        - Domain Users
+      state: present

--- a/docs/PacketFence_Developers_Guide.asciidoc
+++ b/docs/PacketFence_Developers_Guide.asciidoc
@@ -1081,6 +1081,7 @@ Install following softwares:
 * link:https://www.vagrantup.com/docs/installation/[Vagrant] (>= 1.9.3)
 * Virtualbox if you wan to use Virtualbox as a provider for Vagrant
 * libvirt, KVM/QEMU and vagrant-libvirt if you want to use libvirt as a provider for Vagrant
+* pywinrm > 0.3.0 if you want to use Windows virtual machine
 
 ==== Virtual environment: initial setup
 
@@ -1178,6 +1179,32 @@ packetfence_install__centos_packages:
 EOF
 ansible-playbook site.yml --limit VM_NAME -e @extra.yml
 ----
+
+=== Running virtual machines other than PF
+
+==== Active directory server
+
+You can start a virtual machine called `ad` by running: [command]`vagrant up
+ad`. This virtual machine will be auto-provision with:
+
+* a DNS domain
+* an Active Directory domain
+* AD CS services with auto-enrollment using a GPO
+* a packetfence account
+
+.Vagrant admin accounts:
+[source,yaml]
+----
+include::../addons/vagrant/inventory/group_vars/winservers/domain_setup.yml[]
+----
+
+.PacketFence domain account:
+[source,yaml]
+----
+include::../addons/vagrant/inventory/group_vars/winservers/domain_account.yml[]
+----
+
+
 
 == Running tests
 

--- a/docs/PacketFence_Developers_Guide.asciidoc
+++ b/docs/PacketFence_Developers_Guide.asciidoc
@@ -1184,8 +1184,7 @@ ansible-playbook site.yml --limit VM_NAME -e @extra.yml
 
 ==== Active directory server
 
-You can start a virtual machine called `ad` by running: [command]`vagrant up
-ad`. This virtual machine will be auto-provision with:
+You can start a virtual machine called `ad` by running: [command]`vagrant up ad`. This virtual machine will be auto-provision with:
 
 * a DNS domain
 * an Active Directory domain


### PR DESCRIPTION
# Description
Provision an AD server with:
- a domain
- a DNS server
- AD CS services with auto-enrollment
- a packetfence domain account

# Impacts
CI tests

# Delete branch after merge
YES

# Checklist
- [x] Document the feature