### PR TITLE
Align Apache timeout with captive_portal.request_timeout

### DIFF
--- a/conf/httpd.conf.d/httpd.portal.tt.example
+++ b/conf/httpd.conf.d/httpd.portal.tt.example
@@ -108,7 +108,9 @@ TraceEnable Off
 ServerTokens Prod
 ServerSignature Off
 UseCanonicalName Off
-Timeout 5
+# Allow for 5 more seconds than the request_timeout of Catalyst since it must always be allowed to complete in order to catch the alarm it sets
+# See https://github.com/inverse-inc/packetfence/issues/7037 for details
+Timeout [% captive_portal.request_timeout + 5 %]
 KeepAlive Off
 
 MaxClients [% max_clients %]


### PR DESCRIPTION

# Description
Align Apache timeout with captive_portal.request_timeout

# Impacts
Apache httpd.portal

# Issue
fixes #7037 

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* Align Apache timeout with captive_portal.request_timeout (#7037)

