### PR TITLE
Revert "Remove interval"

### DIFF
--- a/lib/pf/pfcron/task.pm
+++ b/lib/pf/pfcron/task.pm
@@ -25,6 +25,8 @@ has id => (is => 'ro', isa => 'Str', required => 1);
 
 has status => (is => 'ro', isa => 'Str', required => 1);
 
+has interval => (is => 'ro', isa => 'PfInterval', required => 1, coerce => 1);
+
 =head2 run
 
 The method for the sub classes to override


### PR DESCRIPTION
# Description
Adds back in interval for pf::pfcron::task.

Reverts commit f4816f570ecd5c4f9703581bdb043d54de6e4894.

# Issue
Fixes  #6757

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

