### PR TITLE
Fix/honor timezone on the os

### DIFF
--- a/lib/pfconfig/namespaces/config/Pf.pm
+++ b/lib/pfconfig/namespaces/config/Pf.pm
@@ -165,8 +165,21 @@ sub build_child {
         $logger->info("No timezone defined, using $tz");
         $Config{general}{timezone} = $tz;
     }
+    set_timezone($Config{general}{timezone});
 
     return \%Config;
+}
+
+sub set_timezone {
+    my ($tz) = @_;
+    my $lt = readlink("/etc/localtime"); 
+    $lt =~ s/..\/usr\/share\/zoneinfo\///g;
+    if($lt ne $tz) {
+        my $msg = "WARNING: The timezone is being changed from $lt to $tz on the system. It is advised to reboot the server so that all services start with the correct timezone.\n";
+        print STDERR $msg;
+        get_logger->warn($msg);
+        system("sudo timedatectl set-timezone $tz") && die "Unable to set timezone on the system \n";
+    }
 }
 
 =head1 AUTHOR

--- a/lib/pfconfig/namespaces/config/Pf.pm
+++ b/lib/pfconfig/namespaces/config/Pf.pm
@@ -160,12 +160,14 @@ sub build_child {
         $Config{alerting}{smtp_port} = $ALERTING_PORTS{$Config{alerting}{smtp_encryption}} // $DEFAULT_SMTP_PORT;
     }
 
-    unless ($Config{general}{timezone}) {
+    if ($Config{general}{timezone}) {
+        set_timezone($Config{general}{timezone});
+    }
+    else {
         my $tz = DateTime::TimeZone->new(name => 'local')->name();
         $logger->info("No timezone defined, using $tz");
         $Config{general}{timezone} = $tz;
     }
-    set_timezone($Config{general}{timezone});
 
     return \%Config;
 }

--- a/packetfence.sudoers
+++ b/packetfence.sudoers
@@ -1,4 +1,4 @@
-pf ALL=NOPASSWD: /sbin/iptables, /usr/sbin/ipset, /sbin/ipset, /sbin/ip, /sbin/vconfig, /sbin/route, /usr/bin/systemctl, /usr/bin/tee, /usr/local/pf/sbin/pfdhcplistener, /bin/kill, /usr/sbin/radiusd, /usr/sbin/snort, /usr/bin/suricata, /usr/sbin/chroot, /usr/local/pf/bin/pfcmd, /usr/sbin/conntrack, /usr/sbin/tc
+pf ALL=NOPASSWD: /sbin/iptables, /usr/sbin/ipset, /sbin/ipset, /sbin/ip, /sbin/vconfig, /sbin/route, /usr/bin/systemctl, /usr/bin/tee, /usr/local/pf/sbin/pfdhcplistener, /bin/kill, /usr/sbin/radiusd, /usr/sbin/snort, /usr/bin/suricata, /usr/sbin/chroot, /usr/local/pf/bin/pfcmd, /usr/sbin/conntrack, /usr/sbin/tc, /usr/bin/timedatectl
 Defaults !requiretty
 # Do not log commands that starts by '/sbin/ip netns exec'
 # i.e. net ads join, testjoin and leave


### PR DESCRIPTION
# Description
Honor the timezone in pf.conf on the operating system to be consistent.

# Impacts
All services using the timezone on the system so I'd say everything.

# Issue
fixes #5205 

# Delete branch after merge

# NEWS file entries
## Bug Fixes
* Issue with the timezone in the admin not being honored on the system (#5205)

# UPGRADE file entries

The timezone set in pf.conf will be set on the operating system every time PacketFence reloads its configuration. For this reason, you should review the timezone setting in the general section of pf.conf (System Configuration -> General Configuration in the admin). If its empty, PacketFence will use the timezone that is already set on the server and you don't have anything to do. Otherwise, it will set the timezone in this setting on the operating system layer for consistency which may modify the timezone setting of your operating system. In this case you should ensure that you reboot the server after completing all the steps of the upgrade so that the services start with the right timezone.