### PR TITLE
If proxied then use local secret

### DIFF
--- a/go/pfconfigdriver/structs.go
+++ b/go/pfconfigdriver/structs.go
@@ -380,6 +380,14 @@ type ClusterName struct {
 	Element                 string
 }
 
+type LocalSecret struct {
+	StructConfig
+	PfconfigMethod          string `val:"element"`
+	PfconfigNS              string `val:"resource::local_secret"`
+	PfconfigDecodeInElement string `val:"yes"`
+	Element                 string
+}
+
 type NetInterface struct {
 	StructConfig
 	PfconfigHostnameOverlay string `val:"yes"`


### PR DESCRIPTION
# Description
Use the local secret as the shared secret when radius accounting is proxied.

# Impacts
radius accounting in cluster mode.

# Issue
Related to #5969 

## Bug Fixes
* Switch defined by mac address are not processed by pfacct in cluster mode (#5969)


