### PR TITLE
Added a role selection field for self reg portal

### DIFF
--- a/addons/upgrade/to-10.2-selfservice-conf.pl
+++ b/addons/upgrade/to-10.2-selfservice-conf.pl
@@ -1,0 +1,75 @@
+#!/usr/bin/perl
+
+=head1 NAME
+
+to-10.2-selfservice-conf.pl
+
+=cut
+
+=head1 DESCRIPTION
+
+Rename device_registration_role to device_registration_roles
+
+=cut
+
+use strict;
+use warnings;
+use lib qw(/usr/local/pf/lib);
+use pf::IniFiles;
+use pf::file_paths qw(
+    $self_service_config_file
+);
+use List::MoreUtils qw(any);
+use pf::util;
+use File::Copy;
+
+run_as_pf();
+
+my $ss_ini = pf::IniFiles->new(-file => $self_service_config_file, -allowempty => 1);
+
+my %remap = (
+    device_registration_role => "device_registration_roles",
+);
+for my $section ($ss_ini->Sections()) {
+    while(my ($old, $new) = each(%remap)) {
+        print "Renaming parameter $old to $new in section $section in file $self_service_config_file \n";
+        my $val = $ss_ini->val($section, $old);
+        $ss_ini->newval($section, $new, $val);
+        $ss_ini->delval($section, $old);
+    }
+}
+
+$ss_ini->RewriteConfig();
+
+$profile_ini->RewriteConfig();
+
+print "All done\n";
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2020 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+

--- a/conf/self_service.conf.defaults
+++ b/conf/self_service.conf.defaults
@@ -2,5 +2,5 @@
 [default]
 description=default
 device_registration_allowed_devices=
-device_registration_role=
+device_registration_roles=
 roles_allowed_to_unregister=

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/DeviceRegistration.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/DeviceRegistration.pm
@@ -78,13 +78,17 @@ sub index : Path : Args(0) {
         my $device_mac = clean_mac($request->param('device_mac'));
         my $device_type;
         $device_type = $request->param('console_type') if ( defined($request->param('console_type')) );
-
+        my $registration_role = $request->param('registration_role') if ( defined($request->param('registration_role')) );
         if(valid_mac($device_mac)) {
             # Register device
-            $c->forward('registerNode', [ $pid, $device_mac, $device_type ]);
+            $c->forward('registerNode', [ $pid, $device_mac, $device_type, $registration_role ]);
         }
         $c->stash(txt_auth_error => "Please verify the provided MAC address.");
     }
+
+    my $device_reg_profile = $c->profile->{'_self_service'};
+    my @registration_roles = map { { value => $_, label => $_ } } split(',', $ConfigSelfService{$device_reg_profile}{'device_registration_list_roles'});
+    $c->stash->{device_registration_list_roles} = \@registration_roles;
     # User is authenticated so display registration page
     $c->stash(title => "Registration", template => 'device-registration/registration.html');
 }
@@ -118,7 +122,7 @@ sub landing : Local : Args(0) {
 }
 
 sub registerNode : Private {
-    my ( $self, $c, $pid, $mac, $type ) = @_;
+    my ( $self, $c, $pid, $mac, $type, $role ) = @_;
     my $logger = $c->log;
     my $device_reg_profile = $c->profile->{'_self_service'};
     if ( is_allowed($mac, $device_reg_profile) && valid_mac($mac) ) {
@@ -133,15 +137,16 @@ sub registerNode : Private {
             my $params = { username => $pid, 'context' => $pf::constants::realm::PORTAL_CONTEXT};
             $c->stash->{device_mac} = $mac;
             # Get role for device registration
-            my $role =
-              $ConfigSelfService{$device_reg_profile}{'device_registration_role'};
-            if ($role) {
-                $logger->debug("Device registration role is $role (from pf.conf)");
-            } else {
-                # Use role of user
-                $role = pf::authentication::match( $source_id, $params , $Actions::SET_ROLE, undef, $c->user_session->{extra});
-                $logger->debug("Gaming devices role is $role (from username $pid)");
-            }
+            if (!(defined($role))) {
+	        $role = $ConfigSelfService{$device_reg_profile}{'device_registration_role'};
+                if ($role) {
+                    $logger->debug("Device registration role is $role (from self_service.conf)");
+                } else {
+                    # Use role of user
+                    $role = pf::authentication::match( $source_id, $params , $Actions::SET_ROLE, undef, $c->user_session->{extra});
+                    $logger->debug("Gaming devices role is $role (from username $pid)");
+                }
+	    }
 
             my $duration = $ConfigSelfService{$device_reg_profile}{'device_registration_access_duration'};
             if($duration > 0) {

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/DeviceRegistration.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/DeviceRegistration.pm
@@ -87,7 +87,7 @@ sub index : Path : Args(0) {
     }
 
     my $device_reg_profile = $c->profile->{'_self_service'};
-    my @registration_roles = map { { value => $_, label => $_ } } split(',', $ConfigSelfService{$device_reg_profile}{'device_registration_list_roles'});
+    my @registration_roles = map { { value => $_, label => $_ } } split(',', $ConfigSelfService{$device_reg_profile}{'device_registration_role'});
     $c->stash->{device_registration_list_roles} = \@registration_roles;
     # User is authenticated so display registration page
     $c->stash(title => "Registration", template => 'device-registration/registration.html');

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/DeviceRegistration.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/DeviceRegistration.pm
@@ -138,7 +138,7 @@ sub registerNode : Private {
             $c->stash->{device_mac} = $mac;
             # Get role for device registration
             if (!(defined($role))) {
-	        $role = $ConfigSelfService{$device_reg_profile}{'device_registration_role'};
+                $role = $ConfigSelfService{$device_reg_profile}{'device_registration_role'};
                 if ($role) {
                     $logger->debug("Device registration role is $role (from self_service.conf)");
                 } else {

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/DeviceRegistration.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/DeviceRegistration.pm
@@ -87,7 +87,7 @@ sub index : Path : Args(0) {
     }
 
     my $device_reg_profile = $c->profile->{'_self_service'};
-    my @registration_roles = map { { value => $_, label => $_ } } split(',', $ConfigSelfService{$device_reg_profile}{'device_registration_role'});
+    my @registration_roles = map { { value => $_, label => $_ } } split(',', $ConfigSelfService{$device_reg_profile}{'device_registration_roles'});
     $c->stash->{device_registration_list_roles} = \@registration_roles;
     # User is authenticated so display registration page
     $c->stash(title => "Registration", template => 'device-registration/registration.html');
@@ -138,7 +138,7 @@ sub registerNode : Private {
             $c->stash->{device_mac} = $mac;
             # Get role for device registration
             if (!(defined($role))) {
-                $role = $ConfigSelfService{$device_reg_profile}{'device_registration_role'};
+                $role = $ConfigSelfService{$device_reg_profile}{'device_registration_roles'};
                 if ($role) {
                     $logger->debug("Device registration role is $role (from self_service.conf)");
                 } else {

--- a/html/captive-portal/templates/device-registration/registration.html
+++ b/html/captive-portal/templates/device-registration/registration.html
@@ -26,6 +26,17 @@
         <input class="field" name="device_mac" id="device_mac" type="text" value="[% device_mac %]" />
       </div>
 
+      [% IF device_registration_list_roles.size > 1 %]
+      <div class="input-container">
+        <label>[% i18n("Select registration role") %]</label>
+        <select name="registration_role">
+          [% FOREACH registration_role IN device_registration_list_roles %]
+          <option value='[% registration_role.value %]'>[% registration_role.label %]</option>
+          [% END %]
+        </select>
+      </div>
+      [% END %]
+
       [% IF console_types.size > 1 %]
       <div class="input-container">
         <label>[% i18n("Device Type") %]</label>

--- a/html/pfappserver/lib/pfappserver/Form/Config/SelfService.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/SelfService.pm
@@ -49,10 +49,11 @@ has_field 'roles_allowed_to_unregister' =>
 has_field 'device_registration_role' =>
   (
    type => 'Select',
+   multiple => 1,
    label => 'Role to assign',
    options_method => \&options_roles,
    tags => { after_element => \&help,
-             help => 'The role to assign to devices registered from the self-service portal. If none is specified, the role of the registrant is used.' },
+             help => 'The role to assign to devices registered from the self-service portal. If none is specified, the role of the registrant is used. If multiples are defined then the user will have to choose' },
   );
 
 has_field 'device_registration_access_duration' =>
@@ -80,18 +81,6 @@ has_field 'device_registration_allowed_devices' =>
    fingerbank_model => "fingerbank::Model::Device",
   );
 
-has_field 'device_registration_list_roles' =>
-  (
-   type => 'Select',
-   label => 'Allowed roles list',
-   multiple => 1,
-   element_class => ['chzn-deselect'],
-   element_attr => {'data-placeholder' => 'Click to add a role'},
-   options_method => \&options_roles,
-   tags => { after_element => \&help,
-             help => 'The list of roles that are allowed to be used by the user to select in which role the device should be register.' },
-  );
-
 has_block definition =>
   (
    render_list => [ qw(id description) ],
@@ -104,7 +93,7 @@ has_block status_definition =>
 
 has_block device_registration_definition =>
   (
-   render_list => [ qw(device_registration_role device_registration_access_duration device_registration_allowed_devices device_registration_list_roles) ],
+   render_list => [ qw(device_registration_role device_registration_access_duration device_registration_allowed_devices) ],
   );
 
 =head2 options_roles

--- a/html/pfappserver/lib/pfappserver/Form/Config/SelfService.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/SelfService.pm
@@ -80,6 +80,18 @@ has_field 'device_registration_allowed_devices' =>
    fingerbank_model => "fingerbank::Model::Device",
   );
 
+has_field 'device_registration_list_roles' =>
+  (
+   type => 'Select',
+   label => 'Allowed roles list',
+   multiple => 1,
+   element_class => ['chzn-deselect'],
+   element_attr => {'data-placeholder' => 'Click to add a role'},
+   options_method => \&options_roles,
+   tags => { after_element => \&help,
+             help => 'The list of roles that are allowed to be used by the user to select in which role the device should be register.' },
+  );
+
 has_block definition =>
   (
    render_list => [ qw(id description) ],
@@ -92,7 +104,7 @@ has_block status_definition =>
 
 has_block device_registration_definition =>
   (
-   render_list => [ qw(device_registration_role device_registration_access_duration device_registration_allowed_devices) ],
+   render_list => [ qw(device_registration_role device_registration_access_duration device_registration_allowed_devices device_registration_list_roles) ],
   );
 
 =head2 options_roles

--- a/html/pfappserver/lib/pfappserver/Form/Config/SelfService.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/SelfService.pm
@@ -46,7 +46,7 @@ has_field 'roles_allowed_to_unregister' =>
              help => 'The list of roles that are allowed to unregister devices using the self-service portal. Leaving this empty will allow all users to unregister their devices.' },
   );
 
-has_field 'device_registration_role' =>
+has_field 'device_registration_roles' =>
   (
    type => 'Select',
    multiple => 1,
@@ -93,7 +93,7 @@ has_block status_definition =>
 
 has_block device_registration_definition =>
   (
-   render_list => [ qw(device_registration_role device_registration_access_duration device_registration_allowed_devices) ],
+   render_list => [ qw(device_registration_roles device_registration_access_duration device_registration_allowed_devices) ],
   );
 
 =head2 options_roles

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_config/selfService.js
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_config/selfService.js
@@ -146,12 +146,12 @@ export const view = (form = {}, meta = {}) => {
         },
         {
           label: i18n.t('Role to assign'),
-          text: i18n.t('The role to assign to devices registered from the self-service portal. If none is specified, the role of the registrant is used.'),
+          text: i18n.t('The role to assign to devices registered from the self-service portal. If none is specified, the role of the registrant is used. If multiples are defined then the user will have to choose.'),
           cols: [
             {
-              namespace: 'device_registration_role',
+              namespace: 'device_registration_roles',
               component: pfFormChosen,
-              attrs: attributesFromMeta(meta, 'device_registration_role')
+              attrs: attributesFromMeta(meta, 'device_registration_roles')
             }
           ]
         },
@@ -201,7 +201,7 @@ export const validators = (form = {}, meta = {}) => {
     },
     description: validatorsFromMeta(meta, 'description', i18n.t('Description')),
     roles_allowed_to_unregister: validatorsFromMeta(meta, 'roles_allowed_to_unregister', i18n.t('Allowed roles')),
-    device_registration_role: validatorsFromMeta(meta, 'device_registration_role', i18n.t('Role to assign')),
+    device_registration_roles: validatorsFromMeta(meta, 'device_registration_roles', i18n.t('Role to assign')),
     device_registration_access_duration: {
       interval: validatorsFromMeta(meta, 'device_registration_access_duration.interval', i18n.t('Interval')),
       unit: validatorsFromMeta(meta, 'device_registration_access_duration.unit', i18n.t('Unit'))

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_config/selfService.js
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_config/selfService.js
@@ -156,17 +156,6 @@ export const view = (form = {}, meta = {}) => {
           ]
         },
         {
-          label: i18n.t('Roles list'),
-          text: i18n.t('The list of roles that are allowed to be used by the user to select in which role the device should be register. If defined the "Role to assign" parameter will be ignored.'),
-          cols: [
-            {
-              namespace: 'device_registration_list_roles',
-              component: pfFormChosen,
-              attrs: attributesFromMeta(meta, 'device_registration_list_roles')
-            }
-          ]
-        },
-        {
           label: i18n.t('Access duration to assign'),
           text: i18n.t(`The access duration to assign to devices registered from the self-service portal. If zero is specified, the access duration of the registrant is used.`),
           cols: [

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_config/selfService.js
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_config/selfService.js
@@ -156,6 +156,17 @@ export const view = (form = {}, meta = {}) => {
           ]
         },
         {
+          label: i18n.t('Roles list'),
+          text: i18n.t('The list of roles that are allowed to be used by the user to select in which role the device should be register. If defined the "Role to assign" parameter will be ignored.'),
+          cols: [
+            {
+              namespace: 'device_registration_list_roles',
+              component: pfFormChosen,
+              attrs: attributesFromMeta(meta, 'device_registration_list_roles')
+            }
+          ]
+        },
+        {
           label: i18n.t('Access duration to assign'),
           text: i18n.t(`The access duration to assign to devices registered from the self-service portal. If zero is specified, the access duration of the registrant is used.`),
           cols: [

--- a/lib/pf/ConfigStore/SelfService.pm
+++ b/lib/pf/ConfigStore/SelfService.pm
@@ -72,7 +72,7 @@ sub cleanupBeforeCommit {
 =cut
 
 sub _fields_expanded {
-    return qw(device_registration_allowed_devices roles_allowed_to_unregister);
+    return qw(device_registration_allowed_devices roles_allowed_to_unregister device_registration_list_roles);
 }
 
 =head1 AUTHOR

--- a/lib/pf/ConfigStore/SelfService.pm
+++ b/lib/pf/ConfigStore/SelfService.pm
@@ -72,7 +72,7 @@ sub cleanupBeforeCommit {
 =cut
 
 sub _fields_expanded {
-    return qw(device_registration_allowed_devices roles_allowed_to_unregister device_registration_role);
+    return qw(device_registration_allowed_devices roles_allowed_to_unregister device_registration_roles);
 }
 
 =head1 AUTHOR

--- a/lib/pf/ConfigStore/SelfService.pm
+++ b/lib/pf/ConfigStore/SelfService.pm
@@ -72,7 +72,7 @@ sub cleanupBeforeCommit {
 =cut
 
 sub _fields_expanded {
-    return qw(device_registration_allowed_devices roles_allowed_to_unregister device_registration_list_roles);
+    return qw(device_registration_allowed_devices roles_allowed_to_unregister device_registration_role);
 }
 
 =head1 AUTHOR


### PR DESCRIPTION
# Description
Choose the role to use to register a device on the self service page

# Impacts
Self-service page

# Issue
fixes #5114

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* Select the role of the device when register via self-service portal.

# UPGRADE file entries

=== Self registration portal

device_registration_role has been renamed device_registration_roles in order to apply the change run the following script:
./addons/upgrade/to-10.2-selfservice-conf.pl
