### PR TITLE
Restart rsyslog after new systemd config has been applied

### DIFF
--- a/rpm/packetfence.spec
+++ b/rpm/packetfence.spec
@@ -658,9 +658,6 @@ if [ ! -e /usr/local/pf/logs/$fic_log ]; then
 fi
 done
 
-echo "Restarting rsyslogd"
-/bin/systemctl restart rsyslog
-
 #Make ssl certificate
 cd /usr/local/pf
 make conf/ssl/server.pem
@@ -715,6 +712,9 @@ sysctl -p /etc/sysctl.d/99-ip_forward.conf
 
 # reloading systemd unit files
 /bin/systemctl daemon-reload
+
+echo "Restarting rsyslogd"
+/bin/systemctl restart rsyslog
 
 #Starting PacketFence.
 #removing old cache


### PR DESCRIPTION
# Description
Restart `rsyslog` during PacketFence installation on EL after `systemctl daemon-reload` has been run.

# Impacts
PacketFence installation (on a fresh CentOS). No impact on ZEN.

# Issue
fixes #5588 

# Delete branch after merge
YES

## Bug Fixes
* Logs files not generated until `rsyslog` has been restarted by hand (#5588 )

