### PR TITLE
Permit to send the deauth request on the previous equipment.

### DIFF
--- a/html/pfappserver/lib/pfappserver/Form/Config/Switch.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Switch.pm
@@ -100,10 +100,7 @@ has_field 'useCoA' =>
 has_field 'deauthOnPrevious' =>
   (
    type => 'Toggle',
-   label => 'Deauth On previous switch',
    default => 'N',
-   tags => { after_element => \&help,
-             help => 'This option parameter will allow you to do the deauth/CoA on the previous switch the device connected.' },
   );
 
 has_field 'VlanMap' =>

--- a/html/pfappserver/lib/pfappserver/Form/Config/Switch.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Switch.pm
@@ -97,6 +97,15 @@ has_field 'useCoA' =>
              help => 'Use CoA when available to deauthenticate the user. When disabled, RADIUS Disconnect will be used instead if it is available.' },
   );
 
+has_field 'deauthOnPrevious' =>
+  (
+   type => 'Toggle',
+   label => 'Deauth On previous switch',
+   default => 'N',
+   tags => { after_element => \&help,
+             help => 'This option parameter will allow you to do the deauth/CoA on the previous switch the device connected.' },
+  );
+
 has_field 'VlanMap' =>
   (
    type => 'Toggle',
@@ -256,7 +265,12 @@ has_field macSearchesSleepInterval  =>
    },
   );
 
-has_field 'SNMPVersion' =>
+has_block definition =>
+  (
+   render_list => [ qw(description type mode group deauthMethod useCoA deauthOnPrevious cliAccess ExternalPortalEnforcement VoIPEnabled VoIPLLDPDetect VoIPCDPDetect VoIPDHCPDetect uplink_dynamic uplink controllerIp disconnectPort coaPort) ],
+  );
+
+  has_field 'SNMPVersion' =>
   (
    type => 'Select',
    label => 'Version',

--- a/html/pfappserver/root/src/views/Configuration/switchGroups/_components/TheForm.vue
+++ b/html/pfappserver/root/src/views/Configuration/switchGroups/_components/TheForm.vue
@@ -46,7 +46,7 @@
 
         <form-group-deauth-on-previous namespace="deauthOnPrevious"
           :column-label="$i18n.t('Deauth on previous switch')"
-          :text="$i18n.t('This option parameter will allow you to do the deauthentication/CoA on the previous switch the device connected.')"
+          :text="$i18n.t('This option parameter will allow you to do the deauthentication/CoA on the previous switch where the device was connected.')"
         />
 
         <form-group-cli-access namespace="cliAccess"

--- a/html/pfappserver/root/src/views/Configuration/switchGroups/_components/TheForm.vue
+++ b/html/pfappserver/root/src/views/Configuration/switchGroups/_components/TheForm.vue
@@ -44,6 +44,11 @@
           :text="$i18n.t('Use CoA when available to deauthenticate the user. When disabled, RADIUS Disconnect will be used instead if it is available.')"
         />
 
+        <form-group-deauth-on-previous namespace="deauthOnPrevious"
+          :column-label="$i18n.t('Deauth on previous switch')"
+          :text="$i18n.t('This option parameter will allow you to do the deauthentication/CoA on the previous switch the device connected.')"
+        />
+
         <form-group-cli-access namespace="cliAccess"
           :column-label="$i18n.t('CLI Access Enabled')"
           :text="$i18n.t('Allow this switch to use PacketFence as a RADIUS server for CLI access.')"
@@ -465,6 +470,7 @@ import {
   FormGroupUplink,
   FormGroupUplinkDynamic,
   FormGroupUseCoa,
+  FormGroupDeauthOnPrevious,
   FormGroupVoipEnabled,
   FormGroupVoipLldpDetect,
   FormGroupVoipCdpDetect,
@@ -533,6 +539,7 @@ const components = {
   FormGroupUplink,
   FormGroupUplinkDynamic,
   FormGroupUseCoa,
+  FormGroupDeauthOnPrevious,
   FormGroupVoipEnabled,
   FormGroupVoipLldpDetect,
   FormGroupVoipCdpDetect,

--- a/html/pfappserver/root/src/views/Configuration/switchGroups/_components/index.js
+++ b/html/pfappserver/root/src/views/Configuration/switchGroups/_components/index.js
@@ -67,6 +67,7 @@ export {
   BaseFormGroupInput                      as FormGroupUplink,
   BaseFormGroupToggleStaticDynamicDefault as FormGroupUplinkDynamic,
   BaseFormGroupToggleNYDefault            as FormGroupUseCoa,
+  BaseFormGroupToggleNYDefault            as FormGroupDeauthOnPrevious,
   BaseFormGroupToggleNYDefault            as FormGroupToggleAccessListMap,
   BaseFormGroupToggleNYDefault            as FormGroupToggleRoleMap,
   BaseFormGroupToggleNYDefault            as FormGroupToggleUrlMap,

--- a/html/pfappserver/root/src/views/Configuration/switches/_components/TheForm.vue
+++ b/html/pfappserver/root/src/views/Configuration/switches/_components/TheForm.vue
@@ -49,7 +49,7 @@
 
         <form-group-deauth-on-previous namespace="deauthOnPrevious"
           :column-label="$i18n.t('Deauth on previous switch')"
-          :text="$i18n.t('This option parameter will allow you to do the deauthentication/CoA on the previous switch the device connected.')"
+          :text="$i18n.t('This option parameter will allow you to do the deauthentication/CoA on the previous switch whre the device was connected.')"
         />
 
         <form-group-cli-access namespace="cliAccess"

--- a/html/pfappserver/root/src/views/Configuration/switches/_components/TheForm.vue
+++ b/html/pfappserver/root/src/views/Configuration/switches/_components/TheForm.vue
@@ -47,6 +47,11 @@
           :text="$i18n.t('Use CoA when available to deauthenticate the user. When disabled, RADIUS Disconnect will be used instead if it is available.')"
         />
 
+        <form-group-deauth-on-previous namespace="deauthOnPrevious"
+          :column-label="$i18n.t('Deauth on previous switch')"
+          :text="$i18n.t('This option parameter will allow you to do the deauthentication/CoA on the previous switch the device connected.')"
+        />
+
         <form-group-cli-access namespace="cliAccess"
           :column-label="$i18n.t('CLI Access Enabled')"
           :text="$i18n.t('Allow this switch to use PacketFence as a RADIUS server for CLI access.')"
@@ -398,6 +403,7 @@ import {
   FormGroupUplink,
   FormGroupUplinkDynamic,
   FormGroupUseCoa,
+  FormGroupDeauthOnPrevious,
   FormGroupVoipEnabled,
   FormGroupVoipLldpDetect,
   FormGroupVoipCdpDetect,
@@ -464,6 +470,7 @@ const components = {
   FormGroupUplink,
   FormGroupUplinkDynamic,
   FormGroupUseCoa,
+  FormGroupDeauthOnPrevious,
   FormGroupVoipEnabled,
   FormGroupVoipLldpDetect,
   FormGroupVoipCdpDetect,

--- a/html/pfappserver/root/src/views/Configuration/switches/_components/index.js
+++ b/html/pfappserver/root/src/views/Configuration/switches/_components/index.js
@@ -68,6 +68,7 @@ export {
   BaseFormGroupToggleStaticDynamicDefault as FormGroupUplinkDynamic,
   BaseFormGroupToggleNYDefault            as FormGroupUseCoa,
   BaseFormGroupToggleNYDefault            as FormGroupToggleAccessListMap,
+  BaseFormGroupToggleNYDefault            as FormGroupDeauthOnPrevious,
   BaseFormGroupToggleNYDefault            as FormGroupToggleRoleMap,
   BaseFormGroupToggleNYDefault            as FormGroupToggleUrlMap,
   BaseFormGroupToggleNYDefault            as FormGroupToggleVlanMap,

--- a/lib/pf/enforcement.pm
+++ b/lib/pf/enforcement.pm
@@ -171,6 +171,11 @@ sub _vlan_reevaluation {
         return $FALSE;
     }
 
+    if (isenabled($switch->{_deauthOnPrevious})) {
+        $locationlog_entry = locationlog_last_entry_previous_switch($mac,$switch);
+        $switch = pf::SwitchFactory->instantiate( { switch_mac => $locationlog_entry->{'switch_mac'}, switch_ip => $locationlog_entry->{'switch_ip'} } );
+    }
+
     my $sync = $opts{sync};
     my $conn_type = str_to_connection_type($locationlog_entry->{'connection_type'} );
 

--- a/lib/pf/locationlog.pm
+++ b/lib/pf/locationlog.pm
@@ -52,6 +52,7 @@ BEGIN {
         locationlog_get_session
         locationlog_last_entry_mac
         locationlog_last_entry_non_inline_mac
+        locationlog_last_entry_previous_switch
 
         locationlog_unique_ssids
     );
@@ -618,6 +619,23 @@ sub _locationlog_last {
         -order_by => { -desc => 'start_time' },
         -limit => 1,
     });
+}
+
+=item locationlog_last_entry_previous_switch
+
+Return the last locationlog entry for a mac on a previous switch.
+
+=cut
+
+sub locationlog_last_entry_previous_switch {
+    my ($mac, $switch) = @_;
+    $mac = clean_mac($mac);
+    my %where = (
+        mac             => $mac,
+        switch => { "!=" => $switch->{_id} },
+    );
+    my $columns = pf::dal::locationlog->table_field_names;
+    return _locationlog_last(\%where, $columns);
 }
 
 =back


### PR DESCRIPTION
# Description
Send the deauth request to the previous switch the device was connected.
In the case you have 2 equipment, one AP and a dhcp that trigger a radius request and you want the deauth request to be sent only on the dhcp equipment. 

# Impacts
Deauth

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* Deauth request can be made on the previous equipment the device was connected.
