### PR TITLE
fix/6791

### DIFF
--- a/lib/pf/ConfigStore/Switch.pm
+++ b/lib/pf/ConfigStore/Switch.pm
@@ -105,7 +105,8 @@ sub _expandMapping {
             my $type = $2;
             my $role = $1;
             if ($type eq 'AccessList' && ref($val) eq 'ARRAY') {
-                $toset->{$attr} = join("\n", @$val);
+                $val = join("\n", @$val);
+                $toset->{$attr} = $val;
             }
 
             my $key;

--- a/t/data/switches.conf
+++ b/t/data/switches.conf
@@ -295,3 +295,10 @@ wsPass=admin
 type=PacketFence::Standard
 VoIPLLDPDetect=yes
 radiusSecret=
+
+[172.16.8.37]
+type=Cisco::Catalyst_2960
+registrationAccessList= <<EOT
+permit udp any range bootps 65347 any range bootpc 65348
+deny ip any any
+EOT

--- a/t/unittest/UnifiedApi/Controller/Config/Switches.t
+++ b/t/unittest/UnifiedApi/Controller/Config/Switches.t
@@ -22,7 +22,7 @@ BEGIN {
     use setup_test_config;
 }
 
-use Test::More tests => 60;
+use Test::More tests => 64;
 use List::Util qw(first);
 use Test::Mojo;
 use Utils;
@@ -231,6 +231,22 @@ $t->patch_ok("$base_url/172.16.8.24" => json => {RoleMap => 'Y'})
 $t->get_ok("$base_url/172.16.8.24")
   ->status_is(200)
   ->json_is('/item/RoleMap', 'Y');
+
+$t->get_ok("$base_url/172.16.8.37")
+  ->status_is(200)->json_is(
+    '/item/registrationAccessList',
+    "permit udp any range bootps 65347 any range bootpc 65348\ndeny ip any any"
+  )
+  ->json_is(
+    '/item/AccessListMapping',
+    [
+        {
+            accesslist =>
+"permit udp any range bootps 65347 any range bootpc 65348\ndeny ip any any",
+            role => 'registration'
+        }
+    ]
+  );
 
 =head1 AUTHOR
 

--- a/t/unittest/pfconfig/cached_hash.t
+++ b/t/unittest/pfconfig/cached_hash.t
@@ -57,7 +57,7 @@ ok(!exists($SwitchConfig{zammit}), "zammit switch doesn't exists");
 # Test keys and KEYS
 
 
-my $SWITCH_COUNT = 39;
+my $SWITCH_COUNT = 40;
 
 my @extra_switches;
 


### PR DESCRIPTION

# Description
Ensure the role access list mappings are flatten.

# Impacts
pfperl-api 
 - api/v1/config/switches
 - api/v1/config/switch

# Issue
fixes #6791

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ ] Document the feature
- [x] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
## Bug Fixes
* Multiline entries in "Role by access list" are returned as a string (#6791)
