### PR TITLE
Fix MariaDB-backup on standalone installations

### DIFF
--- a/addons/backup-and-maintenance.sh
+++ b/addons/backup-and-maintenance.sh
@@ -142,7 +142,7 @@ backup_db(){
             elif [ $MARIADB_REMOTE_CLUSTER -eq 1 ]; then
                 echo "mariabackup can't backup remote databases, uninstall Mariabackup and retry"
             else
-                mariabackup --defaults-file=/usr/local/pf/var/conf/mariadb.conf --user=$REP_USER --password=$REP_PWD  --no-timestamp --stream=xbstream --tmpdir=$INNO_TMP --backup 2>> /usr/local/pf/logs/innobackup.log | gzip - > $BACKUP_DIRECTORY/$BACKUP_DB_FILENAME-innobackup-`date +%F_%Hh%M`.xbstream.gz
+                mariabackup --defaults-file=/usr/local/pf/var/conf/mariadb.conf --user=$DB_USER --password=$DB_PWD  --no-timestamp --stream=xbstream --tmpdir=$INNO_TMP --backup 2>> /usr/local/pf/logs/innobackup.log | gzip - > $BACKUP_DIRECTORY/$BACKUP_DB_FILENAME-innobackup-`date +%F_%Hh%M`.xbstream.gz
             fi
             tail -1 /usr/local/pf/logs/innobackup.log | grep 'completed OK!'
             BACKUPRC=$?

--- a/docs/installation/performance_optimizations.asciidoc
+++ b/docs/installation/performance_optimizations.asciidoc
@@ -180,7 +180,7 @@ The installation instructions below are made for CentOS 7 but adjusting them to 
 Once this is done, grant the proper rights to the `pf` user (or the one you configured in pf.conf):
 
   # mysql -u root -p
-  MariaDB> GRANT RELOAD, LOCK TABLES, REPLICATION CLIENT ON *.* TO 'pf'@'localhost';
+  MariaDB> GRANT PROCESS, RELOAD, LOCK TABLES, REPLICATION CLIENT ON *.* TO 'pf'@'localhost';
   MariaDB> FLUSH PRIVILEGES;
 
 Next, run the maintenance script [filename]`/usr/local/pf/addons/backup-and-maintenance.sh` and ensure that the following line is part of the output:


### PR DESCRIPTION
# Description
- Fix backup script
- [x] adjust GRANT instructions in documentation to have correct privileges

# Impacts
DB backup

# Issue
fixes #6424

# Delete branch after merge
YES

# Checklist
- [x] Document the feature

# NEWS file entries
## Bug Fixes
* Backup DB using MariaDB-backup doesn't work on standalone installation (#6424)
