### PR TITLE
pfpki: workaround for Windows devices configured through Intune

### DIFF
--- a/go/caddy/pfpki/pfpki.go
+++ b/go/caddy/pfpki/pfpki.go
@@ -131,9 +131,13 @@ func buildPfpkiHandler(ctx context.Context) (types.Handler, error) {
 
 	api.Handle("/scep/{id}", handlers.ManageSCEP(PFPki)).Methods("GET", "POST")
 
+	api.Handle("/scep/{id}/pkiclient.exe", handlers.ManageSCEP(PFPki)).Methods("GET", "POST")
+
 	api.Handle("/pki/scep", handlers.ManageSCEP(PFPki)).Methods("GET", "POST")
 
 	api.Handle("/pki/scep/{id}", handlers.ManageSCEP(PFPki)).Methods("GET", "POST")
+
+	api.Handle("/pki/scep/{id}/pkiclient.exe", handlers.ManageSCEP(PFPki)).Methods("GET", "POST")
 
 	api.Handle("/pki/scep/{id}/", handlers.ManageSCEP(PFPki)).Methods("GET", "POST")
 

--- a/go/go.mod
+++ b/go/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/inverse-inc/go-ipset/v2 v2.2.4
 	github.com/inverse-inc/go-radius v0.0.0-20201019132414-82756e2d8d47
 	github.com/inverse-inc/go-utils v0.0.0-20210420024101-48a17e73abae
-	github.com/inverse-inc/scep v0.0.0-20210513203155-0afeb79ee054
+	github.com/inverse-inc/scep v0.0.0-20211116205743-0d87c67a5e4c
 	github.com/jcuga/golongpoll v1.1.0
 	github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a
 	github.com/jinzhu/gorm v1.9.16

--- a/go/go.sum
+++ b/go/go.sum
@@ -386,6 +386,8 @@ github.com/inverse-inc/pkcs7 v0.0.0-20210506124822-140ab7b963b3 h1:YAWsp7d4RknQd
 github.com/inverse-inc/pkcs7 v0.0.0-20210506124822-140ab7b963b3/go.mod h1:adBgAyadl5D9Mz9rhkQyzZpwcUK9eXdKslXH4oImbB0=
 github.com/inverse-inc/scep v0.0.0-20210513203155-0afeb79ee054 h1:4a2mcGgMp+o+eOIezaceGFXVq00Np1RL52g93xiEAfg=
 github.com/inverse-inc/scep v0.0.0-20210513203155-0afeb79ee054/go.mod h1:gk824OzLdCFRAvk4Je/hPXxbmET1WPvLXEGVhpv8c5g=
+github.com/inverse-inc/scep v0.0.0-20211116205743-0d87c67a5e4c h1:hBhYabg+XQi1LASGs+apsBrnIzh4GKJ1/m3+ledYBeg=
+github.com/inverse-inc/scep v0.0.0-20211116205743-0d87c67a5e4c/go.mod h1:gk824OzLdCFRAvk4Je/hPXxbmET1WPvLXEGVhpv8c5g=
 github.com/jcuga/golongpoll v1.1.0 h1:2CWYEd5sH23aOxzMZ9xw5yjiZC8XdNG5wa70+KBkJrQ=
 github.com/jcuga/golongpoll v1.1.0/go.mod h1:sM63poxLraGZiLM83pQwKL3GbcPxWaxWcD7Hj94CcBc=
 github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a h1:BcF8coBl0QFVhe8vAMMlD+CV8EISiu9MGKLoj6ZEyJA=


### PR DESCRIPTION
# Description
Reply to Windows devices configured through Intune even if they requested a non-existing URL.
Not configurable on Intune side.

# Impacts
pfpki

# Delete branch after merge
YES

# NEWS file entries
## Bug fixes
* Reply to Windows devices configured through Intune even if they requested a non-existing URL.