### PR TITLE
Add oauth response debug info

### DIFF
--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/OAuth.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/OAuth.pm
@@ -165,6 +165,7 @@ sub handle_callback {
 
     if ($response->is_success) {
         my $info = $self->_decode_response($response); 
+        get_logger->debug( use Data::Dumper; "OAuth2 response: ".Dumper($info));
         my $pid = $self->_extract_username_from_response($info); 
         
         $self->username($pid);

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/OAuth.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/OAuth.pm
@@ -165,7 +165,7 @@ sub handle_callback {
 
     if ($response->is_success) {
         my $info = $self->_decode_response($response); 
-        get_logger->debug( sub { use Data::Dumper; "OAuth2 response: ".Dumper($info)i });
+        get_logger->debug( sub { use Data::Dumper; "OAuth2 response: ".Dumper($info) });
         my $pid = $self->_extract_username_from_response($info); 
         
         $self->username($pid);

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/OAuth.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/OAuth.pm
@@ -165,7 +165,7 @@ sub handle_callback {
 
     if ($response->is_success) {
         my $info = $self->_decode_response($response); 
-        get_logger->debug( use Data::Dumper; "OAuth2 response: ".Dumper($info));
+        get_logger->debug( sub { use Data::Dumper; "OAuth2 response: ".Dumper($info)i });
         my $pid = $self->_extract_username_from_response($info); 
         
         $self->username($pid);


### PR DESCRIPTION
# Description
Add a dump of the full oauth protected resource response to help the user know which OpenID attributes it can use in the fields

The debug shows the following info for a AzureAD account using the `beta` version of the microsoft graph `me` resource:
```
Jul 31 20:12:17 esquiu packetfence_httpd.portal: httpd.portal(842) INFO: [mac:00:11:22:22:11:00] OAuth2 response: $VAR1 = {
          'employeeOrgData' => undef,
          'jobTitle' => undef,
          'department' => 'IT',
          'deletedDateTime' => undef,
          'onPremisesDistinguishedName' => undef,
          'onPremisesSecurityIdentifier' => undef,
          'isManagementRestricted' => undef,
          'onPremisesDomainName' => undef,
          'mailNickname' => 'mediatel',
          'employeeHireDate' => undef,
          'createdDateTime' => '2021-07-01T17:53:35Z',
          'creationType' => undef,
          'mobilePhone' => undef,
          'companyName' => undef,
          'userType' => 'Member',
          'preferredLanguage' => undef,
          'consentProvidedForMinor' => undef,
          'faxNumber' => undef,
          'legalAgeGroupClassification' => undef,
          'passwordProfile' => undef,
          'officeLocation' => undef,
          'deviceKeys' => [],
          'externalUserStateChangeDateTime' => undef,
          'businessPhones' => [],
          'country' => undef,
          'preferredDataLocation' => undef,
          'externalUserState' => undef,
          'onPremisesUserPrincipalName' => undef,
          'showInAddressList' => undef,
          'ageGroup' => undef,
          'postalCode' => undef,
          'employeeType' => undef,
          'onPremisesProvisioningErrors' => [],
          'state' => undef,
          'onPremisesSyncEnabled' => undef,
          'otherMails' => [],
          'infoCatalogs' => [],
          'id' => '<HIDDEN>',
          'employeeId' => undef,
          'identities' => [],
          'surname' => undef,
          'refreshTokensValidFromDateTime' => '2021-07-01T17:53:35Z',
          'streetAddress' => undef,
          'givenName' => 'Mediatel',
          'isResourceAccount' => undef,
          'onPremisesImmutableId' => undef,
          'city' => undef,
          'usageLocation' => 'AR',
          'signInSessionsValidFromDateTime' => '2021-07-01T17:53:35Z',
          'mail' => '<HIDDEN>',
          'displayName' => 'Mediatel',
          '@odata.context' => 'https://graph.microsoft.com/beta/$metadata#users/$entity',
          'onPremisesSamAccountName' => undef,
          'accountEnabled' => bless( do{\(my $o = 1)}, 'JSON::PP::Boolean' ),
          'passwordPolicies' => 'None',
          'onPremisesLastSyncDateTime' => undef,
          'userPrincipalName' => '<HIDDEN>'
        };
```

# Impacts
Minimal, just a debug dump on the OpenId/Oauth2 workflow

# Delete branch after merge
YES 

# Checklist
(REQUIRED) - [yes, no or n/a]
- [n/a] Document the feature
- [n/a] Add unit tests
- [n/a] Add acceptance tests (TestLink)

# NEWS file entries
(REQUIRED, but may be optional...)

## Enhancements
* Debug now shows available Oauth/OpenID attributes and their values (httpd.admin must be set to debug level)

## Bug Fixes
* Used to help troubleshoot #6463 


