### PR TITLE
Log error on test + use the port defined in eduroam authentication

### DIFF
--- a/go/pfconfigdriver/structs.go
+++ b/go/pfconfigdriver/structs.go
@@ -480,6 +480,8 @@ type AuthenticationSourceEduroam struct {
 	RadiusSecret   string `json:"radius_secret"`
 	Server1Address string `json:"server1_address"`
 	Server2Address string `json:"server2_address"`
+	Server1Port    string `json:"server1_port"`
+	Server2Port    string `json:"server2_port"`
 	Monitor        string `json:"monitor"`
 	Type           string `json:"type"`
 }


### PR DESCRIPTION
source

# Description
Return the error messages on pfstats radius/eduroam test
Use the eduroam port defined in the configuration to test eduroam sources

# Impacts
pfstats


# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* return error message on pfstats eduroam/radius test
* Use the eduroam port defined in configuration to test the source

