### PR TITLE
Fingerbank Upstream DB image builder

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -533,6 +533,7 @@ img_dev:
   parallel:
     matrix:
       - IMAGE_NAME:
+          - "fingerbank-db"
           - "haproxy-portal"
 
 rad_based_dev:
@@ -593,6 +594,7 @@ img_br_maint:
   parallel:
     matrix:
       - IMAGE_NAME:
+          - "fingerbank-db"
           - "haproxy-portal"
 
 rad_based_br_maint:

--- a/containers/fingerbank-db/Dockerfile
+++ b/containers/fingerbank-db/Dockerfile
@@ -1,0 +1,10 @@
+FROM alpine
+
+ARG FINGERBANK_API_KEY
+
+RUN apk update && apk add curl
+
+RUN mkdir -p /usr/local/fingerbank/db
+
+RUN curl -H "Authorization: Bearer ${FINGERBANK_API_KEY}" https://api.fingerbank.org/api/v2/download/db > /usr/local/fingerbank/db/fingerbank_Upstream.db
+

--- a/containers/fingerbank-db/Dockerfile
+++ b/containers/fingerbank-db/Dockerfile
@@ -6,5 +6,5 @@ RUN apk update && apk add curl
 
 RUN mkdir -p /usr/local/fingerbank/db
 
-RUN curl -H "Authorization: Bearer ${FINGERBANK_BUILD_API_KEY}" https://api.fingerbank.org/api/v2/download/db > /usr/local/fingerbank/db/fingerbank_Upstream.db
+RUN curl --fail -H "Authorization: Bearer ${FINGERBANK_BUILD_API_KEY}" https://api.fingerbank.org/api/v2/download/db > /usr/local/fingerbank/db/fingerbank_Upstream.db
 

--- a/containers/fingerbank-db/Dockerfile
+++ b/containers/fingerbank-db/Dockerfile
@@ -6,5 +6,5 @@ RUN apk update && apk add curl
 
 RUN mkdir -p /usr/local/fingerbank/db
 
-RUN curl --fail -H "Authorization: Bearer ${FINGERBANK_BUILD_API_KEY}" https://api.fingerbank.org/api/v2/download/db > /usr/local/fingerbank/db/fingerbank_Upstream.db
+RUN curl --fail --retry 3 -H "Authorization: Bearer ${FINGERBANK_BUILD_API_KEY}" https://api.fingerbank.org/api/v2/download/db > /usr/local/fingerbank/db/fingerbank_Upstream.db
 

--- a/containers/fingerbank-db/Dockerfile
+++ b/containers/fingerbank-db/Dockerfile
@@ -1,10 +1,10 @@
 FROM alpine
 
-ARG FINGERBANK_API_KEY
+ARG FINGERBANK_BUILD_API_KEY
 
 RUN apk update && apk add curl
 
 RUN mkdir -p /usr/local/fingerbank/db
 
-RUN curl -H "Authorization: Bearer ${FINGERBANK_API_KEY}" https://api.fingerbank.org/api/v2/download/db > /usr/local/fingerbank/db/fingerbank_Upstream.db
+RUN curl -H "Authorization: Bearer ${FINGERBANK_BUILD_API_KEY}" https://api.fingerbank.org/api/v2/download/db > /usr/local/fingerbank/db/fingerbank_Upstream.db
 

--- a/containers/kanikobuild
+++ b/containers/kanikobuild
@@ -8,8 +8,6 @@ set -o nounset -o pipefail -o errexit
 setup_vars() {
     DOCKFILE_PATH=$CI_PROJECT_DIR/containers/$IMAGE_NAME/Dockerfile
 
-    env
-
     ### collect variables needed inside Dockerfile
     # returns X.Y
     export PF_VERSION=$(egrep -o '[0-9]+\.[0-9]+' $CI_PROJECT_DIR/conf/pf-release)

--- a/containers/kanikobuild
+++ b/containers/kanikobuild
@@ -8,6 +8,8 @@ set -o nounset -o pipefail -o errexit
 setup_vars() {
     DOCKFILE_PATH=$CI_PROJECT_DIR/containers/$IMAGE_NAME/Dockerfile
 
+    env
+
     ### collect variables needed inside Dockerfile
     # returns X.Y
     export PF_VERSION=$(egrep -o '[0-9]+\.[0-9]+' $CI_PROJECT_DIR/conf/pf-release)

--- a/containers/kanikobuild
+++ b/containers/kanikobuild
@@ -17,7 +17,7 @@ setup_vars() {
     export IMAGE_TAG=$(echo $IMAGE_TAGS | cut -d ',' -f 1)
 
     # variables to pass during build
-    DOCKFILE_VARS='PF_VERSION KNK_REGISTRY_URL IMAGE_TAG FINGERBANK_API_KEY'
+    DOCKFILE_VARS='PF_VERSION KNK_REGISTRY_URL IMAGE_TAG FINGERBANK_BUILD_API_KEY'
 
     echo "Building ${IMAGE_NAME} using ${DOCKFILE_PATH}"
 }

--- a/containers/kanikobuild
+++ b/containers/kanikobuild
@@ -17,7 +17,7 @@ setup_vars() {
     export IMAGE_TAG=$(echo $IMAGE_TAGS | cut -d ',' -f 1)
 
     # variables to pass during build
-    DOCKFILE_VARS='PF_VERSION KNK_REGISTRY_URL IMAGE_TAG'
+    DOCKFILE_VARS='PF_VERSION KNK_REGISTRY_URL IMAGE_TAG FINGERBANK_API_KEY'
 
     echo "Building ${IMAGE_NAME} using ${DOCKFILE_PATH}"
 }


### PR DESCRIPTION
# Description
Build a docker image that contains the Fingerbank upstream DB so that it can be mounted in k8s deployments
This only creates the image, we'll need to setup a schedule that publishes it on a regular basis to keep it up to date

# Impacts
Gitlab builds

# Delete branch after merge
YES

