### PR TITLE
Allow to use the sAMAccountName from the searchattributes in MSCHAP machine authentication

### DIFF
--- a/conf/radiusd/mschap.conf.example
+++ b/conf/radiusd/mschap.conf.example
@@ -386,7 +386,7 @@ mschap chrooted_mschap_machine {
 
         require_strong = yes
         ntlm_auth = "/usr/bin/sudo /usr/sbin/chroot /chroots/%{PacketFence-Domain} /usr/local/pf/bin/ntlm_auth_wrapper -p %%statsd_port%% -- \
-             --request-nt-key --username=%{mschap:User-Name:-None} --challenge=%{mschap:Challenge:-00} --nt-response=%{mschap:NT-Response:-00} %{PacketFence-NTLMv2-Only}"
+             --request-nt-key --username=%{%{control:AD-Samaccountname}:-%{mschap:User-Name:-None}} --challenge=%{mschap:Challenge:-00} --nt-response=%{mschap:NT-Response:-00} %{PacketFence-NTLMv2-Only}"
 
 
         allow_retry = no
@@ -399,7 +399,7 @@ mschap mschap_machine {
         require_encryption = yes
         require_strong = yes
         ntlm_auth = "/usr/local/pf/bin/ntlm_auth_wrapper -p %%statsd_port%% -- \
-             --request-nt-key --username=%{mschap:User-Name:-None} --challenge=%{mschap:Challenge:-00} --nt-response=%{mschap:NT-Response:-00} %{PacketFence-NTLMv2-Only}"
+             --request-nt-key --username=%{%{control:AD-Samaccountname}:-%{mschap:User-Name:-None}} --challenge=%{mschap:Challenge:-00} --nt-response=%{mschap:NT-Response:-00} %{PacketFence-NTLMv2-Only}"
         allow_retry = no
 	ntlm_auth_timeout = 3
 }


### PR DESCRIPTION
# Description
Allow to use the sAMAccountName from the searchattributes in MSCHAP machine authentication

# Impacts
802.1x EAP PEAP MSCHAPv2 machine auth

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [n/a] Document the feature
- [n/a] Add unit tests
- [n/a] Add acceptance tests (TestLink)

# NEWS file entries
## Enhancements
* Allow to use the sAMAccountName from the searchattributes in MSCHAP machine authentication
