### PR TITLE
Do not ignore 'PID field' from Authentication::Password

### DIFF
--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/Login.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/Login.pm
@@ -123,6 +123,7 @@ Authenticate the POSTed username and password
 sub authenticate {
     my ($self, $user) = @_;
     my $username = $user || $self->request_fields->{$self->pid_field};
+    my $pid = $self->request_fields->{$self->pid_field} || $username;
     my $password = $self->request_fields->{password};
 
     my ($stripped_username, $realm) = strip_username($username);
@@ -231,6 +232,7 @@ sub authenticate {
         }
     }
 
+    $self->username($pid);
     pf::lookup::person::async_lookup_person($username,$self->source->id,$pf::constants::realm::PORTAL_CONTEXT);
     $self->update_person_from_fields();
     $self->done();


### PR DESCRIPTION
Authentication::Password does askes for non-required PID field.
Even when provided, it was ignored by Authentication::Login.

If 'PID field' is missing, it will use username as usual.

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>