### PR TITLE
Close only wired connections

### DIFF
--- a/lib/pf/locationlog.pm
+++ b/lib/pf/locationlog.pm
@@ -278,6 +278,7 @@ sub locationlog_update_end_switchport_no_VoIP {
         -where => {
             switch => $switch,
             port   => $ifIndex,
+            connection_type => { -like => 'Ethernet%'},
             end_time => $ZERO_DATE,
             voip   => { "!=" => "yes" },
         },
@@ -295,6 +296,7 @@ sub locationlog_update_end_switchport_only_VoIP {
         -where => {
             switch => $switch,
             port   => $ifIndex,
+            connection_type => { -like => 'Ethernet%'},
             end_time => $ZERO_DATE,
             voip   => "yes",
         },


### PR DESCRIPTION
# Description
* Close only the wired connection when wireless connections share the same ifindex as wired on the same switch.

# Impacts
locationlog syncronization

# Issue
fixes #6741

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
## Bug Fixes
* Close only the wired connection when wireless connections share the same ifindex as wired on the same switch. (#6741)
