### PR TITLE
add radius filter to use ttls-pap username from inner tunnel in reply

### DIFF
--- a/conf/radius_filters.conf.defaults
+++ b/conf/radius_filters.conf.defaults
@@ -1,3 +1,13 @@
+[pap-username-from-tunnel]
+merge_answer=yes
+status=enabled
+scopes=returnRadiusAccessAccept
+condition=connection_type == "Wireless-802.11-EAP" && connection_sub_type == "EAP-TTLS"
+description=papusername
+top_op=and
+radius_status=RLM_MODULE_OK
+answer.0=reply:User-Name = ${radius_request.User-Name}
+
 [EXAMPLE_Ethernet-EAP-Accept]
 status=disabled
 description=Return Access-Accept with VSA when the connection is Ethernet-EAP and when there is no security event

--- a/conf/radius_filters.conf.defaults
+++ b/conf/radius_filters.conf.defaults
@@ -1,13 +1,3 @@
-[pap-username-from-tunnel]
-merge_answer=yes
-status=enabled
-scopes=returnRadiusAccessAccept
-condition=connection_type == "Wireless-802.11-EAP" && connection_sub_type == "EAP-TTLS"
-description=papusername
-top_op=and
-radius_status=RLM_MODULE_OK
-answer.0=reply:User-Name = ${radius_request.User-Name}
-
 [EXAMPLE_Ethernet-EAP-Accept]
 status=disabled
 description=Return Access-Accept with VSA when the connection is Ethernet-EAP and when there is no security event

--- a/conf/radiusd/packetfence-tunnel.example
+++ b/conf/radiusd/packetfence-tunnel.example
@@ -23,8 +23,9 @@ authorize {
 	# TTLS does not send an EAP-Message to be parsed so the eap module
 	# cannot assign the EAP-Type
 	if ( outer.EAP-Type == TTLS) {
-		update request {
-			&EAP-Type := TTLS
+		update {
+			&request:EAP-Type := TTLS
+			&reply:User-Name = "%{User-Name}"
 		}
 	}
 	packetfence-set-realm-if-machine
@@ -38,9 +39,9 @@ authorize {
 	#
 	filter_username
 
-        update {
-                &request:PacketFence-Outer-User := "%{outer.request:User-Name}"
-        }
+	update {
+		&request:PacketFence-Outer-User := "%{outer.request:User-Name}"
+	}
 
 
 	#


### PR DESCRIPTION
# Description
Makes the User-Name sent in a TTLS-PAP reply use the identity of the inner tunnel

# Impacts
EAP-TTLS PAP

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* The User-Name value in an EAP-TTLS PAP reply will always be the identity of the inner tunnel
