### PR TITLE
[pkg] don't start packetfence-httpd.admin at end of install in CI env

### DIFF
--- a/debian/packetfence.postinst
+++ b/debian/packetfence.postinst
@@ -153,8 +153,13 @@ case "$1" in
         set +e
         /usr/local/pf/bin/pfcmd configreload
         /usr/local/pf/bin/pfcmd fixpermissions
-        set -e
-        /bin/systemctl start packetfence-httpd.admin
+        if [ -n "$CI" ]; then
+            echo "CI environment, not starting PacketFence Administration GUI with default config to save ressources"
+        else
+            echo "Starting PacketFence Administration GUI..."
+            set -e
+            /bin/systemctl start packetfence-httpd.admin
+        fi
         systemctl enable packetfence-iptables
         /usr/local/pf/bin/pfcmd service pf updatesystemd
         # On new stretch install this should work but not on upgrade

--- a/debian/packetfence.postinst
+++ b/debian/packetfence.postinst
@@ -124,7 +124,6 @@ case "$1" in
         sysctl -p /etc/sysctl.d/99-ip_forward.conf
  
         #Starting PacketFence.
-        echo "Starting PacketFence Administration GUI..."
         #removing old cache
         rm -rf /usr/local/pf/var/cache/
         # Start packetfence web administration
@@ -157,7 +156,6 @@ case "$1" in
             echo "CI environment, not starting PacketFence Administration GUI with default config to save ressources"
         else
             echo "Starting PacketFence Administration GUI..."
-            set -e
             /bin/systemctl start packetfence-httpd.admin
         fi
         systemctl enable packetfence-iptables

--- a/rpm/packetfence.spec
+++ b/rpm/packetfence.spec
@@ -694,7 +694,6 @@ sysctl -p /etc/sysctl.d/99-ip_forward.conf
 /bin/systemctl daemon-reload
 
 #Starting PacketFence.
-echo "Starting PacketFence Administration GUI..."
 #removing old cache
 rm -rf /usr/local/pf/var/cache/
 /usr/bin/firewall-cmd --zone=public --add-port=1443/tcp
@@ -708,8 +707,12 @@ rm -rf /usr/local/pf/var/cache/
 /bin/systemctl enable packetfence-iptables
 /bin/systemctl enable packetfence-tracking-config.path
 /usr/local/pf/bin/pfcmd configreload
-/bin/systemctl restart packetfence-httpd.admin
-
+if [ -n "$CI" ]; then
+    echo "CI environment, not starting PacketFence Administration GUI with default config to save ressources"
+else
+    echo "Starting PacketFence Administration GUI..."
+    /bin/systemctl restart packetfence-httpd.admin
+fi
 
 
 echo Installation complete


### PR DESCRIPTION
# Description
Don't start automatically `packetfence-httpd.admin` service at end of package installation in a CI environment.

The idea is to start `packetfence-httpd.admin` later (during Ansible provisioning) with limited ressources to avoid consuming a lot of RAM when several virtual machines are running during integration tests.

# Impacts
RPM and DEB package installations.

# Delete branch after merge
YES
