### PR TITLE
Ubiquiti EdgeSwitch: set NAS-Port-Type to virtual when undef

### DIFF
--- a/lib/pf/Switch/Ubiquiti/EdgeSwitch.pm
+++ b/lib/pf/Switch/Ubiquiti/EdgeSwitch.pm
@@ -20,6 +20,7 @@ use warnings;
 use pf::log;
 
 use base ('pf::Switch::Ubiquiti');
+use pf::util qw(clean_mac);
 use pf::constants;
 use pf::config qw(
     $WIRED_802_1X
@@ -231,6 +232,25 @@ sub getVoipVsa {
     my ($self) = @_;
     return (
     );
+}
+
+=item parseRequest
+
+=cut
+
+sub parseRequest {
+    my ( $self, $radius_request ) = @_;
+
+    my $client_mac      = ref($radius_request->{'Calling-Station-Id'}) eq 'ARRAY'
+                           ? clean_mac($radius_request->{'Calling-Station-Id'}[0])
+                           : clean_mac($radius_request->{'Calling-Station-Id'});
+    my $user_name       = $self->parseRequestUsername($radius_request);
+    my $nas_port_type   = ( defined($radius_request->{'NAS-Port-Type'}) ? $radius_request->{'NAS-Port-Type'} : "virtual" );
+    my $port            = $radius_request->{'NAS-Port'};
+    my $eap_type        = ( exists($radius_request->{'EAP-Type'}) ? $radius_request->{'EAP-Type'} : 0 );
+    my $nas_port_id     = ( defined($radius_request->{'NAS-Port-Id'}) ? $radius_request->{'NAS-Port-Id'} : undef );
+
+    return ($nas_port_type, $eap_type, $client_mac, $port, $user_name, $nas_port_id, undef, $nas_port_id);
 }
 
 =head1 AUTHOR


### PR DESCRIPTION
# Description
Force NAS-Port-Type to Virtual when not defined by switch to match on CLI-Access in connection profile.

# Impacts
Ubiquiti EdgeSwitch switch module

# Delete branch after merge
YES


# NEWS file entries
## Enhancements
* Improve CLI login support on Ubiquiti Edge switches
