### PR TITLE
Allow multiple access levels in source admin rules

### DIFF
--- a/html/pfappserver/lib/pfappserver/Form/Field/SourceRuleAction.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Field/SourceRuleAction.pm
@@ -72,7 +72,10 @@ inflate the value from the config store
 sub inflate {
     my ($self, $value) = @_;
     my %condition;
-    @condition{qw(type value)} = split /\s*=\s*/, $value;
+    @condition{qw(type value)} = split /\s*=\s*/, $value,2;
+    if ($condition{type} eq 'set_access_level') {
+        $condition{value} = [split /\s*,\s*/, $condition{value} ];
+    }
     return \%condition;
 }
 

--- a/html/pfappserver/root/static.alt/src/globals/pfField.js
+++ b/html/pfappserver/root/static.alt/src/globals/pfField.js
@@ -75,8 +75,8 @@ export const pfFieldTypeComponent = {
   [pfFieldType.TOGGLE]:                pfComponentType.TOGGLE,
 
   /* additional component types */
-  [pfFieldType.ADMINROLE]:             pfComponentType.SELECTONE,
-  [pfFieldType.ADMINROLE_BY_ACL_USER]: pfComponentType.SELECTONE,
+  [pfFieldType.ADMINROLE]:             pfComponentType.SELECTMANY,
+  [pfFieldType.ADMINROLE_BY_ACL_USER]: pfComponentType.SELECTMANY,
   [pfFieldType.CONNECTION]:            pfComponentType.SELECTONE,
   [pfFieldType.CONNECTION_TYPE]:       pfComponentType.SELECTONE,
   [pfFieldType.CONNECTION_SUB_TYPE]:   pfComponentType.SELECTONE,


### PR DESCRIPTION
# Description
Allow multiple choices in `set_access_level` of Authentication Sources Administratin Rule Actions.

# Impacts
n/a 

# Issue
fixes #5440

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

## Bug Fixes
* Impossible to set multiple access level in administration rule (#5440)
