### PR TITLE
Feature/tenant id unifiedapiclient

### DIFF
--- a/go/unifiedapiclient/client.go
+++ b/go/unifiedapiclient/client.go
@@ -39,12 +39,15 @@ func init() {
 	}
 }
 
+const UnsetTenantId = -1
+
 type Client struct {
 	Username string
 	Password string
 	Host     string
 	Port     string
 	token    string
+	tenantId int
 }
 
 type DummyReply struct{}
@@ -63,6 +66,7 @@ func New(ctx context.Context, username, password, proto, host, port string) *Cli
 		Password: password,
 		Host:     host,
 		Port:     port,
+		tenantId: UnsetTenantId,
 	}
 }
 
@@ -209,5 +213,17 @@ func (c *Client) buildRequest(ctx context.Context, method, path, body string) *h
 		r.Header.Set("Authorization", "Bearer "+c.token)
 	}
 
+	if c.tenantId != UnsetTenantId {
+		r.Header.Set("X-PacketFence-Tenant-Id", fmt.Sprintf("%d", c.tenantId))
+	}
+
 	return r
+}
+
+func (c *Client) SetTenantId(ctx context.Context, tenantId int) {
+	c.tenantId = tenantId
+}
+
+func (c *Client) ResetTenantId(ctx context.Context) {
+	c.tenantId = UnsetTenantId
 }

--- a/go/unifiedapiclient/client_test.go
+++ b/go/unifiedapiclient/client_test.go
@@ -50,6 +50,25 @@ func TestClientBuildRequest(t *testing.T) {
 		t.Error("An authorization header was set although the token is empty")
 	}
 
+	// Test the tenant ID
+
+	if r.Header.Get("X-PacketFence-Tenant-Id") != "" {
+		t.Error("Tenant ID was set when it wasn't specified in the client")
+	}
+
+	tenantId := 69
+	c.SetTenantId(testCtx, tenantId)
+
+	r = c.buildRequest(testCtx, method, path, body)
+	if r.Header.Get("X-PacketFence-Tenant-Id") != "69" {
+		t.Error("Tenant ID wasn't set correctly in the request")
+	}
+
+	c.ResetTenantId(testCtx)
+	r = c.buildRequest(testCtx, method, path, body)
+	if r.Header.Get("X-PacketFence-Tenant-Id") != "" {
+		t.Error("Tenant ID was set when it was reset in the client")
+	}
 }
 
 func TestClientRequest(t *testing.T) {

--- a/lib/pf/api/unifiedapiclient.pm
+++ b/lib/pf/api/unifiedapiclient.pm
@@ -112,6 +112,14 @@ The current token that was obtained by the login
 
 has token => (is => 'rw');
 
+=head2 tenant_id
+
+The tenant ID to send in the X-PacketFence-Tenant-Id header if any. When sent to undef (default value), it doesn't send it
+
+=cut
+
+has tenant_id => (is => 'rw', default => sub{undef});
+
 use constant REQUEST => 0;
 use constant RESPONSE => 2;
 use constant NOTIFICATION => 2;
@@ -183,7 +191,11 @@ sub call {
     $curl->setopt(CURLOPT_CUSTOMREQUEST, $method);
 
     if($self->token) {
-        $curl->setopt(CURLOPT_HTTPHEADER, ["Authorization: Bearer ".$self->token]);
+        $curl->pushopt(CURLOPT_HTTPHEADER, ["Authorization: Bearer ".$self->token]);
+    }
+
+    if(defined($self->tenant_id)) {
+        $curl->pushopt(CURLOPT_HTTPHEADER, ["X-PacketFence-Tenant-Id: ".$self->tenant_id]);
     }
 
     # Starts the actual request
@@ -295,6 +307,17 @@ sub url {
 sub build_json_rest_payload {
     my ($self,$args) = @_;
     return encode_json $args;
+}
+
+=head2 reset_tenant_id
+
+Resets the tenant ID of the client
+
+=cut
+
+sub reset_tenant_id {
+    my ($self) = @_;
+    $self->tenant_id(undef);
 }
 
 =head1 AUTHOR

--- a/lib/pf/api/unifiedapiclient.pm
+++ b/lib/pf/api/unifiedapiclient.pm
@@ -194,9 +194,8 @@ sub call {
         $curl->pushopt(CURLOPT_HTTPHEADER, ["Authorization: Bearer ".$self->token]);
     }
 
-    if(defined($self->tenant_id)) {
-        $curl->pushopt(CURLOPT_HTTPHEADER, ["X-PacketFence-Tenant-Id: ".$self->tenant_id]);
-    }
+    my $tenant_id = ( defined($self->tenant_id) ) ? $self->tenant_id : $pf::config::tenant::CURRENT_TENANT;
+    $curl->pushopt(CURLOPT_HTTPHEADER, ["X-PacketFence-Tenant-Id: " . $tenant_id]);
 
     # Starts the actual request
     my $curl_return_code = $curl->perform;


### PR DESCRIPTION
# Description
Adds the ability to set the X-PacketFence-Tenant-Id in the Perl and Golang UnifiedAPI clients

# Impacts
Unified API clients

# Issue
fixes #5554

# Delete branch after merge
YES

