### PR TITLE
Improve stability of tests on maintenance (11.2 and after)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -401,7 +401,15 @@ variables:
   script:
     - MAKE_TARGET=run make -e -C ${TESTDIR} ${CI_JOB_NAME}
   after_script:
-    - MAKE_TARGET=halt make -e -C ${TESTDIR} ${CI_JOB_NAME}
+    - >
+      if [ $CI_JOB_STATUS == 'success' ]; then
+        echo 'Passed tests, no need to keep VM'
+        MAKE_TARGET=clean make -e -C ${TESTDIR} ${CI_JOB_NAME}
+      else
+        echo 'Failed tests, shutdown VM to analyze issue'
+        MAKE_TARGET=halt make -e -C ${TESTDIR} ${CI_JOB_NAME}
+      fi
+
 
 ################################################################################
 # JOBS
@@ -585,7 +593,7 @@ publish_ppa_devel_release_branches_and_maintenance::
 ### development
 unit_tests_el8:
   variables:
-    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_COMMIT_REF_SLUG}
+    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
   extends:
     - .test_job
     - .test_script_job
@@ -593,7 +601,7 @@ unit_tests_el8:
 
 dot1x_eap_peap_el8:
   variables:
-    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_COMMIT_REF_SLUG}
+    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
   extends:
     - .test_job
     - .test_script_job
@@ -601,7 +609,7 @@ dot1x_eap_peap_el8:
 
 dot1x_eap_peap_deb11:
   variables:
-    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_COMMIT_REF_SLUG}
+    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
   extends:
     - .test_job
     - .test_script_job
@@ -609,7 +617,7 @@ dot1x_eap_peap_deb11:
 
 mac_auth_el8:
   variables:
-    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_COMMIT_REF_SLUG}
+    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
   extends:
     - .test_job
     - .test_script_job
@@ -617,7 +625,7 @@ mac_auth_el8:
 
 mac_auth_deb11:
   variables:
-    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_COMMIT_REF_SLUG}
+    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
   extends:
     - .test_job
     - .test_script_job
@@ -625,7 +633,7 @@ mac_auth_deb11:
 
 dot1x_eap_tls_el8:
   variables:
-    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_COMMIT_REF_SLUG}
+    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
   extends:
     - .test_job
     - .test_script_job
@@ -633,7 +641,7 @@ dot1x_eap_tls_el8:
 
 dot1x_eap_tls_deb11:
   variables:
-    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_COMMIT_REF_SLUG}
+    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
   extends:
     - .test_job
     - .test_script_job
@@ -641,7 +649,7 @@ dot1x_eap_tls_deb11:
 
 fingerbank_invalid_db_deb11:
   variables:
-    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_COMMIT_REF_SLUG}
+    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
   extends:
     - .test_job
     - .test_script_job
@@ -649,7 +657,7 @@ fingerbank_invalid_db_deb11:
 
 security_events_deb11:
   variables:
-    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_COMMIT_REF_SLUG}
+    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
   extends:
     - .test_job
     - .test_script_job
@@ -657,7 +665,7 @@ security_events_deb11:
 
 cli_login_deb11:
   variables:
-    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_COMMIT_REF_SLUG}
+    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
   extends:
     - .test_job
     - .test_script_job
@@ -665,7 +673,7 @@ cli_login_deb11:
 
 cli_login_el8:
   variables:
-    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_COMMIT_REF_SLUG}
+    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
   extends:
     - .test_job
     - .test_script_job
@@ -673,7 +681,7 @@ cli_login_el8:
 
 external_integrations_deb11:
   variables:
-    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_COMMIT_REF_SLUG}
+    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
   extends:
     - .test_job
     - .test_script_job
@@ -681,7 +689,7 @@ external_integrations_deb11:
 
 captive_portal_el8:
   variables:
-    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_COMMIT_REF_SLUG}
+    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
   extends:
     - .test_job
     - .test_script_job
@@ -689,7 +697,7 @@ captive_portal_el8:
 
 captive_portal_deb11:
   variables:
-    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_COMMIT_REF_SLUG}
+    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
   extends:
     - .test_job
     - .test_script_job

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -397,7 +397,7 @@ variables:
 
 .test_script_job:
   variables:
-    VAGRANT_COMMON_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-common
+    VAGRANT_COMMON_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-common-${CI_COMMIT_REF_SLUG}
   script:
     - MAKE_TARGET=run make -e -C ${TESTDIR} ${CI_JOB_NAME}
   after_script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,6 +31,7 @@ variables:
   CHECKDIR: ${CILIBDIR}/check
   BUILDDIR: ${CILIBDIR}/build
   RELEASEDIR: ${CILIBDIR}/release
+  TESTCIDIR: ${CILIBDIR}/test
   PACKERDIR: $CIDIR/packer
   ZENDIR: $CIDIR/packer/zen
   ISODIR: $CIDIR/debian-installer
@@ -401,14 +402,7 @@ variables:
   script:
     - MAKE_TARGET=run make -e -C ${TESTDIR} ${CI_JOB_NAME}
   after_script:
-    - >
-      if [ $CI_JOB_STATUS == 'success' ]; then
-        echo 'Passed tests, no need to keep VM'
-        MAKE_TARGET=clean make -e -C ${TESTDIR} ${CI_JOB_NAME}
-      else
-        echo 'Failed tests, shutdown VM to analyze issue'
-        MAKE_TARGET=halt make -e -C ${TESTDIR} ${CI_JOB_NAME}
-      fi
+    - ${TESTCIDIR}/clean-test-environment.sh
 
 
 ################################################################################

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -705,7 +705,7 @@ captive_portal_deb11:
 
 inline_deb11:
   variables:
-    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_COMMIT_TAG}
+    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
   extends:
     - .test_job
     - .test_script_job
@@ -713,7 +713,7 @@ inline_deb11:
 
 inline_el8:
   variables:
-    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_COMMIT_TAG}
+    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
   extends:
     - .test_job
     - .test_script_job

--- a/addons/vagrant/Vagrantfile
+++ b/addons/vagrant/Vagrantfile
@@ -17,6 +17,9 @@ Vagrant.configure("2") do |config|
   # use same private key on all machines
   config.ssh.insert_key = false
 
+  # Number of seconds to wait for establishing an SSH connection to the guest
+  config.ssh.connect_timeout = 60
+
   config.vm.provider "libvirt" do |vm|
     vm.default_prefix = DOMAIN_PREFIX
   end

--- a/addons/vagrant/inventory/group_vars/pfservers/debian.yml
+++ b/addons/vagrant/inventory/group_vars/pfservers/debian.yml
@@ -1,0 +1,6 @@
+---
+apt_services:
+  - apt-daily.timer  
+  - apt-daily.service
+  - apt-daily-upgrade.timer
+  - apt-daily-upgrade.service

--- a/addons/vagrant/playbooks/tasks/disable_apt_services.yml
+++ b/addons/vagrant/playbooks/tasks/disable_apt_services.yml
@@ -1,0 +1,15 @@
+---
+- name: stop, disable and mask apt-daily services and respective timers
+  systemd:
+    name: '{{ item }}'
+    state: 'stopped'
+    enabled: False
+    masked: True
+  loop: '{{ apt_services }}'
+  register: disable_apt_services_register
+  when: ansible_os_family == 'Debian'
+
+- name: apply systemd changes
+  systemd:
+    daemon_reload: True
+  when: disable_apt_services_register is changed

--- a/addons/vagrant/playbooks/tasks/register_rhel_subscription_tasks.yml
+++ b/addons/vagrant/playbooks/tasks/register_rhel_subscription_tasks.yml
@@ -6,7 +6,7 @@
   no_log: True
   register: reg_rhel_sub_register_username
   retries: 3
-  delay: 1
+  delay: 10
   until: reg_rhel_sub_register_username is successful
 
 - name: Get RHEL password using psonoci
@@ -16,7 +16,7 @@
   no_log: True
   register: reg_rhel_sub_register_password
   retries: 3
-  delay: 1
+  delay: 10
   until: reg_rhel_sub_register_password is successful
   
 - name: Register RHEL subscription
@@ -27,5 +27,5 @@
     auto_attach: true
   register: reg_rhel_sub_register_el
   retries: 3
-  delay: 1
+  delay: 10
   until: reg_rhel_sub_register_el is successful

--- a/addons/vagrant/playbooks/tasks/unregister_rhel_subscription_tasks.yml
+++ b/addons/vagrant/playbooks/tasks/unregister_rhel_subscription_tasks.yml
@@ -6,7 +6,7 @@
   no_log: True
   register: unreg_rhel_sub_register_username
   retries: 3
-  delay: 1
+  delay: 10
   until: unreg_rhel_sub_register_username is successful
 
 - name: Get RHEL password using psonoci
@@ -16,7 +16,7 @@
   no_log: True
   register: unreg_rhel_sub_register_password
   retries: 3
-  delay: 1
+  delay: 10
   until: unreg_rhel_sub_register_password is successful
 
 # username and password are necessary to unregister system
@@ -28,5 +28,5 @@
     auto_attach: true
   register: unreg_rhel_sub_register_el
   retries: 3
-  delay: 1
+  delay: 10
   until: unreg_rhel_sub_register_el is successful

--- a/addons/vagrant/playbooks/upgrade_deb_os.yml
+++ b/addons/vagrant/playbooks/upgrade_deb_os.yml
@@ -4,15 +4,24 @@
   gather_facts: True
   tags: upgrade
 
+  collections:
+    - debops.debops
+    - debops.roles01
+    - debops.roles02
+    - debops.roles03
+
   tasks:
+    - import_tasks: tasks/disable_apt_services.yml
+      tags: apt_services
+
     - name: update to latest OS version (Deb)
       apt:
         name: '*'
         state: latest
         update_cache: yes
-      register: upgrade_os_el_register
+      register: upgrade_os_deb_register
       when: ansible_os_family == 'Debian'
 
     - name: reboot to have latest Linux kernel packages in place when installing PacketFence
       reboot:
-      when: upgrade_os_el_register is changed
+      when: upgrade_os_deb_register is changed

--- a/ci/lib/test/clean-test-environment.sh
+++ b/ci/lib/test/clean-test-environment.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -o nounset -o pipefail -o errexit
+
+# full path to dir of current script
+SCRIPT_DIR=$(readlink -e $(dirname ${BASH_SOURCE[0]}))
+
+# full path to root of PF sources
+PF_SRC_DIR=$(echo ${SCRIPT_DIR} | grep -oP '.*?(?=\/ci\/)')
+
+# full path to test dir
+TEST_DIR=${PF_SRC_DIR}/t/venom
+
+# path to all functions
+FUNCTIONS_FILE=${PF_SRC_DIR}/ci/lib/common/functions.sh
+
+source ${FUNCTIONS_FILE}
+
+
+configure_and_check() {
+    CI_JOB_STATUS=${CI_JOB_STATUS:-}
+    CI_JOB_NAME=${CI_JOB_NAME:-}
+
+    if [ "$CI_JOB_STATUS" = "success" ]; then
+        echo "Passed tests, no need to keep VM"
+        MAKE_TARGET=clean make -e -C ${TEST_DIR} ${CI_JOB_NAME}
+    else
+        echo 'Failed tests, shutdown VM to analyze issue'
+        MAKE_TARGET=halt make -e -C ${TEST_DIR} ${CI_JOB_NAME}
+    fi
+
+    declare -p CI_JOB_STATUS CI_JOB_NAME
+    declare -p TEST_DIR
+}
+
+
+log_section "Configure and check"
+configure_and_check

--- a/t/venom/Makefile
+++ b/t/venom/Makefile
@@ -56,6 +56,7 @@ halt:
 	./test-wrapper.sh halt
 
 clean:
+	RESULT_DIR=$(RESULT_DIR) \
 	./test-wrapper.sh teardown
 
 ### Pristine images

--- a/t/venom/Makefile
+++ b/t/venom/Makefile
@@ -16,7 +16,7 @@ ifeq ($(CI), true)
  RESULT_DIR=$(CI_PROJECT_DIR)/results
 else
  $(info localdev environment detected)
- MAKE_TARGET=run_w_clean
+ MAKE_TARGET=run
  DEV_ENV=localdev
  RESULT_DIR=$(SRC_ROOT_DIR)/results
 endif
@@ -24,21 +24,11 @@ endif
 #==============================================================================
 # Targets
 #==============================================================================
-.PHONY: install run run_w_clean halt clean
+.PHONY: install run halt clean
 install:
 	./install-venom.sh
 
-run: clean
-	CI_PIPELINE_ID=$(CI_PIPELINE_ID) \
-	PF_MINOR_RELEASE=$(PF_MINOR_RELEASE) \
-	RESULT_DIR=$(RESULT_DIR) \
-	PF_VM_NAMES="$(PF_VM_NAMES)" \
-	CLUSTER_NAME="$(CLUSTER_NAME)" \
-	INT_TEST_VM_NAMES="$(INT_TEST_VM_NAMES)" \
-	SCENARIOS_TO_RUN="$(SCENARIOS_TO_RUN)" \
-	./test-wrapper.sh run
-
-run_w_clean:
+run:
 	CI_PIPELINE_ID=$(CI_PIPELINE_ID) \
 	PF_MINOR_RELEASE=$(PF_MINOR_RELEASE) \
 	RESULT_DIR=$(RESULT_DIR) \

--- a/t/venom/lib/check_host_internet_access.yml
+++ b/t/venom/lib/check_host_internet_access.yml
@@ -9,4 +9,5 @@ steps:
     user: '{{.input.user}}'
     command: |
       cd '{{.venom_dir}}'  ; \
-      sudo '{{.venom_dir}}/venom-wrapper.sh' '{{.test_suites_dir}}/common/check_internet_access.yml'
+      sudo VENOM_COMMON_FLAGS='--output-dir={{.test_suite_results_dir}}/{{.venom.testcase}}' \
+      '{{.venom_dir}}/venom-wrapper.sh' '{{.test_suites_dir}}/common/check_internet_access.yml'

--- a/t/venom/test-wrapper.sh
+++ b/t/venom/test-wrapper.sh
@@ -84,6 +84,7 @@ run() {
 start_vm() {
     local vm=$1
     local dotfile_path=$2
+    declare -p dotfile_path
     if [ -e "${dotfile_path}/machines/${vm}/libvirt/id" ]; then
         echo "Machine $vm already exists"
         machine_uuid=$(cat ${dotfile_path}/machines/${vm}/libvirt/id)
@@ -123,7 +124,11 @@ start_and_provision_other_vm() {
     log_subsection "Start and provision $vm_names"
 
     for vm in ${vm_names}; do
-        start_vm ${vm} ${VAGRANT_COMMON_DOTFILE_PATH}
+        if [ "$vm" = "node01" ] || [ "$vm" = "node03" ]; then
+            start_vm ${vm} ${VAGRANT_PF_DOTFILE_PATH}
+        else
+            start_vm ${vm} ${VAGRANT_COMMON_DOTFILE_PATH}
+        fi
     done
 }
 
@@ -195,8 +200,6 @@ destroy() {
         delete_dir_if_exists ${VAGRANT_COMMON_DOTFILE_PATH}
     else
         destroy_pf_vm
-        destroy_node01_vm
-        destroy_node03_vm
         delete_dir_if_exists ${VAGRANT_PF_DOTFILE_PATH}
     fi
 }
@@ -206,16 +209,6 @@ destroy() {
 destroy_pf_vm() {
     ( cd $VAGRANT_DIR ; \
       VAGRANT_DOTFILE_PATH=${VAGRANT_PF_DOTFILE_PATH} vagrant destroy -f || true )
-}
-
-destroy_node01_vm() {
-    ( cd $VAGRANT_DIR ; \
-      VAGRANT_DOTFILE_PATH=${VAGRANT_COMMON_DOTFILE_PATH} vagrant destroy -f node01 )
-}
-
-destroy_node03_vm() {
-    ( cd $VAGRANT_DIR ; \
-      VAGRANT_DOTFILE_PATH=${VAGRANT_COMMON_DOTFILE_PATH} vagrant destroy -f node03 )
 }
 
 # using "|| true" as a workaround to unusual behavior

--- a/t/venom/test-wrapper.sh
+++ b/t/venom/test-wrapper.sh
@@ -179,6 +179,7 @@ halt() {
 
 teardown() {
     log_section "Teardown"
+    halt
     delete_ansible_files
     destroy
 }

--- a/t/venom/test_suites/captive_portal/locales/00_check_locales_on_portal.yml
+++ b/t/venom/test_suites/captive_portal/locales/00_check_locales_on_portal.yml
@@ -7,5 +7,5 @@ testcases:
         user: '{{.ssh_user}}'
         command: |
           cd /usr/local/pf/t/venom ; \
-          sudo VENOM_COMMON_FLAGS='--var configurator.interfaces.reg.ip={{.configurator.interfaces.reg.ip}}' \
+          sudo VENOM_COMMON_FLAGS='--output-dir={{.test_suite_results_dir}}/{{.venom.testcase}} --var configurator.interfaces.reg.ip={{.configurator.interfaces.reg.ip}}' \
           /usr/local/pf/t/venom/venom-wrapper.sh {{.nodes_test_suite_dir}}/captive_portal/{{.venom.testcase}}.yml

--- a/t/venom/test_suites/common/kill_wireless01_wpasupplicant.yml
+++ b/t/venom/test_suites/common/kill_wireless01_wpasupplicant.yml
@@ -7,4 +7,5 @@ testcases:
         user: '{{.ssh_user}}'
         command: |
           cd /usr/local/pf/t/venom ; \
-          sudo /usr/local/pf/t/venom/venom-wrapper.sh {{.nodes_test_suite_dir}}/common/kill_wpasupplicant.yml
+          sudo VENOM_COMMON_FLAGS='--output-dir={{.test_suite_results_dir}}/{{.venom.testcase}}' \
+          /usr/local/pf/t/venom/venom-wrapper.sh {{.nodes_test_suite_dir}}/common/kill_wpasupplicant.yml

--- a/t/venom/test_suites/common/kill_wpasupplicant.yml
+++ b/t/venom/test_suites/common/kill_wpasupplicant.yml
@@ -7,4 +7,5 @@ testcases:
         user: '{{.ssh_user}}'
         command:  |
           cd /usr/local/pf/t/venom ; \
-          sudo /usr/local/pf/t/venom/venom-wrapper.sh {{.nodes_test_suite_dir}}/common/kill_wpasupplicant.yml
+          sudo VENOM_COMMON_FLAGS='--output-dir={{.test_suite_results_dir}}/{{.venom.testcase}}' \
+          /usr/local/pf/t/venom/venom-wrapper.sh {{.nodes_test_suite_dir}}/common/kill_wpasupplicant.yml

--- a/t/venom/test_suites/configurator/50_run_configurator_step4.yml
+++ b/t/venom/test_suites/configurator/50_run_configurator_step4.yml
@@ -55,16 +55,40 @@ testcases:
   - type: exec
     script: sleep 10
 
-- name: start_packetfence_and_fingerbank_service
+- name: start_pf_services
   steps:
   - type: http
     method: POST
     url: '{{.pfserver_webadmin_url}}/api/v1/configurator/service/pf/start'
     ignore_verify_ssl: true
+    body: >-
+      {
+        "async": true
+      }
     headers:
       "Content-Type": "application/json"
     assertions:
+      - result.statuscode ShouldEqual 202
+    vars:
+      task_id:
+        from: result.bodyjson.task_id
+
+  - type: http
+    method: GET
+    url: '{{.pfserver_webadmin_url}}/api/v1/configurator/pfqueue/task/{{.start_pf_services.task_id}}/status/poll'
+    ignore_verify_ssl: true
+    headers:
+      "Authorization": "{{.get_login_token.result.token}}"
+      "Content-Type": "application/json"
+    assertions:
       - result.statuscode ShouldEqual 200
+      - result.bodyjson.message ShouldEqual Completed
+      - result.bodyjson.progress ShouldEqual 100
+      - result.bodyjson.status ShouldEqual 200
+    # wait three minutes before failing
+    retry: 12
+    delay: 15
+
 
 - name: disable_configurator
   steps:

--- a/t/venom/test_suites/configurator_inline/50_run_configurator_step4.yml
+++ b/t/venom/test_suites/configurator_inline/50_run_configurator_step4.yml
@@ -55,16 +55,39 @@ testcases:
   - type: exec
     script: sleep 10
 
-- name: start_packetfence_and_fingerbank_service
+- name: start_pf_services
   steps:
   - type: http
     method: POST
     url: '{{.pfserver_webadmin_url}}/api/v1/configurator/service/pf/start'
     ignore_verify_ssl: true
+    body: >-
+      {
+        "async": true
+      }
     headers:
       "Content-Type": "application/json"
     assertions:
+      - result.statuscode ShouldEqual 202
+    vars:
+      task_id:
+        from: result.bodyjson.task_id
+
+  - type: http
+    method: GET
+    url: '{{.pfserver_webadmin_url}}/api/v1/configurator/pfqueue/task/{{.start_pf_services.task_id}}/status/poll'
+    ignore_verify_ssl: true
+    headers:
+      "Authorization": "{{.get_login_token.result.token}}"
+      "Content-Type": "application/json"
+    assertions:
       - result.statuscode ShouldEqual 200
+      - result.bodyjson.message ShouldEqual Completed
+      - result.bodyjson.progress ShouldEqual 100
+      - result.bodyjson.status ShouldEqual 200
+    # wait three minutes before failing
+    retry: 12
+    delay: 15
 
 - name: disable_configurator
   steps:

--- a/t/venom/test_suites/configurator_inline_l2/50_run_configurator_step4.yml
+++ b/t/venom/test_suites/configurator_inline_l2/50_run_configurator_step4.yml
@@ -43,7 +43,7 @@ testcases:
   - type: exec
     script: sleep 10
 
-- name: start_packetfence_and_fingerbank_service
+- name: start_pf_services
   steps:
   - type: http
     method: POST
@@ -52,7 +52,30 @@ testcases:
     headers:
       "Content-Type": "application/json"
     assertions:
+      - result.statuscode ShouldEqual 202
+    vars:
+      task_id:
+        from: result.bodyjson.task_id
+
+  - type: http
+    method: GET
+    url: '{{.pfserver_webadmin_url}}/api/v1/configurator/pfqueue/task/{{.start_pf_services.task_id}}/status/poll'
+    ignore_verify_ssl: true
+    body: >-
+      {
+        "async": true
+      }
+    headers:
+      "Authorization": "{{.get_login_token.result.token}}"
+      "Content-Type": "application/json"
+    assertions:
       - result.statuscode ShouldEqual 200
+      - result.bodyjson.message ShouldEqual Completed
+      - result.bodyjson.progress ShouldEqual 100
+      - result.bodyjson.status ShouldEqual 200
+    # wait three minutes before failing
+    retry: 12
+    delay: 15
 
 - name: disable_configurator
   steps:

--- a/t/venom/test_suites/wired_dot1x_eap_peap/05_join_domain.yml
+++ b/t/venom/test_suites/wired_dot1x_eap_peap/05_join_domain.yml
@@ -3,6 +3,7 @@ vars:
   # temp, workaround for https://github.com/ovh/venom/issues/445
   # pf only accepts hostname with less than 14 characters
   random_server_name: "{{ randAlpha 13 }}"
+  random_ad_domain_id: "{{ randAlpha 7 }}"
 testcases:
 - name: get_login_token
   steps:
@@ -21,7 +22,7 @@ testcases:
         "bind_pass": null,
         "dns_name": "{{.ad_dns_domain}}",
         "dns_servers": "{{.ad_mgmt_ip}}",
-        "id": "{{.ad_domain_id_wired_dot1x_eap_peap}}",
+        "id": "{{.random_ad_domain_id}}",
         "ntlm_cache": null,
         "ntlm_cache_expiry": 3600,
         "ntlm_cache_source": null,
@@ -43,11 +44,11 @@ testcases:
   steps:
   - type: http
     method: POST
-    url: '{{.pfserver_webadmin_url}}/api/v1/config/domain/{{.ad_domain_id_wired_dot1x_eap_peap}}/join'
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/domain/{{.random_ad_domain_id}}/join'
     ignore_verify_ssl: true
     body: >-
       {
-        "id": "{{.ad_domain_id_wired_dot1x_eap_peap}}",
+        "id": "{{.random_ad_domain_id}}",
         "username": "{{.ad_domain_admin_user}}@{{.ad_dns_domain}}",
         "password": "{{.ad_domain_admin_password}}"
       }
@@ -80,7 +81,7 @@ testcases:
   steps:
   - type: http
     method: GET
-    url: '{{.pfserver_webadmin_url}}/api/v1/config/domain/{{.ad_domain_id_wired_dot1x_eap_peap}}/test_join'
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/domain/{{.random_ad_domain_id}}/test_join'
     ignore_verify_ssl: true
     headers:
       "Authorization": "{{.get_login_token.result.token}}"

--- a/t/venom/test_suites/wired_dot1x_eap_peap/05_join_domain.yml
+++ b/t/venom/test_suites/wired_dot1x_eap_peap/05_join_domain.yml
@@ -21,7 +21,7 @@ testcases:
         "bind_pass": null,
         "dns_name": "{{.ad_dns_domain}}",
         "dns_servers": "{{.ad_mgmt_ip}}",
-        "id": "{{.ad_domain_id}}",
+        "id": "{{.ad_domain_id_wired_dot1x_eap_peap}}",
         "ntlm_cache": null,
         "ntlm_cache_expiry": 3600,
         "ntlm_cache_source": null,
@@ -43,11 +43,11 @@ testcases:
   steps:
   - type: http
     method: POST
-    url: '{{.pfserver_webadmin_url}}/api/v1/config/domain/{{.ad_domain_id}}/join'
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/domain/{{.ad_domain_id_wired_dot1x_eap_peap}}/join'
     ignore_verify_ssl: true
     body: >-
       {
-        "id": "{{.ad_domain_id}}",
+        "id": "{{.ad_domain_id_wired_dot1x_eap_peap}}",
         "username": "{{.ad_domain_admin_user}}@{{.ad_dns_domain}}",
         "password": "{{.ad_domain_admin_password}}"
       }
@@ -80,7 +80,7 @@ testcases:
   steps:
   - type: http
     method: GET
-    url: '{{.pfserver_webadmin_url}}/api/v1/config/domain/{{.ad_domain_id}}/test_join'
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/domain/{{.ad_domain_id_wired_dot1x_eap_peap}}/test_join'
     ignore_verify_ssl: true
     headers:
       "Authorization": "{{.get_login_token.result.token}}"

--- a/t/venom/test_suites/wired_dot1x_eap_peap/07_create_realms.yml
+++ b/t/venom/test_suites/wired_dot1x_eap_peap/07_create_realms.yml
@@ -13,7 +13,7 @@ testcases:
     body: >-
       {
         "admin_strip_username": "enabled",
-        "domain": "{{.ad_domain_id}}",
+        "domain": "{{.ad_domain_id_wired_dot1x_eap_peap}}",
         "eduroam_options": null,
         "eduroam_radius_acct": null,
         "eduroam_radius_acct_proxy_type": "load-balance",
@@ -45,7 +45,7 @@ testcases:
     body: >-
       {
         "admin_strip_username": "enabled",
-        "domain": "{{.ad_domain_id}}",
+        "domain": "{{.ad_domain_id_wired_dot1x_eap_peap}}",
         "eduroam_options": null,
         "eduroam_radius_acct": null,
         "eduroam_radius_acct_proxy_type": "load-balance",
@@ -78,7 +78,7 @@ testcases:
     ignore_verify_ssl: true
     body: >-
       {
-        "domain": "{{.ad_domain_id}}"
+        "domain": "{{.ad_domain_id_wired_dot1x_eap_peap}}"
       }
     headers:
       "Authorization": "{{.get_login_token.result.token}}"
@@ -92,7 +92,7 @@ testcases:
     ignore_verify_ssl: true
     body: >-
       {
-        "domain": "{{.ad_domain_id}}"
+        "domain": "{{.ad_domain_id_wired_dot1x_eap_peap}}"
       }
     headers:
       "Authorization": "{{.get_login_token.result.token}}"

--- a/t/venom/test_suites/wired_dot1x_eap_peap/07_create_realms.yml
+++ b/t/venom/test_suites/wired_dot1x_eap_peap/07_create_realms.yml
@@ -4,6 +4,21 @@ testcases:
   steps:
   - type: get_login_token
 
+- name: get_ad_domain_id
+  steps:
+  - type: http
+    method: GET
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/domains'
+    ignore_verify_ssl: true
+    headers:
+      "Authorization": "{{.get_login_token.result.token}}"
+      "Content-Type": "application/json"
+    assertions:
+      - result.statuscode ShouldEqual 200
+    vars:
+      domain_id:
+        from: result.bodyjson.items.items0.id
+
 - name: create_realms
   steps:
   - type: http
@@ -13,7 +28,7 @@ testcases:
     body: >-
       {
         "admin_strip_username": "enabled",
-        "domain": "{{.ad_domain_id_wired_dot1x_eap_peap}}",
+        "domain": "{{.get_ad_domain_id.domain_id}}",
         "eduroam_options": null,
         "eduroam_radius_acct": null,
         "eduroam_radius_acct_proxy_type": "load-balance",
@@ -45,7 +60,7 @@ testcases:
     body: >-
       {
         "admin_strip_username": "enabled",
-        "domain": "{{.ad_domain_id_wired_dot1x_eap_peap}}",
+        "domain": "{{.get_ad_domain_id.domain_id}}",
         "eduroam_options": null,
         "eduroam_radius_acct": null,
         "eduroam_radius_acct_proxy_type": "load-balance",
@@ -78,7 +93,7 @@ testcases:
     ignore_verify_ssl: true
     body: >-
       {
-        "domain": "{{.ad_domain_id_wired_dot1x_eap_peap}}"
+        "domain": "{{.get_ad_domain_id.domain_id}}"
       }
     headers:
       "Authorization": "{{.get_login_token.result.token}}"
@@ -92,7 +107,7 @@ testcases:
     ignore_verify_ssl: true
     body: >-
       {
-        "domain": "{{.ad_domain_id_wired_dot1x_eap_peap}}"
+        "domain": "{{.get_ad_domain_id.domain_id}}"
       }
     headers:
       "Authorization": "{{.get_login_token.result.token}}"

--- a/t/venom/test_suites/wired_dot1x_eap_peap/45_run_wpasupplicant.yml
+++ b/t/venom/test_suites/wired_dot1x_eap_peap/45_run_wpasupplicant.yml
@@ -7,4 +7,5 @@ testcases:
         user: '{{.ssh_user}}'
         command:  |
           cd /usr/local/pf/t/venom ; \
-          sudo /usr/local/pf/t/venom/venom-wrapper.sh {{.nodes_test_suite_dir}}/dot1x_eap_peap/{{.venom.testcase}}.yml
+          sudo VENOM_COMMON_FLAGS='--output-dir={{.test_suite_results_dir}}/{{.venom.testcase}}' \
+          /usr/local/pf/t/venom/venom-wrapper.sh {{.nodes_test_suite_dir}}/dot1x_eap_peap/{{.venom.testcase}}.yml

--- a/t/venom/test_suites/wired_dot1x_eap_peap/teardown/90_teardown.yml
+++ b/t/venom/test_suites/wired_dot1x_eap_peap/teardown/90_teardown.yml
@@ -4,6 +4,21 @@ testcases:
   steps:
   - type: get_login_token
 
+- name: get_ad_domain_id
+  steps:
+  - type: http
+    method: GET
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/domains'
+    ignore_verify_ssl: true
+    headers:
+      "Authorization": "{{.get_login_token.result.token}}"
+      "Content-Type": "application/json"
+    assertions:
+      - result.statuscode ShouldEqual 200
+    vars:
+      domain_id:
+        from: result.bodyjson.items.items0.id
+
 - name: unset_domain_on_builtin_realms
   steps:
   - type: http
@@ -60,7 +75,7 @@ testcases:
   steps:
   - type: http
     method: DELETE
-    url: '{{.pfserver_webadmin_url}}/api/v1/config/domain/{{.ad_domain_id_wired_dot1x_eap_peap}}'
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/domain/{{.get_ad_domain_id.domain_id}}'
     ignore_verify_ssl: true
     headers:
       "Authorization": "{{.get_login_token.result.token}}"

--- a/t/venom/test_suites/wired_dot1x_eap_peap/teardown/90_teardown.yml
+++ b/t/venom/test_suites/wired_dot1x_eap_peap/teardown/90_teardown.yml
@@ -60,13 +60,19 @@ testcases:
   steps:
   - type: http
     method: DELETE
-    url: '{{.pfserver_webadmin_url}}/api/v1/config/domain/{{.ad_domain_id}}'
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/domain/{{.ad_domain_id_wired_dot1x_eap_peap}}'
     ignore_verify_ssl: true
     headers:
       "Authorization": "{{.get_login_token.result.token}}"
       "Content-Type": "application/json"
     assertions:
       - result.statuscode ShouldEqual 200
+
+# it will be restarted when a new join will start
+- name: stop_packetfence_winbindd
+  steps:
+  - type: exec
+    script: systemctl stop packetfence-winbindd
 
 - name: delete_connection_profile
   steps:

--- a/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_https/05_join_domain.yml
+++ b/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_https/05_join_domain.yml
@@ -1,1 +1,0 @@
-../wired_dot1x_eap_peap/05_join_domain.yml

--- a/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_https/06_join_domain.yml
+++ b/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_https/06_join_domain.yml
@@ -1,0 +1,91 @@
+name: Join domain
+vars:
+  # temp, workaround for https://github.com/ovh/venom/issues/445
+  # pf only accepts hostname with less than 14 characters
+  random_server_name: "{{ randAlpha 13 }}"
+testcases:
+- name: get_login_token
+  steps:
+  - type: get_login_token
+
+- name: create_domain
+  steps:
+  - type: http
+    method: POST
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/domains'
+    ignore_verify_ssl: true
+    body: >-
+      {
+        "ad_server": "{{.ad_mgmt_ip}}",
+        "bind_dn": null,
+        "bind_pass": null,
+        "dns_name": "{{.ad_dns_domain}}",
+        "dns_servers": "{{.ad_mgmt_ip}}",
+        "id": "{{.ad_domain_id_wired_dot1x_eap_peap_sso_https}}",
+        "ntlm_cache": null,
+        "ntlm_cache_expiry": 3600,
+        "ntlm_cache_source": null,
+        "ntlmv2_only": null,
+        "ou": "Computers",
+        "registration": null,
+        "server_name": "{{.random_server_name}}",
+        "status": "enabled",
+        "sticky_dc": "*",
+        "workgroup": "{{.ad_domain_upper}}"
+      }
+    headers:
+      "Authorization": "{{.get_login_token.result.token}}"
+      "Content-Type": "application/json"
+    assertions:
+      - result.statuscode ShouldEqual 201
+
+- name: join_domain
+  steps:
+  - type: http
+    method: POST
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/domain/{{.ad_domain_id_wired_dot1x_eap_peap_sso_https}}/join'
+    ignore_verify_ssl: true
+    body: >-
+      {
+        "id": "{{.ad_domain_id_wired_dot1x_eap_peap_sso_https}}",
+        "username": "{{.ad_domain_admin_user}}@{{.ad_dns_domain}}",
+        "password": "{{.ad_domain_admin_password}}"
+      }
+    headers:
+      "Authorization": "{{.get_login_token.result.token}}"
+      "Content-Type": "application/json"
+    assertions:
+      - result.statuscode ShouldEqual 202
+    vars:
+      task_id:
+        from: result.bodyjson.task_id
+
+  - type: http
+    method: GET
+    url: '{{.pfserver_webadmin_url}}/api/v1/pfqueue/task/{{.join_domain.task_id}}/status/poll'
+    ignore_verify_ssl: true
+    headers:
+      "Authorization": "{{.get_login_token.result.token}}"
+      "Content-Type": "application/json"
+    assertions:
+      - result.statuscode ShouldEqual 200
+      - result.bodyjson.message ShouldEqual Completed
+      - result.bodyjson.progress ShouldEqual 100
+      - result.bodyjson.status ShouldEqual 200
+    # wait three minutes before failing
+    retry: 12
+    delay: 15
+
+- name: test_join
+  steps:
+  - type: http
+    method: GET
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/domain/{{.ad_domain_id_wired_dot1x_eap_peap_sso_https}}/test_join'
+    ignore_verify_ssl: true
+    headers:
+      "Authorization": "{{.get_login_token.result.token}}"
+      "Content-Type": "application/json"
+    assertions:
+      - result.statuscode ShouldEqual 200
+      - result.bodyjson.status ShouldEqual 200
+      - result.bodyjson.message ShouldEqual "Join is OK"

--- a/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_https/06_join_domain.yml
+++ b/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_https/06_join_domain.yml
@@ -3,6 +3,7 @@ vars:
   # temp, workaround for https://github.com/ovh/venom/issues/445
   # pf only accepts hostname with less than 14 characters
   random_server_name: "{{ randAlpha 13 }}"
+  random_ad_domain_id: "{{ randAlpha 7 }}"
 testcases:
 - name: get_login_token
   steps:
@@ -21,7 +22,7 @@ testcases:
         "bind_pass": null,
         "dns_name": "{{.ad_dns_domain}}",
         "dns_servers": "{{.ad_mgmt_ip}}",
-        "id": "{{.ad_domain_id_wired_dot1x_eap_peap_sso_https}}",
+        "id": "{{.random_ad_domain_id}}",
         "ntlm_cache": null,
         "ntlm_cache_expiry": 3600,
         "ntlm_cache_source": null,
@@ -43,11 +44,11 @@ testcases:
   steps:
   - type: http
     method: POST
-    url: '{{.pfserver_webadmin_url}}/api/v1/config/domain/{{.ad_domain_id_wired_dot1x_eap_peap_sso_https}}/join'
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/domain/{{.random_ad_domain_id}}/join'
     ignore_verify_ssl: true
     body: >-
       {
-        "id": "{{.ad_domain_id_wired_dot1x_eap_peap_sso_https}}",
+        "id": "{{.random_ad_domain_id}}",
         "username": "{{.ad_domain_admin_user}}@{{.ad_dns_domain}}",
         "password": "{{.ad_domain_admin_password}}"
       }
@@ -80,7 +81,7 @@ testcases:
   steps:
   - type: http
     method: GET
-    url: '{{.pfserver_webadmin_url}}/api/v1/config/domain/{{.ad_domain_id_wired_dot1x_eap_peap_sso_https}}/test_join'
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/domain/{{.random_ad_domain_id}}/test_join'
     ignore_verify_ssl: true
     headers:
       "Authorization": "{{.get_login_token.result.token}}"

--- a/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_https/07_create_realms.yml
+++ b/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_https/07_create_realms.yml
@@ -1,1 +1,0 @@
-../wired_dot1x_eap_peap/07_create_realms.yml

--- a/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_https/08_create_realms.yml
+++ b/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_https/08_create_realms.yml
@@ -4,6 +4,21 @@ testcases:
   steps:
   - type: get_login_token
 
+- name: get_ad_domain_id
+  steps:
+  - type: http
+    method: GET
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/domains'
+    ignore_verify_ssl: true
+    headers:
+      "Authorization": "{{.get_login_token.result.token}}"
+      "Content-Type": "application/json"
+    assertions:
+      - result.statuscode ShouldEqual 200
+    vars:
+      domain_id:
+        from: result.bodyjson.items.items0.id
+
 - name: create_realms
   steps:
   - type: http
@@ -13,7 +28,7 @@ testcases:
     body: >-
       {
         "admin_strip_username": "enabled",
-        "domain": "{{.ad_domain_id_wired_dot1x_eap_peap_sso_https}}",
+        "domain": "{{.get_ad_domain_id.domain_id}}",
         "eduroam_options": null,
         "eduroam_radius_acct": null,
         "eduroam_radius_acct_proxy_type": "load-balance",
@@ -45,7 +60,7 @@ testcases:
     body: >-
       {
         "admin_strip_username": "enabled",
-        "domain": "{{.ad_domain_id_wired_dot1x_eap_peap_sso_https}}",
+        "domain": "{{.get_ad_domain_id.domain_id}}",
         "eduroam_options": null,
         "eduroam_radius_acct": null,
         "eduroam_radius_acct_proxy_type": "load-balance",
@@ -78,7 +93,7 @@ testcases:
     ignore_verify_ssl: true
     body: >-
       {
-        "domain": "{{.ad_domain_id_wired_dot1x_eap_peap_sso_https}}"
+        "domain": "{{.get_ad_domain_id.domain_id}}"
       }
     headers:
       "Authorization": "{{.get_login_token.result.token}}"
@@ -92,7 +107,7 @@ testcases:
     ignore_verify_ssl: true
     body: >-
       {
-        "domain": "{{.ad_domain_id_wired_dot1x_eap_peap_sso_https}}"
+        "domain": "{{.get_ad_domain_id.domain_id}}"
       }
     headers:
       "Authorization": "{{.get_login_token.result.token}}"

--- a/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_https/08_create_realms.yml
+++ b/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_https/08_create_realms.yml
@@ -1,0 +1,101 @@
+name: Create and configure REALMS
+testcases:
+- name: get_login_token
+  steps:
+  - type: get_login_token
+
+- name: create_realms
+  steps:
+  - type: http
+    method: POST
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/realms'
+    ignore_verify_ssl: true
+    body: >-
+      {
+        "admin_strip_username": "enabled",
+        "domain": "{{.ad_domain_id_wired_dot1x_eap_peap_sso_https}}",
+        "eduroam_options": null,
+        "eduroam_radius_acct": null,
+        "eduroam_radius_acct_proxy_type": "load-balance",
+        "eduroam_radius_auth": null,
+        "eduroam_radius_auth_compute_in_pf": "enabled",
+        "eduroam_radius_auth_proxy_type": "keyed-balance",
+        "id": "{{.ad_domain_upper}}",
+        "ldap_source": null,
+        "options": null,
+        "permit_custom_attributes": "disabled",
+        "portal_strip_username": "enabled",
+        "radius_acct": null,
+        "radius_acct_proxy_type": "load-balance",
+        "radius_auth": null,
+        "radius_auth_compute_in_pf": "enabled",
+        "radius_auth_proxy_type": "keyed-balance",
+        "radius_strip_username": "enabled"
+      }
+    headers:
+      "Authorization": "{{.get_login_token.result.token}}"
+      "Content-Type": "application/json"
+    assertions:
+      - result.statuscode ShouldEqual 201
+
+  - type: http
+    method: POST
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/realms'
+    ignore_verify_ssl: true
+    body: >-
+      {
+        "admin_strip_username": "enabled",
+        "domain": "{{.ad_domain_id_wired_dot1x_eap_peap_sso_https}}",
+        "eduroam_options": null,
+        "eduroam_radius_acct": null,
+        "eduroam_radius_acct_proxy_type": "load-balance",
+        "eduroam_radius_auth": null,
+        "eduroam_radius_auth_compute_in_pf": "enabled",
+        "eduroam_radius_auth_proxy_type": "keyed-balance",
+        "id": "{{.ad_dns_domain}}",
+        "ldap_source": null,
+        "options": null,
+        "permit_custom_attributes": "disabled",
+        "portal_strip_username": "enabled",
+        "radius_acct": null,
+        "radius_acct_proxy_type": "load-balance",
+        "radius_auth": null,
+        "radius_auth_compute_in_pf": "enabled",
+        "radius_auth_proxy_type": "keyed-balance",
+        "radius_strip_username": "enabled"
+      }
+    headers:
+      "Authorization": "{{.get_login_token.result.token}}"
+      "Content-Type": "application/json"
+    assertions:
+      - result.statuscode ShouldEqual 201
+
+- name: modify_builtin_realms
+  steps:
+  - type: http
+    method: PATCH
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/realm/DEFAULT'
+    ignore_verify_ssl: true
+    body: >-
+      {
+        "domain": "{{.ad_domain_id_wired_dot1x_eap_peap_sso_https}}"
+      }
+    headers:
+      "Authorization": "{{.get_login_token.result.token}}"
+      "Content-Type": "application/json"
+    assertions:
+      - result.statuscode ShouldEqual 200
+
+  - type: http
+    method: PATCH
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/realm/NULL'
+    ignore_verify_ssl: true
+    body: >-
+      {
+        "domain": "{{.ad_domain_id_wired_dot1x_eap_peap_sso_https}}"
+      }
+    headers:
+      "Authorization": "{{.get_login_token.result.token}}"
+      "Content-Type": "application/json"
+    assertions:
+      - result.statuscode ShouldEqual 200

--- a/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_https/teardown/01_kill_wpasupplicant.yml
+++ b/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_https/teardown/01_kill_wpasupplicant.yml
@@ -7,4 +7,5 @@ testcases:
         user: '{{.ssh_user}}'
         command:  |
           cd /usr/local/pf/t/venom ; \
-          sudo /usr/local/pf/t/venom/venom-wrapper.sh {{.nodes_test_suite_dir}}/common/kill_wpasupplicant.yml
+          sudo VENOM_COMMON_FLAGS='--output-dir={{.test_suite_results_dir}}/{{.venom.testcase}}' \
+          /usr/local/pf/t/venom/venom-wrapper.sh {{.nodes_test_suite_dir}}/common/kill_wpasupplicant.yml

--- a/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_https/teardown/90_teardown.yml
+++ b/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_https/teardown/90_teardown.yml
@@ -1,1 +1,0 @@
-../../wired_dot1x_eap_peap/teardown/90_teardown.yml

--- a/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_https/teardown/91_teardown.yml
+++ b/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_https/teardown/91_teardown.yml
@@ -1,0 +1,110 @@
+name: Teardown
+testcases:
+- name: get_login_token
+  steps:
+  - type: get_login_token
+
+- name: unset_domain_on_builtin_realms
+  steps:
+  - type: http
+    method: PATCH
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/realm/DEFAULT'
+    ignore_verify_ssl: true
+    body: >-
+      {
+        "domain": null
+      }
+    headers:
+      "Authorization": "{{.get_login_token.result.token}}"
+      "Content-Type": "application/json"
+    assertions:
+      - result.statuscode ShouldEqual 200
+
+  - type: http
+    method: PATCH
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/realm/NULL'
+    ignore_verify_ssl: true
+    body: >-
+      {
+        "domain": null
+      }
+    headers:
+      "Authorization": "{{.get_login_token.result.token}}"
+      "Content-Type": "application/json"
+    assertions:
+      - result.statuscode ShouldEqual 200
+
+- name: delete_realms
+  steps:
+  - type: http
+    method: DELETE
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/realm/{{.ad_domain_upper}}'
+    ignore_verify_ssl: true
+    headers:
+      "Authorization": "{{.get_login_token.result.token}}"
+      "Content-Type": "application/json"
+    assertions:
+      - result.statuscode ShouldEqual 200
+
+  - type: http
+    method: DELETE
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/realm/{{.ad_dns_domain}}'
+    ignore_verify_ssl: true
+    headers:
+      "Authorization": "{{.get_login_token.result.token}}"
+      "Content-Type": "application/json"
+    assertions:
+      - result.statuscode ShouldEqual 200
+
+- name: delete_domain
+  steps:
+  - type: http
+    method: DELETE
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/domain/{{.ad_domain_id_wired_dot1x_eap_peap_sso_https}}'
+    ignore_verify_ssl: true
+    headers:
+      "Authorization": "{{.get_login_token.result.token}}"
+      "Content-Type": "application/json"
+    assertions:
+      - result.statuscode ShouldEqual 200
+
+# it will be restarted when a new join will start
+- name: stop_packetfence_winbindd
+  steps:
+  - type: exec
+    script: systemctl stop packetfence-winbindd
+
+- name: delete_connection_profile
+  steps:
+  - type: http
+    method: DELETE
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/connection_profile/{{.dot1x_eap_peap.profiles.wired.id}}'
+    ignore_verify_ssl: true
+    headers:
+      "Authorization": "{{.get_login_token.result.token}}"
+      "Content-Type": "application/json"
+    assertions:
+      - result.statuscode ShouldEqual 200
+
+- name: delete_sources
+  steps:
+  - type: http
+    method: DELETE
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/source/{{.dot1x_eap_peap.sources.ad_user.name}}'
+    ignore_verify_ssl: true
+    headers:
+      "Authorization": "{{.get_login_token.result.token}}"
+      "Content-Type": "application/json"
+    assertions:
+      - result.statuscode ShouldEqual 200
+
+  - type: http
+    method: DELETE
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/source/{{.dot1x_eap_peap.sources.ad_machine.name}}'
+    ignore_verify_ssl: true
+    headers:
+      "Authorization": "{{.get_login_token.result.token}}"
+      "Content-Type": "application/json"
+    assertions:
+      - result.statuscode ShouldEqual 200
+

--- a/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_https/teardown/91_teardown.yml
+++ b/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_https/teardown/91_teardown.yml
@@ -4,6 +4,21 @@ testcases:
   steps:
   - type: get_login_token
 
+- name: get_ad_domain_id
+  steps:
+  - type: http
+    method: GET
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/domains'
+    ignore_verify_ssl: true
+    headers:
+      "Authorization": "{{.get_login_token.result.token}}"
+      "Content-Type": "application/json"
+    assertions:
+      - result.statuscode ShouldEqual 200
+    vars:
+      domain_id:
+        from: result.bodyjson.items.items0.id
+
 - name: unset_domain_on_builtin_realms
   steps:
   - type: http
@@ -60,7 +75,7 @@ testcases:
   steps:
   - type: http
     method: DELETE
-    url: '{{.pfserver_webadmin_url}}/api/v1/config/domain/{{.ad_domain_id_wired_dot1x_eap_peap_sso_https}}'
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/domain/{{.get_ad_domain_id.domain_id}}'
     ignore_verify_ssl: true
     headers:
       "Authorization": "{{.get_login_token.result.token}}"

--- a/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_radius/05_join_domain.yml
+++ b/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_radius/05_join_domain.yml
@@ -1,1 +1,0 @@
-../wired_dot1x_eap_peap/05_join_domain.yml

--- a/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_radius/06_join_domain.yml
+++ b/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_radius/06_join_domain.yml
@@ -1,0 +1,91 @@
+name: Join domain
+vars:
+  # temp, workaround for https://github.com/ovh/venom/issues/445
+  # pf only accepts hostname with less than 14 characters
+  random_server_name: "{{ randAlpha 13 }}"
+testcases:
+- name: get_login_token
+  steps:
+  - type: get_login_token
+
+- name: create_domain
+  steps:
+  - type: http
+    method: POST
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/domains'
+    ignore_verify_ssl: true
+    body: >-
+      {
+        "ad_server": "{{.ad_mgmt_ip}}",
+        "bind_dn": null,
+        "bind_pass": null,
+        "dns_name": "{{.ad_dns_domain}}",
+        "dns_servers": "{{.ad_mgmt_ip}}",
+        "id": "{{.ad_domain_id_wired_dot1x_eap_peap_sso_radius}}",
+        "ntlm_cache": null,
+        "ntlm_cache_expiry": 3600,
+        "ntlm_cache_source": null,
+        "ntlmv2_only": null,
+        "ou": "Computers",
+        "registration": null,
+        "server_name": "{{.random_server_name}}",
+        "status": "enabled",
+        "sticky_dc": "*",
+        "workgroup": "{{.ad_domain_upper}}"
+      }
+    headers:
+      "Authorization": "{{.get_login_token.result.token}}"
+      "Content-Type": "application/json"
+    assertions:
+      - result.statuscode ShouldEqual 201
+
+- name: join_domain
+  steps:
+  - type: http
+    method: POST
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/domain/{{.ad_domain_id_wired_dot1x_eap_peap_sso_radius}}/join'
+    ignore_verify_ssl: true
+    body: >-
+      {
+        "id": "{{.ad_domain_id_wired_dot1x_eap_peap_sso_radius}}",
+        "username": "{{.ad_domain_admin_user}}@{{.ad_dns_domain}}",
+        "password": "{{.ad_domain_admin_password}}"
+      }
+    headers:
+      "Authorization": "{{.get_login_token.result.token}}"
+      "Content-Type": "application/json"
+    assertions:
+      - result.statuscode ShouldEqual 202
+    vars:
+      task_id:
+        from: result.bodyjson.task_id
+
+  - type: http
+    method: GET
+    url: '{{.pfserver_webadmin_url}}/api/v1/pfqueue/task/{{.join_domain.task_id}}/status/poll'
+    ignore_verify_ssl: true
+    headers:
+      "Authorization": "{{.get_login_token.result.token}}"
+      "Content-Type": "application/json"
+    assertions:
+      - result.statuscode ShouldEqual 200
+      - result.bodyjson.message ShouldEqual Completed
+      - result.bodyjson.progress ShouldEqual 100
+      - result.bodyjson.status ShouldEqual 200
+    # wait three minutes before failing
+    retry: 12
+    delay: 15
+
+- name: test_join
+  steps:
+  - type: http
+    method: GET
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/domain/{{.ad_domain_id_wired_dot1x_eap_peap_sso_radius}}/test_join'
+    ignore_verify_ssl: true
+    headers:
+      "Authorization": "{{.get_login_token.result.token}}"
+      "Content-Type": "application/json"
+    assertions:
+      - result.statuscode ShouldEqual 200
+      - result.bodyjson.status ShouldEqual 200
+      - result.bodyjson.message ShouldEqual "Join is OK"

--- a/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_radius/06_join_domain.yml
+++ b/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_radius/06_join_domain.yml
@@ -3,6 +3,7 @@ vars:
   # temp, workaround for https://github.com/ovh/venom/issues/445
   # pf only accepts hostname with less than 14 characters
   random_server_name: "{{ randAlpha 13 }}"
+  random_ad_domain_id: "{{ randAlpha 7 }}"
 testcases:
 - name: get_login_token
   steps:
@@ -21,7 +22,7 @@ testcases:
         "bind_pass": null,
         "dns_name": "{{.ad_dns_domain}}",
         "dns_servers": "{{.ad_mgmt_ip}}",
-        "id": "{{.ad_domain_id_wired_dot1x_eap_peap_sso_radius}}",
+        "id": "{{.random_ad_domain_id}}",
         "ntlm_cache": null,
         "ntlm_cache_expiry": 3600,
         "ntlm_cache_source": null,
@@ -43,11 +44,11 @@ testcases:
   steps:
   - type: http
     method: POST
-    url: '{{.pfserver_webadmin_url}}/api/v1/config/domain/{{.ad_domain_id_wired_dot1x_eap_peap_sso_radius}}/join'
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/domain/{{.random_ad_domain_id}}/join'
     ignore_verify_ssl: true
     body: >-
       {
-        "id": "{{.ad_domain_id_wired_dot1x_eap_peap_sso_radius}}",
+        "id": "{{.random_ad_domain_id}}",
         "username": "{{.ad_domain_admin_user}}@{{.ad_dns_domain}}",
         "password": "{{.ad_domain_admin_password}}"
       }
@@ -80,7 +81,7 @@ testcases:
   steps:
   - type: http
     method: GET
-    url: '{{.pfserver_webadmin_url}}/api/v1/config/domain/{{.ad_domain_id_wired_dot1x_eap_peap_sso_radius}}/test_join'
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/domain/{{.random_ad_domain_id}}/test_join'
     ignore_verify_ssl: true
     headers:
       "Authorization": "{{.get_login_token.result.token}}"

--- a/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_radius/07_create_realms.yml
+++ b/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_radius/07_create_realms.yml
@@ -1,1 +1,0 @@
-../wired_dot1x_eap_peap/07_create_realms.yml

--- a/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_radius/08_create_realms.yml
+++ b/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_radius/08_create_realms.yml
@@ -4,6 +4,21 @@ testcases:
   steps:
   - type: get_login_token
 
+- name: get_ad_domain_id
+  steps:
+  - type: http
+    method: GET
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/domains'
+    ignore_verify_ssl: true
+    headers:
+      "Authorization": "{{.get_login_token.result.token}}"
+      "Content-Type": "application/json"
+    assertions:
+      - result.statuscode ShouldEqual 200
+    vars:
+      domain_id:
+        from: result.bodyjson.items.items0.id
+
 - name: create_realms
   steps:
   - type: http
@@ -13,7 +28,7 @@ testcases:
     body: >-
       {
         "admin_strip_username": "enabled",
-        "domain": "{{.ad_domain_id_wired_dot1x_eap_peap_sso_radius}}",
+        "domain": "{{.get_ad_domain_id.domain_id}}",
         "eduroam_options": null,
         "eduroam_radius_acct": null,
         "eduroam_radius_acct_proxy_type": "load-balance",
@@ -45,7 +60,7 @@ testcases:
     body: >-
       {
         "admin_strip_username": "enabled",
-        "domain": "{{.ad_domain_id_wired_dot1x_eap_peap_sso_radius}}",
+        "domain": "{{.get_ad_domain_id.domain_id}}",
         "eduroam_options": null,
         "eduroam_radius_acct": null,
         "eduroam_radius_acct_proxy_type": "load-balance",
@@ -78,7 +93,7 @@ testcases:
     ignore_verify_ssl: true
     body: >-
       {
-        "domain": "{{.ad_domain_id_wired_dot1x_eap_peap_sso_radius}}"
+        "domain": "{{.get_ad_domain_id.domain_id}}"
       }
     headers:
       "Authorization": "{{.get_login_token.result.token}}"
@@ -92,7 +107,7 @@ testcases:
     ignore_verify_ssl: true
     body: >-
       {
-        "domain": "{{.ad_domain_id_wired_dot1x_eap_peap_sso_radius}}"
+        "domain": "{{.get_ad_domain_id.domain_id}}"
       }
     headers:
       "Authorization": "{{.get_login_token.result.token}}"

--- a/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_radius/08_create_realms.yml
+++ b/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_radius/08_create_realms.yml
@@ -1,0 +1,101 @@
+name: Create and configure REALMS
+testcases:
+- name: get_login_token
+  steps:
+  - type: get_login_token
+
+- name: create_realms
+  steps:
+  - type: http
+    method: POST
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/realms'
+    ignore_verify_ssl: true
+    body: >-
+      {
+        "admin_strip_username": "enabled",
+        "domain": "{{.ad_domain_id_wired_dot1x_eap_peap_sso_radius}}",
+        "eduroam_options": null,
+        "eduroam_radius_acct": null,
+        "eduroam_radius_acct_proxy_type": "load-balance",
+        "eduroam_radius_auth": null,
+        "eduroam_radius_auth_compute_in_pf": "enabled",
+        "eduroam_radius_auth_proxy_type": "keyed-balance",
+        "id": "{{.ad_domain_upper}}",
+        "ldap_source": null,
+        "options": null,
+        "permit_custom_attributes": "disabled",
+        "portal_strip_username": "enabled",
+        "radius_acct": null,
+        "radius_acct_proxy_type": "load-balance",
+        "radius_auth": null,
+        "radius_auth_compute_in_pf": "enabled",
+        "radius_auth_proxy_type": "keyed-balance",
+        "radius_strip_username": "enabled"
+      }
+    headers:
+      "Authorization": "{{.get_login_token.result.token}}"
+      "Content-Type": "application/json"
+    assertions:
+      - result.statuscode ShouldEqual 201
+
+  - type: http
+    method: POST
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/realms'
+    ignore_verify_ssl: true
+    body: >-
+      {
+        "admin_strip_username": "enabled",
+        "domain": "{{.ad_domain_id_wired_dot1x_eap_peap_sso_radius}}",
+        "eduroam_options": null,
+        "eduroam_radius_acct": null,
+        "eduroam_radius_acct_proxy_type": "load-balance",
+        "eduroam_radius_auth": null,
+        "eduroam_radius_auth_compute_in_pf": "enabled",
+        "eduroam_radius_auth_proxy_type": "keyed-balance",
+        "id": "{{.ad_dns_domain}}",
+        "ldap_source": null,
+        "options": null,
+        "permit_custom_attributes": "disabled",
+        "portal_strip_username": "enabled",
+        "radius_acct": null,
+        "radius_acct_proxy_type": "load-balance",
+        "radius_auth": null,
+        "radius_auth_compute_in_pf": "enabled",
+        "radius_auth_proxy_type": "keyed-balance",
+        "radius_strip_username": "enabled"
+      }
+    headers:
+      "Authorization": "{{.get_login_token.result.token}}"
+      "Content-Type": "application/json"
+    assertions:
+      - result.statuscode ShouldEqual 201
+
+- name: modify_builtin_realms
+  steps:
+  - type: http
+    method: PATCH
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/realm/DEFAULT'
+    ignore_verify_ssl: true
+    body: >-
+      {
+        "domain": "{{.ad_domain_id_wired_dot1x_eap_peap_sso_radius}}"
+      }
+    headers:
+      "Authorization": "{{.get_login_token.result.token}}"
+      "Content-Type": "application/json"
+    assertions:
+      - result.statuscode ShouldEqual 200
+
+  - type: http
+    method: PATCH
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/realm/NULL'
+    ignore_verify_ssl: true
+    body: >-
+      {
+        "domain": "{{.ad_domain_id_wired_dot1x_eap_peap_sso_radius}}"
+      }
+    headers:
+      "Authorization": "{{.get_login_token.result.token}}"
+      "Content-Type": "application/json"
+    assertions:
+      - result.statuscode ShouldEqual 200

--- a/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_radius/46_run_wpasupplicant.yml
+++ b/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_radius/46_run_wpasupplicant.yml
@@ -7,4 +7,5 @@ testcases:
         user: '{{.ssh_user}}'
         command:  |
           cd /usr/local/pf/t/venom ; \
-          sudo /usr/local/pf/t/venom/venom-wrapper.sh {{.nodes_test_suite_dir}}/dot1x_eap_peap/{{.venom.testcase}}.yml
+          sudo VENOM_COMMON_FLAGS='--output-dir={{.test_suite_results_dir}}/{{.venom.testcase}}' \
+          /usr/local/pf/t/venom/venom-wrapper.sh {{.nodes_test_suite_dir}}/dot1x_eap_peap/{{.venom.testcase}}.yml

--- a/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_radius/teardown/01_kill_wpasupplicant.yml
+++ b/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_radius/teardown/01_kill_wpasupplicant.yml
@@ -7,4 +7,5 @@ testcases:
         user: '{{.ssh_user}}'
         command:  |
           cd /usr/local/pf/t/venom ; \
-          sudo /usr/local/pf/t/venom/venom-wrapper.sh {{.nodes_test_suite_dir}}/common/kill_wpasupplicant.yml
+          sudo VENOM_COMMON_FLAGS='--output-dir={{.test_suite_results_dir}}/{{.venom.testcase}}' \
+          /usr/local/pf/t/venom/venom-wrapper.sh {{.nodes_test_suite_dir}}/common/kill_wpasupplicant.yml

--- a/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_radius/teardown/90_teardown.yml
+++ b/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_radius/teardown/90_teardown.yml
@@ -1,1 +1,0 @@
-../../wired_dot1x_eap_peap/teardown/90_teardown.yml

--- a/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_radius/teardown/91_teardown.yml
+++ b/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_radius/teardown/91_teardown.yml
@@ -1,0 +1,110 @@
+name: Teardown
+testcases:
+- name: get_login_token
+  steps:
+  - type: get_login_token
+
+- name: unset_domain_on_builtin_realms
+  steps:
+  - type: http
+    method: PATCH
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/realm/DEFAULT'
+    ignore_verify_ssl: true
+    body: >-
+      {
+        "domain": null
+      }
+    headers:
+      "Authorization": "{{.get_login_token.result.token}}"
+      "Content-Type": "application/json"
+    assertions:
+      - result.statuscode ShouldEqual 200
+
+  - type: http
+    method: PATCH
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/realm/NULL'
+    ignore_verify_ssl: true
+    body: >-
+      {
+        "domain": null
+      }
+    headers:
+      "Authorization": "{{.get_login_token.result.token}}"
+      "Content-Type": "application/json"
+    assertions:
+      - result.statuscode ShouldEqual 200
+
+- name: delete_realms
+  steps:
+  - type: http
+    method: DELETE
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/realm/{{.ad_domain_upper}}'
+    ignore_verify_ssl: true
+    headers:
+      "Authorization": "{{.get_login_token.result.token}}"
+      "Content-Type": "application/json"
+    assertions:
+      - result.statuscode ShouldEqual 200
+
+  - type: http
+    method: DELETE
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/realm/{{.ad_dns_domain}}'
+    ignore_verify_ssl: true
+    headers:
+      "Authorization": "{{.get_login_token.result.token}}"
+      "Content-Type": "application/json"
+    assertions:
+      - result.statuscode ShouldEqual 200
+
+- name: delete_domain
+  steps:
+  - type: http
+    method: DELETE
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/domain/{{.ad_domain_id_wired_dot1x_eap_peap_sso_radius}}'
+    ignore_verify_ssl: true
+    headers:
+      "Authorization": "{{.get_login_token.result.token}}"
+      "Content-Type": "application/json"
+    assertions:
+      - result.statuscode ShouldEqual 200
+
+# it will be restarted when a new join will start
+- name: stop_packetfence_winbindd
+  steps:
+  - type: exec
+    script: systemctl stop packetfence-winbindd
+
+- name: delete_connection_profile
+  steps:
+  - type: http
+    method: DELETE
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/connection_profile/{{.dot1x_eap_peap.profiles.wired.id}}'
+    ignore_verify_ssl: true
+    headers:
+      "Authorization": "{{.get_login_token.result.token}}"
+      "Content-Type": "application/json"
+    assertions:
+      - result.statuscode ShouldEqual 200
+
+- name: delete_sources
+  steps:
+  - type: http
+    method: DELETE
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/source/{{.dot1x_eap_peap.sources.ad_user.name}}'
+    ignore_verify_ssl: true
+    headers:
+      "Authorization": "{{.get_login_token.result.token}}"
+      "Content-Type": "application/json"
+    assertions:
+      - result.statuscode ShouldEqual 200
+
+  - type: http
+    method: DELETE
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/source/{{.dot1x_eap_peap.sources.ad_machine.name}}'
+    ignore_verify_ssl: true
+    headers:
+      "Authorization": "{{.get_login_token.result.token}}"
+      "Content-Type": "application/json"
+    assertions:
+      - result.statuscode ShouldEqual 200
+

--- a/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_radius/teardown/91_teardown.yml
+++ b/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_radius/teardown/91_teardown.yml
@@ -4,6 +4,21 @@ testcases:
   steps:
   - type: get_login_token
 
+- name: get_ad_domain_id
+  steps:
+  - type: http
+    method: GET
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/domains'
+    ignore_verify_ssl: true
+    headers:
+      "Authorization": "{{.get_login_token.result.token}}"
+      "Content-Type": "application/json"
+    assertions:
+      - result.statuscode ShouldEqual 200
+    vars:
+      domain_id:
+        from: result.bodyjson.items.items0.id
+
 - name: unset_domain_on_builtin_realms
   steps:
   - type: http
@@ -60,7 +75,7 @@ testcases:
   steps:
   - type: http
     method: DELETE
-    url: '{{.pfserver_webadmin_url}}/api/v1/config/domain/{{.ad_domain_id_wired_dot1x_eap_peap_sso_radius}}'
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/domain/{{.get_ad_domain_id.domain_id}}'
     ignore_verify_ssl: true
     headers:
       "Authorization": "{{.get_login_token.result.token}}"

--- a/t/venom/test_suites/wired_dot1x_eap_tls_manual/80_run_wpasupplicant.yml
+++ b/t/venom/test_suites/wired_dot1x_eap_tls_manual/80_run_wpasupplicant.yml
@@ -7,4 +7,5 @@ testcases:
         user: '{{.ssh_user}}'
         command:  |
           cd /usr/local/pf/t/venom ; \
-          sudo /usr/local/pf/t/venom/venom-wrapper.sh {{.nodes_test_suite_dir}}/wired_dot1x_eap_tls/{{.venom.testcase}}.yml
+          sudo VENOM_COMMON_FLAGS='--output-dir={{.test_suite_results_dir}}/{{.venom.testcase}}' \
+          /usr/local/pf/t/venom/venom-wrapper.sh {{.nodes_test_suite_dir}}/wired_dot1x_eap_tls/{{.venom.testcase}}.yml

--- a/t/venom/test_suites/wired_dot1x_eap_tls_scep/75_run_sscep_on_node01.yml
+++ b/t/venom/test_suites/wired_dot1x_eap_tls_scep/75_run_sscep_on_node01.yml
@@ -7,4 +7,5 @@ testcases:
         user: '{{.ssh_user}}'
         command:  |
           cd /usr/local/pf/t/venom ; \
-          sudo VENOM_COMMON_FLAGS='--var pfserver_mgmt_ip={{.pfserver_mgmt_ip}}' /usr/local/pf/t/venom/venom-wrapper.sh {{.nodes_test_suite_dir}}/wired_dot1x_eap_tls/{{.venom.testcase}}.yml
+          sudo VENOM_COMMON_FLAGS='--output-dir={{.test_suite_results_dir}}/{{.venom.testcase}} --var pfserver_mgmt_ip={{.pfserver_mgmt_ip}}' \
+          /usr/local/pf/t/venom/venom-wrapper.sh {{.nodes_test_suite_dir}}/wired_dot1x_eap_tls/{{.venom.testcase}}.yml

--- a/t/venom/test_suites/wired_dot1x_eap_tls_scep/80_run_wpasupplicant.yml
+++ b/t/venom/test_suites/wired_dot1x_eap_tls_scep/80_run_wpasupplicant.yml
@@ -7,4 +7,5 @@ testcases:
         user: '{{.ssh_user}}'
         command:  |
           cd /usr/local/pf/t/venom ; \
-          sudo /usr/local/pf/t/venom/venom-wrapper.sh {{.nodes_test_suite_dir}}/wired_dot1x_eap_tls/{{.venom.testcase}}.yml
+          sudo VENOM_COMMON_FLAGS='--output-dir={{.test_suite_results_dir}}/{{.venom.testcase}}' \
+          /usr/local/pf/t/venom/venom-wrapper.sh {{.nodes_test_suite_dir}}/wired_dot1x_eap_tls/{{.venom.testcase}}.yml

--- a/t/venom/test_suites/wireless_dot1x_eap_peap/05_join_domain.yml
+++ b/t/venom/test_suites/wireless_dot1x_eap_peap/05_join_domain.yml
@@ -3,6 +3,7 @@ vars:
   # temp, workaround for https://github.com/ovh/venom/issues/445
   # pf only accepts hostname with less than 14 characters
   random_server_name: "{{ randAlpha 13 }}"
+  random_ad_domain_id: "{{ randAlpha 7 }}"
 testcases:
 - name: get_login_token
   steps:
@@ -21,7 +22,7 @@ testcases:
         "bind_pass": null,
         "dns_name": "{{.ad_dns_domain}}",
         "dns_servers": "{{.ad_mgmt_ip}}",
-        "id": "{{.ad_domain_id_wireless_dot1x_eap_peap}}",
+        "id": "{{.random_ad_domain_id}}",
         "ntlm_cache": null,
         "ntlm_cache_expiry": 3600,
         "ntlm_cache_source": null,
@@ -43,11 +44,11 @@ testcases:
   steps:
   - type: http
     method: POST
-    url: '{{.pfserver_webadmin_url}}/api/v1/config/domain/{{.ad_domain_id_wireless_dot1x_eap_peap}}/join'
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/domain/{{.random_ad_domain_id}}/join'
     ignore_verify_ssl: true
     body: >-
       {
-        "id": "{{.ad_domain_id_wireless_dot1x_eap_peap}}",
+        "id": "{{.random_ad_domain_id}}",
         "username": "{{.ad_domain_admin_user}}@{{.ad_dns_domain}}",
         "password": "{{.ad_domain_admin_password}}"
       }
@@ -80,7 +81,7 @@ testcases:
   steps:
   - type: http
     method: GET
-    url: '{{.pfserver_webadmin_url}}/api/v1/config/domain/{{.ad_domain_id_wireless_dot1x_eap_peap}}/test_join'
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/domain/{{.random_ad_domain_id}}/test_join'
     ignore_verify_ssl: true
     headers:
       "Authorization": "{{.get_login_token.result.token}}"

--- a/t/venom/test_suites/wireless_dot1x_eap_peap/05_join_domain.yml
+++ b/t/venom/test_suites/wireless_dot1x_eap_peap/05_join_domain.yml
@@ -21,7 +21,7 @@ testcases:
         "bind_pass": null,
         "dns_name": "{{.ad_dns_domain}}",
         "dns_servers": "{{.ad_mgmt_ip}}",
-        "id": "{{.ad_domain_id}}",
+        "id": "{{.ad_domain_id_wireless_dot1x_eap_peap}}",
         "ntlm_cache": null,
         "ntlm_cache_expiry": 3600,
         "ntlm_cache_source": null,
@@ -43,11 +43,11 @@ testcases:
   steps:
   - type: http
     method: POST
-    url: '{{.pfserver_webadmin_url}}/api/v1/config/domain/{{.ad_domain_id}}/join'
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/domain/{{.ad_domain_id_wireless_dot1x_eap_peap}}/join'
     ignore_verify_ssl: true
     body: >-
       {
-        "id": "{{.ad_domain_id}}",
+        "id": "{{.ad_domain_id_wireless_dot1x_eap_peap}}",
         "username": "{{.ad_domain_admin_user}}@{{.ad_dns_domain}}",
         "password": "{{.ad_domain_admin_password}}"
       }
@@ -80,7 +80,7 @@ testcases:
   steps:
   - type: http
     method: GET
-    url: '{{.pfserver_webadmin_url}}/api/v1/config/domain/{{.ad_domain_id}}/test_join'
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/domain/{{.ad_domain_id_wireless_dot1x_eap_peap}}/test_join'
     ignore_verify_ssl: true
     headers:
       "Authorization": "{{.get_login_token.result.token}}"

--- a/t/venom/test_suites/wireless_dot1x_eap_peap/07_create_realms.yml
+++ b/t/venom/test_suites/wireless_dot1x_eap_peap/07_create_realms.yml
@@ -13,7 +13,7 @@ testcases:
     body: >-
       {
         "admin_strip_username": "enabled",
-        "domain": "{{.ad_domain_id}}",
+        "domain": "{{.ad_domain_id_wireless_dot1x_eap_peap}}",
         "eduroam_options": null,
         "eduroam_radius_acct": null,
         "eduroam_radius_acct_proxy_type": "load-balance",
@@ -45,7 +45,7 @@ testcases:
     body: >-
       {
         "admin_strip_username": "enabled",
-        "domain": "{{.ad_domain_id}}",
+        "domain": "{{.ad_domain_id_wireless_dot1x_eap_peap}}",
         "eduroam_options": null,
         "eduroam_radius_acct": null,
         "eduroam_radius_acct_proxy_type": "load-balance",
@@ -78,7 +78,7 @@ testcases:
     ignore_verify_ssl: true
     body: >-
       {
-        "domain": "{{.ad_domain_id}}"
+        "domain": "{{.ad_domain_id_wireless_dot1x_eap_peap}}"
       }
     headers:
       "Authorization": "{{.get_login_token.result.token}}"
@@ -92,7 +92,7 @@ testcases:
     ignore_verify_ssl: true
     body: >-
       {
-        "domain": "{{.ad_domain_id}}"
+        "domain": "{{.ad_domain_id_wireless_dot1x_eap_peap}}"
       }
     headers:
       "Authorization": "{{.get_login_token.result.token}}"

--- a/t/venom/test_suites/wireless_dot1x_eap_peap/07_create_realms.yml
+++ b/t/venom/test_suites/wireless_dot1x_eap_peap/07_create_realms.yml
@@ -4,6 +4,21 @@ testcases:
   steps:
   - type: get_login_token
 
+- name: get_ad_domain_id
+  steps:
+  - type: http
+    method: GET
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/domains'
+    ignore_verify_ssl: true
+    headers:
+      "Authorization": "{{.get_login_token.result.token}}"
+      "Content-Type": "application/json"
+    assertions:
+      - result.statuscode ShouldEqual 200
+    vars:
+      domain_id:
+        from: result.bodyjson.items.items0.id
+
 - name: create_realms
   steps:
   - type: http
@@ -13,7 +28,7 @@ testcases:
     body: >-
       {
         "admin_strip_username": "enabled",
-        "domain": "{{.ad_domain_id_wireless_dot1x_eap_peap}}",
+        "domain": "{{.get_ad_domain_id.domain_id}}",
         "eduroam_options": null,
         "eduroam_radius_acct": null,
         "eduroam_radius_acct_proxy_type": "load-balance",
@@ -45,7 +60,7 @@ testcases:
     body: >-
       {
         "admin_strip_username": "enabled",
-        "domain": "{{.ad_domain_id_wireless_dot1x_eap_peap}}",
+        "domain": "{{.get_ad_domain_id.domain_id}}",
         "eduroam_options": null,
         "eduroam_radius_acct": null,
         "eduroam_radius_acct_proxy_type": "load-balance",
@@ -78,7 +93,7 @@ testcases:
     ignore_verify_ssl: true
     body: >-
       {
-        "domain": "{{.ad_domain_id_wireless_dot1x_eap_peap}}"
+        "domain": "{{.get_ad_domain_id.domain_id}}"
       }
     headers:
       "Authorization": "{{.get_login_token.result.token}}"
@@ -92,7 +107,7 @@ testcases:
     ignore_verify_ssl: true
     body: >-
       {
-        "domain": "{{.ad_domain_id_wireless_dot1x_eap_peap}}"
+        "domain": "{{.get_ad_domain_id.domain_id}}"
       }
     headers:
       "Authorization": "{{.get_login_token.result.token}}"

--- a/t/venom/test_suites/wireless_dot1x_eap_peap/35_enable_dot1x_eap_peap_int.yml
+++ b/t/venom/test_suites/wireless_dot1x_eap_peap/35_enable_dot1x_eap_peap_int.yml
@@ -7,4 +7,5 @@ testcases:
       user: '{{.ssh_user}}'
       command:  |
           cd /usr/local/pf/t/venom ; \
-          sudo /usr/local/pf/t/venom/venom-wrapper.sh {{.switch_test_suite_dir}}/common/enable_wlan0_dot1x_int.yml
+          sudo VENOM_COMMON_FLAGS='--output-dir={{.test_suite_results_dir}}/{{.venom.testcase}}' \
+          /usr/local/pf/t/venom/venom-wrapper.sh {{.switch_test_suite_dir}}/common/enable_wlan0_dot1x_int.yml

--- a/t/venom/test_suites/wireless_dot1x_eap_peap/39_check_wireless_dot1x_status.yml
+++ b/t/venom/test_suites/wireless_dot1x_eap_peap/39_check_wireless_dot1x_status.yml
@@ -7,4 +7,5 @@ testcases:
       user: '{{.ssh_user}}'
       command:  |
           cd /usr/local/pf/t/venom ; \
-          sudo /usr/local/pf/t/venom/venom-wrapper.sh {{.switch_test_suite_dir}}/common/check_wlan0_int_status.yml
+          sudo VENOM_COMMON_FLAGS='--output-dir={{.test_suite_results_dir}}/{{.venom.testcase}}' \
+          /usr/local/pf/t/venom/venom-wrapper.sh {{.switch_test_suite_dir}}/common/check_wlan0_int_status.yml

--- a/t/venom/test_suites/wireless_dot1x_eap_peap/40_run_wpasupplicant.yml
+++ b/t/venom/test_suites/wireless_dot1x_eap_peap/40_run_wpasupplicant.yml
@@ -7,4 +7,5 @@ testcases:
       user: '{{.ssh_user}}'
       command:  |
           cd /usr/local/pf/t/venom ; \
-          sudo /usr/local/pf/t/venom/venom-wrapper.sh {{.nodes_test_suite_dir}}/wireless_dot1x_eap_peap/run_wpasupplicant.yml
+          sudo VENOM_COMMON_FLAGS='--output-dir={{.test_suite_results_dir}}/{{.venom.testcase}}' \
+          /usr/local/pf/t/venom/venom-wrapper.sh {{.nodes_test_suite_dir}}/wireless_dot1x_eap_peap/run_wpasupplicant.yml

--- a/t/venom/test_suites/wireless_dot1x_eap_peap/60_check_wireless_dot1x_int_status.yml
+++ b/t/venom/test_suites/wireless_dot1x_eap_peap/60_check_wireless_dot1x_int_status.yml
@@ -7,4 +7,5 @@ testcases:
       user: '{{.ssh_user}}'
       command:  |
           cd /usr/local/pf/t/venom ; \
-          sudo /usr/local/pf/t/venom/venom-wrapper.sh {{.switch_test_suite_dir}}/common/check_wlan0.x_int_status_eap_peap_user.yml
+          sudo VENOM_COMMON_FLAGS='--output-dir={{.test_suite_results_dir}}/{{.venom.testcase}}' \
+          /usr/local/pf/t/venom/venom-wrapper.sh {{.switch_test_suite_dir}}/common/check_wlan0.x_int_status_eap_peap_user.yml

--- a/t/venom/test_suites/wireless_dot1x_eap_peap/teardown/05_disable_wireless_dot1x_eap_peap_int.yml
+++ b/t/venom/test_suites/wireless_dot1x_eap_peap/teardown/05_disable_wireless_dot1x_eap_peap_int.yml
@@ -7,4 +7,5 @@ testcases:
       user: '{{.ssh_user}}'
       command:  |
           cd /usr/local/pf/t/venom ; \
-          sudo /usr/local/pf/t/venom/venom-wrapper.sh {{.switch_test_suite_dir}}/common/disable_wlan0_dot1x_int.yml
+          sudo VENOM_COMMON_FLAGS='--output-dir={{.test_suite_results_dir}}/{{.venom.testcase}}' \
+          /usr/local/pf/t/venom/venom-wrapper.sh {{.switch_test_suite_dir}}/common/disable_wlan0_dot1x_int.yml

--- a/t/venom/test_suites/wireless_dot1x_eap_peap/teardown/90_teardown.yml
+++ b/t/venom/test_suites/wireless_dot1x_eap_peap/teardown/90_teardown.yml
@@ -4,6 +4,21 @@ testcases:
   steps:
   - type: get_login_token
 
+- name: get_ad_domain_id
+  steps:
+  - type: http
+    method: GET
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/domains'
+    ignore_verify_ssl: true
+    headers:
+      "Authorization": "{{.get_login_token.result.token}}"
+      "Content-Type": "application/json"
+    assertions:
+      - result.statuscode ShouldEqual 200
+    vars:
+      domain_id:
+        from: result.bodyjson.items.items0.id
+
 - name: unset_domain_on_builtin_realms
   steps:
   - type: http
@@ -60,7 +75,7 @@ testcases:
   steps:
   - type: http
     method: DELETE
-    url: '{{.pfserver_webadmin_url}}/api/v1/config/domain/{{.ad_domain_id_wireless_dot1x_eap_peap}}'
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/domain/{{.get_ad_domain_id.domain_id}}'
     ignore_verify_ssl: true
     headers:
       "Authorization": "{{.get_login_token.result.token}}"

--- a/t/venom/test_suites/wireless_dot1x_eap_peap/teardown/90_teardown.yml
+++ b/t/venom/test_suites/wireless_dot1x_eap_peap/teardown/90_teardown.yml
@@ -60,13 +60,19 @@ testcases:
   steps:
   - type: http
     method: DELETE
-    url: '{{.pfserver_webadmin_url}}/api/v1/config/domain/{{.ad_domain_id}}'
+    url: '{{.pfserver_webadmin_url}}/api/v1/config/domain/{{.ad_domain_id_wireless_dot1x_eap_peap}}'
     ignore_verify_ssl: true
     headers:
       "Authorization": "{{.get_login_token.result.token}}"
       "Content-Type": "application/json"
     assertions:
       - result.statuscode ShouldEqual 200
+
+# it will be restarted when a new join will start
+- name: stop_packetfence_winbindd
+  steps:
+  - type: exec
+    script: systemctl stop packetfence-winbindd
 
 - name: delete_connection_profile
   steps:

--- a/t/venom/test_suites/wireless_mac_auth/15_enable_mac_auth_int.yml
+++ b/t/venom/test_suites/wireless_mac_auth/15_enable_mac_auth_int.yml
@@ -7,4 +7,5 @@ testcases:
       user: '{{.ssh_user}}'
       command:  |
           cd /usr/local/pf/t/venom ; \
-          sudo /usr/local/pf/t/venom/venom-wrapper.sh {{.switch_test_suite_dir}}/common/enable_wlan0_mac_auth_int.yml
+          sudo VENOM_COMMON_FLAGS='--output-dir={{.test_suite_results_dir}}/{{.venom.testcase}}' \
+          /usr/local/pf/t/venom/venom-wrapper.sh {{.switch_test_suite_dir}}/common/enable_wlan0_mac_auth_int.yml

--- a/t/venom/test_suites/wireless_mac_auth/20_enable_wpa_supplicant.yml
+++ b/t/venom/test_suites/wireless_mac_auth/20_enable_wpa_supplicant.yml
@@ -7,4 +7,5 @@ testcases:
       user: '{{.ssh_user}}'
       command:  |
           cd /usr/local/pf/t/venom ; \
-          sudo /usr/local/pf/t/venom/venom-wrapper.sh {{.nodes_test_suite_dir}}/wireless_mac_auth/run_wpasupplicant.yml
+          sudo VENOM_COMMON_FLAGS='--output-dir={{.test_suite_results_dir}}/{{.venom.testcase}}' \
+          /usr/local/pf/t/venom/venom-wrapper.sh {{.nodes_test_suite_dir}}/wireless_mac_auth/run_wpasupplicant.yml

--- a/t/venom/test_suites/wireless_mac_auth/35_check_wlan0.x_status.yml
+++ b/t/venom/test_suites/wireless_mac_auth/35_check_wlan0.x_status.yml
@@ -7,4 +7,5 @@ testcases:
       user: '{{.ssh_user}}'
       command:  |
           cd /usr/local/pf/t/venom ; \
-          sudo /usr/local/pf/t/venom/venom-wrapper.sh {{.switch_test_suite_dir}}/common/check_wlan0.x_int_status_mac_auth.yml
+          sudo VENOM_COMMON_FLAGS='--output-dir={{.test_suite_results_dir}}/{{.venom.testcase}}' \
+          /usr/local/pf/t/venom/venom-wrapper.sh {{.switch_test_suite_dir}}/common/check_wlan0.x_int_status_mac_auth.yml

--- a/t/venom/test_suites/wireless_mac_auth/teardown/07_disable_mac_auth_int.yml
+++ b/t/venom/test_suites/wireless_mac_auth/teardown/07_disable_mac_auth_int.yml
@@ -7,4 +7,5 @@ testcases:
       user: '{{.ssh_user}}'
       command:  |
           cd /usr/local/pf/t/venom ; \
-          sudo /usr/local/pf/t/venom/venom-wrapper.sh {{.switch_test_suite_dir}}/common/disable_wlan0_mac_auth_int.yml
+          sudo VENOM_COMMON_FLAGS='--output-dir={{.test_suite_results_dir}}/{{.venom.testcase}}' \
+          /usr/local/pf/t/venom/venom-wrapper.sh {{.switch_test_suite_dir}}/common/disable_wlan0_mac_auth_int.yml

--- a/t/venom/vars/all.yml
+++ b/t/venom/vars/all.yml
@@ -41,7 +41,11 @@ pfserver_pfqueue_workers: 8
 pfserver_haproxy_admin_server_timeout: 240s
 
 # ad variables
-ad_domain_id: example
+ad_domain_id_wired_dot1x_eap_peap: example1
+ad_domain_id_wired_dot1x_eap_peap_sso_https: example2
+ad_domain_id_wired_dot1x_eap_peap_sso_radius: example3
+ad_domain_id_wireless_dot1x_eap_peap: example4
+
 ad_domain_upper: EXAMPLE
 ad_dns_domain: example.lan
 ad_domain_admin_user: vagrant-domain

--- a/t/venom/vars/all.yml
+++ b/t/venom/vars/all.yml
@@ -41,11 +41,6 @@ pfserver_pfqueue_workers: 8
 pfserver_haproxy_admin_server_timeout: 240s
 
 # ad variables
-ad_domain_id_wired_dot1x_eap_peap: example1
-ad_domain_id_wired_dot1x_eap_peap_sso_https: example2
-ad_domain_id_wired_dot1x_eap_peap_sso_radius: example3
-ad_domain_id_wireless_dot1x_eap_peap: example4
-
 ad_domain_upper: EXAMPLE
 ad_dns_domain: example.lan
 ad_domain_admin_user: vagrant-domain


### PR DESCRIPTION
# Description
Fixes:
- keep VM available if a test failed, destroy VM if a test passed, extract logs in both cases. Cleanup job has been deployed on runners
- disable apt-daily timers to prevent lock during initial upgrade
- increase SSH timeout when booting Vagrant VM
- start services at end of configurator using "poll" mechanism to avoid 504 errors
- create dedicated AD domain (example1, example2, etc.) for each test suite
- keep more logs on node* VM in place of log of latest test suite
- share common VM (ad, switch01) per branch

TODO:
- ~[ ] upgrade Ansible on runners to 2.12 to benefit from (https://github.com/ansible/ansible/commit/ee725846f070fc6b0dd79b5e8c5199ec652faf87) which should limit timeout when calling ansible-galaxy API~

**Please note** that this PR is opened against `maintenance/11.2` branch and not `devel` branch.

# Impacts
Tests

# Delete branch after merge
*NO*

# TODO post-merge
- [X] Need to backport things to maintenance/11.1 and maintenance/11.0
- [ ] Need to backport possible things to devel. Venom code has changed a lot between `maintenance/11.2` and `devel` due to #6813
- [X] Re-enable tests 
