### PR TITLE
Feature/configurable portal fake ip

### DIFF
--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1045,6 +1045,13 @@ description=<<EOT
 Comma-delimited list of interfaces used to SNAT inline level 2 traffic
 EOT
 
+[captive_portal.ip_address]
+type=text
+description=<<EOT
+The IP address the portal uses in the registration and isolation networks.
+Do not change unless you know what you are doing.
+EOT
+
 [captive_portal.network_detection]
 type=toggle
 options=enabled|disabled

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -745,7 +745,7 @@ interfaceSNAT=
 # The IP address the portal uses in the registration and isolation networks.
 # This IP address should point to an IP outside the registration and isolation networks.
 # Do not change unless you know what you are doing.
-ip_address=69.172.200.235
+ip_address=66.70.255.147
 #
 # captive_portal.network_detection
 #

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -740,6 +740,13 @@ interfaceSNAT=
 
 [captive_portal]
 #
+# captive_portal.ip_address
+#
+# The IP address the portal uses in the registration and isolation networks.
+# This IP address should point to an IP outside the registration and isolation networks.
+# Do not change unless you know what you are doing.
+ip_address=69.172.200.235
+#
 # captive_portal.network_detection
 #
 # Enable or not the network detection feature after registration

--- a/go/coredns/plugin/pfdns/pfdns.go
+++ b/go/coredns/plugin/pfdns/pfdns.go
@@ -17,7 +17,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/inverse-inc/packetfence/go/coredns/plugin"
 	"github.com/inverse-inc/packetfence/go/coredns/request"
 	"github.com/inverse-inc/packetfence/go/db"
@@ -383,8 +382,6 @@ func (pf *pfdns) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 				}
 			}
 		}
-
-		spew.Dump(pf.InternalPortalIP)
 
 		var returnedIP []byte
 		found = false

--- a/go/coredns/plugin/pfdns/pfdns.go
+++ b/go/coredns/plugin/pfdns/pfdns.go
@@ -449,7 +449,7 @@ func (pf *pfdns) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 	}
 
 	a.Answer = []dns.RR{rr}
-	log.LoggerWContext(ctx).Info("Returned portal for MAC " + mac + " with IP " + srcIP + "for fqdn " + state.QName())
+	log.LoggerWContext(ctx).Debug("Returned portal for MAC " + mac + " with IP " + srcIP + "for fqdn " + state.QName())
 	state.SizeAndDo(a)
 	pf.logreply(ctx, srcIP, mac, state.QName(), state.Type(), a, "Portal")
 	w.WriteMsg(a)

--- a/go/coredns/plugin/pfdns/setup.go
+++ b/go/coredns/plugin/pfdns/setup.go
@@ -28,6 +28,10 @@ func setuppfdns(c *caddy.Controller) error {
 	var ip net.IP
 	ctx := context.Background()
 	pfconfigdriver.PfconfigPool.AddStruct(ctx, &pfconfigdriver.Config.PfConf.General)
+	pfconfigdriver.PfconfigPool.AddStruct(ctx, &pfconfigdriver.Config.PfConf.CaptivePortal)
+
+	pfconfigdriver.PfconfigPool.Refresh(ctx)
+
 	for c.Next() {
 		// block with extra parameters
 		for c.NextBlock() {
@@ -91,6 +95,7 @@ func setuppfdns(c *caddy.Controller) error {
 
 	dnsserver.GetConfig(c).AddPlugin(
 		func(next plugin.Handler) plugin.Handler {
+			pf.InternalPortalIP = net.ParseIP(pfconfigdriver.Config.PfConf.CaptivePortal.IpAddress).To4()
 			pf.RedirectIP = ip
 			pf.Next = next
 			return pf

--- a/go/pfconfigdriver/structs.go
+++ b/go/pfconfigdriver/structs.go
@@ -134,6 +134,7 @@ type PfConfCaptivePortal struct {
 	PfconfigMethod               string   `val:"hash_element"`
 	PfconfigNS                   string   `val:"config::Pf"`
 	PfconfigHashNS               string   `val:"captive_portal"`
+	IpAddress                    string   `json:"ip_address"`
 	DetectionMecanismBypass      string   `json:"detection_mecanism_bypass"`
 	DetectionMecanismUrls        []string `json:"detection_mecanism_urls"`
 	NetworkDetection             string   `json:"network_detection"`

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_config/captivePortal.js
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_config/captivePortal.js
@@ -18,7 +18,7 @@ export const view = (form = {}, meta = {}) => {
       rows: [
         {
           label: i18n.t('IP address'),
-          text: i18n.t('The IP address the portal uses in the registration and isolation networks. Do not change unless you know what you are doing.'),
+          text: i18n.t('The IP address the portal uses in the registration and isolation networks. Do not change unless you know what you are doing. Changing this requires to restart all of the PacketFence services.'),
           cols: [
             {
               namespace: 'ip_address',

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_config/captivePortal.js
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_config/captivePortal.js
@@ -17,6 +17,17 @@ export const view = (form = {}, meta = {}) => {
       tab: null,
       rows: [
         {
+          label: i18n.t('IP address'),
+          text: i18n.t('The IP address the portal uses in the registration and isolation networks. Do not change unless you know what you are doing.'),
+          cols: [
+            {
+              namespace: 'ip_address',
+              component: pfFormInput,
+              attrs: attributesFromMeta(meta, 'ip_address')
+            }
+          ]
+        },
+        {
           label: i18n.t('Network detection'),
           text: i18n.t('Enable the automatic network detection feature for registration auto-redirect.'),
           cols: [
@@ -30,7 +41,7 @@ export const view = (form = {}, meta = {}) => {
           ]
         },
         {
-          label: i18n.t('IP'),
+          label: i18n.t('Network detection IP'),
           text: i18n.t(`This IP is used as the webserver who hosts the common/network-access-detection.gif which is used to detect if network access was enabled. It cannot be a domain name since it is used in registration or quarantine where DNS is blackholed. It is recommended that you allow your users to reach your PacketFence server and put your LAN's PacketFence IP. By default we will make this reach PacketFence's website as an easy solution.`),
           cols: [
             {
@@ -243,6 +254,7 @@ export const view = (form = {}, meta = {}) => {
 
 export const validators = (form = {}, meta = {}) => {
   return {
+    ip_address: validatorsFromMeta(meta, 'ip_address', i18n.t('IP address')),
     network_detection_ip: {
       ...validatorsFromMeta(meta, 'network_detection_ip', 'IP'),
       ...{

--- a/lib/pf/iptables.pm
+++ b/lib/pf/iptables.pm
@@ -207,6 +207,7 @@ sub generate_filter_if_src_to_chain {
     my $rules_forward = '';
     my $passthrough_enabled = (isenabled($Config{'fencing'}{'passthrough'}) || isenabled($Config{'fencing'}{'isolation_passthrough'}));
     my $isolation_passthrough_enabled = isenabled($Config{'fencing'}{'isolation_passthrough'});
+    my $internal_portal_ip = $Config{captive_portal}{ip_address};
 
     # internal interfaces handling
     foreach my $interface (@internal_nets) {
@@ -239,7 +240,7 @@ sub generate_filter_if_src_to_chain {
             $rules .= "# DHCP Sync\n";
             $rules .= "-A INPUT --in-interface $dev --protocol tcp --match tcp --dport 647 -j ACCEPT\n" if ($pf::cluster_enabled);
             $rules .= "-A INPUT --in-interface $dev --protocol udp --match udp --dport 67 -j ACCEPT\n";
-            $rules .= "-A INPUT --in-interface $dev -d 192.0.2.1 --jump $chain\n";
+            $rules .= "-A INPUT --in-interface $dev -d $internal_portal_ip --jump $chain\n";
             $rules .= "-A INPUT --in-interface $dev -d ".$cluster_ip." --jump $chain\n" if ($cluster_enabled);
             $rules .= "-A INPUT --in-interface $dev -d " . $interface->tag("vip") . " --jump $chain\n" if $interface->tag("vip");
             $rules .= "-A INPUT --in-interface $dev -d " . $interface->tag("ip") . " --jump $chain\n";
@@ -261,7 +262,7 @@ sub generate_filter_if_src_to_chain {
             $rules .= "# DHCP Sync\n";
             $rules .= "-A INPUT --in-interface $dev --protocol tcp --match tcp --dport 647 -j ACCEPT\n" if ($cluster_enabled);
             $rules .= "-A INPUT --in-interface $dev --protocol udp --match udp --dport 67 -j ACCEPT\n";
-            $rules .= "-A INPUT --in-interface $dev -d 192.0.2.1 --jump $FW_FILTER_INPUT_INT_VLAN\n";
+            $rules .= "-A INPUT --in-interface $dev -d $internal_portal_ip --jump $FW_FILTER_INPUT_INT_VLAN\n";
             $rules .= "-A INPUT --in-interface $dev -d ".$cluster_ip." --jump $FW_FILTER_INPUT_INT_INLINE\n" if ($cluster_enabled);
             $rules .= "-A INPUT --in-interface $dev --protocol udp --match udp --dport 53 --jump $FW_FILTER_INPUT_INT_INLINE\n";
             $rules .= "-A INPUT --in-interface $dev --protocol tcp --match tcp --dport 53 --jump $FW_FILTER_INPUT_INT_INLINE\n";

--- a/lib/pf/services/manager/haproxy_admin.pm
+++ b/lib/pf/services/manager/haproxy_admin.pm
@@ -280,11 +280,12 @@ The creates the portal preview ip addresss
 
 sub portal_preview_ip {
     my ($self) = @_;
+    my $internal_portal_ip = $Config{captive_portal}{ip_address};
     if (!$cluster_enabled) {
         return "127.0.0.1";
     }
     my  @ints = uniq (@internal_nets, @portal_ints);
-    return $ints[0]->{Tvip} ? $ints[0]->{Tvip} : $ints[0]->{Tip} ? $ints[0]->{Tip} : "192.0.2.1";
+    return $ints[0]->{Tvip} ? $ints[0]->{Tvip} : $ints[0]->{Tip} ? $ints[0]->{Tip} : $internal_portal_ip;
 }
 
 =head1 AUTHOR

--- a/lib/pf/services/manager/haproxy_portal.pm
+++ b/lib/pf/services/manager/haproxy_portal.pm
@@ -223,11 +223,12 @@ EOT
         ? $management_network->tag('vip')
         : $management_network->tag('ip');
 
+    my $internal_portal_ip = $Config{captive_portal}{ip_address};
     if (scalar @portal_ip > 0) {
 $tags{'http'} .= <<"EOT";
 
-frontend portal-http-192.0.2.1
-        bind 192.0.2.1:80
+frontend portal-http-$internal_portal_ip
+        bind $internal_portal_ip:80
         capture request header Host len 40
         stick-table type ip size 1m expire 10s store gpc0,http_req_rate(10s)
         tcp-request connection track-sc1 src
@@ -250,8 +251,8 @@ EOT
         default_backend $ip_cluster-backend
         $bind_process
 
-frontend portal-https-192.0.2.1
-        bind 192.0.2.1:443 ssl no-sslv3 crt /usr/local/pf/conf/ssl/server.pem
+frontend portal-https-$internal_portal_ip
+        bind $internal_portal_ip:443 ssl no-sslv3 crt /usr/local/pf/conf/ssl/server.pem
         capture request header Host len 40
         stick-table type ip size 1m expire 10s store gpc0,http_req_rate(10s)
         tcp-request connection track-sc1 src

--- a/lib/pf/services/manager/keepalived.pm
+++ b/lib/pf/services/manager/keepalived.pm
@@ -64,6 +64,8 @@ sub generateConfig {
     my ($package, $filename, $line) = caller();
     $logger->info("$package, $filename, $line");
 
+    my $internal_portal_ip = $Config{captive_portal}{ip_address};
+
     my %tags;
     $tags{'template'} = "$conf_dir/keepalived.conf";
     
@@ -81,7 +83,7 @@ sub generateConfig {
     $tags{'vrrp'} .= <<"EOT";
 
 static_ipaddress {
-    192.0.2.1 dev lo scope link
+    $internal_portal_ip dev lo scope link
     $ips
 }
 


### PR DESCRIPTION
# Description
Use an Inverse owned IP for the captive portal IP (instead of 192.0.2.1)
Configurable captive portal IP

# Impacts
Captive portal detection and access

# Issue
fixes #5679 

# Delete branch after merge
YES

# NEWS file entries
## Enhancements
* Removed hardcoded 192.0.2.1 IP address for the L2 captive portal and switch to an Inverse owned IP
* Allow configuration of the IP address for the L2 captive portal