### PR TITLE
Master/Slave radius proxy and degraded workflow

### DIFF
--- a/conf/radiusd/auth.conf.example
+++ b/conf/radiusd/auth.conf.example
@@ -20,7 +20,7 @@ listen {
         ipaddr = [% ip %]
         port = 0
         type = auth
-        virtual_server = packetfence
+        virtual_server = [% virtual_server %]
 }
 
 listen {

--- a/conf/radiusd/eap.conf.example
+++ b/conf/radiusd/eap.conf.example
@@ -12,12 +12,12 @@
 #  common side effect of setting 'Auth-Type := EAP' is that the
 #  users then cannot use ANY other authentication method.
 #
-[% FOREACH section IN [ '' "eap-remote" ] %]
+[% FOREACH section IN [ '' "eap-degraded" ] %]
 [% FOREACH key IN eap.keys %]
 [% IF key == 'default' %]
 eap [% section %] {
 [% ELSE %]
-[% IF section == 'eap-remote' %]
+[% IF section == 'eap-degraded' %]
 eap [% key -%]-[% section %] {
 [% ELSE %]
 eap [% key -%] {
@@ -667,7 +667,11 @@ eap [% key -%] {
 		#  the virtual server that processed the
 		#  outer requests.
 		#
+[% IF section == 'eap-degraded' %]
 		virtual_server = "packetfence-tunnel"
+[% ELSE %]
+		virtual-server = "packetfence-degraded-tunnel"
+[% END %]
 
 		#  This has the same meaning, and overwrites, the
 		#  same field in the "tls" configuration, above.
@@ -788,8 +792,11 @@ eap [% key -%] {
 		#  the virtual server that processed the
 		#  outer requests.
 		#
+[% IF section == 'eap-degraded' %]
 		virtual_server = "packetfence-tunnel"
-
+[% ELSE %]
+		virtual-server = "packetfence-degraded-tunnel"
+[% END %]
 		#
 		# Unlike EAP-TLS, PEAP does not require a client certificate.
 		# However, you can require one by setting the following

--- a/conf/radiusd/eap.conf.example
+++ b/conf/radiusd/eap.conf.example
@@ -793,9 +793,9 @@ eap [% key -%] {
 		#  outer requests.
 		#
 [% IF section == 'eap-degraded' %]
-		virtual_server = "packetfence-tunnel"
-[% ELSE %]
 		virtual_server = "packetfence-degraded-tunnel"
+[% ELSE %]
+		virtual_server = "packetfence-tunnel"
 [% END %]
 		#
 		# Unlike EAP-TLS, PEAP does not require a client certificate.

--- a/conf/radiusd/eap.conf.example
+++ b/conf/radiusd/eap.conf.example
@@ -668,9 +668,9 @@ eap [% key -%] {
 		#  outer requests.
 		#
 [% IF section == 'eap-degraded' %]
-		virtual_server = "packetfence-tunnel"
+		virtual_server = "packetfence-degraded-tunnel"
 [% ELSE %]
-		virtual-server = "packetfence-degraded-tunnel"
+		virtual_server = "packetfence-tunnel"
 [% END %]
 
 		#  This has the same meaning, and overwrites, the
@@ -795,7 +795,7 @@ eap [% key -%] {
 [% IF section == 'eap-degraded' %]
 		virtual_server = "packetfence-tunnel"
 [% ELSE %]
-		virtual-server = "packetfence-degraded-tunnel"
+		virtual_server = "packetfence-degraded-tunnel"
 [% END %]
 		#
 		# Unlike EAP-TLS, PEAP does not require a client certificate.

--- a/conf/radiusd/eap.conf.example
+++ b/conf/radiusd/eap.conf.example
@@ -12,11 +12,16 @@
 #  common side effect of setting 'Auth-Type := EAP' is that the
 #  users then cannot use ANY other authentication method.
 #
+[% FOREACH section IN [ '' "eap-remote" ] %]
 [% FOREACH key IN eap.keys %]
 [% IF key == 'default' %]
-eap {
+eap [% $section %] {
+[% ELSE %]
+[% IF section == 'eap-remote' %]
+eap [% key -%]-[% $section %] {
 [% ELSE %]
 eap [% key -%] {
+[% END %]
 [% END %]
 	#  Invoke the default supported EAP type when
 	#  EAP-Identity response is received.
@@ -928,4 +933,4 @@ eap [% key -%] {
 		use_tunneled_reply = yes
 
 	}[% END %][% END %]
-}[% END -%]
+}[% END -%][% END %]

--- a/conf/radiusd/eap.conf.example
+++ b/conf/radiusd/eap.conf.example
@@ -15,10 +15,10 @@
 [% FOREACH section IN [ '' "eap-remote" ] %]
 [% FOREACH key IN eap.keys %]
 [% IF key == 'default' %]
-eap [% $section %] {
+eap [% section %] {
 [% ELSE %]
 [% IF section == 'eap-remote' %]
-eap [% key -%]-[% $section %] {
+eap [% key -%]-[% section %] {
 [% ELSE %]
 eap [% key -%] {
 [% END %]

--- a/conf/radiusd/packetfence-cli.example
+++ b/conf/radiusd/packetfence-cli.example
@@ -263,7 +263,7 @@ accounting {
 	#  Log traffic to an SQL database.
 	#
 	#  See "Accounting queries" in mods-available/sql
-	#%%accounting_sql%%
+	# [% accounting_sql %]
 
 	#
 	#  If you receive stop packets with zero session length,

--- a/conf/radiusd/packetfence-tunnel.example
+++ b/conf/radiusd/packetfence-tunnel.example
@@ -74,13 +74,13 @@ authorize {
 	suffix
 	ntdomain
 
-        %%authorize_filter%%
+        [% authorize_filter %]
 
-%%userPrincipalName%%
+[% userPrincipalName %]
 
-	%%multi_domain%%
+	[% multi_domain %]
 
-	%%redis_ntlm_cache_fetch%%
+	[% redis_ntlm_cache_fetch %]
 
 	#
 	#  The "suffix" module takes care of stripping the domain
@@ -107,7 +107,7 @@ authorize {
 	#  or PEAP.  The load on those servers will therefore be reduced.
 	#
 
-%%authorize_eap_choice%%
+[% authorize_eap_choice %]
 
 %%authorize_ldap_choice%%
 
@@ -212,7 +212,7 @@ authenticate {
 		}
 	}
 
-%%authentication_auth_type%%
+[% authentication_auth_type %]
 
 %%authentication_ldap_auth_type%%
 
@@ -448,9 +448,9 @@ authorize {
 	suffix
 	ntdomain
 
-	%%multi_domain%%
+	[% multi_domain %]
 
-	%%redis_ntlm_cache_fetch%%
+	[% redis_ntlm_cache_fetch %]
 
 	#
 	#  The "suffix" module takes care of stripping the domain

--- a/conf/radiusd/packetfence-tunnel.example
+++ b/conf/radiusd/packetfence-tunnel.example
@@ -109,7 +109,7 @@ authorize {
 
 [% authorize_eap_choice %]
 
-%%authorize_ldap_choice%%
+[% authorize_ldap_choice %]
 
 	#
 	#  Read the 'users' file
@@ -126,7 +126,7 @@ authorize {
 
 	#
 
-%%edir_configuration%%
+[% edir_configuration %]
 
 	#
 	#  If no other module has claimed responsibility for
@@ -214,7 +214,7 @@ authenticate {
 
 [% authentication_auth_type %]
 
-%%authentication_ldap_auth_type%%
+[% authentication_ldap_auth_type %]
 
 	# Uncomment it if you want to use ldap for authentication
 	#

--- a/conf/radiusd/packetfence.example
+++ b/conf/radiusd/packetfence.example
@@ -76,7 +76,7 @@ server packetfence {
 		suffix
 		ntdomain
 
-	%%authorize_filter%%
+	[% authorize_filter %]
 
 		#
 		#  This module takes care of EAP-MD5, EAP-TLS, and EAP-LEAP
@@ -95,7 +95,7 @@ server packetfence {
 		#  TTLS or PEAP.
 		#
 
-	%%authorize_eap_choice%%
+	[% authorize_eap_choice %]
 
 		#
 		#  Read the 'users' file.  In v3, this is located in
@@ -186,7 +186,7 @@ server packetfence {
 			packetfence-mschap-authenticate
 		}
 
-	%%authentication_auth_type%%
+	[% authentication_auth_type %]
 
 		#  Uncomment it if you want to use ldap for authentication
 		#
@@ -261,7 +261,7 @@ server packetfence {
 		#  home server as authentication requests.
 		#	IPASS
 		suffix
-		%%preacct_filter%%
+		[% preacct_filter %]
 		ntdomain
 
 		#
@@ -287,7 +287,7 @@ server packetfence {
 		#  Log traffic to an SQL database.
 		#
 		#  See "Accounting queries" in mods-available/sql
-		%%accounting_sql%%
+		[% accounting_sql %]
 
 		#
 		#  If you receive stop packets with zero session length,
@@ -352,7 +352,7 @@ server packetfence {
 		#	&reply: += &session-state:
 		#}
 		if ("%{%{control:PacketFence-Proxied-From}:-False}" == "True") {
-	%%local_realm%%
+	[% local_realm %]
 			if ("%{%{control:PacketFence-Authorization-Status}:-Allow}" == "deny") {
 				packetfence-audit-log-reject
 				reject
@@ -422,7 +422,7 @@ server packetfence {
 	#
 	pre-proxy {
 		attr_filter.packetfence_pre_proxy
-		%%pre_proxy_filter%%
+		[% pre_proxy_filter %]
 	}
 
 	#
@@ -469,12 +469,13 @@ server packetfence {
 			PacketFence-Proxied-From := "True"
 		}
 
-		%%post_proxy_filter%%
+		[% post_proxy_filter %]
 	}
 }
 
+[% IF remote == "YES" %]
 
-%%members%%
+[% members %]
 
 home_server degraded {
 	virtual_server = pf.degraded
@@ -484,7 +485,7 @@ home_server degraded {
 home_server_pool pf_auth_pool {
 	type = fail-over
 
-%%home_server%%
+[% home_server %]
 
 	home_server = degraded
 }
@@ -492,7 +493,7 @@ home_server_pool pf_auth_pool {
 home_server_pool pf_acct_pool {
 	type = fail-over
 
-%%home_server%%
+[% home_server %]
 
 }
 
@@ -500,6 +501,8 @@ realm remote {
 auth_pool = pf_auth_pool
 	acct_pool = pf_acct_pool
 }
+
+[% END %]
 
 server pf-remote {
 	pre-proxy {

--- a/conf/radiusd/packetfence.example
+++ b/conf/radiusd/packetfence.example
@@ -1,275 +1,587 @@
 server packetfence {
-#
-#  Authorization. First preprocess (hints and huntgroups files),
-#  then realms, and finally look in the "users" file.
-#
-#  Any changes made here should also be made to the "inner-tunnel"
-#  virtual server.
-#
-#  The order of the realm modules will determine the order that
-#  we try to find a matching realm.
-#
-#  Make *sure* that 'preprocess' comes before any realm if you
-#  need to setup hints for the remote radius server
-authorize {
-	packetfence-nas-ip-address
+	#
+	#  Authorization. First preprocess (hints and huntgroups files),
+	#  then realms, and finally look in the "users" file.
+	#
+	#  Any changes made here should also be made to the "inner-tunnel"
+	#  virtual server.
+	#
+	#  The order of the realm modules will determine the order that
+	#  we try to find a matching realm.
+	#
+	#  Make *sure* that 'preprocess' comes before any realm if you
+	#  need to setup hints for the remote radius server
+	authorize {
 
-	# Add in PacketFence specific configuration
-	update {
-		&request:FreeRADIUS-Client-IP-Address := "%{Packet-Src-IP-Address}"
-		&request:PacketFence-Radius-Ip := "%{Packet-Dst-IP-Address}"
-		&control:PacketFence-RPC-Server = ${rpc_host}
-		&control:PacketFence-RPC-Port = ${rpc_port}
-		&control:PacketFence-RPC-User = ${rpc_user}
-		&control:PacketFence-RPC-Pass = ${rpc_pass}
-		&control:PacketFence-RPC-Proto = ${rpc_proto}
-		&control:Tmp-Integer-0 := "%l"
-		&control:PacketFence-Request-Time := 0
-	}
-	packetfence-set-realm-if-machine
-	packetfence-balanced-key-policy
-	packetfence-set-tenant-id
-	rewrite_calling_station_id
-	rewrite_called_station_id
-
-	if ( "%{client:shortname}" =~ /eduroam_tlrs/ ) {
-		update request {
-			PacketFence-ShortName := "%{client:shortname}"
-		}
-	}
-
-	#
-	#  Take a User-Name, and perform some checks on it, for spaces and other
-	#  invalid characters.  If the User-Name appears invalid, reject the
-	#  request.
-	#
-	#  See policy.d/filter for the definition of the filter_username policy.
-	#
-	filter_username
-
-	#
-	#  Some broken equipment sends passwords with embedded zeros.
-	#  i.e. the debug output will show
-	#
-	#	User-Password = "password\000\000"
-	#
-	#  This policy will fix it to just be "password".
-	#
-	filter_password
-
-	#
-	#  The preprocess module takes care of sanitizing some bizarre
-	#  attributes in the request, and turning them into attributes
-	#  which are more standard.
-	#
-	#  It takes care of processing the 'raddb/hints' and the
-	#  'raddb/huntgroups' files.
-	preprocess
-
-	mschap
-
-	#
-	#  If you are using multiple kinds of realms, you probably
-	#  want to set "ignore_null = yes" for all of them.
-	#  Otherwise, when the first style of realm doesn't match,
-	#  the other styles won't be checked.
-	#
-	suffix
-	ntdomain
-
-%%authorize_filter%%
-
-	#
-	#  This module takes care of EAP-MD5, EAP-TLS, and EAP-LEAP
-	#  authentication.
-	#
-	#  It also sets the EAP-Type attribute in the request
-	#  attribute list to the EAP type from the packet.
-	#
-	#  The EAP module returns "ok" if it is not yet ready to
-	#  authenticate the user.  The configuration below checks for
-	#  that code, and stops processing the "authorize" section if
-	#  so.
-	#
-	#  Any LDAP and/or SQL servers will not be queried for the
-	#  initial set of packets that go back and forth to set up
-	#  TTLS or PEAP.
-	#
-
-%%authorize_eap_choice%%
-
-	#
-	#  Read the 'users' file.  In v3, this is located in
-	#  raddb/mods-config/files/authorize
-	#files
-
-	# Accept any non-eap request and send it to the packetfence module for authorization
-	if ( !EAP-Message && "%{%{Control:Auth-type}:-No-MS_CHAP}" != "MS-CHAP") {
+		# Add in PacketFence specific configuration
 		update {
-			&control:Auth-Type := Accept
+			&request:FreeRADIUS-Client-IP-Address := "%{Packet-Src-IP-Address}"
+			&request:PacketFence-Radius-Ip := "%{Packet-Dst-IP-Address}"
+			&control:PacketFence-RPC-Server = ${rpc_host}
+			&control:PacketFence-RPC-Port = ${rpc_port}
+			&control:PacketFence-RPC-User = ${rpc_user}
+			&control:PacketFence-RPC-Pass = ${rpc_pass}
+			&control:PacketFence-RPC-Proto = ${rpc_proto}
+			&control:Tmp-Integer-0 := "%l"
+			&control:PacketFence-Request-Time := 0
+		}
+		packetfence-set-realm-if-machine
+		packetfence-balanced-key-policy
+		packetfence-set-tenant-id
+		rewrite_calling_station_id
+		rewrite_called_station_id
+
+		if ( "%{client:shortname}" =~ /eduroam_tlrs/ ) {
+			update request {
+				PacketFence-ShortName := "%{client:shortname}"
+			}
+		}
+
+		#
+		#  Take a User-Name, and perform some checks on it, for spaces and other
+		#  invalid characters.  If the User-Name appears invalid, reject the
+		#  request.
+		#
+		#  See policy.d/filter for the definition of the filter_username policy.
+		#
+		filter_username
+
+		#
+		#  Some broken equipment sends passwords with embedded zeros.
+		#  i.e. the debug output will show
+		#
+		#	User-Password = "password\000\000"
+		#
+		#  This policy will fix it to just be "password".
+		#
+		filter_password
+
+		#
+		#  The preprocess module takes care of sanitizing some bizarre
+		#  attributes in the request, and turning them into attributes
+		#  which are more standard.
+		#
+		#  It takes care of processing the 'raddb/hints' and the
+		#  'raddb/huntgroups' files.
+		preprocess
+
+		mschap
+
+		#
+		#  If you are using multiple kinds of realms, you probably
+		#  want to set "ignore_null = yes" for all of them.
+		#  Otherwise, when the first style of realm doesn't match,
+		#  the other styles won't be checked.
+		#
+		suffix
+		ntdomain
+
+	%%authorize_filter%%
+
+		#
+		#  This module takes care of EAP-MD5, EAP-TLS, and EAP-LEAP
+		#  authentication.
+		#
+		#  It also sets the EAP-Type attribute in the request
+		#  attribute list to the EAP type from the packet.
+		#
+		#  The EAP module returns "ok" if it is not yet ready to
+		#  authenticate the user.  The configuration below checks for
+		#  that code, and stops processing the "authorize" section if
+		#  so.
+		#
+		#  Any LDAP and/or SQL servers will not be queried for the
+		#  initial set of packets that go back and forth to set up
+		#  TTLS or PEAP.
+		#
+
+	%%authorize_eap_choice%%
+
+		#
+		#  Read the 'users' file.  In v3, this is located in
+		#  raddb/mods-config/files/authorize
+		#files
+
+		# Accept any non-eap request and send it to the packetfence module for authorization
+		if ( !EAP-Message && "%{%{Control:Auth-type}:-No-MS_CHAP}" != "MS-CHAP") {
+			update {
+				&control:Auth-Type := Accept
+			}
+		}
+		if (Control:Auth-type == "MS-CHAP") {
+			packetfence-multi-domain
+		}
+		packetfence-eap-mac-policy
+
+		#
+		#  Look in an SQL database.  The schema of the database
+		#  is meant to mirror the "users" file.
+		#
+		#  See "Authorization Queries" in mods-available/sql
+		#-sql
+
+		#
+		#  If no other module has claimed responsibility for
+		#  authentication, then try to use PAP.  This allows the
+		#  other modules listed above to add a "known good" password
+		#  to the request, and to do nothing else.  The PAP module
+		#  will then see that password, and use it to do PAP
+		#  authentication.
+		#
+		#  This module should be listed last, so that the other modules
+		#  get a chance to set Auth-Type for themselves.
+		#
+		pap
+
+	}
+
+
+	#  Authentication.
+	#
+	#
+	#  This section lists which modules are available for authentication.
+	#  Note that it does NOT mean 'try each module in order'.  It means
+	#  that a module from the 'authorize' section adds a configuration
+	#  attribute 'Auth-Type := FOO'.  That authentication type is then
+	#  used to pick the appropriate module from the list below.
+	#
+
+	#  In general, you SHOULD NOT set the Auth-Type attribute.  The server
+	#  will figure it out on its own, and will do the right thing.  The
+	#  most common side effect of erroneously setting the Auth-Type
+	#  attribute is that one authentication method will work, but the
+	#  others will not.
+	#
+	#  The common reasons to set the Auth-Type attribute by hand
+	#  is to either forcibly reject the user (Auth-Type := Reject),
+	#  or to or forcibly accept the user (Auth-Type := Accept).
+	#
+	#  Note that Auth-Type := Accept will NOT work with EAP.
+	#
+	#  Please do not put "unlang" configurations into the "authenticate"
+	#  section.  Put them in the "post-auth" section instead.  That's what
+	#  the post-auth section is for.
+	#
+	authenticate {
+		#
+		#  PAP authentication, when a back-end database listed
+		#  in the 'authorize' section supplies a password.  The
+		#  password can be clear-text, or encrypted.
+		Auth-Type PAP {
+			pap
+		}
+
+		#
+		#  Most people want CHAP authentication
+		#  A back-end database listed in the 'authorize' section
+		#  MUST supply a CLEAR TEXT password.  Encrypted passwords
+		#  won't work.
+		Auth-Type CHAP {
+			chap
+		}
+
+		#
+		#  MSCHAP authentication.
+		Auth-Type MS-CHAP {
+			packetfence-mschap-authenticate
+		}
+
+	%%authentication_auth_type%%
+
+		#  Uncomment it if you want to use ldap for authentication
+		#
+		#  Note that this means "check plain-text password against
+		#  the ldap database", which means that EAP won't work,
+		#  as it does not supply a plain-text password.
+		#
+		#  We do NOT recommend using this.  LDAP servers are databases.
+		#  They are NOT authentication servers.  FreeRADIUS is an
+		#  authentication server, and knows what to do with authentication.
+		#  LDAP servers do not.
+		#
+		#	Auth-Type LDAP {
+		#		ldap
+		#	}
+
+		#
+		#  Allow EAP authentication.
+		eap
+	}
+
+
+	#
+	#  Pre-accounting.  Decide which accounting type to use.
+	#
+	preacct {
+		preprocess
+		packetfence-set-realm-if-machine
+		packetfence-balanced-key-policy
+		packetfence-set-tenant-id
+		set_calling_station_id
+		rewrite_calling_station_id
+		rewrite_called_station_id
+
+		#
+		#  Merge Acct-[Input|Output]-Gigawords and Acct-[Input-Output]-Octets
+		#  into a single 64bit counter Acct-[Input|Output]-Octets64.
+		#
+		# acct_counters64
+
+		#
+		#  Session start times are *implied* in RADIUS.
+		#  The NAS never sends a "start time".  Instead, it sends
+		#  a start packet, *possibly* with an Acct-Delay-Time.
+		#  The server is supposed to conclude that the start time
+		#  was "Acct-Delay-Time" seconds in the past.
+		#
+		#  The code below creates an explicit start time, which can
+		#  then be used in other modules.  It will be *mostly* correct.
+		#  Any errors are due to the 1-second resolution of RADIUS,
+		#  and the possibility that the time on the NAS may be off.
+		#
+		#  The start time is: NOW - delay - session_length
+		#
+
+		#	update request {
+		#	  	FreeRADIUS-Acct-Session-Start-Time = "%{expr: %l - %{%{Acct-Session-Time}:-0} - %{%{Acct-Delay-Time}:-0}}"
+		#	}
+
+
+		#
+		#  Ensure that we have a semi-unique identifier for every
+		#  request, and many NAS boxes are broken.
+		acct_unique
+
+		#
+		#  Look for IPASS-style 'realm/', and if not found, look for
+		#  '@realm', and decide whether or not to proxy, based on
+		#  that.
+		#
+		#  Accounting requests are generally proxied to the same
+		#  home server as authentication requests.
+		#	IPASS
+		suffix
+		%%preacct_filter%%
+		ntdomain
+
+		#
+		#  Read the 'acct_users' file
+		files
+	}
+
+	#
+	#  Accounting.  Log the accounting data.
+	#
+	accounting {
+		# Add in PacketFence specific configuration
+		update {
+			&request:FreeRADIUS-Client-IP-Address := "%{Packet-Src-IP-Address}"
+			&control:PacketFence-RPC-Server = ${rpc_host}
+			&control:PacketFence-RPC-Port = ${rpc_port}
+			&control:PacketFence-RPC-User = ${rpc_user}
+			&control:PacketFence-RPC-Pass = ${rpc_pass}
+			&control:PacketFence-RPC-Proto = ${rpc_proto}
+		}
+		packetfence-set-tenant-id
+		#
+		#  Log traffic to an SQL database.
+		#
+		#  See "Accounting queries" in mods-available/sql
+		%%accounting_sql%%
+
+		#
+		#  If you receive stop packets with zero session length,
+		#  they will NOT be logged in the database.  The SQL module
+		#  will print a message (only in debugging mode), and will
+		#  return "noop".
+		#
+		#  You can ignore these packets by uncommenting the following
+		#  three lines.  Otherwise, the server will not respond to the
+		#  accounting request, and the NAS will retransmit.
+		#
+		if (noop) {
+			ok
+		}
+
+		#  Filter attributes from the accounting response.
+		attr_filter.accounting_response
+		if !( ("%{client:shortname}" =~ /eduroam_tlrs/)  || (&request:PacketFence-ShortName && &request:PacketFence-ShortName =~ /eduroam_tlrs/)) {
+			rest
 		}
 	}
-	if (Control:Auth-type == "MS-CHAP") {
-		packetfence-multi-domain
+
+
+	#  Session database, used for checking Simultaneous-Use. Either the radutmp
+	#  or rlm_sql module can handle this.
+	#  The rlm_sql module is *much* faster
+	session {
+		#	radutmp
+
+		#
+		#  See "Simultaneous Use Checking Queries" in mods-available/sql
+		#	sql
 	}
-	packetfence-eap-mac-policy
+
+
+	#  Post-Authentication
+	#  Once we KNOW that the user has been authenticated, there are
+	#  additional steps we can take.
+	post-auth {
+
+		# Add in PacketFence configuration
+		update {
+			&request:FreeRADIUS-Client-IP-Address := "%{Packet-Src-IP-Address}"
+			&request:PacketFence-Radius-Ip := "%{Packet-Dst-IP-Address}"
+			&control:PacketFence-RPC-Server = ${rpc_host}
+			&control:PacketFence-RPC-Port = ${rpc_port}
+			&control:PacketFence-RPC-User = ${rpc_user}
+			&control:PacketFence-RPC-Pass = ${rpc_pass}
+			&control:PacketFence-RPC-Proto = ${rpc_proto}
+		}
+		packetfence-set-tenant-id
+		#
+		#  For EAP-TTLS and PEAP, add the cached attributes to the reply.
+		#  The "session-state" attributes are automatically cached when
+		#  an Access-Challenge is sent, and automatically retrieved
+		#  when an Access-Request is received.
+		#
+		#  The session-state attributes are automatically deleted after
+		#  an Access-Reject or Access-Accept is sent.
+		#
+		#update {
+		#	&reply: += &session-state:
+		#}
+		if ("%{%{control:PacketFence-Proxied-From}:-False}" == "True") {
+	%%local_realm%%
+			if ("%{%{control:PacketFence-Authorization-Status}:-Allow}" == "deny") {
+				packetfence-audit-log-reject
+				reject
+			} else {
+				packetfence-audit-log-accept
+			}
+		}
+
+		# If the request has not been handled inside the inner-tunnel
+		# send it to packetfence
+		if (! EAP-Type || (EAP-Type != TTLS  && EAP-Type != PEAP) ) {
+			rest
+			update {
+				&request:User-Password := "******"
+			}
+			if ("%{%{control:PacketFence-Authorization-Status}:-Allow}" == "deny") {
+				packetfence-audit-log-reject
+				reject
+			} else {
+				packetfence-audit-log-accept
+			}
+		}
+
+		attr_filter.packetfence_post_auth
+		linelog
+		#
+		#  Access-Reject packets are sent through the REJECT sub-section of the
+		#  post-auth section.
+		#
+		#  Add the ldap module name (or instance) if you have set
+		#  'edir_account_policy_check = yes' in the ldap module configuration
+		#
+		#  The "session-state" attributes are not available here.
+		#
+		Post-Auth-Type REJECT {
+			packetfence-set-tenant-id
+			update {
+				&request:User-Password := "******"
+			}
+			if (! EAP-Type || (EAP-Type != TTLS  && EAP-Type != PEAP) ) {
+				packetfence-audit-log-reject
+			}
+			if ("%{%{control:PacketFence-Proxied-From}:-False}" == "True") {
+				packetfence-audit-log-reject
+			}
+			attr_filter.access_reject
+			attr_filter.packetfence_post_auth
+
+			# Insert EAP-Failure message if the request was
+			# rejected by policy instead of because of an
+			# authentication failure
+			eap
+
+			#  Remove reply message if the response contains an EAP-Message
+			remove_reply_message_if_eap
+			linelog
+		}
+	}
 
 	#
-	#  Look in an SQL database.  The schema of the database
-	#  is meant to mirror the "users" file.
+	#  When the server decides to proxy a request to a home server,
+	#  the proxied request is first passed through the pre-proxy
+	#  stage.  This stage can re-write the request, or decide to
+	#  cancel the proxy.
 	#
-	#  See "Authorization Queries" in mods-available/sql
-	#-sql
+	#  Only a few modules currently have this method.
+	#
+	pre-proxy {
+		attr_filter.packetfence_pre_proxy
+		%%pre_proxy_filter%%
+	}
 
 	#
-	#  If no other module has claimed responsibility for
-	#  authentication, then try to use PAP.  This allows the
-	#  other modules listed above to add a "known good" password
-	#  to the request, and to do nothing else.  The PAP module
-	#  will then see that password, and use it to do PAP
-	#  authentication.
+	#  When the server receives a reply to a request it proxied
+	#  to a home server, the request may be massaged here, in the
+	#  post-proxy stage.
 	#
-	#  This module should be listed last, so that the other modules
-	#  get a chance to set Auth-Type for themselves.
-	#
-	pap
+	post-proxy {
 
+		#
+		#  If you are proxying LEAP, you MUST configure the EAP
+		#  module, and you MUST list it here, in the post-proxy
+		#  stage.
+		#
+		#  You MUST also use the 'nostrip' option in the 'realm'
+		#  configuration.  Otherwise, the User-Name attribute
+		#  in the proxied request will not match the user name
+		#  hidden inside of the EAP packet, and the end server will
+		#  reject the EAP request.
+		#
+		eap
+
+		#
+		#  If the server tries to proxy a request and fails, then the
+		#  request is processed through the modules in this section.
+		#
+		#  The main use of this section is to permit robust proxying
+		#  of accounting packets.  The server can be configured to
+		#  proxy accounting packets as part of normal processing.
+		#  Then, if the home server goes down, accounting packets can
+		#  be logged to a local "detail" file, for processing with
+		#  radrelay.  When the home server comes back up, radrelay
+		#  will read the detail file, and send the packets to the
+		#  home server.
+		#
+		#  With this configuration, the server always responds to
+		#  Accounting-Requests from the NAS, but only writes
+		#  accounting packets to disk if the home server is down.
+		#
+		#	Post-Proxy-Type Fail-Accounting {
+		#			detail
+		#	}
+		update control {
+			PacketFence-Proxied-From := "True"
+		}
+
+		%%post_proxy_filter%%
+	}
 }
 
 
-#  Authentication.
-#
-#
-#  This section lists which modules are available for authentication.
-#  Note that it does NOT mean 'try each module in order'.  It means
-#  that a module from the 'authorize' section adds a configuration
-#  attribute 'Auth-Type := FOO'.  That authentication type is then
-#  used to pick the appropriate module from the list below.
-#
+%%members%%
 
-#  In general, you SHOULD NOT set the Auth-Type attribute.  The server
-#  will figure it out on its own, and will do the right thing.  The
-#  most common side effect of erroneously setting the Auth-Type
-#  attribute is that one authentication method will work, but the
-#  others will not.
-#
-#  The common reasons to set the Auth-Type attribute by hand
-#  is to either forcibly reject the user (Auth-Type := Reject),
-#  or to or forcibly accept the user (Auth-Type := Accept).
-#
-#  Note that Auth-Type := Accept will NOT work with EAP.
-#
-#  Please do not put "unlang" configurations into the "authenticate"
-#  section.  Put them in the "post-auth" section instead.  That's what
-#  the post-auth section is for.
-#
-authenticate {
-	#
-	#  PAP authentication, when a back-end database listed
-	#  in the 'authorize' section supplies a password.  The
-	#  password can be clear-text, or encrypted.
-	Auth-Type PAP {
-		pap
-	}
-
-	#
-	#  Most people want CHAP authentication
-	#  A back-end database listed in the 'authorize' section
-	#  MUST supply a CLEAR TEXT password.  Encrypted passwords
-	#  won't work.
-	Auth-Type CHAP {
-		chap
-	}
-
-	#
-	#  MSCHAP authentication.
-	Auth-Type MS-CHAP {
-		packetfence-mschap-authenticate
-	}
-
-%%authentication_auth_type%%
-
-	#  Uncomment it if you want to use ldap for authentication
-	#
-	#  Note that this means "check plain-text password against
-	#  the ldap database", which means that EAP won't work,
-	#  as it does not supply a plain-text password.
-	#
-	#  We do NOT recommend using this.  LDAP servers are databases.
-	#  They are NOT authentication servers.  FreeRADIUS is an
-	#  authentication server, and knows what to do with authentication.
-	#  LDAP servers do not.
-	#
-#	Auth-Type LDAP {
-#		ldap
-#	}
-
-	#
-	#  Allow EAP authentication.
-	eap
+home_server degraded {
+	virtual_server = pf.degraded
 }
 
+#  Put all of the servers into a pool.
+home_server_pool pf_auth_pool {
+	type = fail-over
 
-#
-#  Pre-accounting.  Decide which accounting type to use.
-#
-preacct {
-	preprocess
-	packetfence-set-realm-if-machine
-	packetfence-balanced-key-policy
-	packetfence-set-tenant-id
-	set_calling_station_id
+%%home_server%%
+
+	home_server = degraded
+}
+
+home_server_pool pf_acct_pool {
+	type = fail-over
+
+%%home_server%%
+
+}
+
+realm remote {
+auth_pool = pf_auth_pool
+	acct_pool = pf_acct_pool
+}
+
+server pf-remote {
+	pre-proxy {
+		#  Insert pre-proxy rules here
+	}
+
 	rewrite_calling_station_id
 	rewrite_called_station_id
 
-	#
-	#  Merge Acct-[Input|Output]-Gigawords and Acct-[Input-Output]-Octets
-	#  into a single 64bit counter Acct-[Input|Output]-Octets64.
-	#
-#	acct_counters64
+	post-proxy {
+		update control {
+			PacketFence-Proxied-To := "%{home_server:ipaddr}"
+		}
+		if (&proxy-reply:Packet-Type == Access-Accept) {
+			%{sql_degraded:DELETE FROM radreply where username="%{Calling-Station-Id}"}
+			reply_in_db
+			%{sql_degraded:%{control:PacketFence-reply-insert}}
+		}
+		else {
+			noop
+		}
+		attr_filter.packetfence_post_auth
+	}
 
-	#
-	#  Session start times are *implied* in RADIUS.
-	#  The NAS never sends a "start time".  Instead, it sends
-	#  a start packet, *possibly* with an Acct-Delay-Time.
-	#  The server is supposed to conclude that the start time
-	#  was "Acct-Delay-Time" seconds in the past.
-	#
-	#  The code below creates an explicit start time, which can
-	#  then be used in other modules.  It will be *mostly* correct.
-	#  Any errors are due to the 1-second resolution of RADIUS,
-	#  and the possibility that the time on the NAS may be off.
-	#
-	#  The start time is: NOW - delay - session_length
-	#
-
-	#	update request {
-	#	  	FreeRADIUS-Acct-Session-Start-Time = "%{expr: %l - %{%{Acct-Session-Time}:-0} - %{%{Acct-Delay-Time}:-0}}"
-	#	}
+	authorize {
+		update control {
+			Load-Balance-Key := "%{Calling-Station-Id}"
+			Proxy-To-Realm := "remote"
+		}
+		if(!NAS-IP-Address){
+			update request {
+				NAS-IP-Address := "%{Packet-Src-IP-Address}"
+			}
+		}
+	}
 
 
-	#
-	#  Ensure that we have a semi-unique identifier for every
-	#  request, and many NAS boxes are broken.
-	acct_unique
+	authenticate {
+	}
+	accounting {
+		update control {
+			Proxy-To-Realm := "remote"
+		}
+		if(!NAS-IP-Address){
+			update request {
+				NAS-IP-Address := "%{Packet-Src-IP-Address}"
+			}
+		}
+	}
 
-	#
-	#  Look for IPASS-style 'realm/', and if not found, look for
-	#  '@realm', and decide whether or not to proxy, based on
-	#  that.
-	#
-	#  Accounting requests are generally proxied to the same
-	#  home server as authentication requests.
-	#	IPASS
-	suffix
-	%%preacct_filter%%
-	ntdomain
-
-	#
-	#  Read the 'acct_users' file
-	files
 }
 
+
+
+server pf.degraded {
+	authorize {
+		rewrite_calling_station_id
+		rewrite_called_station_id
+
+		filter_username
+
+		filter_password
+
+		preprocess
+
+		suffix
+
+		ntdomain
+
+		eap-remote {
+			ok = return
+		}
+
+		if ( !EAP-Message ) {
+			update {
+				&control:Auth-Type := Accept
+			}
+		}
+		-sql_degraded
+		pap
+
+<<<<<<< HEAD
 #
 #  Accounting.  Log the accounting data.
 #
@@ -285,193 +597,152 @@ accounting {
 		&control:PacketFence-RPC-Pass = ${rpc_pass}
 		&control:PacketFence-RPC-Proto = ${rpc_proto}
 	}
-	packetfence-set-tenant-id
-	#
-	#  Log traffic to an SQL database.
-	#
-	#  See "Accounting queries" in mods-available/sql
-	%%accounting_sql%%
 
-	#
-	#  If you receive stop packets with zero session length,
-	#  they will NOT be logged in the database.  The SQL module
-	#  will print a message (only in debugging mode), and will
-	#  return "noop".
-	#
-	#  You can ignore these packets by uncommenting the following
-	#  three lines.  Otherwise, the server will not respond to the
-	#  accounting request, and the NAS will retransmit.
-	#
-	if (noop) {
-		ok
+
+	authenticate {
+		Auth-Type PAP {
+			pap
+		}
+
+		Auth-Type CHAP {
+			chap
+		}
+
+		Auth-Type MS-CHAP {
+			mschap
+		}
+
+	#	Auth-Type LDAP {
+	#		ldap
+	#	}
+
+		#
+		#  Allow EAP authentication.
+		eap-remote
 	}
 
-	#  Filter attributes from the accounting response.
-	attr_filter.accounting_response
-	if !( ("%{client:shortname}" =~ /eduroam_tlrs/)  || (&request:PacketFence-ShortName && &request:PacketFence-ShortName =~ /eduroam_tlrs/)) {
-		rest
-	}
-}
-
-
-#  Session database, used for checking Simultaneous-Use. Either the radutmp
-#  or rlm_sql module can handle this.
-#  The rlm_sql module is *much* faster
-session {
-	#	radutmp
 
 	#
-	#  See "Simultaneous Use Checking Queries" in mods-available/sql
-	#	sql
-}
-
-
-#  Post-Authentication
-#  Once we KNOW that the user has been authenticated, there are
-#  additional steps we can take.
-post-auth {
-
-	# Add in PacketFence configuration
-	update {
-		&request:FreeRADIUS-Client-IP-Address := "%{Packet-Src-IP-Address}"
-		&request:PacketFence-Radius-Ip := "%{Packet-Dst-IP-Address}"
-		&control:PacketFence-RPC-Server = ${rpc_host}
-		&control:PacketFence-RPC-Port = ${rpc_port}
-		&control:PacketFence-RPC-User = ${rpc_user}
-		&control:PacketFence-RPC-Pass = ${rpc_pass}
-		&control:PacketFence-RPC-Proto = ${rpc_proto}
-	}
-	packetfence-set-tenant-id
+	#  Pre-accounting.  Decide which accounting type to use.
 	#
-	#  For EAP-TTLS and PEAP, add the cached attributes to the reply.
-	#  The "session-state" attributes are automatically cached when
-	#  an Access-Challenge is sent, and automatically retrieved
-	#  when an Access-Request is received.
-	#
-	#  The session-state attributes are automatically deleted after
-	#  an Access-Reject or Access-Accept is sent.
-	#
-	#update {
-	#	&reply: += &session-state:
-	#}
-	if ("%{%{control:PacketFence-Proxied-From}:-False}" == "True") {
-%%local_realm%%
-		if ("%{%{control:PacketFence-Authorization-Status}:-Allow}" == "deny") {
-			packetfence-audit-log-reject
-			reject
-		} else {
-			packetfence-audit-log-accept
-		}
+	preacct {
+		preprocess
+
 	}
 
-	# If the request has not been handled inside the inner-tunnel
-	# send it to packetfence
-	if (! EAP-Type || (EAP-Type != TTLS  && EAP-Type != PEAP) ) {
-		rest
-		update {
-			&request:User-Password := "******"
+	#
+	#  Accounting.  Log the accounting data.
+	#
+	accounting {
+		if (noop) {
+			ok
 		}
-		if ("%{%{control:PacketFence-Authorization-Status}:-Allow}" == "deny") {
-			packetfence-audit-log-reject
-			reject
-		} else {
-			packetfence-audit-log-accept
-		}
+
+		attr_filter.accounting_response
 	}
 
-	attr_filter.packetfence_post_auth
-	linelog
-	#
-	#  Access-Reject packets are sent through the REJECT sub-section of the
-	#  post-auth section.
-	#
-	#  Add the ldap module name (or instance) if you have set
-	#  'edir_account_policy_check = yes' in the ldap module configuration
-	#
-	#  The "session-state" attributes are not available here.
-	#
-	Post-Auth-Type REJECT {
-		packetfence-set-tenant-id
-		update {
-			&request:User-Password := "******"
-		}
-		if (! EAP-Type || (EAP-Type != TTLS  && EAP-Type != PEAP) ) {
-			packetfence-audit-log-reject
-		}
-	        if ("%{%{control:PacketFence-Proxied-From}:-False}" == "True") {
-			packetfence-audit-log-reject
-		}
-		attr_filter.access_reject
+
+	session {
+	}
+
+
+	post-auth {
 		attr_filter.packetfence_post_auth
-
-		# Insert EAP-Failure message if the request was
-		# rejected by policy instead of because of an
-		# authentication failure
-		eap
-
-		#  Remove reply message if the response contains an EAP-Message
-		remove_reply_message_if_eap
 		linelog
+		Post-Auth-Type REJECT {
+			attr_filter.access_reject
+			attr_filter.packetfence_post_auth
+
+			# Insert EAP-Failure message if the request was
+			# rejected by policy instead of because of an
+			# authentication failure
+			eap-remote
+
+			#  Remove reply message if the response contains an EAP-Message
+			remove_reply_message_if_eap
+			linelog
+		}
+	}
+
+	pre-proxy {
+	}
+
+	post-proxy {
+
+		eap-remote
 	}
 }
 
-#
-#  When the server decides to proxy a request to a home server,
-#  the proxied request is first passed through the pre-proxy
-#  stage.  This stage can re-write the request, or decide to
-#  cancel the proxy.
-#
-#  Only a few modules currently have this method.
-#
-pre-proxy {
-	attr_filter.packetfence_pre_proxy
-	%%pre_proxy_filter%%
-}
+server packetfence-degraded-tunnel {
 
-#
-#  When the server receives a reply to a request it proxied
-#  to a home server, the request may be massaged here, in the
-#  post-proxy stage.
-#
-post-proxy {
+	authorize {
+		filter_username
+		mschap
+		suffix
+		ntdomain
+		update control {
+			&Proxy-To-Realm := LOCAL
+		}
+		eap-remote {
+			ok = return
+		}
 
-	#
-	#  If you are proxying LEAP, you MUST configure the EAP
-	#  module, and you MUST list it here, in the post-proxy
-	#  stage.
-	#
-	#  You MUST also use the 'nostrip' option in the 'realm'
-	#  configuration.  Otherwise, the User-Name attribute
-	#  in the proxied request will not match the user name
-	#  hidden inside of the EAP packet, and the end server will
-	#  reject the EAP request.
-	#
-	eap
+		rewrite_called_station_id
 
-	#
-	#  If the server tries to proxy a request and fails, then the
-	#  request is processed through the modules in this section.
-	#
-	#  The main use of this section is to permit robust proxying
-	#  of accounting packets.  The server can be configured to
-	#  proxy accounting packets as part of normal processing.
-	#  Then, if the home server goes down, accounting packets can
-	#  be logged to a local "detail" file, for processing with
-	#  radrelay.  When the home server comes back up, radrelay
-	#  will read the detail file, and send the packets to the
-	#  home server.
-	#
-	#  With this configuration, the server always responds to
-	#  Accounting-Requests from the NAS, but only writes
-	#  accounting packets to disk if the home server is down.
-	#
-#	Post-Proxy-Type Fail-Accounting {
-#			detail
-#	}
-	update control {
-		PacketFence-Proxied-From := "True"
+		# Uncomment the following line to enable local PEAP authentication
+		packetfence-degraded-auth
+		-sql_degraded
+
+
+		pap
 	}
 
-	%%post_proxy_filter%%
-}
+
+	authenticate {
+		Auth-Type PAP {
+			pap
+		}
+		Auth-Type CHAP {
+			chap
+		}
+
+		Auth-Type MS-CHAP {
+			mschap
+		}
+
+
+		eap-remote
+	}
+
+	session {
+		radutmp
+	}
+
+
+	post-auth {
+		update outer.session-state {
+			&MS-MPPE-Encryption-Policy !* ANY
+			&MS-MPPE-Encryption-Types !* ANY
+			&MS-MPPE-Send-Key !* ANY
+			&MS-MPPE-Recv-Key !* ANY
+			&Message-Authenticator !* ANY
+			&EAP-Message !* ANY
+			&Proxy-State !* ANY
+		}
+
+		Post-Auth-Type REJECT {
+			attr_filter.access_reject
+			update outer.session-state {
+				&Module-Failure-Message := &request:Module-Failure-Message
+			}
+		}
+	}
+
+	pre-proxy {
+	}
+
+	post-proxy {
+		eap-remote
+	}
+
 }

--- a/conf/radiusd/packetfence.example
+++ b/conf/radiusd/packetfence.example
@@ -572,7 +572,7 @@ server pf.degraded {
 
 		ntdomain
 
-		[% authorize_eap_choice %]
+		[% authorize_eap_choice_degraded %]
 
 		if ( !EAP-Message ) {
 			update {
@@ -619,7 +619,7 @@ accounting {
 
 		#
 		#  Allow EAP authentication.
-		[% authentication_auth_type %]
+		[% authentication_auth_type_degraged %]
 	}
 
 
@@ -685,7 +685,7 @@ server packetfence-degraded-tunnel {
 			&Proxy-To-Realm := LOCAL
 		}
 
-[% authorize_eap_choice %]
+[% authorize_eap_choice_degraded %]
 
 		rewrite_called_station_id
 
@@ -710,7 +710,7 @@ server packetfence-degraded-tunnel {
 			mschap
 		}
 
-[% authentication_auth_type %]
+[% authentication_auth_type_degraded %]
 
 	}
 

--- a/conf/radiusd/packetfence.example
+++ b/conf/radiusd/packetfence.example
@@ -521,6 +521,7 @@ server pf-remote {
 		}
 		if (&proxy-reply:Packet-Type == Access-Accept) {
 			%{sql_degraded:DELETE FROM radreply where username="%{Calling-Station-Id}"}
+			packetfence-set-tenant-id
 			reply_in_db
 			%{sql_degraded:%{control:PacketFence-reply-insert}}
 		}
@@ -582,6 +583,7 @@ server pf.degraded {
 				&control:Auth-Type := Accept
 			}
 		}
+		packetfence-set-tenant-id
 		-sql_degraded
 		pap
 
@@ -693,6 +695,7 @@ server packetfence-degraded-tunnel {
 
 		# Uncomment the following line to enable local PEAP authentication
 		#packetfence-degraded-auth
+		packetfence-set-tenant-id
 		-sql_degraded
 
 

--- a/conf/radiusd/packetfence.example
+++ b/conf/radiusd/packetfence.example
@@ -572,9 +572,7 @@ server pf.degraded {
 
 		ntdomain
 
-		eap-remote {
-			ok = return
-		}
+		[% authorize_eap_choice %]
 
 		if ( !EAP-Message ) {
 			update {
@@ -621,7 +619,7 @@ accounting {
 
 		#
 		#  Allow EAP authentication.
-		eap-remote
+		[% authentication_auth_type %]
 	}
 
 
@@ -686,9 +684,8 @@ server packetfence-degraded-tunnel {
 		update control {
 			&Proxy-To-Realm := LOCAL
 		}
-		eap-remote {
-			ok = return
-		}
+
+[% authorize_eap_choice %]
 
 		rewrite_called_station_id
 
@@ -713,8 +710,8 @@ server packetfence-degraded-tunnel {
 			mschap
 		}
 
+[% authentication_auth_type %]
 
-		eap-remote
 	}
 
 	session {

--- a/conf/radiusd/packetfence.example
+++ b/conf/radiusd/packetfence.example
@@ -572,7 +572,7 @@ server pf.degraded {
 
 		ntdomain
 
-		[% authorize_eap_choice_degraded %]
+[% authorize_eap_choice_degraded %]
 
 		if ( !EAP-Message ) {
 			update {
@@ -620,7 +620,8 @@ accounting {
 		#
 		#  Allow EAP authentication.
 
-		[% authentication_auth_type_degraded %]
+[% authentication_auth_type_degraded %]
+
 	}
 
 

--- a/conf/radiusd/packetfence.example
+++ b/conf/radiusd/packetfence.example
@@ -619,7 +619,8 @@ accounting {
 
 		#
 		#  Allow EAP authentication.
-		[% authentication_auth_type_degraged %]
+
+		[% authentication_auth_type_degraded %]
 	}
 
 
@@ -657,7 +658,7 @@ accounting {
 			# Insert EAP-Failure message if the request was
 			# rejected by policy instead of because of an
 			# authentication failure
-			eap-remote
+			eap-degraded
 
 			#  Remove reply message if the response contains an EAP-Message
 			remove_reply_message_if_eap
@@ -670,7 +671,7 @@ accounting {
 
 	post-proxy {
 
-		eap-remote
+		eap-degraded
 	}
 }
 
@@ -742,7 +743,7 @@ server packetfence-degraded-tunnel {
 	}
 
 	post-proxy {
-		eap-remote
+		eap-degraded
 	}
 
 }

--- a/conf/radiusd/packetfence.example
+++ b/conf/radiusd/packetfence.example
@@ -683,6 +683,19 @@ server packetfence-degraded-tunnel {
 		mschap
 		suffix
 		ntdomain
+		packetfence-multi-domain
+
+		if(User-Name =~ /^host\//) {
+			update {
+				&control:NT-Password := "%{redis_ntlm:GET NTHASH:%{%{PacketFence-Domain}:-''}:%{tolower:%{%{mschap:User-Name}:-None}}}"
+			}
+		}
+		else {
+			update {
+				&control:NT-Password := "%{redis_ntlm:GET NTHASH:%{%{PacketFence-Domain}:-''}:%{tolower:%{%{Stripped-User-Name}:-%{%{User-Name}:-None}}}}"
+			}
+		}
+
 		update control {
 			&Proxy-To-Realm := LOCAL
 		}
@@ -692,7 +705,7 @@ server packetfence-degraded-tunnel {
 		rewrite_called_station_id
 
 		# Uncomment the following line to enable local PEAP authentication
-		packetfence-degraded-auth
+		#packetfence-degraded-auth
 		-sql_degraded
 
 
@@ -709,7 +722,33 @@ server packetfence-degraded-tunnel {
 		}
 
 		Auth-Type MS-CHAP {
-			mschap
+			packetfence     # increment the StatsD counter
+			# If there is already an NT-Password populated in the control, we'll try it
+			# In the event it fails, it will fallback to an ntlm_auth call below
+			if(&control:NT-Password && &control:NT-Password != "") {
+				update {
+					&control:PacketFence-NTCacheHash := 1
+				}
+				mschap_local {
+					reject = 2
+				}
+				if (reject || fail) {
+					packetfence-mschap-authenticate
+					update {
+						&control:PacketFence-NTCacheHash := 0
+					}
+				}
+				update control {
+					Cache-Status-Only = 'yes'
+				}
+				PacketFence-NTCacheHash
+				if (notfound) {
+					PacketFence-NTCacheHash
+				}
+			}
+			else {
+				packetfence-mschap-authenticate
+			}
 		}
 
 [% authentication_auth_type_degraded %]

--- a/conf/radiusd/packetfence.example
+++ b/conf/radiusd/packetfence.example
@@ -512,10 +512,10 @@ server pf-remote {
 		#  Insert pre-proxy rules here
 	}
 
-	rewrite_calling_station_id
-	rewrite_called_station_id
-
 	post-proxy {
+		rewrite_calling_station_id
+		rewrite_called_station_id
+		packetfence-set-tenant-id
 		update control {
 			PacketFence-Proxied-To := "%{home_server:ipaddr}"
 		}

--- a/conf/radiusd/packetfence.example
+++ b/conf/radiusd/packetfence.example
@@ -12,6 +12,7 @@ server packetfence {
 	#  Make *sure* that 'preprocess' comes before any realm if you
 	#  need to setup hints for the remote radius server
 	authorize {
+		packetfence-nas-ip-address
 
 		# Add in PacketFence specific configuration
 		update {
@@ -273,6 +274,8 @@ server packetfence {
 	#  Accounting.  Log the accounting data.
 	#
 	accounting {
+		packetfence-nas-ip-address
+
 		# Add in PacketFence specific configuration
 		update {
 			&request:FreeRADIUS-Client-IP-Address := "%{Packet-Src-IP-Address}"
@@ -582,23 +585,7 @@ server pf.degraded {
 		-sql_degraded
 		pap
 
-<<<<<<< HEAD
-#
-#  Accounting.  Log the accounting data.
-#
-accounting {
-	packetfence-nas-ip-address
-
-	# Add in PacketFence specific configuration
-	update {
-		&request:FreeRADIUS-Client-IP-Address := "%{Packet-Src-IP-Address}"
-		&control:PacketFence-RPC-Server = ${rpc_host}
-		&control:PacketFence-RPC-Port = ${rpc_port}
-		&control:PacketFence-RPC-User = ${rpc_user}
-		&control:PacketFence-RPC-Pass = ${rpc_pass}
-		&control:PacketFence-RPC-Proto = ${rpc_proto}
 	}
-
 
 	authenticate {
 		Auth-Type PAP {

--- a/conf/radiusd/sql.conf.example
+++ b/conf/radiusd/sql.conf.example
@@ -258,7 +258,7 @@ sql {
 	# This entry should be used for the default instance (sql {})
 	# of the SQL module.
 	group_attribute = "SQL-Group"
-
+	safe_characters = "@abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-_: /(),'"
 	# Read database-specific queries
 	$INCLUDE ${modconfdir}/${.:name}/main/${dialect}/queries.conf
 }

--- a/conf/radiusd/sql.conf.example
+++ b/conf/radiusd/sql.conf.example
@@ -471,3 +471,37 @@ sql sql_reject {
         $INCLUDE ${modconfdir}/${.:name}/main/mysql/reject.conf
 }
 
+sql sql_degraded {
+        database = "mysql"
+        driver = "rlm_sql_${database}"
+
+        server = "%%db_host%%"
+        port = %%db_port%%
+        login = "%%db_username%%"
+        password = "%%db_password%%"
+
+
+        radius_db = "%%db_database%%"
+        acct_table1 = "radacct"
+        acct_table2 = "radacct"
+        postauth_table = "radpostauth"
+        authcheck_table = "password"
+        authreply_table = "radreply"
+        groupcheck_table = "radgroupcheck"
+        groupreply_table = "radgroupreply"
+        usergroup_table = "radusergroup"
+
+        delete_stale_sessions = yes
+        sqltrace = no
+        sqltracefile = ${logdir}/sqltrace.sql
+
+        sql_user_name = "%{User-Name}"
+
+        postauth_query = ""
+        group_membership_query = ""
+        pool = sql
+        client_table = "radius_nas"
+        # Read database-specific queries
+        $INCLUDE ${modconfdir}/${.:name}/main/mysql/reject.conf
+        safe_characters = "@abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-_: /(),'"
+}

--- a/conf/radiusd/sql.conf.example
+++ b/conf/radiusd/sql.conf.example
@@ -481,11 +481,12 @@ sql sql_degraded {
         password = "%%db_password%%"
 
 
+        read_groups = no
         radius_db = "%%db_database%%"
         acct_table1 = "radacct"
         acct_table2 = "radacct"
         postauth_table = "radpostauth"
-        authcheck_table = "password"
+        authcheck_table = "radreply"
         authreply_table = "radreply"
         groupcheck_table = "radgroupcheck"
         groupreply_table = "radgroupreply"
@@ -503,5 +504,4 @@ sql sql_degraded {
         client_table = "radius_nas"
         # Read database-specific queries
         $INCLUDE ${modconfdir}/${.:name}/main/mysql/reject.conf
-        safe_characters = "@abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-_: /(),'"
 }

--- a/db/pf-schema-X.Y.Z.sql
+++ b/db/pf-schema-X.Y.Z.sql
@@ -690,6 +690,18 @@ CREATE TABLE radacct_log (
   KEY acctuniqueid (acctuniqueid)
 ) ENGINE=InnoDB;
 
+-- Adding RADIUS radreply table
+
+CREATE TABLE radreply (
+  id int(11) unsigned NOT NULL auto_increment,
+  username varchar(64) NOT NULL default '',
+  attribute varchar(64) NOT NULL default '',
+  op char(2) NOT NULL DEFAULT '=',
+  value varchar(253) NOT NULL default '',
+  PRIMARY KEY  (id),
+  KEY username (username(32))
+);
+
 -- Adding RADIUS Updates Stored Procedure
 
 DROP PROCEDURE IF EXISTS `acct_start`;

--- a/db/pf-schema-X.Y.Z.sql
+++ b/db/pf-schema-X.Y.Z.sql
@@ -697,13 +697,13 @@ CREATE TABLE radreply (
   tenant_id int NOT NULL DEFAULT 1,
   username varchar(64) NOT NULL default '',
   attribute varchar(64) NOT NULL default '',
-  op char(2) NOT NULL DEFAULT '=',
+  op char(2) NOT NULL DEFAULT ':=',
   value varchar(253) NOT NULL default '',
   PRIMARY KEY (id),
   KEY (`tenant_id`, `username`)
 );
 
-INSERT INTO radreply (username, attribute, value, op) values ('00:00:00:00:00:00','User-Name','*', '=*');
+INSERT INTO radreply (tenant_id, username, attribute, value, op) values ('1', '00:00:00:00:00:00','User-Name','*', '=*');
 
 -- Adding RADIUS Updates Stored Procedure
 

--- a/db/pf-schema-X.Y.Z.sql
+++ b/db/pf-schema-X.Y.Z.sql
@@ -694,12 +694,12 @@ CREATE TABLE radacct_log (
 
 CREATE TABLE radreply (
   id int(11) unsigned NOT NULL auto_increment,
+  tenant_id int NOT NULL DEFAULT 1,
   username varchar(64) NOT NULL default '',
   attribute varchar(64) NOT NULL default '',
   op char(2) NOT NULL DEFAULT '=',
   value varchar(253) NOT NULL default '',
-  PRIMARY KEY  (id),
-  KEY username (username(32))
+  PRIMARY KEY (`tenant_id`, `username`)
 );
 
 INSERT INTO radreply (username, attribute, value, op) values ('00:00:00:00:00:00','User-Name','*', '=*');

--- a/db/pf-schema-X.Y.Z.sql
+++ b/db/pf-schema-X.Y.Z.sql
@@ -702,6 +702,8 @@ CREATE TABLE radreply (
   KEY username (username(32))
 );
 
+INSERT INTO radreply (username, attribute, value, op) values ('00:00:00:00:00:00','User-Name','*', '=*');
+
 -- Adding RADIUS Updates Stored Procedure
 
 DROP PROCEDURE IF EXISTS `acct_start`;

--- a/db/pf-schema-X.Y.Z.sql
+++ b/db/pf-schema-X.Y.Z.sql
@@ -699,7 +699,8 @@ CREATE TABLE radreply (
   attribute varchar(64) NOT NULL default '',
   op char(2) NOT NULL DEFAULT '=',
   value varchar(253) NOT NULL default '',
-  PRIMARY KEY (`tenant_id`, `username`)
+  PRIMARY KEY (id),
+  KEY (`tenant_id`, `username`)
 );
 
 INSERT INTO radreply (username, attribute, value, op) values ('00:00:00:00:00:00','User-Name','*', '=*');

--- a/db/upgrade-X.X.X-X.Y.Z.sql
+++ b/db/upgrade-X.X.X-X.Y.Z.sql
@@ -202,7 +202,8 @@ CREATE TABLE radreply (
   attribute varchar(64) NOT NULL default '',
   op char(2) NOT NULL DEFAULT '=',
   value varchar(253) NOT NULL default '',
-  PRIMARY KEY (`tenant_id`, `username`)
+  PRIMARY KEY (id),
+  KEY (`tenant_id`, `username`)
 );
 
 INSERT INTO radreply (username, attribute, value, op) values ('00:00:00:00:00:00','User-Name','*', '=*');

--- a/db/upgrade-X.X.X-X.Y.Z.sql
+++ b/db/upgrade-X.X.X-X.Y.Z.sql
@@ -200,13 +200,13 @@ CREATE TABLE radreply (
   tenant_id int NOT NULL DEFAULT 1,
   username varchar(64) NOT NULL default '',
   attribute varchar(64) NOT NULL default '',
-  op char(2) NOT NULL DEFAULT '=',
+  op char(2) NOT NULL DEFAULT ':=',
   value varchar(253) NOT NULL default '',
   PRIMARY KEY (id),
   KEY (`tenant_id`, `username`)
 );
 
-INSERT INTO radreply (username, attribute, value, op) values ('00:00:00:00:00:00','User-Name','*', '=*');
+INSERT INTO radreply (tenant_id, username, attribute, value, op) values ('1', '00:00:00:00:00:00','User-Name','*', '=*');
 
 \! echo "Incrementing PacketFence schema version...";
 INSERT IGNORE INTO pf_version (id, version) VALUES (@VERSION_INT, CONCAT_WS('.', @MAJOR_VERSION, @MINOR_VERSION, @SUBMINOR_VERSION));

--- a/db/upgrade-X.X.X-X.Y.Z.sql
+++ b/db/upgrade-X.X.X-X.Y.Z.sql
@@ -197,12 +197,12 @@ ALTER TABLE activation ADD COLUMN `category_id` int AFTER `unregdate`;
 
 CREATE TABLE radreply (
   id int(11) unsigned NOT NULL auto_increment,
+  tenant_id int NOT NULL DEFAULT 1,
   username varchar(64) NOT NULL default '',
   attribute varchar(64) NOT NULL default '',
   op char(2) NOT NULL DEFAULT '=',
   value varchar(253) NOT NULL default '',
-  PRIMARY KEY  (id),
-  KEY username (username(32))
+  PRIMARY KEY (`tenant_id`, `username`)
 );
 
 INSERT INTO radreply (username, attribute, value, op) values ('00:00:00:00:00:00','User-Name','*', '=*');

--- a/db/upgrade-X.X.X-X.Y.Z.sql
+++ b/db/upgrade-X.X.X-X.Y.Z.sql
@@ -205,6 +205,8 @@ CREATE TABLE radreply (
   KEY username (username(32))
 );
 
+INSERT INTO radreply (username, attribute, value, op) values ('00:00:00:00:00:00','User-Name','*', '=*');
+
 \! echo "Incrementing PacketFence schema version...";
 INSERT IGNORE INTO pf_version (id, version) VALUES (@VERSION_INT, CONCAT_WS('.', @MAJOR_VERSION, @MINOR_VERSION, @SUBMINOR_VERSION));
 

--- a/db/upgrade-X.X.X-X.Y.Z.sql
+++ b/db/upgrade-X.X.X-X.Y.Z.sql
@@ -192,6 +192,19 @@ DELIMITER ;
 \! echo "Adding category_id column to activation table"
 ALTER TABLE activation ADD COLUMN `category_id` int AFTER `unregdate`;
 
+
+-- Adding RADIUS radreply table
+
+CREATE TABLE radreply (
+  id int(11) unsigned NOT NULL auto_increment,
+  username varchar(64) NOT NULL default '',
+  attribute varchar(64) NOT NULL default '',
+  op char(2) NOT NULL DEFAULT '=',
+  value varchar(253) NOT NULL default '',
+  PRIMARY KEY  (id),
+  KEY username (username(32))
+);
+
 \! echo "Incrementing PacketFence schema version...";
 INSERT IGNORE INTO pf_version (id, version) VALUES (@VERSION_INT, CONCAT_WS('.', @MAJOR_VERSION, @MINOR_VERSION, @SUBMINOR_VERSION));
 

--- a/lib/pf/api.pm
+++ b/lib/pf/api.pm
@@ -1839,15 +1839,21 @@ sub queue_submit_delayed :Public {
     return $id;
 }
 
-sub insert_user_in_redis_cache Public {
+=head2 insert_user_in_redis_cache
+
+insert_user_in_redis_cache
+
+=cut
+
+sub insert_user_in_redis_cache :Public {
     my ($class, %postdata) = @_;
     my ($domain, $user, $nthash) = @_;
     my @require = qw(domain user nthash);
     my @found = grep {exists $postdata{$_}} @require;
     return unless pf::util::validate_argv(\@require,\@found);
 
-    my $logger = get_logger;
-    my $config = $ConfigDomain{$postdata{'domain'}};
+    my $logger = pf::log::get_logger();
+    my $config = $pf::config::ConfigDomain{$postdata{'domain'}};
 
     # pf::Redis has a cache for the connection
     my $redis = pf::Redis->new(server => "$NTLM_REDIS_CACHE_HOST:$NTLM_REDIS_CACHE_PORT", reconnect => 5);
@@ -1856,7 +1862,6 @@ sub insert_user_in_redis_cache Public {
     $logger->info("Inserting '$key' => '$postdata{'nthash'}'");
     $redis->set($key, $nthash, 'EX', $config->{ntlm_cache_expiry});
 }
-
 
 =head1 AUTHOR
 

--- a/lib/pf/api.pm
+++ b/lib/pf/api.pm
@@ -1851,12 +1851,13 @@ sub insert_user_in_redis_cache :Public {
     my $logger = pf::log::get_logger();
     my $config = $pf::config::ConfigDomain{$domain};
 
+    my $expire = (pf::cluster::isSlaveMode()) ? 86400 : $config->{ntlm_cache_expiry};
     # pf::Redis has a cache for the connection
     my $redis = pf::Redis->new(server => "$NTLM_REDIS_CACHE_HOST:$NTLM_REDIS_CACHE_PORT", reconnect => 5);
 
     my $key = "NTHASH:$domain:$user";
     $logger->info("Inserting '$key' => '$nthash'");
-    $redis->set($key, $nthash, 'EX', $config->{ntlm_cache_expiry});
+    $redis->set($key, $nthash, 'EX', $expire);
 }
 
 =head2 update_user_in_redis_cache
@@ -1870,6 +1871,7 @@ sub update_user_in_redis_cache {
     my $logger = pf::log::get_logger();
     my $config = $pf::config::ConfigDomain{$domain};
 
+    my $expire = (pf::cluster::isSlaveMode()) ? 86400 : $config->{ntlm_cache_expiry};
     # pf::Redis has a cache for the connection
     my $redis = pf::Redis->new(server => "$NTLM_REDIS_CACHE_HOST:$NTLM_REDIS_CACHE_PORT", reconnect => 5);
 
@@ -1877,7 +1879,7 @@ sub update_user_in_redis_cache {
     my $key = "NTHASH:$domain:$username";
     my $nthash = $redis->get($key);
     if (defined($nthash)) {
-        $redis->set($key, $nthash, 'EX', $config->{ntlm_cache_expiry});
+        $redis->set($key, $nthash, 'EX', $expire);
         $logger->info("Updating '$key' => '$nthash'");
     }
 }

--- a/lib/pf/api/queue_cluster.pm
+++ b/lib/pf/api/queue_cluster.pm
@@ -130,6 +130,26 @@ sub cluster_notify {
     return; 
 }
 
+=head2 cluster_notify_all
+
+Send to the all available members of the cluster
+
+=cut
+
+sub cluster_notify_all {
+    my ($self, $method, @args) = @_;
+    foreach my $server ($self->servers) {
+        if ($server->{host} eq $pf::cluster::host_id) {
+            $self->local_notify($method, @args);
+        }
+
+        if ($self->server_notify($server, $method, @args)) {
+            get_logger->debug("sent $method to $server->{host}");
+        }
+    }
+    return;
+}
+
 =head2 server_notify
 
 Sends a queue notify request to a server

--- a/lib/pf/api/queue_cluster.pm
+++ b/lib/pf/api/queue_cluster.pm
@@ -138,13 +138,13 @@ Send to the all available members of the cluster
 
 sub cluster_notify_all {
     my ($self, $method, @args) = @_;
-    foreach my $server ($self->servers) {
+    foreach my $server ($self->all_servers) {
         if ($server->{host} eq $pf::cluster::host_id) {
             $self->local_notify($method, @args);
-        }
-
-        if ($self->server_notify($server, $method, @args)) {
-            get_logger->debug("sent $method to $server->{host}");
+        } else {
+            if ($self->server_notify($server, $method, @args)) {
+                get_logger->debug("sent $method to $server->{host}");
+            }
         }
     }
     return;
@@ -286,6 +286,17 @@ Return a the list of available servers in random order
 sub servers {
     shuffle grep {!is_server_down($_)} pf::cluster::enabled_servers();
 }
+
+=head2 all_servers
+
+Return a the list of all available servers in random order
+
+=cut
+
+sub all_servers {
+    shuffle grep {!is_server_down($_)}  pf::cluster::config_enabled_servers();
+}
+
 
 =head1 AUTHOR
 

--- a/lib/pf/cluster.pm
+++ b/lib/pf/cluster.pm
@@ -790,6 +790,14 @@ sub getDBMaster {
     return $FALSE;
 }
 
+sub getDBMaster {
+    if (defined(${pf::config::cluster::getClusterConfig(${pf::config::cluster::getClusterConfig($clusters_hostname_map{$host_id})}{CLUSTER}{masterdb})}{CLUSTER}{management_ip})) {
+        return ${pf::config::cluster::getClusterConfig(${pf::config::cluster::getClusterConfig($clusters_hostname_map{$host_id})}{CLUSTER}{masterdb})}{CLUSTER}{management_ip};
+    } else {
+        return $FALSE;
+    }
+}
+
 =head1 AUTHOR
 
 Inverse inc. <info@inverse.ca>

--- a/lib/pf/cluster.pm
+++ b/lib/pf/cluster.pm
@@ -790,14 +790,6 @@ sub getDBMaster {
     return $FALSE;
 }
 
-sub getDBMaster {
-    if (defined(${pf::config::cluster::getClusterConfig(${pf::config::cluster::getClusterConfig($clusters_hostname_map{$host_id})}{CLUSTER}{masterdb})}{CLUSTER}{management_ip})) {
-        return ${pf::config::cluster::getClusterConfig(${pf::config::cluster::getClusterConfig($clusters_hostname_map{$host_id})}{CLUSTER}{masterdb})}{CLUSTER}{management_ip};
-    } else {
-        return $FALSE;
-    }
-}
-
 =head1 AUTHOR
 
 Inverse inc. <info@inverse.ca>

--- a/lib/pf/services/manager/galera_autofix.pm
+++ b/lib/pf/services/manager/galera_autofix.pm
@@ -25,7 +25,6 @@ sub isManaged {
     return $self->SUPER::isManaged() && $cluster_enabled && !pf::cluster::isSlaveMode();
 }
 
-
 =head1 AUTHOR
 
 Inverse inc. <info@inverse.ca>

--- a/lib/pf/services/manager/radiusd_child.pm
+++ b/lib/pf/services/manager/radiusd_child.pm
@@ -305,12 +305,11 @@ EOT
 
     generate_ldap_choice(\$tags{'authorize_ldap_choice'}, \$tags{'authentication_ldap_auth_type'}, \$tags{'edir_configuration'});
 
-    $tags{'template'}    = "$conf_dir/raddb/sites-enabled/packetfence-tunnel";
-    parse_template( \%tags, "$conf_dir/radiusd/packetfence-tunnel", "$install_dir/raddb/sites-enabled/packetfence-tunnel" );
+    $tt->process("$conf_dir/radiusd/packetfence-tunnel", \%tags, "$install_dir/raddb/sites-enabled/packetfence-tunnel") or die $tt->error();
 
     %tags = ();
     $tags{'template'}    = "$conf_dir/raddb/sites-enabled/packetfence-cli";
-    parse_template( \%tags, "$conf_dir/radiusd/packetfence-cli", "$install_dir/raddb/sites-enabled/packetfence-cli" );
+    $tt->process("$conf_dir/radiusd/packetfence-cli", \%tags, "$install_dir/raddb/sites-enabled/packetfence-cli") or die $tt->error();
 
 }
 
@@ -659,7 +658,9 @@ EOT
 }
 
 =head2 generate_radiusd_eapconf
+
 Generates the eap.conf configuration file
+
 =cut
 
 sub generate_radiusd_eapconf {

--- a/lib/pf/services/manager/radiusd_child.pm
+++ b/lib/pf/services/manager/radiusd_child.pm
@@ -1297,14 +1297,15 @@ EOT
     if ($if eq 'elsif') {
         $$authorize_eap_choice .= <<"EOT";
             else {
-                eap $suffix {
+                eap {
                     ok = return
                 }
             }
 EOT
     } else {
+        my $eap = (defined($suffix) && $suffix ne "" ) ? $suffix : "eap";
         $$authorize_eap_choice .= <<"EOT";
-            eap $suffix {
+            $eap {
                 ok = return
             }
 EOT

--- a/lib/pf/services/manager/radiusd_child.pm
+++ b/lib/pf/services/manager/radiusd_child.pm
@@ -365,6 +365,11 @@ sub generate_radiusd_authconf {
         }
     }
 
+    $tags{'virtual_server'} = "packetfence";
+    if (pf::cluster::isSlaveMode()) {
+        $tags{'virtual_server'} = "pf-remote";
+    }
+
     $tags{'listen_ips'} = [uniq @listen_ips];
     $tags{'pid_file'} = "$var_dir/run/radiusd.pid";
     $tags{'socket_file'} = "$var_dir/run/radiusd.sock";

--- a/lib/pf/services/manager/radiusd_child.pm
+++ b/lib/pf/services/manager/radiusd_child.pm
@@ -1228,8 +1228,10 @@ EOT
 
         
         push @radius_backend, $cluster_ip;
-        foreach my $radius_back (@radius_backend) {
-            $tags{'config'} .= <<"EOT";
+        push @radius_backend, map { $_->{management_ip} } pf::cluster::config_enabled_servers();
+
+        foreach my $radius_back (uniq(@radius_backend)) {
+	    $tags{'config'} .= <<"EOT";
 client $radius_back {
         ipaddr = $radius_back
         secret = $local_secret

--- a/lib/pf/services/manager/radiusd_child.pm
+++ b/lib/pf/services/manager/radiusd_child.pm
@@ -309,7 +309,9 @@ EOT
     parse_template( \%tags, "$conf_dir/radiusd/packetfence-tunnel", "$install_dir/raddb/sites-enabled/packetfence-tunnel" );
 
     %tags = ();
-    $tt->process("$conf_dir/radiusd/packetfence-cli", \%tags, "$install_dir/raddb/sites-enabled/packetfence-cli") or die $tt->error();
+    $tags{'template'}    = "$conf_dir/raddb/sites-enabled/packetfence-cli";
+    parse_template( \%tags, "$conf_dir/radiusd/packetfence-cli", "$install_dir/raddb/sites-enabled/packetfence-cli" );
+
 }
 
 

--- a/lib/pf/services/manager/radiusd_child.pm
+++ b/lib/pf/services/manager/radiusd_child.pm
@@ -1234,7 +1234,7 @@ EOT
         push @radius_backend, map { $_->{management_ip} } pf::cluster::config_enabled_servers();
 
         foreach my $radius_back (uniq(@radius_backend)) {
-	    $tags{'config'} .= <<"EOT";
+        $tags{'config'} .= <<"EOT";
 client $radius_back {
         ipaddr = $radius_back
         secret = $local_secret

--- a/raddb/dictionary.inverse
+++ b/raddb/dictionary.inverse
@@ -50,6 +50,7 @@ ATTRIBUTE       PacketFence-NTCacheHash               34       string
 ATTRIBUTE       PacketFence-NTLMv2-Only               35       string
 ATTRIBUTE       PacketFence-Outer-User                36       string
 ATTRIBUTE       PacketFence-UserDN                    37       string
+ATTRIBUTE       PacketFence-reply-insert              38       string
 
 END-VENDOR      Inverse
 

--- a/raddb/mods-available/perl
+++ b/raddb/mods-available/perl
@@ -101,3 +101,7 @@ perl packetfence-multi-domain {
 	#
 	filename = ${modconfdir}/perl/packetfence-multi-domain.pm
 }
+
+perl reply_in_db {
+        filename = ${modconfdir}/perl/reply_in_db.pm
+}

--- a/raddb/mods-config/perl/reply_in_db.pm
+++ b/raddb/mods-config/perl/reply_in_db.pm
@@ -1,0 +1,45 @@
+use strict;
+use warnings;
+
+our (%RAD_REQUEST, %RAD_REPLY, %RAD_CHECK, %RAD_STATE, %RAD_CONFIG, %RAD_REQUEST_PROXY_REPLY);
+
+use constant {
+	RLM_MODULE_REJECT   => 0, # immediately reject the request
+	RLM_MODULE_OK       => 2, # the module is OK, continue
+	RLM_MODULE_HANDLED  => 3, # the module handled the request, so stop
+	RLM_MODULE_INVALID  => 4, # the module considers the request invalid
+	RLM_MODULE_USERLOCK => 5, # reject the request (user is locked out)
+	RLM_MODULE_NOTFOUND => 6, # user not found
+	RLM_MODULE_NOOP     => 7, # module succeeded without doing anything
+	RLM_MODULE_UPDATED  => 8, # OK (pairs modified)
+	RLM_MODULE_NUMCODES => 9  # How many return codes there are
+};
+
+# Same as src/include/log.h
+use constant {
+	L_AUTH         => 2,  # Authentication message
+	L_INFO         => 3,  # Informational message
+	L_ERR          => 4,  # Error message
+	L_WARN         => 5,  # Warning
+	L_PROXY        => 6,  # Proxy messages
+	L_ACCT         => 7,  # Accounting messages
+	L_DBG          => 16, # Only displayed when debugging is enabled
+	L_DBG_WARN     => 17, # Warning only displayed when debugging is enabled
+	L_DBG_ERR      => 18, # Error only displayed when debugging is enabled
+	L_DBG_WARN_REQ => 19, # Less severe warning only displayed when debugging is enabled
+	L_DBG_ERR_REQ  => 20, # Less severe error only displayed when debugging is enabled
+};
+
+sub post_proxy {
+       my @values;
+       my %reply = %RAD_REQUEST_PROXY_REPLY;
+       my @attributes = ("Message-Authenticator", "EAP-Message", "MS-MPPE-Recv-Key", "MS-MPPE-Send-Key");
+       delete @reply{@attributes};
+       for (keys %reply) {
+           next if ($_ =~ /^Proxy/);
+           push (@values , "('$RAD_REQUEST{'Calling-Station-Id'}','$_','$reply{$_}')");
+       }
+       my $values = join (", ", @values);
+       $RAD_CHECK{"PacketFence-reply-insert"} = "INSERT into radreply (username, attribute, value) values $values";
+       return RLM_MODULE_OK;
+}

--- a/raddb/mods-config/perl/reply_in_db.pm
+++ b/raddb/mods-config/perl/reply_in_db.pm
@@ -37,9 +37,9 @@ sub post_proxy {
        delete @reply{@attributes};
        for (keys %reply) {
            next if ($_ =~ /^Proxy/);
-           push (@values , "('$RAD_REQUEST{'Calling-Station-Id'}','$_','$reply{$_}')");
+           push (@values , "('$RAD_CONFIG{'PacketFence-Tenant-Id'}','$RAD_REQUEST{'Calling-Station-Id'}','$_','$reply{$_}')");
        }
        my $values = join (", ", @values);
-       $RAD_CHECK{"PacketFence-reply-insert"} = "INSERT into radreply (username, attribute, value) values $values";
+       $RAD_CHECK{"PacketFence-reply-insert"} = "INSERT into radreply (tenant_id, username, attribute, value) values $values";
        return RLM_MODULE_OK;
 }

--- a/raddb/mods-config/sql/main/mysql/reject.conf
+++ b/raddb/mods-config/sql/main/mysql/reject.conf
@@ -79,3 +79,9 @@ post-auth {
 
     }
 }
+
+authorize_reply_query = "\
+        SELECT id, username, attribute, value, op \
+        FROM ${authreply_table} \
+        WHERE username = '%{Calling-Station-Id}' \
+        ORDER BY id"

--- a/raddb/mods-config/sql/main/mysql/reject.conf
+++ b/raddb/mods-config/sql/main/mysql/reject.conf
@@ -80,6 +80,12 @@ post-auth {
     }
 }
 
+authorize_check_query = "\
+        SELECT id, username, attribute, value, op \
+        FROM ${authcheck_table} \
+        WHERE username = '00:00:00:00:00:00' \
+        ORDER BY id"
+
 authorize_reply_query = "\
         SELECT id, username, attribute, value, op \
         FROM ${authreply_table} \

--- a/raddb/mods-config/sql/main/mysql/reject.conf
+++ b/raddb/mods-config/sql/main/mysql/reject.conf
@@ -83,11 +83,11 @@ post-auth {
 authorize_check_query = "\
         SELECT id, username, attribute, value, op \
         FROM ${authcheck_table} \
-        WHERE username = '00:00:00:00:00:00' \
+        WHERE username = '00:00:00:00:00:00' AND tenant_id = '%{control:PacketFence-Tenant-Id}' \
         ORDER BY id"
 
 authorize_reply_query = "\
         SELECT id, username, attribute, value, op \
         FROM ${authreply_table} \
-        WHERE username = '%{Calling-Station-Id}' \
+        WHERE username = '%{Calling-Station-Id}' AND tenant_id = '%{control:PacketFence-Tenant-Id}' \
         ORDER BY id"

--- a/raddb/policy.d/packetfence
+++ b/raddb/policy.d/packetfence
@@ -233,3 +233,17 @@ packetfence-nas-ip-address {
             }
     }
 }
+
+packetfence-degraded-auth {
+    # Disable ntlm_auth
+    update control {
+        &MS-CHAP-Use-NTLM-Auth := No
+    }
+    # Check password table for local user
+    sql_degraded
+    if (fail || notfound || noop) {
+        update control {
+            &MS-CHAP-Use-NTLM-Auth := Yes
+        }
+    }
+}

--- a/raddb/policy.d/packetfence
+++ b/raddb/policy.d/packetfence
@@ -235,6 +235,7 @@ packetfence-nas-ip-address {
 }
 
 packetfence-degraded-auth {
+    packetfence-set-tenant-id
     # Disable ntlm_auth
     update control {
         &MS-CHAP-Use-NTLM-Auth := No


### PR DESCRIPTION
# Description
Proxy radius request when the server is in slave mode.
It include a degraded radius configuration in order to reply even if the main radius server is down.

When the main server is up, the slave radius server proxy to the main one and store the reply in the radreply table.

If it 802.1x the nthash key is shared all accross the servers member and in degraded situation radius use this hash and reply with the latest attributes coming from previous authentication (radreply table).

If it's mac-auth we reply with the previous attributes.

# Impacts
Master Slave configuration.

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
## New Features
* Master/Slave radius proxy and degraded workflow
