### PR TITLE
set valid_from equals to 1970-01-01 in SQL schema

### DIFF
--- a/ci/packer/zen/scripts/install-pf.sh
+++ b/ci/packer/zen/scripts/install-pf.sh
@@ -33,6 +33,6 @@ cat <<EOT >> /usr/local/pf/db/pf-schema.sql
 -- Insert the demo user for testing
 --
 
-INSERT INTO password (pid, password, valid_from, expiration, access_duration, access_level, category) VALUES ('demouser', 'demouser', NOW(), '2038-01-01', '1D', NULL, 1);
+INSERT INTO password (pid, password, valid_from, expiration, access_duration, access_level, category) VALUES ('demouser', 'demouser', '1970-01-01', '2038-01-01', '1D', NULL, 1);
 
 EOT

--- a/db/pf-schema-10.3.0.sql
+++ b/db/pf-schema-10.3.0.sql
@@ -488,7 +488,7 @@ CREATE TABLE `password` (
 
 INSERT INTO `person` (pid,notes) VALUES ("admin","Default Admin User - do not delete");
 INSERT INTO `person` (pid,notes) VALUES ("default","Default User - do not delete");
-INSERT INTO password (pid, password, valid_from, expiration, access_duration, access_level, category) VALUES ('admin', 'admin', NOW(), '2038-01-01', NULL, 'ALL', NULL);
+INSERT INTO password (pid, password, valid_from, expiration, access_duration, access_level, category) VALUES ('admin', 'admin', '1970-01-01', '2038-01-01', NULL, 'ALL', NULL);
 
 --
 -- Trigger to delete the temp password from 'password' when deleting the pid associated with

--- a/t/venom/pfservers/configurator/20_run_configurator_step2.yml
+++ b/t/venom/pfservers/configurator/20_run_configurator_step2.yml
@@ -197,8 +197,7 @@ testcases:
     body: >-
       {
         "password": "{{.configurator.admin.password}}",
-        "pid": "admin",
-        "valid_from": "{{.configurator.admin.valid_from}}"
+        "pid": "admin"
       }
     headers:
       "Content-Type": "application/json"

--- a/t/venom/vars/all.yml
+++ b/t/venom/vars/all.yml
@@ -284,7 +284,6 @@ configurator.timezone: '{{.timezone}}'
 
 # Admin account
 configurator.admin.password: '{{.pfserver_admin_password}}'
-configurator.admin.valid_from: 1970-01-01 00:00:00
 
 ### Step 3
 # Fingerbank


### PR DESCRIPTION
# Description
Create `admin` user with correct `valid_from` value when creating database in place of doing a change during configurator.

# Impacts
admin user creation
demouser creation (only ZEN)

# Issue
fixes #6329

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* regression: configurator set valid_from field to current time in place of 1970-01-01 00:00:00 (#6329)

