### PR TITLE
Added CLI Switch Access for Avaya ERS Switches

### DIFF
--- a/lib/pf/Switch/Avaya.pm
+++ b/lib/pf/Switch/Avaya.pm
@@ -643,6 +643,47 @@ sub radiusDisconnect {
     return;
 }
 
+=item returnAuthorizeRead
+
+Return radius attributes to allow read access. Returns Service-Type = 7 (NAS-Prompt-User)
+
+=cut
+
+sub returnAuthorizeRead {
+    my ($self, $args) = @_;
+    my $logger = $self->logger;
+    my $radius_reply_ref;
+    my $status;
+    $radius_reply_ref->{'Service-Type'} = '7';
+    $radius_reply_ref->{'Reply-Message'} = "Switch read access granted by PacketFence";
+    $logger->info("User $args->{'user_name'} logged in $args->{'switch'}{'_id'} with read access");
+    my $filter = pf::access_filter::radius->new;
+    my $rule = $filter->test('returnAuthorizeRead', $args);
+    ($radius_reply_ref, $status) = $filter->handleAnswerInRule($rule,$args,$radius_reply_ref);
+    return [$status, %$radius_reply_ref];
+}
+
+=item returnAuthorizeWrite
+
+Return radius attributes to allow write access. Returns Service-Type = 6 (Administrative-User)
+
+=cut
+
+sub returnAuthorizeWrite {
+    my ($self, $args) = @_;
+    my $logger = $self->logger;
+    my $radius_reply_ref;
+    my $status;
+    $radius_reply_ref->{'Service-Type'} = '6';
+    $radius_reply_ref->{'Reply-Message'} = "Switch enable access granted by PacketFence";
+    $logger->info("User $args->{'user_name'} logged in $args->{'switch'}{'_id'} with write access");
+    my $filter = pf::access_filter::radius->new;
+    my $rule = $filter->test('returnAuthorizeWrite', $args);
+    ($radius_reply_ref, $status) = $filter->handleAnswerInRule($rule,$args,$radius_reply_ref);
+    return [$status, %$radius_reply_ref];
+}
+
+
 =head1 AUTHOR
 
 Inverse inc. <info@inverse.ca>


### PR DESCRIPTION
This block of code was taken from Extreme.pm, and the Read Access service type was changed from 0 to 6. 

This has been tested on my switches here.

# Description
(REQUIRED)
Allow for CLI Switch Login on Avaya ERS Switches

# Impacts
(REQUIRED)
Should only impact Avaya switches that have CLI Access enabled.

# Delete branch after merge
(REQUIRED)
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
(REQUIRED, but may be optional...)
## New Features
* CLI Access Enabled for Avaya Switches

## Enhancements
* CLI Access Enabled for Avaya Switches

## Bug Fixes
* Fixes Issue #6399 