### PR TITLE
handle DBI ping 'die' in pfconfig mysql backend

### DIFF
--- a/lib/pfconfig/backend/mysql.pm
+++ b/lib/pfconfig/backend/mysql.pm
@@ -37,8 +37,16 @@ Get a connection to the database
 
 sub _get_db {
     my ($self) = @_;
-    return $self->{_db} if (defined $self->{_db} && $self->{_db}->ping);
     my $logger = get_logger;
+
+    my $self_dbh_valid = 0;
+    eval {
+        $self_dbh_valid = (defined $self->{_db} && $self->{_db}->ping);
+    };
+    if($@) {
+        $logger->error("DB handler is unable to ping the DB, reconnecting...");
+    }
+
     $logger->info("Connecting to MySQL database");
     
     my $cfg    = pfconfig::config->new->section('mysql');


### PR DESCRIPTION
# Description
Handle DBI library ping call dying in pfconfig mysql backend. This prevents a pfconfig resource from being fetched under specific timing conditions.

# Impacts
pfconfig mysql backend

# Issue
fixes #6895 

# Delete branch after merge
YES

## Bug Fixes
* Handle DBI library ping call dying in pfconfig mysql backend (#6895)

