### PR TITLE
Be more precise in auth match when finding access for CLI login

### DIFF
--- a/lib/pf/authentication.pm
+++ b/lib/pf/authentication.pm
@@ -408,6 +408,8 @@ sub match2 {
         $params->{'rule_class'} = pf::Authentication::Rule->meta->get_attribute('class')->default;
         $logger->warn("Calling match with empty/invalid rule class. Defaulting to '" . $params->{'rule_class'} . "'");
     }
+    
+    my $desired_action = delete $params->{action};
 
     #TODO: evaluate if we want to die or have another behavior
     my $context = $params->{'context'} // die "No authentication context provided";
@@ -425,7 +427,7 @@ sub match2 {
     $logger->info("Using sources ".join(', ', (map {$_->id} @sources))." for matching");
 
     foreach my $source (@sources) {
-        my ($rule, $ignored_action, $matched) = $source->match($params, undef, $extra);
+        my ($rule, $ignored_action, $matched) = $source->match($params, $desired_action, $extra);
         next unless defined $rule;
         my %values;
         $actions = $rule->{actions};

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -984,6 +984,7 @@ sub returnRadiusCli{
 
     $merged->{'rule_class'} = $Rules::ADMIN;
     $merged->{'context'} = $pf::constants::realm::RADIUS_CONTEXT;
+    $merged->{'action'} = $Actions::SET_ACCESS_LEVEL;
     $matched = pf::authentication::match2($source_id, $merged, $extra, \$attributes);
     my $value = $matched->{values}{$Actions::SET_ACCESS_LEVEL} if $matched;
     if ($value) {


### PR DESCRIPTION
# Description
Be more precise in auth match when finding access for CLI login

# Impacts
CLI login

# Issue
fixes #6349 

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* Ignore 'Mark as sponsor' administration rules when finding the access level of a VPN/CLI user (#6349)

