### PR TITLE
fix/6136

### DIFF
--- a/go/cmd/pfacct/pfacct.go
+++ b/go/cmd/pfacct/pfacct.go
@@ -15,8 +15,8 @@ import (
 	"github.com/inverse-inc/packetfence/go/log"
 	"github.com/inverse-inc/packetfence/go/mac"
 	"github.com/inverse-inc/packetfence/go/pfconfigdriver"
-	"github.com/inverse-inc/packetfence/go/tryableonce"
 	"github.com/inverse-inc/packetfence/go/sharedutils"
+	"github.com/inverse-inc/packetfence/go/tryableonce"
 	statsd "gopkg.in/alexcesaro/statsd.v2"
 )
 
@@ -30,6 +30,7 @@ type radiusRequest struct {
 	switchInfo *SwitchInfo
 	status     rfc2866.AcctStatusType
 	mac        mac.Mac
+	done       chan struct{}
 }
 
 type PfAcct struct {

--- a/go/cmd/pfacct/radius.go
+++ b/go/cmd/pfacct/radius.go
@@ -96,6 +96,7 @@ func (h *PfAcct) HandleAccounting(w radius.ResponseWriter, r *radius.Request) {
 		status:     status,
 		switchInfo: switchInfo,
 		mac:        mac,
+		done:       make(chan struct{}),
 	}
 
 	h.sendRadiusRequestToQueue(rr)
@@ -106,6 +107,7 @@ func (h *PfAcct) HandleAccounting(w radius.ResponseWriter, r *radius.Request) {
 func (h *PfAcct) sendRadiusRequestToQueue(rr radiusRequest) {
 	queueIndex := djb2Hash(rr.mac[:]) % uint64(len(h.radiusRequests))
 	h.radiusRequests[queueIndex] <- rr
+	<-rr.done
 }
 
 func (h *PfAcct) handleAccountingRequest(rr radiusRequest) {
@@ -113,7 +115,10 @@ func (h *PfAcct) handleAccountingRequest(rr radiusRequest) {
 	defer h.NewTiming().Send("pfacct.accounting." + rr.status.String())
 	outPacket := r.Response(radius.CodeAccountingResponse)
 	rfc2865.ReplyMessage_SetString(outPacket, "Accounting OK")
-	defer w.Write(h.AddProxyState(outPacket, r))
+	defer func() {
+		w.Write(h.AddProxyState(outPacket, r))
+		rr.done <- struct{}{}
+	}()
 	ctx := r.Context()
 	in_bytes := int64(rfc2866.AcctInputOctets_Get(r.Packet))
 	out_bytes := int64(rfc2866.AcctOutputOctets_Get(r.Packet))


### PR DESCRIPTION
Description
===========
Don't return until the accounting request was handled.
To avoid massive amount of go routines from running at the same time.

Impacts
=======
pfacct - radius

NEWS file entries
=======================
Bug Fixes
-------------
* Don't return until the accounting request was handled.

Issue
=====
fixes #6136

Delete branch after merge
=========================
NO

Checklist
=========
- [ ] Document the feature
- [x] Add unit tests
- [ ] Add acceptance tests (TestLink)