### PR TITLE
Portal Message module without layout

### DIFF
--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Message.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Message.pm
@@ -19,6 +19,8 @@ has 'skipable' => (is => 'rw', default => sub {1});
 
 has 'message' => (is => 'rw', required => 1);
 
+has 'with_layout' => ('is' => 'rw', default => sub {1});
+
 =head2 execute_child
 
 Display the message to the user and handle the continue if applicable
@@ -35,6 +37,7 @@ sub execute_child {
             message => $self->message, 
             skipable => $self->skipable,
             title => $self->description,
+            layout => $self->with_layout,
         });
     }
 }

--- a/html/captive-portal/templates/message.html
+++ b/html/captive-portal/templates/message.html
@@ -1,3 +1,4 @@
+[% IF layout %]
 <div class="o-layout--center u-padding">
   <p>[% i18n(message) | none %]</p>
 
@@ -11,3 +12,7 @@
   </div>
   [% END %]
 </div>
+
+[% ELSE %]
+[% i18n(message) | none %]
+[% END %]

--- a/html/pfappserver/lib/pfappserver/Form/Config/PortalModule/Message.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/PortalModule/Message.pm
@@ -46,6 +46,14 @@ has_field 'template' =>
              help => 'The template to use to display the message' },
   );
 
+has_field 'with_layout' =>
+  (
+   type => 'Checkbox',
+   label => 'Enable Layout',
+   checkbox_value => 1,
+   input_without_param => 0,
+  );
+
 sub child_definition {
     return qw(message template skipable);
 }

--- a/html/pfappserver/lib/pfappserver/Form/Config/PortalModule/Message.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/PortalModule/Message.pm
@@ -62,6 +62,7 @@ sub BUILD {
     my ($self) = @_;
     $self->field('template')->default($self->for_module->meta->find_attribute_by_name('template')->default->());
     $self->field('skipable')->default($self->for_module->meta->find_attribute_by_name('skipable')->default->());
+    $self->field('with_layout')->default($self->for_module->meta->find_attribute_by_name('with_layout')->default->());
 }
 
 =over

--- a/html/pfappserver/root/src/views/Configuration/portalModules/_components/FormTypeMessage.vue
+++ b/html/pfappserver/root/src/views/Configuration/portalModules/_components/FormTypeMessage.vue
@@ -28,6 +28,11 @@
       :text="$i18n.t('Whether or not, this message can be skipped')"
     />
 
+    <form-group-with-layout namespace="with_layout"
+      :column-label="$i18n.t('Render portal layout')"
+      :text="$i18n.t('Enabled will render with the portal layout')"
+    />
+
     <form-group-actions namespace="actions"
       :column-label="$i18n.t('Actions')"
       :text="$i18n.t('If none are specified, the default ones of the module will be used.')"
@@ -42,7 +47,8 @@ import {
   FormGroupDescription,
   FormGroupMessage,
   FormGroupSkipable,
-  FormGroupTemplate
+  FormGroupTemplate,
+  FormGroupWithLayout
 } from './'
 
 const components = {
@@ -53,7 +59,8 @@ const components = {
   FormGroupDescription,
   FormGroupMessage,
   FormGroupSkipable,
-  FormGroupTemplate
+  FormGroupTemplate,
+  FormGroupWithLayout
 }
 
 import { useForm as setup, useFormProps as props } from '../_composables/useForm'

--- a/html/pfappserver/root/src/views/Configuration/portalModules/_components/index.js
+++ b/html/pfappserver/root/src/views/Configuration/portalModules/_components/index.js
@@ -47,6 +47,7 @@ export {
   BaseFormGroupInput                        as FormGroupUrl,
   BaseFormGroupInput                        as FormGroupUsername,
   BaseFormGroupToggle                       as FormGroupWithAup,
+  BaseFormGroupToggle                       as FormGroupWithLayout,
 
   TheForm,
   TheView


### PR DESCRIPTION
# Description
Added configuration checkbox to enable or no the usage of the portal layout for a message portal module.

# Impacts
Portal modules

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* Message portal module can be used without the portal template.
