### PR TITLE
Temporary fix for password encoding in rest

### DIFF
--- a/conf/radiusd/packetfence-cli.example
+++ b/conf/radiusd/packetfence-cli.example
@@ -115,6 +115,7 @@ authorize {
 	#  get a chance to set Auth-Type for themselves.
 	#
 	#pap
+	packetfence-base64-password
 	rest-cli
 	if (updated || ok || noop) {
 		update {

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -75,6 +75,7 @@ use pf::Redis;
 use pf::constants::eap_type qw($EAP_TLS $MS_EAP_AUTHENTICATION $EAP_PSK);
 use pf::person;
 use pf::factory::mfa;
+use MIME::Base64;
 
 our $VERSION = 1.03;
 
@@ -790,6 +791,9 @@ sub switch_access {
     my $connection_type = $connection->attributesToBackwardCompatible;
     my $connection_sub_type = $connection->subType;
     my $password = $radius_request->{'User-Password'};
+    if (exists($radius_request->{'PacketFence-UserPassword'})) {
+        $password = decode_base64($radius_request->{'PacketFence-UserPassword'});
+    }
     my $otp;
 
     # is switch object correct?

--- a/raddb/dictionary.inverse
+++ b/raddb/dictionary.inverse
@@ -51,6 +51,7 @@ ATTRIBUTE       PacketFence-NTLMv2-Only               35       string
 ATTRIBUTE       PacketFence-Outer-User                36       string
 ATTRIBUTE       PacketFence-UserDN                    37       string
 ATTRIBUTE       PacketFence-reply-insert              38       string
+ATTRIBUTE       PacketFence-UserPassword              39       string
 
 END-VENDOR      Inverse
 

--- a/raddb/policy.d/packetfence
+++ b/raddb/policy.d/packetfence
@@ -226,3 +226,10 @@ packetfence-degraded-auth {
         }
     }
 }
+
+packetfence-base64-password {
+    update {
+        request:PacketFence-UserPassword := "%{base64: %{User-Password}}"
+    }
+}
+

--- a/raddb/policy.d/packetfence
+++ b/raddb/policy.d/packetfence
@@ -228,8 +228,10 @@ packetfence-degraded-auth {
 }
 
 packetfence-base64-password {
-    update {
-        request:PacketFence-UserPassword := "%{base64: %{User-Password}}"
+    if (&User-Password) {
+        update {
+            request:PacketFence-UserPassword := "%{base64: %{User-Password}}"
+        }
     }
 }
 


### PR DESCRIPTION
# Description
Fix the the cli/vpn access the password encoding is this one contain special char like ç .

# Impacts
RADIUS Cli/VPN

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Bug Fixes
* Fix the wrong encoding of special char in the rest call to packetfence (use base64)
