### PR TITLE
Fix/bandwidth deadlock

### DIFF
--- a/db/pf-schema-X.Y.sql
+++ b/db/pf-schema-X.Y.sql
@@ -1776,7 +1776,7 @@ BEGIN
 
     DROP TABLE IF EXISTS to_delete;
     SET @end_bucket= p_end_bucket, @batch = p_batch;
-    SET @create_table_to_delete_stmt = CONCAT('CREATE TEMPORARY TABLE to_delete ENGINE=MEMORY, MAX_ROWS=', @batch, ' SELECT node_id, tenant_id, mac, time_bucket as new_time_bucket, time_bucket, in_bytes, out_bytes FROM bandwidth_accounting_history LIMIT 0');
+    SET @create_table_to_delete_stmt = CONCAT('CREATE TEMPORARY TABLE to_delete INDEX(node_id, new_time_bucket) ENGINE=MEMORY, MAX_ROWS=', @batch, ' SELECT node_id, tenant_id, mac, time_bucket as new_time_bucket, time_bucket, in_bytes, out_bytes FROM bandwidth_accounting_history LIMIT 0');
     PREPARE create_table_to_delete FROM @create_table_to_delete_stmt;
     EXECUTE create_table_to_delete;
     DEALLOCATE PREPARE create_table_to_delete;

--- a/db/pf-schema-X.Y.sql
+++ b/db/pf-schema-X.Y.sql
@@ -1621,6 +1621,7 @@ BEGIN
     PREPARE insert_into_to_delete FROM @insert_into_to_delete_stmt;
 
     START TRANSACTION;
+    SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
     EXECUTE insert_into_to_delete using @end_bucket, @batch;
     SELECT COUNT(*) INTO @count FROM to_delete;
     IF @count > 0 THEN
@@ -1784,8 +1785,8 @@ BEGIN
     SET @insert_into_to_delete_stmt = CONCAT('INSERT INTO to_delete SELECT node_id, tenant_id, mac, ', @date_rounding,'(time_bucket) as new_time_bucket, time_bucket, in_bytes, out_bytes FROM bandwidth_accounting_history WHERE time_bucket <= ? AND time_bucket != ', @date_rounding, '(time_bucket) LIMIT ?');
     PREPARE insert_into_to_delete FROM @insert_into_to_delete_stmt;
 
-    SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
     START TRANSACTION;
+    SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
     EXECUTE insert_into_to_delete using @end_bucket, @batch;
     SELECT COUNT(*) INTO @count FROM to_delete;
     IF @count > 0 THEN

--- a/db/pf-schema-X.Y.sql
+++ b/db/pf-schema-X.Y.sql
@@ -1612,7 +1612,7 @@ BEGIN
 
     DROP TABLE IF EXISTS to_delete;
     SET @end_bucket= p_end_bucket, @batch = p_batch;
-    SET @create_table_to_delete_stmt = CONCAT('CREATE TEMPORARY TABLE to_delete ENGINE=MEMORY, MAX_ROWS=', @batch, ' SELECT node_id, tenant_id, mac, time_bucket as new_time_bucket, time_bucket, unique_session_id, in_bytes, out_bytes, last_updated FROM bandwidth_accounting LIMIT 0');
+    SET @create_table_to_delete_stmt = CONCAT('CREATE TEMPORARY TABLE to_delete INDEX(node_id, unique_session_id, new_time_bucket) ENGINE=MEMORY, MAX_ROWS=', @batch, ' SELECT node_id, tenant_id, mac, time_bucket as new_time_bucket, time_bucket, unique_session_id, in_bytes, out_bytes, last_updated FROM bandwidth_accounting LIMIT 0');
     PREPARE create_table_to_delete FROM @create_table_to_delete_stmt;
     EXECUTE create_table_to_delete;
     DEALLOCATE PREPARE create_table_to_delete;

--- a/db/pf-schema-X.Y.sql
+++ b/db/pf-schema-X.Y.sql
@@ -1784,6 +1784,7 @@ BEGIN
     SET @insert_into_to_delete_stmt = CONCAT('INSERT INTO to_delete SELECT node_id, tenant_id, mac, ', @date_rounding,'(time_bucket) as new_time_bucket, time_bucket, in_bytes, out_bytes FROM bandwidth_accounting_history WHERE time_bucket <= ? AND time_bucket != ', @date_rounding, '(time_bucket) LIMIT ?');
     PREPARE insert_into_to_delete FROM @insert_into_to_delete_stmt;
 
+    SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
     START TRANSACTION;
     EXECUTE insert_into_to_delete using @end_bucket, @batch;
     SELECT COUNT(*) INTO @count FROM to_delete;


### PR DESCRIPTION
# Description
Additional Fixes #6788

# Impacts
* Add index in `@create_table_to_delete_stmt`
* Changes transaction isolation level within `bandwidth_aggregation_history` stored procedure to prevent SELECT deadlocks within `@insert_into_to_delete_stmt`
