### PR TITLE
Allow only TLS 1.2 in Freeradius

### DIFF
--- a/conf/radiusd/eap.conf.example
+++ b/conf/radiusd/eap.conf.example
@@ -268,8 +268,29 @@ eap [% key -%] {
         # the EAP keys correctly.  The fix is to upgrade
         # OpenSSL, or disable TLS 1.2 here. 
 #       disable_tlsv1_2 = no
-
+        disable_tlsv1_1 = yes
+        disable_tlsv1 = yes
         #
+
+        #  Set min / max TLS version.  Mainly for Debian
+        #  "trusty", which disables older versions of TLS, and
+        #  requires the application to manually enable them.
+        #
+        #  If you are running Debian trusty, you should set
+        #  these options, otherwise older clients will not be
+        #  able to connect.
+        #
+        #  Allowed values are "1.0", "1.1", "1.2", and "1.3".
+        #
+        #  Note that the server WILL NOT permit negotiation of
+        #  TLS 1.3.  The EAP-TLS standards for TLS 1.3 are NOT
+        #  finished.  It is therefore impossible for the server
+        #  to negotiate EAP-TLS correctly with TLS 1.3.
+        #
+        #  The values must be in quotes.
+        #
+        tls_min_version = "1.2"
+        tls_max_version = "1.2"
 
         #
         #  Elliptical cryptography configuration


### PR DESCRIPTION
# Description
Set TLS 1.2 the only TLS version available in Freeradius
(The configuration allows TLS 1.0 and/or TLS 1.1.  We STRONGLY recommned using only TLS 1.2 for security)

# Impacts
RADIUS authorize workflow

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* Define TLS 1.2 as the only version available in RADIUS


