### PR TITLE
Added option to disable nat for dns in inline mode

### DIFF
--- a/go/cmd/pfdhcp/utils.go
+++ b/go/cmd/pfdhcp/utils.go
@@ -193,7 +193,7 @@ func NodeInformation(ctx context.Context, target net.HardwareAddr) (r NodeInfo) 
 
 // ShuffleDNS return the dns list
 func ShuffleDNS(ConfNet pfconfigdriver.RessourseNetworkConf) (r []byte) {
-	if ConfNet.NatDNS == "disabled" {
+	if !sharedutils.IsEnabled(ConfNet.NatDNS) {
 		var excluded []string
 		return Shuffle(ConfNet.Dns, excluded)
 	}

--- a/go/cmd/pfdhcp/utils.go
+++ b/go/cmd/pfdhcp/utils.go
@@ -193,6 +193,10 @@ func NodeInformation(ctx context.Context, target net.HardwareAddr) (r NodeInfo) 
 
 // ShuffleDNS return the dns list
 func ShuffleDNS(ConfNet pfconfigdriver.RessourseNetworkConf) (r []byte) {
+	if ConfNet.NatDNS == "0" {
+		var excluded []string
+		return Shuffle(ConfNet.Dns, excluded)
+	}
 	if ConfNet.ClusterIPs != "" {
 		if ConfNet.Dnsvip != "" {
 			return []byte(net.ParseIP(ConfNet.Dnsvip).To4())

--- a/go/cmd/pfdhcp/utils.go
+++ b/go/cmd/pfdhcp/utils.go
@@ -193,7 +193,7 @@ func NodeInformation(ctx context.Context, target net.HardwareAddr) (r NodeInfo) 
 
 // ShuffleDNS return the dns list
 func ShuffleDNS(ConfNet pfconfigdriver.RessourseNetworkConf) (r []byte) {
-	if ConfNet.NatDNS == "0" {
+	if ConfNet.NatDNS == "disabled" {
 		var excluded []string
 		return Shuffle(ConfNet.Dns, excluded)
 	}

--- a/go/pfconfigdriver/structs.go
+++ b/go/pfconfigdriver/structs.go
@@ -403,6 +403,7 @@ type RessourseNetworkConf struct {
 	PoolBackend              string    `json:"pool_backend"`
 	Algorithm                string    `json:"algorithm"`
 	NetflowAccountingEnabled string    `json:"netflow_accounting_enabled"`
+	NatDNS                   string    `json:"nat_dns"`
 }
 
 type PfRoles struct {

--- a/html/pfappserver/lib/pfappserver/Form/Config/Network/Routed.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Network/Routed.pm
@@ -79,6 +79,14 @@ has_field 'nat_enabled' => (
     label => 'Enable NATting',
 );
 
+has_field 'nat_dns' => (
+    type => 'Toggle',
+    checkbox_value => 1,
+    unchecked_value => 0,
+    default => 1,
+    label => 'Enable DNS NATting',
+);
+
 has_field 'coa' => (
     type => 'Toggle',
     checkbox_value => "enabled",

--- a/html/pfappserver/lib/pfappserver/Form/Interface.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Interface.pm
@@ -92,6 +92,14 @@ has_field 'nat_enabled' => (
     label => 'Enable NATting',
 );
 
+has_field 'nat_dns' => (
+    type => 'Toggle',
+    checkbox_value => 1,
+    unchecked_value => 0,
+    default => 1,
+    label => 'Enable DNS NATting',
+);
+
 has_field 'split_network' => (
     type => 'Toggle',
     checkbox_value => 1,

--- a/html/pfappserver/lib/pfappserver/Model/Interface.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Interface.pm
@@ -270,7 +270,7 @@ sub get {
                 $result->{"$interface"}->{'dns'} = $network->{dns};
                 $result->{"$interface"}->{'dhcpd_enabled'} = $network->{dhcpd};
                 $result->{"$interface"}->{'nat_enabled'} = $network->{nat_enabled};
-		$result->{"$interface"}->{'nat_dns'} = $network->{nat_dns};
+                $result->{"$interface"}->{'nat_dns'} = $network->{nat_dns};
                 $result->{"$interface"}->{'split_network'} = $network->{split_network};
                 $result->{"$interface"}->{'coa'} = $network->{coa};
                 $result->{"$interface"}->{'netflow_accounting_enabled'} = $network->{netflow_accounting_enabled};

--- a/html/pfappserver/lib/pfappserver/Model/Interface.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Interface.pm
@@ -270,6 +270,7 @@ sub get {
                 $result->{"$interface"}->{'dns'} = $network->{dns};
                 $result->{"$interface"}->{'dhcpd_enabled'} = $network->{dhcpd};
                 $result->{"$interface"}->{'nat_enabled'} = $network->{nat_enabled};
+		$result->{"$interface"}->{'nat_dns'} = $network->{nat_dns};
                 $result->{"$interface"}->{'split_network'} = $network->{split_network};
                 $result->{"$interface"}->{'coa'} = $network->{coa};
                 $result->{"$interface"}->{'netflow_accounting_enabled'} = $network->{netflow_accounting_enabled};
@@ -546,6 +547,7 @@ sub setType {
             }
             $network_ref->{dhcpd} = isenabled($interface_ref->{'dhcpd_enabled'}) ? 'enabled' : 'disabled';
             $network_ref->{nat_enabled} = isenabled($interface_ref->{'nat_enabled'}) ? 'enabled' : 'disabled';
+            $network_ref->{nat_dns} = isenabled($interface_ref->{'nat_dns'}) ? 'enabled' : 'disabled';
             $network_ref->{split_network} = isenabled($interface_ref->{'split_network'}) ? 'enabled' : 'disabled';
             $network_ref->{coa} = isenabled($interface_ref->{'coa'}) ? 'enabled' : 'disabled';
             $network_ref->{netflow_accounting_enabled} = isenabled($interface_ref->{'netflow_accounting_enabled'}) ? 'enabled' : 'disabled';

--- a/html/pfappserver/root/src/views/Configuration/_config/interface.js
+++ b/html/pfappserver/root/src/views/Configuration/_config/interface.js
@@ -225,3 +225,4 @@ export const columns = [
     locked: true
   }
 ]
+

--- a/html/pfappserver/root/src/views/Configuration/networks/interfaces/_components/TheForm.vue
+++ b/html/pfappserver/root/src/views/Configuration/networks/interfaces/_components/TheForm.vue
@@ -71,6 +71,9 @@
           {{ $i18n.t(`Since NAT is disabled, PacketFence will adjust iptables to route traffic rather than using NAT. Make sure to add the routes on the system.`) }}
         </div>
       </b-form-group>
+      <form-group-nat-dns namespace="nat_dns"
+        :column-label="$i18n.t('Enable DNS NAT')"
+      />
     </template>
 
     <form-group-split-network v-show="isType('inlinel2')"
@@ -124,6 +127,7 @@ import {
   FormGroupIpv6Address,
   FormGroupIpv6Prefix,
   FormGroupNatEnabled,
+  FormGroupNatDns,
   FormGroupNetflowAccountingEnabled,
   FormGroupNetmask,
   FormGroupRegNetwork,
@@ -145,6 +149,7 @@ const components = {
   FormGroupIpv6Address,
   FormGroupIpv6Prefix,
   FormGroupNatEnabled,
+  FormGroupNatDns,
   FormGroupNetflowAccountingEnabled,
   FormGroupNetmask,
   FormGroupRegNetwork,

--- a/html/pfappserver/root/src/views/Configuration/networks/interfaces/_components/TheForm.vue
+++ b/html/pfappserver/root/src/views/Configuration/networks/interfaces/_components/TheForm.vue
@@ -72,7 +72,7 @@
         </div>
       </b-form-group>
       <form-group-nat-dns namespace="nat_dns"
-        :column-label="$i18n.t('Enable DNS NAT')"
+        :column-label="$i18n.t('Use pfdns to proxy the request to the DNS server defined above when the device is registered.')"
       />
     </template>
 

--- a/html/pfappserver/root/src/views/Configuration/networks/interfaces/_components/TheForm.vue
+++ b/html/pfappserver/root/src/views/Configuration/networks/interfaces/_components/TheForm.vue
@@ -72,7 +72,8 @@
         </div>
       </b-form-group>
       <form-group-nat-dns namespace="nat_dns"
-        :column-label="$i18n.t('Use pfdns to proxy the request to the DNS server defined above when the device is registered.')"
+        :column-label="$i18n.t('Proxy DNS')"
+        :text="$i18n.t('Use pfdns to proxy the request to the DNS server defined above when the device is registered.')"
       />
     </template>
 

--- a/html/pfappserver/root/src/views/Configuration/networks/interfaces/_components/index.js
+++ b/html/pfappserver/root/src/views/Configuration/networks/interfaces/_components/index.js
@@ -25,6 +25,7 @@ export {
   BaseFormGroupInput                  as FormGroupIpv6Address,
   BaseFormGroupInputNumber            as FormGroupIpv6Prefix,
   BaseFormGroupToggleDisabledEnabled  as FormGroupNatEnabled,
+  BaseFormGroupToggleDisabledEnabled  as FormGroupNatDns,
   BaseFormGroupToggleDisabledEnabled  as FormGroupNetflowAccountingEnabled,
   BaseFormGroupInput                  as FormGroupNetmask,
   BaseFormGroupInput                  as FormGroupRegNetwork,

--- a/html/pfappserver/root/src/views/Configuration/networks/routedNetworks/_components/TheForm.vue
+++ b/html/pfappserver/root/src/views/Configuration/networks/routedNetworks/_components/TheForm.vue
@@ -26,6 +26,11 @@
           :column-label="$i18n.t('Enable NAT')"
         />
 
+        <form-group-nat-dns v-show="isType('inlinel3')"
+          namespace="nat_dns"
+          :column-label="$i18n.t('Enable DNS NAT')"
+        />
+
         <form-group-fake-mac-enabled v-show="isType('inlinel3')"
           namespace="fake_mac_enabled"
           :column-label="$i18n.t('Fake MAC Address')"
@@ -150,6 +155,7 @@ import {
   FormGroupIpAssigned,
   FormGroupIpReserved,
   FormGroupNatEnabled,
+  FormGroupNatDns,
   FormGroupNetflowAccountingEnabled,
   FormGroupNetmask,
   FormGroupNextHop,
@@ -176,6 +182,7 @@ const components = {
   FormGroupIpAssigned,
   FormGroupIpReserved,
   FormGroupNatEnabled,
+  FormGroupNatDns,
   FormGroupNetflowAccountingEnabled,
   FormGroupNetmask,
   FormGroupNextHop,

--- a/html/pfappserver/root/src/views/Configuration/networks/routedNetworks/_components/index.js
+++ b/html/pfappserver/root/src/views/Configuration/networks/routedNetworks/_components/index.js
@@ -30,6 +30,7 @@ export {
   BaseFormGroupTextarea                     as FormGroupIpAssigned,
   BaseFormGroupTextarea                     as FormGroupIpReserved,
   BaseFormGroupToggleZeroOneIntegerAsOffOn  as FormGroupNatEnabled,
+  BaseFormGroupToggleZeroOneIntegerAsOffOn  as FormGroupNatDns,
   BaseFormGroupToggleDisabledEnabled        as FormGroupNetflowAccountingEnabled,
   BaseFormGroupInput                        as FormGroupNetmask,
   BaseFormGroupInput                        as FormGroupNextHop,

--- a/lib/pfconfig/namespaces/resource/network_config.pm
+++ b/lib/pfconfig/namespaces/resource/network_config.pm
@@ -58,6 +58,7 @@ sub build {
             $interface{'mask'} = $interface->mask();
             $interface{'int'} = $interface->tag("int");
             $interface{'cidr'} = $interface->desc();
+            $ConfigNetwork{$network}{'nat_dns'} = $self->{networks}{$network}{'nat_dns'} // "1";
             if ( defined($self->{networks}{$network}{'next_hop'})) {
                 my $ip = new NetAddr::IP::Lite clean_ip($self->{networks}{$network}{'next_hop'});
                 if ($net_addr->contains($ip)) {

--- a/lib/pfconfig/namespaces/resource/network_config.pm
+++ b/lib/pfconfig/namespaces/resource/network_config.pm
@@ -58,7 +58,7 @@ sub build {
             $interface{'mask'} = $interface->mask();
             $interface{'int'} = $interface->tag("int");
             $interface{'cidr'} = $interface->desc();
-            $ConfigNetwork{$network}{'nat_dns'} = $self->{networks}{$network}{'nat_dns'} // "1";
+            $ConfigNetwork{$network}{'nat_dns'} = $self->{networks}{$network}{'nat_dns'} // "enabled";
             if ( defined($self->{networks}{$network}{'next_hop'})) {
                 my $ip = new NetAddr::IP::Lite clean_ip($self->{networks}{$network}{'next_hop'});
                 if ($net_addr->contains($ip)) {


### PR DESCRIPTION
# Description
Added the option in inline networks to disable the natting of the dns (in fact reply in the dhcp the dns configured in the config)

# Impacts
Inline

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
## Enhancements
* Enable/disable the natting traffic for inline networks
