### PR TITLE
Update HP.pm returnAuthorizeRead/returnAuthorizeWrite used incorrect …

### DIFF
--- a/lib/pf/Switch/HP.pm
+++ b/lib/pf/Switch/HP.pm
@@ -518,7 +518,7 @@ sub returnAuthorizeWrite {
    my $logger = $self->logger;
    my $radius_reply_ref = {};
    my $status;
-   $radius_reply_ref->{'APC-Service-Type'} = 'Admin';
+   $radius_reply_ref->{'Service-Type'} = 'Administrative-User';
    $radius_reply_ref->{'Reply-Message'} = "Switch enable access granted by PacketFence";
    $logger->info("User $args->{'user_name'} logged in $args->{'switch'}{'_id'} with write access");
    my $filter = pf::access_filter::radius->new;
@@ -538,7 +538,7 @@ sub returnAuthorizeRead {
    my $logger = $self->logger;
    my $radius_reply_ref = {};
    my $status;
-   $radius_reply_ref->{'APC-Service-Type'} = 'ReadOnly';
+   $radius_reply_ref->{'Service-Type'} = 'NAS-Prompt-User';
    $radius_reply_ref->{'Reply-Message'} = "Switch read access granted by PacketFence";
    $logger->info("User $args->{'user_name'} logged in $args->{'switch'}{'_id'} with read access");
    my $filter = pf::access_filter::radius->new;


### PR DESCRIPTION
…radius reply.


# Description
https://wiki.freeradius.org/vendor/HP#administrative-interface-authentication. Worked unless you have aaa authentication login privilege-mode turned on. Tested working on HP Procurve 2920 (firmware versions from 16.x1.xxxx-current), Aruba 2530 (firmware versions from 16.x1.xxxx-current), Aruba 3810m (firmware versions from 16.x1.xxxx-current), Aruba 2930F (firmware versions from 16.x1.xxxx-current), HP Procurve 2910al (firmware 15.14 and a couple before that).

# Impacts
RADIUS authorize reply

# Delete branch after merge
YES

# Checklist
- [n/a] Document the feature
- [n/a] Add unit tests
- [n/a] Add acceptance tests (TestLink)


## Enhancements
* Radius reply can contain either NAS-Prompt-User to grant read only access, or Administrative-User for login directly to priv mode.
