### PR TITLE
Modify index for bandwidth account to improve speed

### DIFF
--- a/db/pf-schema-X.Y.sql
+++ b/db/pf-schema-X.Y.sql
@@ -1572,7 +1572,7 @@ CREATE TABLE bandwidth_accounting (
     PRIMARY KEY (node_id, time_bucket, unique_session_id),
     KEY bandwidth_aggregate_buckets (time_bucket, node_id, unique_session_id, in_bytes, out_bytes),
     KEY bandwidth_source_type_time_bucket (source_type, time_bucket),
-    KEY bandwidth_last_updated_source_type (last_updated, source_type),
+    KEY bandwidth_last_updated_source_type_time_bucket (last_updated, source_type, time_bucket),
     KEY bandwidth_node_id_unique_session_id_last_updated (node_id, unique_session_id, last_updated),
     KEY bandwidth_accounting_tenant_id_mac_last_updated (tenant_id, mac, last_updated)
 );

--- a/db/upgrade-X.X-X.Y.sql
+++ b/db/upgrade-X.X-X.Y.sql
@@ -86,8 +86,9 @@ ALTER TABLE `pki_revoked_certs`
 \! echo "Updating bandwidth_accounting indexes";
 ALTER TABLE bandwidth_accounting
  DROP INDEX IF EXISTS bandwidth_accounting_tenant_id_mac,
- ADD INDEX bandwidth_accounting_tenant_id_mac_last_updated (tenant_id, mac, last_updated);
-
+ ADD INDEX bandwidth_accounting_tenant_id_mac_last_updated (tenant_id, mac, last_updated),
+ DROP INDEX IF EXISTS bandwidth_last_updated_source_type,
+ ADD INDEX IF NOT EXISTS  bandwidth_last_updated_source_type_time_bucket (last_updated, source_type, time_bucket);
 
 \! echo "Incrementing PacketFence schema version...";
 INSERT IGNORE INTO pf_version (id, version, created_at) VALUES (@VERSION_INT, CONCAT_WS('.', @MAJOR_VERSION, @MINOR_VERSION), NOW());


### PR DESCRIPTION
# Description
Update bandwidth accounting indexing to improve speed of processing cleanup/rotation

# Impacts
pfcron job bandwidth_maintenance and pfacct

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
## Enhancements
* Improved speed of cleanup/rotation of bandwidth accounting record on large tables.
