### PR TITLE
fix/6088

### DIFF
--- a/lib/pf/Switch.pm
+++ b/lib/pf/Switch.pm
@@ -1451,11 +1451,11 @@ Usually used to force the operating system to do a new DHCP Request after a VLAN
 =cut
 
 sub bouncePortSNMP {
-    my ($self, $ifIndex) = @_;
+    my ($self, $ifIndex, $mac) = @_;
 
-    $self->setAdminStatus( $ifIndex, $SNMP::DOWN );
+    $self->setAdminStatus( $ifIndex, $SNMP::DOWN, $mac );
     sleep($Config{'snmp_traps'}{'bounce_duration'});
-    $self->setAdminStatus( $ifIndex, $SNMP::UP );
+    $self->setAdminStatus( $ifIndex, $SNMP::UP, $mac );
 
     return $TRUE;
 }

--- a/lib/pf/Switch.pm
+++ b/lib/pf/Switch.pm
@@ -1453,9 +1453,9 @@ Usually used to force the operating system to do a new DHCP Request after a VLAN
 sub bouncePortSNMP {
     my ($self, $ifIndex, $mac) = @_;
 
-    $self->setAdminStatus( $ifIndex, $SNMP::DOWN, $mac );
+    $self->setAdminStatus( $ifIndex, $SNMP::DOWN );
     sleep($Config{'snmp_traps'}{'bounce_duration'});
-    $self->setAdminStatus( $ifIndex, $SNMP::UP, $mac );
+    $self->setAdminStatus( $ifIndex, $SNMP::UP );
 
     return $TRUE;
 }

--- a/lib/pf/Switch.pm
+++ b/lib/pf/Switch.pm
@@ -1439,8 +1439,8 @@ Usually used to force the operating system to do a new DHCP Request after a VLAN
 =cut
 
 sub bouncePort {
-    my ($self, $ifIndex) = @_;
-    return $self->bouncePortSNMP($ifIndex);
+    my ($self, $ifIndex, $mac) = @_;
+    return $self->bouncePortSNMP($ifIndex, $mac);
 }
 
 =item bouncePortSNMP
@@ -2713,7 +2713,7 @@ sub handleReAssignVlanTrapForWiredMacAuth {
     # actually once CoA will be implemented, we should consider offering the same option to users
     # as we currently do with port-security and VoIP which is bounce or not bounce and suffer consequences
     # this should be a choice exposed in configuration and not hidden in code
-    $self->bouncePort($ifIndex);
+    $self->bouncePort($ifIndex, $mac);
 }
 
 =item extractSsid

--- a/lib/pf/Switch/Cisco/Cisco_IOS.pm
+++ b/lib/pf/Switch/Cisco/Cisco_IOS.pm
@@ -1018,14 +1018,14 @@ sub dot1xPortReauthenticate {
     # If VoIP isn't enabled on this switch: bounce
     if (!$self->isVoIPEnabled()) {
         $logger->debug("VoIP is diabled on switch at $self->{_ip}. Will bounce ifIndex $ifIndex.");
-        return $self->bouncePort($ifIndex);
+        return $self->bouncePort($ifIndex, $mac);
     }
 
     # If there's no phone on the ifIndex, we also bounce
     my $hasPhone = $self->hasPhoneAtIfIndex($ifIndex);
     if ( !$hasPhone ) {
         $logger->debug("No VoIP is currently connected at $self->{_ip} ifIndex $ifIndex. Boucing ifIndex.");
-        return $self->bouncePort($ifIndex);
+        return $self->bouncePort($ifIndex, $mac);
     }
 
     # there's a phone, we need to fetch the MAC on the ifIndex in order to do a setVlan!

--- a/lib/pf/Switch/Juniper/Junos_v18_x.pm
+++ b/lib/pf/Switch/Juniper/Junos_v18_x.pm
@@ -199,7 +199,7 @@ Usually used to force the operating system to do a new DHCP Request after a VLAN
 =cut
 
 sub bouncePort {
-    my ($self, $ifIndex) = @_;
+    my ($self, $ifIndex, $mac) = @_;
 
     $self->setAdminStatus( $ifIndex );
 

--- a/lib/pf/Switch/Juniper/Junos_v18_x.pm
+++ b/lib/pf/Switch/Juniper/Junos_v18_x.pm
@@ -154,7 +154,7 @@ sub bouncePortRadius {
 
         if (!$mac) {
             $logger->info("Can't find MAC address in the locationlog... we won't perform port bounce");
-            return $TRUE;
+            return $FALSE;
         }
     }
 

--- a/lib/pf/Switch/Juniper/Junos_v18_x.pm
+++ b/lib/pf/Switch/Juniper/Junos_v18_x.pm
@@ -120,14 +120,14 @@ sub radiusDisconnect {
     return;
 }
 
-=head2 setAdminStatus - bounce switch port with radius CoA technique
+=head2 bouncePortRadius - bounce switch port with radius CoA technique
 
 Send a CoA request to bounce switch port
 
 =cut
 
-sub setAdminStatus {
-    my ( $self, $ifIndex, $status, $mac ) = @_;
+sub bouncePortRadius {
+    my ( $self, $ifIndex, $mac ) = @_;
     my $logger = $self->logger;
 
 
@@ -203,10 +203,7 @@ Usually used to force the operating system to do a new DHCP Request after a VLAN
 
 sub bouncePort {
     my ($self, $ifIndex, $mac) = @_;
-
-    $self->setAdminStatus( $ifIndex, undef, $mac );
-
-    return $TRUE;
+    return $self->bouncePortRadius( $ifIndex, $mac );
 }
 
 =head1 AUTHOR

--- a/lib/pf/Switch/MockedSwitch.pm
+++ b/lib/pf/Switch/MockedSwitch.pm
@@ -551,8 +551,8 @@ Just performing the wait, no setAdminStatus
 =cut
 
 sub bouncePort {
-    my ($self, $ifIndex) = @_;
-    return $self->bouncePortSNMP($ifIndex);
+    my ($self, $ifIndex, $mac) = @_;
+    return $self->bouncePortSNMP($ifIndex, $mac);
 }
 
 sub bouncePortSNMP {

--- a/lib/pf/Switch/Pica8.pm
+++ b/lib/pf/Switch/Pica8.pm
@@ -86,7 +86,7 @@ use pf::SwitchSupports qw(
 =cut
 
 sub setAdminStatus {
-    my ( $self, $ifIndex, $status, $mac ) = @_;
+    my ( $self, $ifIndex, $status) = @_;
     my $logger = $self->logger;
 
     if ( !$self->isProductionMode() ) {

--- a/lib/pf/Switch/Pica8.pm
+++ b/lib/pf/Switch/Pica8.pm
@@ -81,11 +81,11 @@ use pf::SwitchSupports qw(
     ~AccessListBasedEnforcement
 );
 
-=item setAdminStatus - bounce host port with radius CoA technique
+=item bouncePortRadius - bounce host port with radius CoA technique
 
 =cut
 
-sub setAdminStatus {
+sub bouncePortRadius {
     my ( $self, $ifIndex, $status) = @_;
     my $logger = $self->logger;
 
@@ -157,9 +157,7 @@ Usually used to force the operating system to do a new DHCP Request after a VLAN
 sub bouncePort {
     my ($self, $ifIndex, $mac) = @_;
 
-    $self->setAdminStatus( $ifIndex, undef, $mac );
-
-    return $TRUE;
+    return $self->bouncePortRadius( $ifIndex, $mac );
 }
 
 =head2 deauthenticateMacRadius

--- a/lib/pf/Switch/Pica8.pm
+++ b/lib/pf/Switch/Pica8.pm
@@ -86,7 +86,7 @@ use pf::SwitchSupports qw(
 =cut
 
 sub bouncePortRadius {
-    my ( $self, $ifIndex, $status) = @_;
+    my ( $self, $ifIndex, $mac) = @_;
     my $logger = $self->logger;
 
     if ( !$self->isProductionMode() ) {
@@ -96,11 +96,11 @@ sub bouncePortRadius {
 
     #We need to fetch the MAC on the ifIndex in order to bounce host port with CoA, only MAC works with CoA!
     my @locationlog = locationlog_view_open_switchport_no_VoIP( $self->{_ip}, $ifIndex );
-    my $mac = $locationlog[0]->{'mac'};
+    $mac = $locationlog[0]->{'mac'};
 
     #Port bounce with CoA is not supported for WIRED_MAC_AUTH connection type.
     if ($locationlog[0]->{'connection_type'} eq 'WIRED_MAC_AUTH') {
-    $logger->info("Port bounce for this connection type is not supported");
+        $logger->info("Port bounce for this connection type is not supported");
         return 1;
     }
 

--- a/lib/pf/Switch/Template.pm
+++ b/lib/pf/Switch/Template.pm
@@ -488,7 +488,7 @@ sub bouncePort {
         return $self->SUPER::bouncePort($ifindex, $mac);
     }
 
-    return $self->_bouncePortCoa($ifindex, $mac, $radiusBounce);
+    return $self->bouncePortRadius($ifindex, $mac, $radiusBounce);
 }
 
 sub handleReAssignVlanTrapForWiredMacAuth {
@@ -496,7 +496,7 @@ sub handleReAssignVlanTrapForWiredMacAuth {
     return $self->bouncePortSNMP($ifIndex, $mac);
 }
 
-sub _bouncePortCoa {
+sub bouncePortRadius {
     my ($self, $ifIndex, $mac, $radiusBounce) = @_;
     my $logger = $self->logger;
     my $id = $self->{_id};

--- a/lib/pf/Switch/ThreeCom/Switch_4200G.pm
+++ b/lib/pf/Switch/ThreeCom/Switch_4200G.pm
@@ -166,7 +166,7 @@ sub dot1xPortReauthenticate {
         "Bouncing the port instead of performing 802.1x port re-authentication because of a 4200G bug. "
         . "Your mileage may vary"
     );
-    return $self->bouncePort($ifIndex);
+    return $self->bouncePort($ifIndex, $mac);
 }
 
 =back

--- a/lib/pf/UnifiedApi/Controller/Nodes.pm
+++ b/lib/pf/UnifiedApi/Controller/Nodes.pm
@@ -651,7 +651,7 @@ sub do_restart_switchport {
         return ($STATUS::NOT_FOUND, "Unable to instantiate switch $ll->{switch}");
     }
 
-    unless ($switch->bouncePort($ll->{port})) {
+    unless ($switch->bouncePort($ll->{port}, $mac)) {
         return ($STATUS::INTERNAL_SERVER_ERROR, "Couldn't restart port.");
     }
 

--- a/lib/pf/api.pm
+++ b/lib/pf/api.pm
@@ -491,7 +491,7 @@ sub _reassignSNMPConnections {
     } # end case PORTSEC
 
     $logger->info( "Flipping admin status on switch (".$switch->{'_id'}.") ifIndex $ifIndex. " );
-    $switch->bouncePort($ifIndex);
+    $switch->bouncePort($ifIndex, $mac);
 }
 
 =head2 _node_determine_and_set_into_VLAN


### PR DESCRIPTION
Description
===========
Avoid looking up a mac lookup when bouncing a port when the mac is known.


Impacts
=======
Bouncing ports

NEWS file entries
=======================
Bug Fixes
-------------
* Bounce the correct node when bounce a port.

Issue
=====
fixes #6088

Delete branch after merge
=========================
NO

Checklist
=========
- [ ] Document the feature
- [x] Add unit tests
- [ ] Add acceptance tests (TestLink)