### PR TITLE
Change behavior pf::condition::not_equal to always succeed when match value is undef

### DIFF
--- a/t/unittest/condition/not_equal.t
+++ b/t/unittest/condition/not_equal.t
@@ -1,46 +1,37 @@
-package pf::condition::not_equals;
+#!/usr/bin/perl
+
 =head1 NAME
 
-pf::condition::not_equals
+Tests for pf::condition::not_equals
 
 =cut
 
 =head1 DESCRIPTION
 
-pf::condition::not_equals
+Tests for pf::condition::not_equals
 
 =cut
 
 use strict;
 use warnings;
-use Moose;
-extends qw(pf::condition);
-use pf::constants;
 
-=head2 value
-
-The value to compare against
-
-=cut
-
-has value => (
-    is => 'ro',
-    required => 1,
-    isa  => 'Str',
-);
-
-=head2 match
-
-Match if the argument if not equal to the value
-
-=cut
-
-sub match {
-    my ($self,$arg,$args) = @_;
-    return $TRUE if(!defined($arg));
-    my $value = $self->evalParam($self->value, $args);
-    return $arg ne $value;
+BEGIN {
+    use lib qw(/usr/local/pf/t);
+    use setup_test_config;
 }
+
+use Test::More tests => 4;                      # last test to print
+
+use Test::NoWarnings;
+use pf::condition::not_equals;
+
+my $filter = pf::condition::not_equals->new(value => "test");
+
+ok(!$filter->match('test'), "test does not match");
+
+ok($filter->match('wrong_test'),"wrong_test matches");
+
+ok($filter->match(undef), "undef matches");
 
 =head1 AUTHOR
 
@@ -70,4 +61,5 @@ USA.
 =cut
 
 1;
+
 


### PR DESCRIPTION
# Description

Change behavior of ```pf::condition::not_equal``` to always succeed when match value is undef.

# Delete branch after merging
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ ] Document the feature
- [x] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* Change the behavior of ```pf::condition::not_equal``` to always succeed when match value is undef.

# UPGRADE file entries
If any condition for filters (VLAN, RADIUS, Switch, DNS, DHCP, and Profile) uses a ```not equals`` operator.
Check if the logic is still ok if the value is null/undef.

If the filter needs to ensure that the value is defined you would need to add an additional defined condition to that filter.
