### PR TITLE
multiple fixes to LDAP EAP-TTLS PAP

### DIFF
--- a/conf/radiusd/packetfence-tunnel.example
+++ b/conf/radiusd/packetfence-tunnel.example
@@ -111,8 +111,6 @@ authorize {
 
 [% authorize_ldap_choice %]
 
-	oauth2
-
 	#
 	#  Read the 'users' file
 	#files

--- a/lib/pf/services/manager/radiusd_child.pm
+++ b/lib/pf/services/manager/radiusd_child.pm
@@ -804,12 +804,12 @@ $edir_options
 EOT
 
         my $client_auth = "";
-	if($ConfigAuthenticationLdap{$ldap}{client_cert_file} && $ConfigAuthenticationLdap{$ldap}{client_key_file}) {
+        if($ConfigAuthenticationLdap{$ldap}{client_cert_file} && $ConfigAuthenticationLdap{$ldap}{client_key_file}) {
             $client_auth = <<"EOT";
-       certificate_file = $ConfigAuthenticationLdap{$ldap}{client_cert_file}
-       private_key_file = $ConfigAuthenticationLdap{$ldap}{client_key_file}
+        certificate_file = $ConfigAuthenticationLdap{$ldap}{client_cert_file}
+        private_key_file = $ConfigAuthenticationLdap{$ldap}{client_key_file}
 EOT
-	}
+        }
 
         if ($ConfigAuthenticationLdap{$ldap}->{encryption} eq "ssl") {
             $tags{'servers'} .= <<"EOT";
@@ -1422,7 +1422,7 @@ sub generate_ldap_choice {
             $choice = $pf::config::ConfigRealm{$key}->{'regex'} if (defined $pf::config::ConfigRealm{$key}->{'regex'} && $pf::config::ConfigRealm{$key}->{'regex'} ne '');
             $$authorize_ldap_choice .= <<"EOT";
         $oauth2_if (Realm =~ /$choice/) {
-		oauth2
+            oauth2
         }
 EOT
             $oauth2_if = 'elsif';

--- a/lib/pf/services/manager/radiusd_child.pm
+++ b/lib/pf/services/manager/radiusd_child.pm
@@ -731,7 +731,10 @@ sub generate_radiusd_ldap {
     foreach my $ldap (keys %ConfigAuthenticationLdap) {
         my $active = $FALSE;
         foreach my $realm ( @pf::config::ConfigOrderedRealm ) {
-            if (defined($pf::config::ConfigRealm{$realm}->{ldap_source_ttls_pap}) && ($pf::config::ConfigRealm{$realm}->{ldap_source_ttls_pap} eq $ldap) ) {
+            if (defined($pf::config::ConfigRealm{$realm}->{ldap_source}) && ($pf::config::ConfigRealm{$realm}->{ldap_source} eq $ldap) ) {
+                $active = $TRUE;
+            }
+            elsif (defined($pf::config::ConfigRealm{$realm}->{ldap_source_ttls_pap}) && ($pf::config::ConfigRealm{$realm}->{ldap_source_ttls_pap} eq $ldap) ) {
                 $active = $TRUE;
             }
         }

--- a/lib/pfconfig/namespaces/resource/authentication_sources_ldap.pm
+++ b/lib/pfconfig/namespaces/resource/authentication_sources_ldap.pm
@@ -27,7 +27,7 @@ sub build {
     my ($self) = @_;
     my %hash;
     while ( my ($id, $data) = each %{$self->{_authentication_config}->{authentication_config_hash}}) {
-        next unless $data->{'type'} eq "AD" or $data->{'type'} eq "LDAP" or $data->{'type'} eq "EDIR";
+        next unless $data->{'type'} eq "AD" or $data->{'type'} eq "LDAP" or $data->{'type'} eq "EDIR" or $data->{'type'} eq "GoogleWorkspaceLDAP";
         $hash{$id} = $data;
     }
     return \%hash;


### PR DESCRIPTION
# Description
A bunch of fixes for EAP TTLS PAP (see news below)

# Impacts
All of EAP-TTLS PAP

# Issue
fixes #6571
starts addressing #6570 

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* Match the realm more strictly when its not a regex in EAP-TTLS PAP
* Populate the LDAP config for enabled LDAP EAP-TTLS PAP realms
* Only call oauth2 in authorize for the realms that have an Azure AD EAP-TTLS PAP configuration
* Use source username in LDAP module for EAP-TTLS PAP instead of always using sAMAccoutName
* Support LDAP certificate client auth for LDAP EAP-TTLS PAP authentication
* Allow to use Google Workspace LDAP sources in EAP-TTLS PAP authentication
