### PR TITLE
adjust the NAS-IP-Address in the RADIUS source

### DIFF
--- a/docs/PacketFence_Upgrade_Guide.asciidoc
+++ b/docs/PacketFence_Upgrade_Guide.asciidoc
@@ -1899,6 +1899,12 @@ With the containerization of several services, it didn't make sense to keep them
 
 However, it's still possible to perform these commands on a PacketFence server using `pfcmd fixpermissions` and `pfcmd checkup`.
 
+=== Change of behavior for the RADIUS source NAS-IP-Address
+
+NOTE: This applies to administrators that have a RADIUS authentication source configured in PacketFence. If you are using PacketFence as a RADIUS server but do not have any RADIUS authentication source configured, this section does not apply to you.
+
+RADIUS authentication sources previously used the source IP of the packet in the NAS-IP-Address field when communicating with the RADIUS server. This behavior has been deprecated in favor of using the management IP address (or VIP in a cluster) in the NAS-IP-Address. If you do need to use another value in the NAS-IP-Address attribute, it is configurable in the RADIUS authentication source directly.
+
 === Log files names updated
 
 The name of some log files have changed. You can find a list below:

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source/RADIUS.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source/RADIUS.pm
@@ -80,6 +80,12 @@ has_field 'options',
    default => 'type = auth+acct',
 );
 
+has_field 'nas_ip_address' =>
+  (
+   type => 'Text',
+   default => pf::Authentication::Source::RADIUSSource->meta->get_attribute('nas_ip_address')->default,
+  );
+
 sub _options_set_role_from_source {
     my ($self) = @_;
     return map { $_ => $_} @{$Config{radius_configuration}{radius_attributes}};

--- a/html/pfappserver/root/src/views/Configuration/sources/_components/FormTypeRadius.vue
+++ b/html/pfappserver/root/src/views/Configuration/sources/_components/FormTypeRadius.vue
@@ -41,6 +41,11 @@
       :text="$i18n.t('Use the available PacketFence connectors to connect to this authentication source. By default, a local connector is hosted on this server. Using remote connectors is only supported on a standalone instance at the moment.')"
     />
 
+    <form-group-nas-ip-address namespace="nas_ip_address"
+      :column-label="$i18n.t('NAS IP Address')"
+      :text="$i18n.t('Which NAS IP Address to use when communicating with the RADIUS server. Leaving this empty will make the source use the management IP of the server (management VIP in a cluster).')"
+    />
+
     <form-group-options namespace="options"
       :column-label="$i18n.t('Options')"
       :text="$i18n.t('Define options for FreeRADIUS home_server definition (if you use the source in the realm configuration). Need a radiusd restart.')"
@@ -69,6 +74,7 @@ import {
   FormGroupHost,
   FormGroupIdentifier,
   FormGroupMonitor,
+  FormGroupNasIpAddress,
   FormGroupOptions,
   FormGroupPort,
   FormGroupRealms,
@@ -86,6 +92,7 @@ const components = {
   FormGroupHost,
   FormGroupIdentifier,
   FormGroupMonitor,
+  FormGroupNasIpAddress,
   FormGroupOptions,
   FormGroupPort,
   FormGroupRealms,

--- a/html/pfappserver/root/src/views/Configuration/sources/_components/index.js
+++ b/html/pfappserver/root/src/views/Configuration/sources/_components/index.js
@@ -93,6 +93,7 @@ export {
   BaseFormGroupInput                        as FormGroupMerchantIdentifier,
   BaseFormGroupTextarea                     as FormGroupMessage,
   BaseFormGroupToggle                       as FormGroupMonitor,
+  BaseFormGroupInput                        as FormGroupNasIpAddress,
   BaseFormGroupTextarea                     as FormGroupOptions,
   BaseFormGroupActiveDirectoryPasswordTest  as FormGroupPassword,
   BaseFormGroupInput                        as FormGroupPasswordEmailUpdate,


### PR DESCRIPTION
# Description
Adjust the NAS-IP-Address value when sending an Access-Request in the RADIUS source

# Impacts
RADIUS authentication source (not RADIUS auth server)

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [X] Document the feature
- [N/A] Add unit tests
- [N/A] Add acceptance tests (TestLink)

# NEWS file entries
## Enhancements
* The NAS-IP-Address can now be configured for RADIUS authentication sources

# UPGRADE file entries
Included in the PR