### PR TITLE
fix/6883

### DIFF
--- a/html/pfappserver/root/src/views/Configuration/filterEngines/_components/BaseConditionValue.vue
+++ b/html/pfappserver/root/src/views/Configuration/filterEngines/_components/BaseConditionValue.vue
@@ -29,12 +29,22 @@
         :disabled="disabled"
       />
 
-      <base-input-group-textarea v-else
-        class="flex-grow-1 m-1"
-        :namespace="`${namespace}.value`"
-        :disabled="disabled"
-        autoFit
-      />
+      <template v-else>
+
+        <base-input-group-textarea v-if="['time_period', 'not_time_period'].includes(inputValueOperator)"
+          class="flex-grow-1 m-1"
+          :namespace="`${namespace}.value`"
+          :disabled="disabled"
+          autoFit
+        />
+
+        <base-input v-else
+          class="flex-grow-1 m-1"
+          :namespace="`${namespace}.value`"
+          :disabled="disabled"
+        />
+
+      </template>
 
     </template>
 
@@ -60,6 +70,7 @@
 </template>
 <script>
 import {
+  BaseInput,
   BaseInputGroupTextarea,
   BaseInputChosenOne
 } from '@/components/new/'
@@ -67,6 +78,7 @@ import BaseConditionOperator from './BaseConditionOperator'
 
 const components = {
   BaseConditionOperator,
+  BaseInput,
   BaseInputGroupTextarea,
   BaseInputChosenOne
 }

--- a/html/pfappserver/root/src/views/Configuration/filterEngines/_components/BaseConditionValue.vue
+++ b/html/pfappserver/root/src/views/Configuration/filterEngines/_components/BaseConditionValue.vue
@@ -29,10 +29,11 @@
         :disabled="disabled"
       />
 
-      <base-input v-else
+      <base-input-group-textarea v-else
         class="flex-grow-1 m-1"
         :namespace="`${namespace}.value`"
         :disabled="disabled"
+        autoFit
       />
 
     </template>
@@ -59,14 +60,14 @@
 </template>
 <script>
 import {
-  BaseInput,
+  BaseInputGroupTextarea,
   BaseInputChosenOne
 } from '@/components/new/'
 import BaseConditionOperator from './BaseConditionOperator'
 
 const components = {
   BaseConditionOperator,
-  BaseInput,
+  BaseInputGroupTextarea,
   BaseInputChosenOne
 }
 
@@ -218,3 +219,19 @@ export default {
   setup
 }
 </script>
+
+<style lang="scss">
+* [draggable] {
+  textarea[autofit] {
+    white-space: pre;
+    overflow: hidden;
+    max-height: $input-height;
+    transition: max-height .3s ease-in-out;
+    &:hover, &:focus {
+      max-height: 250px;
+      white-space: pre-wrap;
+      overflow: auto;
+    }
+  }
+}
+</style>


### PR DESCRIPTION
# Description
Use textareea within filter engine condition in order to display entire value within draggable parent. Add CSS to collapse textarea by. default and expand on hover or focus. Changes all input to textarea.

# Issue
fixes #6883 

# Delete branch after merge
YES 