### PR TITLE
Disable database backups if DB is remote

### DIFF
--- a/addons/backup-and-maintenance.sh
+++ b/addons/backup-and-maintenance.sh
@@ -89,7 +89,6 @@ should_backup(){
 
     if [ $MARIADB_REMOTE_CLUSTER -eq 1 ]; then
         echo "Remote database detected: backup should be done on database server itself."
-        SHOULD_BACKUP=0
         exit $BACKUPRC
     fi
 
@@ -98,7 +97,6 @@ should_backup(){
         MARIADB_LOCAL_CLUSTER=1
         FIRST_SERVER=`mysql -u$REP_USER -p$REP_PWD -e 'show status like "wsrep_incoming_addresses";' | tail -1 | awk '{ print $2 }' | awk -F "," '{ print $1 }' | awk -F ":" '{ print $1 }'`
         if ! ip a | grep $FIRST_SERVER > /dev/null; then
-            SHOULD_BACKUP=0
             echo "Not the first server of the cluster: database backup canceled."
             exit $BACKUPRC
         else

--- a/addons/backup-and-maintenance.sh
+++ b/addons/backup-and-maintenance.sh
@@ -37,10 +37,12 @@ NODE2_HOSTNAME=''
 NODE1_IP=''
 NODE2_IP=''
 
-# Only for MariaDB remote clusters
-MARIADB_REMOTE_CLUSTER=0
-# should be equal to return of hostname command
-MARIADB_BACKUP_SERVER_HOSTNAME=''
+# to detect MariaDB remote DB
+if [ "$DB_HOST" != "localhost" ] && [ "$DB_HOST" != "100.64.0.1" ]; then
+    MARIADB_REMOTE_CLUSTER=1
+else
+    MARIADB_REMOTE_CLUSTER=0
+fi
 
 # Create the backup directory
 if [ ! -d "$BACKUP_DIRECTORY" ]; then
@@ -84,6 +86,13 @@ should_backup(){
     # Default choices
     SHOULD_BACKUP=1
     MARIADB_LOCAL_CLUSTER=0
+
+    if [ $MARIADB_REMOTE_CLUSTER -eq 1 ]; then
+        echo "Remote database detected: backup should be done on database server itself."
+        SHOULD_BACKUP=0
+        exit $BACKUPRC
+    fi
+
     # If we are using Galera cluster and that we're not the first server in the galera incomming addresses, we will not backup
     if [ -f /var/lib/mysql/grastate.dat ]; then
         MARIADB_LOCAL_CLUSTER=1
@@ -94,15 +103,6 @@ should_backup(){
             exit $BACKUPRC
         else
             echo -e "First server of the cluster : database backup will start.\n"
-        fi
-    elif [ $MARIADB_REMOTE_CLUSTER -eq 1 ]; then
-        PF_SERVER_HOSTNAME=$(hostname)
-        if [ "$MARIADB_BACKUP_SERVER_HOSTNAME" == "$PF_SERVER_HOSTNAME" ]; then
-            echo "Backup server detected: database backup will start"
-        else
-            SHOULD_BACKUP=0
-            echo "Server not configured to do DB backups: database backup canceled."
-            exit $BACKUPRC
         fi
     else
         echo "Database backup will start"
@@ -122,10 +122,6 @@ backup_db(){
         if [ $MARIADB_LOCAL_CLUSTER -eq 1 ]; then
              echo "Temporarily stopping Galera cluster sync for DB backup"
              mysql -u$REP_USER -p$REP_PWD -e 'set global wsrep_desync=ON;' || die "mysql command failed"
-        elif [ $MARIADB_REMOTE_CLUSTER -eq 1 ]; then
-             echo "Temporarily stopping **remote** Galera cluster sync for DB backup"
-             # We couldn't use the local socket
-             mysql -u$DB_USER -p$DB_PWD -h $DB_HOST -e 'set global wsrep_desync=ON;' || die "mysql command failed"
         else
             echo "Not a Galera cluster, nothing to stop"
         fi
@@ -137,8 +133,6 @@ backup_db(){
             mkdir -p $INNO_TMP
             if [ $MARIADB_LOCAL_CLUSTER -eq 1 ]; then
                 mariabackup --defaults-file=/usr/local/pf/var/conf/mariadb.conf --user=$REP_USER --password=$REP_PWD  --stream=xbstream --tmpdir=$INNO_TMP --backup 2>> /usr/local/pf/logs/innobackup.log | gzip - > $BACKUP_DIRECTORY/$BACKUP_DB_FILENAME-innobackup-`date +%F_%Hh%M`.xbstream.gz
-            elif [ $MARIADB_REMOTE_CLUSTER -eq 1 ]; then
-                echo "mariabackup can't backup remote databases, uninstall Mariabackup and retry"
             else
                 mariabackup --defaults-file=/usr/local/pf/var/conf/mariadb.conf --user=$DB_USER --password=$DB_PWD  --stream=xbstream --tmpdir=$INNO_TMP --backup 2>> /usr/local/pf/logs/innobackup.log | gzip - > $BACKUP_DIRECTORY/$BACKUP_DB_FILENAME-innobackup-`date +%F_%Hh%M`.xbstream.gz
             fi
@@ -169,9 +163,6 @@ backup_db(){
         if [ $MARIADB_LOCAL_CLUSTER -eq 1 ]; then
              echo "Reenabling Galera cluster sync"
              mysql -u$REP_USER -p$REP_PWD -e 'set global wsrep_desync=OFF;' || die "mysql command failed"
-        elif [ $MARIADB_REMOTE_CLUSTER -eq 1 ]; then
-             echo "Reenabling **remote** Galera cluster sync"
-             mysql -u$DB_USER -p$DB_PWD -h $DB_HOST -e 'set global wsrep_desync=OFF;' || die "mysql command failed"
         else
             echo "Not a Galera cluster, nothing to reenable"
         fi
@@ -185,8 +176,6 @@ backup_db(){
 should_backup
 # Is the database running on the current server and should we be running a backup ?
 if [ $SHOULD_BACKUP -eq 1 ] && { [ -f /var/run/mysqld/mysqld.pid ] || [ -f /var/run/mariadb/mariadb.pid ] || [ -f /var/lib/mysql/`hostname`.pid ]; }; then
-    backup_db
-elif [ $SHOULD_BACKUP -eq 1 ] && [ $MARIADB_REMOTE_CLUSTER -eq 1 ]; then
     backup_db
 else
     echo "Nothing to do"


### PR DESCRIPTION
# Description
We assume that a remote DB is backup by a tool directly on remote DB

This commit also deprecate the ability to backup a remote DB from a PacketFence server added by #4090

I will an upgrade note to warn about the deprecation even I don't think a lot of users are using this feature.

# Impacts
Backups of remote databases

# Issue
Related to #6396

# Delete branch after merge
YES

# UPGRADE file entries

```asciidoc
=== Remote database backups

Ability to backup a remote database configured in PacketFence has been deprecated. A dedicated tool on the database server itself must be used to backup PacketFence database.
```