### PR TITLE
Display high-availability setting correctly

### DIFF
--- a/html/pfappserver/root/static.alt/src/views/Configuration/_config/interface.js
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_config/interface.js
@@ -499,7 +499,7 @@ export const view = (form = {}, meta = {}) => {
               namespace: 'high_availability',
               component: pfFormRangeToggle,
               attrs: {
-                values: { checked: '1', unchecked: '0' }
+                values: { checked: 1, unchecked: 0 }
               }
             }
           ]

--- a/lib/pf/UnifiedApi/Controller/Config/Interfaces.pm
+++ b/lib/pf/UnifiedApi/Controller/Config/Interfaces.pm
@@ -126,7 +126,7 @@ sub normalize_interface {
         $interface->{$bool} = $interface->{$bool} ? $self->json_true : $self->json_false;
     }
 
-    ($interface->{type}, @{$interface->{additional_listening_daemons}}) = split(',', $interface->{type});
+    ($interface->{type}, @{$interface->{additional_listening_daemons}}) = grep { !/high-availability/ } split(',', $interface->{type});
     
     # Ensure all fields have a default value
     while(my ($field, $default) = each(%FIELDS)) {


### PR DESCRIPTION
# Description
fixes #5963 

# Impacts
Interfaces management

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* web admin: high-availability setting is not display correctly when editing an interface (#5963)