### PR TITLE
Fix eap tls for windows (add back the test if not windows)

### DIFF
--- a/html/captive-portal/templates/wireless-profile-tls.xml
+++ b/html/captive-portal/templates/wireless-profile-tls.xml
@@ -70,6 +70,7 @@
                         <key>PayloadVersion</key>
                         <integer>1</integer>
                 </dict>
+                [% IF !for_windows %]
                 <dict>
                         <key>PayloadCertificateFileName</key>
                         <string>[% server_cn %]</string>
@@ -98,6 +99,7 @@
                         <key>PayloadVersion</key>
                         <integer>1</integer>
                 </dict>
+                [% END %]
                 <dict>
                         <key>PayloadCertificateFileName</key>
                         <string>[% ca_cn %]</string>


### PR DESCRIPTION
# Description
Fix windows eap tls
The previous version is broken the windows agent!

# Impacts
Need to be add in the same maintenance as the #5970

# Delete branch after merge
YES