### PR TITLE
Sync iptables-input config and ip6table* files across cluster

### DIFF
--- a/addons/full-import/find-extra-files.pl
+++ b/addons/full-import/find-extra-files.pl
@@ -29,6 +29,10 @@ my %ignored_params = (
 
 my @extra_files_to_export = (
     $pf::file_paths::fingerbank_config_file,
+    $pf::file_paths::iptable_input_config_file,
+    $pf::file_paths::iptable_input_management_config_file,
+    $pf::file_paths::ip6table_input_config_file,
+    $pf::file_paths::ip6table_input_management_config_file,
     $pf::file_paths::report_config_file,
 );
 

--- a/docs/installation/export_import_mechanism.asciidoc
+++ b/docs/installation/export_import_mechanism.asciidoc
@@ -46,7 +46,7 @@ It can be used to automate parts of upgrades or to restore PacketFence installat
 ** [filename]`/usr/local/pf/conf/radiusd/*`
 ** [filename]`/usr/local/pf/conf/log.conf`
 ** [filename]`/usr/local/pf/conf/log.conf.d/*`
-** [filename]`/usr/local/pf/conf/iptables.conf`
+** [filename]`/usr/local/pf/conf/iptables.conf` (but [filename]`/usr/local/pf/conf/iptables-input*.conf` and [filename]`/usr/local/pf/conf/ip6tables-input*.conf` are restored)
 ** [filename]`/usr/local/pf/conf/cluster.conf`
 
 

--- a/lib/pf/constants/cluster.pm
+++ b/lib/pf/constants/cluster.pm
@@ -26,6 +26,12 @@ use pf::file_paths qw(
     $radius_server_cert
     $radius_ca_cert
     $conf_dir
+    $iptable_config_file
+    $iptable_input_config_file
+    $iptable_input_management_config_file
+    $ip6table_config_file
+    $ip6table_input_config_file
+    $ip6table_input_management_config_file
     $local_secret_file
     $unified_api_system_pass_file
     $network_behavior_policy_config_file
@@ -43,8 +49,13 @@ our @FILES_TO_SYNC = (
     $local_secret_file, 
     $unified_api_system_pass_file,
     $network_behavior_policy_config_file,
-    $pfconfig::constants::CONFIG_FILE_PATH, 
-    "$conf_dir/iptables.conf", 
+    $pfconfig::constants::CONFIG_FILE_PATH,
+    $iptable_config_file,
+    $iptable_input_config_file,
+    $iptable_input_management_config_file,
+    $ip6table_config_file,
+    $ip6table_input_config_file,
+    $ip6table_input_management_config_file,
     $fingerbank::FilePath::CONF_FILE, 
     $fingerbank::FilePath::LOCAL_DB_FILE
 );

--- a/lib/pf/file_paths.pm
+++ b/lib/pf/file_paths.pm
@@ -114,6 +114,11 @@ our (
     $fingerbank_doc_file,
     $api_i18n_dir,
     $iptable_config_file,
+    $iptable_input_config_file,
+    $iptable_input_management_config_file,
+    $ip6table_config_file,
+    $ip6table_input_config_file,
+    $ip6table_input_management_config_file,
     $ssl_config_file, $ssl_default_config_file,
     $tls_config_file, $tls_default_config_file,
     $ocsp_config_file, $ocsp_default_config_file,
@@ -212,6 +217,11 @@ BEGIN {
         $fingerbank_doc_file
         $api_i18n_dir
         $iptable_config_file
+        $iptable_input_config_file
+        $iptable_input_management_config_file
+        $ip6table_config_file
+        $ip6table_input_config_file
+        $ip6table_input_management_config_file
         $ssl_config_file $ssl_default_config_file
         $tls_config_file $tls_default_config_file
         $ocsp_config_file $ocsp_default_config_file
@@ -336,6 +346,11 @@ $switch_filters_config_file = catfile($conf_dir,"switch_filters.conf");
 $stats_config_file = catfile($conf_dir, "stats.conf");
 $stats_config_default_file = catfile($conf_dir, "stats.conf.defaults");
 $iptable_config_file = catfile($conf_dir, "iptables.conf");
+$iptable_input_config_file = catfile($conf_dir, "iptables-input.conf.inc");
+$iptable_input_management_config_file = catfile($conf_dir, "iptables-input-management.conf.inc");
+$ip6table_config_file = catfile($conf_dir, "ip6tables.conf");
+$ip6table_input_config_file = catfile($conf_dir, "ip6tables-input.conf.inc");
+$ip6table_input_management_config_file = catfile($conf_dir, "ip6tables-input-management.conf.inc");
 $ssl_config_file = catfile($conf_dir,"ssl.conf");
 $ssl_default_config_file = catfile($conf_dir,"ssl.conf.defaults");
 $tls_config_file = catfile($conf_dir,"radiusd/tls.conf");


### PR DESCRIPTION
# Description
Sync iptables-input config and ip6table* files across cluster

Related to #6583 and #6836 

# Impacts
Cluster synchronization

# Delete branch after merge
YES

# NEWS file entries
## Enhancements
* iptables-input* and ip6tables-input are handled by export/import mechanism

## Bug Fixes
* ip6tables configuration files are not synced across a cluster
* iptables-input configuration files are not synced across a cluster