### PR TITLE
fixed Aruba 2930 radiusDisconnect request

### DIFF
--- a/lib/pf/Switch/Aruba/2930M.pm
+++ b/lib/pf/Switch/Aruba/2930M.pm
@@ -210,7 +210,7 @@ sub radiusDisconnect {
             'User-Name' => $username,
             'Calling-Station-Id' => $mac,
             'NAS-IP-Address' => $send_disconnect_to,
-            'NAS-Port-Id' => $locationlog->{port},
+            'NAS-Port' => $locationlog->{port},
 
         };
         # merging additional attributes provided by caller to the standard attributes


### PR DESCRIPTION
# Description
Radius CoA request in Aruba 2930M Perl module corrected:
* The request attribute **NAS-Port-Id** changed to **NAS-Port** .

See [Aruba 2930F / 2930M Access Security Guide for ArubaOS-Switch 16.10](https://asp.arubanetworks.com/downloads/documents/RmlsZTo1MDk5ODgzYS0xOTk4LTExZWItODlmNS05YmMwYzMwODM4ZDU%3D) page 152.

# Impacts
- Radius disconnect request sent to an Aruba 2930M will now be accepted and executed by the switch

# Issue
fixes #6371

# Delete branch after merge
YES

# Checklist
- [n/a] Document the feature
- [n/a] Add unit tests
- [n/a] Add acceptance tests (TestLink)

## Bug Fixes
* Aruba 2930M perl module - CoA request fails #6371
