### PR TITLE
Add FortiGate Role Based Enforcement

### DIFF
--- a/lib/pf/Switch/Fortinet/FortiGate.pm
+++ b/lib/pf/Switch/Fortinet/FortiGate.pm
@@ -48,6 +48,7 @@ use pf::SwitchSupports qw(
     WirelessMacAuth
     WiredMacAuth
     WirelessDot1x
+    RoleBasedEnforcement
     VPN
 );
 
@@ -157,6 +158,18 @@ sub getAcceptForm {
 
     $logger->debug("Generated the following html form : ".$html_form);
     return $html_form;
+}
+
+=item returnRoleAttribute
+
+What RADIUS Attribute (usually VSA) should the role returned into.
+
+=cut
+
+sub returnRoleAttribute {
+    my ($self) = @_;
+
+    return 'Fortinet-Group-Name';
 }
 
 =item deauthenticateMacDefault


### PR DESCRIPTION
Add FortiGate WSSO Role Based Enforcement.
https://docs.fortinet.com/document/fortiap/6.2.0/fortiwifi-and-fortiap-cookbook/414919/wifi-with-wsso-using-windows-nps-and-user-groups