### PR TITLE
add profile name as args attribute

### DIFF
--- a/NEWS.asciidoc
+++ b/NEWS.asciidoc
@@ -58,6 +58,7 @@ For a list of compatibility related changes see the <<PacketFence_Upgrade_Guide.
 * web admin: sender is wrong when you use Preview feature (#6023)
 * sponsor guest registration: unexpected strings in email subject (#3669)
 * Use the proper attribute name for Mikrotik in returnRadiusAccessAccept (#6051)
+* Audit log: profile has an empty value when doing Ethernet/Wireless-NoEAP (#5977)
 
 == Version 10.2.0 released on 2020-10-07
 

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -257,7 +257,8 @@ sub authorize {
     $options->{'fingerbank_info'}     = $args->{'fingerbank_info'};
 
     my $profile = pf::Connection::ProfileFactory->instantiate($args->{'mac'},$options);
-    $args->{'profile'} = $profile; 
+    $args->{'profile'} = $profile;
+    $args->{'portal'} = $profile->getName;
     
     $args->{'autoreg'} = 0;
     # should we auto-register? let's ask the VLAN object
@@ -968,6 +969,7 @@ our %ARGS_TO_RADIUS_ATTRIBUTES = (
     connection_type => 'PacketFence-Connection-Type',
     user_role => 'PacketFence-Role',
     time => 'PacketFence-Request-Time',
+    portal => 'PacketFence-Profile',
 );
 
 our %NODE_ATTRIBUTES_TO_RADIUS_ATTRIBUTES = (

--- a/t/venom/pfservers/dot1x_eap_peap/55_check_radius_audit_log.yml
+++ b/t/venom/pfservers/dot1x_eap_peap/55_check_radius_audit_log.yml
@@ -97,4 +97,4 @@ testcases:
     assertions:
       - result.statuscode ShouldEqual 200
       - result.bodyjson.item.radius_reply ShouldContainSubstring 'Tunnel-Private-Group-Id = "{{.dot1x_eap_peap.roles.ad_user.vlan_id}}"'
-
+      - result.bodyjson.item.profile ShouldEqual "{{.dot1x_eap_peap.profiles.wired.id}}"

--- a/t/venom/pfservers/wired_mac_auth/25_check_radius_audit_log.yml
+++ b/t/venom/pfservers/wired_mac_auth/25_check_radius_audit_log.yml
@@ -97,4 +97,5 @@ testcases:
     assertions:
       - result.statuscode ShouldEqual 200
       - result.bodyjson.item.radius_reply ShouldContainSubstring 'Tunnel-Private-Group-Id = "{{.wired_mac_auth.roles.headless_device.vlan_id}}"'
+      - result.bodyjson.item.profile ShouldEqual "{{.wired_mac_auth.profiles.wired.id}}"
 


### PR DESCRIPTION
# Description
Profile is now a args and a node attribute. It means that when doing Ethernet-NoEAP or Wireless-NoEAP, connection profile matched is saved in radius_audit_log table.

# Impacts
RADIUS audit log

# Issue
fixes #5977

# Delete branch after merge
YES

# Checklist
- [x] Add unit tests

# NEWS file entries
## Bug Fixes
* Audit log: profile has an empty value when doing Ethernet/Wireless-NoEAP (#5977)
