### PR TITLE
Added Gateway on vip option

### DIFF
--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1472,6 +1472,13 @@ description=<<EOT
 Set the name server option in DHCP replies to point only to the VIP in cluster mode rather than to all servers in the cluster.
 EOT
 
+[active_active.gateway_on_vip_only]
+type=toggle
+options=enabled|disabled
+description=<<EOT
+Set the gateway option in DHCP replies to point only to the VIP in cluster mode rather than to all servers in the cluster.
+EOT
+
 [active_active.centralized_deauth]
 type=toggle
 options=enabled|disabled

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -1093,6 +1093,10 @@ vrrp_unicast=disabled
 # Set the name server option in DHCP replies to point only to the VIP in cluster mode rather than to all servers in the cluster.
 dns_on_vip_only=disabled
 #
+# active_active.gateway_on_vip_only
+# Set the gateway option in DHCP replies to point only to the VIP in cluster mode rather than to all servers in the cluster.
+gateway_on_vip_only=disabled
+#
 # active_active.centralized_deauth
 #
 # Centralize the deauthentication to the management node of the cluster.

--- a/docs/api/spec/components/schemas/configbase.yaml
+++ b/docs/api/spec/components/schemas/configbase.yaml
@@ -745,6 +745,10 @@ ConfigBase:
         description: Set the name server option in DHCP replies to point only to the
           VIP in cluster mode rather than to all servers in the cluster.
         type: string
+      gateway_on_vip_only:
+        description: Set the gateway option in DHCP replies to point only to the
+          VIP in cluster mode rather than to all servers in the cluster.
+        type: string
       galera_replication:
         description: Whether or not to activate galera cluster when using a cluster
         type: string

--- a/docs/api/spec/openapi.json
+++ b/docs/api/spec/openapi.json
@@ -1307,6 +1307,10 @@
                         "description" : "Set the name server option in DHCP replies to point only to the VIP in cluster mode rather than to all servers in the cluster.",
                         "type" : "string"
                      },
+		     "gateway_on_vip_only" : {
+                        "description" : "Set the gateway option in DHCP replies to point only to the VIP in cluster mode rather than to all servers in the cluster.",
+                        "type" : "string"
+                     },
                      "galera_replication" : {
                         "description" : "Whether or not to activate galera cluster when using a cluster",
                         "type" : "string"

--- a/docs/api/spec/openapi.yaml
+++ b/docs/api/spec/openapi.yaml
@@ -1113,6 +1113,10 @@ components:
             description: Set the name server option in DHCP replies to point only
               to the VIP in cluster mode rather than to all servers in the cluster.
             type: string
+          gateway_on_vip_only:
+            description: Set the gateway option in DHCP replies to point only
+              to the VIP in cluster mode rather than to all servers in the cluster.
+            type: string
           galera_replication:
             description: Whether or not to activate galera cluster when using a cluster
             type: string

--- a/go/cmd/pfdhcp/utils.go
+++ b/go/cmd/pfdhcp/utils.go
@@ -219,6 +219,9 @@ func ShuffleGateway(ConfNet pfconfigdriver.RessourseNetworkConf) (r []byte) {
 		if ConfNet.Type == "inlinel2" && ConfNet.NatEnabled == "disabled" {
 			return []byte(net.ParseIP(ConfNet.Gateway).To4())
 		}
+		if ConfNet.Gatewayvip != "" {
+			return []byte(net.ParseIP(ConfNet.Gatewayvip).To4())
+		}
 
 		excluded := DetectDisabledServer(ConfNet.ClusterIPs, ConfNet.Interface.InterfaceName)
 		return Shuffle(ConfNet.ClusterIPs, excluded)

--- a/go/cmd/pfdhcp/utils.go
+++ b/go/cmd/pfdhcp/utils.go
@@ -219,8 +219,8 @@ func ShuffleGateway(ConfNet pfconfigdriver.RessourseNetworkConf) (r []byte) {
 		if ConfNet.Type == "inlinel2" && ConfNet.NatEnabled == "disabled" {
 			return []byte(net.ParseIP(ConfNet.Gateway).To4())
 		}
-		if ConfNet.Gatewayvip != "" {
-			return []byte(net.ParseIP(ConfNet.Gatewayvip).To4())
+		if ConfNet.ForceGatewayVIP != "" {
+			return []byte(net.ParseIP(ConfNet.ForceGatewayVIP).To4())
 		}
 
 		excluded := DetectDisabledServer(ConfNet.ClusterIPs, ConfNet.Interface.InterfaceName)

--- a/go/pfconfigdriver/structs.go
+++ b/go/pfconfigdriver/structs.go
@@ -404,7 +404,7 @@ type RessourseNetworkConf struct {
 	Algorithm                string    `json:"algorithm"`
 	NetflowAccountingEnabled string    `json:"netflow_accounting_enabled"`
 	NatDNS                   string    `json:"nat_dns"`
-	Gatewayvip               string    `json:"gateway_vip"`
+	ForceGatewayVIP          string    `json:"force_gateway_vip"`
 }
 
 type PfRoles struct {

--- a/go/pfconfigdriver/structs.go
+++ b/go/pfconfigdriver/structs.go
@@ -404,6 +404,7 @@ type RessourseNetworkConf struct {
 	Algorithm                string    `json:"algorithm"`
 	NetflowAccountingEnabled string    `json:"netflow_accounting_enabled"`
 	NatDNS                   string    `json:"nat_dns"`
+	Gatewayvip               string    `json:"gateway_vip"`
 }
 
 type PfRoles struct {

--- a/html/pfappserver/root/src/views/Configuration/activeActive/_components/TheForm.vue
+++ b/html/pfappserver/root/src/views/Configuration/activeActive/_components/TheForm.vue
@@ -25,6 +25,11 @@
       :text="$i18n.t('Set the name server option in DHCP replies to point only to the VIP in cluster mode rather than to all servers in the cluster.')"
     />
 
+    <form-group-gateway-on-vip-only namespace="gateway_on_vip_only"
+      :column-label="$i18n.t('Gateway on VIP only')"
+      :text="$i18n.t('Set the gateway option in DHCP replies to point only to the VIP in cluster mode rather than to all servers in the cluster.')"
+    />
+
     <form-group-centralized-deauth namespace="centralized_deauth"
       :column-label="$i18n.t('Centralized access reevaluation')"
       :text="$i18n.t('Centralize the deauthentication to the management node of the cluster.')"
@@ -67,6 +72,7 @@ import {
   FormGroupCentralizedDeauth,
   FormGroupConflictResolutionThreshold,
   FormGroupDnsOnVipOnly,
+  FormGroupGatewayOnVipOnly,
   FormGroupGaleraReplication,
   FormGroupGaleraReplicationUsername,
   FormGroupGaleraReplicationPassword,
@@ -82,6 +88,7 @@ const components = {
   FormGroupCentralizedDeauth,
   FormGroupConflictResolutionThreshold,
   FormGroupDnsOnVipOnly,
+  FormGroupGatewayOnVipOnly,
   FormGroupGaleraReplication,
   FormGroupGaleraReplicationUsername,
   FormGroupGaleraReplicationPassword,

--- a/html/pfappserver/root/src/views/Configuration/activeActive/_components/index.js
+++ b/html/pfappserver/root/src/views/Configuration/activeActive/_components/index.js
@@ -18,6 +18,7 @@ export {
   BaseFormGroupToggleDisabledEnabled  as FormGroupCentralizedDeauth,
   BaseFormGroupIntervalUnit           as FormGroupConflictResolutionThreshold,
   BaseFormGroupToggleDisabledEnabled  as FormGroupDnsOnVipOnly,
+  BaseFormGroupToggleDisabledEnabled  as FormGroupGatewayOnVipOnly,
   BaseFormGroupToggleDisabledEnabled  as FormGroupGaleraReplication,
   BaseFormGroupInput                  as FormGroupGaleraReplicationUsername,
   BaseFormGroupInputPassword          as FormGroupGaleraReplicationPassword,

--- a/lib/pfconfig/namespaces/resource/network_config.pm
+++ b/lib/pfconfig/namespaces/resource/network_config.pm
@@ -76,6 +76,9 @@ sub build {
                     if(isenabled($self->{config_pf}->{active_active}->{dns_on_vip_only})||exists $NET_INLINE_TYPES{$ConfigNetwork{$network}{'type'}}) {
                         $ConfigNetwork{$network}{'dns_vip'} = $self->{cluster_resource}->{cfg}->{CLUSTER}->{'interface '. $interface{'int'}}->{ip} || $interface{'ip'};
                     }
+                    if(isenabled($self->{config_pf}->{active_active}->{gateway_on_vip_only})) {
+                        $ConfigNetwork{$network}{'gateway_vip'} = $self->{cluster_resource}->{cfg}->{CLUSTER}->{'interface '. $interface{'int'}}->{ip} || $interface{'ip'};
+                    }
                     $ConfigNetwork{$network}{'vip'} = $self->{cluster_resource}->{cfg}->{CLUSTER}->{'interface '. $interface{'int'}}->{ip} || $interface{'ip'};
                     $ConfigNetwork{$network}{'interface'} = \%interface;
                 }

--- a/lib/pfconfig/namespaces/resource/network_config.pm
+++ b/lib/pfconfig/namespaces/resource/network_config.pm
@@ -77,7 +77,7 @@ sub build {
                         $ConfigNetwork{$network}{'dns_vip'} = $self->{cluster_resource}->{cfg}->{CLUSTER}->{'interface '. $interface{'int'}}->{ip} || $interface{'ip'};
                     }
                     if(isenabled($self->{config_pf}->{active_active}->{gateway_on_vip_only})) {
-                        $ConfigNetwork{$network}{'gateway_vip'} = $self->{cluster_resource}->{cfg}->{CLUSTER}->{'interface '. $interface{'int'}}->{ip} || $interface{'ip'};
+                        $ConfigNetwork{$network}{'force_gateway_vip'} = $self->{cluster_resource}->{cfg}->{CLUSTER}->{'interface '. $interface{'int'}}->{ip} || $interface{'ip'};
                     }
                     $ConfigNetwork{$network}{'vip'} = $self->{cluster_resource}->{cfg}->{CLUSTER}->{'interface '. $interface{'int'}}->{ip} || $interface{'ip'};
                     $ConfigNetwork{$network}{'interface'} = \%interface;


### PR DESCRIPTION
# Description
Add an option to force the vip as the default gateway on layer2 registration network

# Impacts
DHCP

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* Add an option to force the vip as the default gateway on layer2 registration network

