### PR TITLE
Handle WebAuth on Extreme Controller without web form

### DIFF
--- a/docs/network/networkdevice/extreme_networks_wireless.asciidoc
+++ b/docs/network/networkdevice/extreme_networks_wireless.asciidoc
@@ -21,20 +21,20 @@ endif::[]
 
 ==== Access points AP305C (managed by Extreme Cloud IQ Controller)
 
-In such deployment, PacketFence communicate directly with access
-points using RADIUS. Extreme Cloud IQ controller is only used to configure
+In such deployment, PacketFence communicates directly with the access
+points using RADIUS. The Extreme Cloud IQ controller is only used to configure
 access points in a central place.
 
 ===== Web authentication
 
 ====== Extreme Cloud IQ Controller
 
-On Extreme Cloud IQ Controller, you should have builtin IP Firewall policies:
+On the Extreme Cloud IQ Controller, there should already be two built-in IP Firewall policies:
 
 * Redirect-only policy: this policy must have "redirect" rules
 * Internet-access-only policy
 
-On Extreme Cloud IQ Controller, create two user profiles:
+On the Extreme Cloud IQ Controller, create two user profiles:
 
 * Registration
 ** VLAN: 5
@@ -46,7 +46,7 @@ On Extreme Cloud IQ Controller, create two user profiles:
 ** Firewall rules: Enabled
 ** IP Firewall Name: Internet-access-only policy
 
-On Extreme Cloud IQ Controller, create a wireless network with following configuration:
+Still, on the Extreme Cloud IQ Controller, create a wireless network with the following configuration:
 
 * SSID Authentication: Open
 ** Enable Captive Web Portal: No

--- a/docs/network/networkdevice/extreme_networks_wireless.asciidoc
+++ b/docs/network/networkdevice/extreme_networks_wireless.asciidoc
@@ -1,0 +1,85 @@
+// to display images directly on GitHub
+ifdef::env-github[]
+:encoding: UTF-8
+:lang: en
+:doctype: book
+:toc: left
+:imagesdir: ../../images
+endif::[]
+
+////
+
+    This file is part of the PacketFence project.
+
+    See PacketFence_Network_Devices_Configuration_Guide.asciidoc
+    for authors, copyright and license information.
+
+////
+
+
+//=== Extreme Networks
+
+==== Access points AP305C (managed by Extreme Cloud IQ Controller)
+
+In such deployment, PacketFence communicate directly with access
+points using RADIUS. Extreme Cloud IQ controller is only used to configure
+access points in a central place.
+
+===== Web authentication
+
+====== Extreme Cloud IQ Controller
+
+On Extreme Cloud IQ Controller, you should have builtin IP Firewall policies:
+
+* Redirect-only policy: this policy must have "redirect" rules
+* Internet-access-only policy
+
+On Extreme Cloud IQ Controller, create two user profiles:
+
+* Registration
+** VLAN: 5
+** Firewall rules: Enabled
+** IP Firewall Name: Redirect-only policy
+** Redirect URL: http://192.168.1.5/Extreme::AP
+* Guest
+** VLAN: 5
+** Firewall rules: Enabled
+** IP Firewall Name: Internet-access-only policy
+
+On Extreme Cloud IQ Controller, create a wireless network with following configuration:
+
+* SSID Authentication: Open
+** Enable Captive Web Portal: No
+* MAC Authentication tab
+** Enable MAC authentication: Yes
+** Authentication protocol: CHAP
+** Authenticate via RADIUS server
+*** Create a RADIUS group with an External RADIUS Server
+**** Permit Dynamic Change Of Authorization Messages (RFC 3576): Enabled
+** User access settings
+*** Apply a different user profile to various clients and user groups: Enabled
+**** Allow user profile assignment using RADIUS attributes in addition to the three tunnel RADIUS attributes: Enabled
+***** Standard RADIUS Attribute: Filter-Id
+
+Under User access settings, you need to create following rules:
+
+.User Access Settings rules
+|===
+| User profile name | VLAN/VLAN Group | Assignment rules
+
+| Registration      |  5              | If Filter-ID equals "Registration"
+| Guest             |  5              | If Filter-ID equals "Guest"
+|===
+
+====== PacketFence
+
+Create a switch with following configuration:
+
+* Definition tab
+** Identifier: subnet of your Extreme AP
+** External portal enforcement: Yes
+** Deauthentication method: RADIUS
+* Roles tab
+** Role by Switch Role: Yes
+*** registration: Registration
+*** guest: Guest

--- a/docs/network/wireless_controllers_and_access_point_configuration.asciidoc
+++ b/docs/network/wireless_controllers_and_access_point_configuration.asciidoc
@@ -131,6 +131,10 @@ include::networkdevice/coovachilli.asciidoc[]
 
 NOTE: To be contributed...
 
+=== Extreme Networks
+
+include::networkdevice/extreme_networks_wireless.asciidoc[]
+
 === Extricom
 
 include::networkdevice/extricom.asciidoc[]

--- a/lib/pf/Switch/Extreme/AP.pm
+++ b/lib/pf/Switch/Extreme/AP.pm
@@ -1,0 +1,247 @@
+package pf::Switch::Extreme::AP;
+
+=head1 NAME
+
+pf::Switch::Extreme::AP
+
+=head1 SYNOPSIS
+
+Module to manage Extreme APs managed by an Extreme Cloud IQ (cloud)
+
+=head1 STATUS
+
+Developed and tested on AeroHIVE AP305C running IQ Engine 10.4r6.
+
+=over
+
+=back 
+
+=cut
+use strict;
+use warnings;
+
+use pf::config qw(
+    $WIRELESS_MAC_AUTH
+    $WEBAUTH_WIRELESS
+);
+use pf::constants;
+use pf::locationlog;
+use pf::util;
+use pf::security_event;
+use pf::constants::role qw($REJECT_ROLE);
+use pf::config qw(
+    $WIRED_802_1X
+    $WIRED_MAC_AUTH
+    $WEBAUTH_WIRED
+    $WEBAUTH_WIRELESS
+);
+use pf::Switch::constants;
+use pf::util::radius qw(perform_disconnect perform_coa);
+use pf::roles::custom;
+use base ('pf::Switch');
+use Try::Tiny;
+use pf::SwitchSupports qw(
+    ExternalPortal
+    RoleBasedEnforcement
+    WirelessDot1x
+    WirelessMacAuth
+);
+
+
+sub description { 'Extreme AP' }
+
+
+=head1 METHODS
+
+=over
+
+=cut
+
+=item parseExternalPortalRequest
+
+Parse external portal request using URI and it's parameters then return an hash reference with the appropriate parameters
+
+See L<pf::web::externalportal::handle>
+
+=cut
+
+sub parseExternalPortalRequest {
+    my ( $self, $r, $req ) = @_;
+    my $logger = $self->logger;
+
+    # Using a hash to contain external portal parameters
+    my %params = ();
+
+    %params = (
+        switch_id               => $req->param('RADIUS-NAS-IP'),
+        client_mac              => clean_mac($req->param('Calling-Station-Id')),
+        client_ip               => $req->param('STA-IP'),
+        ssid                    => $req->param('ssid'),
+        redirect_url            => defined($req->param('destination_url')),
+        grant_url               => $req->param('url'),
+        status_code             => '200',
+        synchronize_locationlog => $TRUE,
+        connection_type         => $WEBAUTH_WIRELESS,
+    );
+
+    return \%params;
+}
+
+=item deauthenticateMacDefault
+
+return Default Deauthentication Default technique
+
+=cut
+
+sub deauthenticateMacDefault {
+    my ( $self, $mac, $is_dot1x ) = @_;
+    my $logger = $self->logger;
+
+    if ( !$self->isProductionMode() ) {
+        $logger->info("not in production mode... we won't perform deauthentication");
+        return 1;
+    }
+
+    $logger->debug("deauthenticate $mac using RADIUS Disconnect-Request deauth method");
+    return $self->radiusDisconnect($mac);
+}
+
+=item radiusDisconnect
+
+Sends a RADIUS Disconnect-Request to the NAS with the MAC as the Calling-Station-Id to disconnect.
+
+Optionally you can provide other attributes as an hashref.
+
+Uses L<pf::util::radius> for the low-level RADIUS stuff.
+
+=cut
+
+# TODO consider whether we should handle retries or not?
+
+sub radiusDisconnect {
+    my ($self, $mac, $add_attributes_ref) = @_;
+    my $logger = $self->logger;
+
+    # initialize
+    $add_attributes_ref = {} if (!defined($add_attributes_ref));
+
+    if (!defined($self->{'_radiusSecret'})) {
+        $logger->warn(
+            "Unable to perform RADIUS CoA-Request on $self->{'_ip'}: RADIUS Shared Secret not configured"
+        );
+        return;
+    }
+
+    $logger->info("deauthenticating $mac");
+
+    # Where should we send the RADIUS CoA-Request?
+    # to network device by default
+    my $send_disconnect_to = $self->{'_ip'};
+    # but if controllerIp is set, we send there
+    if (defined($self->{'_controllerIp'}) && $self->{'_controllerIp'} ne '') {
+        $logger->info("controllerIp is set, we will use controller $self->{_controllerIp} to perform deauth");
+        $send_disconnect_to = $self->{'_controllerIp'};
+    }
+    # allowing client code to override where we connect with NAS-IP-Address
+    $send_disconnect_to = $add_attributes_ref->{'NAS-IP-Address'}
+        if (defined($add_attributes_ref->{'NAS-IP-Address'}));
+
+    my $response;
+    try {
+        my $connection_info = {
+            useConnector => $self->shouldUseConnectorForRadiusDeauth(),
+            nas_ip => $send_disconnect_to,
+            secret => $self->{'_radiusSecret'},
+            LocalAddr => $self->deauth_source_ip($send_disconnect_to),
+        };
+
+        $logger->debug("network device supports roles. Evaluating role to be returned");
+        my $roleResolver = pf::roles::custom->instance();
+        my $role = $roleResolver->getRoleForNode($mac, $self);
+
+        # transforming MAC to the expected format 00-11-22-33-CA-FE
+        $mac = uc($mac);
+        $mac =~ s/:/-/g;
+
+        # Standard Attributes
+        my $attributes_ref = {
+            'Calling-Station-Id' => $mac,
+            'NAS-IP-Address' => $send_disconnect_to,
+        };
+
+        # merging additional attributes provided by caller to the standard attributes
+        $attributes_ref = { %$attributes_ref, %$add_attributes_ref };
+
+        if ( $self->shouldUseCoA({role => $role}) ) {
+
+            $attributes_ref = {
+                %$attributes_ref,
+                'Filter-Id' => $role,
+            };
+            $logger->info("[$self->{'_ip'}] Returning ACCEPT with role: $role");
+            $response = perform_coa($connection_info, $attributes_ref);
+
+        }
+        else {
+            $response = perform_disconnect($connection_info, $attributes_ref);
+        }
+    } catch {
+        chomp;
+        $logger->warn("Unable to perform RADIUS CoA-Request: $_");
+        $logger->error("Wrong RADIUS secret or unreachable network device...") if ($_ =~ /^Timeout/);
+    };
+    return if (!defined($response));
+
+    return $TRUE if ( ($response->{'Code'} eq 'Disconnect-ACK') || ($response->{'Code'} eq 'CoA-ACK') );
+
+    $logger->warn(
+        "Unable to perform RADIUS Disconnect-Request."
+        . ( defined($response->{'Code'}) ? " $response->{'Code'}" : 'no RADIUS code' ) . ' received'
+        . ( defined($response->{'Error-Cause'}) ? " with Error-Cause: $response->{'Error-Cause'}." : '' )
+    );
+    return;
+}
+
+=item returnRoleAttribute
+
+What RADIUS Attribute (usually VSA) should the role returned into.
+
+=cut
+
+sub returnRoleAttribute {
+    my ($self) = @_;
+
+    return 'Filter-Id';
+}
+
+=back
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2022 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;
+

--- a/lib/pf/web/constants.pm
+++ b/lib/pf/web/constants.pm
@@ -121,6 +121,7 @@ Readonly::Scalar our $EXT_URL_CAMBIUM               => '^/Cambium';
 Readonly::Scalar our $EXT_URL_MOJO                  => '^/Mojo';
 Readonly::Scalar our $EST_URL_DELL                  => '^/Dell:N1500';
 Readonly::Scalar our $EXT_URL_EXOS                  => '^/Extreme::EXOS';
+Readonly::Scalar our $EXT_URL_EXTREME_AP            => '^/Extreme::AP';
 Readonly::Scalar our $EXT_URL_F5                    => '^/F5';
 
 # Ubiquiti doesn't support setting the URL so we much detect it using this URL which will then map to the Ubiquiti module in pf::web::externalportal


### PR DESCRIPTION
# Description
Handle WebAuth on Extreme Controller without web form

Web form usage still work but some browsers complain when they have to send a web form to 1.1.1.1/reg.php using HTTP (in place of HTTPS). Switching to HTTPS break everything.

# Delete branch after merge
YES

# NEWS file entries
## Enhancements
* Improve WebAuth support on Extreme controllers

