### PR TITLE
Feature/vagrant debian locales

### DIFF
--- a/addons/vagrant/inventory/hosts
+++ b/addons/vagrant/inventory/hosts
@@ -102,7 +102,7 @@ all:
               memory: 6144
             pfdeb9dev:
               box: inverse-inc/pfdeb9dev
-              box_version: 10.2.20210301135511
+              box_version: 10.2.20210326094954
               mgmt_ip: 172.17.17.12
               mgmt_netmask: 255.255.255.0
               ansible_host: "{{ mgmt_ip }}"

--- a/ci/packer/vagrant_img/provisioners/inventory/group_vars/pfservers/locales.yml
+++ b/ci/packer/vagrant_img/provisioners/inventory/group_vars/pfservers/locales.yml
@@ -1,0 +1,13 @@
+---
+# based on locales currently supported in PacketFence
+locales__group_list:
+  - es_ES.UTF-8
+  - fr_FR.UTF-8
+  - fr_CA.UTF-8
+  - de_DE.UTF-8
+  - he_IL.UTF-8
+  - it_IT.UTF-8
+  - nb_NO.UTF-8
+  - nl_NL.UTF-8
+  - pl_PL.UTF-8
+  - pt_BR.UTF-8

--- a/ci/packer/vagrant_img/provisioners/playbooks/debian.yml
+++ b/ci/packer/vagrant_img/provisioners/playbooks/debian.yml
@@ -5,6 +5,10 @@
     update_cache: yes
   register: upgrade_os_deb_register
 
+- name: install PacketFence locales
+  import_role:
+    name: locales
+
 - name: reboot to have latest Linux kernel packages in place
   reboot:
   when: upgrade_os_deb_register is changed

--- a/ci/packer/vagrant_img/provisioners/playbooks/upgrade_os.yml
+++ b/ci/packer/vagrant_img/provisioners/playbooks/upgrade_os.yml
@@ -3,9 +3,12 @@
   become: True
   gather_facts: True
   tags: upgrade
+  collections:
+    - debops.debops
+    - debops.roles01
+    - debops.roles02
+    - debops.roles03
 
   tasks:
     - name: include distribution specific tasks
       include_tasks: "{{ ansible_os_family|lower }}.yml"
-
-

--- a/ci/packer/vagrant_img/provisioners/requirements.yml
+++ b/ci/packer/vagrant_img/provisioners/requirements.yml
@@ -4,3 +4,4 @@ roles:
 
 collections:
   - name: inverse_inc.utils
+  - name: debops.debops

--- a/t/venom/Makefile
+++ b/t/venom/Makefile
@@ -21,7 +21,7 @@ configurator:
 # if setup is a dependency to test target, putting setup as a dependency to other
 # targets doesn't cause a recall
 .PHONY: test
-test: setup global_config dot1x_eap_peap wired_mac_auth wireless_dot1x_eap_peap wireless_mac_auth backup_db_and_restore global_teardown
+test: setup global_config dot1x_eap_peap wired_mac_auth wireless_dot1x_eap_peap wireless_mac_auth captive_portal backup_db_and_restore global_teardown
 
 .PHONY: setup
 setup:


### PR DESCRIPTION
# Description
* Generate locales used by PacketFence inside PacketFence Vagrant images. Needed to re-enable captive_portal integration tests.
* Put back captive portal integration tests 

# Dependencies
Depends on #6229 

# Impacts
Tests

# Delete branch after merge
YES