### PR TITLE
Configurable Sender email address for monit

### DIFF
--- a/addons/monit/monit_build_configuration.pl
+++ b/addons/monit/monit_build_configuration.pl
@@ -36,7 +36,7 @@ my $MONIT_EXTRA_PATH = "$MONIT_PATH/packetfence";
 
 
 if ( $#ARGV eq "-1" ) {
-    print "Usage: ./monit_configuration_builder.pl 'email(s)' 'subject' 'configurations' 'mailserver'\n\n";
+    print "Usage: ./monit_configuration_builder.pl 'email(s)' 'subject' 'configurations' 'mailserver' 'sender email'\n\n";
     print "email(s): List of alerting email address(es) (comma-separated if more than one)\n";
     print "subject: Identifier for email alerts\n";
     print "configurations: List of configuration to generate (comma-separated if more than one)\n";
@@ -50,11 +50,12 @@ if ( $#ARGV eq "-1" ) {
     die "\n";
 }
 
-my ( $emails, $subject_identifier, $configurations, $mailserver ) = @ARGV;
+my ( $emails, $subject_identifier, $configurations, $mailserver, $sender ) = @ARGV;
 die "No alerting email address(es) specified\n" if !defined $emails;
 die "No alerting subject specified\n" if !defined $subject_identifier;
 die "No configuration(s) specified\n" if !defined $configurations;
 $mailserver = "localhost" if !defined $mailserver;
+$sender = 'monit@$HOST' if !defined $sender;
 
 
 my @emails = split(/\,/, $emails);
@@ -87,6 +88,7 @@ sub generate_monit_configurations {
         SUBJECT_IDENTIFIER  => $subject_identifier,
         MAILSERVER          => $mailserver,
         ALERTING_CONF       => $Config{alerting},
+        SENDER              => $sender,
     };
     my $tt = Template->new(ABSOLUTE => 1);
     my $template_file;

--- a/addons/monit/monit_configurations/monit_general.tt
+++ b/addons/monit/monit_configurations/monit_general.tt
@@ -16,7 +16,7 @@ set mailserver [% ALERTING_CONF.smtpserver %]
 [% END %]
 
 set mail-format {
-    from: monit@$HOST
+    from: [% SENDER %]
     subject: [% SUBJECT_IDENTIFIER %] | Monit Alert -- $EVENT on resource '$SERVICE'
     message:
 Date:        $DATE

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -2029,3 +2029,10 @@ type=text
 description=<<EOT
 The service URL for netdata
 EOT
+
+[monit.sender]
+type=text
+description=<<EOT
+Field described in JS files
+EOT
+

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -1440,6 +1440,7 @@ alert_email_to=
 subject_prefix=
 configurations=packetfence,os-checks
 mailserver=
+sender=monit@$HOST
 
 [services_url]
 httpd_portal=[% ENV.env_or_default("PF_SERVICES_URL_HTTPD_PORTAL", "http://containers-gateway.internal:8080") %]

--- a/html/pfappserver/root/src/views/Configuration/monit/_components/TheForm.vue
+++ b/html/pfappserver/root/src/views/Configuration/monit/_components/TheForm.vue
@@ -16,7 +16,7 @@
 
     <form-group-sender namespace="sender"
       :column-label="$i18n.t('Sender Email Address')"
-      :text="$i18n.t('Email address of the sender of the monit alerts. When left empty, the emails address will be monit@$HOST.')"
+      :text="$i18n.t('Email address of the sender of the monit alerts. When left empty, the email address will be monit@$HOST.')"
     />
 
     <form-group-alert-email-to namespace="alert_email_to"

--- a/html/pfappserver/root/src/views/Configuration/monit/_components/TheForm.vue
+++ b/html/pfappserver/root/src/views/Configuration/monit/_components/TheForm.vue
@@ -14,6 +14,11 @@
       :text="$i18n.t('Whether or not monit should be enabled on this system. Enabling or disabling the service requires to run the following command: `/usr/local/pf/bin/pfcmd service pf updatesystemd`')"
     />
 
+    <form-group-sender namespace="sender"
+      :column-label="$i18n.t('Sender Email Address')"
+      :text="$i18n.t('Email address of the sender of the monit alerts. When left empty, the emails address will be monit@$HOST.')"
+    />
+
     <form-group-alert-email-to namespace="alert_email_to"
       :column-label="$i18n.t('Alert Email To')"
       :text="$i18n.t('Comma-delimited list of emails addressed who should receive the monit alerts. When left empty, the emails defined in Alerting will receive the alerts.')"
@@ -42,6 +47,7 @@ import {
 } from '@/components/new/'
 import schemaFn from '../schema'
 import {
+  FormGroupSender,
   FormGroupAlertEmailTo,
   FormGroupConfigurations,
   FormGroupMailserver,
@@ -52,6 +58,7 @@ import {
 const components = {
   BaseForm,
 
+  FormGroupSender,
   FormGroupAlertEmailTo,
   FormGroupConfigurations,
   FormGroupMailserver,

--- a/html/pfappserver/root/src/views/Configuration/monit/_components/index.js
+++ b/html/pfappserver/root/src/views/Configuration/monit/_components/index.js
@@ -11,6 +11,7 @@ import TheView from './TheView'
 export {
   BaseFormButtonBar                   as FormButtonBar,
 
+  BaseFormGroupTextarea               as FormGroupSender,
   BaseFormGroupTextarea               as FormGroupAlertEmailTo,
   BaseFormGroupInput                  as FormGroupConfigurations,
   BaseFormGroupInput                  as FormGroupMailserver,

--- a/lib/pf/cmd/pf/generatemonitconfig.pm
+++ b/lib/pf/cmd/pf/generatemonitconfig.pm
@@ -26,7 +26,7 @@ sub _run {
         $configurations .= ",active-active";
     }
     my $emails = $Config{monit}{alert_email_to} ? $Config{monit}{alert_email_to} : $Config{alerting}{emailaddr};
-    return system("/usr/local/pf/addons/monit/monit_build_configuration.pl", $emails, $Config{monit}{subject_prefix}, $configurations, $Config{monit}{mailserver});
+    return system("/usr/local/pf/addons/monit/monit_build_configuration.pl", $emails, $Config{monit}{subject_prefix}, $configurations, $Config{monit}{mailserver}, $Config{monit}{sender});
 }
 
 =head1 AUTHOR


### PR DESCRIPTION
# Description
Added Monit Sender address configurable in the admin gui

# Impacts
Monit configuration

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* Monit Sender address configurable from the admin gui.
