### PR TITLE
Permit to disable kaniko cache on demand

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,6 +30,7 @@ variables:
   KANIKO_DEBUG_IMG: gcr.io/kaniko-project/executor:debug
   KNK_REGISTRY: ghcr.io
   KNK_REGISTRY_URL: ${KNK_REGISTRY}/inverse-inc/packetfence
+  KNK_CACHE: "true"
   PFBUILD_DEFAULT_DEV_TAG: latest
   CIDIR: ci
   CILIBDIR: ci/lib

--- a/containers/kanikobuild
+++ b/containers/kanikobuild
@@ -74,17 +74,29 @@ generate_destinations() {
     echo "$destinations"
 }
 
+generate_cache_opt() {
+    local cache=''
+    if [ "$KNK_CACHE" = true ]; then
+        cache="--cache=true"
+    else
+        cache="--cache=false"
+    fi
+    echo "$cache"
+}
+
 build_image() {
     /kaniko/executor --context $CI_PROJECT_DIR \
          --dockerfile ${DOCKFILE_PATH} \
-         --cache \
-         --cache-repo ${KNK_REGISTRY_URL}/cache \
+         $(generate_cache_opt) \
          $(generate_destinations) \
          $(generate_build_args)
 }
 
 setup_vars
 generate_knk_config
-generate_build_args
+# just to display options in CI jobs
+generate_cache_opt
 generate_destinations
+generate_build_args
+#
 build_image


### PR DESCRIPTION
# Description
Permit to disable kaniko cache on demand using `KNK_CACHE=false`
 
`--cache-repo` option has been removed because we are using the default location for cache image.

# Impacts
Build of containers

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)
