### PR TITLE
don't write extra GATEWAY= in /etc/sysconfig/network

### DIFF
--- a/html/pfappserver/lib/pfappserver/Model/Config/System.pm
+++ b/html/pfappserver/lib/pfappserver/Model/Config/System.pm
@@ -341,17 +341,16 @@ sub writeNetworkConfigs {
     my $logger = get_logger();
 
     my $status_msg;
-    my $default_interface = (split(" ", `LANG=C sudo ip route show to 0/0`))[4];
-    my $defroute ="no";
+    my $interface_gateway;
+    my $interface_defroute ="no";
     while (my ($interface, $interface_values) = each %$interfaces_ref) {
         next if ( !$interface_values->{is_running} );
-        if ($default_interface eq $interface) {
-            $defroute = "yes";
-            my $default_gateway = (split(" ", `LANG=C sudo ip route show to 0/0`))[2];
-            $gateway = "GATEWAY=".$default_gateway;
+        if ($gateway_interface eq $interface) {
+            $interface_defroute = "yes";
+            $interface_gateway = $gateway;
         } else {
-            $defroute = "no";
-            $gateway = "";
+            $interface_defroute = "no";
+            $interface_gateway = undef;
         }
         my %vars = (
             logical_name => $interface,
@@ -361,8 +360,8 @@ sub writeNetworkConfigs {
             netmask      => $interface_values->{'netmask'},
             ipv6_address => $interface_values->{'ipv6_address'},
             ipv6_prefix  => $interface_values->{'ipv6_prefix'},
-            defroute     => $defroute,
-            gateway      => $gateway,
+            defroute     => $interface_defroute,
+            gateway      => $interface_gateway,
         );
 
         my $template = Template->new({

--- a/html/pfappserver/root/interface/interface_rhel.tt
+++ b/html/pfappserver/root/interface/interface_rhel.tt
@@ -5,7 +5,9 @@ BOOTPROTO=static
 IPADDR=[% ipaddr %]
 NETMASK=[% netmask %]
 DEFROUTE=[% defroute %]
-[% gateway %]
+[% IF gateway -%]
+GATEWAY=[% gateway %]
+[% END -%]
 [% IF ipv6_address -%]
 IPV6INIT=yes
 IPV6ADDR=[% ipv6_address %]/[% ipv6_prefix %]


### PR DESCRIPTION
# Description
- Remove additionnal `GATEWAY` added in `/etc/sysconfig/network`
- Don't recompute gateway using new commands
- Write GATEWAY when necessary in `/etc/sysconfig/network-scripts`

# Impacts
Gateway and interfaces configuration on EL8

# Issue
fixes #6508
Related to d5742d3c794a460abab45c1bf8e4516cf1f065be and #6466 

# Delete branch after merge
YES
