### PR TITLE
Feature/rework cluster upgrade

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -878,6 +878,13 @@ build_artifacts_doc_devel_and_branches:
     - .build_artifacts_doc_job
     - .build_artifacts_doc_devel_and_branches_rules
 
+# build_artifacts_doc jobs for release
+build_artifacts_doc_release:
+  image: ${PFBUILD_DEB_BULLSEYE_IMG}:${CI_COMMIT_TAG}
+  extends:
+    - .build_artifacts_doc_job
+    - .release_only_rules
+
 ########################################
 # SIGN JOBS
 ########################################

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -212,6 +212,14 @@ variables:
     - if: '$CI_COMMIT_REF_NAME != "devel" && $CI_COMMIT_REF_NAME !~ /^maintenance\/[[:digit:]]+\.[[:digit:]]+$/ && $CI_COMMIT_TAG == null && $CI_PIPELINE_SOURCE == "web" && ( $BUILD_ARTIFACTS_MATERIAL == "yes" || $CI_COMMIT_MESSAGE =~ /build_artifacts_material=yes/ )'
 
 
+# run this job on:
+# - devel branch with BUILD_ARTIFACTS_DOC variable defined or build_artifacts_doc=yes in commit message
+# - all branches, except maintenance/X.Y and devel (web) if variable BUILD_ARTIFACTS_DOC sets to yes or if CI_COMMIT_MESSAGE contains "build_artifacts_doc=yes".
+.build_artifacts_doc_devel_and_branches_rules:
+  rules:
+    - if: '$CI_COMMIT_REF_NAME == "devel" && ( $BUILD_ARTIFACTS_DOC == "yes" || $CI_COMMIT_MESSAGE =~ /build_artifacts_doc=yes/ )'
+    - if: '$CI_COMMIT_REF_NAME != "devel" && $CI_COMMIT_REF_NAME !~ /^maintenance\/[[:digit:]]+\.[[:digit:]]+$/ && $CI_COMMIT_TAG == null && $CI_PIPELINE_SOURCE == "web" && ( $BUILD_ARTIFACTS_DOC == "yes" || $CI_COMMIT_MESSAGE =~ /build_artifacts_doc=yes/ )'
+
 # don't run if DEPLOY_PKG is equals to 'no'
 # run only jobs on "devel" branch (push, schedule and web)
 .deploy_devel_rules:
@@ -317,6 +325,20 @@ variables:
     - ${BUILDDIR}/start-pfconfig-in-container.sh
     - make material
     - ${RELEASEDIR}/publish-to-git.sh ${SRC_FILE} ${DST_FILE}
+  tags:
+    - docker
+
+.build_artifacts_doc_job:
+  stage: build_artifacts
+  dependencies: []
+  script:
+    - make -C html/pfappserver/root/ vendor
+    - make -C html/pfappserver/root/ light-dist
+    - make html
+  artifacts:
+    expire_in: 1 day
+    paths:
+      - docs/*.html
   tags:
     - docker
 
@@ -845,6 +867,13 @@ material_release:
   extends:
     - .build_artifacts_material_job
     - .release_only_rules
+
+# build_artifacts_doc jobs for development
+build_artifacts_doc_devel_and_branches:
+  image: ${PFBUILD_DEB_BULLSEYE_IMG}:${PFBUILD_DEFAULT_DEV_TAG}
+  extends:
+    - .build_artifacts_doc_job
+    - .build_artifacts_doc_devel_and_branches_rules
 
 ########################################
 # SIGN JOBS

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -335,10 +335,13 @@ variables:
     - make -C html/pfappserver/root/ vendor
     - make -C html/pfappserver/root/ light-dist
     - make html
+    - make pdf
   artifacts:
     expire_in: 1 day
     paths:
       - docs/*.html
+      - docs/*.pdf
+      - docs/images/*
   tags:
     - docker
 

--- a/addons/full-upgrade/run-upgrade.sh
+++ b/addons/full-upgrade/run-upgrade.sh
@@ -256,7 +256,7 @@ RELOAD_FAILED=0
 
 # This was found to be necessary in some cases where the first configreload would fail.
 # If the reload did succeed, then it will just ignore this and continue
-if [ $RELOAD_FAILED -eq 1 ];
+if [ $RELOAD_FAILED -eq 1 ]; then
   echo "Failed to configreload once. Will wait a few seconds and try again"
   sleep 10
   /usr/local/pf/bin/pfcmd configreload hard

--- a/addons/full-upgrade/run-upgrade.sh
+++ b/addons/full-upgrade/run-upgrade.sh
@@ -251,7 +251,16 @@ systemctl restart packetfence-config
 
 sub_splitter
 echo "Reloading configuration"
-/usr/local/pf/bin/pfcmd configreload hard
+RELOAD_FAILED=0
+/usr/local/pf/bin/pfcmd configreload hard || RELOAD_FAILED=1
+
+# This was found to be necessary in some cases where the first configreload would fail.
+# If the reload did succeed, then it will just ignore this and continue
+if [ $RELOAD_FAILED -eq 1 ];
+  echo "Failed to configreload once. Will wait a few seconds and try again"
+  sleep 10
+  /usr/local/pf/bin/pfcmd configreload hard
+fi
 
 sub_splitter
 echo "Updating systemd services state"

--- a/addons/full-upgrade/run-upgrade.sh
+++ b/addons/full-upgrade/run-upgrade.sh
@@ -222,11 +222,15 @@ upgrade_packetfence_package $INCLUDE_OS_UPDATE
 
 hook_if_exists do-upgrade-post-package-upgrade.sh
 
-main_splitter
-db_name=`get_db_name /usr/local/pf/conf/pf.conf`
-upgrade_database $db_name
+UPGRADE_CLUSTER_SECONDARY="${UPGRADE_CLUSTER_SECONDARY:-}"
+# Do not upgrade the database when upgrading secondary nodes of a cluster (the primary will sync its data to them)
+if [ "$UPGRADE_CLUSTER_SECONDARY" != "yes" ]; then
+  main_splitter
+  db_name=`get_db_name /usr/local/pf/conf/pf.conf`
+  upgrade_database $db_name
 
-hook_if_exists do-upgrade-post-db-upgrade.sh
+  hook_if_exists do-upgrade-post-db-upgrade.sh
+fi
 
 main_splitter
 upgrade_configuration `egrep -o '[0-9]+\.[0-9]+\.[0-9]+$' /usr/local/pf/conf/pf-release.preupgrade`

--- a/addons/full-upgrade/run-upgrade.sh
+++ b/addons/full-upgrade/run-upgrade.sh
@@ -157,14 +157,6 @@ function handle_pkgnew_files() {
   done
 }
 
-ALLOW_CLUSTER_UPGRADE="${ALLOW_CLUSTER_UPGRADE:-no}"
-if ! is_enabled $ALLOW_CLUSTER_UPGRADE && is_cluster; then
-  echo "Upgrading a cluster is not supported by this tool at the moment."
-  echo "You can use it **at your own risk** by setting the following environment variable:"
-  echo "  export ALLOW_CLUSTER_UPGRADE=yes"
-  exit 1
-fi
-
 function hook_if_exists() {
   hook=/usr/local/pf/addons/full-upgrade/hooks/hook-$1
   if [ -f $hook ]; then

--- a/addons/full-upgrade/run-upgrade.sh
+++ b/addons/full-upgrade/run-upgrade.sh
@@ -216,8 +216,10 @@ hook_if_exists do-upgrade-post-package-upgrade.sh
 
 if [ -f /usr/local/pf/db/upgrade-X.X-X.Y.sql ]; then
   main_splitter
-  UPGRADING_FROM=`egrep -o '[0-9]+\.[0-9]+\.[0-9]+$' /usr/local/pf/conf/pf-release.preupgrade | egrep -o '^[0-9]+\.[0-9]+'`
-  echo "Upgrade to a devel package detected. Upgrading from $UPGRADING_FROM to $UPGRADE_TO. Renaming DB upgrade schema accordingly"
+  echo "Upgrade to a devel package detected. Renaming DB upgrade schema accordingly"
+  sub_splitter
+  echo -n "You need to input the PF version that comes before $UPGRADE_TO. This will replace X.X in the upgrade-X.X-X.Y.sql filename. Only input the minor version (ex: 11.2): "
+  read UPGRADING_FROM
   cp /usr/local/pf/db/upgrade-X.X-X.Y.sql /usr/local/pf/db/upgrade-$UPGRADING_FROM-$UPGRADE_TO.sql
 fi
 

--- a/addons/full-upgrade/run-upgrade.sh
+++ b/addons/full-upgrade/run-upgrade.sh
@@ -214,6 +214,13 @@ upgrade_packetfence_package $INCLUDE_OS_UPDATE
 
 hook_if_exists do-upgrade-post-package-upgrade.sh
 
+if [ -f /usr/local/pf/db/upgrade-X.X-X.Y.sql ]; then
+  main_splitter
+  UPGRADING_FROM=`egrep -o '[0-9]+\.[0-9]+\.[0-9]+$' /usr/local/pf/conf/pf-release.preupgrade | egrep -o '^[0-9]+\.[0-9]+'`
+  echo "Upgrade to a devel package detected. Upgrading from $UPGRADING_FROM to $UPGRADE_TO. Renaming DB upgrade schema accordingly"
+  cp /usr/local/pf/db/upgrade-X.X-X.Y.sql /usr/local/pf/db/upgrade-$UPGRADING_FROM-$UPGRADE_TO.sql
+fi
+
 UPGRADE_CLUSTER_SECONDARY="${UPGRADE_CLUSTER_SECONDARY:-}"
 # Do not upgrade the database when upgrading secondary nodes of a cluster (the primary will sync its data to them)
 if [ "$UPGRADE_CLUSTER_SECONDARY" != "yes" ]; then

--- a/docs/PacketFence_Upgrade_Guide.asciidoc
+++ b/docs/PacketFence_Upgrade_Guide.asciidoc
@@ -1858,33 +1858,6 @@ notify about next certificates expirations for certificates without emails.
 
 == Upgrading from a version prior to X.Y.Z
 
-==== Configuration upgrade
-
-[source,bash]
-----
-/usr/local/pf/addons/upgrade/to-12.0-remove-tenant.pl
-/usr/local/pf/addons/upgrade/to-12.0-use-proxysql.pl
-----
-
-If you use a Syslog Forwarder to send log files to a remote Syslog server, you should run following script:
-
-[source,bash]
-----
-/usr/local/pf/addons/upgrade/to-12.0-rename-log-files.pl
-----
-
-=== Database schema
-
-Changes have been made to the database schema. You will need to update it accordingly.
-An SQL upgrade script has been provided to upgrade the database from the X.X schema to X.Y.
-
-To upgrade the database schema, run the following command:
-
-[source,bash]
-----
-mysql -u root -p pf -v < /usr/local/pf/db/upgrade-X.X-X.Y.sql
-----
-
 === Bandwidth accounting is now disabled by default.
 
 Tracking the bandwidth accounting information is now disabled by default.

--- a/docs/PacketFence_Upgrade_Guide.asciidoc
+++ b/docs/PacketFence_Upgrade_Guide.asciidoc
@@ -1862,7 +1862,7 @@ notify about next certificates expirations for certificates without emails.
 
 PacketFence previously used haproxy (via the haproxy-db service) to load balance and failover database connections from the PacketFence services to the database servers. This is now performed by ProxySQL which allows for splitting reads and writes to different members which offers greater performance and scalability.
 
-If you suspect that using ProxySQL causes issues in your deployment, you can revert back to using haproxy-db by following <<PacketFence_Clustering_Guide.asciidoc#TODO NQB HELP :D,these instructions>>
+If you suspect that using ProxySQL causes issues in your deployment, you can revert back to using haproxy-db by following <<PacketFence_Clustering_Guide.asciidoc#_database_via_proxysql_or_haproxy_db,these instructions>>
 
 === Bandwidth accounting is now disabled by default.
 

--- a/docs/PacketFence_Upgrade_Guide.asciidoc
+++ b/docs/PacketFence_Upgrade_Guide.asciidoc
@@ -1335,19 +1335,33 @@ Now, make sure you follow the directives in the <<PacketFence_Upgrade_Guide.asci
 
 ====== Start service on node C
 
-Now, start the application service on node C using the instructions provided
-in
-<<PacketFence_Upgrade_Guide.asciidoc#_restart_all_packetfence_services,Restart
-all PacketFence services section>>.
+Now, start the application service on node C using following instructions:
+
+[source,bash]
+----
+/usr/local/pf/bin/pfcmd fixpermissions
+/usr/local/pf/bin/pfcmd pfconfig clear_backend
+systemctl restart packetfence-config
+/usr/local/pf/bin/pfcmd configreload hard
+/usr/local/pf/bin/pfcmd service pf restart
+----
 
 ====== Stop services on nodes A and B
 
 Next, stop all application services on node A and B:
 
-* See <<PacketFence_Upgrade_Guide.asciidoc#_stop_all_packetfence_services,Stop all
-PacketFence services section>>
+* Stop all PacketFence services:
++
+[source,bash]
+----
+/usr/local/pf/bin/pfcmd fixpermissions
+/usr/local/pf/bin/pfcmd pfconfig clear_backend
+systemctl restart packetfence-config
+/usr/local/pf/bin/pfcmd configreload hard
+/usr/local/pf/bin/pfcmd service pf restart
+----
 * Stop database:
-
++
 [source,bash]
 ----
 systemctl stop packetfence-mariadb
@@ -1562,17 +1576,31 @@ upgrades:
 systemctl restart packetfence-mariadb
 ----
 
-You can now safely start PacketFence on nodes A and B using the instructions
-provided in
-<<PacketFence_Upgrade_Guide.asciidoc#_restart_all_packetfence_services,Restart
-all PacketFence services section>>.
+You can now safely start PacketFence on nodes A and B using following instructions:
+
+[source,bash]
+----
+/usr/local/pf/bin/pfcmd fixpermissions
+/usr/local/pf/bin/pfcmd pfconfig clear_backend
+systemctl restart packetfence-config
+/usr/local/pf/bin/pfcmd configreload hard
+/usr/local/pf/bin/pfcmd service pf restart
+----
 
 ===== Restart node C
 
-Now, you should restart PacketFence on node C using the instructions provided
-in
-<<PacketFence_Upgrade_Guide.asciidoc#_restart_all_packetfence_services,Restart
-all PacketFence services section>>.  So it becomes aware of its peers again.
+Now, you should restart PacketFence on node C using following instructions:
+
+[source,bash]
+----
+/usr/local/pf/bin/pfcmd fixpermissions
+/usr/local/pf/bin/pfcmd pfconfig clear_backend
+systemctl restart packetfence-config
+/usr/local/pf/bin/pfcmd configreload hard
+/usr/local/pf/bin/pfcmd service pf restart
+----
+
+So it becomes aware of its peers again.
 
 You should now have full service on all 3 nodes using the latest version of PacketFence.
 

--- a/docs/PacketFence_Upgrade_Guide.asciidoc
+++ b/docs/PacketFence_Upgrade_Guide.asciidoc
@@ -1858,6 +1858,12 @@ notify about next certificates expirations for certificates without emails.
 
 == Upgrading from a version prior to X.Y.Z
 
+=== Clusters now use ProxySQL to load balance the DB connections
+
+PacketFence previously used haproxy (via the haproxy-db service) to load balance and failover database connections from the PacketFence services to the database servers. This is now performed by ProxySQL which allows for splitting reads and writes to different members which offers greater performance and scalability.
+
+If you suspect that using ProxySQL causes issues in your deployment, you can revert back to using haproxy-db by following <<PacketFence_Clustering_Guide.asciidoc#TODO NQB HELP :D,these instructions>>
+
 === Bandwidth accounting is now disabled by default.
 
 Tracking the bandwidth accounting information is now disabled by default.

--- a/docs/PacketFence_Upgrade_Guide.asciidoc
+++ b/docs/PacketFence_Upgrade_Guide.asciidoc
@@ -269,8 +269,7 @@ include::common/new_config_files.asciidoc[]
 
 === Restart all PacketFence services
 
-Once all <<_steps,steps of upgrade procedure>> are completed, restart
-`packetfence-config` and `packetfence` services:
+Once all <<_steps,steps of upgrade procedure>> are completed, restart PacketFence services:
 
 include::common/restart.asciidoc[]
 

--- a/docs/PacketFence_Upgrade_Guide.asciidoc
+++ b/docs/PacketFence_Upgrade_Guide.asciidoc
@@ -1542,7 +1542,7 @@ You do not need to follow the upgrade procedure when upgrading these nodes. You 
 
 [source,bash]
 ----
-/usr/local/pf/bin/cluster/sync --from=192.168.1.5 --api-user=packet --api-password=fence
+/usr/local/pf/bin/cluster/sync --from=192.168.1.5 --api-user=packet --api-password=anotherMoreSecurePassword
 /usr/local/pf/bin/pfcmd configreload hard
 ----
 

--- a/docs/cluster/appendix.asciidoc
+++ b/docs/cluster/appendix.asciidoc
@@ -218,7 +218,7 @@ If you are happy about the state of your upgrade on node C, you can move on to u
 [source,bash]
 ----
 export UPGRADE_CLUSTER_SECONDARY=yes
-systemctl start packetfence-mariadb
+systemctl restart packetfence-mariadb
 ----
 
 Then, <<PacketFence_Installation_Guide.asciidoc#_automation_of_upgrades,apply the upgrade process described here>> **on nodes A and B**.

--- a/docs/cluster/appendix.asciidoc
+++ b/docs/cluster/appendix.asciidoc
@@ -204,12 +204,6 @@ Once you are feeling confident to try your failover to node C again, you can do 
 
 If you are happy about the state of your upgrade on node C, you can move on to upgrading the other nodes.
 
-.On nodes A and B
-[source,bash]
-----
-export UPGRADE_CLUSTER_SECONDARY=yes
-----
-
 .On node A
 ----
 /usr/local/pf/bin/cluster/node node-B-hostname disable
@@ -218,6 +212,13 @@ export UPGRADE_CLUSTER_SECONDARY=yes
 .On node B
 ----
 /usr/local/pf/bin/cluster/node node-A-hostname disable
+----
+
+.On nodes A and B
+[source,bash]
+----
+export UPGRADE_CLUSTER_SECONDARY=yes
+systemctl start packetfence-mariadb
 ----
 
 Then, <<PacketFence_Installation_Guide.asciidoc#_automation_of_upgrades,apply the upgrade process described here>> **on nodes A and B**.

--- a/docs/cluster/appendix.asciidoc
+++ b/docs/cluster/appendix.asciidoc
@@ -124,7 +124,7 @@ PacketFence application services on it:
 
 IMPORTANT: `packetfence-config` should stay started in order to run `/usr/local/pf/bin/cluster/node` commands.
   
-Next, you can upgrade your operating system and/or PacketFence on node C.
+In the next following steps, you will be upgrading PacketFence on node C.
 
 ===== Detach node C from the cluster
 

--- a/docs/cluster/appendix.asciidoc
+++ b/docs/cluster/appendix.asciidoc
@@ -58,7 +58,7 @@ In this procedure, the 3 nodes will be named A, B and C and they are in this ord
 
 ==== Backups
 
-First, ensure you have taken backups of your data. We highly encourage you to perform snapshots of all the virtual machines prior to the upgrade. You should also take a backup of the database and the `/usr/local/pf` directory using <<PacketFence_Upgrade_Guide.asciidoc#__database_and_configurations_backup,Database and configurations backup instructions>>.
+Re-importable backups will be taken during the upgrade process. We highly encourage you to perform snapshots of all the virtual machines prior to the upgrade if possible.
 
 ==== Disabling the auto-correction of configuration
 

--- a/docs/cluster/appendix.asciidoc
+++ b/docs/cluster/appendix.asciidoc
@@ -267,7 +267,7 @@ You should now sync the configuration by running the following **on nodes A and 
 
 [source,bash]
 ----
-/usr/local/pf/bin/cluster/sync --from=192.168.1.5 --api-user=packet --api-password=fence
+/usr/local/pf/bin/cluster/sync --from=192.168.1.5 --api-user=packet --api-password=anotherMoreSecurePassword
 /usr/local/pf/bin/pfcmd configreload hard
 ----
 

--- a/docs/cluster/appendix.asciidoc
+++ b/docs/cluster/appendix.asciidoc
@@ -204,11 +204,13 @@ Once you are feeling confident to try your failover to node C again, you can do 
 If you are happy about the state of your upgrade on node C, you can move on to upgrading the other nodes.
 
 .On node A
+[source,bash]
 ----
 /usr/local/pf/bin/cluster/node node-B-hostname disable
 ----
 
 .On node B
+[source,bash]
 ----
 /usr/local/pf/bin/cluster/node node-A-hostname disable
 ----

--- a/docs/cluster/appendix.asciidoc
+++ b/docs/cluster/appendix.asciidoc
@@ -69,7 +69,6 @@ In order to do so, go in _Configuration->System Configuration->Maintenance_ and 
 
 Once this is done, restart `pfcron` on all nodes using:
 
-.For PacketFence versions 10.2 and later
 [source,bash]
 ----
 /usr/local/pf/bin/pfcmd service pfcron restart

--- a/docs/cluster/appendix.asciidoc
+++ b/docs/cluster/appendix.asciidoc
@@ -25,6 +25,29 @@ endif::[]
  * 'Management node/server': The first server of a PacketFence cluster as defined in `/usr/local/pf/conf/cluster.conf`.
  * 'Node': In the context of this document, a node is a member of the cluster while in other PacketFence documents it may represent an endpoint.
 
+=== Database via ProxySQL or haproxy-db
+
+In PacketFence 12.0, proxysql became the default way for PacketFence services to obtain their connection to a database member. ProxySQL has the ability to split reads and writes to different members which offers greater performance and scalability.
+
+If you suspect that using ProxySQL causes issues in your deployment, you can revert back to using haproxy-db by changing `database.port` in `conf/pf.conf` to `3306`. 
+
+Once that is changed on one of your cluster members, propagate your change using:
+
+[source,bash]
+----
+/usr/local/pf/bin/pfcmd configreload hard
+/usr/local/pf/bin/cluster/sync --as-master
+----
+
+And restart PacketFence on all your cluster members:
+
+[source,bash]
+----
+/usr/local/pf/bin/pfcmd service pf restart
+----
+
+Additionally, you could change pfconfig's configuration to use haproxy-db as well although its usage of the database is extremelly light. Still, if you want to change it for pfconfig, edit `conf/pconfig.conf` and change `mysql.port` to `3306`. After doing this change, restart pfconfig using `systemctl restart packetfence-config`. Note that this change must be done on all cluster members.
+
 === IP addresses in a cluster environment
 
 ==== DHCP and DNS services

--- a/docs/cluster/appendix.asciidoc
+++ b/docs/cluster/appendix.asciidoc
@@ -172,6 +172,18 @@ The commands above will make sure that nodes A and B will not be forwarding requ
 From that moment node C is in standalone for its database. We can proceed to update the packages, configuration and database schema
 In order to do so, <<PacketFence_Installation_Guide.asciidoc#_automation_of_upgrades,apply the upgrade process described here>> **on node C only**.
 
+===== Check upgrade on node C
+
+Prior to migrating the service on node C, it is advised to run a checkup of your configuration to validate your upgrade. In order to do so, perform:
+
+[source,bash]
+----
+systemctl start packetfence-proxysql
+/usr/local/pf/bin/pfcmd checkup
+----
+
+Review the checkup output to ensure no errors are shown. Any 'FATAL' error will prevent PacketFence from starting up and should be dealt with immediately.
+
 ===== Stop services on nodes A and B
 
 Next, stop all application services on node A and B:

--- a/docs/cluster/appendix.asciidoc
+++ b/docs/cluster/appendix.asciidoc
@@ -97,7 +97,7 @@ Once this is done, stop `galera-autofix` service on *all* nodes using:
 /usr/local/pf/bin/pfcmd service galera-autofix stop
 ----
 
-==== Upgrading node C
+==== Detaching and upgrading node C
 
 
 In order to be able to work on node C, we first need to stop all the
@@ -107,19 +107,7 @@ PacketFence services section>>.
   
 Next, you can upgrade your operating system and/or PacketFence on node C by following instructions of <<PacketFence_Upgrade_Guide.asciidoc#_packages_upgrades,Packages upgrades section>>.
 
-===== Next steps
-
-Now, make sure you follow the directives in the <<PacketFence_Upgrade_Guide.asciidoc#,upgrade guide>> as you would on a standalone server with the exception of the database schema updates.
-
-==== Migrating service on node C
-
-
-Node C should currently be running the latest version of PacketFence while A and B should still be running the older version and still be offering service. The database is also still being synced to node C via the `packetfence-mariadb` service.
-
-NOTE: The steps below will cause a temporary loss of service.
-
 ===== Detach node C from the cluster
-
 
 First, we need to tell A and B to ignore C in their cluster configuration. In order to do so, execute the following command **on A and B** while changing `node-C-hostname` with the actual hostname of node C:
 
@@ -130,24 +118,6 @@ First, we need to tell A and B to ignore C in their cluster configuration. In or
 
 Once this is done proceed to restart the following services on nodes A and B **one at a time**. This will cause service failure during the restart on node A
 
-.For PacketFence versions prior to 8.0
-[source,bash]
-----
-/usr/local/pf/bin/pfcmd service haproxy restart
-/usr/local/pf/bin/pfcmd service keepalived restart
-----
-
-.For PacketFence versions from 8.0 to 10.0
-[source,bash]
-----
-/usr/local/pf/bin/pfcmd service radiusd restart
-/usr/local/pf/bin/pfcmd service pfdhcplistener restart
-/usr/local/pf/bin/pfcmd service haproxy-db restart
-/usr/local/pf/bin/pfcmd service haproxy-portal restart
-/usr/local/pf/bin/pfcmd service keepalived restart
-----
-
-.For PacketFence version 10.0 and later
 [source,bash]
 ----
 /usr/local/pf/bin/pfcmd service radiusd restart
@@ -178,10 +148,10 @@ NOTE: From this moment on, you will lose the configuration changes and data chan
 
 The commands above will make sure that nodes A and B will not be forwarding requests to C even if it is alive. Same goes for C which won't be sending traffic to A and B. This means A and B will continue to have the same database informations while C will start to diverge from it when it goes live. We'll make sure to reconcile this data afterwards.
 
-===== Complete upgrade of node C
+===== Upgrade node C
 
-From that moment node C is in standalone for its database. We can proceed to update the database schema so it matches the one of the latest version.
-In order to do so, upgrade the database schema using the instructions provided in <<PacketFence_Upgrade_Guide.asciidoc#,Upgrade guide>>.
+From that moment node C is in standalone for its database. We can proceed to update the packages, configuration and database schema
+In order to do so, apply the upgrade process described here **on node C only** <<PacketFence_Installation_Guide.asciidoc#AUTOMATION OF UPGRADES HELP NQB :)>>.
 
 ===== Start service on node C
 

--- a/docs/cluster/appendix.asciidoc
+++ b/docs/cluster/appendix.asciidoc
@@ -75,7 +75,7 @@ Once this is done, restart `pfcron` on all nodes using:
 /usr/local/pf/bin/pfcmd service pfcron restart
 ----
 
-==== Disabling galera-autofix (for PacketFence version 10.0 and later)
+==== Disabling galera-autofix
 
 You should disable the `galera-autofix` service in the configuration to disable the automated resolution of cluster issues during the upgrade.
 

--- a/docs/cluster/appendix.asciidoc
+++ b/docs/cluster/appendix.asciidoc
@@ -50,6 +50,7 @@ You only need to allow this IP address in your network devices.
 
 === Performing an upgrade on a cluster
 
+NOTE: This guide only covers upgrading from PacketFence 11.0.0 or above.
 
 CAUTION: Performing a live upgrade on a PacketFence cluster is not a straightforward operation and should be done meticulously.
 

--- a/docs/cluster/appendix.asciidoc
+++ b/docs/cluster/appendix.asciidoc
@@ -93,11 +93,16 @@ Once this is done, stop `galera-autofix` service on *all* nodes using:
 
 
 In order to be able to work on node C, we first need to stop all the
-PacketFence application services on it, see
-<<PacketFence_Upgrade_Guide.asciidoc#_stop_all_packetfence_services,Stop all
-PacketFence services section>>.
+PacketFence application services on it:
+
+[source,bash]
+----
+/usr/local/pf/bin/pfcmd service pf stop
+----
+
+IMPORTANT: `packetfence-config` should stay started in order to run `/usr/local/pf/bin/cluster/node` commands.
   
-Next, you can upgrade your operating system and/or PacketFence on node C by following instructions of <<PacketFence_Upgrade_Guide.asciidoc#_packages_upgrades,Packages upgrades section>>.
+Next, you can upgrade your operating system and/or PacketFence on node C.
 
 ===== Detach node C from the cluster
 
@@ -143,7 +148,7 @@ The commands above will make sure that nodes A and B will not be forwarding requ
 ===== Upgrade node C
 
 From that moment node C is in standalone for its database. We can proceed to update the packages, configuration and database schema
-In order to do so, <<PacketFence_Installation_Guide.asciidoc#AUTOMATION OF UPGRADES HELP NQB :),apply the upgrade process described here>> **on node C only**.
+In order to do so, <<PacketFence_Installation_Guide.asciidoc#_automation_of_upgrades,apply the upgrade process described here>> **on node C only**.
 
 ===== Stop services on nodes A and B
 
@@ -157,6 +162,7 @@ PacketFence services section>>
 ----
 systemctl stop packetfence-mariadb
 ----
+
 ===== Start service on node C
 
 Now, start the application service on node C using the instructions provided
@@ -208,7 +214,7 @@ export UPGRADE_CLUSTER_SECONDARY=yes
 /usr/local/pf/bin/cluster/node node-A-hostname disable
 ----
 
-Then, <<PacketFence_Installation_Guide.asciidoc#AUTOMATION OF UPGRADES HELP NQB :),apply the upgrade process described here>> **on nodes A and B**.
+Then, <<PacketFence_Installation_Guide.asciidoc#_automation_of_upgrades,apply the upgrade process described here>> **on nodes A and B**.
 
 NOTE: It is important that you run the upgrade commands in the same shell you ran your `export` so that the environment variable is properly taken into consideration when the upgrade script executes.
 

--- a/docs/cluster/appendix.asciidoc
+++ b/docs/cluster/appendix.asciidoc
@@ -154,14 +154,20 @@ In order to do so, <<PacketFence_Installation_Guide.asciidoc#_automation_of_upgr
 
 Next, stop all application services on node A and B:
 
-* See <<PacketFence_Upgrade_Guide.asciidoc#_stop_all_packetfence_services,Stop all
-PacketFence services section>>
+* Stop PacketFence services:
++
+[source,bash]
+----
+/usr/local/pf/bin/pfcmd service pf stop
+----
 * Stop database:
 +
 [source,bash]
 ----
 systemctl stop packetfence-mariadb
 ----
+
+IMPORTANT: `packetfence-config` should stay started in order to run `/usr/local/pf/bin/cluster/node` commands.
 
 ===== Start service on node C
 

--- a/docs/cluster/appendix.asciidoc
+++ b/docs/cluster/appendix.asciidoc
@@ -197,7 +197,7 @@ If you are happy about the state of your upgrade on node C, you can move on to u
 .On nodes A and B
 [source,bash]
 ----
-export SKIP_POST_UPGRADE=yes
+export UPGRADE_CLUSTER_SECONDARY=yes
 ----
 
 .On node A

--- a/docs/cluster/appendix.asciidoc
+++ b/docs/cluster/appendix.asciidoc
@@ -69,13 +69,7 @@ The PacketFence clustering stack has a mechanism that allows configuration confl
 
 In order to do so, go in _Configuration->System Configuration->Maintenance_ and disable the _Cluster Check_ task.
 
-Once this is done, restart `pfmon` or `pfcron` on all nodes using:
-
-.For PacketFence versions prior to 10.2
-[source,bash]
-----
-/usr/local/pf/bin/pfcmd service pfmon restart
-----
+Once this is done, restart `pfcron` on all nodes using:
 
 .For PacketFence versions 10.2 and later
 [source,bash]
@@ -151,14 +145,7 @@ The commands above will make sure that nodes A and B will not be forwarding requ
 ===== Upgrade node C
 
 From that moment node C is in standalone for its database. We can proceed to update the packages, configuration and database schema
-In order to do so, apply the upgrade process described here **on node C only** <<PacketFence_Installation_Guide.asciidoc#AUTOMATION OF UPGRADES HELP NQB :)>>.
-
-===== Start service on node C
-
-Now, start the application service on node C using the instructions provided
-in
-<<PacketFence_Upgrade_Guide.asciidoc#_restart_all_packetfence_services,Restart
-all PacketFence services section>>.
+In order to do so, <<PacketFence_Installation_Guide.asciidoc#AUTOMATION OF UPGRADES HELP NQB :),apply the upgrade process described here>> **on node C only**.
 
 ===== Stop services on nodes A and B
 
@@ -172,14 +159,18 @@ PacketFence services section>>
 ----
 systemctl stop packetfence-mariadb
 ----
+===== Start service on node C
+
+Now, start the application service on node C using the instructions provided
+in
+<<PacketFence_Upgrade_Guide.asciidoc#_restart_all_packetfence_services,Restart
+all PacketFence services section>>.
 
 ==== Validate migration
-
 
 You should now have full service on node C and should validate that all functionnalities are working as expected. Once you continue past this point, there will be no way to migrate back to nodes A and B in case of issues other than to use the snapshots taken prior to the upgrade.
 
 ===== If all goes wrong
-
 
 If your migration to node C goes wrong, you can fail back to nodes A and B by stopping all services on node C and starting them on nodes A and B
 
@@ -201,21 +192,31 @@ Once you are feeling confident to try your failover to node C again, you can do 
 
 ===== If all goes well
 
+If you are happy about the state of your upgrade on node C, you can move on to upgrading the other nodes.
 
-If you are happy about the state of your upgrade, you can continue on the steps below in order to complete the upgrade of the two remaining nodes.
+.On nodes A and B
+[source,bash]
+----
+export SKIP_POST_UPGRADE=yes
+----
 
-==== Upgrading nodes A and B
+.On node A
+----
+/usr/local/pf/bin/cluster/node node-B-hostname disable
+----
 
-Next, you can upgrade your operating system and/or PacketFence on nodes A and B by
-following instructions of
-<<PacketFence_Upgrade_Guide.asciidoc#_packages_upgrades,Packages upgrades
-section>>.
+.On node B
+----
+/usr/local/pf/bin/cluster/node node-A-hostname disable
+----
 
-WARNING: You only need to merge changes of new configuration files that will not be synced by `/usr/local/pf/bin/cluster/sync` command described below.
+Then, <<PacketFence_Installation_Guide.asciidoc#AUTOMATION OF UPGRADES HELP NQB :),apply the upgrade process described here>> **on nodes A and B**.
+
+NOTE: It is important that you run the upgrade commands in the same shell you ran your `export` so that the environment variable is properly taken into consideration when the upgrade script executes.
 
 ===== Configuration synchronisation
 
-You do not need to follow the upgrade procedure when upgrading these nodes. You should instead do a sync from node C on nodes A and B:
+You should now sync the configuration by running the following **on nodes A and B**
 
 [source,bash]
 ----
@@ -259,19 +260,12 @@ MariaDB> truncate TABLE_NAME;
 
 ===== Elect node C as database master
 
-
-In order for node C to be able to elect itself as database master, we must tell it there are other members in its cluster by re-enabling nodes A and B
+Now that all the members are ready to reintegrate the cluster, run the following commands on **all cluster members**
 
 [source,bash]
 ----
 /usr/local/pf/bin/cluster/node node-A-hostname enable
 /usr/local/pf/bin/cluster/node node-B-hostname enable
-----
-
-Next, enable node C on nodes A and B by executing the following command on the two servers:
-
-[source,bash]
-----
 /usr/local/pf/bin/cluster/node node-C-hostname enable
 ----
 
@@ -281,7 +275,8 @@ Now, stop `packetfence-mariadb` on node C, regenerate the MariaDB configuration 
 ----
 systemctl stop packetfence-mariadb
 /usr/local/pf/bin/pfcmd generatemariadbconfig
-/usr/local/pf/sbin/pf-mariadb --force-new-cluster
+systemctl set-environment MARIADB_ARGS=--force-new-cluster
+systemctl restart packetfence-mariadb
 ----
 
 You should validate that you are able to connect to the MariaDB database even
@@ -310,9 +305,16 @@ systemctl start packetfence-mariadb
 Should there be any issues during the sync, make sure you look into the MariaDB log ([filename]`/usr/local/pf/logs/mariadb.log`)
 
 Once both nodes have completely synced (try connecting to it using the MariaDB
-command line), then you can break the cluster election command you have
-running on node C and start node C normally (using `systemctl start
-packetfence-mariadb`).
+command line).
+Once you have confirmed all members are joined to the MariaDB cluster, perform the following **on node C**
+
+[source,bash]
+----
+systemctl stop packetfence-mariadb
+systemctl unset-environment MARIADB_ARGS
+systemctl start packetfence-mariadb
+----
+
 
 ===== Start nodes A and B
 

--- a/docs/cluster/appendix.asciidoc
+++ b/docs/cluster/appendix.asciidoc
@@ -58,10 +58,7 @@ In this procedure, the 3 nodes will be named A, B and C and they are in this ord
 
 ==== Backups
 
-First, ensure you have taken backups of your data. We highly encourage you to perform snapshots of all the virtual machines prior to the upgrade. You should also take a backup of the database and the `/usr/local/pf` directory using:
-
-* <<PacketFence_Upgrade_Guide.asciidoc#_database_backup,Database backup instructions>>
-* <<PacketFence_Upgrade_Guide.asciidoc#_packetfence_configurations_and_codebase_backup,PacketFence configurations and codebase backup instructions>>
+First, ensure you have taken backups of your data. We highly encourage you to perform snapshots of all the virtual machines prior to the upgrade. You should also take a backup of the database and the `/usr/local/pf` directory using <<PacketFence_Upgrade_Guide.asciidoc#__database_and_configurations_backup,Database and configurations backup instructions>>.
 
 ==== Disabling the auto-correction of configuration
 

--- a/docs/cluster/appendix.asciidoc
+++ b/docs/cluster/appendix.asciidoc
@@ -307,7 +307,7 @@ MariaDB> truncate TABLE_NAME;
 
 ===== Elect node C as database master
 
-NOTE: The steps in next sections will cause brief service interruptions
+NOTE: The steps in next sections will cause brief service disruptions
 
 Now that all the members are ready to reintegrate the cluster, run the following commands on **all cluster members**
 

--- a/docs/cluster/appendix.asciidoc
+++ b/docs/cluster/appendix.asciidoc
@@ -307,6 +307,8 @@ MariaDB> truncate TABLE_NAME;
 
 ===== Elect node C as database master
 
+NOTE: The steps in next sections will cause brief service interruptions
+
 Now that all the members are ready to reintegrate the cluster, run the following commands on **all cluster members**
 
 [source,bash]

--- a/docs/cluster/assumptions.asciidoc
+++ b/docs/cluster/assumptions.asciidoc
@@ -22,8 +22,8 @@ endif::[]
 * The servers must have IPv6 disabled (see next section)
 * The servers must have a fully qualified domain name (FQDN) to identify them
 * The servers are located within the following latency limits (requirement for Galera cluster)
- * For smaller deployments, 75ms of latency can be tolerated between the cluster nodes
- * For larger deployments, 50ms of latency can be tolerated between the cluster nodes
+** For smaller deployments, 75ms of latency can be tolerated between the cluster nodes
+** For larger deployments, 50ms of latency can be tolerated between the cluster nodes
 // * PacketFence does support external MySQL primary/replicas to allow deployments which are geo distributed (see 'Geo Distributed Database' in this document for details)
 
 NOTE: Appended to this guide is a glossary on specialized terms used in this document.

--- a/docs/cluster/layer_3_clusters.asciidoc
+++ b/docs/cluster/layer_3_clusters.asciidoc
@@ -420,7 +420,7 @@ Transfer this file to the remote server (eg: /root/backup/)
 
 Connect to the remote server and perform the following to sync the configuration from the master cluster:
 
- /usr/local/pf/bin/cluster/sync --from=192.168.1.11 --api-user=packet --api-password=fence
+ /usr/local/pf/bin/cluster/sync --from=192.168.1.11 --api-user=packet --api-password=anotherMoreSecurePassword
  /usr/local/pf/bin/pfcmd configreload hard
 
 Then the following command to import the backup:

--- a/docs/common/restart.asciidoc
+++ b/docs/common/restart.asciidoc
@@ -1,8 +1,6 @@
 [source,bash]
 ----
-/usr/local/pf/bin/pfcmd fixpermissions
 /usr/local/pf/bin/pfcmd pfconfig clear_backend
-systemctl restart packetfence-config
 /usr/local/pf/bin/pfcmd configreload hard
 /usr/local/pf/bin/pfcmd service pf restart
 ----

--- a/docs/installation/automation_of_upgrades.asciidoc
+++ b/docs/installation/automation_of_upgrades.asciidoc
@@ -29,7 +29,7 @@ This section covers automation of upgrades available since PacketFence 11.0.0.
 * You can perform automated upgrades starting from PacketFence 11.0.0
 * A backup and an export of your configuration are performed before doing upgrade
 
-=== Full upgrade (for PacketFence version 11.0.0 only)
+=== Full upgrade (for PacketFence version 11.0.0 only - see next section for 11.1.0 and above)
 
 ==== Preliminary steps
 


### PR DESCRIPTION
# Description
Refreshes the cluster upgrade guide by 
* Reusing the `do-upgrade.sh` script we have for standalone.
* Detaching node C at the start of the upgrade process (mimics what we actually do in real life)
* Removing notes from pre-v11 since this guide only applies to 11+

Other:
* Build HTML and PDF docs in GitLab

# Impacts
Documentation, upgrade script

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [X] Document the feature
- [N/A] Add unit tests
- [X] Add acceptance tests (TestLink)

