### PR TITLE
Update preseed.cfg.tmpl

### DIFF
--- a/ci/debian-installer/preseed.cfg.tmpl
+++ b/ci/debian-installer/preseed.cfg.tmpl
@@ -397,9 +397,9 @@ d-i grub-installer/with_other_os boolean true
 
 # Due notably to potential USB sticks, the location of the primary drive can
 # not be determined safely in general, so this needs to be specified:
-d-i grub-installer/bootdev  string /dev/sda
+# d-i grub-installer/bootdev  string /dev/sda
 # To install to the primary device (assuming it is not a USB stick):
-#d-i grub-installer/bootdev  string default
+d-i grub-installer/bootdev  string default
 
 # Alternatively, if you want to install to a location other than the UEFI
 # parition/boot record, uncomment and edit these lines:


### PR DESCRIPTION
Changed grub boot device from string  /dev/sda to string  default
this will install grub on the default drive, being the first drive. May be problematic if installing ISO using a USB drive but should be tested. /dev/sda is the default on physical hardware but some virtual drives present differently such as /dev/vda or /dev/xvda

# Description
Changed grub boot device from string  /dev/sda to string  default


# Impacts
this will install grub on the default drive, being the first drive. May be problematic if installing ISO using a USB drive but should be tested. /dev/sda is the default on physical hardware but some virtual drives present differently such as /dev/vda or /dev/xvda


# Issue
fixes #7113

# Delete branch after merge
(REQUIRED)
NO

# Checklist
(REQUIRED) - [yes, no or n/a]
- [n ] Document the feature
- [n ] Add unit tests
- [ n] Add acceptance tests (TestLink)
