### PR TITLE
PacketFence ZEN: reboot after OS upgrade

### DIFF
--- a/addons/ZEN-vagrant-builder/Vagrantfile
+++ b/addons/ZEN-vagrant-builder/Vagrantfile
@@ -71,6 +71,12 @@ Vagrant.configure("2") do |config|
     v.memory = "2048"
   end
 
+  config.vm.provision "shell", reboot: true, inline: <<-SHELL
+    echo "Upgrade OS and reboot"
+
+    yum upgrade -y
+  SHELL
+
   config.vm.provision "shell", inline: <<-SHELL
     export PFREPO="#{ENV['PFREPO'] || "packetfence"}"
     export PFPACKAGE="#{ENV['PFPACKAGE'] || "packetfence"}"

--- a/addons/ZEN-vagrant-builder/installer/install-pf.sh
+++ b/addons/ZEN-vagrant-builder/installer/install-pf.sh
@@ -2,9 +2,6 @@
 
 echo "nameserver 8.8.8.8" > /etc/resolv.conf
 
-# Upgrade to latest version
-yum upgrade -y
-
 # Install the PacketFence repos
 yum localinstall http://inverse.ca/downloads/PacketFence/CentOS7/x86_64/RPMS/packetfence-release-2.0.0-20191126180126.98740132.0007.el7.noarch.rpm -y
 

--- a/addons/ZEN-vagrant-builder/installer/install-pf.sh
+++ b/addons/ZEN-vagrant-builder/installer/install-pf.sh
@@ -3,10 +3,7 @@
 echo "nameserver 8.8.8.8" > /etc/resolv.conf
 
 # Install the PacketFence repos
-yum localinstall http://inverse.ca/downloads/PacketFence/CentOS7/x86_64/RPMS/packetfence-release-2.0.0-20191126180126.98740132.0007.el7.noarch.rpm -y
-
-# Update the release to be sure we run its latest version
-yum update packetfence-release --enablerepo=packetfence -y
+yum localinstall http://packetfence.org/downloads/PacketFence/RHEL7/packetfence-release-7.stable.noarch.rpm -y
 
 # Utils installation
 yum install ntpd -y


### PR DESCRIPTION
# Description
- Reboot after OS upgrade to install correctly Netflow Kernel module during PacketFence installation
- Install  `packetfence-release` using a static filename like in Installation Guide
 
# Impacts
ZEN builds

# NEW Package(s) required
Need to rebuild and upload a ZEN

# Issue
fixes #5388 

# Delete branch after merge
YES
