### PR TITLE
Feature/admin cert san

### DIFF
--- a/addons/packetfence-perl/dependencies.csv
+++ b/addons/packetfence-perl/dependencies.csv
@@ -208,7 +208,7 @@ Digest::HMAC_MD5,1.04,ARODLAND/Digest-HMAC-1.04.tar.gz,True,A/AR/ARODLAND/Digest
 Switch,2.17,CHORNY/Switch-2.17.tar.gz,True,C/CH/CHORNY/Switch-2.17.tar.gz,2
 Rose::DB::Object,0.820,JSIRACUSA/Rose-DB-Object-0.820.tar.gz,True,J/JS/JSIRACUSA/Rose-DB-Object-0.820.tar.gz,2
 Data::Phrasebook::Loader::YAML,0.13,BARBIE/Data-Phrasebook-Loader-YAML-0.13.tar.gz,True,B/BA/BARBIE/Data-Phrasebook-Loader-YAML-0.13.tar.gz,2
-Crypt::OpenSSL::X509,1.908,JONASBN/Crypt-OpenSSL-X509-1.908.tar.gz,True,J/JO/JONASBN/Crypt-OpenSSL-X509-1.908.tar.gz,2
+Crypt::OpenSSL::X509,1.910,JONASBN/Crypt-OpenSSL-X509-1.910.tar.gz,True,J/JO/JONASBN/Crypt-OpenSSL-X509-1.910.tar.gz,2
 Template::AutoFilter,0.143050,MITHALDU/Template-AutoFilter-0.143050.tar.gz,True,M/MI/MITHALDU/Template-AutoFilter-0.143050.tar.gz,2
 Config::IniFiles,3.000003,SHLOMIF/Config-IniFiles-3.000003.tar.gz,True,S/SH/SHLOMIF/Config-IniFiles-3.000003.tar.gz,2
 MIME::Lite::TT,0.02,HORIUCHI/MIME-Lite-TT-0.02.tar.gz,True,H/HO/HORIUCHI/MIME-Lite-TT-0.02.tar.gz,2

--- a/html/pfappserver/root/src/views/Configuration/sslCertificates/_components/TheForm.vue
+++ b/html/pfappserver/root/src/views/Configuration/sslCertificates/_components/TheForm.vue
@@ -57,7 +57,10 @@
             class="mb-3" :class="{ 'border-top': index }" fluid>
             <b-row align-v="center" v-for="(value, key) in ca" :key="key">
               <b-col sm="3" class="col-form-label">{{ key }}</b-col>
-              <b-col sm="9">{{ value }}</b-col>
+              <b-col sm="9" v-if="Array.isArray(value)">
+                <b-badge v-for="(v, k) in value" :key="`${key}-${k}`" class="mr-1" variant="secondary">{{ v }}</b-badge>
+              </b-col>
+            <b-col sm="9" v-else>{{ value }}</b-col>
             </b-row>
           </b-container>
         </template>

--- a/html/pfappserver/root/src/views/Configuration/sslCertificates/_components/TheForm.vue
+++ b/html/pfappserver/root/src/views/Configuration/sslCertificates/_components/TheForm.vue
@@ -37,7 +37,10 @@
           </b-row>
           <b-row align-v="baseline" v-for="(value, key) in certificateLocale" :key="key">
             <b-col sm="3" class="col-form-label">{{ key }}</b-col>
-            <b-col sm="9">{{ value }}</b-col>
+              <b-col sm="9" v-if="Array.isArray(value)">
+                <b-badge v-for="(v, k) in value" :key="`${key}-${k}`" class="mr-1" variant="secondary">{{ v }}</b-badge>
+              </b-col>
+            <b-col sm="9" v-else>{{ value }}</b-col>
           </b-row>
         </b-container>
       </b-card>

--- a/html/pfappserver/root/src/views/Configuration/sslCertificates/_composables/useForm.js
+++ b/html/pfappserver/root/src/views/Configuration/sslCertificates/_composables/useForm.js
@@ -4,7 +4,8 @@ import i18n from '@/utils/locale'
 import schemaFn from '../schema'
 import {
   certificateServices,
-  strings
+  strings,
+  sortSslKeys,
 } from '../config'
 
 const useFormProps = {
@@ -49,7 +50,6 @@ const useForm = (form, props, context) => {
     return lets_encrypt
   })
 
-  const sortSslKeys = ['serial', 'issuer', 'not_before', 'not_after', 'subject', 'common_name']
   const fnSortSslKeys = (a, b) => {
     return sortSslKeys.indexOf(a) - sortSslKeys.indexOf(b)
   }

--- a/html/pfappserver/root/src/views/Configuration/sslCertificates/config.js
+++ b/html/pfappserver/root/src/views/Configuration/sslCertificates/config.js
@@ -17,3 +17,5 @@ export const strings = {
   subject:          'Subject', // i18n defer
   subject_alt_name: 'Subject Alternative Names', // i18n defer
 }
+
+export const sortSslKeys = ['serial', 'issuer', 'not_before', 'not_after', 'subject', 'common_name']

--- a/html/pfappserver/root/src/views/Configuration/sslCertificates/config.js
+++ b/html/pfappserver/root/src/views/Configuration/sslCertificates/config.js
@@ -18,4 +18,4 @@ export const strings = {
   subject_alt_name: 'Subject Alternative Names', // i18n defer
 }
 
-export const sortSslKeys = ['serial', 'issuer', 'not_before', 'not_after', 'subject', 'common_name']
+export const sortSslKeys = ['serial', 'issuer', 'not_before', 'not_after', 'subject', 'common_name', 'subject_alt_name']

--- a/html/pfappserver/root/src/views/Configuration/sslCertificates/config.js
+++ b/html/pfappserver/root/src/views/Configuration/sslCertificates/config.js
@@ -9,10 +9,11 @@ export const certificateServices = {
 }
 
 export const strings = {
-  common_name:  'Common name (CN)', // i18n defer
-  issuer:       'Issuer', // i18n defer
-  not_after:    'Not after', // i18n defer
-  not_before:   'Not before', // i18n defer
-  serial:       'Serial', // i18n defer
-  subject:      'Subject', // i18n defer
+  common_name:      'Common name (CN)', // i18n defer
+  issuer:           'Issuer', // i18n defer
+  not_after:        'Not after', // i18n defer
+  not_before:       'Not before', // i18n defer
+  serial:           'Serial', // i18n defer
+  subject:          'Subject', // i18n defer
+  subject_alt_name: 'Subject Alternative Names', // i18n defer
 }

--- a/html/pfappserver/root/src/views/Configuration/sslCertificates/schema.js
+++ b/html/pfappserver/root/src/views/Configuration/sslCertificates/schema.js
@@ -26,7 +26,8 @@ export const schema = () => {
         then: yup.string().nullable().required(i18n.t('Private key required.')),
         otherwise: yup.string().nullable(),
       }),
-    intermediate_cas: schemaIntermediateCertificateAuthorities.meta({ invalidFeedback: i18n.t('Intermediate CA certificates contain one or more errors.') })
+    intermediate_cas: schemaIntermediateCertificateAuthorities.meta({ invalidFeedback: i18n.t('Intermediate CA certificates contain one or more errors.') }),
+    subject_alt_name: yup.array().of(yup.string())
   })
 }
 

--- a/lib/pf/ssl.pm
+++ b/lib/pf/ssl.pm
@@ -373,6 +373,7 @@ sub x509_info {
         not_before => $x509->notBefore(),
         not_after => $x509->notAfter(),
         serial => $x509->serial(),
+        subject_alt_name => [split(/\s*,\s*/, $x509->extensions_by_name()->{'subjectAltName'}->to_string)],
     };
 }
 

--- a/lib/pf/ssl.pm
+++ b/lib/pf/ssl.pm
@@ -321,6 +321,8 @@ sub generate_csr {
 
     my $csr = Crypt::OpenSSL::PKCS10->new_from_rsa($rsa);
     $csr->set_subject($subject);
+    $csr->add_ext(Crypt::OpenSSL::PKCS10::NID_subject_alt_name, "DNS:".$info->{common_name});
+    $csr->add_ext_final();
     $csr->sign();
     
     return ($TRUE, $csr);

--- a/t/unittest/ssl.t
+++ b/t/unittest/ssl.t
@@ -22,7 +22,7 @@ BEGIN {
     use setup_test_config;
 }
 
-use Test::More tests => 20;
+use Test::More tests => 22;
 use Test::NoWarnings;
 
 use pf::constants qw($TRUE $FALSE);
@@ -287,6 +287,55 @@ is(ref($x509_ca), "Crypt::OpenSSL::X509", "x509_from_string returns a Crypt::Ope
     is($res, $FALSE, "Cert with custom chain shouldn't be valid unless all certs are passed");
 }
 
+my $multi_san_cert = <<EOF;
+-----BEGIN CERTIFICATE-----
+MIIHNDCCBhygAwIBAgIQAkqjsfPxRBK39S6WehRc/zANBgkqhkiG9w0BAQsFADBN
+MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMScwJQYDVQQDEx5E
+aWdpQ2VydCBTSEEyIFNlY3VyZSBTZXJ2ZXIgQ0EwHhcNMjExMTAxMDAwMDAwWhcN
+MjIxMDExMjM1OTU5WjBgMQswCQYDVQQGEwJDQTEPMA0GA1UECBMGUXVlYmVjMREw
+DwYDVQQHEwhNb250cmVhbDEUMBIGA1UEChMLSW52ZXJzZSBJbmMxFzAVBgNVBAMT
+Dnd3dy5pbnZlcnNlLmNhMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEuC5+eGO/
+HaKJD6IbGW4MOmrg/Q5Hck90UdQAJFH1OOH6l6NNKpcZMVBzKqefzEY1wSj/dQUx
+bnROtGyYggKhsaOCBMYwggTCMB8GA1UdIwQYMBaAFA+AYRyCMWHVLyjnjUY4tCzh
+xtniMB0GA1UdDgQWBBS4i+rx6FU3f3vLMHJ0Ttlg/WgDVjCCAY8GA1UdEQSCAYYw
+ggGCghJhcGkuZmluZ2VyYmFuay5vcmeCD2NoYXQuaW52ZXJzZS5jYYIMZGVtby5z
+b2dvLm51gg5maW5nZXJiYW5rLm9yZ4IOZ2l0LmludmVyc2UuY2GCD2hlbHAuaW52
+ZXJzZS5jYYIKaW52ZXJzZS5jYYIWam9sbHlqdW1wZXIuaW52ZXJzZS5jYYIQa2lt
+YWkuaW52ZXJzZS5jYYIQbGlzdHMuaW52ZXJzZS5jYYIVbW9uaXRvcmluZy5pbnZl
+cnNlLmNhghNwYWNrYWdlcy5pbnZlcnNlLmNhgg9wYWNrZXRmZW5jZS5vcmeCEHBz
+b25vLmludmVyc2UuY2GCFHNvZ28tZGVtby5pbnZlcnNlLmNhgg9zb2dvLmludmVy
+c2UuY2GCB3NvZ28ubnWCD3dpa2kuaW52ZXJzZS5jYYISd3d3LmZpbmdlcmJhbmsu
+b3Jngg53d3cuaW52ZXJzZS5jYYITd3d3LnBhY2tldGZlbmNlLm9yZ4ILd3d3LnNv
+Z28ubnUwDgYDVR0PAQH/BAQDAgeAMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggrBgEF
+BQcDAjBvBgNVHR8EaDBmMDGgL6AthitodHRwOi8vY3JsMy5kaWdpY2VydC5jb20v
+c3NjYS1zaGEyLWc2LTEuY3JsMDGgL6AthitodHRwOi8vY3JsNC5kaWdpY2VydC5j
+b20vc3NjYS1zaGEyLWc2LTEuY3JsMD4GA1UdIAQ3MDUwMwYGZ4EMAQICMCkwJwYI
+KwYBBQUHAgEWG2h0dHA6Ly93d3cuZGlnaWNlcnQuY29tL0NQUzB8BggrBgEFBQcB
+AQRwMG4wJAYIKwYBBQUHMAGGGGh0dHA6Ly9vY3NwLmRpZ2ljZXJ0LmNvbTBGBggr
+BgEFBQcwAoY6aHR0cDovL2NhY2VydHMuZGlnaWNlcnQuY29tL0RpZ2lDZXJ0U0hB
+MlNlY3VyZVNlcnZlckNBLmNydDAMBgNVHRMBAf8EAjAAMIIBfwYKKwYBBAHWeQIE
+AgSCAW8EggFrAWkAdwBGpVXrdfqRIDC1oolp9PN9ESxBdL79SbiFq/L8cP5tRwAA
+AXzcs/6cAAAEAwBIMEYCIQCYTH948tekZNl/55gAVkK8zNdBO1XM93bLjxVt5mbJ
+RwIhAP4gOBrszJL4ZQEDU2psBoiMBoI4buiE0JwS8J51YxqaAHYAUaOw9f0BeZxW
+bbg3eI8MpHrMGyfL956IQpoN/tSLBeUAAAF83LP+3wAABAMARzBFAiAcJVlBBkn4
+59uGolzYKAxSjC64ljJ0LTt+PCtRoOp6IQIhAP5L7EhMKIP0pVo+RaE85RRm7CT8
+25YDGjGyXT648i+5AHYAQcjKsd8iRkoQxqE6CUKHXk4xixsD6+tLx2jwkGKWBvYA
+AAF83LP+ZwAABAMARzBFAiAnq52qCcCOxV62UuARPXdxLJBIWjQcGOc8Vw6rop1L
+RgIhAIkcYm7CRrdiSd/xEWkerxhsVYWHjQmQQeohuoMGlwVFMA0GCSqGSIb3DQEB
+CwUAA4IBAQBNhSbcp9YgU1xcz4wIY38l95jBChUveHZ/9xSDSw8iGcqE2f98x+Xq
+MkaPp1mpYKhKPzsbMeNGSn6veMKSPoIRh0OH0Oi55lxff1QnmDsWW2XmmgOOR8Is
+lMSEXh7L3m71/tp5qzqQPkOnOyNs3BSXsoLJOFoa0HJimJCIAxeIOZTjn4+XBEUY
+9fKl7PuL/G89yQ3l9wvvSvI53DulG2/RbJgnSmZUyhnw1SrjU1fRJ2zR9glH8A7M
+vApr8fkrLMKOqDEiMKs+1iZLm0KWcdzkyxTV+IiJMkS0HEvf64I9clss/A9OspSU
+nGmJe3LRdsNx7P7pu57GY8lEv1tWkAO9
+-----END CERTIFICATE-----
+EOF
+
+$x509= pf::ssl::x509_from_string($multi_san_cert);
+my $x509_info = pf::ssl::x509_info($x509);
+
+is($x509_info->{common_name}, "www.inverse.ca", "Common name is properly read in x509_info");
+is_deeply($x509_info->{subject_alt_name},['DNS:api.fingerbank.org','DNS:chat.inverse.ca','DNS:demo.sogo.nu','DNS:fingerbank.org','DNS:git.inverse.ca','DNS:help.inverse.ca','DNS:inverse.ca','DNS:jollyjumper.inverse.ca','DNS:kimai.inverse.ca','DNS:lists.inverse.ca','DNS:monitoring.inverse.ca','DNS:packages.inverse.ca','DNS:packetfence.org','DNS:psono.inverse.ca','DNS:sogo-demo.inverse.ca','DNS:sogo.inverse.ca','DNS:sogo.nu','DNS:wiki.inverse.ca','DNS:www.fingerbank.org','DNS:www.inverse.ca','DNS:www.packetfence.org','DNS:www.sogo.nu'],"Subject alternative name is properly read from the x509_info");
 
 =head1 AUTHOR
 


### PR DESCRIPTION
# Description
Add support for SAN in the certificates section

# Impacts
Certificates display and new CSRs that will be issued via the admin interface

# NEW Package(s) required
A new version of packetfence-perl must be built with Crypt-OpenSSL-X509-1.910.tar.gz

# Issue
fixes #6689 

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [N/A] Document the feature
- [X] Add unit tests
- [N/A] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* Certificate signing requests created via the admin interface now include a Subject Alternative Name (SAN)
* The Subject Alternative Names of a certificate are now displayed in the admin interface

