### PR TITLE
[CI] build ZEN using packer

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,6 +17,7 @@ stages:
   - publish
   - test
   - upload
+  - build_zen
 
 ################################################################################
 # VARIABLES
@@ -27,12 +28,14 @@ variables:
   CIDIR: ci
   CILIBDIR: ci/lib
   PACKERDIR: $CIDIR/packer
+  ZENDIR: $PACKERDIR/zen
   MAINTDIR: $CILIBDIR/maintenance
   TESTDIR: $CILIBDIR/test
   UPLOAD_DIR: $CILIBDIR/upload
   RPM_DIR: rpm
   DEB_DIR: debian
   PUBLIC_REPO_URL: http://packetfence.org/downloads/PacketFence
+  SF_REPO_URL: https://sourceforge.net/projects/packetfence/files/PacketFence%20ZEN
   # env variables
   ANSIBLE_FORCE_COLOR: 1
   ANSIBLE_STDOUT_CALLBACK: yaml
@@ -219,6 +222,16 @@ variables:
     url: ${PUBLIC_REPO_URL}/RHEL7
   script:
     - ./${UPLOAD_DIR}/deploy-artifacts.sh packetfence-release
+  tags:
+    - shell
+
+.build_zen_job:
+  stage: build_zen
+  environment:
+    name: sourceforge
+    url: ${SF_REPO_URL}/${CI_COMMIT_REF_NAME}
+  after_script:
+    - make -e -C ${ZENDIR} clean
   tags:
     - shell
 
@@ -554,3 +567,31 @@ deploy_maintenance:
   environment:
     name: maintenance
     url: ${PUBLIC_REPO_URL}/${CI_ENVIRONMENT_NAME}
+
+########################################
+# BUILD_ZEN JOBS
+########################################
+build_zen_devel:
+  extends:
+    - .build_zen_job
+    - .job_devel_only_triggers
+  script:
+    - make -e -C ${ZENDIR} zen-devel
+  when: manual
+
+build_zen_devel_nightly:
+  extends:
+    - .build_zen_job
+  script:
+    - make -e -C ${ZENDIR} zen-devel
+  # only run this job during a schedule pipeline, on devel branch with RUN_BUILD_ZEN set to yes
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && $CI_COMMIT_REF_NAME == "devel" && $RUN_BUILD_ZEN == "yes"'
+
+build_zen_release:
+  extends:
+    - .build_zen_job
+    - .job_release_triggers
+  script:
+    - make -e -C ${ZENDIR} zen-release
+  when: manual

--- a/ci/packer/zen/.gitignore
+++ b/ci/packer/zen/.gitignore
@@ -1,0 +1,2 @@
+packer_cache
+results

--- a/ci/packer/zen/Makefile
+++ b/ci/packer/zen/Makefile
@@ -1,0 +1,54 @@
+#==============================================================================
+# Specific variables
+#==============================================================================
+PF_VERSION=$(CI_COMMIT_REF_NAME)
+VM_NAME=$(PKR_VAR_vm_name)
+RESULT_DIR=results
+# PKR_VAR_myvar environment variable is read by Packer to set myvar in Packer 
+PKR_VAR_vm_name=PacketFence-ZEN
+PKR_VAR_output_vbox_directory=$(RESULT_DIR)/virtualbox
+PKR_VAR_output_vmware_directory=$(RESULT_DIR)/vmware
+
+#==============================================================================
+# Targets
+#==============================================================================
+.PHONY: zen
+zen:
+	PKR_VAR_vm_name=$(PKR_VAR_vm_name) \
+	PKR_VAR_output_vbox_directory=$(PKR_VAR_output_vbox_directory) \
+	PKR_VAR_output_vmware_directory=$(PKR_VAR_output_vmware_directory) \
+	packer build -only="virtualbox-iso.*" .
+	PF_VERSION=$(PF_VERSION) \
+	VBOX_RESULT_DIR=$(PKR_VAR_output_vbox_directory) \
+	VMWARE_RESULT_DIR=$(PKR_VAR_output_vmware_directory) \
+	VM_NAME=$(VM_NAME) \
+	./build-and-upload.sh
+
+.PHONY: clean
+clean:
+	rm -rf $(RESULT_DIR)
+
+.PHONY: zen-release
+zen-release:
+	make \
+	PKR_VAR_pf_repo=packetfence \
+	PKR_VAR_pf_package=packetfence \
+	PKR_VAR_pf_branch=stable \
+	zen
+
+.PHONY: zen-devel
+zen-devel:
+	make \
+	PKR_VAR_pf_repo=packetfence-devel \
+	PKR_VAR_pf_package=packetfence \
+	PKR_VAR_pf_branch=devel \
+	zen \
+
+#==============================================================================
+# Targets used for local tests
+#==============================================================================
+.PHONY: zen-test
+zen-test:
+	make \
+	PF_VERSION=devel \
+	zen-devel \

--- a/ci/packer/zen/build-and-upload.sh
+++ b/ci/packer/zen/build-and-upload.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+set -o nounset -o pipefail -o errexit
+
+VM_NAME=${VM_NAME:-vm}
+
+VBOX_RESULT_DIR=${VBOX_RESULT_DIR:-results/virtualbox}
+VBOX_OVA_NAME=${VM_NAME}.ova
+VBOX_OVF_NAME=${VM_NAME}.ovf
+
+VMWARE_RESULT_DIR=${VMWARE_RESULT_DIR:-results/vmware}
+VMX_OVA_NAME=${VM_NAME}-${PF_VERSION}.ova
+
+# upload
+SF_RESULT_DIR=results/sf/${PF_VERSION}
+PUBLIC_REPO_DIR="/home/frs/project/p/pa/packetfence/PacketFence\ ZEN/${PF_VERSION}"
+DEPLOY_SF_USER=${DEPLOY_SF_USER:-inverse-bot,packetfence}
+DEPLOY_SF_HOST=${DEPLOY_SF_HOST:-frs.sourceforge.net}
+
+declare -p VM_NAME
+declare -p VBOX_RESULT_DIR VBOX_OVA_NAME VBOX_OVF_NAME
+declare -p VMWARE_RESULT_DIR VMX_OVA_NAME
+
+generate_manifest() {
+    local vmx_dir=${1}
+    ( cd ${vmx_dir} ;
+      sha1sum --tag ${VBOX_OVF_NAME} ${VM_NAME}-disk001.vmdk > ${VM_NAME}.mf
+      )
+}
+
+compress_vmware_ova() {
+    local ova_file=${1}
+    
+    # replace .ova by .zip
+    local zip_file=$(basename ${ova_file/.ova/.zip})
+    
+    zip -j ${SF_RESULT_DIR}/${zip_file} ${ova_file}
+}
+
+upload_to_sf() {
+    # warning: slashs at end of dirs are significant for rsync
+    local src_dir="${SF_RESULT_DIR}/"
+    local dst_repo="${PUBLIC_REPO_DIR}/"
+    local dst_dir="${DEPLOY_SF_USER}@${DEPLOY_SF_HOST}:${dst_repo}"
+    declare -p src_dir dst_dir
+    echo "rsync: $src_dir -> $dst_dir"
+
+    # quotes to handle space in filename
+    rsync -avz $src_dir "$dst_dir"
+}
+
+mkdir -p ${VMWARE_RESULT_DIR} ${SF_RESULT_DIR}
+
+echo "===> Extract Virtualbox OVA to ${VMWARE_RESULT_DIR}"
+tar xvf ${VBOX_RESULT_DIR}/${VBOX_OVA_NAME} -C ${VMWARE_RESULT_DIR}
+
+echo "===> Convert OVF in-place for VMware"
+sed -i 's/<OperatingSystemSection ovf:id="80">/<OperatingSystemSection ovf:id="101">/' ${VMWARE_RESULT_DIR}/${VBOX_OVF_NAME}
+sed -i 's/<vssd:VirtualSystemType>virtualbox-2.2/<vssd:VirtualSystemType>vmx-07/' ${VMWARE_RESULT_DIR}/${VBOX_OVF_NAME}
+
+# Manifest need to be generate by hand because we modify OVF during last step
+echo "===> Generate a manifest"
+generate_manifest ${VMWARE_RESULT_DIR}
+
+echo "===> Generate OVA for VMware"
+ovftool --shaAlgorithm=SHA1 --lax ${VMWARE_RESULT_DIR}/${VBOX_OVF_NAME} ${VMWARE_RESULT_DIR}/${VMX_OVA_NAME}
+
+echo "===> Compress VMware OVA"
+compress_vmware_ova ${VMWARE_RESULT_DIR}/${VMX_OVA_NAME}
+
+echo "===> Upload to Sourceforge"
+upload_to_sf

--- a/ci/packer/zen/build.pkr.hcl
+++ b/ci/packer/zen/build.pkr.hcl
@@ -1,0 +1,26 @@
+build {
+  sources = [
+    "source.virtualbox-iso.centos-7",
+    "source.vmware-iso.centos-7"
+  ]
+
+  provisioner "file" {
+    source = "files/rc.local"
+    destination = "/tmp/rc.local"
+  }
+
+  provisioner "shell" {
+    execute_command = "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'"
+    inline = [ "cp /tmp/rc.local /etc/rc.d/rc.local" ]
+  }
+
+  provisioner "shell" {
+    execute_command = "echo 'vagrant' | {{.Vars}} sudo -S -E bash '{{.Path}}'"
+    script = "scripts/install-pf.sh"
+    environment_vars = [
+      "PFREPO=${var.pf_repo}",
+      "PFPACKAGE=${var.pf_package}",
+      "PFBRANCH=${var.pf_branch}"
+    ]
+  }
+}

--- a/ci/packer/zen/files/centos7.ks.cfg
+++ b/ci/packer/zen/files/centos7.ks.cfg
@@ -1,0 +1,163 @@
+install
+url --url http://mirror.centos.org/centos/7/os/x86_64/
+repo --name updates --baseurl=http://mirror.centos.org/centos/7/updates/x86_64/
+text
+keyboard us
+lang en_US.UTF-8
+skipx
+network --device eth0 --bootproto dhcp
+rootpw --plaintext vagrant
+firewall --disabled
+authconfig --enableshadow --enablemd5
+selinux --enforcing
+timezone --utc UTC
+# The biosdevname and ifnames options ensure we get "eth0" as our interface
+# even in environments like virtualbox that emulate a real NW card
+bootloader --timeout=1 --append="no_timer_check console=tty0 console=ttyS0,115200n8 net.ifnames=0 biosdevname=0 elevator=noop"
+zerombr
+clearpart --all --drives=sda
+part / --fstype=ext4 --asprimary --size=1024 --grow --ondisk=sda
+
+user --name=vagrant --password=vagrant
+
+reboot
+
+%packages --instLangs=en
+deltarpm
+bash-completion
+man-pages
+bzip2
+rsync
+nfs-utils
+cifs-utils
+chrony
+yum-utils
+kernel-headers
+-e2fsprogs
+-btrfs-progs
+# Vagrant boxes aren't normally visible, no need for Plymouth
+-plymouth
+# Microcode updates cannot work in a VM
+-microcode_ctl
+# Firmware packages are not needed in a VM
+-aic94xx-firmware
+-alsa-firmware
+-alsa-tools-firmware
+-ivtv-firmware
+-iwl100-firmware
+-iwl1000-firmware
+-iwl105-firmware
+-iwl135-firmware
+-iwl2000-firmware
+-iwl2030-firmware
+-iwl3160-firmware
+-iwl3945-firmware
+-iwl4965-firmware
+-iwl5000-firmware
+-iwl5150-firmware
+-iwl6000-firmware
+-iwl6000g2a-firmware
+-iwl6000g2b-firmware
+-iwl6050-firmware
+-iwl7260-firmware
+-iwl7265-firmware
+-linux-firmware
+# Don't build rescue initramfs
+-dracut-config-rescue
+
+%end
+
+# kdump needs to reserve 160MB + 2bits/4kB RAM, and automatic allocation only
+# works on systems with at least 2GB RAM (which excludes most Vagrant boxes)
+%addon com_redhat_kdump --disable
+%end
+
+%post
+# configure swap to a file
+fallocate -l 2G /swapfile
+chmod 600 /swapfile
+mkswap /swapfile
+echo "/swapfile none swap defaults 0 0" >> /etc/fstab
+
+# sudo
+echo "%vagrant ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/vagrant
+chmod 0440 /etc/sudoers.d/vagrant
+
+# Fix for https://github.com/CentOS/sig-cloud-instance-build/issues/38
+cat > /etc/sysconfig/network-scripts/ifcfg-eth0 << EOF
+DEVICE="eth0"
+BOOTPROTO="dhcp"
+ONBOOT="yes"
+TYPE="Ethernet"
+PERSISTENT_DHCLIENT="yes"
+EOF
+
+# sshd: disable password authentication and DNS checks
+ex -s /etc/ssh/sshd_config <<EOF
+:%substitute/^#\(UseDNS\) yes$/&\r\1 no/
+:update
+:quit
+EOF
+cat >>/etc/sysconfig/sshd <<EOF
+
+# Decrease connection time by preventing reverse DNS lookups
+# (see https://lists.centos.org/pipermail/centos-devel/2016-July/014981.html
+#  and man sshd for more information)
+OPTIONS="-u0"
+EOF
+
+# Default insecure vagrant key
+mkdir -m 0700 -p /home/vagrant/.ssh
+echo "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key" >> /home/vagrant/.ssh/authorized_keys
+chmod 600 /home/vagrant/.ssh/authorized_keys
+chown -R vagrant:vagrant /home/vagrant/.ssh
+
+# Fix for issue #76, regular users can gain admin privileges via su
+ex -s /etc/pam.d/su <<'EOF'
+# allow vagrant to use su, but prevent others from becoming root or vagrant
+/^account\s\+sufficient\s\+pam_succeed_if.so uid = 0 use_uid quiet$/
+:append
+account		[success=1 default=ignore] \\
+				pam_succeed_if.so user = vagrant use_uid quiet
+account		required	pam_succeed_if.so user notin root:vagrant
+.
+:update
+:quit
+EOF
+
+# systemd should generate a new machine id during the first boot, to
+# avoid having multiple Vagrant instances with the same id in the local
+# network. /etc/machine-id should be empty, but it must exist to prevent
+# boot errors (e.g.  systemd-journald failing to start).
+:>/etc/machine-id
+
+echo 'vag' > /etc/yum/vars/infra
+
+# Blacklist the floppy module to avoid probing timeouts
+echo blacklist floppy > /etc/modprobe.d/nofloppy.conf
+chcon -u system_u -r object_r -t modules_conf_t /etc/modprobe.d/nofloppy.conf
+
+# Customize the initramfs
+pushd /etc/dracut.conf.d
+# There's no floppy controller, but probing for it generates timeouts
+echo 'omit_drivers+=" floppy "' > nofloppy.conf
+popd
+# Fix the SELinux context of the new files
+restorecon -f - <<EOF
+/etc/sudoers.d/vagrant
+/etc/dracut.conf.d/nofloppy.conf
+EOF
+
+# Rerun dracut for the installed kernel (not the running kernel):
+KERNEL_VERSION=$(rpm -q kernel --qf '%{version}-%{release}.%{arch}\n')
+dracut -f /boot/initramfs-${KERNEL_VERSION}.img ${KERNEL_VERSION}
+
+# Seal for deployment
+rm -rf /etc/ssh/ssh_host_*
+hostnamectl set-hostname localhost.localdomain
+rm -rf /etc/udev/rules.d/70-*
+
+# upgrade OS to have latest bug fixes
+yum upgrade -y
+yum clean all
+%end

--- a/ci/packer/zen/files/rc.local
+++ b/ci/packer/zen/files/rc.local
@@ -4,8 +4,8 @@
 # You can put your own initialization stuff in here if you don't
 # want to do the full Sys V style init stuff.
 
-# Ensure we delete the vagrant user if it exists
-userdel vagrant
+# Ensure we delete the vagrant user if it exists and it's home directory
+userdel -r vagrant
 
 cat /etc/redhat-release > /etc/issue
 echo "Kernel \r on an \m" >> /etc/issue

--- a/ci/packer/zen/scripts/install-pf.sh
+++ b/ci/packer/zen/scripts/install-pf.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -o nounset -o pipefail -o errexit
+
+# Variables are set using environment variables
+
+echo "nameserver 8.8.8.8" > /etc/resolv.conf
+
+# Install the PacketFence repos
+yum localinstall http://packetfence.org/downloads/PacketFence/RHEL7/packetfence-release-7.${PFBRANCH}.noarch.rpm -y
+
+# Utils installation
+yum install ntp -y
+
+# PacketFence installation
+yum install perl -y
+echo "Installing $PFPACKAGE from repo $PFREPO"
+yum install --enablerepo=$PFREPO $PFPACKAGE -y
+
+# Setting the hostname
+hostname packetfence
+echo "packetfence" > /etc/hostname
+echo "NETWORKING=yes HOSTNAME=packetfence" > /etc/sysconfig/network
+
+# Systemd won't execute /etc/rc.local unless we do this
+chmod +x /etc/rc.d/rc.local
+
+# Set the root password
+echo "p@ck3tf3nc3" | passwd root --stdin
+
+# Put the demo user insert statement into the schema file
+cat <<EOT >> /usr/local/pf/db/pf-schema.sql
+--
+-- Insert the demo user for testing
+--
+
+INSERT INTO password (pid, password, valid_from, expiration, access_duration, access_level, category) VALUES ('demouser', 'demouser', NOW(), '2038-01-01', '1D', NULL, 1);
+
+EOT

--- a/ci/packer/zen/sources.pkr.hcl
+++ b/ci/packer/zen/sources.pkr.hcl
@@ -1,0 +1,56 @@
+# VirtualBox builds
+source "virtualbox-iso" "centos-7" {
+  vm_name = "${var.vm_name}"
+  disk_size = "40000"
+  guest_os_type = "RedHat_64"
+  hard_drive_interface = "scsi"
+  headless = "true"
+  vboxmanage = [
+    ["modifyvm", "{{.Name}}", "--cpus", "4"],
+    ["modifyvm", "{{.Name}}", "--memory", "12288"],
+    ["modifyvm", "{{.Name}}", "--uartmode1", "disconnected"]
+  ]
+  iso_url = "http://centos.mirror.iweb.ca/7/isos/x86_64/CentOS-7-x86_64-Minimal-2003.iso"
+  iso_checksum = "659691c28a0e672558b003d223f83938f254b39875ee7559d1a4a14c79173193"
+  iso_checksum_type = "sha256"
+  boot_command = [
+    "<up><tab><spacebar>",
+    "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos7.ks.cfg<return>"
+  ]
+  http_directory = "files"
+  ssh_username = "vagrant"
+  ssh_password = "vagrant"
+  ssh_timeout = "60m"
+  shutdown_command = "sudo poweroff"
+  # export
+  format = "ova"
+  output_directory = "${var.output_vbox_directory}"
+}
+
+# VMware builds
+source "vmware-iso" "centos-7" {
+  vm_name = "${var.vm_name}"
+  disk_size = "40000"
+  guest_os_type = "centos-64"
+  disk_adapter_type = "scsi"
+  headless = "true"
+  vmx_data = {
+    memsize = 12288
+    numvcpus = 4
+  } 
+  iso_url = "http://centos.mirror.iweb.ca/7/isos/x86_64/CentOS-7-x86_64-Minimal-2003.iso"
+  iso_checksum = "659691c28a0e672558b003d223f83938f254b39875ee7559d1a4a14c79173193"
+  iso_checksum_type = "sha256"
+  boot_command = [
+    "<up><tab><spacebar>",
+    "inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/centos7.ks.cfg<return>"
+  ]
+  http_directory = "files"
+  ssh_username = "vagrant"
+  ssh_password = "vagrant"
+  ssh_timeout = "60m"
+  shutdown_command = "sudo poweroff"
+  # export
+  format = "ova"
+  output_directory = "${var.output_vmware_directory}"
+}

--- a/ci/packer/zen/variables.pkr.hcl
+++ b/ci/packer/zen/variables.pkr.hcl
@@ -1,0 +1,25 @@
+# We only declare variables without defaults
+# defaults are in Makefile
+variable output_vbox_directory {
+  type = string
+}
+
+variable output_vmware_directory {
+  type = string
+}
+
+variable vm_name {
+  type = string
+}
+
+variable pf_repo {
+  type = string
+}
+
+variable pf_package {
+  type = string
+}
+
+variable pf_branch {
+  type = string
+}


### PR DESCRIPTION
# Description
Build PacketFence-ZEN (stable) using `packer` in pipeline

Notes:
- Some actions previously done in `install-pf.sh` script have been migrated to `kickstart` file
  - kernel-headers are installed directly at this step
- Some actions previously done by `build.sh` script are now done by `virtualbox-iso` and `build-and-upload.sh` script
- Previous ZEN were build based on old `centos/7` Vagrant box which has some differences with latest `centos/7` Vagrant box
- Resulting image is uploaded on SourceForge

# Impacts
PacketFence-ZEN builds

# NEW Package(s) required
Yes

# Issue
fixes #5388 

# Delete branch after merge
YES

# NEWS file entries
## Enhancements
* PacketFence-ZEN is automatically built using `packer` from a CentOS ISO in pipeline
