### PR TITLE
fix(docs): remove deduped html/images files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,14 +48,14 @@ docs/index.js: $(HTML)
 images:
 	@echo "install images dir and all subdirectories"
 	for subdir in `find docs/images/* -type d -printf "%f\n"` ; do \
-		install -d -m0755 $(DESTDIR)/usr/local/pf/html/pfappserver/root/doc/images/$$subdir ; \
+		install -d -m0755 $(DESTDIR)/usr/local/pf/docs/images/$$subdir ; \
 		for img in `find docs/images/$$subdir -type f`; do \
-			install -m0644 $$img $(DESTDIR)/usr/local/pf/html/pfappserver/root/doc/images/$$subdir ; \
+			install -m0644 $$img $(DESTDIR)/usr/local/pf/docs/images/$$subdir ; \
 		done \
 	done
 	@echo "install only images at depth0 in images/ directory"
 	for img in `find docs/images/* -maxdepth 0 -type f`; do \
-		install -m0644 $$img $(DESTDIR)/usr/local/pf/html/pfappserver/root/doc/images/ ; \
+		install -m0644 $$img $(DESTDIR)/usr/local/pf/docs/images/ ; \
 	done
 
 .PHONY: html

--- a/conf/caddy-services/httpadmindispatcher.conf.example
+++ b/conf/caddy-services/httpadmindispatcher.conf.example
@@ -6,6 +6,10 @@
   httpdportalpreview
 }
 
+:8891/static/doc {
+  root /usr/local/pf/docs
+}
+
 :8891/static {
   root /usr/local/pf/html/pfappserver/root
 }

--- a/debian/rules
+++ b/debian/rules
@@ -51,10 +51,10 @@ install: build
 	done
 
 	# Install all except debian and t directory
-	for i in `find * ! -path 'debian/*' ! -path 'debian' ! -path 't/*' ! -path 't' ! -path 'lib/pfconfig/*' ! -path 'lib/pfconfig' ! -path 'sbin/pfconfig' -type d`; do \
+	for i in `find * ! -path 'debian/*' ! -path 'debian' ! -path 'docs/*' ! -path 'docs' ! -path 't/*' ! -path 't' ! -path 'lib/pfconfig/*' ! -path 'lib/pfconfig' ! -path 'sbin/pfconfig' -type d`; do \
 		install -d -m0700 $(CURDIR)/debian/packetfence$(PREFIX)/$(NAME)/$$i; \
 	done
-	for i in `find * ! -path 'debian/*' ! -path 'debian' ! -path 't/*' ! -path 't' ! -path 'lib/pfconfig/*' ! -path 'lib/pfconfig' ! -path 'sbin/pfconfig' ! -path 'conf/pfconfig.conf*' ! -path 'conf/redis_cache.conf*' ! -type d`; do \
+	for i in `find * ! -path 'debian/*' ! -path 'debian' ! -path 'docs/*' ! -path 'docs' ! -path 't/*' ! -path 't' ! -path 'lib/pfconfig/*' ! -path 'lib/pfconfig' ! -path 'sbin/pfconfig' ! -path 'conf/pfconfig.conf*' ! -path 'conf/redis_cache.conf*' ! -type d`; do \
 		$(INSTALL) $$i $(CURDIR)/debian/packetfence$(PREFIX)/$(NAME)/$$i; \
 	done
 	for i in `find * -path 't*' -type d`; do \
@@ -145,7 +145,7 @@ install: build
 	# packetfence-tracking-config
 	install -m0644 $(CURDIR)/debian/packetfence-tracking-config.path $(CURDIR)/debian/packetfence/lib/systemd/system/packetfence-tracking-config.path
 
-	#Portal javascript/css
+	# Portal javascript/css
 	rm -f $(CURDIR)/debian/packetfence$(PREFIX)/$(NAME)/html/common/styles.css
 	rm -f $(CURDIR)/debian/packetfence$(PREFIX)/$(NAME)/html/common/styles.css.map
 	make -C html/common/ vendor
@@ -159,10 +159,10 @@ install: build
 
 	# Documentation
 	make html
-	# install html in pfappserver for embedded doc
-	install -d -m0755 $(CURDIR)/debian/packetfence-doc$(PREFIX)/$(NAME)/html/pfappserver/root/doc
+	# install html
+	install -d -m0755 $(CURDIR)/debian/packetfence-doc$(PREFIX)/$(NAME)/docs
 	for i in `find "docs" "(" -name "*.html" -or -iname "*.js" ")" -type f`; do \
-		install -m0644 $$i $(CURDIR)/debian/packetfence-doc$(PREFIX)/$(NAME)/html/pfappserver/root/doc/; \
+		install -m0644 $$i $(CURDIR)/debian/packetfence-doc$(PREFIX)/$(NAME)/docs/; \
 	done
 	# images
 	make DESTDIR=$(CURDIR)/debian/packetfence-doc images
@@ -172,7 +172,7 @@ install: build
 	for i in `find 'html/pfappserver/root/dist' -type f`; do \
 		install -D -m0644 $$i $(CURDIR)/debian/packetfence-pfappserver-javascript$(PREFIX)/$(NAME)/$$i; \
 	done
-	#Golang binary
+	# Golang binary
 	install -d -m0744 $(CURDIR)/debian/packetfence-golang-daemon$(PREFIX)/$(NAME)/sbin
 	make -C go all
 	make -C go DESTDIR=$(CURDIR)/debian/packetfence-golang-daemon copy

--- a/rpm/packetfence.spec
+++ b/rpm/packetfence.spec
@@ -469,7 +469,6 @@ cp -r COPYING %{buildroot}/usr/local/pf/
 cp -r db %{buildroot}/usr/local/pf/
 cp -r docs %{buildroot}/usr/local/pf/
 rm -rf %{buildroot}/usr/local/pf/docs/fonts
-rm -rf %{buildroot}/usr/local/pf/docs/images
 rm -rf %{buildroot}/usr/local/pf/docs/api
 
 # install Golang binaries
@@ -479,15 +478,6 @@ rm -rf %{buildroot}/usr/local/pf/docs/api
 
 # install html directory
 %{__make} DESTDIR=%{buildroot} html_install
-
-# install html in pfappserver for embedded doc
-%{__install} -d -m0755 %{buildroot}/usr/local/pf/html/pfappserver/root/doc
-for i in `find docs "(" -name "*.html" -or -name "*.js" ")"  -type f`; do \
-	%{__install} -m0644 $i %{buildroot}/usr/local/pf/html/pfappserver/root/doc/; \
-done
-
-# images
-%{__make} DESTDIR=%{buildroot} images
 
 cp -r lib %{buildroot}/usr/local/pf/
 cp -r go %{buildroot}/usr/local/pf/


### PR DESCRIPTION
# Description

Instead of copying the HTML files of the documentation to a different directory, expose the source directory of the documentation from Caddy.

# Delete branch after merge

NO
