### PR TITLE
Feature: Add stress-tester/dhcp_test in debian and rhel8

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -94,6 +94,7 @@ Depends: ${misc:Depends}, vlan,
  libnet-ip-perl, libdigest-hmac-perl, libcrypt-openssl-pkcs10-perl, libcrypt-openssl-rsa-perl, libfile-tempdir-perl,
  liburi-escape-xs-perl, libsql-abstract-more-perl (>= 1.28), libsql-abstract-plugin-insertmulti-perl, libio-socket-timeout-perl, libwww-twilio-api-perl,
  libpod-markdown-perl, libmojolicious-perl (>= 7.74), libmojox-log-log4perl-perl, liblingua-en-inflexion-perl,
+ libnet-dhcp-perl
 # hard-coded to specific version because v3 broke the API and we haven't ported to it yet
 # see #1313: Port our Net-Appliance-Session to the version 3 API
 # http://packetfence.org/bugs/view.php?id=1313

--- a/debian/control
+++ b/debian/control
@@ -94,7 +94,7 @@ Depends: ${misc:Depends}, vlan,
  libnet-ip-perl, libdigest-hmac-perl, libcrypt-openssl-pkcs10-perl, libcrypt-openssl-rsa-perl, libfile-tempdir-perl,
  liburi-escape-xs-perl, libsql-abstract-more-perl (>= 1.28), libsql-abstract-plugin-insertmulti-perl, libio-socket-timeout-perl, libwww-twilio-api-perl,
  libpod-markdown-perl, libmojolicious-perl (>= 7.74), libmojox-log-log4perl-perl, liblingua-en-inflexion-perl,
- libnet-dhcp-perl
+ libnet-dhcp-perl,
 # hard-coded to specific version because v3 broke the API and we haven't ported to it yet
 # see #1313: Port our Net-Appliance-Session to the version 3 API
 # http://packetfence.org/bugs/view.php?id=1313

--- a/debian/rules
+++ b/debian/rules
@@ -350,7 +350,7 @@ binary-arch: build install
 	# Venom
 	chmod 0755 $(CURDIR)/debian/packetfence-test$(PREFIX)/$(NAME)/t/venom/*.sh
 	# Addon Stress-tester
-	#chmod 0755 $(CURDIR)/debian/packetfence$(PREFIX)/$(NAME)/addons/stress-test/dhcp_test
+	chmod 0755 $(CURDIR)/debian/packetfence$(PREFIX)/$(NAME)/addons/stress-tester/dhcp_test
 	# packetfence pkg
 	chmod 0755 $(CURDIR)/debian/packetfence$(PREFIX)/$(NAME)/addons/*.pl
 	chmod 0755 $(CURDIR)/debian/packetfence$(PREFIX)/$(NAME)/addons/*.sh
@@ -368,7 +368,6 @@ binary-arch: build install
 	chmod 0755 $(CURDIR)/debian/packetfence$(PREFIX)/$(NAME)/addons/dev-helpers/*.sh
 	chmod 0755 $(CURDIR)/debian/packetfence$(PREFIX)/$(NAME)/addons/hostapd/*.sh
 	chmod 0755 $(CURDIR)/debian/packetfence$(PREFIX)/$(NAME)/addons/eapol_test/*.sh
-	chmod 0755 $(CURDIR)/debian/packetfence$(PREFIX)/$(NAME)/addons/stress-test/dhcp_test
 	chmod 0755 $(CURDIR)/debian/packetfence$(PREFIX)/$(NAME)/bin/*
 	chmod 0755 $(CURDIR)/debian/packetfence$(PREFIX)/$(NAME)/bin/cluster/*
 	chmod 0755 $(CURDIR)/debian/packetfence$(PREFIX)/$(NAME)/sbin/*

--- a/debian/rules
+++ b/debian/rules
@@ -310,6 +310,7 @@ binary-arch: build install
 	chmod 0755 $(CURDIR)/debian/packetfence-test$(PREFIX)/$(NAME)/t/serialized_unittests/UnifiedApi/Controller/*.t
 	# stress-test
 	chmod 0755 $(CURDIR)/debian/packetfence-test$(PREFIX)/$(NAME)/t/stress-test/*.pl
+	chmod 0755 $(CURDIR)/debian/packetfence-test$(PREFIX)/$(NAME)/t/stress-test/
 	# unittest
 	chmod 0755 $(CURDIR)/debian/packetfence-test$(PREFIX)/$(NAME)/t/unittest/*.t
 	chmod 0755 $(CURDIR)/debian/packetfence-test$(PREFIX)/$(NAME)/t/unittest/Portal/*.t
@@ -349,6 +350,8 @@ binary-arch: build install
 	chmod 0755 $(CURDIR)/debian/packetfence-test$(PREFIX)/$(NAME)/t/unittest/Authentication/Source/*.t
 	# Venom
 	chmod 0755 $(CURDIR)/debian/packetfence-test$(PREFIX)/$(NAME)/t/venom/*.sh
+	# Addon Stress-tester
+	chmod 0755 $(CURDIR)/debian/packetfence$(PREFIX)/$(NAME)/addons/stress-test/dhcp_test
 	# packetfence pkg
 	chmod 0755 $(CURDIR)/debian/packetfence$(PREFIX)/$(NAME)/addons/*.pl
 	chmod 0755 $(CURDIR)/debian/packetfence$(PREFIX)/$(NAME)/addons/*.sh

--- a/debian/rules
+++ b/debian/rules
@@ -310,7 +310,6 @@ binary-arch: build install
 	chmod 0755 $(CURDIR)/debian/packetfence-test$(PREFIX)/$(NAME)/t/serialized_unittests/UnifiedApi/Controller/*.t
 	# stress-test
 	chmod 0755 $(CURDIR)/debian/packetfence-test$(PREFIX)/$(NAME)/t/stress-test/*.pl
-	chmod 0755 $(CURDIR)/debian/packetfence-test$(PREFIX)/$(NAME)/t/stress-test/
 	# unittest
 	chmod 0755 $(CURDIR)/debian/packetfence-test$(PREFIX)/$(NAME)/t/unittest/*.t
 	chmod 0755 $(CURDIR)/debian/packetfence-test$(PREFIX)/$(NAME)/t/unittest/Portal/*.t
@@ -351,7 +350,7 @@ binary-arch: build install
 	# Venom
 	chmod 0755 $(CURDIR)/debian/packetfence-test$(PREFIX)/$(NAME)/t/venom/*.sh
 	# Addon Stress-tester
-	chmod 0755 $(CURDIR)/debian/packetfence$(PREFIX)/$(NAME)/addons/stress-test/dhcp_test
+	#chmod 0755 $(CURDIR)/debian/packetfence$(PREFIX)/$(NAME)/addons/stress-test/dhcp_test
 	# packetfence pkg
 	chmod 0755 $(CURDIR)/debian/packetfence$(PREFIX)/$(NAME)/addons/*.pl
 	chmod 0755 $(CURDIR)/debian/packetfence$(PREFIX)/$(NAME)/addons/*.sh
@@ -369,6 +368,7 @@ binary-arch: build install
 	chmod 0755 $(CURDIR)/debian/packetfence$(PREFIX)/$(NAME)/addons/dev-helpers/*.sh
 	chmod 0755 $(CURDIR)/debian/packetfence$(PREFIX)/$(NAME)/addons/hostapd/*.sh
 	chmod 0755 $(CURDIR)/debian/packetfence$(PREFIX)/$(NAME)/addons/eapol_test/*.sh
+	chmod 0755 $(CURDIR)/debian/packetfence$(PREFIX)/$(NAME)/addons/stress-test/dhcp_test
 	chmod 0755 $(CURDIR)/debian/packetfence$(PREFIX)/$(NAME)/bin/*
 	chmod 0755 $(CURDIR)/debian/packetfence$(PREFIX)/$(NAME)/bin/cluster/*
 	chmod 0755 $(CURDIR)/debian/packetfence$(PREFIX)/$(NAME)/sbin/*

--- a/rpm/packetfence.spec
+++ b/rpm/packetfence.spec
@@ -823,7 +823,7 @@ fi
 %dir                    /usr/local/pf/addons/pfconfig/comparator
 %attr(0755, pf, pf)     /usr/local/pf/addons/pfconfig/comparator/*.pl
 %attr(0755, pf, pf)     /usr/local/pf/addons/pfconfig/comparator/*.sh
-%attr(0755, pf, pf)     /usr/local/pf/addons/pfconfig/stress-tester/dhcp_test
+%attr(0755, pf, pf)     /usr/local/pf/addons/stress-tester/dhcp_test
 %dir                    /usr/local/pf/addons/upgrade
 %attr(0755, pf, pf)     /usr/local/pf/addons/upgrade/*.pl
 %attr(0755, pf, pf)     /usr/local/pf/addons/upgrade/*.sh

--- a/rpm/packetfence.spec
+++ b/rpm/packetfence.spec
@@ -824,6 +824,7 @@ fi
 %attr(0755, pf, pf)     /usr/local/pf/addons/pfconfig/comparator/*.pl
 %attr(0755, pf, pf)     /usr/local/pf/addons/pfconfig/comparator/*.sh
 %dir                    /usr/local/pf/addons/stress-tester
+                        /usr/local/pf/addons/stress-tester/*
 %attr(0755, pf, pf)     /usr/local/pf/addons/stress-tester/dhcp_test
 %dir                    /usr/local/pf/addons/upgrade
 %attr(0755, pf, pf)     /usr/local/pf/addons/upgrade/*.pl

--- a/rpm/packetfence.spec
+++ b/rpm/packetfence.spec
@@ -280,6 +280,9 @@ Requires: openvas-libraries
 # pki
 Requires: perl(Crypt::SMIME)
 
+# dhcp-stress-test
+Requires: perl(Net::DHCP)
+
 # Language packs
 Requires: langpacks-fr, langpacks-es, langpacks-de, langpacks-he, langpacks-it, langpacks-nb, langpacks-nl, langpacks-pl, langpacks-pt
 

--- a/rpm/packetfence.spec
+++ b/rpm/packetfence.spec
@@ -823,7 +823,7 @@ fi
 %dir                    /usr/local/pf/addons/pfconfig/comparator
 %attr(0755, pf, pf)     /usr/local/pf/addons/pfconfig/comparator/*.pl
 %attr(0755, pf, pf)     /usr/local/pf/addons/pfconfig/comparator/*.sh
-%dir                    /usr/local/pf/addons/stress-tester/
+%dir                    /usr/local/pf/addons/stress-tester
 %attr(0755, pf, pf)     /usr/local/pf/addons/stress-tester/dhcp_test
 %dir                    /usr/local/pf/addons/upgrade
 %attr(0755, pf, pf)     /usr/local/pf/addons/upgrade/*.pl

--- a/rpm/packetfence.spec
+++ b/rpm/packetfence.spec
@@ -822,7 +822,8 @@ fi
 %exclude                /usr/local/pf/addons/pfconfig/pfconfig.init
 %dir                    /usr/local/pf/addons/pfconfig/comparator
 %attr(0755, pf, pf)     /usr/local/pf/addons/pfconfig/comparator/*.pl
-%attr(0755, pf, pf)     /usr/local/pf/addons/pfconfig/comparator/*.sh
+%attr(0755, pf, pf)     /usr/local/pf/Rddons/pfconfig/comparator/*.sh
+%dir                    /usr/local/pf/addons/stress-tester/
 %attr(0755, pf, pf)     /usr/local/pf/addons/stress-tester/dhcp_test
 %dir                    /usr/local/pf/addons/upgrade
 %attr(0755, pf, pf)     /usr/local/pf/addons/upgrade/*.pl

--- a/rpm/packetfence.spec
+++ b/rpm/packetfence.spec
@@ -822,7 +822,7 @@ fi
 %exclude                /usr/local/pf/addons/pfconfig/pfconfig.init
 %dir                    /usr/local/pf/addons/pfconfig/comparator
 %attr(0755, pf, pf)     /usr/local/pf/addons/pfconfig/comparator/*.pl
-%attr(0755, pf, pf)     /usr/local/pf/Rddons/pfconfig/comparator/*.sh
+%attr(0755, pf, pf)     /usr/local/pf/addons/pfconfig/comparator/*.sh
 %dir                    /usr/local/pf/addons/stress-tester/
 %attr(0755, pf, pf)     /usr/local/pf/addons/stress-tester/dhcp_test
 %dir                    /usr/local/pf/addons/upgrade

--- a/rpm/packetfence.spec
+++ b/rpm/packetfence.spec
@@ -473,6 +473,7 @@ cp -r addons/upgrade/ %{buildroot}/usr/local/pf/addons/
 cp -r addons/watchdog/ %{buildroot}/usr/local/pf/addons/
 cp -r addons/AD/* %{buildroot}/usr/local/pf/addons/AD/
 cp -r addons/monit/ %{buildroot}/usr/local/pf/addons/
+cp -r addons/stress-tester/ %{buildroot}/usr/local/pf/addons/
 cp addons/full-import/*.sh %{buildroot}/usr/local/pf/addons/full-import/
 cp addons/full-import/*.pl %{buildroot}/usr/local/pf/addons/full-import/
 cp addons/functions/*.functions %{buildroot}/usr/local/pf/addons/functions/
@@ -822,6 +823,7 @@ fi
 %dir                    /usr/local/pf/addons/pfconfig/comparator
 %attr(0755, pf, pf)     /usr/local/pf/addons/pfconfig/comparator/*.pl
 %attr(0755, pf, pf)     /usr/local/pf/addons/pfconfig/comparator/*.sh
+%attr(0755, pf, pf)     /usr/local/pf/addons/pfconfig/stress-tester/dhcp_test
 %dir                    /usr/local/pf/addons/upgrade
 %attr(0755, pf, pf)     /usr/local/pf/addons/upgrade/*.pl
 %attr(0755, pf, pf)     /usr/local/pf/addons/upgrade/*.sh


### PR DESCRIPTION
# Description
Add stress-tester/dhcp_test in debian and rhel8 + perl dependencies

# Impacts
allow to use addon/stress-tester/dhcp_test

# NEW Package(s) required
perl-Net-DHCP

# Delete branch after merge
YES