### PR TITLE
local account creation expiration should follow the access validity

### DIFF
--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication.pm
@@ -292,6 +292,15 @@ sub create_local_account {
     # with different parameters coming from the authentication source (ie.: expiration date)
     $actions = $actions // pf::authentication::match( $self->source->id, $auth_params, undef, $self->session->{extra} );
 
+    for my $action (@$actions) {
+        if($action->type eq "set_access_duration") {
+            push @$actions, pf::Authentication::Action->new(class => "authentication", type => "expiration", value => pf::config::access_duration($action->value));
+        }
+        if($action->type eq "set_unreg_date") {
+            push @$actions, pf::Authentication::Action->new(class => "authentication", type => "expiration", value => $action->value);
+        }
+    }
+    
     my $login_amount = ($self->source->local_account_logins eq $LOCAL_ACCOUNT_UNLIMITED_LOGINS) ? undef : $self->source->local_account_logins;
     $password = pf::password::generate($self->app->session->{username}, $actions, $password, $login_amount, $self->source);
 


### PR DESCRIPTION
# Description
Tie the expiration of the local account to the duration of the access.
Example: you are given access for 2 months, your local account is valid for 2 months
At the moment, all local accounts are only valid 31 days

# Impacts
Create local account on the captive portal

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* Validity of the local accounts created on the portal is tied to the access duration of the user.

