### PR TITLE
Fix eap peap tls on android

### DIFF
--- a/html/captive-portal/templates/wireless-profile-peap.xml
+++ b/html/captive-portal/templates/wireless-profile-peap.xml
@@ -78,11 +78,11 @@
                         <key>PayloadVersion</key>
                         <integer>1</integer>
                 </dict>
-                [% IF for_windows OR for_android  %]
+                [% IF ( for_windows OR for_android ) AND provisioner.raw_ca_cert_string() != "" %]
                 <dict>
                         <key>PayloadContent</key>
-			<string>[% provisioner.raw_ca_cert_string() %]</string>
-			<key>PayloadType</key>
+                        <string>[% provisioner.raw_ca_cert_string() %]</string>
+                        <key>PayloadType</key>
                         <string>com.apple.security.radius.ca</string>
                 </dict>
                 [% END %]

--- a/html/captive-portal/templates/wireless-profile-peap.xml
+++ b/html/captive-portal/templates/wireless-profile-peap.xml
@@ -78,6 +78,14 @@
                         <key>PayloadVersion</key>
                         <integer>1</integer>
                 </dict>
+                [% IF for_windows OR for_android  %]
+                <dict>
+                        <key>PayloadContent</key>
+			<string>[% provisioner.raw_server_radius_ca_string() %]</string>
+			<key>PayloadType</key>
+                        <string>com.apple.security.radius.ca</string>
+                </dict>
+                [% END %]
         </array>
         <key>PayloadDescription</key>
         <string>Profile description.</string>

--- a/html/captive-portal/templates/wireless-profile-peap.xml
+++ b/html/captive-portal/templates/wireless-profile-peap.xml
@@ -81,7 +81,7 @@
                 [% IF for_windows OR for_android  %]
                 <dict>
                         <key>PayloadContent</key>
-			<string>[% provisioner.raw_server_radius_ca_string() %]</string>
+			<string>[% provisioner.raw_ca_cert_string() %]</string>
 			<key>PayloadType</key>
                         <string>com.apple.security.radius.ca</string>
                 </dict>

--- a/html/captive-portal/templates/wireless-profile-tls.xml
+++ b/html/captive-portal/templates/wireless-profile-tls.xml
@@ -70,7 +70,6 @@
                         <key>PayloadVersion</key>
                         <integer>1</integer>
                 </dict>
-                [% IF !for_windows AND !for_android %]
                 <dict>
                         <key>PayloadCertificateFileName</key>
                         <string>[% server_cn %]</string>
@@ -99,7 +98,6 @@
                         <key>PayloadVersion</key>
                         <integer>1</integer>
                 </dict>
-                [% END %]
                 <dict>
                         <key>PayloadCertificateFileName</key>
                         <string>[% ca_cn %]</string>

--- a/html/pfappserver/lib/pfappserver/Form/Config/Provisioning/mobileconfig.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Provisioning/mobileconfig.pm
@@ -91,7 +91,7 @@ has_field 'server_certificate_path' =>
             help => 'The path to the RADIUS server certificate' },       
  );
 
-has_field 'server_radius_ca_path' =>
+has_field 'ca_cert_path' =>
  (
   type => 'Path',
   required_when => { 'eap_type' => 25 },
@@ -159,7 +159,7 @@ sub filter_deflate {
 
 has_block definition =>
   (
-   render_list => [ qw(id description type category ssid broadcast eap_type security_type dpsk passcode pki_provider server_certificate_path server_radius_ca_path apply_role role_to_apply autoregister) ],
+   render_list => [ qw(id description type category ssid broadcast eap_type security_type dpsk passcode pki_provider server_certificate_path ca_cert_path apply_role role_to_apply autoregister) ],
   );
 
 has_block signing =>

--- a/html/pfappserver/lib/pfappserver/Form/Config/Provisioning/mobileconfig.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Provisioning/mobileconfig.pm
@@ -91,6 +91,15 @@ has_field 'server_certificate_path' =>
             help => 'The path to the RADIUS server certificate' },       
  );
 
+has_field 'server_radius_ca_path' =>
+ (
+  type => 'Path',
+  required_when => { 'eap_type' => 25 },
+  label => 'RADIUS server CA path',
+  tags => { after_element => \&help,
+            help => 'The path to the RADIUS server CA' },
+ );
+
 has_field 'cert_chain' =>
   (
    type => 'TextArea',
@@ -150,7 +159,7 @@ sub filter_deflate {
 
 has_block definition =>
   (
-   render_list => [ qw(id description type category ssid broadcast eap_type security_type dpsk passcode pki_provider server_certificate_path apply_role role_to_apply autoregister) ],
+   render_list => [ qw(id description type category ssid broadcast eap_type security_type dpsk passcode pki_provider server_certificate_path server_radius_ca_path apply_role role_to_apply autoregister) ],
   );
 
 has_block signing =>

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_config/provisioning.js
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_config/provisioning.js
@@ -837,7 +837,7 @@ export const viewFields = {
   ca_cert_path: (form = {}, meta = {}) => {
     return {
       label: i18n.t('RADIUS server CA path'),
-      text: i18n.t('The path to the RADIUS server CA which have sign the radius certification.'),
+      text: i18n.t('The path to the RADIUS server CA which signed the radius certification.'),
       cols: [
         {
           namespace: 'ca_cert_path',

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_config/provisioning.js
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_config/provisioning.js
@@ -834,16 +834,16 @@ export const viewFields = {
       ]
     }
   },
-  server_radius_ca_path: (form = {}, meta = {}) => {
+  ca_cert_path: (form = {}, meta = {}) => {
     return {
       label: i18n.t('RADIUS server CA path'),
-      text: i18n.t('The path to the RADIUS server CA.'),
+      text: i18n.t('The path to the RADIUS server CA which have sign the radius certification.'),
       cols: [
         {
-          namespace: 'server_radius_ca_path',
+          namespace: 'ca_cert_path',
           component: pfFormInput,
-          attrs: attributesFromMeta(meta, 'server_radius_ca_path'),
-          validators: validatorsFromMeta(meta, 'server_radius_ca_path', i18n.t('Path'))
+          attrs: attributesFromMeta(meta, 'ca_cert_path'),
+          validators: validatorsFromMeta(meta, 'ca_cert_path', i18n.t('Path'))
         }
       ]
     }
@@ -1010,7 +1010,7 @@ export const view = (form = {}, meta = {}) => {
             ...((security_type === 'WPA2' && ~~eap_type === 25 /* PEAP */)
               ? [
                 viewFields.server_certificate_path(form, meta),
-                viewFields.server_radius_ca_path(form, meta)
+                viewFields.ca_cert_path(form, meta)
                 ]
               : [] // ignore
             ),
@@ -1134,7 +1134,7 @@ export const view = (form = {}, meta = {}) => {
             ...((security_type === 'WPA2' && ~~eap_type === 25 /* PEAP */)
               ? [
                 viewFields.server_certificate_path(form, meta),
-                viewFields.server_radius_ca_path(form, meta)
+                viewFields.ca_cert_path(form, meta)
                 ]
               : [] // ignore
             ),
@@ -1333,7 +1333,7 @@ export const view = (form = {}, meta = {}) => {
             ...((security_type === 'WPA2' && ~~eap_type === 25 /* PEAP */)
               ? [
                 viewFields.server_certificate_path(form, meta),
-                viewFields.server_radius_ca_path(form, meta)
+                viewFields.ca_cert_path(form, meta)
                 ]
               : [] // ignore
             ),
@@ -1561,8 +1561,8 @@ export const validatorFields = {
   server_certificate_path: (form = {}, meta = {}) => {
     return { server_certificate_path: validatorsFromMeta(meta, 'server_certificate_path', i18n.t('Path')) }
   },
-  server_radius_ca_path: (form = {}, meta = {}) => {
-    return { server_radius_ca_path: validatorsFromMeta(meta, 'server_radius_ca_path', i18n.t('Path')) }
+  ca_cert_path: (form = {}, meta = {}) => {
+    return { ca_cert_path: validatorsFromMeta(meta, 'ca_cert_path', i18n.t('Path')) }
   },
   ssid: (form = {}, meta = {}) => {
     return { ssid: validatorsFromMeta(meta, 'ssid', 'SSID') }
@@ -1633,7 +1633,7 @@ export const validators = (form = {}, meta = {}) => {
         ...((security_type === 'WPA2' && ~~eap_type === 25 /* PEAP */)
           ? {
             ...validatorFields.server_certificate_path(form, meta),
-            ...validatorFields.server_radius_ca_path(form, meta)
+            ...validatorFields.ca_cert_path(form, meta)
           }
           : {} // ignore
         ),
@@ -1730,7 +1730,7 @@ export const validators = (form = {}, meta = {}) => {
         ...((security_type === 'WPA2' && ~~eap_type === 25 /* PEAP */)
           ? {
             ...validatorFields.server_certificate_path(form, meta),
-            ...validatorFields.server_radius_ca_path(form, meta)
+            ...validatorFields.ca_cert_path(form, meta)
           }
           : {} // ignore
         ),
@@ -1882,7 +1882,7 @@ export const validators = (form = {}, meta = {}) => {
         ...((security_type === 'WPA2' && ~~eap_type === 25 /* PEAP */)
           ? {
             ...validatorFields.server_certificate_path(form, meta),
-            ...validatorFields.server_radius_ca_path(form, meta)
+            ...validatorFields.ca_cert_path(form, meta)
           }
           : {} // ignore
         ),

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_config/provisioning.js
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_config/provisioning.js
@@ -837,7 +837,7 @@ export const viewFields = {
   ca_cert_path: (form = {}, meta = {}) => {
     return {
       label: i18n.t('RADIUS server CA path'),
-      text: i18n.t('The path to the RADIUS server CA which signed the radius certification.'),
+      text: i18n.t('The path to the RADIUS server CA which signed the RADIUS server certificate.'),
       cols: [
         {
           namespace: 'ca_cert_path',

--- a/html/pfappserver/root/static.alt/src/views/Configuration/_config/provisioning.js
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/_config/provisioning.js
@@ -834,6 +834,20 @@ export const viewFields = {
       ]
     }
   },
+  server_radius_ca_path: (form = {}, meta = {}) => {
+    return {
+      label: i18n.t('RADIUS server CA path'),
+      text: i18n.t('The path to the RADIUS server CA.'),
+      cols: [
+        {
+          namespace: 'server_radius_ca_path',
+          component: pfFormInput,
+          attrs: attributesFromMeta(meta, 'server_radius_ca_path'),
+          validators: validatorsFromMeta(meta, 'server_radius_ca_path', i18n.t('Path'))
+        }
+      ]
+    }
+  },
   ssid: (form = {}, meta = {}) => {
     return {
       label: 'SSID',
@@ -994,7 +1008,10 @@ export const view = (form = {}, meta = {}) => {
               : [] // ignore
             ),
             ...((security_type === 'WPA2' && ~~eap_type === 25 /* PEAP */)
-              ? [viewFields.server_certificate_path(form, meta)]
+              ? [
+                viewFields.server_certificate_path(form, meta),
+                viewFields.server_radius_ca_path(form, meta)
+                ]
               : [] // ignore
             ),
             ...((security_type === 'WPA2' && ~~eap_type === 13 /* EAP-TLS */)
@@ -1115,7 +1132,10 @@ export const view = (form = {}, meta = {}) => {
               : [] // ignore
             ),
             ...((security_type === 'WPA2' && ~~eap_type === 25 /* PEAP */)
-              ? [viewFields.server_certificate_path(form, meta)]
+              ? [
+                viewFields.server_certificate_path(form, meta),
+                viewFields.server_radius_ca_path(form, meta)
+                ]
               : [] // ignore
             ),
             ...((security_type === 'WPA2' && ~~eap_type === 13 /* EAP-TLS */)
@@ -1311,7 +1331,10 @@ export const view = (form = {}, meta = {}) => {
               : [] // ignore
             ),
             ...((security_type === 'WPA2' && ~~eap_type === 25 /* PEAP */)
-              ? [viewFields.server_certificate_path(form, meta)]
+              ? [
+                viewFields.server_certificate_path(form, meta),
+                viewFields.server_radius_ca_path(form, meta)
+                ]
               : [] // ignore
             ),
             ...((security_type === 'WPA2' && ~~eap_type === 13 /* EAP-TLS */)
@@ -1538,6 +1561,9 @@ export const validatorFields = {
   server_certificate_path: (form = {}, meta = {}) => {
     return { server_certificate_path: validatorsFromMeta(meta, 'server_certificate_path', i18n.t('Path')) }
   },
+  server_radius_ca_path: (form = {}, meta = {}) => {
+    return { server_radius_ca_path: validatorsFromMeta(meta, 'server_radius_ca_path', i18n.t('Path')) }
+  },
   ssid: (form = {}, meta = {}) => {
     return { ssid: validatorsFromMeta(meta, 'ssid', 'SSID') }
   },
@@ -1605,7 +1631,10 @@ export const validators = (form = {}, meta = {}) => {
           : {} // ignore
         ),
         ...((security_type === 'WPA2' && ~~eap_type === 25 /* PEAP */)
-          ? validatorFields.server_certificate_path(form, meta)
+          ? {
+            ...validatorFields.server_certificate_path(form, meta),
+            ...validatorFields.server_radius_ca_path(form, meta)
+          }
           : {} // ignore
         ),
         ...((security_type === 'WPA2' && ~~eap_type === 13 /* EAP-TLS */)
@@ -1699,7 +1728,10 @@ export const validators = (form = {}, meta = {}) => {
           : {} // ignore
         ),
         ...((security_type === 'WPA2' && ~~eap_type === 25 /* PEAP */)
-          ? validatorFields.server_certificate_path(form, meta)
+          ? {
+            ...validatorFields.server_certificate_path(form, meta),
+            ...validatorFields.server_radius_ca_path(form, meta)
+          }
           : {} // ignore
         ),
         ...((security_type === 'WPA2' && ~~eap_type === 13 /* EAP-TLS */)
@@ -1848,7 +1880,10 @@ export const validators = (form = {}, meta = {}) => {
           : {} // ignore
         ),
         ...((security_type === 'WPA2' && ~~eap_type === 25 /* PEAP */)
-          ? validatorFields.server_certificate_path(form, meta)
+          ? {
+            ...validatorFields.server_certificate_path(form, meta),
+            ...validatorFields.server_radius_ca_path(form, meta)
+          }
           : {} // ignore
         ),
         ...((security_type === 'WPA2' && ~~eap_type === 13 /* EAP-TLS */)

--- a/lib/pf/provisioner/mobileconfig.pm
+++ b/lib/pf/provisioner/mobileconfig.pm
@@ -160,6 +160,10 @@ has server_certificate_path => (is => 'rw');
 
 has server_certificate => (is => 'ro' , builder => 1, lazy => 1);
 
+has server_radius_ca_path => (is => 'rw');
+
+has server_radius_ca => (is => 'ro' , builder => 1, lazy => 1);
+
 =head1 METHODS
 
 =head2 _build_server_cert
@@ -187,7 +191,6 @@ sub _certificate_cn {
         return $1;
     }
     else {
-        get_logger->error("Cannot find CN of server certificate at ".$self->server_certificate_path);
         return undef;
     }
 }
@@ -211,6 +214,40 @@ sub server_certificate_cn {
     }
     else {
         get_logger->error("cannot find cn of server certificate at ".$self->server_certificate_path);
+    }
+}
+
+=head2 _build_server_radius_ca
+
+Builds an X509 object the server_radius_ca_path
+
+=cut
+
+sub _build_server_radius_ca {
+    my ($self) = @_;
+    return Crypt::OpenSSL::X509->new_from_file($self->server_radius_ca_path);
+}
+
+
+=head2 raw_server_radius_ca_string
+
+Get the Radius server CA content minus the ascii armor
+
+=cut
+
+sub raw_server_radius_ca_string {
+    my ($self) = @_;
+    return $self->_raw_server_cert_string($self->server_radius_ca);
+}
+
+sub server_radius_ca_cn {
+    my ($self) = @_;
+    my $cn = $self->_certificate_cn($self->server_radius_ca);
+    if(defined($cn)){
+        return $cn;
+    }
+    else {
+        get_logger->error("cannot find cn of RADIUS server CA at ".$self->server_radius_ca_path);
     }
 }
 

--- a/lib/pf/provisioner/mobileconfig.pm
+++ b/lib/pf/provisioner/mobileconfig.pm
@@ -225,7 +225,12 @@ Builds an X509 object the ca_cert_path
 
 sub _build_ca_cert {
     my ($self) = @_;
-    return Crypt::OpenSSL::X509->new_from_file($self->ca_cert_path);
+    if($self->ca_cert_path){
+       return Crypt::OpenSSL::X509->new_from_file($self->ca_cert_path);
+    }
+    else {
+       return "";
+    }
 }
 
 
@@ -237,7 +242,13 @@ Get the Radius server CA content minus the ascii armor
 
 sub raw_ca_cert_string {
     my ($self) = @_;
-    return $self->_raw_server_cert_string($self->ca_cert);
+    if($self->ca_cert){
+        return $self->_raw_server_cert_string($self->ca_cert);
+    }
+    else {
+        get_logger->error("cannot find cn of RADIUS server CA at ".$self->ca_cert_path);
+        return "";
+    }
 }
 
 sub ca_cert_cn {
@@ -248,8 +259,10 @@ sub ca_cert_cn {
     }
     else {
         get_logger->error("cannot find cn of RADIUS server CA at ".$self->ca_cert_path);
+        return "";
     }
 }
+
 
 =head2 authorize
 

--- a/lib/pf/provisioner/mobileconfig.pm
+++ b/lib/pf/provisioner/mobileconfig.pm
@@ -226,10 +226,11 @@ Builds an X509 object the ca_cert_path
 sub _build_ca_cert {
     my ($self) = @_;
     if($self->ca_cert_path){
-       return Crypt::OpenSSL::X509->new_from_file($self->ca_cert_path);
+        return Crypt::OpenSSL::X509->new_from_file($self->ca_cert_path);
     }
     else {
-       return "";
+        get_logger->error("cannot build the RADIUS server CA with file: ".$self->ca_cert_path);
+        return "";
     }
 }
 
@@ -246,7 +247,7 @@ sub raw_ca_cert_string {
         return $self->_raw_server_cert_string($self->ca_cert);
     }
     else {
-        get_logger->error("cannot find cn of RADIUS server CA at ".$self->ca_cert_path);
+        get_logger->error("cannot find the RADIUS server CA file at ".$self->ca_cert_path);
         return "";
     }
 }

--- a/lib/pf/provisioner/mobileconfig.pm
+++ b/lib/pf/provisioner/mobileconfig.pm
@@ -160,9 +160,9 @@ has server_certificate_path => (is => 'rw');
 
 has server_certificate => (is => 'ro' , builder => 1, lazy => 1);
 
-has server_radius_ca_path => (is => 'rw');
+has ca_cert_path => (is => 'rw');
 
-has server_radius_ca => (is => 'ro' , builder => 1, lazy => 1);
+has ca_cert => (is => 'ro' , builder => 1, lazy => 1);
 
 =head1 METHODS
 
@@ -217,37 +217,37 @@ sub server_certificate_cn {
     }
 }
 
-=head2 _build_server_radius_ca
+=head2 _build_ca_cert
 
-Builds an X509 object the server_radius_ca_path
+Builds an X509 object the ca_cert_path
 
 =cut
 
-sub _build_server_radius_ca {
+sub _build_ca_cert {
     my ($self) = @_;
-    return Crypt::OpenSSL::X509->new_from_file($self->server_radius_ca_path);
+    return Crypt::OpenSSL::X509->new_from_file($self->ca_cert_path);
 }
 
 
-=head2 raw_server_radius_ca_string
+=head2 raw_ca_cert_string
 
 Get the Radius server CA content minus the ascii armor
 
 =cut
 
-sub raw_server_radius_ca_string {
+sub raw_ca_cert_string {
     my ($self) = @_;
-    return $self->_raw_server_cert_string($self->server_radius_ca);
+    return $self->_raw_server_cert_string($self->ca_cert);
 }
 
-sub server_radius_ca_cn {
+sub ca_cert_cn {
     my ($self) = @_;
-    my $cn = $self->_certificate_cn($self->server_radius_ca);
+    my $cn = $self->_certificate_cn($self->ca_cert);
     if(defined($cn)){
         return $cn;
     }
     else {
-        get_logger->error("cannot find cn of RADIUS server CA at ".$self->server_radius_ca_path);
+        get_logger->error("cannot find cn of RADIUS server CA at ".$self->ca_cert_path);
     }
 }
 


### PR DESCRIPTION
# Description
This will fix eap peap and eap tls for Android agent (and perhaps windows agent if set).
Eap PEAP, it adds a new field for Radius CA in android provisioner. It make the ca cert content available for the Android app.
EAP TLS, it removes the "if" statement to have a "full" xml available.

# Impacts
Now, Android Agent can now create a eap peap and tls profile.

# Issue
fixes #5966

# Delete branch after merge
YES please
