### PR TITLE
fix/4987

### DIFF
--- a/lib/pf/dal/node.pm
+++ b/lib/pf/dal/node.pm
@@ -110,6 +110,13 @@ sub after_create_hook {
         return;
     }
 
+    $self->_trigger_node_discovered();
+    return ;
+}
+
+
+sub _trigger_node_discovered {
+    my ($self) = @_;
     my $apiclient = pf::api::queue->new(queue => 'general');
     eval {
         $apiclient->notify_delayed($NODE_DISCOVERED_TRIGGER_DELAY, "trigger_security_event", mac => $self->{mac}, type => "internal", tid => "node_discovered");
@@ -117,7 +124,6 @@ sub after_create_hook {
     if ($@) {
         $self->logger->error("Error submitting to the queue: $@");
     }
-    return ;
 }
 
 =head2 _update_category_ids

--- a/lib/pf/dal/node.pm
+++ b/lib/pf/dal/node.pm
@@ -48,6 +48,7 @@ BEGIN {
     );
 }
 
+our $TRIGGER_NODE_DISCOVERED = undef;
 use Class::XSAccessor {
     accessors => \@CATEGORY_ACCESSORS,
 # The getters for current location log entries
@@ -104,6 +105,9 @@ sub after_create_hook {
     my ($self) = @_;
     for my $a (@CATEGORY_ACCESSORS) {
         $self->$a(undef);    
+    }
+    if (!$TRIGGER_NODE_DISCOVERED) {
+        return;
     }
 
     my $apiclient = pf::api::queue->new(queue => 'general');

--- a/lib/pf/dhcp/processor_v4.pm
+++ b/lib/pf/dhcp/processor_v4.pm
@@ -240,6 +240,7 @@ Process a packet
 
 sub process_packet {
     my $timer = pf::StatsD::Timer->new();
+    local $pf::dal::node::TRIGGER_NODE_DISCOVERED = 1;
     my ( $self ) = @_;
     if (db_check_readonly()) {
         $logger->trace("The database is in readonly mode skipping processing the database");

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -111,6 +111,7 @@ See http://search.cpan.org/~byrne/SOAP-Lite/lib/SOAP/Lite.pm#IN/OUT,_OUT_PARAMET
 sub authorize {
     my $timer = pf::StatsD::Timer->new();
     my ($self, $radius_request) = @_;
+    local $pf::dal::node::TRIGGER_NODE_DISCOVERED = 1;
     my $logger = $self->logger;
     my ($do_auto_reg, %autoreg_node_defaults, $action);
 
@@ -392,6 +393,7 @@ sub accounting {
     my $timer = pf::StatsD::Timer->new();
     my ($self, $radius_request, $headers) = @_;
     my $logger = $self->logger;
+    local $pf::dal::node::TRIGGER_NODE_DISCOVERED = 1;
 
     my ( $switch_mac, $switch_ip, $source_ip, $stripped_user_name, $realm ) = $self->_parseRequest($radius_request);
 

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -393,7 +393,6 @@ sub accounting {
     my $timer = pf::StatsD::Timer->new();
     my ($self, $radius_request, $headers) = @_;
     my $logger = $self->logger;
-    local $pf::dal::node::TRIGGER_NODE_DISCOVERED = 1;
 
     my ( $switch_mac, $switch_ip, $source_ip, $stripped_user_name, $realm ) = $self->_parseRequest($radius_request);
 

--- a/t/unittest/node.t
+++ b/t/unittest/node.t
@@ -23,13 +23,38 @@ BEGIN {
 }
 
 use pf::node;
+use pf::constants::node qw($NODE_DISCOVERED_TRIGGER_DELAY);
 use pf::locationlog;
+use pf::security_event qw(security_event_view_last_closed);
 use Utils;
 use pf::constants::config qw($WIRELESS_802_1X);
-use Test::More tests => 17;
+use Test::More tests => 21;
 
 #This test will running last
 use Test::NoWarnings;
+
+{
+    no warnings qw(redefine);
+    local $pf::dal::node::TRIGGER_NODE_DISCOVERED = 1;
+    our $triggered = 0;
+    local *pf::dal::node::_trigger_node_discovered = sub {
+        $triggered = 1;
+    };
+    my $mac = Utils::test_mac();
+    ok (node_add_simple($mac), "$mac added");
+    ok ($triggered, "node discovered triggered for $mac");
+}
+
+{
+    no warnings qw(redefine);
+    our $triggered = 0;
+    local *pf::dal::node::_trigger_node_discovered = sub {
+        $triggered = 1;
+    };
+    my $mac = Utils::test_mac();
+    ok (node_add_simple($mac), "$mac added");
+    ok (!$triggered, "node discovered not triggered for $mac");
+}
 
 is ("reg",pf::node::_cleanup_status_value("reg"),"Expecting reg");
 


### PR DESCRIPTION
# Description
Only trigger the node discover security event in the context of radius and pfdhcplistener 

# Impacts
RADIUS / pfdhcplistener workflow

# Issue
fixes #4987

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [x ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
## Bug Fixes
* Only trigger the node discover security event in the context of radius and pfdhcplistener (#4987)
