### PR TITLE
Fix/radius default nas ip address

### DIFF
--- a/conf/radiusd/packetfence-cli.example
+++ b/conf/radiusd/packetfence-cli.example
@@ -12,6 +12,7 @@ server packetfence-cli {
 #  Make *sure* that 'preprocess' comes before any realm if you
 #  need to setup hints for the remote radius server
 authorize {
+	packetfence-nas-ip-address
 
 	# Add in PacketFence specific configuration
 	update {

--- a/conf/radiusd/packetfence-cluster.example
+++ b/conf/radiusd/packetfence-cluster.example
@@ -48,11 +48,7 @@ server pf.cluster {
                 update control {
                         Proxy-To-Realm := "packetfence"
                 }
-                if(!NAS-IP-Address || NAS-IP-Address == "0.0.0.0"){
-                        update request {
-                                NAS-IP-Address := "%{Packet-Src-IP-Address}"
-                        }
-                }
+                packetfence-nas-ip-address
                 if ( "%{client:shortname}" =~ /eduroam_tlrs/ ) {
                         update request {
                                 PacketFence-ShortName := "%{client:shortname}"
@@ -67,11 +63,7 @@ server pf.cluster {
                 update control {
                         Proxy-To-Realm := "packetfence"
                 }
-                if(!NAS-IP-Address || NAS-IP-Address == "0.0.0.0"){
-                        update request {
-                                NAS-IP-Address := "%{Packet-Src-IP-Address}"
-                        }
-                }
+                packetfence-nas-ip-address
                 if ( "%{client:shortname}" =~ /eduroam_tlrs/ ) {
                         update request {
                                 PacketFence-ShortName := "%{client:shortname}"
@@ -97,11 +89,7 @@ server pfcli.cluster {
                         Load-Balance-Key := "%{NAS-IP-Address}"
                         Proxy-To-Realm := "packetfence-cli"
                 }
-                if(!NAS-IP-Address || NAS-IP-Address == "0.0.0.0"){
-                        update request {
-                                NAS-IP-Address := "%{Packet-Src-IP-Address}"
-                        }
-                }
+                packetfence-nas-ip-address
         }
 
 

--- a/conf/radiusd/packetfence.example
+++ b/conf/radiusd/packetfence.example
@@ -12,6 +12,7 @@ server packetfence {
 #  Make *sure* that 'preprocess' comes before any realm if you
 #  need to setup hints for the remote radius server
 authorize {
+	packetfence-nas-ip-address
 
 	# Add in PacketFence specific configuration
 	update {
@@ -273,6 +274,8 @@ preacct {
 #  Accounting.  Log the accounting data.
 #
 accounting {
+	packetfence-nas-ip-address
+
 	# Add in PacketFence specific configuration
 	update {
 		&request:FreeRADIUS-Client-IP-Address := "%{Packet-Src-IP-Address}"

--- a/go/acct/radius.go
+++ b/go/acct/radius.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"hash"
 	"net"
+	"strings"
 	"sync"
 	"time"
 
@@ -208,6 +209,11 @@ func (h *PfAcct) sendRadiusAccounting(r *radius.Request) {
 	attr["PF_HEADERS"] = map[string]string{
 		"X-FreeRADIUS-Server":  "packetfence",
 		"X-FreeRADIUS-Section": "accounting",
+	}
+
+	if val, ok := attr["NAS-IP-Address"]; !ok || val == "0.0.0.0" {
+		attr["NAS-IP-Address"] = strings.Split(r.RemoteAddr.String(), ":")[0]
+		logWarn(ctx, fmt.Sprintf("Empty NAS-IP-Address, using the source IP address of the packet (%s)", attr["NAS-IP-Address"]))
 	}
 
 	if _, err := h.AAAClient.Call(ctx, "radius_accounting", attr, 1); err != nil {

--- a/raddb/policy.d/packetfence
+++ b/raddb/policy.d/packetfence
@@ -225,3 +225,11 @@ packetfence-balanced-key-policy {
         }
     }
 }
+
+packetfence-nas-ip-address {
+    if(!NAS-IP-Address || NAS-IP-Address == "0.0.0.0"){
+            update request {
+                    NAS-IP-Address := "%{Packet-Src-IP-Address}"
+            }
+    }
+}


### PR DESCRIPTION
# Description
Add default NAS-IP-Address for standalone RADIUS

# Impacts
RADIUS inbound requests

# Issue
fixes #5722 

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* Define a default NAS-IP-Address when its missing from the RADIUS packet (was already there in cluster, extended it to standalone)

