### PR TITLE
cleanup Meraki::MR_v2 module so its on par with Cisco::WLC

### DIFF
--- a/lib/pf/Switch/Meraki/MR_v2.pm
+++ b/lib/pf/Switch/Meraki/MR_v2.pm
@@ -16,6 +16,11 @@ Developed and tested on a MR12 access point
 
 use strict;
 use warnings;
+use Try::Tiny;
+use pf::constants;
+use pf::util;
+use pf::node;
+use pf::util::radius qw(perform_coa perform_disconnect);
 
 use base ('pf::Switch::Cisco::WLC');
 
@@ -46,6 +51,147 @@ sub addDPSK {
             $radius_reply_ref->{'Tunnel-Password'} = $args->{profile}->{_default_psk_key};
         }
     }
+}
+
+=item deauthenticateMacDefault
+
+Some of the attributes from Cisco::WLC aren't necessary
+
+=cut
+
+sub deauthenticateMacDefault {
+    my ( $self, $mac, $is_dot1x ) = @_;
+    my $logger = $self->logger;
+
+    if ( !$self->isProductionMode() ) {
+        $logger->info("not in production mode... we won't perform deauthentication");
+        return 1;
+    }
+
+    $logger->debug("deauthenticate $mac using RADIUS Disconnect-Request deauth method");
+    # TODO push Login-User => 1 (RFC2865) in pf::radius::constants if someone ever reads this
+    # (not done because it doesn't exist in current branch)
+    return $self->radiusDisconnect( $mac, );
+}
+
+=item radiusDisconnect
+
+Sends a RADIUS Disconnect-Request to the NAS with the MAC as the Calling-Station-Id to disconnect.
+
+Optionally you can provide other attributes as an hashref.
+
+Uses L<pf::util::radius> for the low-level RADIUS stuff.
+
+=cut
+
+sub radiusDisconnect {
+    my ($self, $mac, $add_attributes_ref) = @_;
+    my $logger = $self->logger;
+
+    # initialize
+    $add_attributes_ref = {} if (!defined($add_attributes_ref));
+
+    if (!defined($self->{'_radiusSecret'})) {
+        $logger->warn(
+            "Unable to perform RADIUS CoA-Request on (".$self->{'_id'}."): RADIUS Shared Secret not configured"
+        );
+        return;
+    }
+
+    $logger->info("deauthenticating");
+
+    # Where should we send the RADIUS CoA-Request?
+    # to network device by default
+    my $send_disconnect_to = $self->{'_ip'};
+    # but if controllerIp is set, we send there
+    if (defined($self->{'_controllerIp'}) && $self->{'_controllerIp'} ne '') {
+        $logger->info("controllerIp is set, we will use controller $self->{_controllerIp} to perform deauth");
+        $send_disconnect_to = $self->{'_controllerIp'};
+    }
+    # On which port we have to send the CoA-Request ?
+    my $nas_port = $self->{'_disconnectPort'} || '3799';
+    my $coa_port = $self->{'_coaPort'} || '1700';
+    # allowing client code to override where we connect with NAS-IP-Address
+    $send_disconnect_to = $add_attributes_ref->{'NAS-IP-Address'}
+        if (defined($add_attributes_ref->{'NAS-IP-Address'}));
+
+    my $response;
+    try {
+        my $connection_info = {
+            nas_ip => $send_disconnect_to,
+            secret => $self->{'_radiusSecret'},
+            LocalAddr => $self->deauth_source_ip($send_disconnect_to),
+            nas_port => $coa_port,
+        };
+
+        $logger->debug("network device (".$self->{'_id'}.") supports roles. Evaluating role to be returned");
+        my $roleResolver = pf::roles::custom->instance();
+        my $role = $roleResolver->getRoleForNode($mac, $self);
+
+        my $node_info = node_view($mac);
+        # transforming MAC to the expected format 00-11-22-33-CA-FE
+        $mac = uc($mac);
+        $mac =~ s/:/-/g;
+        # Standard Attributes
+
+        my $attributes_ref = {
+            'Calling-Station-Id' => $mac,
+            'NAS-IP-Address' => $send_disconnect_to,
+        };
+
+        # merging additional attributes provided by caller to the standard attributes
+        $attributes_ref = { %$attributes_ref, %$add_attributes_ref };
+
+        # Roles are configured and the user should have one.
+        # We send a regular disconnect if there is an open trapping security_event
+        # to ensure the VLAN is actually changed to the isolation VLAN.
+        if ( $self->shouldUseCoA({role => $role}) ) {
+            $logger->info("Returning ACCEPT with Role: $role");
+
+            my $vsa = [
+                {
+                vendor => "Cisco",
+                attribute => "Cisco-AVPair",
+                value => "audit-session-id=$node_info->{'sessionid'}",
+                },
+                {
+                vendor => "Cisco",
+                attribute => "Cisco-AVPair",
+                value => "subscriber:command=reauthenticate",
+                },
+                {
+                vendor => "Cisco",
+                attribute => "Cisco-AVPair",
+                value => "subscriber:reauthenticate-type=last",
+                }
+            ];
+            $response = perform_coa($connection_info, $attributes_ref, $vsa);
+
+        }
+        else {
+            $connection_info = {
+                nas_ip => $send_disconnect_to,
+                secret => $self->{'_radiusSecret'},
+                LocalAddr => $self->deauth_source_ip($send_disconnect_to),
+                nas_port => $nas_port,
+            };
+            $response = perform_disconnect($connection_info, $attributes_ref);
+        }
+    } catch {
+        chomp;
+        $logger->warn("Unable to perform RADIUS CoA-Request on (".$self->{'_id'}."): $_");
+        $logger->error("Wrong RADIUS secret or unreachable network device (".$self->{'_id'}.")... On some Cisco Wireless Controllers you might have to set disconnectPort=1700 as some versions ignore the CoA requests on port 3799") if ($_ =~ /^Timeout/);
+    };
+    return if (!defined($response));
+
+    return $TRUE if ( ($response->{'Code'} eq 'Disconnect-ACK') || ($response->{'Code'} eq 'CoA-ACK') );
+
+    $logger->warn(
+        "Unable to perform RADIUS Disconnect-Request on (".$self->{'_id'}.")."
+        . ( defined($response->{'Code'}) ? " $response->{'Code'}" : 'no RADIUS code' ) . ' received'
+        . ( defined($response->{'Error-Cause'}) ? " with Error-Cause: $response->{'Error-Cause'}." : '' )
+    );
+    return;
 }
 
 =head1 AUTHOR

--- a/lib/pf/Switch/Meraki/MR_v2.pm
+++ b/lib/pf/Switch/Meraki/MR_v2.pm
@@ -19,13 +19,6 @@ use warnings;
 
 use base ('pf::Switch::Cisco::WLC');
 
-use Net::SNMP;
-use Try::Tiny;
-use pf::constants;
-use pf::util;
-use pf::node;
-use pf::util::radius qw(perform_coa);
-
 sub description { 'Meraki cloud controller V2' }
 
 =head2 returnRoleAttribute

--- a/lib/pf/Switch/Meraki/MR_v2.pm
+++ b/lib/pf/Switch/Meraki/MR_v2.pm
@@ -36,23 +36,6 @@ sub returnRoleAttribute {
     return 'Airespace-ACL-Name';
 }
 
-=head2 addDPSK
-
-Add the DPSK to a RADIUS reply
-
-=cut
-
-sub addDPSK {
-    my ($self, $args, $radius_reply_ref, $av_pairs) = @_;
-    if ($args->{profile}->dpskEnabled()) {
-        if (defined($args->{owner}->{psk})) {
-            $radius_reply_ref->{'Tunnel-Password'} = $args->{owner}->{psk};
-        } else {
-            $radius_reply_ref->{'Tunnel-Password'} = $args->{profile}->{_default_psk_key};
-        }
-    }
-}
-
 =item deauthenticateMacDefault
 
 Some of the attributes from Cisco::WLC aren't necessary
@@ -192,6 +175,23 @@ sub radiusDisconnect {
         . ( defined($response->{'Error-Cause'}) ? " with Error-Cause: $response->{'Error-Cause'}." : '' )
     );
     return;
+}
+
+=head2 addDPSK
+
+Add the DPSK to a RADIUS reply
+
+=cut
+
+sub addDPSK {
+    my ($self, $args, $radius_reply_ref, $av_pairs) = @_;
+    if ($args->{profile}->dpskEnabled()) {
+        if (defined($args->{owner}->{psk})) {
+            $radius_reply_ref->{'Tunnel-Password'} = $args->{owner}->{psk};
+        } else {
+            $radius_reply_ref->{'Tunnel-Password'} = $args->{profile}->{_default_psk_key};
+        }
+    }
 }
 
 =head1 AUTHOR


### PR DESCRIPTION
# Description
cleanup Meraki::MR_v2 module so its on par with Cisco::WLC

# Impacts
Meraki::MR_v2 module

# Issue
fixes #6649 

# Delete branch after merge
YES

# NEWS file entries
## Enhancements
* Allow Meraki::MR_v2 module to be able to use a RADIUS Disconnect instead of only a RADIUS CoA