### PR TITLE
CI: automatically test package installation at release

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -435,7 +435,7 @@ pages:
 ########################################
 # TEST JOBS
 ########################################
-test_pkg_dev_and_release_centos_7:
+test_pkg_devel_centos_7:
   variables:
     PF_VM_NAME: pfcen7dev
     PERL_UNIT_TESTS: 'yes'
@@ -444,8 +444,21 @@ test_pkg_dev_and_release_centos_7:
   extends:
     - .test_job
     - .test_script
-    - .job_dev_and_release_triggers
+    - .job_dev_triggers
   when: manual
+
+test_pkg_release_centos_7:
+  variables:
+    PF_VM_NAME: pfcen7dev
+    PERL_UNIT_TESTS: 'no'
+    GOLANG_UNIT_TESTS: 'no'
+    INTEGRATION_TESTS: 'no'
+    # only install packages, don't run tests
+    RUN_TESTS: 'yes'
+  extends:
+    - .test_job
+    - .test_script
+    - .job_release_triggers
 
 test_pkg_nigthly_centos_7:
   variables:
@@ -458,7 +471,7 @@ test_pkg_nigthly_centos_7:
     - .test_script
     - .job_nightly_triggers
 
-test_pkg_dev_and_release_debian_stretch:
+test_pkg_devel_debian_stretch:
   variables:
     PF_VM_NAME: pfdeb9dev
     PERL_UNIT_TESTS: 'no'
@@ -467,8 +480,21 @@ test_pkg_dev_and_release_debian_stretch:
   extends:
     - .test_job
     - .test_script
-    - .job_dev_and_release_triggers
+    - .job_dev_triggers
   when: manual
+
+test_pkg_release_debian_stretch:
+  variables:
+    PF_VM_NAME: pfdeb9dev
+    PERL_UNIT_TESTS: 'no'
+    GOLANG_UNIT_TESTS: 'no'
+    INTEGRATION_TESTS: 'no'
+    # only install packages, don't run tests
+    RUN_TESTS: 'yes'
+  extends:
+    - .test_job
+    - .test_script
+    - .job_release_triggers
 
 test_pkg_nightly_debian_stretch:
   variables:

--- a/ci/lib/test/vagrant-wrapper.sh
+++ b/ci/lib/test/vagrant-wrapper.sh
@@ -40,7 +40,7 @@ configure_and_check() {
     PERL_UNIT_TESTS=${PERL_UNIT_TESTS:-}
     GOLANG_UNIT_TESTS=${GOLANG_UNIT_TESTS:-}
     INTEGRATION_TESTS=${INTEGRATION_TESTS:-}
-    RUN_TESTS=no
+    RUN_TESTS=${RUN_TESTS:-no}
     if [ "$PERL_UNIT_TESTS" = "yes" ]; then
         RUN_TESTS=${PERL_UNIT_TESTS}
     fi


### PR DESCRIPTION
# Description
When making a release, test stage will start automatically and will **only** try to install packetfence packages and dependencies on OS supported. We assumed unit and integration tests have been done last night before release.

If this step failed, pipeline will be stopped.

# Impacts
Release pipeline.

# Delete branch after merge
YES

# NEWS file entries
## Enhancements
* CI: automatically test package installation at release
