### PR TITLE
Feature/packer fixes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ before_script:
 # STAGES
 ################################################################################
 stages:
-  - build_images
+  - build_img
   - build_pkg
   - build_maintenance
   - sign
@@ -55,14 +55,12 @@ variables:
   # run jobs on any branches/tags via "Run pipeline", except:
   # - vX.Y.Z tag
   # - maintenance/X.Y branches
-  # - feature/packer-.* branches
   only:
     - /^devel$/
     - web
   except:
     - /^v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$/
     - /^maintenance/[[:digit:]]+\.[[:digit:]]+$/
-    - /^feature/packer-.*$/
 
 # triggers for release jobs
 .job_release_triggers:
@@ -79,14 +77,12 @@ variables:
   # run jobs on "devel" branch *or* vX.Y.Z tag (push, schedules and web)
   # run jobs on any branches/tags via "Run pipeline", except:
   # - maintenance/X.Y branches
-  # - feature/packer-.* branches
   only:
     - /^v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$/
     - /^devel$/
     - web
   except:
     - /^maintenance/[[:digit:]]+\.[[:digit:]]+$/
-    - /^feature/packer-.*$/
 
 # triggers for maintenance jobs
 .job_maintenance_triggers:
@@ -108,23 +104,23 @@ variables:
     - /^devel$/
 
 .job_branches_only_triggers:
-  # run jobs on any branches/tags only via "Run pipeline", except:
+  # run jobs on any branches only via "Run pipeline", except:
   # - devel branch
   # - vX.Y.Z tag
   # - maintenance/X.Y branches
-  # - feature/packer-.* branches
   only:
     - web
   except:
     - /^devel$/
     - /^v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$/
     - /^maintenance/[[:digit:]]+\.[[:digit:]]+$/
-    - /^feature/packer-.*$/    
 ########################################    
 # JOBS
 ########################################
-.pfbuild_job:
-  stage: build_images
+.build_img_job:
+  stage: build_img
+  script:
+    - make -e -C ${PACKERDIR} build_img
   tags:
     - shell
 
@@ -276,31 +272,43 @@ variables:
 ################################################################################
 
 ########################################
-# BUILD_IMAGES JOBS
+# BUILD_IMG JOBS
 ########################################
-pfbuild_manual:
-  extends: .pfbuild_job
-  script:
-    - make -e -C ${PACKERDIR} pfbuild
+build_img_dev:
+  extends:
+    - .build_img_job
+    - .job_devel_only_triggers
+  variables:
+    DOCKER_MAIN_TAG: latest
+    DOCKER_EXTRA_TAG: maintenance-99-9
   # job need to be explicitly started
   # will not block other stages/jobs
   # will not run when we click "Run pipeline"
   when: manual
 
-pfbuild_test:
-  extends: .pfbuild_job
+build_img_branches:
+  extends:
+    - .build_img_job
+    - .job_branches_only_triggers
   variables:
-    DOCKER_TAGS: ${CI_COMMIT_REF_SLUG}
-  script:
-    - make -e -C ${PACKERDIR} pfbuild
-  only:
-    - /^feature/packer-.*$/
+    DOCKER_MAIN_TAG: ${CI_COMMIT_REF_SLUG}
+    DOCKER_EXTRA_TAG: extra_branches
+  when: manual
+
+build_img_maintenance:
+  extends:
+    - .build_img_job
+    - .job_maintenance_triggers
+  variables:
+    DOCKER_MAIN_TAG: ${CI_COMMIT_REF_SLUG}
+    DOCKER_EXTRA_TAG: extra_maintenance
+  when: manual
 
 # build a docker image at release
 # used to build release packages and maintenance artifacts for maintenance
-pfbuild_release:
+build_img_release:
   extends:
-    - .pfbuild_job
+    - .build_img_job
     - .job_release_triggers
   variables:
     ANSIBLE_CENTOS_GROUP: stable_centos
@@ -309,16 +317,6 @@ pfbuild_release:
     ANSIBLE_DEBIAN_GROUP: stable_debian
     ANSIBLE_RUBYGEMS_GROUP: stable_rubygems
     ACTIVE_BUILDS: 'pfbuild-centos-7,pfbuild-stretch'
-  script:
-    # extra tag to release images: maintenance-X-Y
-    # permit to simplify definition of maintenance jobs below
-    # based on their branch name using CI_COMMIT_REF_SLUG
-    # CI_COMMIT_TAG contains vX.Y.Z
-    # PF_RELEASE_REV contains X.Y
-    # DOCKER_TAGS contains vX.Y.Z,maintenance-X-Y
-    - PF_RELEASE_REV=$(perl -ne 'print $1 if (m/.*?(\d+\.\d+)./)' conf/pf-release)
-    - export DOCKER_TAGS="${CI_COMMIT_TAG},maintenance-${PF_RELEASE_REV/./-}"
-    - make -e -C ${PACKERDIR} pfbuild
 
 ########################################
 #  BUILD_PKG JOBS

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -279,8 +279,7 @@ build_img_dev:
     - .build_img_job
     - .job_devel_only_triggers
   variables:
-    DOCKER_MAIN_TAG: latest
-    DOCKER_EXTRA_TAG: maintenance-99-9
+    DOCKER_TAGS: latest,maintenance-99-9
   # job need to be explicitly started
   # will not block other stages/jobs
   # will not run when we click "Run pipeline"
@@ -291,8 +290,7 @@ build_img_branches:
     - .build_img_job
     - .job_branches_only_triggers
   variables:
-    DOCKER_MAIN_TAG: ${CI_COMMIT_REF_SLUG}
-    DOCKER_EXTRA_TAG: extra_branches
+    DOCKER_TAGS: ${CI_COMMIT_REF_SLUG}
   when: manual
 
 build_img_maintenance:
@@ -300,8 +298,7 @@ build_img_maintenance:
     - .build_img_job
     - .job_maintenance_triggers
   variables:
-    DOCKER_MAIN_TAG: ${CI_COMMIT_REF_SLUG}
-    DOCKER_EXTRA_TAG: extra_maintenance
+    DOCKER_TAGS: ${CI_COMMIT_REF_SLUG}
   when: manual
 
 # build a docker image at release
@@ -311,6 +308,7 @@ build_img_release:
     - .build_img_job
     - .job_release_triggers
   variables:
+    DOCKER_TAGS: ${CI_COMMIT_TAG}
     ANSIBLE_CENTOS_GROUP: stable_centos
     ANSIBLE_CENTOS7_GROUP: stable_centos7
     ANSIBLE_CENTOS8_GROUP: stable_centos8

--- a/ci/packer/Makefile
+++ b/ci/packer/Makefile
@@ -1,46 +1,12 @@
-# All variables defined below and in config.mk can be considered as defaults
-# for packer invocation. They can be override by:
-# - environment variables (VAR=value make -e target)
-# - command variables (make VAR=VALUE target)
-
 include ../../config.mk
-
-#==============================================================================
-# Packer command line variables
-#==============================================================================
-ACTIVE_BUILDS = 'pfbuild-centos-7,pfbuild-centos-8,pfbuild-stretch,pfbuild-buster'
-
-# workaround for https://github.com/hashicorp/packer/issues/7904
-PARALLEL = false
 
 #==============================================================================
 # Targets
 #==============================================================================
 
 .PHONY: all
-all: pfbuild
+all: build_img
 
-# Environment variables are mentioned before 'packer build' commands to
-# - display their values when running in CI (be careful with secret variables)
-# - avoid passing each variable on CLI when running outside CI
-
-.PHONY: pfbuild
-pfbuild:
-	packer validate $@.json
-	DOCKER_TAGS=$(DOCKER_TAGS) \
-	GOVERSION=$(GOVERSION) \
-	REGISTRY=$(REGISTRY) \
-	REGISTRY_USER=$(REGISTRY_USER) \
-	ANSIBLE_FORCE_COLOR=$(ANSIBLE_FORCE_COLOR) \
-	ANSIBLE_CENTOS_GROUP=$(ANSIBLE_CENTOS_GROUP) \
-	ANSIBLE_CENTOS7_GROUP=$(ANSIBLE_CENTOS7_GROUP) \
-	ANSIBLE_CENTOS8_GROUP=$(ANSIBLE_CENTOS8_GROUP) \
-	ANSIBLE_DEBIAN_GROUP=$(ANSIBLE_DEBIAN_GROUP) \
-	ANSIBLE_RUBYGEMS_GROUP=$(ANSIBLE_RUBYGEMS_GROUP) \
-	packer build \
-	-only=$(ACTIVE_BUILDS) \
-	-parallel=$(PARALLEL) $@.json
-
-.PHONY: variables
-variables:
-	$(foreach var,$(.VARIABLES),$(info $(var) = $($(var))))
+.PHONY: build_img
+build_img:
+	GOVERSION=$(GOVERSION) ./packer-wrapper.sh

--- a/ci/packer/packer-wrapper.sh
+++ b/ci/packer/packer-wrapper.sh
@@ -11,7 +11,7 @@ configure_and_check() {
     ANSIBLE_CENTOS8_GROUP=${ANSIBLE_CENTOS8_GROUP:-devel_centos8}
     ANSIBLE_DEBIAN_GROUP=${ANSIBLE_DEBIAN_GROUP:-devel_debian}
     ANSIBLE_RUBYGEMS_GROUP=${ANSIBLE_RUBYGEMS_GROUP:-devel_rubygems}
-    ACTIVE_BUILDS=${ACTIVE_BUILDS:-'pfbuild-centos-7,pfbuild-centos-8,pfbuild-stretch,pfbuild-buster'}
+    ACTIVE_BUILDS=${ACTIVE_BUILDS:-'pfbuild-centos-7,pfbuild-stretch'}
     PARALLEL=${PARALLEL:-2}
     PACKER_TEMPLATE=${PACKER_TEMPLATE:-pfbuild.json}
 

--- a/ci/packer/packer-wrapper.sh
+++ b/ci/packer/packer-wrapper.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -o nounset -o pipefail -o errexit
+
+configure_and_check() {
+    GOVERSION=${GOVERSION:-}
+    REGISTRY=${REGISTRY:-docker.io}
+    REGISTRY_USER=${REGISTRY_USER:-inverseinc}
+    ANSIBLE_FORCE_COLOR=${ANSIBLE_FORCE_COLOR:-1}
+    ANSIBLE_CENTOS_GROUP=${ANSIBLE_CENTOS_GROUP:-devel_centos}
+    ANSIBLE_CENTOS7_GROUP=${ANSIBLE_CENTOS7_GROUP:-devel_centos7}
+    ANSIBLE_CENTOS8_GROUP=${ANSIBLE_CENTOS8_GROUP:-devel_centos8}
+    ANSIBLE_DEBIAN_GROUP=${ANSIBLE_DEBIAN_GROUP:-devel_debian}
+    ANSIBLE_RUBYGEMS_GROUP=${ANSIBLE_RUBYGEMS_GROUP:-devel_rubygems}
+    ACTIVE_BUILDS=${ACTIVE_BUILDS:-'pfbuild-centos-7,pfbuild-centos-8,pfbuild-stretch,pfbuild-buster'}
+    PARALLEL=${PARALLEL:-2}
+    PACKER_TEMPLATE=${PACKER_TEMPLATE:-pfbuild.json}
+
+    declare -p GOVERSION
+    declare -p REGISTRY REGISTRY_USER 
+    declare -p ANSIBLE_FORCE_COLOR ANSIBLE_CENTOS_GROUP ANSIBLE_CENTOS7_GROUP
+    declare -p ANSIBLE_CENTOS8_GROUP ANSIBLE_DEBIAN_GROUP ANSIBLE_RUBYGEMS_GROUP
+    declare -p PACKER_TEMPLATE
+    
+    # Docker tags
+    DOCKER_MAIN_TAG=${DOCKER_MAIN_TAG:-}
+    DOCKER_EXTRA_TAG=${DOCKER_EXTRA_TAG:-}
+    CI_COMMIT_TAG=${CI_COMMIT_TAG:-}
+
+    # extra tag is added when we release to avoid creating two images
+    if [ -n "$CI_COMMIT_TAG" ]; then
+        echo "Release tag detected, adding maintenance tag"
+        DOCKER_MAIN_TAG="${CI_COMMIT_TAG}"
+        DOCKER_EXTRA_TAG=$(generate_maintenance_tag)
+    else
+        echo "Not a release, no need to generate additionnal Docker tag"
+    fi
+    declare -p CI_COMMIT_TAG DOCKER_MAIN_TAG DOCKER_EXTRA_TAG
+    export GOVERSION
+    export CI_COMMIT_TAG DOCKER_MAIN_TAG DOCKER_EXTRA_TAG
+    export REGISTRY REGISTRY_USER
+    export ANSIBLE_FORCE_COLOR ANSIBLE_CENTOS_GROUP ANSIBLE_CENTOS7_GROUP
+    export ANSIBLE_CENTOS8_GROUP ANSIBLE_DEBIAN_GROUP ANSIBLE_RUBYGEMS_GROUP
+}
+
+# we use this logic to simplify definition of maintenance CI jobs based
+# on their branch name using CI_COMMIT_REF_SLUG
+generate_maintenance_tag() {
+    # pf_release_rev contains X.Y
+    local pf_release_rev=$(perl -ne 'print $1 if (m/.*?(\d+\.\d+)./)' ../../conf/pf-release)
+    # generated tag is maintenance-X-Y
+    echo "maintenance-${pf_release_rev/./-}"
+}
+
+run_packer() {
+    local pkr_template=${1}
+    packer validate ${pkr_template}
+    local pkr_command="packer build -only=${ACTIVE_BUILDS} -parallel-builds=${PARALLEL} ${pkr_template}"
+    echo "${pkr_command}"
+    ${pkr_command}
+}
+
+configure_and_check
+run_packer ${PACKER_TEMPLATE}

--- a/ci/packer/packer-wrapper.sh
+++ b/ci/packer/packer-wrapper.sh
@@ -22,21 +22,20 @@ configure_and_check() {
     declare -p PACKER_TEMPLATE
     
     # Docker tags
-    DOCKER_MAIN_TAG=${DOCKER_MAIN_TAG:-}
-    DOCKER_EXTRA_TAG=${DOCKER_EXTRA_TAG:-}
+    DOCKER_TAGS=${DOCKER_TAGS:-}
     CI_COMMIT_TAG=${CI_COMMIT_TAG:-}
 
     # extra tag is added when we release to avoid creating two images
     if [ -n "$CI_COMMIT_TAG" ]; then
         echo "Release tag detected, adding maintenance tag"
-        DOCKER_MAIN_TAG="${CI_COMMIT_TAG}"
-        DOCKER_EXTRA_TAG=$(generate_maintenance_tag)
+        docker_extra_tag=$(generate_maintenance_tag)
+        DOCKER_TAGS="${CI_COMMIT_TAG},${docker_extra_tag}"
     else
-        echo "Not a release, no need to generate additionnal Docker tag"
+        echo "Not a release, no need to generate additionnal maintenance tag"
     fi
-    declare -p CI_COMMIT_TAG DOCKER_MAIN_TAG DOCKER_EXTRA_TAG
+    declare -p CI_COMMIT_TAG DOCKER_TAGS
     export GOVERSION
-    export CI_COMMIT_TAG DOCKER_MAIN_TAG DOCKER_EXTRA_TAG
+    export CI_COMMIT_TAG DOCKER_TAGS
     export REGISTRY REGISTRY_USER
     export ANSIBLE_FORCE_COLOR ANSIBLE_CENTOS_GROUP ANSIBLE_CENTOS7_GROUP
     export ANSIBLE_CENTOS8_GROUP ANSIBLE_DEBIAN_GROUP ANSIBLE_RUBYGEMS_GROUP

--- a/ci/packer/pfbuild.json
+++ b/ci/packer/pfbuild.json
@@ -17,8 +17,7 @@
         "ansible_debian_group": "{{env `ANSIBLE_DEBIAN_GROUP`}}",
         "ansible_rubygems_group": "{{env `ANSIBLE_RUBYGEMS_GROUP`}}",
         "go_version": "{{env `GOVERSION`}}",
-        "docker_main_tag": "{{env `DOCKER_MAIN_TAG`}}",
-        "docker_extra_tag": "{{env `DOCKER_EXTRA_TAG`}}",
+        "docker_tags": "{{env `DOCKER_TAGS`}}",
         "docker_user": "{{env `REGISTRY_USER`}}",
         "docker_password": "{{env `REGISTRY_PASSWORD`}}",
         "docker_registry": "{{env `REGISTRY`}}"
@@ -172,7 +171,7 @@
                 "name": "set-tag",
                 "only": ["{{user `builder_prefix`}}-centos-7"],
                 "repository": "{{user `docker_user`}}/{{user `builder_prefix`}}-centos-7",
-                "tags": ["{{user `docker_main_tag`}}", "{{user `docker_extra_tag`}}"]
+                "tags": "{{user `docker_tags`}}"
             },
             {
                 "type": "docker-push",
@@ -190,7 +189,7 @@
                 "name": "set-tag",
                 "only": ["{{user `builder_prefix`}}-centos-8"],
                 "repository": "{{user `docker_user`}}/{{user `builder_prefix`}}-centos-8",
-                "tags": ["{{user `docker_main_tag`}}", "{{user `docker_extra_tag`}}"]
+                "tags": "{{user `docker_tags`}}"
             },
             {
                 "type": "docker-push",
@@ -208,7 +207,7 @@
                 "name": "set-tag",
                 "only": ["{{user `builder_prefix`}}-stretch"],
                 "repository": "{{user `docker_user`}}/{{user `builder_prefix`}}-debian-stretch",
-                "tags": ["{{user `docker_main_tag`}}", "{{user `docker_extra_tag`}}"]
+                "tags": "{{user `docker_tags`}}"
             },
             {
                 "type": "docker-push",
@@ -226,7 +225,7 @@
                 "name": "set-tag",
                 "only": ["{{user `builder_prefix`}}-buster"],
                 "repository": "{{user `docker_user`}}/{{user `builder_prefix`}}-debian-buster",
-                "tags": ["{{user `docker_main_tag`}}", "{{user `docker_extra_tag`}}"]
+                "tags": "{{user `docker_tags`}}"
             },
             {
                 "type": "docker-push",

--- a/ci/packer/pfbuild.json
+++ b/ci/packer/pfbuild.json
@@ -17,7 +17,8 @@
         "ansible_debian_group": "{{env `ANSIBLE_DEBIAN_GROUP`}}",
         "ansible_rubygems_group": "{{env `ANSIBLE_RUBYGEMS_GROUP`}}",
         "go_version": "{{env `GOVERSION`}}",
-        "docker_tags": "{{env `DOCKER_TAGS`}}",
+        "docker_main_tag": "{{env `DOCKER_MAIN_TAG`}}",
+        "docker_extra_tag": "{{env `DOCKER_EXTRA_TAG`}}",
         "docker_user": "{{env `REGISTRY_USER`}}",
         "docker_password": "{{env `REGISTRY_PASSWORD`}}",
         "docker_registry": "{{env `REGISTRY`}}"
@@ -171,7 +172,7 @@
                 "name": "set-tag",
                 "only": ["{{user `builder_prefix`}}-centos-7"],
                 "repository": "{{user `docker_user`}}/{{user `builder_prefix`}}-centos-7",
-                "tag": "{{user `docker_tags`}}"
+                "tags": ["{{user `docker_main_tag`}}", "{{user `docker_extra_tag`}}"]
             },
             {
                 "type": "docker-push",
@@ -189,7 +190,7 @@
                 "name": "set-tag",
                 "only": ["{{user `builder_prefix`}}-centos-8"],
                 "repository": "{{user `docker_user`}}/{{user `builder_prefix`}}-centos-8",
-                "tag": "{{ user `docker_tags`}}"
+                "tags": ["{{user `docker_main_tag`}}", "{{user `docker_extra_tag`}}"]
             },
             {
                 "type": "docker-push",
@@ -207,7 +208,7 @@
                 "name": "set-tag",
                 "only": ["{{user `builder_prefix`}}-stretch"],
                 "repository": "{{user `docker_user`}}/{{user `builder_prefix`}}-debian-stretch",
-                "tag": "{{user `docker_tags`}}"
+                "tags": ["{{user `docker_main_tag`}}", "{{user `docker_extra_tag`}}"]
             },
             {
                 "type": "docker-push",
@@ -225,7 +226,7 @@
                 "name": "set-tag",
                 "only": ["{{user `builder_prefix`}}-buster"],
                 "repository": "{{user `docker_user`}}/{{user `builder_prefix`}}-debian-buster",
-                "tag": "{{user `docker_tags`}}"
+                "tags": ["{{user `docker_main_tag`}}", "{{user `docker_extra_tag`}}"]
             },
             {
                 "type": "docker-push",

--- a/config.mk
+++ b/config.mk
@@ -1,23 +1,4 @@
 #==============================================================================
-# CI
-#==============================================================================
-
-#
-# Packer
-#
-# to manage several tags, use DOCKER_TAGS = "tag1,tag2"
-DOCKER_TAGS = "latest"
-REGISTRY = docker.io
-REGISTRY_USER = inverseinc
-ANSIBLE_FORCE_COLOR = 1
-ANSIBLE_CENTOS_GROUP = devel_centos
-ANSIBLE_CENTOS7_GROUP = devel_centos7
-ANSIBLE_CENTOS8_GROUP = devel_centos8
-ANSIBLE_DEBIAN_GROUP = devel_debian
-ANSIBLE_RUBYGEMS_GROUP = devel_rubygems
-
-
-#==============================================================================
 # PacketFence application
 #==============================================================================
 

--- a/docs/packer/README.asciidoc
+++ b/docs/packer/README.asciidoc
@@ -57,14 +57,13 @@ manually or detect changes on packages specifications files to start.
 ==== Makefile
 
 Because we run build inside a GitLab pipeline, many environment variables can
-be set to change build behavior. A [filename]`Makefile` is provided to
-simplify creation a new Docker images based on environment variables.
+be set to change build behavior. A [filename]`Makefile` and a wrapper are provided to
+simplify creation of a new Docker images based on environment variables.
 
 .Example usage of Makefile
 [source,bash]
 ----
-make -C ci/packer
-GOVERSION=go1.9.3 DOCKER_TAG=$GOVERSION ACTIVE_BUILDS=pfbuild-stretch \
+GOVERSION=go1.9.3 DOCKER_TAGS=$GOVERSION ACTIVE_BUILDS=pfbuild-stretch \
 make -e -C ci/packer
 ----
 


### PR DESCRIPTION
# Description
- Refactor build_images to fix issues with DOCKER_TAGS at each release
- Remove direct build on `feature/packer-*` branches
- Use a wrapper to simplify management of environment variables
- Build all images the same way to avoid a different build at release (only variables changed)
- Minor adjustements related to Packer v1.6.0
  - Builds two images on same runner

# Impacts
Build images on tag, devel and branches (maintenance branches included)

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [X] Document the feature
