### PR TITLE
fix: use CRLF for mails sent to SMTP servers

### DIFF
--- a/lib/pf/Authentication/Source/SMSSource.pm
+++ b/lib/pf/Authentication/Source/SMSSource.pm
@@ -118,7 +118,7 @@ sub sendSMS {
     my $msg = MIME::Lite->new(
         To          =>  $email,
         Subject     =>  "Network Activation",
-        Data        =>  $info->{message} . "\n",
+        Data        =>  $info->{message} . "\r\n",
     );
     return pf::config::util::send_mime_lite($msg);
 }

--- a/lib/pf/UnifiedApi/Controller/Config/Bases.pm
+++ b/lib/pf/UnifiedApi/Controller/Config/Bases.pm
@@ -277,7 +277,7 @@ sub test_smtp {
     my $msg = MIME::Lite->new(
         To => $email,
         Subject => "PacketFence SMTP Test",
-        Data => "PacketFence SMTP Test successful!\n"
+        Data => "PacketFence SMTP Test successful!\r\n"
     );
 
     my $results = eval {

--- a/lib/pf/config/util.pm
+++ b/lib/pf/config/util.pm
@@ -137,7 +137,7 @@ sub pfmailer {
     my $msg = MIME::Lite->new(
         To      => $to,
         Subject => $subject,
-        Data    => $data{message} . "\n",
+        Data    => $data{message} . "\r\n",
     );
     return send_mime_lite($msg);
 }


### PR DESCRIPTION
# Description
Switch from LF to CRLF for mails send using PacketFence

Here I only changed last line of message. I assumed messages sent by PacketFence only contain CRLF and not LF.

# Impacts
Emails sent by PacketFence

# Issue
fixes #5380

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* Replace LF by CRLF at end of mails sent by PacketFence (#5380)
