### PR TITLE
Disable secure redirect on self signed certificate

### DIFF
--- a/lib/pfconfig/namespaces/config/Pf.pm
+++ b/lib/pfconfig/namespaces/config/Pf.pm
@@ -183,7 +183,7 @@ sub build_child {
 
     if (isenabled($Config{'captive_portal'}{'secure_redirect'}) && isSelfSigned()) {
         $Config{'captive_portal'}{'secure_redirect'} = 'disabled';
-        get_logger->warn("secure redirect has been disabled since the portal certificate is a self-signed");
+        get_logger->info("secure redirect has been disabled since the portal certificate is a self-signed");
     }
 
     return \%Config;

--- a/lib/pfconfig/namespaces/config/Pf.pm
+++ b/lib/pfconfig/namespaces/config/Pf.pm
@@ -26,11 +26,14 @@ use pf::file_paths qw(
     $pf_default_file
     $pf_config_file
     $log_dir
+    $server_pem
 );
 use pf::util;
 use pf::constants::config qw($DEFAULT_SMTP_PORT $DEFAULT_SMTP_PORT_SSL $DEFAULT_SMTP_PORT_TLS %ALERTING_PORTS);
+use pf::constants qw($TRUE $FALSE);
 use List::MoreUtils qw(uniq any);
 use DateTime::TimeZone;
+use Crypt::OpenSSL::X509;
 
 use base 'pfconfig::namespaces::config';
 
@@ -177,6 +180,11 @@ sub build_child {
         port     => $webservices->{'port'},
     };
 
+
+    if (isenabled($Config{'captive_portal'}{'secure_redirect'}) && selfSigned()) {
+        $Config{'captive_portal'}{'secure_redirect'} = 'disabled';
+    }
+
     return \%Config;
 }
 
@@ -190,6 +198,26 @@ sub set_timezone {
         get_logger->warn($msg);
         system("sudo timedatectl set-timezone $tz") && die "Unable to set timezone on the system \n";
     }
+}
+
+sub selfSigned {
+    open (my $BUNDLE, '<', $server_pem);
+
+    my $pemcert = "";
+
+    while (my $row = <$BUNDLE>) {
+        $pemcert .= $row;
+        if($row =~ /^\-+END(\s\w+)?\sCERTIFICATE\-+$/) {
+            my $cert = Crypt::OpenSSL::X509->new_from_string($pemcert);
+            my $self_signed = $cert->is_selfsigned;
+            if ($self_signed) {
+                return $TRUE;
+            }
+            $pemcert = "";
+        }
+    }
+    close $BUNDLE;
+    return $FALSE;
 }
 
 =head1 AUTHOR

--- a/lib/pfconfig/namespaces/config/Pf.pm
+++ b/lib/pfconfig/namespaces/config/Pf.pm
@@ -211,6 +211,7 @@ sub selfSigned {
             my $cert = Crypt::OpenSSL::X509->new_from_string($pemcert);
             my $self_signed = $cert->is_selfsigned;
             if ($self_signed) {
+                close $BUNDLE;
                 return $TRUE;
             }
             $pemcert = "";


### PR DESCRIPTION
# Description
DIsable secure redirect if the portal certificate is self signed.

# Impacts
Portal

# Issue
fixes #5233

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Bug Fixes
* Issue with chrome who don't show the portal on self signed certificate (#5233)
