### PR TITLE
Fix Connection type detection on Dell switches (n1500)

### DIFF
--- a/lib/pf/Switch/Dell/N1500.pm
+++ b/lib/pf/Switch/Dell/N1500.pm
@@ -471,6 +471,25 @@ sub parseExternalPortalRequest {
     return \%params;
 }
 
+=item identifyConnectionType
+
+Determine Connection Type based on radius attributes
+
+=cut
+
+sub identifyConnectionType {
+    my ( $self, $connection, $radius_request ) = @_;
+
+    my @require = qw(NAS-Port-Type);
+    my @found = grep {exists $radius_request->{$_}} @require;
+    if (@require != @found) {
+        $connection->isVPN($FALSE);
+        $connection->isCLI($TRUE);
+        $connection->isMacAuth($FALSE);
+        $connection->transport("Virtual");
+    }
+}
+
 =head1 AUTHOR
 
 Inverse inc. <info@inverse.ca>

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -143,7 +143,7 @@ sub authorize {
 
     Log::Log4perl::MDC->put( 'mac', $mac );
     my $connection = pf::Connection->new;
-    $connection->identifyType($nas_port_type, $eap_type, $mac, $user_name, $switch);
+    $connection->identifyType($nas_port_type, $eap_type, $mac, $user_name, $switch, $radius_request);
     my $connection_type = $connection->attributesToBackwardCompatible;
     my $connection_sub_type = $connection->subType;
     # switch-specific information retrieval
@@ -419,7 +419,7 @@ sub accounting {
     my $isUpdate = $acct_status_type  == $ACCOUNTING::INTERIM_UPDATE;
 
     my $connection = pf::Connection->new;
-    $connection->identifyType($nas_port_type, $eap_type, $mac, $user_name, $switch);
+    $connection->identifyType($nas_port_type, $eap_type, $mac, $user_name, $switch, $radius_request);
     my $connection_type = $connection->attributesToBackwardCompatible;
     my $connection_sub_type = $connection->subType;
 
@@ -1277,7 +1277,7 @@ sub radius_filter {
         $node_obj = pf::dal::node->new({"mac" => $mac});
     }
     my $connection = pf::Connection->new;
-    $connection->identifyType($nas_port_type, $eap_type, $mac, $user_name, $switch);
+    $connection->identifyType($nas_port_type, $eap_type, $mac, $user_name, $switch, $radius_request);
     my $connection_type = $connection->attributesToBackwardCompatible;
     my $connection_sub_type = $connection->subType;
     # switch-specific information retrieval


### PR DESCRIPTION
# Description
When packetfence receive a radius request for a cli access from the N1500 switch then the NAS-Port-Type is undefined.
If it´s not there it mean that it´s not a ethernet request.

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
## Enhancements
* Detect Cli-Access from Dell N1500 switch
