### PR TITLE
Make ocsp available on the portal

### DIFF
--- a/conf/haproxy-portal.conf.example
+++ b/conf/haproxy-portal.conf.example
@@ -57,7 +57,7 @@ backend static
     option forwardfor
     http-request set-uri http://127.0.0.1:8889%[path]?%[query]
 
-backend scep
+backend pki
     option httpclose
     option http_proxy
     option forwardfor

--- a/conf/passthrough.lua.tt.example
+++ b/conf/passthrough.lua.tt.example
@@ -18,8 +18,8 @@ core.register_action("select", { "http-req" }, function(txn)
         txn:set_var("req.action","static")
     elseif ( string.match(txn.sf:path(), '/rfc7710') ) then
         txn:set_var("req.action","proxy")
-    elseif ( string.match(txn.sf:path(), '/pki/scep') or string.match(txn.sf:path(), '/scep') ) then
-        txn:set_var("req.action","scep")
+    elseif ( string.match(txn.sf:path(), '/pki/scep') or string.match(txn.sf:path(), '/scep') or string.match(txn.sf:path(), '/pki/oscp') ) then
+        txn:set_var("req.action","pki")
     elseif ( not ([% FOREACH host IN portal_host %] string.match(txn.sf:req_fhdr("Host"):lower(), '^[% host FILTER lower %][0-9:]*$') or[% END %] false ) ) then
         txn:set_var("req.action","proxy")
     elseif ( string.match(txn.sf:path() , '/generate_204') ) then

--- a/conf/passthrough.lua.tt.example
+++ b/conf/passthrough.lua.tt.example
@@ -18,7 +18,7 @@ core.register_action("select", { "http-req" }, function(txn)
         txn:set_var("req.action","static")
     elseif ( string.match(txn.sf:path(), '/rfc7710') ) then
         txn:set_var("req.action","proxy")
-    elseif ( string.match(txn.sf:path(), '/pki/scep') or string.match(txn.sf:path(), '/scep') or string.match(txn.sf:path(), '/pki/oscp') ) then
+    elseif ( string.match(txn.sf:path(), '/pki/scep') or string.match(txn.sf:path(), '/scep') or string.match(txn.sf:path(), '/pki/ocsp') ) then
         txn:set_var("req.action","pki")
     elseif ( not ([% FOREACH host IN portal_host %] string.match(txn.sf:req_fhdr("Host"):lower(), '^[% host FILTER lower %][0-9:]*$') or[% END %] false ) ) then
         txn:set_var("req.action","proxy")


### PR DESCRIPTION
# Description
Made ocsp available on the portal.


# Impacts
No

# Issue
fixes #5825

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* OCSP available on the portal interfaces

## Bug Fixes
* packetfence-pki: configure OCSP to listen on specific interfaces  #5825


