### PR TITLE
Use new radius request attribute to identify vpn access and modified valid_mac to reject ip address (detect 123.456.789.123 as 12:34:56:78:91:23)

### DIFF
--- a/lib/pf/Switch/Fortinet/FortiGate.pm
+++ b/lib/pf/Switch/Fortinet/FortiGate.pm
@@ -247,7 +247,6 @@ sub identifyConnectionType {
     }
 }
 
-
 =item returnAuthorizeVPN
 
 Return radius attributes to allow VPN access

--- a/lib/pf/util.pm
+++ b/lib/pf/util.pm
@@ -300,27 +300,27 @@ our $NON_VALID_MAC_REGEX = qr/^(00|ff)(:\g1){5}$/;
 our $VALID_PF_MAC_REGEX = qr/^[0-9a-f]{2}(:[0-9a-f]{2}){5}$/;
 
 sub valid_mac {
-   my ($mac) = @_;
-   return (0) unless defined $mac;
-   my $logger = get_logger();
-   if ( !defined($mac) ) {
-       return(0);
-   }
-   if ( $mac !~ $VALID_MAC_REGEX) {
-       $logger->debug("invalid MAC: $mac");
-       return (0);
-   }
-   if ($mac =~ /^((?:\d{1,3}\.){3}\d{1,3})$/) {
-       $logger->debug("invalid MAC: $mac");
-       return (0);
-   }
-   $mac = clean_mac($mac);
-   if( !$mac || $mac =~ $NON_VALID_MAC_REGEX || $mac !~ $VALID_PF_MAC_REGEX) {
-       $logger->debug("invalid MAC: " . ($mac?$mac:"empty"));
-       return (0);
-   } else {
-       return (1);
-   }
+    my ($mac) = @_;
+    return (0) unless defined $mac;
+    my $logger = get_logger();
+    if ( !defined($mac) ) {
+        return(0);
+    }
+    if ( $mac !~ $VALID_MAC_REGEX) {
+        $logger->debug("invalid MAC: $mac");
+        return (0);
+    }
+    if ($mac =~ $VALID_IP_REGEX) {
+        $logger->debug("invalid MAC: $mac");
+        return (0);
+    }
+    $mac = clean_mac($mac);
+    if( !$mac || $mac =~ $NON_VALID_MAC_REGEX || $mac !~ $VALID_PF_MAC_REGEX) {
+        $logger->debug("invalid MAC: " . ($mac?$mac:"empty"));
+        return (0);
+    } else {
+        return (1);
+    }
 }
 
 =item  macoui2nb


### PR DESCRIPTION
# Description
Added new radius attribute vpn detection for fortigate
Modifed valid_mac that identify some ip address as mac

# Impacts
RADIUS vpn workflow

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* Added new radius attribute vpn detection for fortigate
* Fixed valid_mac that identify some ip address as mac
