### PR TITLE
handle the case when authorizing a guest with a ZERO date

### DIFF
--- a/lib/pf/Switch/Ubiquiti/Unifi.pm
+++ b/lib/pf/Switch/Ubiquiti/Unifi.pm
@@ -227,6 +227,8 @@ sub _deauthenticateMacWithHTTP {
     };
     my $command;
     unless ($node_info->{status} eq $STATUS_UNREGISTERED || security_event_count_reevaluate_access($mac))  {
+        $command = "authorize-guest";
+
         if($node_info->{unregdate} ne $ZERO_DATE) {
             my $now = DateTime->now();
             $now->set_time_zone('local');

--- a/lib/pf/Switch/Ubiquiti/Unifi.pm
+++ b/lib/pf/Switch/Ubiquiti/Unifi.pm
@@ -227,14 +227,15 @@ sub _deauthenticateMacWithHTTP {
     };
     my $command;
     unless ($node_info->{status} eq $STATUS_UNREGISTERED || security_event_count_reevaluate_access($mac))  {
-        $command = "authorize-guest";
-        my $now = DateTime->now();
-        $now->set_time_zone('local');
-        
-        my $unregdate = DateTime::Format::MySQL->parse_datetime($node_info->{unregdate});
-        $unregdate->set_time_zone('local');
-        
-        $args->{minutes} = $now->delta_ms($unregdate)->in_units('minutes');
+        if($node_info->{unregdate} ne $ZERO_DATE) {
+            my $now = DateTime->now();
+            $now->set_time_zone('local');
+
+            my $unregdate = DateTime::Format::MySQL->parse_datetime($node_info->{unregdate});
+            $unregdate->set_time_zone('local');
+
+            $args->{minutes} = $now->delta_ms($unregdate)->in_units('minutes');
+        }
     } else {
         $command = "unauthorize-guest";
     }


### PR DESCRIPTION
# Description
handle the case when authorizing a guest with a ZERO date on Unifi

# Impacts
Unifi switch module

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* Fixed issue authorizing a user in web-auth on Unifi when the node has its date set to '0000-00-00 00:00:00'