### PR TITLE
[RFC] Add new POTD portal auth module (WIP)

### DIFF
--- a/html/captive-portal/lib/captiveportal/DynamicRouting/Module/Authentication/POTD.pm
+++ b/html/captive-portal/lib/captiveportal/DynamicRouting/Module/Authentication/POTD.pm
@@ -1,0 +1,45 @@
+package captiveportal::DynamicRouting::Module::Authentication::POTD;
+use Moose;
+
+BEGIN { extends 'captiveportal::PacketFence::DynamicRouting::Module::Authentication::POTD'; }
+
+=head1 NAME
+
+captiveportal::DynamicRouting::Module::Authentication::POTD - Login Controller with a predifined username for captiveportal
+
+=head1 DESCRIPTION
+
+[enter your description here]
+
+=cut
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2019 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+__PACKAGE__->meta->make_immutable unless $ENV{"PF_SKIP_MAKE_IMMUTABLE"};
+
+1;

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/Login.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/Login.pm
@@ -123,6 +123,7 @@ Authenticate the POSTed username and password
 sub authenticate {
     my ($self, $user) = @_;
     my $username = $user || $self->request_fields->{$self->pid_field};
+    my $pid = $self->request_fields->{$self->pid_field} || $username;
     my $password = $self->request_fields->{password};
 
     my ($stripped_username, $realm) = strip_username($username);
@@ -231,6 +232,7 @@ sub authenticate {
         }
     }
 
+    $self->username($pid);
     pf::lookup::person::async_lookup_person($username,$self->source->id,$pf::constants::realm::PORTAL_CONTEXT);
     $self->update_person_from_fields();
     $self->done();

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/POTD.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/POTD.pm
@@ -1,0 +1,92 @@
+package captiveportal::PacketFence::DynamicRouting::Module::Authentication::POTD;
+
+=head1 NAME
+
+captiveportal::DynamicRouting::Module::Authentication::POTD
+
+=head1 DESCRIPTION
+
+Login Controller with a predefined username for captiveportal
+
+=cut
+
+use Moose;
+extends 'captiveportal::DynamicRouting::Module::Authentication::Login';
+with 'captiveportal::Role::FieldValidation';
+with 'captiveportal::Role::MultiSource';
+
+has '+username' => (is => 'rw');
+
+=head2 _build_required_fields
+
+Build the required fields based on the PID field, the custom fields and the mandatory fields of the source
+
+=cut
+
+#sub _build_required_fields {
+#    my ($self) = @_;
+#    my @fields = ((grep {$_ ne 'username' && $_ ne 'password' } @{$self->SUPER::_build_required_fields()}), "password");
+#
+#    return \@fields;
+#}
+
+=head2 execute_child
+
+Execute this module
+
+=cut
+
+sub execute_child {
+    my ($self) = @_;
+    if($self->app->request->method eq "POST"){
+        if($self->app->request->path eq "challenge") {
+            if( defined $self->challenge_data){
+                $self->challenge();
+            }
+            else {
+                $self->prompt_fields();
+            }
+        } else {
+            $self->authenticate($self->request_fields->{username});
+        }
+    }
+    else {
+        if( defined $self->challenge_data){
+            $self->display_challenge();
+        }
+        else {
+            $self->prompt_fields();
+        }
+    }
+};
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2019 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+__PACKAGE__->meta->make_immutable unless $ENV{"PF_SKIP_MAKE_IMMUTABLE"};
+
+1;

--- a/html/pfappserver/lib/pfappserver/Form/Config/PortalModule/Authentication/POTD.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/PortalModule/Authentication/POTD.pm
@@ -1,0 +1,70 @@
+package pfappserver::Form::Config::PortalModule::Authentication::POTD;
+
+=head1 NAME
+
+pfappserver::Form::Config::PortalModule::Authentcation::POTD
+
+=head1 DESCRIPTION
+
+Form definition to create or update an authentication portal module.
+
+=cut
+
+use HTML::FormHandler::Moose;
+extends 'pfappserver::Form::Config::PortalModule::Authentication';
+with 'pfappserver::Base::Form::Role::Help';
+
+use captiveportal::DynamicRouting::Module::Authentication::POTD;
+sub for_module {'captiveportal::PacketFence::DynamicRouting::Module::Authentication::POTD'}
+
+## Definition
+
+has_field 'username' =>
+  (
+   type => 'Text',
+   label => 'Username',
+   required => 1,
+   tags => { after_element => \&help,
+             help => 'Defines the username used for all authentications' },
+  );
+
+=head2 auth_module_definition
+
+Overriding to remove the username
+
+=cut
+
+sub auth_module_definition {
+    my ($self) = @_;
+    return (qw(username));
+}
+
+=over
+
+=back
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2019 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+__PACKAGE__->meta->make_immutable unless $ENV{"PF_SKIP_MAKE_IMMUTABLE"};
+1;

--- a/lib/pf/UnifiedApi/Controller/Config/PortalModules.pm
+++ b/lib/pf/UnifiedApi/Controller/Config/PortalModules.pm
@@ -41,6 +41,7 @@ use pfappserver::Form::Config::PortalModule::Authentication::Email;
 use pfappserver::Form::Config::PortalModule::Authentication::Login;
 use pfappserver::Form::Config::PortalModule::Authentication::Null;
 use pfappserver::Form::Config::PortalModule::Authentication::OAuth;
+use pfappserver::Form::Config::PortalModule::Authentication::POTD;
 use pfappserver::Form::Config::PortalModule::Authentication::Password;
 use pfappserver::Form::Config::PortalModule::Authentication::SAML;
 use pfappserver::Form::Config::PortalModule::Authentication::SMS;
@@ -76,6 +77,7 @@ our %TYPES_TO_FORMS = (
         Authentication::Login
         Authentication::Null
         Authentication::OAuth
+        Authentication::POTD
         Authentication::Password
         Authentication::SAML
         Authentication::SMS


### PR DESCRIPTION
It's a copy of Authentication::Password but without a fixed
username (it uses the one provided by the user just like
Authentication::Login). The difference is that PID and username
are treated independently. Username is only considered for
authentication while PID is used to actually create the user
in DB.

It depends on #5208 
Does it fix #3762?

The web module configuration is not working. It is still not listing the new module. I can use it manually changing conf/portal_modules.conf. However, it gives me a blank form when I edit it.
I need some help here. I also still need to remove username string field.

Maybe it should not be Authentication::POTD but something like Authentication::AltUser. However, it does not make sense to have a POTD != username when the user has its own password. I'll wait for comments.