### PR TITLE
Use the mac that has been detected in external portal

### DIFF
--- a/html/captive-portal/lib/captiveportal/PacketFence/Model/Portal/Session.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Model/Portal/Session.pm
@@ -240,7 +240,11 @@ sub _build_clientMac {
         if ( $clientIP->type eq $pf::IPv6::TYPE ) {
             $mac = pf::ip6log::ip2mac( $clientIP->normalizedIP ) unless defined $mac;
         } else {
-            $mac = pf::ip4log::ip2mac( $clientIP->normalizedIP ) unless defined $mac;
+            if (defined($self->dispatcherSession->{_client_mac}) && $self->dispatcherSession->{_client_mac} ne "") {
+                $mac = $self->dispatcherSession->{_client_mac};
+            } else {
+                $mac = pf::ip4log::ip2mac( $clientIP->normalizedIP ) unless defined $mac;
+            }
         }
     }
 

--- a/lib/pf/Portal/Session.pm
+++ b/lib/pf/Portal/Session.pm
@@ -115,7 +115,7 @@ sub _initialize {
     );
 
     my $client_mac = $self->{_client_mac};
-    $self->{_dummy_session} = (defined($client_mac) && $client_mac eq $DUMMY_MAC);
+    $self->{_dummy_session} = ($sid eq md5_hex($DUMMY_MAC));
 
     $self->session->param("_client_mac", $client_mac);
 

--- a/lib/pf/web/externalportal.pm
+++ b/lib/pf/web/externalportal.pm
@@ -199,6 +199,7 @@ sub _setup_session {
     $portalSession->setDestinationUrl($redirect_url) if (defined($redirect_url));
     $portalSession->setGrantUrl($grant_url) if (defined($grant_url));
     $portalSession->session->param('is_external_portal', $TRUE);
+    $portalSession->setClientMac($client_mac) if (defined($client_mac));
     if(defined($req)){
         my $params = $req->param // {};
         foreach my $key (keys %$params) {


### PR DESCRIPTION
# Description
Save in the Portal Session the mac address that has been detected in the external portal.
It help in the case that the request is coming from the same ip address (reverse procy/ natted network)

# Impacts
External portal

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* Save in the Portal Session the device mac address that has been detected on the external portal
