### PR TITLE
Dell N1500: use common regex to get MAC from LLDP

### DIFF
--- a/lib/pf/Switch/Dell/N1500.pm
+++ b/lib/pf/Switch/Dell/N1500.pm
@@ -199,9 +199,7 @@ sub getPhonesLLDPAtIfIndex {
                         && ($MACresult->{
                                 "$oid_lldpRemPortId.$cache_lldpRemTimeMark.$cache_lldpRemLocalPortNum.$cache_lldpRemIndex"
                             }
-                            =~ /([0-9A-Z]{2})\s?([0-9A-Z]{2})\s?([0-9A-Z]{2})\s?([0-9A-Z]{2})\s?([0-9A-Z]{2})\s?([0-9A-Z]{2}).*/i
-                        )
-                        )
+                            =~ /^(?:0x)?([0-9A-F]{2})([0-9A-F]{2})([0-9A-F]{2})([0-9A-F]{2})([0-9A-F]{2})([0-9A-F]{2})(?::..)?$/i))
                     {
                         push @phones, lc("$1:$2:$3:$4:$5:$6");
                     }


### PR DESCRIPTION
# Description
Use common regex to get MAC from LLDP

Tested on 6.6.0.15

# Impacts
Dell N1500 switch module + dedicated unit test.

# Issue
fixes #5758 

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* Dell N1500.pm: LLDP detection doesn't work (#5758)
