### PR TITLE
use the auth header for Github access token

### DIFF
--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/OAuth/Github.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/OAuth/Github.pm
@@ -15,7 +15,7 @@ extends 'captiveportal::DynamicRouting::Module::Authentication::OAuth';
 
 has '+source' => (isa => 'pf::Authentication::Source::GithubSource');
 
-has '+token_scheme' => (default => sub{"uri-query:access_token"});
+has '+token_scheme' => (default => "auth-header:token");
 
 =head2 _extract_username_from_response
 


### PR DESCRIPTION
# Description
Use the "Authorization" header when performing calls to Github during OAuth

# Impacts
Github oauth authentication

# Issue
fixes #5600

# Delete branch after merge
YES

# NEWS file entries
## Enhancements
* Use the "Authorization" header when performing API calls to Github in the OAuth context