### PR TITLE
Make default admin frontend listen on all addresses

### DIFF
--- a/lib/pf/services/manager/haproxy_admin.pm
+++ b/lib/pf/services/manager/haproxy_admin.pm
@@ -250,8 +250,8 @@ backend api
         errorfile 503 /usr/local/pf/html/pfappserver/root/errors/503.json.http
         server 127.0.0.1 127.0.0.1:9999 weight 1 maxconn 100 check  ssl verify none
 
-frontend admin-https-0.0.0.0
-        bind 0.0.0.0:1443 ssl no-sslv3 crt /usr/local/pf/conf/ssl/server.pem
+frontend admin-https-all
+        bind :::1443 v4v6 ssl no-sslv3 crt /usr/local/pf/conf/ssl/server.pem
         errorfile 502 /usr/local/pf/html/pfappserver/root/errors/502.json.http
         errorfile 503 /usr/local/pf/html/pfappserver/root/errors/503.json.http
         capture request header Host len 40


### PR DESCRIPTION
# Description
Makes the admin portal listen on IPv6 as well as IPv4.

# Impacts
Makes the admin portal listen on IPv6 as well as IPv4.

# Issue
Fixes #6450.

# Delete branch after merge
YES

# Checklist
- [n/a] Document the feature
- [n/a] Add unit tests
- [n/a] Add acceptance tests (TestLink)

# NEWS file entries
* The admin portal now listens on IPv6 as well as IPv4.

## Enhancements
* The admin portal now listens on IPv6 as well as IPv4.

## Bug Fixes
If an issue exists on Github, please refer to it (name) along with it's number...
* Issue from Gunni about admin panel not working on IPv6 #6450.