### PR TITLE
Use the full date and time for expiration of password

### DIFF
--- a/lib/pf/password.pm
+++ b/lib/pf/password.pm
@@ -358,7 +358,7 @@ sub validate_password {
             'password.pid' => $pid,
             'person.potd' => $allow_potd ? 'yes' : ['no', undef],
         },
-        -columns => [qw(password.pid|pid password.password|password), 'IFNULL(UNIX_TIMESTAMP(valid_from),0)|valid_from', 'IFNULL(UNIX_TIMESTAMP(DATE_FORMAT(expiration,"%Y-%m-%d 23:59:59")),0)|expiration', qw(password.access_duration|access_duration password.category|category person.potd|potd)],
+        -columns => [qw(password.pid|pid password.password|password), 'IFNULL(UNIX_TIMESTAMP(valid_from),0)|valid_from', 'IFNULL(UNIX_TIMESTAMP(expiration),0)|expiration', qw(password.access_duration|access_duration password.category|category person.potd|potd)],
         #To avoid a join
         -limit => 1,
     );
@@ -371,7 +371,6 @@ sub validate_password {
     }
 
     if ( _check_password( $password, $temppass_record->{'password'}) ) {
-
         # password is valid but not yet valid
         # valid_from is in unix timestamp format so an int comparison is enough
         my $valid_from = $temppass_record->{'valid_from'};


### PR DESCRIPTION
# Description
Respect the time of the expiration date of the password.

# Impacts
Local user passwords

# Issue
fixes #7003

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Bug Fixes
* Respect the time of the expiration date of the password. (#7003)
