### PR TITLE
Fix/5954 5952

### DIFF
--- a/html/pfappserver/lib/pfappserver/Form/Config/PortalModule/Authentication.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/PortalModule/Authentication.pm
@@ -35,7 +35,8 @@ has_field 'with_aup' =>
   (
    type => 'Checkbox',
    label => 'Require AUP',
-   checkbox_value => '1',
+   checkbox_value => 1,
+   unchecked_value => 0,
    tags => { after_element => \&help,
              help => 'Require the user to accept the AUP' },
   );

--- a/html/pfappserver/lib/pfappserver/Form/Config/PortalModule/Authentication.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/PortalModule/Authentication.pm
@@ -36,7 +36,7 @@ has_field 'with_aup' =>
    type => 'Checkbox',
    label => 'Require AUP',
    checkbox_value => 1,
-   unchecked_value => 0,
+   input_without_param => 0,
    tags => { after_element => \&help,
              help => 'Require the user to accept the AUP' },
   );

--- a/html/pfappserver/lib/pfappserver/Form/Config/Provisioning/mobileconfig.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Provisioning/mobileconfig.pm
@@ -30,7 +30,7 @@ has_field 'broadcast' =>
    type => 'Checkbox',
    label => 'Broadcast network',
    checkbox_value => 1,
-   unchecked_value => 0,
+   input_without_param => 0,
    default => 1,
    tags => { after_element => \&help,
              help => 'Disable this box if you are using a hidden SSID' },

--- a/html/pfappserver/lib/pfappserver/Form/Config/Provisioning/mobileconfig.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Provisioning/mobileconfig.pm
@@ -30,9 +30,10 @@ has_field 'broadcast' =>
    type => 'Checkbox',
    label => 'Broadcast network',
    checkbox_value => 1,
-   input_without_param => 0,
+   unchecked_value => 0,
+   default => 1,
    tags => { after_element => \&help,
-             help => 'Uncheck this box if you are using a hidden SSID' },
+             help => 'Disable this box if you are using a hidden SSID' },
   );
 
 has_field 'security_type' =>

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_config/portalModule.js
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_config/portalModule.js
@@ -619,7 +619,7 @@ export const viewFields = {
       ]
     }
   },
-  with_aup: () => {
+  with_aup: (form, meta = {}) => {
     return {
       label: i18n.t('Require AUP'),
       text: i18n.t('Require the user to accept the AUP'),
@@ -628,7 +628,10 @@ export const viewFields = {
           namespace: 'with_aup',
           component: pfFormRangeToggle,
           attrs: {
-            values: { checked: '1', unchecked: '0' }
+            ...attributesFromMeta(meta, 'with_aup'),
+            ...{
+              values: { checked: 1, unchecked: 0 }
+            }
           }
         }
       ]

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_config/provisioning.js
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_config/provisioning.js
@@ -267,13 +267,16 @@ export const viewFields = {
   broadcast: (form = {}, meta = {}) => {
     return {
       label: i18n.t('Broadcast network'),
-      text: i18n.t('Uncheck this box if you are using a hidden SSID.'),
+      text: i18n.t('Disable this box if you are using a hidden SSID.'),
       cols: [
         {
           namespace: 'broadcast',
           component: pfFormRangeToggle,
           attrs: {
-            values: { checked: '1', unchecked: '0' }
+            ...attributesFromMeta(meta, 'broadcast'),
+            ...{
+              values: { checked: 1, unchecked: 0 }
+            }  
           }
         }
       ]

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_config/provisioning.js
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_config/provisioning.js
@@ -276,7 +276,7 @@ export const viewFields = {
             ...attributesFromMeta(meta, 'broadcast'),
             ...{
               values: { checked: 1, unchecked: 0 }
-            }  
+            }
           }
         }
       ]


### PR DESCRIPTION
# Description
- SSIDs are not hidden by default when creating a provisioner (#5952) 
- with_aup is correctly displayed on GUI (#5954)

# Impacts
Provisioning
Portal Module

# Issue
fixes #5952 
fixes #5954 

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* SSIDs are not hidden by default when creating a provisioner (#5952) 
* with_aup is correctly displayed on GUI (#5954)
