### PR TITLE
Monit adjustements related to EL8 and Debian 11

### DIFF
--- a/addons/monit/monit_build_configuration.pl
+++ b/addons/monit/monit_build_configuration.pl
@@ -32,6 +32,7 @@ my %CONFIGURATION_TO_TEMPLATE   = (
 
 my $OS = ( -e "/etc/debian_version" ) ? "debian" : "rhel";
 my $MONIT_PATH  = ( $OS eq "rhel" ) ? "/etc/monit.d" : "/etc/monit/conf.d";
+my $MONIT_EXTRA_PATH = "$MONIT_PATH/packetfence";
 
 
 if ( $#ARGV eq "-1" ) {
@@ -65,6 +66,7 @@ foreach my $configuration ( @configurations ) {
 
 
 print "\nHere it goes!\n";
+mkdir $MONIT_EXTRA_PATH unless -d $MONIT_EXTRA_PATH;
 generate_monit_configurations();
 generate_specific_configurations();
 print "\n\nAll set!\n\n";
@@ -94,7 +96,7 @@ sub generate_monit_configurations {
     $destination_file = catfile($MONIT_PATH, "monit_general" . $CONF_FILE_EXTENSION);
     print "Generating '$destination_file'\n";
     if ( -e $destination_file ) {
-        my $backup_file = $destination_file . $BACKUP_FILE_EXTENSION;
+        my $backup_file = catfile($MONIT_EXTRA_PATH, "monit_general" . $CONF_FILE_EXTENSION . $BACKUP_FILE_EXTENSION);
         move($destination_file, $backup_file);
         print "Generating '$backup_file' (BACKED UP FILE)\n";
     }
@@ -106,7 +108,7 @@ sub generate_monit_configurations {
     $destination_file = "/etc/rsyslog.d/monit.conf";
     print "Generating '$destination_file'\n";
     if ( -e $destination_file ) {
-        my $backup_file = catfile($MONIT_PATH, "syslog_monit" . $CONF_FILE_EXTENSION . $BACKUP_FILE_EXTENSION);
+        my $backup_file = catfile($MONIT_EXTRA_PATH, "syslog_monit" . $CONF_FILE_EXTENSION . $BACKUP_FILE_EXTENSION);
         move($destination_file, $backup_file);
         print "Generating '$backup_file' (BACKED UP FILE)\n";
     }
@@ -137,8 +139,9 @@ sub generate_specific_configurations {
 
         # Backing up existing configuration file (just in case)
         if ( -e $destination_file ) {
-            move($destination_file, $destination_file . $BACKUP_FILE_EXTENSION);
-            print " - $destination_file" . "$BACKUP_FILE_EXTENSION (BACKED UP FILE)\n";
+            my $backup_file = catfile($MONIT_EXTRA_PATH, $CONFIGURATION_TO_TEMPLATE{$configuration} . $CONF_FILE_EXTENSION . $BACKUP_FILE_EXTENSION);
+            move($destination_file, $backup_file);
+            print " - $backup_file (BACKED UP FILE)\n";
         }
 
         # Handling domains (winbind configuration)

--- a/addons/monit/monitoring-scripts/setup.sh
+++ b/addons/monit/monitoring-scripts/setup.sh
@@ -6,13 +6,14 @@ else
   monit_dir="/etc/monit/conf.d"
 fi
 
+export packetfence_monit_dir="$monit_dir/packetfence"
+
 export script_registry_url="http://inverse.ca/downloads/PacketFence/monitoring-scripts/v1/monit-script-registry.txt"
-export script_registry_file="$monit_dir/checks-script-registry"
+export script_registry_file="$packetfence_monit_dir/checks-script-registry"
 export script_dir="/usr/local/pf/var/monitoring-scripts/"
 
 export functions_script="$script_dir/.functions.sh"
-
-export uuid_file="$monit_dir/srv-uuid"
+export uuid_file="$packetfence_monit_dir/srv-uuid"
 
 if ! [ -f "$uuid_file" ]; then
   echo "UUID not generated. Proceeding with UUID generation now."
@@ -21,22 +22,22 @@ fi
 
 export uuid=$(cat $uuid_file)
 export uuid_vars_url="http://inverse.ca/downloads/PacketFence/monitoring-scripts/v1/vars/$uuid.txt"
-export uuid_vars_file="$monit_dir/uuid-vars"
+export uuid_vars_file="$packetfence_monit_dir/uuid-vars"
 
 export global_vars_url="http://inverse.ca/downloads/PacketFence/monitoring-scripts/v1/vars.txt"
-export global_vars_file="$monit_dir/global-vars"
+export global_vars_file="$packetfence_monit_dir/global-vars"
 
-export local_vars_file="$monit_dir/local-vars"
+export local_vars_file="$packetfence_monit_dir/local-vars"
 
 export uuid_ignores_url="http://inverse.ca/downloads/PacketFence/monitoring-scripts/v1/ignores/$uuid.txt"
-export uuid_ignores_file="$monit_dir/uuid-ignores"
+export uuid_ignores_file="$packetfence_monit_dir/uuid-ignores"
 
 export global_ignores_url="http://inverse.ca/downloads/PacketFence/monitoring-scripts/v1/ignores.txt"
-export global_ignores_file="$monit_dir/global-ignores"
+export global_ignores_file="$packetfence_monit_dir/global-ignores"
 
-export local_ignores_file="$monit_dir/local-ignores"
+export local_ignores_file="$packetfence_monit_dir/local-ignores"
 
-export combined_vars_file="$monit_dir/vars"
+export combined_vars_file="$packetfence_monit_dir/vars"
 
 function is_ignored {
   touch "$global_ignores_file"

--- a/addons/monit/monitoring-scripts/setup.sh
+++ b/addons/monit/monitoring-scripts/setup.sh
@@ -10,7 +10,7 @@ export packetfence_monit_dir="$monit_dir/packetfence"
 
 export script_registry_url="http://inverse.ca/downloads/PacketFence/monitoring-scripts/v1/monit-script-registry.txt"
 export script_registry_file="$packetfence_monit_dir/checks-script-registry"
-export script_dir="/usr/local/pf/var/monitoring-scripts/"
+export script_dir="/usr/local/pf/var/monitoring-scripts"
 
 export functions_script="$script_dir/.functions.sh"
 export uuid_file="$packetfence_monit_dir/srv-uuid"

--- a/addons/monit/monitoring-scripts/update.sh
+++ b/addons/monit/monitoring-scripts/update.sh
@@ -47,7 +47,7 @@ function execute_and_check {
 
 dir="/tmp/pf-auto-check-update" && mkdir -p $dir && cd $dir && rm -fr *
 
-id -u pf-monitoring || execute_and_check "useradd pf-monitoring"
+id -u pf-monitoring || execute_and_check "useradd pf-monitoring -s /bin/bash"
 execute_and_check "usermod -a -G pf pf-monitoring"
 
 execute_and_check "mkdir -p $script_dir"

--- a/docs/installation/additional_integration.asciidoc
+++ b/docs/installation/additional_integration.asciidoc
@@ -468,7 +468,9 @@ Put full paths of checks in `$MONIT_PATH/packetfence/local-ignores`
 
 ==== Run some checks as root
 
-If you want to run checks as root, you need to add following content in `$MONIT_PATH/packetfence/local-vars`:
+Some scripts need to run as root but are disabled by default. If you want to
+run these checks, you need to add following content in
+[filename]`$MONIT_PATH/packetfence/local-vars`:
 
 ----
 export RUN_ROOT_SCRIPTS=1

--- a/docs/installation/additional_integration.asciidoc
+++ b/docs/installation/additional_integration.asciidoc
@@ -353,45 +353,47 @@ Logs will be kept on PacketFence **and** sent to your remote Syslog server.
 
 For further reference the monit documentation is available at: https://mmonit.com/monit/documentation/monit.html
 
+Monit configuration path is different between EL and Debian systems:
+
+* [filename]`MONIT_PATH=/etc/monit.d` for EL-based systems
+* [filename]`MONIT_PATH=/etc/monit/conf.d` for Debian-based systems
+
+To simplify further documentation, we will use `$MONIT_PATH` variable as a reference to these paths.
+
 ==== Install Monit
 
 The following must be done on each server of a cluster
 
-RHEL / CentOS
-
+.RHEL / CentOS
+[source,bash]
 ----
-yum install monit --enablerepo=packetfence-extra -y
+yum install monit uuid --enablerepo=packetfence -y
 ----
 
-Debian
-
+.Debian
+[source,bash]
 ----
 apt-get update
-apt-get install monit
+apt-get install monit uuid-runtime
 ----
 
+===== Enable httpd interface (Debian-based systems only)
+
+In order to use `monit summary` command, you need to enable `httpd` interface. Simply uncomment following section in [filename]`/etc/monit/monitrc`:
+
+----
+set httpd port 2812 and
+    use address localhost  # only accept connection from localhost (drop if you use M/Monit)
+    allow localhost        # allow localhost to connect to the server and
+    allow admin:monit
+----
 
 ==== Fetch the script signing key
 
+[source,bash]
 ----
 gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys E3A28334
 ----
-
-
-==== Download the Packetfence monit addons
-
-The monit addons are included with Packetfence at `/usr/local/pf/addons/monit`. This step is only needed if you want to upgrade the scripts to the latest version without having to upgrade Packetfence. This means that you can have unexpected behaviors due to difference between PacketFence configuration and monit checks.
-
-----
-cd /tmp/ && wget http://inverse.ca/downloads/PacketFence/monitoring-scripts/v1/monit.tgz && tar xzvf monit.tgz
-----
-
-Replace the monit addons directory
-
-----
-mv /usr/local/pf/addons/monit /usr/local/pf/addons/monit.old ; mv /tmp/monit /usr/local/pf/addons/
-----
-
 
 ==== Generate/Regenerate the monit configuration
 
@@ -414,49 +416,16 @@ Where :
 
 CAUTION: A MTA is needed to correctly relay emails from monit. If _localhost_ is used as `mailserver`, make sure that a MTA is installed and configured on the server. 
 
-NOTE: This command will create configuration scripts in `/etc/monit.d/`, but it will not remove old(er) scripts from an earlier installation. During an upgrade any unused `/etc/monit.d/*.conf` files will be renamed to [filename]`/etc/monit.d/*.conf.bak`.
+NOTE: This command will create configuration scripts in [filename]`$MONIT_PATH` and will move old(er) configuration into `$MONIT_PATH/packetfence`. During an upgrade any unused `$MONIT_PATH/*.conf` files will be renamed to [filename]`$MONIT_PATH/packetfence/*.conf.bak`.
 
 If you don't use Fingerbank, you will need to remove `packetfence-fingerbank-collector` check. 
-
-==== Include the generated configurations in the monit config
-
-At the bottom of `/etc/monit.conf` add the line `include /etc/monit.d/*.conf` either manually, or using `sed`:
-
-
-RHEL / CentOS
-
-----
-sed -i -e 's/^include.*//g' /etc/monit.conf && echo "include /etc/monit.d/*.conf" >> /etc/monit.conf
-----
-
-Debian
-
-----
-sed -i -e 's/include.*\*$//g' /etc/monit/monitrc && echo "include /etc/monit/conf.d/*.conf" >> /etc/monit/monitrc
-----
-
-==== Remove the old monit script
-
-This step is only required during an upgrade from earlier versions.
-----
-rm /etc/monit.d/packetfence.monit
-----
 
 ==== Run the monitoring script update to fetch the scripts and config
 
 This script will download **latest** shell scripts run by monit checks.
 
-RHEL / CentOS
-
+[source,bash]
 ----
-yum install uuid -y
-/usr/local/pf/addons/monit/monitoring-scripts/update.sh
-----
-
-Debian
-
-----
-apt-get install uuid-runtime
 /usr/local/pf/addons/monit/monitoring-scripts/update.sh
 ----
 
@@ -465,12 +434,14 @@ Ensure the script outputs: `Update completed successfully`
 
 ==== Ensure the pf group can write the logs
 
+[source,bash]
 ----
 chmod g+w /usr/local/pf/logs/*
 ----
 
 ==== Run the monitoring scripts
 
+[source,bash]
 ----
 /usr/local/pf/addons/monit/monitoring-scripts/run-all.sh
 ----
@@ -493,18 +464,28 @@ with (a hyphen):
 
 ==== Ignore some checks
 
-Put full paths of checks in `/etc/monit.d/local-ignores`
+Put full paths of checks in `$MONIT_PATH/packetfence/local-ignores`
+
+==== Run some checks as root
+
+If you want to run checks as root, you need to add following content in `$MONIT_PATH/packetfence/local-vars`:
+
+----
+export RUN_ROOT_SCRIPTS=1
+----
 
 ==== Enable and start monit
 
 Enable monit on startup
 
+[source,bash]
 ----
 systemctl enable monit
 ----
 
 Start monit
 
+[source,bash]
 ----
 systemctl restart monit
 ----
@@ -513,20 +494,21 @@ systemctl restart monit
 
 A MTA is needed to correctly relay emails from monit. If _localhost_ is used as smtpserver, make sure that a MTA is installed and configured on the server. 
 
-RHEL / CentOS
-
+.RHEL / CentOS
+[source,bash]
 ----
 yum install mailx -y
 ----
 
-Debian
-
+.Debian
+[source,bash]
 ----
 apt-get install heirloom-mailx
 ----
 
 ==== Test the MTA
 
+[source,bash]
 ----
 echo `hostname` | mail -s "Monit test" user@example.com
 ----
@@ -536,18 +518,11 @@ echo `hostname` | mail -s "Monit test" user@example.com
 
 View the monit summary to ensure all services are status `Running`, `Accessible`, or `Status ok`. Address any services that display any other failed status. Monit will display the services in the same order that they are processed. If the summary appears stuck, troubleshoot the next service in the list.
 
+[source,bash]
 ----
 monit summary
 ----
 
-NOTE: `patch` updates only once a week. It is normal to see status `Waiting`.
-
 TIP: More information on the monit command line arguments is available at https://mmonit.com/monit/documentation/monit.html
 
-
-==== packetfence-etcd
-
-This step is only needed if `monit summary` is stuck `Waiting` on `packetfence-etcd`. This error indicates that the cluster is currently in 'Failure during bootstrapping'. Please follow the instructions in the PacketFence Clustering Guide on how to resolve this. 
-
-TIP: More information on `etcd` failures can be found at https://github.com/coreos/etcd/blob/master/Documentation/op-guide/failures.md
 


### PR DESCRIPTION
# Description
* Use Monit version 5.26 (EL8) and 5.27 (Debian 11)

# Impacts
Monit integration

# Code / PR Dependencies
- https://github.com/inverse-inc/packetfence-monitoring-scripts/pull/36

# Delete branch after merge
YES

# NEWS file entries
## Enhancements
* Use new Monit version
