### PR TITLE
Define recipient address in security event

### DIFF
--- a/html/pfappserver/lib/pfappserver/Form/SecurityEvent.pm
+++ b/html/pfappserver/lib/pfappserver/Form/SecurityEvent.pm
@@ -98,6 +98,23 @@ has_field 'user_mail_message' =>
              help => 'A message that will be added to the e-mail sent to the user regarding this security event.' }, 
   );
 
+  has_field 'email_recipient_message' =>
+  (
+   type => 'TextArea',
+   label => 'Additionnal message for the user',
+   element_class => ['input-large'],
+   tags => { after_element => \&help,
+             help => 'A message that will be added to the e-mail sent to the user regarding this security event.' },
+  );
+
+has_field 'recipient_email' =>
+  (
+   type => 'Text',
+   label => 'Recipient email',
+   tags => { after_element => \&help,
+             help => 'Recipient email addresses that will receive the security event email.' }
+  );
+
 has_field 'triggers' => (
     type => 'Repeatable',
     inactive => 1,

--- a/html/pfappserver/lib/pfappserver/Form/SecurityEvent.pm
+++ b/html/pfappserver/lib/pfappserver/Form/SecurityEvent.pm
@@ -115,6 +115,15 @@ has_field 'recipient_email' =>
              help => 'Recipient email addresses that will receive the security event email.' }
   );
 
+has_field 'recipient_template_email' =>
+  (
+   type => 'Text',
+   label => 'Recipient template email',
+   tags => { after_element => \&help,
+             help => 'Template email to use to send the security event by email.' },
+   default => "security_event-triggered"
+  );
+
 has_field 'triggers' => (
     type => 'Repeatable',
     inactive => 1,

--- a/html/pfappserver/root/static.alt/src/views/Configuration/securityEvents/_components/BaseFormGroupActions.vue
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/securityEvents/_components/BaseFormGroupActions.vue
@@ -95,7 +95,7 @@
           <form-group-email-recipient-message namespace="email_recipient_message"
             :column-label="$t('Additional message')"
           />
-          <form-group-recipient-message namespace="recipient_email"
+          <form-group-recipient-email namespace="recipient_email"
             :column-label="$t('Email address')"
           />
           <form-group-recipient-message namespace="recipient_template_email"
@@ -153,6 +153,9 @@ import {
   BaseFormGroupChosenOne    as FormGroupTargetCategory,
   BaseFormGroupChosenOne    as FormGroupTemplate,
   BaseFormGroupTextarea     as FormGroupUserMailMessage,
+  BaseFormGroupTextarea     as FormGroupEmailRecipientMessage,
+  BaseFormGroupInput        as FormGroupRecipientEmail,
+  BaseFormGroupInput        as FormGroupRecipientTemplateEmail,
   BaseFormGroupChosenOne    as FormGroupVClose,
   BaseFormGroupChosenOne    as FormGroupVlan,
 } from '@/components/new'
@@ -176,6 +179,9 @@ const components = {
   FormGroupTemplate,
   FormGroupUserMailMessage,
   FormGroupVClose,
+  FormGroupEmailRecipientMessage,
+  FormGroupRecipientEmail,
+  FormGroupRecipientTemplateEmail,
   FormGroupVlan,
 
   InputToggleAutoreg:        BaseInputToggleAutoreg,

--- a/html/pfappserver/root/static.alt/src/views/Configuration/securityEvents/_components/BaseFormGroupActions.vue
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/securityEvents/_components/BaseFormGroupActions.vue
@@ -88,6 +88,22 @@
 
       <b-row no-gutters class="border-bottom">
         <b-col cols="3">
+          <input-toggle-email-recipient v-model="email_recipient"/>
+        </b-col>
+        <b-collapse :visible="email_recipient" class="col-sm-9 mt-3">
+
+          <form-group-email-recipient-message namespace="email_recipient_message"
+            :column-label="$t('Additional message')"
+          />
+          <form-group-recipient-message namespace="recipient_message"
+            :column-label="$t('Email address')"
+          />
+
+        </b-collapse>
+      </b-row>
+
+      <b-row no-gutters class="border-bottom">
+        <b-col cols="3">
           <input-toggle-external v-model="external"/>
         </b-col>
         <b-collapse :visible="external" class="col-sm-9 mt-3">
@@ -274,6 +290,20 @@ const setup = () => {
     }
   }))
 
+  const email_recipient = customRef((track, trigger) => ({
+    get() {
+      track()
+      return actionsValue.value.includes('email_recipient')
+    },
+    set(newValue) {
+      if (newValue)
+        add('email_recipient')
+      else
+        remove('email_recipient')
+      trigger()
+    }
+  }))
+
   const external = customRef((track, trigger) => ({
     get() {
       track()
@@ -318,6 +348,7 @@ const setup = () => {
     isolate,
     email_admin,
     email_user,
+    email_recipient,
     external,
     close
   }

--- a/html/pfappserver/root/static.alt/src/views/Configuration/securityEvents/_components/BaseFormGroupActions.vue
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/securityEvents/_components/BaseFormGroupActions.vue
@@ -157,6 +157,7 @@ import BaseInputToggleAutoreg from './BaseInputToggleAutoreg'
 import BaseInputToggleClose from './BaseInputToggleClose'
 import BaseInputToggleEmailAdmin from './BaseInputToggleEmailAdmin'
 import BaseInputToggleEmailUser from './BaseInputToggleEmailUser'
+import BaseInputToggleEmailRecipient './BaseInputToggleEmailRecipient'
 import BaseInputToggleExternal from './BaseInputToggleExternal'
 import BaseInputToggleIsolate from './BaseInputToggleIsolate'
 import BaseInputToggleUnreg from './BaseInputToggleUnreg'
@@ -174,13 +175,14 @@ const components = {
   FormGroupVClose,
   FormGroupVlan,
 
-  InputToggleAutoreg:     BaseInputToggleAutoreg,
-  InputToggleClose:       BaseInputToggleClose,
-  InputToggleEmailAdmin:  BaseInputToggleEmailAdmin,
-  InputToggleEmailUser:   BaseInputToggleEmailUser,
-  InputToggleExternal:    BaseInputToggleExternal,
-  InputToggleIsolate:     BaseInputToggleIsolate,
-  InputToggleUnreg:       BaseInputToggleUnreg,
+  InputToggleAutoreg:        BaseInputToggleAutoreg,
+  InputToggleClose:          BaseInputToggleClose,
+  InputToggleEmailAdmin:     BaseInputToggleEmailAdmin,
+  InputToggleEmailUser:      BaseInputToggleEmailUser,
+  InputToggleEmailRecipient: BaseInputToggleEmailRecipient,
+  InputToggleExternal:       BaseInputToggleExternal,
+  InputToggleIsolate:        BaseInputToggleIsolate,
+  InputToggleUnreg:          BaseInputToggleUnreg,
 }
 
 import { customRef, inject, ref, unref, watch } from '@vue/composition-api'

--- a/html/pfappserver/root/static.alt/src/views/Configuration/securityEvents/_components/BaseFormGroupActions.vue
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/securityEvents/_components/BaseFormGroupActions.vue
@@ -95,8 +95,11 @@
           <form-group-email-recipient-message namespace="email_recipient_message"
             :column-label="$t('Additional message')"
           />
-          <form-group-recipient-message namespace="recipient_message"
+          <form-group-recipient-message namespace="recipient_email"
             :column-label="$t('Email address')"
+          />
+          <form-group-recipient-message namespace="recipient_template_email"
+            :column-label="$t('Template to use for the email')"
           />
 
         </b-collapse>
@@ -157,7 +160,7 @@ import BaseInputToggleAutoreg from './BaseInputToggleAutoreg'
 import BaseInputToggleClose from './BaseInputToggleClose'
 import BaseInputToggleEmailAdmin from './BaseInputToggleEmailAdmin'
 import BaseInputToggleEmailUser from './BaseInputToggleEmailUser'
-import BaseInputToggleEmailRecipient './BaseInputToggleEmailRecipient'
+import BaseInputToggleEmailRecipient from './BaseInputToggleEmailRecipient'
 import BaseInputToggleExternal from './BaseInputToggleExternal'
 import BaseInputToggleIsolate from './BaseInputToggleIsolate'
 import BaseInputToggleUnreg from './BaseInputToggleUnreg'

--- a/html/pfappserver/root/static.alt/src/views/Configuration/securityEvents/_components/BaseInputToggleEmailRecipient.js
+++ b/html/pfappserver/root/static.alt/src/views/Configuration/securityEvents/_components/BaseInputToggleEmailRecipient.js
@@ -1,0 +1,25 @@
+import { BaseInputToggle, BaseInputToggleProps } from '@/components/new/'
+import i18n from '@/utils/locale'
+
+export const props = {
+  ...BaseInputToggleProps,
+
+  // overload :options default
+  options: {
+    type: Array,
+    default: () => ([
+      { value: false, label: i18n.t('Email Recipient') },
+      { value: true, label: i18n.t('Email Recipient'), color: 'var(--primary)' }
+    ])
+  },
+  labelRight: {
+    type: Boolean,
+    default: true
+  }
+}
+
+export default {
+  name: 'base-input-toggle-email-recipient',
+  extends: BaseInputToggle,
+  props
+}

--- a/lib/pf/action.pm
+++ b/lib/pf/action.pm
@@ -322,12 +322,13 @@ sub action_email_user {
 sub action_email_recipient {
     my ($mac, $security_event_id, $notes) = @_;
     my $class_info  = class_view($security_event_id);
+    my $node_info = node_attributes($mac);
 
     my %message;
     my $description = $class_info->{'description'};
 
-    my $additionnal_message = join('<br/>', split('\n', $pf::security_event_config::SecurityEvent_Config{$security_event_id}{user_mail_message}));
-    my $to = $class_info->{email_recipient};
+    my $additionnal_message = join('<br/>', split('\n', $pf::security_event_config::SecurityEvent_Config{$security_event_id}{email_recipient_message}));
+    my $to = $pf::security_event_config::SecurityEvent_Config{$security_event_id}{recipient_email};
     if ($to ne "") {
         pf::config::util::send_email(
             'security_event-triggered',

--- a/lib/pf/action.pm
+++ b/lib/pf/action.pm
@@ -331,7 +331,7 @@ sub action_email_recipient {
     my $to = $pf::security_event_config::SecurityEvent_Config{$security_event_id}{recipient_email};
     if ($to ne "") {
         pf::config::util::send_email(
-            'security_event-triggered',
+            $pf::security_event_config::SecurityEvent_Config{$security_event_id}{recipient_template_email},
             $to,
             "$description detection on $mac",
             {


### PR DESCRIPTION
# Description
Added configuration in order to be able to send email to a 3rd party email address.

# Impacts
Security event

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* Define recipient email address in security event config
