### PR TITLE
Get username from _session in case of SAML authentication

### DIFF
--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/DeviceRegistration.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/DeviceRegistration.pm
@@ -63,7 +63,7 @@ sub isDeviceRegEnabled {
 sub index : Path : Args(0) {
     my ( $self, $c ) = @_;
     my $logger  = $c->log;
-    my $pid     = $c->user_session->{"username"};
+    my $pid     = $c->user_session->{"username"} // $c->{_session}->{username};
     my $request = $c->request;
 
     # See if user is trying to login and if is not already authenticated

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Node/Manager.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Node/Manager.pm
@@ -30,7 +30,8 @@ Catalyst Controller.
 sub unreg :Local :Args(1) {
     my ($self, $c, $mac) = @_;
     my $node = node_view($mac);
-    my $username = lc($c->user_session->{username});
+    my $username = $c->user_session->{"username"} // $c->{_session}->{username};
+    $username = lc($username);
     my $owner = lc($node->{pid});
               
     my $device_reg_profile = $c->profile->{'_self_service'};

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/Status.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/Status.pm
@@ -42,7 +42,7 @@ sub auto :Private {
 
 sub index : Path : Args(0) {
     my ( $self, $c ) = @_;
-    my $pid     = $c->user_session->{"username"};
+    my $pid     = $c->user_session->{"username"} // $c->{_session}->{username};
     if ( $c->has_errors ) {
         $c->stash->{txt_auth_error} = join(' ', grep { ref ($_) eq '' } @{$c->error});
         $c->clear_errors;
@@ -77,7 +77,7 @@ sub is_lost_stolen {
 
 sub userIsAuthenticated : Private {
     my ( $self, $c ) = @_;
-    my $pid   = $c->user_session->{"username"};
+    my $pid     = $c->user_session->{"username"} // $c->{_session}->{username};
     my @person_nodes = person_nodes($pid);
     my @nodes;
     foreach my $person_node (@person_nodes) {


### PR DESCRIPTION
# Description
Allow access to the Node Manager page when the user did SAML auth.

# Impacts
Status/Node Manager/Device Registration page.

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* Allow access to the Status/Node Manager/Device Registration pages on SAML auth.

