### PR TITLE
Adding the {username} variable + Custom LDAPFilter

### DIFF
--- a/lib/pf/Authentication/Source/LDAPSource.pm
+++ b/lib/pf/Authentication/Source/LDAPSource.pm
@@ -757,12 +757,18 @@ Create the filter to search for the dn
 sub _makefilter {
     my ($self,$username) = @_;
     my $append_search = defined($self->{'append_to_searchattributes'}) ? $self->{'append_to_searchattributes'} : '';
+    $append_search =~ s/{username}/$username/gi;
+
     if (@{$self->{'searchattributes'} // []}) {
         my $search = join ("", map { "($_=$username)" } uniq($self->{'usernameattribute'}, @{$self->{'searchattributes'}}));
         return "(&(|$search)".$append_search.")";
-    } else {
-        return '(' . "$self->{'usernameattribute'}=$username" . ')';
     }
+
+    if($append_search eq '') {
+        return "($self->{'usernameattribute'}=$username)";
+    }
+
+    return $append_search;
 }
 
 sub lookupRole {


### PR DESCRIPTION
# Description
Added a regular expression to add the ability to user the {username} string as a variable for the username in LDAP Searches for the "Append search attributes LDAP filter" field
Added the ability to not use the basic search attributes for the search and use the "Append search attributes LDAP filter" as the main search filter for the LDAP Search.

Example:
(|(samAccountName={username})(UserPrincipalName={username})(proxyAddresses=smtp:{username}))
Allows logins proxyAddresses, UPN and UID of the user.

# Impacts
If an installation has an Append search attributes value and no Search Attributes, it may lead to undesired behaviour where the append is preferred over the Default "Username Attribute=$username"

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
(REQUIRED, but may be optional...)
## New Features
* Ability to use custom LDAP filters in Authentication Source

## Enhancements
* Allow for {username} variable in "Append search attributes LDAP filter" of an Authentication Source