### PR TITLE
Fix 7218 (pfconnector dyn reverse cache issue)

### DIFF
--- a/go/chisel/share/settings/active_dyn_reverse.go
+++ b/go/chisel/share/settings/active_dyn_reverse.go
@@ -1,0 +1,21 @@
+package settings
+
+import (
+	"sync"
+)
+
+var ActiveDynReverse = sync.Map{}
+
+func ClearFromActiveDynReverse(r *Remote) bool {
+	cleared := false
+	ActiveDynReverse.Range(func(k, v interface{}) bool {
+		entry := v.(*Remote)
+		if entry.String() == r.String() {
+			ActiveDynReverse.Delete(k)
+			cleared = true
+			return false
+		}
+		return true
+	})
+	return cleared
+}

--- a/go/chisel/share/tunnel/tunnel_in_proxy.go
+++ b/go/chisel/share/tunnel/tunnel_in_proxy.go
@@ -153,6 +153,12 @@ func (p *Proxy) runTCP(ctx context.Context) error {
 				return false
 			}()
 			if shouldReturn {
+				if settings.ClearFromActiveDynReverse(p.remote) {
+					// We've cleared it from the cache, we'll continue monitoring the inactivity of the connection just in case it got sent just before the cache clear
+					p.Infof("Cleared entry from active dynamic reverses")
+					continue
+				}
+
 				p.Infof("Closing due to inactivity timeout")
 				cancel()
 				p.tcp.Close()

--- a/go/chisel/share/tunnel/tunnel_in_proxy_udp.go
+++ b/go/chisel/share/tunnel/tunnel_in_proxy_udp.go
@@ -216,7 +216,14 @@ func (u *udpListener) monitorInactivity(ctx context.Context, cancel func()) erro
 			return false
 		}()
 		if shouldReturn {
+			if settings.ClearFromActiveDynReverse(u.remote) {
+				// We've cleared it from the cache, we'll continue monitoring the inactivity of the connection just in case it got sent just before the cache clear
+				u.Infof("Cleared entry from active dynamic reverses")
+				continue
+			}
+
 			u.Infof("Closing due to inactivity timeout")
+
 			u.inbound.Close()
 			if u.outbound != nil && u.outbound.c != nil {
 				u.outbound.c.Close()


### PR DESCRIPTION
# Description
rework active dyn reverses cache in pfconnector to stop using network binds to test

# Impacts
pfconnector

# Issue
fixes #7218

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* Fixed issue with pfconnector where it would reuse a dynamic reverse that isn't active anymore (#7218)
