### PR TITLE
Make ocsp_timeout and timer_expire text fields

### DIFF
--- a/html/pfappserver/lib/pfappserver/Form/Config/Radiusd/EAPProfile.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Radiusd/EAPProfile.pm
@@ -35,7 +35,7 @@ has_field default_eap_type => (
 );
 
 has_field timer_expire => (
-    type => 'Duration',
+    type => 'Text',
 );
 
 for my $f (qw(ignore_unknown_eap_types cisco_accounting_username_bug)) {

--- a/html/pfappserver/lib/pfappserver/Form/Config/Radiusd/OCSPProfile.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Radiusd/OCSPProfile.pm
@@ -36,7 +36,7 @@ for my $f (qw(ocsp_enable ocsp_override_cert_url ocsp_use_nonce ocsp_softfail)) 
 
 has_field 'ocsp_timeout' =>
   (
-   type => 'Duration',
+   type => 'Text',
   );
 
 has_field 'ocsp_url' => (

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_config/radius/eap.js
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_config/radius/eap.js
@@ -155,22 +155,18 @@ export const view = (form = {}, meta = {}) => {
         },
         {
           label: i18n.t('Expires'),
+          text: i18n.t('The timeout in seconds to keep correlation between EAP-Response packets with EAP-Request packets.'),
           cols: [
             {
-              namespace: 'timer_expire.interval',
+              namespace: 'timer_expire',
               component: pfFormInput,
               attrs: {
-                ...attributesFromMeta(meta, 'timer_expire.interval'),
+                ...attributesFromMeta(meta, 'timer_expire'),
+                ...{
+                  type: 'number',
+                  step: 1
+                },
                 disabled: !isEditable
-              }
-            },
-            {
-              namespace: 'timer_expire.unit',
-              component: pfFormChosen,
-              attrs: {
-                ...attributesFromMeta(meta, 'timer_expire.unit'),
-                disabled: !isEditable,
-                allowEmpty: false
               }
             }
           ]

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_config/radius/eap.js
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_config/radius/eap.js
@@ -307,10 +307,7 @@ export const validators = (form = {}, meta = {}) => {
     ignore_unknown_eap_types: validatorsFromMeta(meta, 'ignore_unknown_eap_types', i18n.t('Ignore Unknown')),
     max_sessions: validatorsFromMeta(meta, 'max_sessions', i18n.t('Max Sessions')),
     peap_tlsprofile: validatorsFromMeta(meta, 'peap_tlsprofile', i18n.t('PEAP Profile')),
-    timer_expire: {
-      unit: validatorsFromMeta(meta, 'timer_expire.unit', i18n.t('Unit')),
-      interval: validatorsFromMeta(meta, 'timer_expire.interval', i18n.t('Interval'))
-    },
+    timer_expire: validatorsFromMeta(meta, 'timer_expire', i18n.t('Expires')),
     tls_tlsprofile: validatorsFromMeta(meta, 'tls_tlsprofile', i18n.t('TLS Profile')),
     ttls_tlsprofile: validatorsFromMeta(meta, 'ttls_tlsprofile', i18n.t('TTLS Profile'))
   }

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_config/radius/ocsp.js
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_config/radius/ocsp.js
@@ -184,20 +184,15 @@ export const view = (form = {}, meta = {}) => {
           text: i18n.t('Number of seconds to wait for the OCSP response. 0 uses system default.'),
           cols: [
             {
-              namespace: 'ocsp_timeout.interval',
+              namespace: 'ocsp_timeout',
               component: pfFormInput,
               attrs: {
-                ...attributesFromMeta(meta, 'ocsp_timeout.interval'),
+                ...attributesFromMeta(meta, 'ocsp_timeout'),
+                ...{
+                  type: 'number',
+                  step: 1
+                },
                 disabled: !isEditable
-              }
-            },
-            {
-              namespace: 'ocsp_timeout.unit',
-              component: pfFormChosen,
-              attrs: {
-                ...attributesFromMeta(meta, 'ocsp_timeout.unit'),
-                disabled: !isEditable,
-                allowEmpty: false
               }
             }
           ]

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_config/radius/ocsp.js
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_config/radius/ocsp.js
@@ -235,10 +235,7 @@ export const validators = (form = {}, meta = {}) => {
     ocsp_enable: validatorsFromMeta(meta, 'ocsp_enable', i18n.t('Enable')),
     ocsp_override_cert_url: validatorsFromMeta(meta, 'ocsp_override_cert_url', i18n.t('URL')),
     ocsp_softfail: validatorsFromMeta(meta, 'ocsp_softfail', i18n.t('Response')),
-    ocsp_timeout: {
-      interval: validatorsFromMeta(meta, 'ocsp_timeout.interval', i18n.t('Interval')),
-      unit: validatorsFromMeta(meta, 'ocsp_timeout.unit', i18n.t('Unit'))
-    },
+    ocsp_timeout: validatorsFromMeta(meta, 'ocsp_timeout', i18n.t('Response timeout')),
     ocsp_url: validatorsFromMeta(meta, 'ocsp_url', i18n.t('URL')),
     ocsp_use_nonce: validatorsFromMeta(meta, 'ocsp_use_nonce', i18n.t('Nonce'))
   }


### PR DESCRIPTION
# Description
Make ocsp_timeout and timer_expire text fields (in place of duration)

# Impacts
EAP and OCSP profiles configuration in web admin

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* web admin: timer_expire and ocsp_timeout are not displayed correctly (#5961)
