### PR TITLE
Fix/don't resolve IPs for LDAP source using SSL and requiring verification

### DIFF
--- a/lib/pf/Authentication/Source/LDAPSource.pm
+++ b/lib/pf/Authentication/Source/LDAPSource.pm
@@ -236,8 +236,14 @@ sub _connect {
   my $connection;
   my $logger = Log::Log4perl::get_logger(__PACKAGE__);
   my $LDAPServer;
-  # Lookup the server hostnames to IPs so they can be shuffled better and to improve the failure detection
-  my @LDAPServers = map { valid_ip($_) ? $_ : @{resolve($_) // []} } @{$self->{'host'} // []};
+  my @LDAPServers;
+  if ($self->{'encryption'} eq SSL && $self->{'verify'} eq 'require') {
+      # Not expanding hostnames in order to allow LDAPS to send SNI header and verify hostname header against certifcate (at the cost of IP based round robin)
+      @LDAPServers = @{$self->{'host'} // []};
+  } else {
+      # Lookup the server hostnames to IPs so they can be shuffled better and to improve the failure detection
+      @LDAPServers = map { valid_ip($_) ? $_ : @{resolve($_) // []} } @{$self->{'host'} // []};     
+  }
   if ($self->shuffle) {
       @LDAPServers = List::Util::shuffle @LDAPServers;
   }


### PR DESCRIPTION
# Description
Prevent LDAP Source host resolving to IPs if using SSL and server verification required. This allows hostname to be sent through to the Net::LDAPS module to be added as SNI header and matched against server certificate hostname at the cost of round robin server IP load balancing. Regression introduced in cc22dd9c9f1be228a5fa8ba8d978be6186d6c922.

# Impacts
LDAP Authentication Source server enumeration and IP based multi server connection for SSL and "Require" verification only

# Delete branch after merge
YES

# Checklist
- [X] Document the feature
- N/A Add unit tests
- N/A Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* Allows LDAPS Authentication Source to use SSL verification based on certificate hostname