### PR TITLE
Fix find-extra-files bug

### DIFF
--- a/addons/full-import/find-extra-files.pl
+++ b/addons/full-import/find-extra-files.pl
@@ -60,5 +60,5 @@ for my $file (@pf::file_paths::stored_config_files) {
 
 for my $file (@extra_files_to_export) {
     next unless -f $file;
-    print $file . '\n';
+    print $file . "\n";
 }


### PR DESCRIPTION
# Description
Single quote in \n causing error in PF configuration export

<img width="1360" alt="image" src="https://user-images.githubusercontent.com/6945439/134225869-27c0ba33-be9f-46a3-a408-0bf55687bd08.png">

# Delete branch after merge
YES 

## Bug Fixes
Corrected the script using double quotes in the file /usr/local/pf/addons/full-import/find-extra-files.pl

