### PR TITLE
Fix source IP for pfconnector-remote deauth

### DIFF
--- a/conf/iptables.conf.example
+++ b/conf/iptables.conf.example
@@ -59,7 +59,6 @@
 # Netdata
 %%netdata%%
 
-
 # RADIUS
 -A input-management-if --protocol tcp --match tcp --dport 1812 --jump ACCEPT
 -A input-management-if --protocol udp --match udp --dport 1812 --jump ACCEPT

--- a/conf/iptables.conf.example
+++ b/conf/iptables.conf.example
@@ -58,8 +58,7 @@
 #-A input-management-if --protocol tcp --match tcp --dport 1026 --jump ACCEPT
 # Netdata
 %%netdata%%
-# pfconnector
-%%pfconnector%%
+
 
 # RADIUS
 -A input-management-if --protocol tcp --match tcp --dport 1812 --jump ACCEPT

--- a/conf/iptables.conf.example
+++ b/conf/iptables.conf.example
@@ -58,6 +58,8 @@
 #-A input-management-if --protocol tcp --match tcp --dport 1026 --jump ACCEPT
 # Netdata
 %%netdata%%
+# pfconnector
+%%pfconnector%%
 
 # RADIUS
 -A input-management-if --protocol tcp --match tcp --dport 1812 --jump ACCEPT

--- a/lib/pf/Switch/AeroHIVE.pm
+++ b/lib/pf/Switch/AeroHIVE.pm
@@ -189,12 +189,7 @@ sub radiusDisconnect {
     try {
         my $roleResolver = pf::roles::custom->instance();
         my $role = $roleResolver->getRoleForNode($mac, $self);
-        my $connection_info = {
-            useConnector => $self->shouldUseConnectorForRadiusDeauth(),
-            nas_ip => $send_disconnect_to,
-            secret => $self->{'_radiusSecret'},
-            LocalAddr => $self->deauth_source_ip($send_disconnect_to),
-        };
+        my $connection_info = $self->radius_deauth_connection_info($send_disconnect_to);
 
         if (defined($self->{'_disconnectPort'}) && $self->{'_disconnectPort'} ne '') {
             $connection_info->{'nas_port'} = $self->{'_disconnectPort'};

--- a/lib/pf/Switch/Alcatel.pm
+++ b/lib/pf/Switch/Alcatel.pm
@@ -189,12 +189,7 @@ sub radiusDisconnect {
 
     my $response;
     try {
-        my $connection_info = {
-            useConnector => $self->shouldUseConnectorForRadiusDeauth(),
-            nas_ip => $send_disconnect_to,
-            secret => $self->{'_radiusSecret'},
-            LocalAddr => $self->deauth_source_ip($send_disconnect_to),
-        };
+        my $connection_info = $self->radius_deauth_connection_info($send_disconnect_to);
 
         my $node_info = node_attributes($mac);
         # transforming MAC to the expected format 00-11-22-33-CA-FE

--- a/lib/pf/Switch/Aruba.pm
+++ b/lib/pf/Switch/Aruba.pm
@@ -521,12 +521,7 @@ sub radiusDisconnect {
 
     my $response;
     try {
-        my $connection_info = {
-            useConnector => $self->shouldUseConnectorForRadiusDeauth(),
-            nas_ip => $send_disconnect_to,
-            secret => $self->{'_radiusSecret'},
-            LocalAddr => $self->deauth_source_ip($send_disconnect_to),
-        };
+        my $connection_info = $self->radius_deauth_connection_info($send_disconnect_to);
 
         $logger->debug("network device supports roles. Evaluating role to be returned");
         my $roleResolver = pf::roles::custom->instance();

--- a/lib/pf/Switch/Aruba/2930M.pm
+++ b/lib/pf/Switch/Aruba/2930M.pm
@@ -189,12 +189,7 @@ sub radiusDisconnect {
     my $response;
     try {
         my $locationlog = locationlog_view_open_mac($mac);
-        my $connection_info = {
-            useConnector => $self->shouldUseConnectorForRadiusDeauth(),
-            nas_ip => $send_disconnect_to,
-            secret => $self->{'_radiusSecret'},
-            LocalAddr => $self->deauth_source_ip($send_disconnect_to),
-        };
+        my $connection_info = $self->radius_deauth_connection_info($send_disconnect_to);
 
         $logger->debug("[$self->{'_ip'}] Network device supports roles. Evaluating role to be returned.");
         my $roleResolver = pf::roles::custom->instance();

--- a/lib/pf/Switch/Aruba/CX.pm
+++ b/lib/pf/Switch/Aruba/CX.pm
@@ -84,13 +84,8 @@ sub radiusDisconnect {
 
     my $response;
     try {
-        my $connection_info = {
-            useConnector => $self->shouldUseConnectorForRadiusDeauth(),
-            nas_ip => $send_disconnect_to,
-            secret => $self->{'_radiusSecret'},
-            LocalAddr => $self->deauth_source_ip($send_disconnect_to),
-            nas_port => $nas_port,
-        };
+        my $connection_info = $self->radius_deauth_connection_info($send_disconnect_to);
+        $connection_info->{nas_port} = $nas_port;
 
         $logger->debug("network device supports roles. Evaluating role to be returned");
         my $roleResolver = pf::roles::custom->instance();

--- a/lib/pf/Switch/Aruba/Instant_Access.pm
+++ b/lib/pf/Switch/Aruba/Instant_Access.pm
@@ -49,12 +49,7 @@ sub radiusDisconnect {
 
     my $response;
     try {
-        my $connection_info = {
-            useConnector => $self->shouldUseConnectorForRadiusDeauth(),
-            nas_ip => $send_disconnect_to,
-            secret => $self->{'_radiusSecret'},
-            LocalAddr => $self->deauth_source_ip($send_disconnect_to),
-        };
+        my $connection_info = $self->radius_deauth_connection_info($send_disconnect_to);
 
         $logger->debug("network device supports roles. Evaluating role to be returned");
         my $roleResolver = pf::roles::custom->instance();

--- a/lib/pf/Switch/ArubaSwitch.pm
+++ b/lib/pf/Switch/ArubaSwitch.pm
@@ -227,12 +227,7 @@ sub radiusDisconnect {
 
     my $response;
     try {
-        my $connection_info = {
-            useConnector => $self->shouldUseConnectorForRadiusDeauth(),
-            nas_ip => $send_disconnect_to,
-            secret => $self->{'_radiusSecret'},
-            LocalAddr => $self->deauth_source_ip($send_disconnect_to),
-        };
+        my $connection_info = $self->radius_deauth_connection_info($send_disconnect_to);
 
         $logger->debug("[$self->{'_ip'}] Network device supports roles. Evaluating role to be returned.");
         my $roleResolver = pf::roles::custom->instance();

--- a/lib/pf/Switch/Avaya.pm
+++ b/lib/pf/Switch/Avaya.pm
@@ -588,12 +588,7 @@ sub radiusDisconnect {
 
     my $response;
     try {
-        my $connection_info = {
-            useConnector => $self->shouldUseConnectorForRadiusDeauth(),
-            nas_ip => $send_disconnect_to,
-            secret => $self->{'_radiusSecret'},
-            LocalAddr => $self->deauth_source_ip($send_disconnect_to),
-        };
+        my $connection_info = $self->radius_deauth_connection_info($send_disconnect_to);
 
         $logger->debug("network device supports roles. Evaluating role to be returned");
         my $roleResolver = pf::roles::custom->instance();

--- a/lib/pf/Switch/Cisco.pm
+++ b/lib/pf/Switch/Cisco.pm
@@ -1558,12 +1558,7 @@ sub _radiusBounceMac {
     my $response;
     my $send_disconnect_to = $self->{'_controllerIp'} || $self->{'_ip'};
     try {
-        my $connection_info = {
-            useConnector => $self->shouldUseConnectorForRadiusDeauth(),
-            nas_ip => $send_disconnect_to,
-            secret => $self->{'_radiusSecret'},
-            LocalAddr => $self->deauth_source_ip($send_disconnect_to),
-        };
+        my $connection_info = $self->radius_deauth_connection_info($send_disconnect_to);
 
         $response = perform_coa( $connection_info,
             {

--- a/lib/pf/Switch/Cisco/ASA.pm
+++ b/lib/pf/Switch/Cisco/ASA.pm
@@ -267,13 +267,8 @@ sub radiusDisconnect {
 
     my $response;
     try {
-        my $connection_info = {
-            useConnector => $self->shouldUseConnectorForRadiusDeauth(),
-            nas_ip => $send_disconnect_to,
-            secret => $self->{'_radiusSecret'},
-            LocalAddr => $self->deauth_source_ip($send_disconnect_to),
-            nas_port => $coa_port,
-        };
+        my $connection_info = $self->radius_deauth_connection_info($send_disconnect_to);
+        $connection_info->{nas_port} = $coa_port;
 
         $logger->debug("network device (".$self->{'_id'}.") supports roles. Evaluating role to be returned");
         my $roleResolver = pf::roles::custom->instance();

--- a/lib/pf/Switch/Cisco/Aironet_1600.pm
+++ b/lib/pf/Switch/Cisco/Aironet_1600.pm
@@ -102,12 +102,7 @@ sub radiusDisconnect {
 
     my $response;
     try {
-        my $connection_info = {
-            useConnector => $self->shouldUseConnectorForRadiusDeauth(),
-            nas_ip => $send_disconnect_to,
-            secret => $self->{'_radiusSecret'},
-            LocalAddr => $self->deauth_source_ip($send_disconnect_to),
-        };
+        my $connection_info = $self->radius_deauth_connection_info($send_disconnect_to);
 
         # Standard Attributes
         my $attributes_ref = {

--- a/lib/pf/Switch/Cisco/Catalyst_2960.pm
+++ b/lib/pf/Switch/Cisco/Catalyst_2960.pm
@@ -407,12 +407,7 @@ sub radiusDisconnect {
 
     my $response;
     try {
-        my $connection_info = {
-            useConnector => $self->shouldUseConnectorForRadiusDeauth(),
-            nas_ip => $send_disconnect_to,
-            secret => $self->{'_radiusSecret'},
-            LocalAddr => $self->deauth_source_ip($send_disconnect_to),
-        };
+        my $connection_info = $self->radius_deauth_connection_info($send_disconnect_to);
 
         $logger->debug("network device (".$self->{'_id'}.") supports roles. Evaluating role to be returned");
 

--- a/lib/pf/Switch/Cisco/WLC.pm
+++ b/lib/pf/Switch/Cisco/WLC.pm
@@ -500,13 +500,8 @@ sub radiusDisconnect {
 
     my $response;
     try {
-        my $connection_info = {
-            useConnector => $self->shouldUseConnectorForRadiusDeauth(),
-            nas_ip => $send_disconnect_to,
-            secret => $self->{'_radiusSecret'},
-            LocalAddr => $self->deauth_source_ip($send_disconnect_to),
-            nas_port => $coa_port,
-        };
+        my $connection_info = $self->radius_deauth_connection_info($send_disconnect_to);
+        $connection_info->{nas_port} = $coa_port;
 
         $logger->debug("network device (".$self->{'_id'}.") supports roles. Evaluating role to be returned");
         my $roleResolver = pf::roles::custom->instance();
@@ -554,13 +549,8 @@ sub radiusDisconnect {
 
         }
         else {
-            $connection_info = {
-                useConnector => $self->shouldUseConnectorForRadiusDeauth(),
-                nas_ip => $send_disconnect_to,
-                secret => $self->{'_radiusSecret'},
-                LocalAddr => $self->deauth_source_ip($send_disconnect_to),
-                nas_port => $nas_port,
-            };
+            my $connection_info = $self->radius_deauth_connection_info($send_disconnect_to);
+            $connection_info->{nas_port} = $nas_port;
             $response = perform_disconnect($connection_info, $attributes_ref);
         }
     } catch {

--- a/lib/pf/Switch/Dell/N1500.pm
+++ b/lib/pf/Switch/Dell/N1500.pm
@@ -287,12 +287,7 @@ sub radiusDisconnect {
 
     my $response;
     try {
-        my $connection_info = {
-            useConnector => $self->shouldUseConnectorForRadiusDeauth(),
-            nas_ip => $send_disconnect_to,
-            secret => $self->{'_radiusSecret'},
-            LocalAddr => $self->deauth_source_ip($send_disconnect_to),
-        };
+        my $connection_info = $self->radius_deauth_connection_info($send_disconnect_to);
 
         $logger->debug("network device (".$self->{'_id'}.") supports roles. Evaluating role to be returned");
 

--- a/lib/pf/Switch/Enterasys/V2110.pm
+++ b/lib/pf/Switch/Enterasys/V2110.pm
@@ -142,12 +142,7 @@ sub radiusDisconnect {
 
     my $response;
     try {
-        my $connection_info = {
-            useConnector => $self->shouldUseConnectorForRadiusDeauth(),
-            nas_ip => $send_disconnect_to,
-            secret => $self->{'_radiusSecret'},
-            LocalAddr => $self->deauth_source_ip($send_disconnect_to),
-        };
+        my $connection_info = $self->radius_deauth_connection_info($send_disconnect_to);
 
         # transforming MAC to the expected format 00-11-22-33-CA-FE
         $mac = uc($mac);

--- a/lib/pf/Switch/Hostapd.pm
+++ b/lib/pf/Switch/Hostapd.pm
@@ -143,12 +143,7 @@ sub radiusDisconnect {
 
     my $response;
     try {
-        my $connection_info = {
-            useConnector => $self->shouldUseConnectorForRadiusDeauth(),
-            nas_ip => $send_disconnect_to,
-            secret => $self->{'_radiusSecret'},
-            LocalAddr => $self->deauth_source_ip($send_disconnect_to),
-        };
+        my $connection_info = $self->radius_deauth_connection_info($send_disconnect_to);
 
         # transforming MAC to the expected format 00-11-22-33-CA-FE
         $mac = uc($mac);

--- a/lib/pf/Switch/Huawei.pm
+++ b/lib/pf/Switch/Huawei.pm
@@ -145,12 +145,7 @@ sub radiusDisconnect {
 
     my $response;
     try {
-        my $connection_info = {
-            useConnector => $self->shouldUseConnectorForRadiusDeauth(),
-            nas_ip => $send_disconnect_to,
-            secret => $self->{'_radiusSecret'},
-            LocalAddr => $self->deauth_source_ip($send_disconnect_to),
-        };
+        my $connection_info = $self->radius_deauth_connection_info($send_disconnect_to);
 
         # transforming MAC to the expected format 00-11-22-33-CA-FE
         $mac = uc($mac);

--- a/lib/pf/Switch/Juniper/EX2200.pm
+++ b/lib/pf/Switch/Juniper/EX2200.pm
@@ -138,12 +138,7 @@ sub radiusDisconnect {
     my $send_disconnect_to = $self->{'_ip'};
     my $response;
     try {
-        my $connection_info = {
-            useConnector => $self->shouldUseConnectorForRadiusDeauth(),
-            nas_ip => $send_disconnect_to,
-            secret => $self->{'_radiusSecret'},
-            LocalAddr => $self->deauth_source_ip($send_disconnect_to),
-        };
+        my $connection_info = $self->radius_deauth_connection_info($send_disconnect_to);
 
         my $acctsessionid = node_accounting_current_sessionid($mac);
         # Standard Attributes

--- a/lib/pf/Switch/Juniper/EX2200_v15.pm
+++ b/lib/pf/Switch/Juniper/EX2200_v15.pm
@@ -61,12 +61,7 @@ sub radiusDisconnect {
     my $send_disconnect_to = $self->{'_ip'};
     my $response;
     try {
-        my $connection_info = {
-            useConnector => $self->shouldUseConnectorForRadiusDeauth(),
-            nas_ip => $send_disconnect_to,
-            secret => $self->{'_radiusSecret'},
-            LocalAddr => $self->deauth_source_ip($send_disconnect_to),
-        };
+        my $connection_info = $self->radius_deauth_connection_info($send_disconnect_to);
 
         my $acctsessionid = node_accounting_current_sessionid($mac);
         # Standard Attributes

--- a/lib/pf/Switch/Juniper/EX2300.pm
+++ b/lib/pf/Switch/Juniper/EX2300.pm
@@ -90,12 +90,7 @@ sub radiusDisconnect {
     my $send_disconnect_to = $self->{'_ip'};
     my $response;
     try {
-        my $connection_info = {
-            useConnector => $self->shouldUseConnectorForRadiusDeauth(),
-            nas_ip => $send_disconnect_to,
-            secret => $self->{'_radiusSecret'},
-            LocalAddr => $self->deauth_source_ip($send_disconnect_to),
-        };
+        my $connection_info = $self->radius_deauth_connection_info($send_disconnect_to);
 
         # Standard Attributes
         my $attributes_ref = {
@@ -169,12 +164,7 @@ sub setAdminStatus {
     my $response;
     my $send_disconnect_to = $self->{'_controllerIp'} || $self->{'_ip'};
     try {
-        my $connection_info = {
-            useConnector => $self->shouldUseConnectorForRadiusDeauth(),
-            nas_ip => $send_disconnect_to,
-            secret => $self->{'_radiusSecret'},
-            LocalAddr => $self->deauth_source_ip($send_disconnect_to),
-        };
+        my $connection_info = $self->radius_deauth_connection_info($send_disconnect_to);
 
         $response = perform_coa( $connection_info,
             {

--- a/lib/pf/Switch/Meraki/MR_v2.pm
+++ b/lib/pf/Switch/Meraki/MR_v2.pm
@@ -100,13 +100,8 @@ sub radiusDisconnect {
 
     my $response;
     try {
-        my $connection_info = {
-            useConnector => $self->shouldUseConnectorForRadiusDeauth(),
-            nas_ip => $send_disconnect_to,
-            secret => $self->{'_radiusSecret'},
-            LocalAddr => $self->deauth_source_ip($send_disconnect_to),
-            nas_port => $coa_port,
-        };
+        my $connection_info = $self->radius_deauth_connection_info($send_disconnect_to);
+        $connection_info->{nas_port} = $coa_port;
 
         $logger->debug("network device (".$self->{'_id'}.") supports roles. Evaluating role to be returned");
 
@@ -149,13 +144,8 @@ sub radiusDisconnect {
 
         }
         else {
-            $connection_info = {
-                useConnector => $self->shouldUseConnectorForRadiusDeauth(),
-                nas_ip => $send_disconnect_to,
-                secret => $self->{'_radiusSecret'},
-                LocalAddr => $self->deauth_source_ip($send_disconnect_to),
-                nas_port => $nas_port,
-            };
+            my $connection_info = $self->radius_deauth_connection_info($send_disconnect_to);
+            $connection_info->{nas_port} = $nas_port;
             $response = perform_disconnect($connection_info, $attributes_ref);
         }
     } catch {

--- a/lib/pf/Switch/Mikrotik.pm
+++ b/lib/pf/Switch/Mikrotik.pm
@@ -242,12 +242,7 @@ sub radiusDisconnect {
 
     my $response;
     try {
-        my $connection_info = {
-            useConnector => $self->shouldUseConnectorForRadiusDeauth(),
-            nas_ip => $send_disconnect_to,
-            secret => $self->{'_radiusSecret'},
-            LocalAddr => $self->deauth_source_ip($send_disconnect_to),
-        };
+        my $connection_info = $self->radius_deauth_connection_info($send_disconnect_to);
 
         # transforming MAC to the expected format 00:11:22:33:CA:FE
         $mac = uc($mac);

--- a/lib/pf/Switch/Mojo.pm
+++ b/lib/pf/Switch/Mojo.pm
@@ -144,13 +144,8 @@ sub radiusDisconnect {
     my $response;
     try {
         my $locationlog = locationlog_view_open_mac($mac);
-        my $connection_info = {
-            useConnector => $self->shouldUseConnectorForRadiusDeauth(),
-            nas_ip => $send_disconnect_to,
-            secret => $self->{'_radiusSecret'},
-            LocalAddr => $self->deauth_source_ip($send_disconnect_to),
-            nas_port => $nas_port,
-        };
+        my $connection_info = $self->radius_deauth_connection_info($send_disconnect_to);
+        $connection_info->{nas_port} = $nas_port;
 
         $logger->debug("network device (".$self->{'_id'}.") supports roles. Evaluating role to be returned");
 
@@ -164,13 +159,6 @@ sub radiusDisconnect {
             'NAS-Identifier' => uc($locationlog->{switch_mac})."-".$locationlog->{ssid} ,
         };
 
-        $connection_info = {
-            useConnector => $self->shouldUseConnectorForRadiusDeauth(),
-            nas_ip => $send_disconnect_to,
-            secret => $self->{'_radiusSecret'},
-            LocalAddr => $self->deauth_source_ip($send_disconnect_to),
-            nas_port => $nas_port,
-        };
         $response = perform_disconnect($connection_info, $attributes_ref);
     } catch {
         chomp;

--- a/lib/pf/Switch/Pica8.pm
+++ b/lib/pf/Switch/Pica8.pm
@@ -119,12 +119,7 @@ sub setAdminStatus {
     my $response;
     my $send_disconnect_to = $self->{'_controllerIp'} || $self->{'_ip'};
     try {
-        my $connection_info = {
-            useConnector => $self->shouldUseConnectorForRadiusDeauth(),
-            nas_ip => $send_disconnect_to,
-            secret => $self->{'_radiusSecret'},
-            LocalAddr => $self->deauth_source_ip($send_disconnect_to),
-        };
+        my $connection_info = $self->radius_deauth_connection_info($send_disconnect_to);
 
         $response = perform_coa( $connection_info,
             {
@@ -209,12 +204,7 @@ sub radiusDisconnect {
 
     my $response;
     try {
-        my $connection_info = {
-            useConnector => $self->shouldUseConnectorForRadiusDeauth(),
-            nas_ip => $send_disconnect_to,
-            secret => $self->{'_radiusSecret'},
-            LocalAddr => $self->deauth_source_ip($send_disconnect_to),
-        };
+        my $connection_info = $self->radius_deauth_connection_info($send_disconnect_to);
 
         $logger->debug("network device (".$self->{'_id'}.") supports roles. Evaluating role to be returned");
 

--- a/lib/pf/Switch/Ruckus/SmartZone.pm
+++ b/lib/pf/Switch/Ruckus/SmartZone.pm
@@ -155,12 +155,7 @@ sub radiusDisconnect {
 
     my $response;
     try {
-        my $connection_info = {
-            useConnector => $self->shouldUseConnectorForRadiusDeauth(),
-            nas_ip => $send_disconnect_to,
-            secret => $self->{'_radiusSecret'},
-            LocalAddr => $self->deauth_source_ip($send_disconnect_to),
-        };
+        my $connection_info = $self->radius_deauth_connection_info($send_disconnect_to);
 
         if (defined($self->{'_disconnectPort'}) && $self->{'_disconnectPort'} ne '') {
             $connection_info->{'nas_port'} = $self->{'_disconnectPort'};

--- a/lib/pf/Switch/Template.pm
+++ b/lib/pf/Switch/Template.pm
@@ -260,12 +260,7 @@ handleDisconnect
 sub handleDisconnect {
     my ($self, $mac, $add_attributes_ref) = @_;
     my $send_disconnect_to = $self->disconnectAddress($add_attributes_ref);
-    my $connection_info = {
-        useConnector => $self->shouldUseConnectorForRadiusDeauth(),
-        nas_ip => $send_disconnect_to,
-        secret => $self->{'_radiusSecret'},
-        LocalAddr => $self->deauth_source_ip($send_disconnect_to),
-    };
+    my $connection_info = $self->radius_deauth_connection_info($send_disconnect_to);
 
     if (defined($self->{'_disconnectPort'}) && $self->{'_disconnectPort'} ne '') {
         $connection_info->{'nas_port'} = $self->{'_disconnectPort'};
@@ -316,12 +311,7 @@ handleCoa
 sub handleCoa {
     my ($self, $mac, $add_attributes_ref, $role) = @_;
     my $send_disconnect_to = $self->disconnectAddress($add_attributes_ref);
-    my $connection_info = {
-        useConnector => $self->shouldUseConnectorForRadiusDeauth(),
-        nas_ip => $send_disconnect_to,
-        secret => $self->{'_radiusSecret'},
-        LocalAddr => $self->deauth_source_ip($send_disconnect_to),
-    };
+    my $connection_info = $self->radius_deauth_connection_info($send_disconnect_to);
 
     if (defined($self->{'_coaPort'}) && $self->{'_coaPort'} ne '') {
         $connection_info->{'nas_port'} = $self->{'_coaPort'};
@@ -532,12 +522,7 @@ sub _bouncePortCoa {
     }
 
     my $send_disconnect_to = $self->disconnectAddress({});
-    my $connection_info = {
-        useConnector => $self->shouldUseConnectorForRadiusDeauth(),
-        nas_ip => $send_disconnect_to,
-        secret => $self->{'_radiusSecret'},
-        LocalAddr => $self->deauth_source_ip($send_disconnect_to),
-    };
+    my $connection_info = $self->radius_deauth_connection_info($send_disconnect_to);
     my %args = (
         disconnectIp => $send_disconnect_to,
         mac => $mac,

--- a/lib/pf/Switch/Ubiquiti/Unifi.pm
+++ b/lib/pf/Switch/Ubiquiti/Unifi.pm
@@ -453,12 +453,7 @@ sub radiusDisconnect {
     my $response;
     try {
         my $locationlog = locationlog_view_open_mac($mac);
-        my $connection_info = {
-            useConnector => $self->shouldUseConnectorForRadiusDeauth(),
-            nas_ip => $send_disconnect_to,
-            secret => $self->{'_radiusSecret'},
-            LocalAddr => $self->deauth_source_ip($send_disconnect_to),
-        };
+        my $connection_info = $self->radius_deauth_connection_info($send_disconnect_to);
 
         # transforming MAC to the expected format 00-11-22-33-CA-FE
         $mac = uc($mac);

--- a/lib/pf/Switch/Xirrus.pm
+++ b/lib/pf/Switch/Xirrus.pm
@@ -230,12 +230,7 @@ sub radiusDisconnect {
 
     my $response;
     try {
-        my $connection_info = {
-            useConnector => $self->shouldUseConnectorForRadiusDeauth(),
-            nas_ip => $send_disconnect_to,
-            secret => $self->{'_radiusSecret'},
-            LocalAddr => $self->deauth_source_ip($send_disconnect_to),
-        };
+        my $connection_info = $self->radius_deauth_connection_info($send_disconnect_to);
 
         # transforming MAC to the expected format 00-11-22-33-CA-FE
         $mac = uc($mac);

--- a/lib/pf/util/radius.pm
+++ b/lib/pf/util/radius.pm
@@ -46,7 +46,6 @@ use pf::node qw (node_view);
 use pf::util qw (clean_mac);
 use pf::util::radius_dictionary qw($RADIUS_DICTIONARY);
 use pf::factory::connector;
-use pf::config::cluster qw($cluster_enabled);
 use pf::log;
 
 my $default_port = '3799';
@@ -111,15 +110,9 @@ sub perform_dynauth {
 
     if($connection_info->{useConnector}) {
         my $connector = pf::factory::connector->for_ip($host);
-        # Skip using the local connector to do deauth if we're in a cluster since pfconnector will not use the VIP
-        if($cluster_enabled && $connector->id eq pf::factory::connector->local_connector->id) {
-            get_logger->debug("Not using local connector to perform deauth because this is a cluster");            
-        }
-        else {
-            my $connector_conn = $connector->dynreverse("$host:$port/udp");
-            $host = $connector_conn->{host};
-            $port = $connector_conn->{port};
-        }
+        my $connector_conn = $connector->dynreverse("$host:$port/udp");
+        $host = $connector_conn->{host};
+        $port = $connector_conn->{port};
     }
 
     # Warning: original code had Reuse => 1 (Note: Reuse is deprecated in favor of ReuseAddr)


### PR DESCRIPTION
# Description
Fix source IP for pfconnector-remote deauth. It prevented the CoA-ACK or Disconnect-ACK from being seen by pfqueue so all attempts would log as failed although they succeeded

# Impacts
RADIUS deauth

# Issue
fixes #7239 

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* Fixed RADIUS deauth through pfconnector-remote in a cluster where it was logging as failed although it succeeded
 
