### PR TITLE
feature/default-switch-packetfence-standard

### DIFF
--- a/addons/upgrade/to-10.2-default-switch-packetfence-standard.pl
+++ b/addons/upgrade/to-10.2-default-switch-packetfence-standard.pl
@@ -1,0 +1,99 @@
+#!/usr/bin/perl
+
+=head1 NAME
+
+to-10.2-default-switch-packetfence-standard.pl
+
+=cut
+
+=head1 DESCRIPTION
+
+Add Generic type where needed
+
+=cut
+
+use strict;
+use warnings;
+use lib qw(/usr/local/pf/lib);
+use pf::IniFiles;
+use pf::file_paths qw(
+    $switches_config_file
+);
+use List::MoreUtils qw(any);
+use pf::util;
+use File::Copy;
+
+run_as_pf();
+
+my $file = $switches_config_file;
+
+if (@ARGV) {
+    $file = $ARGV[0];
+}
+
+my $cs = pf::IniFiles->new(-file => $file, -allowempty => 1);
+my @groups;
+my @switches;
+
+my $default_type = $cs->val('default', 'type');
+
+if ($default_type && $default_type ne 'Generic') {
+    print "Nothing to do\n";
+    exit;
+}
+
+for my $section ($cs->Sections()) {
+    next if $section eq 'default';
+    if ($section =~ /^group /) {
+        push @groups, $section;
+    } else {
+        push @switches, $section;
+    }
+}
+
+for my $group (@groups) {
+    if (!$cs->exists($group, 'type')) {
+        print "$group: setting type to Generic\n";
+        $cs->newval($group, 'type', 'Generic');
+    }
+}
+
+for my $sw (@switches) {
+    if (!$cs->exists($sw, 'type') && (!$cs->exists($sw, 'group') || $cs->val($sw, 'group') eq 'default')) {
+        print "$sw setting type to Generic\n";
+        $cs->newval($sw, 'type', 'Generic');
+    }
+}
+
+$cs->RewriteConfig();
+
+print "All done\n";
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2020 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+

--- a/conf/switches.conf.defaults
+++ b/conf/switches.conf.defaults
@@ -7,7 +7,7 @@
 # http://www.fsf.org/licensing/licenses/gpl.html
 
 [default]
-type=Generic
+type=PacketFence::Standard
 description=Switches Default Values
 vlans = 1,2,3,4,5
 normalVlan = 1

--- a/conf/template_switches.conf.defaults
+++ b/conf/template_switches.conf.defaults
@@ -171,6 +171,22 @@ EOT
 acceptRole=Filter-Id = $role
 disconnect=Calling-Station-Id = $mac
 
+[PacketFence::SNMP]
+# Do not edit.
+# Any changes will be lost on upgrade.
+description=SNMP Switch
+snmpDisconnect=enabled
+acceptVlan= <<EOT
+Tunnel-Medium-Type  = 6
+Tunnel-Type = 13
+Tunnel-Private-Group-Id = $vlan
+EOT
+voip=
+acceptRole=
+coa=
+disconnect=
+reject=Reply-Message = This node is not allowed to use this service
+
 [PacketFence::Standard]
 # Do not edit.
 # Any changes will be lost on upgrade.

--- a/lib/pf/Switch/PacketFence/SNMP.def
+++ b/lib/pf/Switch/PacketFence/SNMP.def
@@ -1,0 +1,15 @@
+# Do not edit.
+# Any changes will be lost on upgrade.
+
+description=SNMP Switch
+snmpDisconnect=enabled
+acceptVlan = <<EOT
+Tunnel-Medium-Type  = 6
+Tunnel-Type = 13
+Tunnel-Private-Group-Id = $vlan
+EOT
+voip=
+acceptRole=
+coa=
+disconnect=
+reject=Reply-Message = This node is not allowed to use this service


### PR DESCRIPTION
Description
===========
Set the default switch type to Packetfence::Standard

NEWS file entries
=======================

Enhancements
-------------
* Set the default switch type to Packetfence::Standard
* Create a PacketFence::SNMP switch to force reevaluate access using SNMP

Issue
=====
fixes #5490

Delete branch after merge
=========================
NO

UPGRADE file entries
=========================

Set the switch type to Generic if it was not previously defined.

/usr/local/pf/addons/upgrade/to-10.2-default-switch-packetfence-standard.pl

Checklist
=========
- [ ] Document the feature
- [x] Add unit tests
- [ ] Add acceptance tests (TestLink)