### PR TITLE
feature/tenant-modify-only-by-global-tenant

### DIFF
--- a/lib/pf/UnifiedApi/Controller/Crud.pm
+++ b/lib/pf/UnifiedApi/Controller/Crud.pm
@@ -234,9 +234,18 @@ sub build_item_lookup {
 
 sub create {
     my ($self) = @_;
+    my ($status, $msg) = $self->can_create();
+    if (is_error($status)) {
+        return $self->render_error($status, $msg);
+    }
+
     return $self->render_create(
         $self->do_create($self->make_create_data())
     );
+}
+
+sub can_create {
+    return (200, '');
 }
 
 =head2 id
@@ -381,10 +390,15 @@ update
 
 sub update {
     my ($self) = @_;
+    my ($status, $msg) = $self->can_update();
+    if (is_error($status)) {
+        return $self->render_error($status, $msg);
+    }
+
     my $req = $self->req;
     my $res = $self->res;
     my $data = $self->update_data;
-    my ($status, $err) = $self->validate($data);
+    ($status, my $err) = $self->validate($data);
     if (is_error($status)) {
         return $self->render_error(
             $status,
@@ -410,6 +424,16 @@ sub update {
 
     $self->post_update($data);
     return $self->render(json => { message => "'$id' updated" });
+}
+
+=head2 can_update
+
+can update
+
+=cut
+
+sub can_update {
+    return (200, '');
 }
 
 =head2 post_update

--- a/lib/pf/UnifiedApi/Controller/Tenants.pm
+++ b/lib/pf/UnifiedApi/Controller/Tenants.pm
@@ -16,10 +16,43 @@ use strict;
 use warnings;
 use Mojo::Base 'pf::UnifiedApi::Controller::Crud';
 use pf::dal::tenant;
+use pf::config::tenant;
+use pf::constants qw($DEFAULT_TENANT_ID);
 
 has dal => 'pf::dal::tenant';
 has url_param_name => 'tenant_id';
 has primary_key => 'id';
+
+sub can_remove {
+    my ($self) = @_;
+    if ($self->is_readonly) {
+        return (403, 'Cannot remove this resource');
+    }
+
+    return $self->SUPER::can_remove;
+}
+
+sub can_update {
+    my ($self) = @_;
+    if ($self->is_readonly) {
+        return (403, 'Cannot update this resource');
+    }
+
+    return $self->SUPER::can_update;
+}
+
+sub can_create {
+    my ($self) = @_;
+    if ($self->is_readonly) {
+        return (403, 'Cannot create this resource');
+    }
+
+    return $self->SUPER::can_create;
+}
+
+sub is_readonly {
+    pf::config::tenant::get_tenant() > $DEFAULT_TENANT_ID
+}
 
 =head1 AUTHOR
 


### PR DESCRIPTION
Description
===========
Restrict create, update, and delete operations to the default and global tenant users.

NEWS file entries
=======================
Enhancements
-------------
* Restrict create, update, and delete operations to the default and global tenant users

Issue
=====
related to #6005

Delete branch after merge
=========================
NO

Checklist
=========
- [ ] Document the feature
- [x] Add unit tests
- [ ] Add acceptance tests (TestLink)