### PR TITLE
Use user-name from the radius accounting when exists for the firewall sso

### DIFF
--- a/lib/pf/api.pm
+++ b/lib/pf/api.pm
@@ -1528,6 +1528,7 @@ sub firewallsso_accounting : Public {
         my $firewallsso_method = "Stop";
         my $timeout = '3600'; #Default to 1 hour
         my $client = pf::client::getClient();
+        my $username = $RAD_REQUEST{'User-Name'} // undef;
 
         if ($node->{status} eq $pf::node::STATUS_REGISTERED) {
             $firewallsso_method = "Update";
@@ -1546,7 +1547,7 @@ sub firewallsso_accounting : Public {
         $firewallsso_method = ($RAD_REQUEST{'Acct-Status-Type'} == $ACCOUNTING::STOP) ? "Stop" : "Update";
 
         $logger->warn("Firewall SSO Notify");
-        $client->notify( 'firewallsso', (method => $firewallsso_method, mac => $mac, ip => $ip, timeout => $timeout) );
+        $client->notify( 'firewallsso', (method => $firewallsso_method, mac => $mac, ip => $ip, timeout => $timeout, username => $username) );
     }
 }
 

--- a/lib/pf/firewallsso.pm
+++ b/lib/pf/firewallsso.pm
@@ -52,8 +52,12 @@ sub do_sso {
     my $node = pf::node::node_attributes($mac);
 
     $logger->info("Sending a firewall SSO '$postdata{method}' request for MAC '$mac' and IP '$postdata{ip}'");
-
-    my $username = $node->{pid};
+    my $username;
+    if (exists($postdata{username}) && !pf::util::valid_mac($postdata{username})) {
+        $username = $postdata{username};
+    } else {
+        $username = $node->{pid};
+    }
     my ($stripped_username, $realm) = pf::util::strip_username($username);
 
     pf::api::unifiedapiclient->management_client->call("POST", "/api/v1/firewall_sso/".lc($postdata{method}), {


### PR DESCRIPTION
# Description
Use the user-name from the radius accounting request to update the firewall.
Fix the case when an accounting stop is sent just after an authentication request (user-name can be different)

# Impacts
Firewall SSO

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Bug Fixes
* Firewall SSO - Fix the case when an accounting stop is sent just after an authentication request (user-name can be different)
