### PR TITLE
CI: deploy RPM an Deb packages to dedicated repository (branches)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -522,12 +522,20 @@ deploy_rpm_packetfence-release_release:
   variables:
     PKG_DEST_NAME: packetfence-release-7.stable.noarch.rpm
 
-deploy_deb_dev:
+deploy_deb_devel:
   extends:
     - .deploy_deb_job
-    - .job_dev_triggers
+    - .job_devel_only_triggers
   environment:
     name: debian-devel
+    url: ${PUBLIC_REPO_URL}/${CI_ENVIRONMENT_NAME}
+
+deploy_deb_branches:
+  extends:
+    - .deploy_deb_job
+    - .job_branches_only_triggers
+  environment:
+    name: debian-branches
     url: ${PUBLIC_REPO_URL}/${CI_ENVIRONMENT_NAME}
 
 deploy_deb_release:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -99,6 +99,24 @@ variables:
   only:
     - schedules
 
+.job_devel_only_triggers:
+  # run jobs on "devel" branch (push, schedules and web)
+  only:
+    - /^devel$/
+
+.job_branches_only_triggers:
+  # run jobs on any branches/tags only via "Run pipeline", except:
+  # - devel branch
+  # - vX.Y.Z tag
+  # - maintenance/X.Y branches
+  # - feature/packer-.* branches
+  only:
+    - web
+  except:
+    - /^devel$/
+    - /^v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$/
+    - /^maintenance/[[:digit:]]+\.[[:digit:]]+$/
+    - /^feature/packer-.*$/    
 ########################################    
 # JOBS
 ########################################
@@ -453,10 +471,10 @@ test_pkg_nightly_debian_stretch:
 ########################################
 # UPLOAD JOBS
 ########################################
-deploy_rpm_dev:
+deploy_rpm_devel:
   extends:
     - .deploy_rpm_job
-    - .job_dev_triggers
+    - .job_devel_only_triggers
   environment:
     name: devel/x86_64
     url: ${PUBLIC_REPO_URL}/RHEL7/${CI_ENVIRONMENT_NAME}
@@ -464,20 +482,27 @@ deploy_rpm_dev:
 # we deploy packetfence-release RPM with
 # a fixed name *outside* a RPM repo
 # for first installation
-deploy_rpm_packetfence-release_dev:
+deploy_rpm_packetfence-release_devel:
   extends:
     - .deploy_rpm_packetfence-release_job
-    - .job_dev_triggers
+    - .job_devel_only_triggers
   variables:
     PKG_DEST_NAME: packetfence-release-7.devel.noarch.rpm
 
-deploy_deb_dev:
+deploy_rpm_branches:
   extends:
-    - .deploy_deb_job
-    - .job_dev_triggers
+    - .deploy_rpm_job
+    - .job_branches_only_triggers
   environment:
-    name: debian-devel
-    url: ${PUBLIC_REPO_URL}/${CI_ENVIRONMENT_NAME}
+    name: branches/x86_64
+    url: ${PUBLIC_REPO_URL}/RHEL7/${CI_ENVIRONMENT_NAME}
+
+deploy_rpm_packetfence-release_branches:
+  extends:
+    - .deploy_rpm_packetfence-release_job
+    - .job_branches_only_triggers
+  variables:
+    PKG_DEST_NAME: packetfence-release-7.branches.noarch.rpm
 
 deploy_rpm_release:
   extends:
@@ -496,6 +521,14 @@ deploy_rpm_packetfence-release_release:
     - .job_release_triggers
   variables:
     PKG_DEST_NAME: packetfence-release-7.stable.noarch.rpm
+
+deploy_deb_dev:
+  extends:
+    - .deploy_deb_job
+    - .job_dev_triggers
+  environment:
+    name: debian-devel
+    url: ${PUBLIC_REPO_URL}/${CI_ENVIRONMENT_NAME}
 
 deploy_deb_release:
   extends:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,7 +17,6 @@ stages:
   - publish
   - test
   - upload
-  - post_upload
 
 ################################################################################
 # VARIABLES
@@ -190,8 +189,8 @@ variables:
     - inverse
     - shell
 
-.post_upload_rpm_packetfence-release_job:
-  stage: post_upload
+.deploy_rpm_packetfence-release_job:
+  stage: upload
   dependencies:
     - sign_dev_and_release
   variables:
@@ -462,6 +461,16 @@ deploy_rpm_dev:
     name: devel/x86_64
     url: ${PUBLIC_REPO_URL}/RHEL7/${CI_ENVIRONMENT_NAME}
 
+# we deploy packetfence-release RPM with
+# a fixed name *outside* a RPM repo
+# for first installation
+deploy_rpm_packetfence-release_dev:
+  extends:
+    - .deploy_rpm_packetfence-release_job
+    - .job_dev_triggers
+  variables:
+    PKG_DEST_NAME: packetfence-release-7.devel.noarch.rpm
+
 deploy_deb_dev:
   extends:
     - .deploy_deb_job
@@ -477,6 +486,16 @@ deploy_rpm_release:
   environment:
     name: x86_64
     url: ${PUBLIC_REPO_URL}/RHEL7/${CI_ENVIRONMENT_NAME}
+
+# we deploy packetfence-release RPM with
+# a fixed name *outside* a RPM repo
+# for first installation
+deploy_rpm_packetfence-release_release:
+  extends:
+    - .deploy_rpm_packetfence-release_job
+    - .job_release_triggers
+  variables:
+    PKG_DEST_NAME: packetfence-release-7.stable.noarch.rpm
 
 deploy_deb_release:
   extends:
@@ -494,23 +513,3 @@ deploy_maintenance:
   environment:
     name: maintenance
     url: ${PUBLIC_REPO_URL}/${CI_ENVIRONMENT_NAME}
-
-########################################
-# POST_UPLOAD JOBS
-########################################
-# we deploy packetfence-release RPM with
-# a fixed name *outside* a RPM repo
-# for first installation
-post_upload_rpm_packetfence-release_dev:
-  extends:
-    - .post_upload_rpm_packetfence-release_job
-    - .job_dev_triggers
-  variables:
-    PKG_DEST_NAME: packetfence-release-7.devel.noarch.rpm
-
-post_upload_rpm_packetfence-release_release:
-  extends:
-    - .post_upload_rpm_packetfence-release_job
-    - .job_release_triggers
-  variables:
-    PKG_DEST_NAME: packetfence-release-7.stable.noarch.rpm

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -100,7 +100,7 @@ variables:
     - schedules
 
 .job_devel_only_triggers:
-  # run jobs on "devel" branch (push, schedules and web)
+  # run only jobs on "devel" branch (push, schedules and web)
   only:
     - /^devel$/
 

--- a/addons/vagrant/extra_vars_branches.yml
+++ b/addons/vagrant/extra_vars_branches.yml
@@ -1,0 +1,24 @@
+---
+# Add branches repository
+packetfence_install__centos_release_rpm: 'http://packetfence.org/downloads/PacketFence/RHEL7/packetfence-release-7.branches.noarch.rpm'
+packetfence_install__centos:
+  repos:
+    - packetfence-devel
+    - packetfence-branches
+
+packetfence_install__deb:
+  repos:
+    - debian
+    - debian-devel
+    # - debian-branches
+
+# Replace by *exact* name of your package
+packetfence_install__centos_packages:
+   - packetfence-9.3.9-20200124160156.113848061.0007.fix~5075.el7
+
+packetfence_install__deb_packages:
+  - packetfence=9.3.9+20200415061223+136088176+0009+fix~pipeline~issues+stretch1
+
+# workaround to install a package with version number using "="
+# using state=latest with packetfence=X.Y.Z is not supported by Ansible apt module
+packetfence_install__devel_repo: False

--- a/addons/vagrant/extra_vars_branches.yml
+++ b/addons/vagrant/extra_vars_branches.yml
@@ -13,11 +13,11 @@ packetfence_install__deb:
     - debian-branches
 
 # Replace by *exact* name of your package
-packetfence_install__centos_packages:
-   - packetfence-9.3.9-20200124160156.113848061.0007.fix~5075.el7
+# i.e. CENTOS_PKG_NAMES='packetfence-9.3.9-20200124160156.113848061.0007.fix~5075.el7'
+packetfence_install__centos_packages: '[ {{ lookup("env", "CENTOS_PKG_NAMES") }} ]'
 
-packetfence_install__deb_packages:
-  - packetfence=9.3.9+20200415061223+136088176+0009+fix~pipeline~issues+stretch1
+# i.e. DEB_PKG_NAMES='packetfence=9.3.9+20200415061223+136088176+0009+fix~pipeline~issues+stretch1'
+packetfence_install__deb_packages: '[ {{ lookup("env", "DEB_PKG_NAMES") }} ]'
 
 # workaround to install a package with version number using "="
 # using state=latest with packetfence=X.Y.Z is not supported by Ansible apt module

--- a/addons/vagrant/extra_vars_branches.yml
+++ b/addons/vagrant/extra_vars_branches.yml
@@ -10,7 +10,7 @@ packetfence_install__deb:
   repos:
     - debian
     - debian-devel
-    # - debian-branches
+    - debian-branches
 
 # Replace by *exact* name of your package
 packetfence_install__centos_packages:

--- a/addons/vagrant/inventory/group_vars/dev/packetfence_install.yml
+++ b/addons/vagrant/inventory/group_vars/dev/packetfence_install.yml
@@ -9,14 +9,15 @@ release_status: '{{ True if lookup("env", "CI_COMMIT_TAG")
 # artifacts)
 packetfence_install__centos_release_rpm: 'packetfence-release'
 
+# only for dependencies, packetfence package is installed using local repo
 packetfence_install__centos:
-  repo: '{{ "packetfence" if release_status|bool
-                          else "packetfence-devel" }}'
+  repos: '{{ ["packetfence"] if release_status|bool
+                          else ["packetfence-devel"] }}'
 
+# only for dependencies, packetfence packages are installed using local repo
 packetfence_install__deb:
   repos: '{{ ["debian"] if release_status|bool
                         else ["debian","debian-devel"] }}'
-
 
 # config
 # need to be defined here to be available to plays

--- a/addons/vagrant/inventory/group_vars/nightly/packetfence_install.yml
+++ b/addons/vagrant/inventory/group_vars/nightly/packetfence_install.yml
@@ -1,7 +1,8 @@
 ---
 packetfence_install__centos_release_rpm: 'http://packetfence.org/downloads/PacketFence/RHEL7/packetfence-release-7.devel.noarch.rpm'
 packetfence_install__centos:
-  repo: packetfence-devel
+  repos:
+    - packetfence-devel
 
 packetfence_install__deb:
   repos:

--- a/addons/vagrant/requirements.yml
+++ b/addons/vagrant/requirements.yml
@@ -5,7 +5,7 @@ roles:
 
 collections:
   - name: inverse_inc.packetfence
-    version: 1.0.0-6
+    version: 1.0.0-7
   - name: debops.debops
   - name: inverse_inc.windows
   - name: inverse_inc.cumulus

--- a/addons/vagrant/requirements.yml
+++ b/addons/vagrant/requirements.yml
@@ -5,7 +5,7 @@ roles:
 
 collections:
   - name: inverse_inc.packetfence
-    version: 1.0.0-7
+    version: 1.0.1
   - name: debops.debops
   - name: inverse_inc.windows
   - name: inverse_inc.cumulus

--- a/rpm/packetfence-release/packetfence-release.spec
+++ b/rpm/packetfence-release/packetfence-release.spec
@@ -1,5 +1,5 @@
 Name:       packetfence-release
-Version:    2.0.0
+Version:    2.1.0
 Release:    1%{?dist}
 BuildArch:  noarch
 Summary:    PacketFence release file and RPM repository configuration
@@ -38,6 +38,18 @@ enabled=0
 [packetfence-extra]
 name=PacketFence Extra Repository
 baseurl=http://inverse.ca/downloads/PacketFence/RHEL\$releasever/extra/\$basearch
+gpgcheck=0
+enabled=0
+
+[packetfence-branches]
+name=PacketFence Branches Repository
+baseurl=http://inverse.ca/downloads/PacketFence/RHEL\$releasever/branches/\$basearch
+gpgcheck=0
+enabled=0
+
+[packetfence-gitlab]
+name=PacketFence GitLab Repository
+baseurl=http://inverse-inc.gitlab.io/packetfence/centos/\$releasever/\$basearch
 gpgcheck=0
 enabled=0
 
@@ -96,8 +108,15 @@ cp /etc/pki/rpm-gpg/RPM-GPG-KEY-PACKETFENCE-CENTOS %{buildroot}%{_sysconfdir}/pk
 
 
 %changelog
+* Wed Apr 15 2020 Nicolas Quiniou-Briand <nqb@inverse.ca> - 2.1.0-1
+- Add packetfence-branches and packetfence-gitlab repositories
+
 * Sat Jul 13 2019 Nicolas Quiniou-Briand <nqb@inverse.ca> - 2.0.0-1
 - Adapt spec file to CI
+
+* Sat Jul 13 2019 Nicolas Quiniou-Briand <nqb@inverse.ca> - 2.0.0-1
+- Adapt spec file to CI
+
 * Wed Apr 12 2017 Inverse inc. <info@inverse.ca> - 1.2-7
 - Permission fix. 
 


### PR DESCRIPTION
# Description
- Deploy RPM built on other branches than devel to packetfence-branches repository
- Deploy Deb built on other branches than devel to debian-branches repository
- Add packetfence-branches and packetfence-gitlab repository to packetfence-release RPM package

This change is necessary to avoid installing packages built on other branches than devel when we only configured -devel repository on machines.

# Impacts
- Packages upload
- Test stage of pipeline

# Code / PR Dependencies
https://github.com/inverse-inc/ansible-packetfence/pull/28 (already merged)

# Delete branch after merge
YES
