### PR TITLE
Exclude the ip address of a disabled server

### DIFF
--- a/go/cmd/pfdhcp/utils.go
+++ b/go/cmd/pfdhcp/utils.go
@@ -3,8 +3,10 @@ package main
 import (
 	"context"
 	"encoding/binary"
+	"fmt"
 	"math/rand"
 	"net"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -195,7 +197,8 @@ func ShuffleDNS(ConfNet pfconfigdriver.RessourseNetworkConf) (r []byte) {
 		if ConfNet.Dnsvip != "" {
 			return []byte(net.ParseIP(ConfNet.Dnsvip).To4())
 		}
-		return Shuffle(ConfNet.ClusterIPs)
+		excluded := DetectDisabledServer(ConfNet.ClusterIPs, ConfNet.Interface.InterfaceName)
+		return Shuffle(ConfNet.ClusterIPs, excluded)
 	}
 	if ConfNet.Dnsvip != "" {
 		return []byte(net.ParseIP(ConfNet.Dnsvip).To4())
@@ -211,7 +214,9 @@ func ShuffleGateway(ConfNet pfconfigdriver.RessourseNetworkConf) (r []byte) {
 		if ConfNet.Type == "inlinel2" && ConfNet.NatEnabled == "disabled" {
 			return []byte(net.ParseIP(ConfNet.Gateway).To4())
 		}
-		return Shuffle(ConfNet.ClusterIPs)
+
+		excluded := DetectDisabledServer(ConfNet.ClusterIPs, ConfNet.Interface.InterfaceName)
+		return Shuffle(ConfNet.ClusterIPs, excluded)
 
 	} else {
 		return []byte(net.ParseIP(ConfNet.Gateway).To4())
@@ -219,9 +224,12 @@ func ShuffleGateway(ConfNet pfconfigdriver.RessourseNetworkConf) (r []byte) {
 }
 
 // Shuffle addresses
-func Shuffle(addresses string) (r []byte) {
+func Shuffle(addresses string, excluded string) (r []byte) {
 	var array []net.IP
 	for _, adresse := range strings.Split(addresses, ",") {
+		if adresse == excluded {
+			continue
+		}
 		array = append(array, net.ParseIP(adresse).To4())
 	}
 
@@ -467,4 +475,38 @@ func setOptionServerIdentifier(srvIP net.IP, handlerIP net.IP) net.IP {
 		return handlerIP
 	}
 	return srvIP
+}
+
+func DetectDisabledServer(addresses string, netint string) string {
+
+	var array []string
+	for _, adresse := range strings.Split(addresses, ",") {
+		array = append(array, adresse)
+	}
+
+	servers := pfconfigdriver.AllClusterServersRaw{}
+
+	pfconfigdriver.FetchDecodeSocketCache(ctx, &servers)
+	var ip string
+	ip = "0.0.0.0"
+	for _, key := range servers.Element {
+		if !(IsDisabled(key.(map[string]interface{})["host"].(string))) {
+			continue
+		}
+		for k, v := range key.(map[string]interface{}) {
+			if k == "interface "+netint {
+				for w, x := range v.(map[string]interface{}) {
+					if w == "ip" {
+						ip = x.(string)
+					}
+				}
+			}
+		}
+	}
+	return ip
+}
+
+func IsDisabled(hostname string) bool {
+	_, err := os.Stat(fmt.Sprintf("/usr/local/pf/var/run/%s-cluster-disabled", hostname))
+	return err == nil
 }

--- a/go/pfconfigdriver/structs.go
+++ b/go/pfconfigdriver/structs.go
@@ -558,6 +558,14 @@ type ClusterServer struct {
 	Host         string `json:"host"`
 }
 
+type AllClusterServersRaw struct {
+	StructConfig
+	PfconfigMethod string `val:"element"`
+	PfconfigNS     string `val:"resource::all_cluster_servers"`
+	PfconfigArray  string `val:"yes"`
+	Element        []interface{}
+}
+
 type SyslogFiles struct {
 	StructConfig
 	PfconfigMethod string `val:"element"`


### PR DESCRIPTION
# Description
Fixes the issue #5677 

# Impacts
DHCP

# Issue
fixes #5677

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Bug Fixes
* Remove the ip address of a server in the dhcp reply when the server has been disabled (#5677)

