### PR TITLE
fix/6789

### DIFF
--- a/lib/pf/pfcmd/checkup.pm
+++ b/lib/pf/pfcmd/checkup.pm
@@ -1206,6 +1206,20 @@ sub cluster {
             }
         }
     }
+
+    _check_database_host_in_cluster();
+}
+
+
+sub _check_database_host_in_cluster {
+    require pf::ConfigStore::Pf;
+    my $cs = pf::ConfigStore::Pf->new();
+    my $db = $cs->readRaw("database");
+    my $host = $db->{host};
+    if ( !defined($host) || $host eq 'localhost' ) {
+        add_problem($WARN, "The database.host should not be configured to 'localhost' in a cluster");
+    }
+
 }
 
 =item valid_fingerbank_device_id


### PR DESCRIPTION
# Description
Warn if the database.host is set to localhost in a cluster during checkup.

# Impacts
pfcmd checkup

# Issue
fixes #6789

# Delete branch after merge
(REQUIRED)
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* Warn if the database.host is set to localhost in a cluster during checkup. (#6789)
