### PR TITLE
Feature/ruckus dpsk

### DIFF
--- a/conf/profiles.conf.defaults
+++ b/conf/profiles.conf.defaults
@@ -30,6 +30,7 @@ provisioners=
 access_registration_when_registered=disabled
 self_service=
 dpsk=disabled
+unbound_dpsk=disabled
 status=enabled
 unreg_on_acct_stop=disabled
 network_logoff=disabled

--- a/html/pfappserver/lib/pfappserver/Form/Config/Profile.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Profile.pm
@@ -174,7 +174,7 @@ The main definition block
 
 has_block 'definition' =>
   (
-    render_list => [qw(id description status root_module preregistration autoregister reuse_dot1x_credentials dot1x_recompute_role_from_portal mac_auth_recompute_role_from_portal dot1x_unset_on_unmatch dpsk default_psk_key unreg_on_acct_stop)],
+    render_list => [qw(id description status root_module preregistration autoregister reuse_dot1x_credentials dot1x_recompute_role_from_portal mac_auth_recompute_role_from_portal dot1x_unset_on_unmatch dpsk unbound_dpsk default_psk_key unreg_on_acct_stop)],
   );
 
 my %ADDITIONAL_FIELD_OPTIONS = (

--- a/html/pfappserver/lib/pfappserver/Form/Config/ProfileCommon.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/ProfileCommon.pm
@@ -43,7 +43,7 @@ The main definition block
 
 has_block 'definition' =>
   (
-    render_list => [qw(id description root_module preregistration autoregister reuse_dot1x_credentials dot1x_recompute_role_from_portal mac_auth_recompute_role_from_portal dot1x_unset_on_unmatch dpsk default_psk_key unreg_on_acct_stop vlan_pool_technique)],
+    render_list => [qw(id description root_module preregistration autoregister reuse_dot1x_credentials dot1x_recompute_role_from_portal mac_auth_recompute_role_from_portal dot1x_unset_on_unmatch dpsk dpsk_sso default_psk_key unreg_on_acct_stop vlan_pool_technique)],
   );
 
 =head2 captive_portal
@@ -202,6 +202,20 @@ has_field 'autoregister' =>
    unchecked_value => 'disabled',
    tags => { after_element => \&help,
              help => 'This activates automatic registation of devices for the profile. Devices will not be shown a captive portal and RADIUS authentication credentials will be used to register the device. This option only makes sense in the context of an 802.1x authentication.' },
+  );
+
+=head2 unbound_dpsk
+
+Controls whether or not this connection profile to enabled Dynamic Unbound PSK
+
+=cut
+
+has_field 'unbound_dpsk' =>
+  (
+   type => 'Toggle',
+   checkbox_value => 'enabled',
+   unchecked_value => 'disabled',
+   default => 'disabled',
   );
 
 =head2 dpsk

--- a/html/pfappserver/lib/pfappserver/Form/Config/ProfileCommon.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/ProfileCommon.pm
@@ -27,7 +27,7 @@ use pf::ConfigStore::SelfService;
 use pf::ConfigStore::PortalModule;
 use pf::web::constants;
 use pf::constants::Connection::Profile;
-use pf::constants::role qw( $POOL_USERNAMEHASH $POOL_RANDOM $POOL_ROUND_ROBBIN );
+use pf::constants::role qw( $POOL_USERNAMEHASH $POOL_RANDOM $POOL_ROUND_ROBBIN $POOL_PER_USER_VLAN);
 use pfappserver::Form::Field::Duration;
 use pfappserver::Base::Form;
 use pf::config qw(%Profiles_Config);
@@ -655,7 +655,7 @@ Returns the list of the vlan pool technique
 
 sub options_vlan_pool {
 
-    return map{ { value => $_, label => $_ } } ( $POOL_ROUND_ROBBIN, $POOL_RANDOM, $POOL_USERNAMEHASH );
+    return map{ { value => $_, label => $_ } } ( $POOL_ROUND_ROBBIN, $POOL_RANDOM, $POOL_USERNAMEHASH, $POOL_PER_USER_VLAN );
 }
 
 

--- a/html/pfappserver/lib/pfappserver/Form/Config/ProfileCommon.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/ProfileCommon.pm
@@ -43,7 +43,7 @@ The main definition block
 
 has_block 'definition' =>
   (
-    render_list => [qw(id description root_module preregistration autoregister reuse_dot1x_credentials dot1x_recompute_role_from_portal mac_auth_recompute_role_from_portal dot1x_unset_on_unmatch dpsk dpsk_sso default_psk_key unreg_on_acct_stop vlan_pool_technique)],
+    render_list => [qw(id description root_module preregistration autoregister reuse_dot1x_credentials dot1x_recompute_role_from_portal mac_auth_recompute_role_from_portal dot1x_unset_on_unmatch dpsk unbound_dpsk default_psk_key unreg_on_acct_stop vlan_pool_technique)],
   );
 
 =head2 captive_portal

--- a/html/pfappserver/lib/pfappserver/Form/Config/Provisioning/dpsk.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Provisioning/dpsk.pm
@@ -27,9 +27,14 @@ has_field 'psk_size' =>
              help => 'This is the length of the PSK key you want to generate. The minimum length is eight characters.' },
   );
 
+has_field 'dpsk_use_local_password' =>
+  (
+   type => 'Checkbox',
+  );
+
 has_block definition =>
   (
-   render_list => [ qw(id description type category ssid oses psk_size apply_role role_to_apply autoregister) ],
+   render_list => [ qw(id description type category ssid oses psk_size apply_role role_to_apply autoregister dpsk_use_local_password) ],
   );
 
 

--- a/html/pfappserver/lib/pfappserver/Form/Config/Provisioning/dpsk.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Provisioning/dpsk.pm
@@ -27,10 +27,11 @@ has_field 'psk_size' =>
              help => 'This is the length of the PSK key you want to generate. The minimum length is eight characters.' },
   );
 
-has_field 'dpsk_use_local_password' =>
-  (
-   type => 'Checkbox',
-  );
+has_field 'dpsk_use_local_password' => (
+   type => 'Toggle',
+   checkbox_value => 'enabled',
+   unchecked_value => 'disabled',
+);
 
 has_block definition =>
   (

--- a/html/pfappserver/lib/pfappserver/Form/Config/Provisioning/mobileconfig.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Provisioning/mobileconfig.pm
@@ -74,10 +74,11 @@ has_field 'dpsk' =>
              help => 'Define if the PSK needs to be generated' },
   );
 
-has_field 'dpsk_use_local_password' =>
-  (
-   type => 'Checkbox',
-  );
+has_field 'dpsk_use_local_password' => (
+   type => 'Toggle',
+   checkbox_value => 'enabled',
+   unchecked_value => 'disabled',
+);
 
 has_field 'psk_size' =>
   (

--- a/html/pfappserver/lib/pfappserver/Form/Config/Provisioning/mobileconfig.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Provisioning/mobileconfig.pm
@@ -74,6 +74,11 @@ has_field 'dpsk' =>
              help => 'Define if the PSK needs to be generated' },
   );
 
+has_field 'dpsk_use_local_password' =>
+  (
+   type => 'Checkbox',
+  );
+
 has_field 'psk_size' =>
   (
    type => 'PSKLength',
@@ -160,7 +165,7 @@ sub filter_deflate {
 
 has_block definition =>
   (
-   render_list => [ qw(id description type category ssid broadcast eap_type security_type dpsk passcode pki_provider server_certificate_path ca_cert_path apply_role role_to_apply autoregister) ],
+   render_list => [ qw(id description type category ssid broadcast eap_type security_type dpsk dpsk_use_local_password passcode pki_provider server_certificate_path ca_cert_path apply_role role_to_apply autoregister) ],
   );
 
 has_block signing =>

--- a/html/pfappserver/root/static.alt/src/views/Configuration/connectionProfiles/_components/TheForm.vue
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/connectionProfiles/_components/TheForm.vue
@@ -67,6 +67,11 @@
           :text="$i18n.t('This is the default PSK key when you enable DPSK on this connection profile. The minimum length is eight characters.')"
         />
 
+        <form-group-unbound-dpsk namespace="unbound_dpsk"
+          :column-label="$i18n.t('Enable Unbound DPSK')"
+          :text="$i18n.t('This enable Dynamic Unbound PSK. If the network equipment supports sending attributes that allow to identify the PSK using the Access-Request attributes, then the user attached to the PSK can be found and used in the same manner as in 802.1x.')"
+        />
+
         <form-group-unreg-on-acct-stop namespace="unreg_on_acct_stop"
           :column-label="$i18n.t('Automatically deregister devices on accounting stop')"
           :text="$i18n.t('This activates automatic deregistation of devices for the profile if PacketFence receives a RADIUS accounting stop. This option only makes sense in the context of an 802.1x authentication.')"
@@ -201,6 +206,7 @@ import {
   FormGroupDot1xUnsetOnUnmatch,
   FormGroupDpsk,
   FormGroupDefaultPskKey,
+  FormGroupUnboundDpsk,
   FormGroupUnregOnAcctStop,
   FormGroupVlanPoolTechnique,
   FormGroupFilterMatchStyle,
@@ -241,6 +247,7 @@ const components = {
   FormGroupDot1xUnsetOnUnmatch,
   FormGroupDpsk,
   FormGroupDefaultPskKey,
+  FormGroupUnboundDpsk,
   FormGroupUnregOnAcctStop,
   FormGroupVlanPoolTechnique,
   FormGroupFilterMatchStyle,

--- a/html/pfappserver/root/static.alt/src/views/Configuration/connectionProfiles/_components/index.js
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/connectionProfiles/_components/index.js
@@ -37,6 +37,7 @@ export {
   BaseFormGroupToggleDisabledEnabled  as FormGroupDot1xUnsetOnUnmatch,
   BaseFormGroupToggleDisabledEnabled  as FormGroupDpsk,
   BaseFormGroupInput                  as FormGroupDefaultPskKey,
+  BaseFormGroupToggleDisabledEnabled  as FormGroupUnboundDpsk,
   BaseFormGroupToggleDisabledEnabled  as FormGroupUnregOnAcctStop,
   BaseFormGroupChosenOne              as FormGroupVlanPoolTechnique,
   BaseFormGroupChosenOne              as FormGroupFilterMatchStyle,

--- a/html/pfappserver/root/static.alt/src/views/Configuration/provisioners/_components/FormTypeAndroid.vue
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/provisioners/_components/FormTypeAndroid.vue
@@ -65,6 +65,12 @@
       :text="$i18n.t('Define if the PSK needs to be generated.')"
     />
 
+    <form-group-dpsk-use-local-password v-if="wantsDpsk"
+      namespace="dpsk_use_local_password"
+      :column-label="$i18n.t('Reuse the local password for DPSK')"
+      :text="$i18n.t('When DPSK is enabled and a local account with a plaintext password exists for the user, then it will reuse this password instead of generating a new PSK. This feature will only work with local users that have a plaintext password entry.')"
+    />
+
     <form-group-passcode v-if="wantsPasscode"
       namespace="passcode"
       :column-label="$i18n.t('Wifi Key')"
@@ -98,6 +104,7 @@ import {
   FormGroupCategory,
   FormGroupDescription,
   FormGroupDpsk,
+  FormGroupDpskUseLocalPassword,
   FormGroupEapType,
   FormGroupEnforce,
   FormGroupIdentifier,
@@ -119,6 +126,7 @@ const components = {
   FormGroupCategory,
   FormGroupDescription,
   FormGroupDpsk,
+  FormGroupDpskUseLocalPassword,
   FormGroupEapType,
   FormGroupEnforce,
   FormGroupIdentifier,

--- a/html/pfappserver/root/static.alt/src/views/Configuration/provisioners/_components/FormTypeDpsk.vue
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/provisioners/_components/FormTypeDpsk.vue
@@ -48,6 +48,12 @@
       :text="$i18n.t('Nodes with the selected OS will be affected.')"
     />
 
+    <form-group-dpsk-use-local-password
+      namespace="dpsk_use_local_password"
+      :column-label="$i18n.t('Reuse the local password for DPSK')"
+      :text="$i18n.t('When DPSK is enabled and a local account with a plaintext password exists for the user, then it will reuse this password instead of generating a new PSK. This feature will only work with local users that have a plaintext password entry.')"
+    />
+
     <form-group-psk-size namespace="psk_size"
       :column-label="$i18n.t('PSK length')"
       :text="$i18n.t('This is the length of the PSK key you want to generate. The minimum length is eight characters.')"
@@ -61,6 +67,7 @@ import {
   FormGroupAutoRegister,
   FormGroupCategory,
   FormGroupDescription,
+  FormGroupDpskUseLocalPassword,
   FormGroupEnforce,
   FormGroupIdentifier,
   FormGroupOses,
@@ -76,6 +83,7 @@ const components = {
   FormGroupAutoRegister,
   FormGroupCategory,
   FormGroupDescription,
+  FormGroupDpskUseLocalPassword,
   FormGroupEnforce,
   FormGroupIdentifier,
   FormGroupOses,

--- a/html/pfappserver/root/static.alt/src/views/Configuration/provisioners/_components/FormTypeMobileconfig.vue
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/provisioners/_components/FormTypeMobileconfig.vue
@@ -67,6 +67,12 @@
           :text="$i18n.t('Define if the PSK needs to be generated.')"
         />
 
+        <form-group-dpsk-use-local-password v-if="wantsDpsk"
+          namespace="dpsk_use_local_password"
+          :column-label="$i18n.t('Reuse the local password for DPSK')"
+          :text="$i18n.t('When DPSK is enabled and a local account with a plaintext password exists for the user, then it will reuse this password instead of generating a new PSK. This feature will only work with local users that have a plaintext password entry.')"
+        />
+
         <form-group-passcode v-if="wantsPasscode"
           namespace="passcode"
           :column-label="$i18n.t('Wifi Key')"
@@ -128,6 +134,7 @@ import {
   FormGroupCertificate,
   FormGroupDescription,
   FormGroupDpsk,
+  FormGroupDpskUseLocalPassword,
   FormGroupEapType,
   FormGroupEnforce,
   FormGroupIdentifier,
@@ -154,6 +161,7 @@ const components = {
   FormGroupCertificate,
   FormGroupDescription,
   FormGroupDpsk,
+  FormGroupDpskUseLocalPassword,
   FormGroupEapType,
   FormGroupEnforce,
   FormGroupIdentifier,

--- a/html/pfappserver/root/static.alt/src/views/Configuration/provisioners/_components/FormTypeWindows.vue
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/provisioners/_components/FormTypeWindows.vue
@@ -65,6 +65,12 @@
       :text="$i18n.t('Define if the PSK needs to be generated.')"
     />
 
+    <form-group-dpsk-use-local-password v-if="wantsDpsk"
+      namespace="dpsk_use_local_password"
+      :column-label="$i18n.t('Reuse the local password for DPSK')"
+      :text="$i18n.t('When DPSK is enabled and a local account with a plaintext password exists for the user, then it will reuse this password instead of generating a new PSK. This feature will only work with local users that have a plaintext password entry.')"
+    />
+
     <form-group-passcode v-if="wantsPasscode"
       namespace="passcode"
       :column-label="$i18n.t('Wifi Key')"
@@ -98,6 +104,7 @@ import {
   FormGroupCategory,
   FormGroupDescription,
   FormGroupDpsk,
+  FormGroupDpskUseLocalPassword,
   FormGroupEapType,
   FormGroupEnforce,
   FormGroupIdentifier,
@@ -119,6 +126,7 @@ const components = {
   FormGroupCategory,
   FormGroupDescription,
   FormGroupDpsk,
+  FormGroupDpskUseLocalPassword,
   FormGroupEapType,
   FormGroupEnforce,
   FormGroupIdentifier,

--- a/html/pfappserver/root/static.alt/src/views/Configuration/provisioners/_components/index.js
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/provisioners/_components/index.js
@@ -48,6 +48,7 @@ export {
   BaseFormGroupToggleDisabledEnabled        as FormGroupDeviceTypeDetection,
   BaseFormGroupInput                        as FormGroupDomains,
   BaseFormGroupToggleZeroOneStringAsOffOn   as FormGroupDpsk,
+  BaseFormGroupToggleDisabledEnabled        as FormGroupDpskUseLocalPassword,
   BaseFormGroupChosenOne                    as FormGroupEapType,
   BaseFormGroupToggleDisabledEnabled        as FormGroupEnforce,
   BaseFormGroupInput                        as FormGroupHost,

--- a/lib/pf/Connection/Profile.pm
+++ b/lib/pf/Connection/Profile.pm
@@ -652,12 +652,24 @@ sub canAccessRegistrationWhenRegistered {
 =item dpskEnabled
 
 Is DPSK is enable or not on this connection profile
+This is implicitely enabled if unbound DPSK is enabled
 
 =cut
 
 sub dpskEnabled {
     my ($self) = @_;
-    return isenabled($self->{'_dpsk'});
+    return isenabled($self->{'_dpsk'}) || isenabled($self->{'_unbound_dpsk'});
+};
+
+=item unboundDpskEnabled
+
+Is Unbound DPSK is enable or not on this connection profile
+
+=cut
+
+sub unboundDpskEnabled {
+    my ($self) = @_;
+    return isenabled($self->{'_unbound_dpsk'});
 };
 
 =item unregOnAcctStop

--- a/lib/pf/Switch.pm
+++ b/lib/pf/Switch.pm
@@ -3590,7 +3590,8 @@ Set the current tenant in the DAL based on the tenant ID configured in the switc
 =cut
 
 sub setCurrentTenant {
-    my ($self) = @_;
+    my ($self, $radius_request) = @_;
+    my $tenant_id = $radius_request->{"PacketFence-Tenant-Id"} // $self->{_TenantId};
     pf::dal->set_tenant($self->{_TenantId});
 }
 

--- a/lib/pf/Switch.pm
+++ b/lib/pf/Switch.pm
@@ -3592,7 +3592,7 @@ Set the current tenant in the DAL based on the tenant ID configured in the switc
 sub setCurrentTenant {
     my ($self, $radius_request) = @_;
     my $tenant_id = $radius_request->{"PacketFence-Tenant-Id"} // $self->{_TenantId};
-    pf::dal->set_tenant($self->{_TenantId});
+    pf::dal->set_tenant($tenant_id);
 }
 
 =head2 getCiscoAvPairAttribute

--- a/lib/pf/Switch.pm
+++ b/lib/pf/Switch.pm
@@ -3712,6 +3712,17 @@ sub fingerbank_dynamic_acl {
     return \@acls;
 }
 
+=head2 find_user_by_psk
+
+Attempts to find a local user by matching the PSK to the attributes in the RADIUS request
+
+=cut
+
+sub find_user_by_psk {
+    my ($self, $radius_request) = @_;
+    $self->logger->debug("Unbound DPSK not implemented for this switch module");
+}
+
 =back
 
 =head1 AUTHOR

--- a/lib/pf/Switch.pm
+++ b/lib/pf/Switch.pm
@@ -3721,6 +3721,7 @@ Attempts to find a local user by matching the PSK to the attributes in the RADIU
 sub find_user_by_psk {
     my ($self, $radius_request) = @_;
     $self->logger->debug("Unbound DPSK not implemented for this switch module");
+    return undef;
 }
 
 =back

--- a/lib/pf/Switch/Ruckus/SmartZone.pm
+++ b/lib/pf/Switch/Ruckus/SmartZone.pm
@@ -29,15 +29,15 @@ use pf::config qw (
     %connection_type_to_str
 );
 use pf::util::radius qw(perform_disconnect);
+use pf::log;
+use pf::util::wpa;
+use Crypt::PBKDF2;
 
 sub description { 'Ruckus SmartZone Wireless Controllers' }
 use pf::SwitchSupports qw(
     WirelessMacAuth
     -WebFormRegistration
 );
-
-use pf::util::wpa;
-use Crypt::PBKDF2;
 
 =over
 
@@ -287,21 +287,6 @@ sub generate_dpsk_attribute_value {
     return "0x00".$hash;
 }
 
-
-sub parseRequest {
-    my ( $self, $radius_request ) = @_;
-
-    my ($nas_port_type, $eap_type, $client_mac, $port, $user_name, $nas_port_id);
-    ($nas_port_type, $eap_type, $client_mac, $port, $user_name, $nas_port_id, undef, $nas_port_id) = $self->SUPER::parseRequest($radius_request);
-
-    use Data::Dumper; use pf::log ; get_logger->info(Dumper($radius_request));
-
-    if(exists($radius_request->{"Ruckus-DPSK-EAPOL-Key-Frame"})) {
-        $self->find_user_by_psk($radius_request);
-    }
-
-    return ($nas_port_type, $eap_type, $client_mac, $port, $user_name, $nas_port_id, undef, $nas_port_id);
-}
 
 sub find_user_by_psk {
     my ($self, $radius_request) = @_;

--- a/lib/pf/Switch/Ruckus/SmartZone.pm
+++ b/lib/pf/Switch/Ruckus/SmartZone.pm
@@ -302,7 +302,7 @@ sub find_user_by_psk {
     my ($self, $radius_request) = @_;
     my ($status, $iter) = pf::dal::person->search(
         -where => {
-            psk => { '!=', '', '!=', undef },
+            psk => {'!=' => [-and => '', undef]},
         },
     );
 

--- a/lib/pf/Switch/Ruckus/SmartZone.pm
+++ b/lib/pf/Switch/Ruckus/SmartZone.pm
@@ -325,6 +325,11 @@ sub find_user_by_psk {
 
 sub check_if_radius_request_psk_matches {
     my ($self, $radius_request, $psk) = @_;
+    if($radius_request->{"Ruckus-DPSK-Cipher"} != 4) {
+        get_logger->error("Ruckus-DPSK-Cipher isn't for WPA2 that uses AES and HMAC-SHA1. This isn't supported by this module.");
+        return $FALSE;
+    }
+
     return pf::util::wpa::match_mic(
       pf::util::wpa::calculate_ptk(
         pf::util::wpa::calculate_pmk($radius_request->{"Ruckus-Wlan-Name"}, $psk),

--- a/lib/pf/Switch/Ruckus/SmartZone.pm
+++ b/lib/pf/Switch/Ruckus/SmartZone.pm
@@ -33,6 +33,7 @@ use pf::ip4log;
 use JSON::MaybeXS qw(encode_json);
 use pf::config qw (
     $WEBAUTH_WIRELESS
+    $WIRELESS_MAC_AUTH
     %connection_type_to_str
 );
 use pf::util::radius qw(perform_disconnect);
@@ -106,7 +107,7 @@ Deauthenticate a client using HTTP or RADIUS depending on the connection type
 sub deauth {
     my ($self, $mac) = @_;
     my $node_info = node_view($mac);
-    if ($node_info->{last_connection_type} eq $connection_type_to_str{$WEBAUTH_WIRELESS}) {
+    if ($node_info->{last_connection_type} eq $connection_type_to_str{$WEBAUTH_WIRELESS} || $node_info->{last_connection_type} eq $connection_type_to_str{$WIRELESS_MAC_AUTH}) {
         $self->deauthenticateMacWebservices($mac);
     }
     else {

--- a/lib/pf/Switch/Ruckus/SmartZone.pm
+++ b/lib/pf/Switch/Ruckus/SmartZone.pm
@@ -8,6 +8,13 @@ pf::Switch::Ruckus::SmartZone
 
 Implements methods to manage Ruckus SmartZone Wireless Controllers
 
+=head1 BUGS AND LIMITATIONS
+
+=head2 Unbound DPSK
+
+- Is currently only supported for WPA2 which uses AES along with HMAC-SHA1
+- Doesn't support 802.11r (Fast Transition). Make sure you disable this on your SmartZone.
+
 =cut
 
 use strict;

--- a/lib/pf/Switch/Ruckus/SmartZone.pm
+++ b/lib/pf/Switch/Ruckus/SmartZone.pm
@@ -110,12 +110,12 @@ sub deauth {
     if (isenabled($self->{_ExternalPortalEnforcement})) {
         if($node_info->{last_connection_type} eq $connection_type_to_str{$WEBAUTH_WIRELESS} || $node_info->{last_connection_type} eq $connection_type_to_str{$WIRELESS_MAC_AUTH}) {
             $self->deauthenticateMacWebservices($mac);
+            return;
         }
     }
-    else {
-        $self->deauthenticateMacDefault($mac);
-    }
+    $self->deauthenticateMacDefault($mac);
 }
+
 
 =head2 radiusDisconnect
 

--- a/lib/pf/Switch/Ruckus/SmartZone.pm
+++ b/lib/pf/Switch/Ruckus/SmartZone.pm
@@ -107,8 +107,10 @@ Deauthenticate a client using HTTP or RADIUS depending on the connection type
 sub deauth {
     my ($self, $mac) = @_;
     my $node_info = node_view($mac);
-    if ($node_info->{last_connection_type} eq $connection_type_to_str{$WEBAUTH_WIRELESS} || $node_info->{last_connection_type} eq $connection_type_to_str{$WIRELESS_MAC_AUTH}) {
-        $self->deauthenticateMacWebservices($mac);
+    if (isenabled($self->{_ExternalPortalEnforcement})) {
+        if($node_info->{last_connection_type} eq $connection_type_to_str{$WEBAUTH_WIRELESS} || $node_info->{last_connection_type} eq $connection_type_to_str{$WIRELESS_MAC_AUTH}) {
+            $self->deauthenticateMacWebservices($mac);
+        }
     }
     else {
         $self->deauthenticateMacDefault($mac);

--- a/lib/pf/Switch/Ruckus/SmartZone.pm
+++ b/lib/pf/Switch/Ruckus/SmartZone.pm
@@ -310,18 +310,24 @@ sub find_user_by_psk {
             psk => { '!=', '', '!=', undef },
         },
     );
-    my $people = $iter->all();
 
     my $matched = 0;
-    for my $person (@$people) {
+    my $pid;
+    while(my $person = $iter->next) {
+        get_logger->debug("User ".$person->{pid}." has a PSK. Checking if it matches the one in the packet");
         if($self->check_if_radius_request_psk_matches($radius_request, $person->{psk})) {
             get_logger->info("PSK matches the one of ".$person->{pid});
             $matched ++;
+            $pid = $person->{pid};
         }
     }
 
     if($matched > 1) {
         get_logger->error("Multiple users use the same PSK. This cannot work with unbound DPSK. Ignoring it.");
+        return undef;
+    }
+    else {
+        return $pid;
     }
 }
 

--- a/lib/pf/constants/role.pm
+++ b/lib/pf/constants/role.pm
@@ -29,6 +29,7 @@ our @EXPORT_OK = qw(
     $GUEST_ROLE
     $GAMING_ROLE
     $REJECT_ROLE
+    $POOL_PER_USER_VLAN
     $POOL_USERNAMEHASH
     $POOL_RANDOM
     $POOL_ROUND_ROBBIN
@@ -76,6 +77,7 @@ Constant used in the pool code
 Readonly::Scalar our $POOL_USERNAMEHASH  => 'username_hash';
 Readonly::Scalar our $POOL_RANDOM  => 'random';
 Readonly::Scalar our $POOL_ROUND_ROBBIN => 'round_robbin';
+Readonly::Scalar our $POOL_PER_USER_VLAN => 'per_user_vlan';
 
 =head1 AUTHOR
 

--- a/lib/pf/provisioner/mobileconfig.pm
+++ b/lib/pf/provisioner/mobileconfig.pm
@@ -20,7 +20,9 @@ use pf::log;
 use pf::constants;
 use fingerbank::Constant;
 
+use pf::util;
 use pf::person;
+use pf::password;
 
 use Crypt::GeneratePassword qw(word);
 
@@ -77,6 +79,14 @@ Does DPSK need to be activated
 =cut
 
 has dpsk => (is => 'rw');
+
+=head2 dpsk_use_local_password
+
+Should the dpsk be the same as the password of a local user if it exists
+
+=cut
+
+has dpsk_use_local_password => (is => 'rw');
 
 =head2 psk_size
 
@@ -319,9 +329,20 @@ sub _build_profile_template {
 sub generate_dpsk {
     my ($self,$username) = @_;
     my $person = person_view($username);
+    my $password = pf::password::view($username);
+    use Data::Dumper ; use pf::log ; get_logger->info(Dumper($password, $self, pf::password::password_get_hash_type($password->{password})));
     if (defined $person->{psk} && $person->{psk} ne '') {
         get_logger->debug("Returning psk key $person->{psk} for user $username");
         return $person->{psk};
+    }
+    elsif (
+            isenabled($self->dpsk_use_local_password) 
+            && defined($password) && pf::password::password_get_hash_type($password->{password}) eq 'plaintext' 
+            && length($password->{password}) >= 8
+        ) {
+        get_logger->info("Using password of local user $username for PSK");
+        person_modify($username,psk => $password->{password});
+        return $password->{password};
     }
     else {
         my $psk_size;

--- a/lib/pf/provisioner/mobileconfig.pm
+++ b/lib/pf/provisioner/mobileconfig.pm
@@ -330,18 +330,18 @@ sub generate_dpsk {
     my ($self,$username) = @_;
     my $person = person_view($username);
     my $password = pf::password::view($username);
-    if (defined $person->{psk} && $person->{psk} ne '') {
-        get_logger->debug("Returning psk key $person->{psk} for user $username");
-        return $person->{psk};
-    }
-    elsif (
-            isenabled($self->dpsk_use_local_password) 
-            && defined($password) && pf::password::password_get_hash_type($password->{password}) eq 'plaintext' 
+    if (
+            isenabled($self->dpsk_use_local_password)
+            && defined($password) && pf::password::password_get_hash_type($password->{password}) eq 'plaintext'
             && length($password->{password}) >= 8
         ) {
         get_logger->info("Using password of local user $username for PSK");
         person_modify($username,psk => $password->{password});
         return $password->{password};
+    }
+    elsif (defined $person->{psk} && $person->{psk} ne '') {
+        get_logger->debug("Returning psk key $person->{psk} for user $username");
+        return $person->{psk};
     }
     else {
         my $psk_size;

--- a/lib/pf/provisioner/mobileconfig.pm
+++ b/lib/pf/provisioner/mobileconfig.pm
@@ -330,7 +330,6 @@ sub generate_dpsk {
     my ($self,$username) = @_;
     my $person = person_view($username);
     my $password = pf::password::view($username);
-    use Data::Dumper ; use pf::log ; get_logger->info(Dumper($password, $self, pf::password::password_get_hash_type($password->{password})));
     if (defined $person->{psk} && $person->{psk} ne '') {
         get_logger->debug("Returning psk key $person->{psk} for user $username");
         return $person->{psk};

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -1155,8 +1155,8 @@ sub handleUnboundDPSK {
     my ($self, $radius_request, $switch, $profile, $connection, $args) = @_;
     my $logger = get_logger;
     
-    my $accept = $FALSE;
     if($profile->unboundDpskEnabled()) {
+        my $accept = $FALSE;
         if(my $pid = $switch->find_user_by_psk($radius_request)) {
             $logger->info("Unbound DPSK user found $pid. Changing this request to use the 802.1x logic");
             $connection->isMacAuth($FALSE);
@@ -1169,9 +1169,11 @@ sub handleUnboundDPSK {
             $args->{username} = $args->{stripped_user_name} = $args->{user_name} = $pid;
             $accept = $TRUE;
         }
+        return ($accept, $connection, $args->{connection_type}, $args->{connection_sub_type}, $args);
     }
-
-    return ($accept, $connection, $args->{connection_type}, $args->{connection_sub_type}, $args);
+    else {
+        return $TRUE;
+    }
 }
 
 =back

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -1172,7 +1172,7 @@ sub handleUnboundDPSK {
         return ($accept, $connection, $args->{connection_type}, $args->{connection_sub_type}, $args);
     }
     else {
-        return $TRUE;
+        return ($TRUE, $connection, $args->{connection_type}, $args->{connection_sub_type}, $args);
     }
 }
 

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -130,7 +130,7 @@ sub authorize {
         goto AUDIT;
     }
 
-    $switch->setCurrentTenant();
+    $switch->setCurrentTenant($radius_request);
     my ($nas_port_type, $eap_type, $mac, $port, $user_name, $nas_port_id, $session_id, $ifDesc) = $switch->parseRequest($radius_request);
 
     if (!$mac) {
@@ -400,7 +400,7 @@ sub accounting {
         return [ $RADIUS::RLM_MODULE_FAIL, ( 'Reply-Message' => "Switch is not managed by PacketFence" ) ];
     }
 
-    $switch->setCurrentTenant();
+    $switch->setCurrentTenant($radius_request);
     my ($nas_port_type, $eap_type, $mac, $port, $user_name, $nas_port_id, $session_id, $ifDesc) = $switch->parseRequest($radius_request);
 
     # update last_seen of MAC address as some activity from it has been seen
@@ -542,7 +542,7 @@ sub update_locationlog_accounting {
         return [ $RADIUS::RLM_MODULE_FAIL, ( 'Reply-Message' => "Switch is not managed by PacketFence" ) ];
     }
 
-    $switch->setCurrentTenant();
+    $switch->setCurrentTenant($radius_request);
     if ($switch->supportsRoamingAccounting()) {
         my ($nas_port_type, $eap_type, $mac, $port, $user_name, $nas_port_id, $session_id, $ifDesc) = $switch->parseRequest($radius_request);
         my $locationlog_mac = locationlog_last_entry_mac($mac);
@@ -1087,7 +1087,7 @@ sub radius_filter {
         return [ $RADIUS::RLM_MODULE_FAIL, ('Reply-Message' => "Switch is not managed by PacketFence") ];
     }
 
-    $switch->setCurrentTenant();
+    $switch->setCurrentTenant($radius_request);
     my ($nas_port_type, $eap_type, $mac, $port, $user_name, $nas_port_id, $session_id, $ifDesc) = $switch->parseRequest($radius_request);
 
     if (!$mac) {

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -260,7 +260,12 @@ sub authorize {
     $args->{'profile'} = $profile;
     $args->{'portal'} = $profile->getName;
     
-    ($connection, $connection_type, $connection_sub_type, $args) = $self->handleUnboundDPSK($radius_request, $switch, $profile, $connection, $args);
+    (my $dpsk_accept, $connection, $connection_type, $connection_sub_type, $args) = $self->handleUnboundDPSK($radius_request, $switch, $profile, $connection, $args);
+    if(!$dpsk_accept) {
+        $logger->error("Unable to find a valid PSK for this request. Rejecting user.");
+        $RAD_REPLY_REF = [ $RADIUS::RLM_MODULE_USERLOCK, ('Reply-Message' => "Invalid PSK") ];
+        goto CLEANUP;
+    }
 
     $args->{'autoreg'} = 0;
     # should we auto-register? let's ask the VLAN object
@@ -1149,6 +1154,8 @@ sub check_lost_stolen {
 sub handleUnboundDPSK {
     my ($self, $radius_request, $switch, $profile, $connection, $args) = @_;
     my $logger = get_logger;
+    
+    my $accept = $FALSE;
     if($profile->unboundDpskEnabled()) {
         if(my $pid = $switch->find_user_by_psk($radius_request)) {
             $logger->info("Unbound DPSK user found $pid. Changing this request to use the 802.1x logic");
@@ -1160,10 +1167,11 @@ sub handleUnboundDPSK {
             $args->{connection_type} = $connection->attributesToBackwardCompatible;
             $args->{connection_sub_type} = $connection->subType;
             $args->{username} = $args->{stripped_user_name} = $args->{user_name} = $pid;
+            $accept = $TRUE;
         }
     }
 
-    return ($connection, $args->{connection_type}, $args->{connection_sub_type}, $args);
+    return ($accept, $connection, $args->{connection_type}, $args->{connection_sub_type}, $args);
 }
 
 =back

--- a/lib/pf/role/pool.pm
+++ b/lib/pf/role/pool.pm
@@ -188,7 +188,7 @@ sub getPerUserVlan {
     my ($self, $args, $range) = @_;
     my $logger = pf::log::get_logger();
 
-    my $pid = $args->{user_name};
+    my $pid = $args->{node_info}->{pid};
     my @vlans = $range->range;
     my $sql_vlans = join(",", map { pf::dal->get_dbh->quote($_) } @vlans);
 

--- a/lib/pf/role/pool.pm
+++ b/lib/pf/role/pool.pm
@@ -19,6 +19,7 @@ use pf::config qw(%Config);
 use pf::util;
 use pf::log();
 use pf::constants::role qw(:all);
+use pf::error qw(is_error is_success);
 
 use pf::node;
 use pf::dal;

--- a/lib/pf/role/pool.pm
+++ b/lib/pf/role/pool.pm
@@ -21,6 +21,7 @@ use pf::log();
 use pf::constants::role qw(:all);
 
 use pf::node;
+use pf::dal;
 
 use Number::Range;
 
@@ -59,6 +60,9 @@ sub getVlanFromPool {
     } elsif ($args->{'profile'}->{'_vlan_pool_technique'} eq $POOL_RANDOM) {
         $logger->trace("Use $POOL_RANDOM algorithm for VLAN pool");
         $vlan = $self->getRandomVlanInPool($args, $range);
+    } elsif ($args->{'profile'}->{'_vlan_pool_technique'} eq $POOL_PER_USER_VLAN) {
+        $logger->trace("Use $POOL_PER_USER_VLAN algorithm for VLAN pool");
+        $vlan = $self->getPerUserVlan($args, $range);
     } else {
         $logger->trace("Use round robin algorithm for VLAN pool");
         $vlan = $self->getRoundRobin($args, $range);
@@ -178,6 +182,60 @@ sub getVlanByUsername {
     $logger->trace("Return VLAN ID: ".$array[$new_vlan]);
     return ($array[$new_vlan]);
 
+}
+
+sub getPerUserVlan {
+    my ($self, $args, $range) = @_;
+    my $logger = pf::log::get_logger();
+
+    my $pid = $args->{user_name};
+    my @vlans = $range->range;
+    my $sql_vlans = join(",", map { pf::dal->get_dbh->quote($_) } @vlans);
+
+    my ($status, $res) = pf::dal->db_execute("
+    SELECT vlan 
+    FROM   locationlog 
+           JOIN node 
+             ON node.tenant_id = locationlog.tenant_id 
+                AND node.mac = locationlog.mac 
+    WHERE  vlan IN ( $sql_vlans ) 
+           AND node.status = 'reg' 
+           AND pid = ? 
+    ", $pid);
+
+    if(defined(my $row = $res->fetchrow_hashref)) {
+        my $vlan = $row->{vlan};
+        $logger->info("Found VLAN $vlan for $pid with registered devices in it.");
+        return $vlan;
+    }
+    else {
+        $logger->debug("Unable to find a VLAN in the pool that $pid has devices in. Finding an available VLAN for this user.");
+        ($status, $res) = pf::dal->db_execute("
+        SELECT vlan 
+        FROM   locationlog 
+               JOIN node 
+                 ON node.tenant_id = locationlog.tenant_id 
+                    AND node.mac = locationlog.mac 
+        WHERE  vlan IN ( $sql_vlans ) 
+               AND node.status != 'unreg' 
+        ");
+        my %used_vlans = map{$_->[0] => 1} @{$res->fetchall_arrayref};
+        my $available_vlan;
+        for my $vlan (@vlans) {
+            if(!exists($used_vlans{$vlan})) {
+                $available_vlan = $vlan;
+                last;
+            }
+        }
+        if($available_vlan) {
+            $logger->info("Found available VLAN $available_vlan in the pool for $pid");
+            return $available_vlan;
+        }
+        else {
+            $logger->error("No available VLAN in the pool");
+            return;
+        }
+    }
 }
 
 =head1 AUTHOR

--- a/lib/pf/util/combined_dictionary
+++ b/lib/pf/util/combined_dictionary
@@ -1,2 +1,2 @@
-$INCLUDE /usr/local/pf/raddb/dictionary.inverse
+$INCLUDE /usr/local/pf/raddb/dictionary
 $INCLUDE /usr/share/freeradius/dictionary

--- a/lib/pf/util/wpa.pm
+++ b/lib/pf/util/wpa.pm
@@ -1,0 +1,93 @@
+package pf::util::wpa;
+
+use strict;
+use warnings;
+
+use List::Util qw(minstr maxstr);
+use pf::log;
+use Digest::SHA qw(hmac_sha1);
+use bytes;
+
+my $PKE = "Pairwise key expansion";
+
+sub strip_hex_prefix {
+    my ($s) = @_;
+    $s =~ s/^0x//g;
+    return $s;
+}
+
+sub prf512 {
+    my ($key,$A,$B) = @_;
+    my $blen = 64;
+    my $i    = 0;
+    my $R    = '';
+    while($i<=(($blen*8+159)/160)) {
+        my $hmacsha1 = hmac_sha1($A.chr(0x00).$B.chr($i), $key);
+        $i+=1;
+        $R = $R.$hmacsha1;
+    }
+    return bytes_range($R, 0, $blen);
+}
+
+sub bytes_range {
+    my ($str, $start, $end) = @_;
+    if(!defined $end) {
+        $end = length($str);
+    }
+    my $size = $end - $start;
+    return substr($str, $start, $size);
+}
+
+sub calculate_pmk {
+    my ($ssid, $psk) = @_;
+    my $pbkdf2 = Crypt::PBKDF2->new(
+        iterations => 4096,
+        output_len => 32,
+    );
+     
+    my $pmk = bytes_range($pbkdf2->PBKDF2($ssid, $psk), 0, 32);
+
+    get_logger->debug("PTK is ".unpack("H*", $pmk));
+    return $pmk;
+}
+
+sub calculate_ptk {
+    my ($pmk, $mac_ap, $mac_cl, $anonce, $snonce) = @_;
+    use Data::Dumper ; get_logger->debug(Dumper(
+        unpack("H*", $pmk),
+        unpack("H*", $mac_ap),
+        unpack("H*", $mac_cl),
+        unpack("H*", $anonce),
+        unpack("H*", $snonce),
+        ));
+    my $key_data = minstr($mac_ap, $mac_cl) . maxstr($mac_ap, $mac_cl) . minstr($anonce,$snonce) . maxstr($anonce,$snonce);
+    my $ptk = prf512($pmk, $PKE, $key_data);
+    get_logger->debug("PTK is ".unpack("H*", $ptk));
+    return $ptk;
+}
+
+sub snonce_from_eapol_key_frame {
+    my ($eapol_key_frame) = @_;
+    return bytes_range($eapol_key_frame, 17, 49);
+}
+
+sub match_mic {
+    my ($ptk, $eapol_key_frame) = @_; 
+
+    # extract the MIC from the packet and zero it out to calculate the MIC based on the PTK
+    my $packet_mic = bytes_range($eapol_key_frame, 81, 97);
+    $eapol_key_frame = bytes_range($eapol_key_frame, 0, 81) . chr(0x0) x 16 . bytes_range($eapol_key_frame, 97);
+
+    my $kck = bytes_range($ptk, 0, 16);
+    get_logger->debug("KCK is ".unpack("H*", $kck));
+
+    my $mic = bytes_range(hmac_sha1($eapol_key_frame, $kck), 0, 16);
+
+    my $packet_mic_hex = unpack("H*", $packet_mic);
+    my $mic_hex = unpack("H*", $mic);
+    get_logger->debug("Computed MIC of packet is $mic_hex and MIC inside the packet is $packet_mic_hex");
+
+    return $packet_mic_hex eq $mic_hex;
+}
+
+1;

--- a/lib/pf/util/wpa.pm
+++ b/lib/pf/util/wpa.pm
@@ -53,13 +53,6 @@ sub calculate_pmk {
 
 sub calculate_ptk {
     my ($pmk, $mac_ap, $mac_cl, $anonce, $snonce) = @_;
-    use Data::Dumper ; get_logger->debug(Dumper(
-        unpack("H*", $pmk),
-        unpack("H*", $mac_ap),
-        unpack("H*", $mac_cl),
-        unpack("H*", $anonce),
-        unpack("H*", $snonce),
-        ));
     my $key_data = minstr($mac_ap, $mac_cl) . maxstr($mac_ap, $mac_cl) . minstr($anonce,$snonce) . maxstr($anonce,$snonce);
     my $ptk = prf512($pmk, $PKE, $key_data);
     get_logger->debug("PTK is ".unpack("H*", $ptk));

--- a/raddb/dictionary
+++ b/raddb/dictionary
@@ -45,6 +45,7 @@
 #	These attributes are examples
 #
 $INCLUDE    /usr/local/pf/raddb/dictionary.inverse
+$INCLUDE    /usr/local/pf/raddb/dictionary.ruckus
 #ATTRIBUTE	My-Local-String		3000	string
 #ATTRIBUTE	My-Local-IPAddr		3001	ipaddr
 #ATTRIBUTE	My-Local-Integer	3002	integer

--- a/raddb/dictionary.ruckus
+++ b/raddb/dictionary.ruckus
@@ -13,4 +13,10 @@ BEGIN-VENDOR	Ruckus
 # Value Format:    group_attr1,group_attr2,...
 ATTRIBUTE	Ruckus-DPSK			142	octets
 
+ATTRIBUTE Ruckus-DPSK-Params                 153 tlv
+ATTRIBUTE Ruckus-DPSK-AKM-Suite              153.1   octets              
+ATTRIBUTE Ruckus-DPSK-Cipher                 153.2   byte                
+ATTRIBUTE Ruckus-DPSK-Anonce                 153.3   octets            
+ATTRIBUTE Ruckus-DPSK-EAPOL-Key-Frame        153.4   octets   
+
 END-VENDOR Ruckus

--- a/raddb/dictionary.ruckus
+++ b/raddb/dictionary.ruckus
@@ -1,0 +1,16 @@
+# -*- text -*-
+# Copyright (C) 2019 The FreeRADIUS Server project and contributors
+# This work is licensed under CC-BY version 4.0 https://creativecommons.org/licenses/by/4.0
+#
+#	Ruckus Wireless, Inc. dictionary
+#
+#
+
+VENDOR		Ruckus				25053
+
+BEGIN-VENDOR	Ruckus
+
+# Value Format:    group_attr1,group_attr2,...
+ATTRIBUTE	Ruckus-DPSK			142	octets
+
+END-VENDOR Ruckus

--- a/rpm/packetfence.spec
+++ b/rpm/packetfence.spec
@@ -91,6 +91,7 @@ Requires: perl(Crypt::OpenSSL::X509)
 Requires: perl(Crypt::OpenSSL::RSA)
 Requires: perl(Crypt::OpenSSL::PKCS10)
 Requires: perl(Crypt::LE)
+Requires: perl(Crypt::PBKDF2), perl(Digest::SHA3)
 Requires: perl(Const::Fast)
 # Perl core modules but still explicitly defined just in case distro's core perl get stripped
 Requires: perl(Time::HiRes)

--- a/t/hardware-snmp-objects.t
+++ b/t/hardware-snmp-objects.t
@@ -60,6 +60,7 @@ my @whitelist = (
     'normalizeTrap', 'findTrapNormalizer', '_findTrapNormalizer', 'linkDownTrapNormalizer', 'linkUpTrapNormalizer', 'dot11DeauthenticateTrapNormalizer', 
     'findTrapVarWithBase', 'getIfIndexFromTrap', 'findTrapOID', 'getMacFromTrapVariablesForOIDBase', 'extractMacFromVariable', 
     'handleTrap', 'getExclusiveLock', 'getExclusiveLockForScope', 'cache_distributed', 'setCurrentTenant', 'cachedSNMPTable', 'parseRequestUsername', 'getCiscoAvPairAttribute', 'supportsVPN', 'vpnAttributes', 'parseVPNRequest', 'canDoCliAccess', 'fingerbank_dynamic_acl', '_parentRoleForVlan',
+    'find_user_by_psk',
 );
 
 my @missing_subs;

--- a/t/unittest/UnifiedApi/GenerateSpec.t
+++ b/t/unittest/UnifiedApi/GenerateSpec.t
@@ -241,6 +241,10 @@ cmp_deeply(
                     type => 'string',
                     description => 'Self service',
                 },
+                unbound_dpsk => {
+                    type => 'string',
+                    description => 'Unbound dpsk',
+                },
                 'dot1x_recompute_role_from_portal' => {
                     type => 'string',
                     description => 'When enabled, PacketFence will not use the role initialy computed on the portal but will use the dot1x username to recompute the role.',


### PR DESCRIPTION
# Missing
* Docs (especially for the new unbound DPSK mode)

# Description
Adds support for bound and unbound DPSK on Ruckus.
Adds ability to reuse local account password for a DPSK
Adds a per-user VLAN pool (round robin that assigns a VLAN that is exclusive for a single user)

# Impacts
Ruckus module, DPSK flow, VLAN pooling

# NEW Package(s) required
perl(Crypt::PBKDF2), perl(Digest::SHA3)

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
(REQUIRED, but may be optional...)
## New Features
* Added support for bound and unbound DPSK on Ruckus.
* Added ability to reuse local account password for a DPSK
* Added a per-user VLAN pool (round robin that assigns a VLAN that is exclusive for a single user)

