### PR TITLE
Add kernel module in wireless

### DIFF
--- a/addons/vagrant/wireless.yml
+++ b/addons/vagrant/wireless.yml
@@ -8,5 +8,6 @@
     - inverse_inc.wireless
 
   roles:
+    - role: mac80211hwsim
     - role: hostapd
     - role: wpasupplicant


### PR DESCRIPTION
# Description
This branch is used to add the kernel role from the ansible wireless repository
Linked to https://github.com/inverse-inc/ansible-wireless/pull/4

# Impacts
Update wireless vagrant config for testing

# Delete branch after merge
YES plase

# Checklist
(REQUIRED) - [yes, no or n/a]
- [x] https://github.com/inverse-inc/ansible-wireless/pull/4 must be merge
- [x] ansible-wireless v0.2.0 must be on galaxy (https://galaxy.ansible.com/inverse_inc/wireless)
