### PR TITLE
Only apply NatDNS if it´s an inline network

### DIFF
--- a/go/cmd/pfdhcp/utils.go
+++ b/go/cmd/pfdhcp/utils.go
@@ -193,9 +193,12 @@ func NodeInformation(ctx context.Context, target net.HardwareAddr) (r NodeInfo) 
 
 // ShuffleDNS return the dns list
 func ShuffleDNS(ConfNet pfconfigdriver.RessourseNetworkConf) (r []byte) {
-	if !sharedutils.IsEnabled(ConfNet.NatDNS) {
-		var excluded []string
-		return Shuffle(ConfNet.Dns, excluded)
+	matched, _ := regexp.MatchString(`inlinel[2-3]`, ConfNet.Type)
+	if matched {
+		if !sharedutils.IsEnabled(ConfNet.NatDNS) {
+			var excluded []string
+			return Shuffle(ConfNet.Dns, excluded)
+		}
 	}
 	if ConfNet.ClusterIPs != "" {
 		if ConfNet.Dnsvip != "" {


### PR DESCRIPTION
# Description
(REQUIRED)
Describe what the new code is used for.
ie: Allow PacketFence to trigger the coffee machine on wireless EAP 802.1X connection to brew a fresh espresso.

# Impacts
pfdhcp

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Bug Fixes
* Fixed ShuffleDNS logic (only apply to inline network)
