### PR TITLE
allow to use existing ip4log entries in web-auth

### DIFF
--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1270,6 +1270,13 @@ description=<<EOT
 Use the information included in the accounting to update the iplog
 EOT
 
+[advanced.update_iplog_with_external_portal_requests]
+type=toggle
+options=enabled|disabled
+description=<<EOT
+Use the information included in the external portal requests to update the iplog
+EOT
+
 [advanced.locationlog_close_on_accounting_stop]
 type=toggle
 options=enabled|disabled

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -918,6 +918,11 @@ pfperl_api_processes=8
 # Use the information included in the accounting to update the iplog
 update_iplog_with_accounting=disabled
 #
+# advanced.update_iplog_with_external_portal_requests
+#
+# Use the information included in the accounting to update the iplog
+update_iplog_with_external_portal_requests=enabled
+#
 # advanced.locationlog_close_on_accounting_stop
 #
 # Close the locationlog for a node on accounting stop

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_config/advanced.js
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_config/advanced.js
@@ -256,6 +256,19 @@ export const view = (form = {}, meta = {}) => {
           ]
         },
         {
+          label: i18n.t('Update the iplog using the external portal requests'),
+          text: i18n.t('Use the information included in the external portal requests to update the iplog.'),
+          cols: [
+            {
+              namespace: 'update_iplog_with_external_portal_requests',
+              component: pfFormRangeToggle,
+              attrs: {
+                values: { checked: 'enabled', unchecked: 'disabled' }
+              }
+            }
+          ]
+        },
+        {
           label: i18n.t('Close locationlog on accounting stop'),
           text: i18n.t('Close the locationlog for a node on accounting stop.'),
           cols: [

--- a/lib/pf/web/externalportal.pm
+++ b/lib/pf/web/externalportal.pm
@@ -24,6 +24,7 @@ use Hash::Merge qw(merge);
 use UNIVERSAL::require;
 
 use pf::config qw(
+    %Config
     $WEBAUTH
 );
 use pf::ip4log;
@@ -164,7 +165,12 @@ sub handle {
 
     $switch->setCurrentTenant();
 
-    pf::ip4log::open($params{'client_ip'}, $params{'client_mac'}, 3600);
+    if(isenabled($Config{advanced}{update_iplog_with_external_portal_requests})) {
+        pf::ip4log::open($params{'client_ip'}, $params{'client_mac'}, 3600);
+    }
+    else {
+        $params{client_ip} = pf::ip4log::mac2ip($params{client_mac});
+    }
 
     # Updating locationlog if required
     $switch->synchronize_locationlog("0", "0", $params{'client_mac'}, 0, $params{'connection_type'}, undef, $params{'client_mac'}, $params{'ssid'}) if ( $params{'synchronize_locationlog'} );


### PR DESCRIPTION
# Description
Allows to disable the mechanism that creates an ip4log entry from a web-auth request and instead uses the data that is already in the ip4log. This way ip4log data from DHCP and accounting can have precedence over the data set by the web-auth request parsing

# Impacts
Web-auth

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
## Enhancements
* Added parameter to prevent external portal requests from updating the ip4log
