### PR TITLE
Cookie session id as param in the redirect url (Akamai MFA)

### DIFF
--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/MFA.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/MFA.pm
@@ -116,7 +116,8 @@ sub execute_child {
         }
     }
     else {
-        my $info = $mfa->redirect_info($self->username);
+        my $cookies = $self->app->request->cookies;
+        my $info = $mfa->redirect_info($self->username, $cookies->{CGISESSION_PF}->value);
         $self->show_mfa($info);
     }
 }

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/MFA.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/MFA.pm
@@ -116,8 +116,7 @@ sub execute_child {
         }
     }
     else {
-        my $cookies = $self->app->request->cookies;
-        my $info = $mfa->redirect_info($self->username, $cookies->{CGISESSION_PF}->value);
+        my $info = $mfa->redirect_info($self->username, $self->app->session->{'captiveportal::Model::Portal::Session'}->{'dispatcherSession'}->{'_session_id'});
         $self->show_mfa($info);
     }
 }

--- a/html/captive-portal/lib/captiveportal/PacketFence/Model/Portal/Session.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Model/Portal/Session.pm
@@ -97,6 +97,10 @@ has redirectURL => (
     is       => 'rw',
 );
 
+has sessionID => (
+    is       => 'rw',
+);
+
 has dispatcherSession => (
     is      => 'rw',
     builder => '_build_dispatcherSession',
@@ -110,6 +114,7 @@ sub ACCEPT_CONTEXT {
     my $class = ref $self || $self;
     my $previous_model = $c->session->{$class};
     my $request       = $c->request;
+    my $session_id =  exists($request->{parameters}->{CGISESSION_PF}) ? $request->{parameters}->{CGISESSION_PF} : undef;
     my $r = $request->{'env'}->{'psgi.input'};
     return $previous_model if(defined($previous_model) && $previous_model->{options}->{in_uri_portal} && !($r->can('pnotes') && defined ($r->pnotes('last_uri') ) ) );
     my $model;
@@ -151,6 +156,7 @@ sub ACCEPT_CONTEXT {
         remoteAddress => $remoteAddress,
         forwardedFor  => $forwardedFor,
         options       => $options,
+        sessionID     => $session_id,
         @args,
     );
     $c->session->{$class} = $model;
@@ -262,9 +268,8 @@ sub _build_profile {
 sub _build_dispatcherSession {
     my ($self) = @_;
     my $logger = get_logger();
-
     # Restore with a dummy MAC since we don't care about what contains the session if it can't be restored from the session ID
-    my $portal_session = new pf::Portal::Session(client_mac => $DUMMY_MAC);
+    my $portal_session = new pf::Portal::Session(client_mac => $DUMMY_MAC, session_id => $self->sessionID);
 
     if($portal_session->{_dummy_session}) {
         $logger->debug("Ignoring dispatcher session as it wasn't restored from a valid session ID");

--- a/lib/pf/Portal/Session.pm
+++ b/lib/pf/Portal/Session.pm
@@ -159,7 +159,7 @@ sub _initialize {
             return $self->getGrantUrl;
         }
     );
-
+    $self->session->param("_session_id", $sid);
     $self->_initializeStash();
 }
 

--- a/lib/pf/mfa/Akamai.pm
+++ b/lib/pf/mfa/Akamai.pm
@@ -461,7 +461,7 @@ Generate redirection information
 =cut
 
 sub redirect_info {
-    my ($self, $username) = @_;
+    my ($self, $username, $cookie) = @_;
     my $logger = get_logger();
     $logger->warn("MFA USERNAME: ".$username);
     my $payload = {
@@ -469,7 +469,7 @@ sub redirect_info {
         timestamp => time(),
         request => {
             username => $username,
-            callback => $self->callback_url,
+            callback => $self->callback_url."?CGISESSION_PF=".$cookie,
         },
     };
     $payload = encode_json($payload);

--- a/lib/pf/mfa/Akamai.pm
+++ b/lib/pf/mfa/Akamai.pm
@@ -461,7 +461,7 @@ Generate redirection information
 =cut
 
 sub redirect_info {
-    my ($self, $username, $cookie) = @_;
+    my ($self, $username, $session_id) = @_;
     my $logger = get_logger();
     $logger->warn("MFA USERNAME: ".$username);
     my $payload = {
@@ -469,7 +469,7 @@ sub redirect_info {
         timestamp => time(),
         request => {
             username => $username,
-            callback => $self->callback_url."?CGISESSION_PF=".$cookie,
+            callback => $self->callback_url."?CGISESSION_PF=".$session_id,
         },
     };
     $payload = encode_json($payload);


### PR DESCRIPTION
# Description
Add the cookie session id to the redirect url for Akamai MFA

# Impacts
Akamai MFA

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* Add the cookie session id as a param of the redirect url (Akamai MFA)

