### PR TITLE
feature/switch-template-nasport2index

### DIFF
--- a/html/pfappserver/lib/pfappserver/Form/Config/TemplateSwitch.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/TemplateSwitch.pm
@@ -72,6 +72,11 @@ has_field 'radiusDisconnect' => (
     ],
 );
 
+has_field 'nasPortToIfindex' => (
+    type    => 'Text',
+    label   => 'NasPort To Ifindex template',
+);
+
 has_field 'acl_template' => (
     type     => 'TextArea',
     element_attr => { placeholder => $DEFAULT_ACL_TEMPLATE},

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_config/switchTemplate.js
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_config/switchTemplate.js
@@ -386,6 +386,16 @@ export const view = (form, meta = {}) => {
               }
             }
           ]
+        },
+        {
+          label: i18n.t('NasPortToIfindex template'),
+          cols: [
+            {
+              namespace: 'nasPortToIfindex',
+              component: pfFormInput,
+              attrs: attributesFromMeta(meta, 'nasPortToIfindex')
+            }
+          ]
         }
       ]
     }

--- a/lib/pf/Switch/Template.pm
+++ b/lib/pf/Switch/Template.pm
@@ -529,6 +529,7 @@ sub _bouncePortCoa {
     my ($attrs, $vsa) = $self->makeRadiusAttributesWithVSA($radiusBounce, \%args);
     # Standard Attributes
     return perform_coa($connection_info, {@$attrs}, $vsa);
+}
 
 sub NasPortToIfIndex {
     my ($self, $nasPort) = @_;

--- a/lib/pf/Switch/Template.pm
+++ b/lib/pf/Switch/Template.pm
@@ -529,6 +529,17 @@ sub _bouncePortCoa {
     my ($attrs, $vsa) = $self->makeRadiusAttributesWithVSA($radiusBounce, \%args);
     # Standard Attributes
     return perform_coa($connection_info, {@$attrs}, $vsa);
+
+sub NasPortToIfIndex {
+    my ($self, $nasPort) = @_;
+    if ($self->{_template}{nasPortToIfindex}) {
+        my $ifindex = $self->{_template}{nasPortToIfindex}->process({ nasPort => $nasPort});
+        if ($ifindex) {
+            return $ifindex;
+        }
+    }
+
+    return $self->SUPER::NasPortToIfIndex($nasPort);
 }
 
 sub returnAuthorizeRead {

--- a/lib/pf/config/builder/template_switches.pm
+++ b/lib/pf/config/builder/template_switches.pm
@@ -48,6 +48,17 @@ sub buildEntry {
         }
     }
 
+    if ($entry->{nasPortToIfindex}) {
+        my $tmpl_text= $entry->{nasPortToIfindex};
+        my $tmpl = eval {
+            pf::mini_template->new($tmpl_text)
+        };
+        if ($@) {
+            push @{$buildData->{errors}}, { message => $@, text => $tmpl_text };
+        }
+        $entry->{nasPortToIfindex} = $tmpl;
+    }
+
     @supports = sort @supports;
     my ($vendor, undef) = split /::/, $type, 2;
     push @{ $buildData->{entries}{'::VENDORS'}{$vendor} },

--- a/t/data/switches.conf
+++ b/t/data/switches.conf
@@ -227,3 +227,9 @@ description=RoleMap use default
 RoleMap=Y
 uplink_dynamic=dynamic
 type=PacketFence::Standard
+
+[172.16.8.26]
+description=RoleMap use default
+RoleMap=Y
+uplink_dynamic=dynamic
+type=Test::NasportToIndex

--- a/t/data/template_switches.conf
+++ b/t/data/template_switches.conf
@@ -14,3 +14,4 @@ voip=
 radiusDisconnect=disconnect
 reject=Reply-Message = This node is not allowed to use this service
 coa=
+nasPortToIfindex=${replace($nasPort, "500", "101")}

--- a/t/data/template_switches.conf
+++ b/t/data/template_switches.conf
@@ -1,0 +1,16 @@
+[Test::NasportToIndex]
+description=Test
+acceptVlan= <<EOT
+Tunnel-Type = 13
+Tunnel-Medium-Type = 6
+Tunnel-Private-Group-Id = $vlan
+EOT
+acceptRole=
+disconnect= <<EOT
+Calling-Station-Id = ${macToEUI48($mac)}
+NAS-IP-Address = $disconnectIp
+EOT
+voip=
+radiusDisconnect=disconnect
+reject=Reply-Message = This node is not allowed to use this service
+coa=

--- a/t/test_paths.pm
+++ b/t/test_paths.pm
@@ -51,6 +51,7 @@ BEGIN {
     $pf::file_paths::server_cert = catfile($test_dir,'data/server.crt');
     $pf::file_paths::server_key = catfile($test_dir,'data/server.key');
     $pf::file_paths::server_pem = catfile($test_dir,'data/server.pem');
+    $pf::file_paths::template_switches_config_file = catfile($test_dir,'data/template_switches.conf');
 
     $pf::file_paths::radius_server_cert = catfile($test_dir,'data/radius_server.crt');
     $pf::file_paths::radius_server_key = catfile($test_dir,'data/radius_server.key');

--- a/t/unittest/Switch/Template.t
+++ b/t/unittest/Switch/Template.t
@@ -29,7 +29,7 @@ BEGIN {
 }
 
 my $builder = pf::config::builder::template_switches->new;
-use Test::More tests => (scalar @FILES) + 3;
+use Test::More tests => (scalar @FILES) + 4;
 #This test will running last
 use Test::NoWarnings;
 for my $file (@FILES) {
@@ -64,6 +64,15 @@ for my $file (@FILES) {
 {
     my $switch = pf::SwitchFactory->instantiate('172.16.8.25');
     my ($switchdeauthMethod, $deauthTechniques) = $switch->deauthTechniques($switch->{'_deauthMethod'});
+}
+
+{
+    my $switch = pf::SwitchFactory->instantiate('172.16.8.26');
+    is (
+        $switch->NasPortToIfIndex("500101"),
+        "101101",
+        "NasPortToIfIndex"
+    );
 }
 
 =head1 AUTHOR


### PR DESCRIPTION
Description
===========
Switch templates can define how to map a NasPort to an IfIndex

Impacts
=======
Switch Templates

NEWS file entries
=======================
Enhancements
-------------
* Switch templates can define how to map a NasPort to an IfIndex

Issue
=====
fixes #5776

Delete branch after merge
=========================
NO

Checklist
=========
- [ ] Document the feature
- [x] Add unit tests
- [ ] Add acceptance tests (TestLink)