### PR TITLE
Various fixes for PKI

### DIFF
--- a/docs/installation/pki/packetfence.asciidoc
+++ b/docs/installation/pki/packetfence.asciidoc
@@ -66,6 +66,9 @@ You can choose to enable SCEP on this template.
 
 image::packetfence-pki-scep.png[scaledwidth="100%",alt="SCEP configuration"]
 
+
+IMPORTANT: Attributes defined in PKI templates will be used to generate certificates requested through SCEP if they are not defined in CSR.
+
 ====== SCEP Test
 
 Let's do a scep request by hand.

--- a/go/caddy/pfpki/models/models.go
+++ b/go/caddy/pfpki/models/models.go
@@ -458,7 +458,7 @@ func (c CA) Search(vars sql.Vars) (types.Info, error) {
 func (c *CA) FindSCEPProfile(options []string) ([]Profile, error) {
 	var profiledb []Profile
 	if len(options) >= 1 {
-		if err := c.DB.Select("id, name, ca_id, ca_name, validity, key_type, key_size, digest, key_usage, extended_key_usage, p12_mail_password, p12_mail_subject, p12_mail_from, p12_mail_header, p12_mail_footer, scep_enabled, scep_challenge_password, scep_days_before_renewal, cloud_enabled, cloud_service").Where("`name` = ?", options[0]).First(&profiledb).Error; err != nil {
+		if err := c.DB.Select("id, name, ca_id, ca_name,  mail, street_address, organisation, organisational_unit, country, state, locality, postal_code, validity, key_type, key_size, digest, key_usage, extended_key_usage, ocsp_url, p12_mail_password, p12_mail_subject, p12_mail_from, p12_mail_header, p12_mail_footer, scep_enabled, scep_challenge_password, scep_days_before_renewal, cloud_enabled, cloud_service").Where("`name` = ?", options[0]).First(&profiledb).Error; err != nil {
 			return profiledb, errors.New("A database error occured. See log for details.")
 		}
 		if len(profiledb) == 0 {
@@ -466,7 +466,7 @@ func (c *CA) FindSCEPProfile(options []string) ([]Profile, error) {
 		}
 
 	} else {
-		c.DB.Select("id, name, ca_id, ca_name, validity, key_type, key_size, digest, key_usage, extended_key_usage, p12_mail_password, p12_mail_subject, p12_mail_from, p12_mail_header, p12_mail_footer, scep_enabled, scep_challenge_password, scep_days_before_renewal, cloud_enabled, cloud_service").Where("`scep_enabled` = ?", "1").First(&profiledb)
+		c.DB.Select("id, name, ca_id, ca_name,  mail, street_address, organisation, organisational_unit, country, state, locality, postal_code, validity, key_type, key_size, digest, key_usage, extended_key_usage, ocsp_url, p12_mail_password, p12_mail_subject, p12_mail_from, p12_mail_header, p12_mail_footer, scep_enabled, scep_challenge_password, scep_days_before_renewal, cloud_enabled, cloud_service").Where("`scep_enabled` = ?", "1").First(&profiledb)
 	}
 	c.SCEPAssociateProfile = profiledb[0].Name
 

--- a/go/caddy/pfpki/models/models.go
+++ b/go/caddy/pfpki/models/models.go
@@ -1214,7 +1214,11 @@ func email(ctx context.Context, cert Cert, profile Profile, file []byte, passwor
 	message.DefaultCatalog = cat
 
 	m := gomail.NewMessage()
-	m.SetHeader("From", alerting.FromAddr)
+	if len(profile.P12MailFrom) > 0 {
+		m.SetHeader("From", profile.P12MailFrom)
+	} else {
+		m.SetHeader("From", alerting.FromAddr)
+	}
 	m.SetHeader("To", cert.Mail)
 	m.SetHeader("Subject", profile.P12MailSubject)
 

--- a/go/caddy/pfpki/models/models.go
+++ b/go/caddy/pfpki/models/models.go
@@ -690,7 +690,7 @@ func (p Profile) Update() (types.Info, error) {
 		Information.Error = err.Error()
 		return Information, errors.New("A database error occured. See log for details.")
 	}
-	p.DB.Select("id, name, ca_id, ca_name, validity, key_type, key_size, digest, key_usage, extended_key_usage, ocsp_url, p12_mail_password, p12_mail_subject, p12_mail_from, p12_mail_header, p12_mail_footer, scep_enabled, scep_challenge_password, scep_days_before_renewal, cloud_enabled, cloud_service").Where("name = ?", p.Name).First(&profiledb)
+	p.DB.Select("id, name, ca_id, ca_name,  mail, street_address, organisation, organisational_unit, country, state, locality, postal_code, validity, key_type, key_size, digest, key_usage, extended_key_usage, ocsp_url, p12_mail_password, p12_mail_subject, p12_mail_from, p12_mail_header, p12_mail_footer, scep_enabled, scep_challenge_password, scep_days_before_renewal, cloud_enabled, cloud_service").Where("name = ?", p.Name).First(&profiledb)
 	Information.Entries = profiledb
 
 	return Information, nil

--- a/go/caddy/pfpki/models/models.go
+++ b/go/caddy/pfpki/models/models.go
@@ -686,7 +686,7 @@ func (p Profile) New() (types.Info, error) {
 func (p Profile) Update() (types.Info, error) {
 	var profiledb []Profile
 	Information := types.Info{}
-	if err := p.DB.Model(&Profile{}).Where("name = ?", p.Name).Updates(map[string]interface{}{"p12_mail_password": p.P12MailPassword, "p12_mail_subject": p.P12MailSubject, "p12_mail_from": p.P12MailFrom, "p12_mail_header": p.P12MailHeader, "p12_mail_footer": p.P12MailFooter, "scep_enabled": p.SCEPEnabled, "scep_challenge_password": p.SCEPChallengePassword, "scep_days_before_renewal": p.SCEPDaysBeforeRenewal, "cloud_enabled": p.CloudEnabled, "cloud_service": p.CloudService}).Error; err != nil {
+	if err := p.DB.Model(&Profile{}).Where("name = ?", p.Name).Updates(map[string]interface{}{"mail": p.Mail, "street_address": p.StreetAddress, "organisation": p.Organisation, "organisational_unit": p.OrganisationalUnit, "country": p.Country, "state": p.State, "locality": p.Locality, "postal_code": p.PostalCode, "validity": p.Validity, "key_type": p.KeyType, "key_size": p.KeySize, "digest": p.Digest, "key_usage": p.KeyUsage, "extended_key_usage": p.ExtendedKeyUsage, "ocsp_url": p.OCSPUrl, "p12_mail_password": p.P12MailPassword, "p12_mail_subject": p.P12MailSubject, "p12_mail_from": p.P12MailFrom, "p12_mail_header": p.P12MailHeader, "p12_mail_footer": p.P12MailFooter, "scep_enabled": p.SCEPEnabled, "scep_challenge_password": p.SCEPChallengePassword, "scep_days_before_renewal": p.SCEPDaysBeforeRenewal, "cloud_enabled": p.CloudEnabled, "cloud_service": p.CloudService}).Error; err != nil {
 		Information.Error = err.Error()
 		return Information, errors.New("A database error occured. See log for details.")
 	}

--- a/go/go.mod
+++ b/go/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/inverse-inc/go-ipset/v2 v2.2.4
 	github.com/inverse-inc/go-radius v0.0.0-20201019132414-82756e2d8d47
 	github.com/inverse-inc/go-utils v0.0.0-20210420024101-48a17e73abae
-	github.com/inverse-inc/scep v0.0.0-20211213183438-e42cdccb7a7a
+	github.com/inverse-inc/scep v0.0.0-20211215151648-cacf3b0d5a9e
 	github.com/jcuga/golongpoll v1.1.0
 	github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a
 	github.com/jinzhu/gorm v1.9.16

--- a/go/go.mod
+++ b/go/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/inverse-inc/go-ipset/v2 v2.2.4
 	github.com/inverse-inc/go-radius v0.0.0-20201019132414-82756e2d8d47
 	github.com/inverse-inc/go-utils v0.0.0-20210420024101-48a17e73abae
-	github.com/inverse-inc/scep v0.0.0-20211125160101-4016f0ecaf94
+	github.com/inverse-inc/scep v0.0.0-20211213183438-e42cdccb7a7a
 	github.com/jcuga/golongpoll v1.1.0
 	github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a
 	github.com/jinzhu/gorm v1.9.16

--- a/go/go.sum
+++ b/go/go.sum
@@ -376,6 +376,8 @@ github.com/inverse-inc/scep v0.0.0-20211116205743-0d87c67a5e4c h1:hBhYabg+XQi1LA
 github.com/inverse-inc/scep v0.0.0-20211116205743-0d87c67a5e4c/go.mod h1:gk824OzLdCFRAvk4Je/hPXxbmET1WPvLXEGVhpv8c5g=
 github.com/inverse-inc/scep v0.0.0-20211125160101-4016f0ecaf94 h1:3g8IGBB9arj3dvV44RmoRoC4RJ3Hj+nn99FtC049BfY=
 github.com/inverse-inc/scep v0.0.0-20211125160101-4016f0ecaf94/go.mod h1:gk824OzLdCFRAvk4Je/hPXxbmET1WPvLXEGVhpv8c5g=
+github.com/inverse-inc/scep v0.0.0-20211213183438-e42cdccb7a7a h1:+JfVBF4EBiLD2kpo8WoNXqNUCw5D2DqVKyUdX9vyd3g=
+github.com/inverse-inc/scep v0.0.0-20211213183438-e42cdccb7a7a/go.mod h1:gk824OzLdCFRAvk4Je/hPXxbmET1WPvLXEGVhpv8c5g=
 github.com/jcuga/golongpoll v1.1.0 h1:2CWYEd5sH23aOxzMZ9xw5yjiZC8XdNG5wa70+KBkJrQ=
 github.com/jcuga/golongpoll v1.1.0/go.mod h1:sM63poxLraGZiLM83pQwKL3GbcPxWaxWcD7Hj94CcBc=
 github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a h1:BcF8coBl0QFVhe8vAMMlD+CV8EISiu9MGKLoj6ZEyJA=

--- a/go/go.sum
+++ b/go/go.sum
@@ -378,6 +378,8 @@ github.com/inverse-inc/scep v0.0.0-20211125160101-4016f0ecaf94 h1:3g8IGBB9arj3dv
 github.com/inverse-inc/scep v0.0.0-20211125160101-4016f0ecaf94/go.mod h1:gk824OzLdCFRAvk4Je/hPXxbmET1WPvLXEGVhpv8c5g=
 github.com/inverse-inc/scep v0.0.0-20211213183438-e42cdccb7a7a h1:+JfVBF4EBiLD2kpo8WoNXqNUCw5D2DqVKyUdX9vyd3g=
 github.com/inverse-inc/scep v0.0.0-20211213183438-e42cdccb7a7a/go.mod h1:gk824OzLdCFRAvk4Je/hPXxbmET1WPvLXEGVhpv8c5g=
+github.com/inverse-inc/scep v0.0.0-20211215151648-cacf3b0d5a9e h1:LnLs/1zz4+iqNCupjPIc6DdsQHmPrbneqD/UNu2IoaQ=
+github.com/inverse-inc/scep v0.0.0-20211215151648-cacf3b0d5a9e/go.mod h1:gk824OzLdCFRAvk4Je/hPXxbmET1WPvLXEGVhpv8c5g=
 github.com/jcuga/golongpoll v1.1.0 h1:2CWYEd5sH23aOxzMZ9xw5yjiZC8XdNG5wa70+KBkJrQ=
 github.com/jcuga/golongpoll v1.1.0/go.mod h1:sM63poxLraGZiLM83pQwKL3GbcPxWaxWcD7Hj94CcBc=
 github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a h1:BcF8coBl0QFVhe8vAMMlD+CV8EISiu9MGKLoj6ZEyJA=

--- a/t/venom/test_suites/nodes/wired_dot1x_eap_tls/run_sscep_on_node01.yml
+++ b/t/venom/test_suites/nodes/wired_dot1x_eap_tls/run_sscep_on_node01.yml
@@ -31,12 +31,7 @@ testcases:
         [ req_attributes ]
         challengePassword = {{.wired_dot1x_eap_tls_manual.certs.user.scep_challenge_password}}
         
-        # only CN is kept by pfpki
         [ dn ]
-        C=FR
-        ST=Radius
-        L=Somewhere
-        O=Example Inc.
         CN={{.wired_dot1x_eap_tls_scep.certs.user.cn}}
         EOF
         

--- a/t/venom/test_suites/wired_dot1x_eap_tls_manual/45_create_eaptls_source.yml
+++ b/t/venom/test_suites/wired_dot1x_eap_tls_manual/45_create_eaptls_source.yml
@@ -15,7 +15,7 @@ testcases:
         "administration_rules": null,
         "authentication_rules": [
           {
-            "id": "check_issuer",
+            "id": "check_issuer_and_subject",
             "description": null,
             "match": "all",
             "actions": [
@@ -33,6 +33,11 @@ testcases:
                 "attribute": "radius_request.TLS-Client-Cert-Issuer",
                 "operator": "equals",
                 "value": "{{.wired_dot1x_eap_tls_manual.certs.ca.issuer}}"
+              },
+              {
+                "attribute": "radius_request.TLS-Client-Cert-Subject",
+                "operator": "equals",
+                "value": "{{.wired_dot1x_eap_tls_manual.certs.user.subject}}"
               }
             ]
           }

--- a/t/venom/test_suites/wired_dot1x_eap_tls_scep/45_create_eaptls_source.yml
+++ b/t/venom/test_suites/wired_dot1x_eap_tls_scep/45_create_eaptls_source.yml
@@ -15,7 +15,7 @@ testcases:
         "administration_rules": null,
         "authentication_rules": [
           {
-            "id": "check_issuer",
+            "id": "check_issuer_and_subject",
             "description": null,
             "match": "all",
             "actions": [
@@ -33,6 +33,11 @@ testcases:
                 "attribute": "radius_request.TLS-Client-Cert-Issuer",
                 "operator": "equals",
                 "value": "{{.wired_dot1x_eap_tls_scep.certs.ca.issuer}}"
+              },
+              {
+                "attribute": "radius_request.TLS-Client-Cert-Subject",
+                "operator": "equals",
+                "value": "{{.wired_dot1x_eap_tls_scep.certs.user.subject}}"
               }
             ]
           }

--- a/t/venom/vars/all.yml
+++ b/t/venom/vars/all.yml
@@ -326,6 +326,7 @@ wired_dot1x_eap_tls_manual.certs.user.mail: '{{.configurator.email}}'
 wired_dot1x_eap_tls_manual.certs.user.scep_enabled: 1
 wired_dot1x_eap_tls_manual.certs.user.scep_challenge_password: secret
 wired_dot1x_eap_tls_manual.certs.user.scep_days_before_renewal: 7
+wired_dot1x_eap_tls_manual.certs.user.subject: "/C={{.wired_dot1x_eap_tls_manual.certs.country}}/ST={{.wired_dot1x_eap_tls_manual.certs.state}}/L={{.wired_dot1x_eap_tls_manual.certs.locality}}/O={{.wired_dot1x_eap_tls_manual.certs.organisation}}/OU={{.wired_dot1x_eap_tls_manual.certs.organisational_unit}}/CN={{.wired_dot1x_eap_tls_manual.certs.user.cn}}"
 
 # OCSP config
 wired_dot1x_eap_tls_manual.ocsp.id: ocsp_from_cert
@@ -401,6 +402,7 @@ wired_dot1x_eap_tls_scep.certs.user.mail: '{{.configurator.email}}'
 wired_dot1x_eap_tls_scep.certs.user.scep_enabled: 1
 wired_dot1x_eap_tls_scep.certs.user.scep_challenge_password: secret
 wired_dot1x_eap_tls_scep.certs.user.scep_days_before_renewal: 7
+wired_dot1x_eap_tls_scep.certs.user.subject: "/C={{.wired_dot1x_eap_tls_scep.certs.country}}/ST={{.wired_dot1x_eap_tls_scep.certs.state}}/L={{.wired_dot1x_eap_tls_scep.certs.locality}}/O={{.wired_dot1x_eap_tls_scep.certs.organisation}}/OU={{.wired_dot1x_eap_tls_scep.certs.organisational_unit}}/CN={{.wired_dot1x_eap_tls_scep.certs.user.cn}}"
 
 # OCSP config
 wired_dot1x_eap_tls_scep.ocsp.id: ocsp_from_cert


### PR DESCRIPTION
# Description
Return all attributes of the profile on PATCH
Fixes PKI templates can be modified by a SCEP request
Fixes PKI send email function to take the From parameter is it exists in the profile
Allow to edit PKI templates

# Impacts
PKI

# Issue
fixes #6713
fixes #6749
fixes #6751
fixes #6370
fixes #6671 

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Bug Fixes
* Fixes issue on PKI template save (#6749)
* Fixes issue on PKI templates can be modified by a SCEP request (#6751)
* Fixes issue with PKI From value when sending certificate by email (#6370)