### PR TITLE
Adjust ISO installer due to Docker

### DIFF
--- a/ci/debian-installer/create-debian-installer.sh
+++ b/ci/debian-installer/create-debian-installer.sh
@@ -33,6 +33,7 @@ cp gtk.cfg isofiles/isolinux/drkgtk.cfg
 cp grub.cfg isofiles/boot/grub/grub.cfg
 chmod 0444 isofiles/isolinux/gtk.cfg isofiles/isolinux/drkgtk.cfg isofiles/boot/grub/grub.cfg
 
+cp postinst-debian-installer.sh isofiles/
 cd isofiles
 chmod +w md5sum.txt
 # The '|| echo' is there so that it always exits with 0 because find returns a non-zero status because there is debian symlink in isofiles that points to '.'

--- a/ci/debian-installer/postinst-debian-installer.sh
+++ b/ci/debian-installer/postinst-debian-installer.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -o nounset -o pipefail -o errexit
+
+PF_VERSION=${1:-}
+
+apt install packetfence -y
+sed -i '/^deb cdrom:/s/^/#/' /etc/apt/sources.list
+sed -i 's/#PermitRootLogin.*/PermitRootLogin yes/g' /etc/ssh/sshd_config
+sed -i 's/.*inverse\.ca.*//g' /etc/apt/sources.list
+echo 'deb http://inverse.ca/downloads/PacketFence/debian/${PF_VERSION} bullseye bullseye' > /etc/apt/sources.list.d/packetfence.list
+echo "SET PASSWORD FOR root@'localhost' = PASSWORD('');" > /tmp/reset-root.sql
+mkdir /run/mysqld
+chown mysql: /run/mysqld/
+timeout 10 mysqld --skip-networking --init-file /tmp/reset-root.sql --user=mysql > /var/reset-root.log 2>&1
+rm -f /tmp/reset-root.sql

--- a/ci/debian-installer/preseed.cfg.tmpl
+++ b/ci/debian-installer/preseed.cfg.tmpl
@@ -370,7 +370,7 @@ d-i pkgsel/include string sudo bzip2 acpid cryptsetup \
                           nfs-common net-tools build-essential \
                           linux-headers-amd64 gnupg2 apt-transport-https \
                           tmux tcpdump lnav apg sysstat bsd-mailx \
-                          packetfence
+                          cgroupfs-mount
 
 # Whether to upgrade packages after debootstrap.
 # Allowed values: none, safe-upgrade, full-upgrade
@@ -484,6 +484,9 @@ d-i preseed/early_command string sed -i \
 # Set the Inverse repo in the official location
 # Reset the MariaDB root password to empty since this install process prevents perl::DBI from connecting without a password on the local UNIX socket
 d-i preseed/late_command string \
+  mount --bind /proc /target/proc ; \
+  mount --bind /sys /target/sys ; \
+  apt-install packetfence ; \
   sed -i '/^deb cdrom:/s/^/#/' /target/etc/apt/sources.list ; \
   sed -i 's/#PermitRootLogin.*/PermitRootLogin yes/g' /target/etc/ssh/sshd_config ; \
   sed -i 's/.*inverse\.ca.*//g' /target/etc/apt/sources.list ; \

--- a/ci/debian-installer/preseed.cfg.tmpl
+++ b/ci/debian-installer/preseed.cfg.tmpl
@@ -486,14 +486,6 @@ d-i preseed/early_command string sed -i \
 d-i preseed/late_command string \
   mount --bind /proc /target/proc ; \
   mount --bind /sys /target/sys ; \
-  apt-install packetfence ; \
-  sed -i '/^deb cdrom:/s/^/#/' /target/etc/apt/sources.list ; \
-  sed -i 's/#PermitRootLogin.*/PermitRootLogin yes/g' /target/etc/ssh/sshd_config ; \
-  sed -i 's/.*inverse\.ca.*//g' /target/etc/apt/sources.list ; \
-  echo 'deb http://inverse.ca/downloads/PacketFence/debian/%%PF_VERSION%% bullseye bullseye' > /target/etc/apt/sources.list.d/packetfence.list ; \
-  echo "SET PASSWORD FOR root@'localhost' = PASSWORD('');" > /target/tmp/reset-root.sql ; \
-  mkdir /target/run/mysqld ; \
-  chroot /target chown mysql: /run/mysqld/ ; \
-  chroot /target timeout 10 mysqld --skip-networking --init-file /tmp/reset-root.sql --user=mysql > /target/var/reset-root.log 2>&1 ; \
-  rm -f /target/tmp/reset-root.sql
-
+  in-target cp -a /media/cdrom/postinst-debian-installer.sh /target/usr/local/bin/ ; \
+  in-target chmod 700 /usr/local/bin/postinst-debian-installer.sh ; \
+  in-target /bin/bash /usr/local/bin/postinst-debian-installer.sh %%PF_VERSION%%

--- a/containers/run-docker-in-debian-installer.sh
+++ b/containers/run-docker-in-debian-installer.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -o nounset -o pipefail -o errexit
+
+# /target is the chroot point used by Debian installer
+# all below commands are run inside it from BusyBox
+
+# need cgroupfs-mount package installed
+# necessary to run Docker daemon
+chroot /target /usr/bin/cgroupfs-mount
+
+# load overlay module to use overlay2 storage driver with Docker daemon
+chroot /target modprobe overlay
+
+# run containerd
+chroot /target /usr/bin/containerd
+
+# run Docker daemon
+chroot /target /usr/bin/dockerd --iptables=false -b=none -s overlay2
+
+

--- a/debian/packetfence.postinst
+++ b/debian/packetfence.postinst
@@ -156,6 +156,9 @@ case "$1" in
         if [ -f /media/cdrom/postinst-debian-installer.sh ]; then
             echo "Debian installer detected, launching Docker manually"
             /usr/local/pf/containers/run-docker-in-debian-installer.sh
+
+            # remove file in advance to timeout more quickly
+            rm -f $PACKETFENCE/var/run/pkg_install_in_progress
         else
             systemctl restart docker
         fi

--- a/debian/packetfence.postinst
+++ b/debian/packetfence.postinst
@@ -152,7 +152,14 @@ case "$1" in
         echo "Restarting rsyslog"
         systemctl restart rsyslog
 
-        systemctl restart docker
+        # check if we are inside our ISO installer (chroot environment)
+        if [ -f /media/cdrom/postinst-debian-installer.sh ]; then
+            echo "Debian installer detected, launching Docker manually"
+            /usr/local/pf/containers/run-docker-in-debian-installer.sh
+        else
+            systemctl restart docker
+        fi
+
         # get containers image and tag them locally
         /usr/local/pf/containers/manage-images.sh
 


### PR DESCRIPTION
# Description
Run Docker inside Debian installer to be able to pull Docker images during PacketFence postinstallation.

# Impacts
- Debian installation
- ISO installer

# Issue
fixes #7155

# Delete branch after merge
YES
