### PR TITLE
Fixes for #6588

### DIFF
--- a/go/cmd/galera-autofix/main.go
+++ b/go/cmd/galera-autofix/main.go
@@ -90,8 +90,8 @@ func seqnoReporting(ctx context.Context) {
 	servers := pfconfigdriver.AllClusterServers{}
 	for {
 		seqno := mariadb.DefaultSeqno
-		if mariadb.IsLocalDBAvailable(ctx) {
-			seqno = getRecordLiveSeqno(ctx)
+		if liveSeqNo := mariadb.GetLiveSeqNo(ctx); liveSeqNo != DefaultSeqno {
+			seqno = liveSeqNo
 		} else {
 			var err error
 			seqno, err = mariadb.GetColdSeqno(ctx)

--- a/go/cmd/galera-autofix/main.go
+++ b/go/cmd/galera-autofix/main.go
@@ -90,7 +90,7 @@ func seqnoReporting(ctx context.Context) {
 	servers := pfconfigdriver.AllClusterServers{}
 	for {
 		seqno := mariadb.DefaultSeqno
-		if liveSeqNo := mariadb.GetLiveSeqNo(ctx); liveSeqNo != DefaultSeqno {
+		if liveSeqNo := mariadb.GetLocalLiveSeqno(ctx); liveSeqNo != mariadb.DefaultSeqno {
 			seqno = liveSeqNo
 		} else {
 			var err error

--- a/go/cmd/galera-autofix/main.go
+++ b/go/cmd/galera-autofix/main.go
@@ -87,14 +87,11 @@ func seqnoReporting(ctx context.Context) {
 		if liveSeqno := mariadb.GetLocalLiveSeqno(ctx); liveSeqno != mariadb.DefaultSeqno {
 			recordLiveSeqno(ctx, liveSeqno)
 			seqno = liveSeqno
+		} else if coldSeqno, err := mariadb.GetColdSeqno(ctx); err == nil {
+			seqno = coldSeqno
 		} else {
-			var err error
-			seqno, err = mariadb.GetColdSeqno(ctx)
-			if err != nil {
-				log.LoggerWContext(ctx).Error("Unable to obtain sequence number")
-				time.Sleep(seqnoReportingInterval)
-				continue
-			}
+			log.LoggerWContext(ctx).Warn("This server doesn't have a seqno. Will report the inexistant seqno. This node will have no chance to be the one running the latest data.")
+			seqno = mariadb.InexistantSeqno
 		}
 
 		pfconfigdriver.FetchDecodeSocketCache(ctx, &servers)

--- a/go/cmd/galera-autofix/main.go
+++ b/go/cmd/galera-autofix/main.go
@@ -265,7 +265,9 @@ func bootAndRejoinCluster(ctx context.Context, node *Node) {
 }
 
 func bootNewCluster(ctx context.Context) {
-	if mariadb.IsActive(ctx) {
+	if mariadb.IsLocalDBAvailable(ctx) {
+		log.LoggerWContext(ctx).Warn("The DB is now available, not booting a new cluster from this node")
+	} else if mariadb.IsActive(ctx) {
 		mariadb.ForceStop(ctx)
 		mariadb.StartNewCluster(ctx)
 	} else {

--- a/go/galeraautofix/mariadb/mariadb.go
+++ b/go/galeraautofix/mariadb/mariadb.go
@@ -18,6 +18,7 @@ import (
 
 const RunningSeqno = -1
 const DefaultSeqno = -2
+const InexistantSeqno = -3
 
 const GaleraAutofixSeqnoFile = "/var/lib/mysql/galera-autofix-seqno.dat"
 


### PR DESCRIPTION
# Description
Fixes for #6588

# Impacts
Galera autofix

# Issue
fixes #6588 

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* Ensure galera-autofix can report sequence numbers when the DB is online in non-primary
* Have galera-autofix do a last minute check for the DB being online before booting in new cluster mode

