### PR TITLE
Create pfconfig.conf on post installation (remove pfconfig.conf.example)

### DIFF
--- a/addons/upgrade/restore-pfconfig-conf.sh
+++ b/addons/upgrade/restore-pfconfig-conf.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -o nounset -o pipefail -o errexit
+
+mv -f -v /usr/local/pf/conf/pfconfig.conf.rpmsave /usr/local/pf/conf/pfconfig.conf
+/bin/systemctl restart packetfence-config

--- a/conf/pfconfig.conf.example
+++ b/conf/pfconfig.conf.example
@@ -1,1 +1,0 @@
-# Copyright (C) Inverse inc.

--- a/containers/radiusd/Dockerfile
+++ b/containers/radiusd/Dockerfile
@@ -72,13 +72,11 @@ RUN mkdir -p /usr/local/pf/bin  && \
 
 COPY ./conf/pf.conf.defaults /usr/local/pf/conf/pf.conf.defaults
 
-RUN touch /usr/local/pf/conf/pf.conf
+RUN touch /usr/local/pf/conf/pf.conf /usr/local/pf/conf/pfconfig.conf
 
 COPY ./conf/chi.conf.defaults /usr/local/pf/conf/chi.conf.defaults
 
 COPY ./conf/chi.conf.example /usr/local/pf/conf/chi.conf
-
-COPY ./conf/pfconfig.conf.example /usr/local/pf/conf/pfconfig.conf
 
 COPY ./conf/pfconfig.conf.defaults /usr/local/pf/conf/pfconfig.conf.defaults
 

--- a/debian/packetfence-config.conffiles
+++ b/debian/packetfence-config.conffiles
@@ -1,1 +1,0 @@
-/usr/local/pf/conf/pfconfig.conf

--- a/debian/packetfence-config.postinst
+++ b/debian/packetfence-config.postinst
@@ -21,7 +21,13 @@ DIST=$(lsb_release -c -s)
 
 case "$1" in
     configure)
-	chown pf.pf /usr/local/pf/conf/pfconfig.conf
+        if [ ! -f /usr/local/pf/conf/pfconfig.conf ]; then
+            echo "pfconfig.conf doesnt exits"
+            touch /usr/local/pf/conf/pfconfig.conf
+            chown pf.pf /usr/local/pf/conf/pfconfig.conf
+        else
+            echo "pfconfig.conf already exists, won't touch it!"
+        fi
 	/sbin/ldconfig
         if [ ${DIST} = "jessie" ] || [ ${DIST} = "stretch" ] || [ ${DIST} = "bullseye" ]; then
 	    systemctl enable packetfence-config

--- a/debian/rules
+++ b/debian/rules
@@ -160,7 +160,6 @@ install: build
 	install -d -m2770 $(CURDIR)/debian/packetfence-config$(PREFIX)/$(NAME)/var/cache/pfconfig
 	install -m0755 sbin/pfconfig $(CURDIR)/debian/packetfence-config$(PREFIX)/$(NAME)/sbin
 	install -m0755 sbin/pfconfig-docker-wrapper $(CURDIR)/debian/packetfence-config$(PREFIX)/$(NAME)/sbin
-	install -m0600 conf/pfconfig.conf.example $(CURDIR)/debian/packetfence-config$(PREFIX)/$(NAME)/conf/pfconfig.conf
 	install -m0600 conf/pfconfig.conf.defaults $(CURDIR)/debian/packetfence-config$(PREFIX)/$(NAME)/conf/pfconfig.conf.defaults
 	# packetfence-redis-cache
 	install -d -m0700 $(CURDIR)/debian/packetfence-redis-cache/lib/systemd/system

--- a/rpm/packetfence.spec
+++ b/rpm/packetfence.spec
@@ -613,9 +613,6 @@ fi
 mkdir -p /usr/local/pf/var/run/
 touch /usr/local/pf/var/run/pkg_install_in_progress
 
-chown pf.pf /usr/local/pf/conf/pfconfig.conf
-echo "Adding PacketFence config startup script"
-
 # Stop packetfence-config during upgrade process to ensure
 # it is started with latest code
 if [ "$(/bin/systemctl show -p ActiveState packetfence-config | awk -F '=' '{print $2}')" = "active" ]; then
@@ -696,6 +693,14 @@ if [ ! -f /usr/local/pf/conf/pf.conf ]; then
   chown pf.pf /usr/local/pf/conf/pf.conf
 else
   echo "pf.conf already exists, won't touch it!"
+fi
+
+if [ ! -f /usr/local/pf/conf/pfconfig.conf ]; then
+  echo "Touch pfconfig.conf because it doesnt exist"
+  touch /usr/local/pf/conf/pfconfig.conf
+  chown pf.pf /usr/local/pf/conf/pfconfig.conf
+else
+  echo "pfconfig.conf already exists, won't touch it!"
 fi
 
 #Getting rid of SELinux
@@ -915,7 +920,6 @@ fi
 %doc                    /usr/local/pf/ChangeLog
                         /usr/local/pf/conf/*.example
 %dir %attr(0770, pf pf) /usr/local/pf/conf
-%config(noreplace)      /usr/local/pf/conf/pfconfig.conf
 %config                 /usr/local/pf/conf/pfconfig.conf.defaults
 %config(noreplace)      /usr/local/pf/conf/adminroles.conf
 %config(noreplace)      /usr/local/pf/conf/allowed_device_oui.txt

--- a/rpm/packetfence.spec
+++ b/rpm/packetfence.spec
@@ -797,6 +797,29 @@ if [ $1 -eq 0 ]; then
 fi
 
 #==============================================================================
+# Post-trans
+#==============================================================================
+%posttrans
+### to handle deletion of pfconfig.conf starting in 12.1.0
+# pfconfig.conf.rpmsave have been created because pfconfig.conf is not
+# part of new package since 12.1.0
+if [ -f /usr/local/pf/conf/pfconfig.conf.rpmsave ]; then
+    echo "pfconfig.conf.rpmsave detected, trying to restore it in pfconfig.conf"
+    if [ ! -f /usr/local/pf/conf/pfconfig.conf ]; then
+        if /usr/local/pf/addons/upgrade/restore-pfconfig-conf.sh; then
+            echo "pfconfig.conf restored, packetfence-config service restarted"
+        else
+            echo "An issue occured while restoring pfconfig.conf.rpmsave"
+            echo "Check pfconfig.conf before you continue"
+        fi
+    else
+        echo "pfconfig.conf already exists, restoration canceled"
+        echo "Check pfconfig.conf before you continue"
+    fi
+fi
+
+
+#==============================================================================
 # Packaged files
 #==============================================================================
 # TODO we should simplify this file manifest to the maximum keeping treating 


### PR DESCRIPTION
# Description
To avoid providing a file which will generate .rpmnew at each upgrade.
Related to #7182
We still create file because `pfcmd` is failing if pfconfig.conf is not here when it starts.
This empty file will be overwritten once we go through configurator.

If a previous `pfconfig.conf` was here, file is keep in place.

# Impacts
- pfconfig
- radiusd
- upgrade
- fresh install

# Issue
fixes #7182 

# Delete branch after merge
YES

# NEWS file entries
## Enhancements
* Manage `pfconfig.conf` through upgrade scripts in place of packaging