### PR TITLE
Improve CLI login on SG300

### DIFF
--- a/lib/pf/Switch/Cisco/SG300.pm
+++ b/lib/pf/Switch/Cisco/SG300.pm
@@ -91,6 +91,26 @@ sub NasPortToIfIndex {
     return $NAS_port;
 }
 
+=head2 returnAuthorizeRead
+
+Return radius attributes to allow read access
+
+=cut
+
+sub returnAuthorizeRead {
+    my ($self, $args) = @_;
+    my $logger = $self->logger;
+    my $radius_reply_ref;
+    my $status;
+    $radius_reply_ref->{'Cisco-AVPair'} = 'shell:priv-lvl=1';
+    $radius_reply_ref->{'Reply-Message'} = "Switch read access granted by PacketFence";
+    $logger->info("User $args->{'user_name'} logged in $args->{'switch'}{'_id'} with read access");
+    my $filter = pf::access_filter::radius->new;
+    my $rule = $filter->test('returnAuthorizeRead', $args);
+    ($radius_reply_ref, $status) = $filter->handleAnswerInRule($rule,$args,$radius_reply_ref);
+    return [$status, %$radius_reply_ref];
+}
+
 =head1 AUTHOR
 
 Inverse inc. <info@inverse.ca>


### PR DESCRIPTION
# Description
- Read-only privilege for SG300 should be set to 1 (in place of 3 on default Cisco switches).
See: https://www.cisco.com/c/en/us/support/docs/smb/switches/cisco-small-business-300-series-managed-switches/smb3927-user-account-configuration-on-300-series-managed-switches.html

- Force NAS-Port-Type to "virtual" when not defined in order to match on a CLI connection profile.
NAS-Port-Type is not set by SG300 when sending a RADIUS request for a CLI login with firmware 1.4.9.4. Otherwise, NAS-Port-Type is set to Ethernet.

# Impacts
SG300 switch module

# Delete branch after merge
YES

# NEWS file entries
## Enhancements
* Enhance CLI login on SG300 switches