### PR TITLE
[systemd] 143 is a legit exit code for haproxy

### DIFF
--- a/conf/systemd/packetfence-haproxy-admin.service
+++ b/conf/systemd/packetfence-haproxy-admin.service
@@ -12,6 +12,7 @@ ExecStartPre=/bin/perl -I/usr/local/pf/lib '-Mpf::services::manager::haproxy_adm
 ExecStart=/usr/sbin/haproxy -Ws -f /usr/local/pf/var/conf/haproxy-admin.conf -p /usr/local/pf/var/run/haproxy-admin.pid
 ExecReload=/bin/kill -USR2 $MAINPID
 Restart=on-failure
+SuccessExitStatus=143
 Slice=packetfence.slice
 
 [Install]

--- a/conf/systemd/packetfence-haproxy-db.service
+++ b/conf/systemd/packetfence-haproxy-db.service
@@ -12,6 +12,7 @@ ExecStartPre=/bin/perl -I/usr/local/pf/lib '-Mpf::services::manager::haproxy_db'
 ExecStart=/usr/sbin/haproxy -Ws -f /usr/local/pf/var/conf/haproxy-db.conf -p /usr/local/pf/var/run/haproxy-db.pid
 ExecReload=/bin/kill -USR2 $MAINPID
 Restart=on-failure
+SuccessExitStatus=143
 
 [Install]
 WantedBy=packetfence-cluster.target

--- a/conf/systemd/packetfence-haproxy-portal.service
+++ b/conf/systemd/packetfence-haproxy-portal.service
@@ -12,6 +12,7 @@ ExecStartPre=/bin/perl -I/usr/local/pf/lib '-Mpf::services::manager::haproxy_por
 ExecStart=/usr/sbin/haproxy -Ws -f /usr/local/pf/var/conf/haproxy-portal.conf -p /usr/local/pf/var/run/haproxy-portal.pid
 ExecReload=/bin/kill -USR2 $MAINPID
 Restart=on-failure
+SuccessExitStatus=143
 Slice=packetfence.slice
 
 [Install]


### PR DESCRIPTION
# Description
Fixes #5745
See https://bugzilla.redhat.com/show_bug.cgi?id=1778844 and https://github.com/haproxy/haproxy/commit/3b479bd5f5f50ce91cabed32bb26556313552d23

# Impacts
`haproxy` services managed through `systemd`

# Issue
fixes #5745 

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* haproxy-db can cause pfcmd service restart to failed (#5745)

