### PR TITLE
Fix the switch_group condition creation for securuty event triggers

### DIFF
--- a/lib/pf/factory/condition/security_event.pm
+++ b/lib/pf/factory/condition/security_event.pm
@@ -77,9 +77,16 @@ sub instantiate {
             }
 
             ($type,$data) = $class->getData($sub_trigger);
-            my $subclass = $class->getModuleName($type);
-            my $condition = $subclass->new($data);
-            push @conditions, pf::condition::key->new(key => $data->{key}, condition => $condition);
+            if ($type eq 'switch_group') {
+                push @conditions, pf::condition::switch_group->new(
+                    key => $data->{key},
+                    condition => pf::condition::equals->new(value => $data->{value})
+                );
+            } else {
+                my $subclass = $class->getModuleName($type);
+                my $condition = $subclass->new($data);
+                push @conditions, pf::condition::key->new(key => $data->{key}, condition => $condition);
+            }
         }
         return pf::condition::all->new(conditions => \@conditions);
     }

--- a/t/data/security_events.conf
+++ b/t/data/security_events.conf
@@ -77,3 +77,11 @@ actions=log,reevaluate_access
 enabled=Y
 window=1d
 delay_by=1m
+
+[1100018]
+desc=Bug 6723
+priority=1
+trigger=(internal::new_dhcp_info_from_production_network&switch_group::bug-6723)
+actions=log,reevaluate_access
+enabled=Y
+grace=0s

--- a/t/data/switches.conf
+++ b/t/data/switches.conf
@@ -257,6 +257,17 @@ type=PacketFence::Standard
 radiusSecret=radiusSecret
 TenantId=0
 
+[group bug-6723]
+
+[172.16.8.30]
+mode=production
+description=Test for bug-6723
+RoleMap=Y
+group=bug-6723
+uplink_dynamic=dynamic
+type=PacketFence::Standard
+radiusSecret=radiusSecret
+
 [172.16.8.31]
 mode=production
 description=Test option82

--- a/t/unittest/factory/condition/security_event.t
+++ b/t/unittest/factory/condition/security_event.t
@@ -1,0 +1,78 @@
+#!/usr/bin/perl
+
+=head1 NAME
+
+security_event
+
+=head1 DESCRIPTION
+
+unit test for security_event
+
+=cut
+
+use strict;
+use warnings;
+
+BEGIN {
+    #include test libs
+    use lib qw(/usr/local/pf/t);
+    #Module for overriding configuration paths
+    use setup_test_config;
+}
+
+use Test::More tests => 2;
+
+#This test will running last
+use Test::NoWarnings;
+use pf::factory::condition::security_event;
+
+my $c = pf::factory::condition::security_event->instantiate('(internal::new_dhcp_info_from_production_network&switch_group::bobob)');
+is_deeply(
+    $c,
+    pf::condition::all->new(
+        conditions => [
+            pf::condition::key->new(
+                key       => 'last_internal_id',
+                condition => pf::condition::equals->new(
+                    value => 'new_dhcp_info_from_production_network'
+                )
+            ),
+            pf::condition::switch_group->new(
+                key       => 'last_switch',
+                condition => pf::condition::equals->new(
+                    value => 'bobob'
+                )
+            )
+        ],
+    ),
+);
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2021 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;
+

--- a/t/unittest/pfconfig/cached_hash.t
+++ b/t/unittest/pfconfig/cached_hash.t
@@ -57,7 +57,7 @@ ok(!exists($SwitchConfig{zammit}), "zammit switch doesn't exists");
 # Test keys and KEYS
 
 
-my $SWITCH_COUNT = 36;
+my $SWITCH_COUNT = 37;
 
 my @extra_switches;
 

--- a/t/unittest/pfconfig/cached_hash.t
+++ b/t/unittest/pfconfig/cached_hash.t
@@ -57,7 +57,7 @@ ok(!exists($SwitchConfig{zammit}), "zammit switch doesn't exists");
 # Test keys and KEYS
 
 
-my $SWITCH_COUNT = 37;
+my $SWITCH_COUNT = 38;
 
 my @extra_switches;
 

--- a/t/unittest/security_events.t
+++ b/t/unittest/security_events.t
@@ -21,7 +21,7 @@ BEGIN {
     use setup_test_config;
 }
 
-use Test::More tests => 27;
+use Test::More tests => 26;
 use Test2::Tools::Compare qw(bag item end);
 use_ok('pf::security_event');
 
@@ -110,7 +110,7 @@ is($security_events[0], "1100014");
     }
 );
 is(@security_events, 1);
-is($security_events[0], "1100017");
+is($security_events[0], "1100018");
 
 #This test will running last
 use Test::NoWarnings;

--- a/t/unittest/security_events.t
+++ b/t/unittest/security_events.t
@@ -42,7 +42,6 @@ is($security_events[0], "1100009");
 
 # Will be able to match multiple security_events on the same trigger
 @security_events = $pf::security_event::SECURITY_EVENT_FILTER_ENGINE->match_all({last_detect_id => 1});
-is(@security_events, 2);
 Test2::Tools::Compare::is(
     \@security_events,
     bag {
@@ -54,9 +53,14 @@ Test2::Tools::Compare::is(
 # Will be able to match multiple security_events on the different triggers
 @security_events = $pf::security_event::SECURITY_EVENT_FILTER_ENGINE->match_all({last_detect_id => 2, device_id => 3});
 @security_events = sort(@security_events);
-is(@security_events, 2);
-is($security_events[0], "1100007");
-is($security_events[1], "1100008");
+Test2::Tools::Compare::is(
+    \@security_events,
+    bag {
+        item '1100007';
+        item '1100008';
+    },
+);
+
 
 # Will be able to match a mac trigger that uses a regex
 @security_events = $pf::security_event::SECURITY_EVENT_FILTER_ENGINE->match_all({mac => "12:34:56:78:90:12"});
@@ -99,6 +103,14 @@ is(@security_events, 0);
 is(@security_events, 1);
 is($security_events[0], "1100014");
 
+@security_events = $pf::security_event::SECURITY_EVENT_FILTER_ENGINE->match_all(
+    {
+        last_internal_id => 'new_dhcp_info_from_production_network',
+        last_switch      => '172.16.8.30'
+    }
+);
+is(@security_events, 1);
+is($security_events[0], "1100017");
 
 #This test will running last
 use Test::NoWarnings;


### PR DESCRIPTION
# Description
Fix the switch_group condition creation for securuty event triggers.

# Issue
fixes #6723

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [x] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
## Bug Fixes
* Fix security event switch group triggers
