### PR TITLE
Fix returnAuthorizeVPN

### DIFF
--- a/lib/pf/Switch/Fortinet/FortiGate.pm
+++ b/lib/pf/Switch/Fortinet/FortiGate.pm
@@ -223,7 +223,7 @@ Return radius attributes to allow VPN access
 
 =cut
 
-sub returnRadiusAuthorizeVPN {
+sub returnAuthorizeVPN {
     my ($self, $args) = @_;
     my $logger = $self->logger;
 


### PR DESCRIPTION
Can't locate object method "returnAuthorizeVPN" via package "pf::Switch::Fortinet::FortiGate"

# Description
(REQUIRED)
Describe what the new code is used for.
ie: Allow PacketFence to trigger the coffee machine on wireless EAP 802.1X connection to brew a fresh espresso.

# Impacts
(REQUIRED)
Describe what to reviewer should look at. Will also help for testing purposes.
ie: - RADIUS authorize workflow

# Code / PR Dependencies
(OPTIONAL. REMOVE IF NOT NEEDED)
List the PRs or other factors on which this PR depends

# NEW Package(s) required
(OPTIONAL. REMOVE IF NOT NEEDED)
Which new package(s) (all supported distributions) are required for this PR to work.

# Issue
(OPTIONAL. REMOVE IF NOT NEEDED)
The following syntax 'fixes #ISSUE_NUMBER' will automatically closes a Github issue on pull-request merge time.
Modify the ISSUE_NUMBER in order to reflect the Github issue that need to be closed
fixes #ISSUE_NUMBER

# Delete branch after merge
(REQUIRED)
YES | NO

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
(REQUIRED, but may be optional...)
## New Features
* Feature 1
* Feature 2

## Enhancements
* Enhancement 1
* Enhancement 2

## Bug Fixes
If an issue exists on Github, please refer to it (name) along with it's number...
* Issue with Zammitbug in sandwich context (#42)
* Issue with Zammitbug in dinde context (#43)

# UPGRADE file entries
(OPTIONAL, but may be required...)
