### PR TITLE
[tests] ensure libvirt interface is correctly set up after configurator

### DIFF
--- a/t/venom/pfservers/configurator/00_configure_dhcp_listener_interface.yml
+++ b/t/venom/pfservers/configurator/00_configure_dhcp_listener_interface.yml
@@ -27,28 +27,15 @@ testcases:
     assertions:
       - result.statuscode ShouldEqual 200
 
-# switch interface to static state
+### switch interface to static state
+# ifdown/ifup scripts are different between EL and Debian
 - name: bounce_dhcp_listener_int
   steps:
-  - type: http
-    method: POST
-    url: '{{.pfserver_webadmin_url}}/api/v1/configurator/config/interface/{{.get_name_of_dhcp_listener_int.dhcp_listener_interface}}/down'
-    ignore_verify_ssl: true
-    headers:
-      "Content-Type": "application/json"
-    assertions:
-      - result.statuscode ShouldEqual 200
-      - result.bodyjson.message ShouldEqual "Interface {{.get_name_of_dhcp_listener_int.dhcp_listener_interface}} disabled"
+  - type: exec
+    script: "ifdown {{.get_name_of_dhcp_listener_int.dhcp_listener_interface}}"
 
-  - type: http
-    method: POST
-    url: '{{.pfserver_webadmin_url}}/api/v1/configurator/config/interface/{{.get_name_of_dhcp_listener_int.dhcp_listener_interface}}/up'
-    ignore_verify_ssl: true
-    headers:
-      "Content-Type": "application/json"
-    assertions:
-      - result.statuscode ShouldEqual 200
-      - result.bodyjson.message ShouldEqual "Interface {{.get_name_of_dhcp_listener_int.dhcp_listener_interface}} enabled"
+  - type: exec
+    script: "ifup {{.get_name_of_dhcp_listener_int.dhcp_listener_interface}}"
 
 # start dhclient without any action on /etc/resolv.conf
 - name: start_dhclient_on_dhcp_listener_int

--- a/t/venom/pfservers/configurator/TESTSUITE.md
+++ b/t/venom/pfservers/configurator/TESTSUITE.md
@@ -25,7 +25,7 @@ Vagrant will not be able to reach anymore PacketFence server because it rely
 on DHCP lease assigned to VM.
 As a workaround, we start `dhclient` as a daemon only for this interface with
 a specific config to **not** override `/etc/resolv.conf`: PacketFence server
-will have two IP addresses one static and another one dynamic.
+can have two IP addresses one static and another one dynamic.
 
 ### Step 1
 1. Configure second interface as management with portal daemon (to test other


### PR DESCRIPTION
# Description
On Debian, switch from systemd-networkd to ifdown doesn't seems to work. So interface was still in DHCP even after configurator.

Related to #5858 

# Impacts
Tests

# Delete branch after merge
YES
