### PR TITLE
Allow to store logo in profile-templates directory

### DIFF
--- a/addons/upgrade/move-logos-to-profile-templates.pl
+++ b/addons/upgrade/move-logos-to-profile-templates.pl
@@ -25,7 +25,6 @@ use List::MoreUtils qw(any);
 use pf::util;
 use File::Copy;
 use File::Basename;
-#use Data::Dumper;
 
 run_as_pf();
 
@@ -104,8 +103,6 @@ for my $section ($ini->Sections()) {
 }
 
 print("==========\n");
-
-#print(Dumper(\%profiles_logos));
 
 for my $profile_id (keys %profiles_logos) {
     if (check_logo_path($profile_id)) {

--- a/addons/upgrade/move-logos-to-profile-templates.pl
+++ b/addons/upgrade/move-logos-to-profile-templates.pl
@@ -1,0 +1,151 @@
+#!/usr/bin/perl
+
+=head1 NAME
+
+move-logos-to-profile-templates.pl
+
+=cut
+
+=head1 DESCRIPTION
+
+- Find all connection profiles with logo defined in conf/profiles.conf
+- Copy each logo into html/captive-portal/profile-templates/PROFILE_NAME/
+- Update each connection profile with logo in conf/profiles.conf with new relative paths to logo
+
+=cut
+
+use strict;
+use warnings;
+use lib qw(/usr/local/pf/lib /usr/local/pf/lib_perl/lib/perl5);
+use pf::IniFiles;
+use pf::file_paths qw(
+    $profiles_config_file
+);
+use List::MoreUtils qw(any);
+use pf::util;
+use File::Copy;
+use File::Basename;
+#use Data::Dumper;
+
+run_as_pf();
+
+my $ini = pf::IniFiles->new(-file => $profiles_config_file, -allowempty => 1);
+my %profiles_logos;
+my $html_prefix = '/usr/local/pf/html';
+my $cp_prefix = '/usr/local/pf/html/captive-portal';
+my $new_logo_prefix = '/profile-templates';
+
+sub store_logo_paths {
+    my ($profile_id) = @_;
+    if (my $logo_path = $ini->val($profile_id, 'logo')) {
+	my $logo_filename = basename($logo_path);
+    	$profiles_logos{$profile_id} = {
+    	    'old_logo_absolute_path' => "$html_prefix$logo_path",
+	    'old_logo_relative_path' => "$logo_path",
+            'new_logo_absolute_path' => "$cp_prefix$new_logo_prefix/$profile_id/$logo_filename",
+	    'new_logo_relative_path' => "$new_logo_prefix/$profile_id/$logo_filename",
+	};
+	print("Logo detected on '$profile_id' connection profile\n");
+    } else {
+	print("No logo declaration detected on '$profile_id' connection profile, profile is using default settings\n");
+    }
+}
+
+
+sub check_logo_path {
+    my ($profile_id) = @_;
+
+    if ( $profiles_logos{$profile_id}->{'old_logo_absolute_path'} =~ "/profile-templates/" ) {
+	print("'$profile_id' has already been migrated\n");
+	return 0;
+    } else {
+	return 1;
+    }
+}
+
+sub copy_logo_to_new_location {
+    my ($profile_id) = @_;
+    my $profile_template_dir = dirname($profiles_logos{$profile_id}->{'new_logo_absolute_path'});
+
+    if (-e "$profiles_logos{$profile_id}->{'old_logo_absolute_path'}") {
+	print("Current logo configured on '$profile_id' exists on filesystem\n");
+    } else {
+	print("Current logo configured on '$profile_id' **doesn't** exist on filesystem, stopping script\n");
+	exit 1;
+    }
+    # check if target dir already exist
+    if (-d "$profile_template_dir" ) {
+	print("$profile_template_dir already exists\n");
+    } else {
+	print("Creating $profile_template_dir\n");
+	mkdir($profile_template_dir);
+    }
+
+    print("Copy $profiles_logos{$profile_id}->{'old_logo_absolute_path'} into $profiles_logos{$profile_id}->{'new_logo_absolute_path'}\n");
+    copy($profiles_logos{$profile_id}->{'old_logo_absolute_path'}, $profiles_logos{$profile_id}->{'new_logo_absolute_path'});
+
+}
+
+sub update_connection_profile {
+    my ($profile_id) = @_;
+    print("Updating logo path for '$profile_id' connection profile\n");
+    $ini->setval($profile_id, 'logo', $profiles_logos{$profile_id}->{'new_logo_relative_path'});
+}
+
+sub apply_changes {
+    $ini->RewriteConfig();
+}
+
+### Main
+
+# section = profile ID
+for my $section ($ini->Sections()) {
+    store_logo_paths($section);
+}
+
+print("==========\n");
+
+#print(Dumper(\%profiles_logos));
+
+for my $profile_id (keys %profiles_logos) {
+    if (check_logo_path($profile_id)) {
+	copy_logo_to_new_location($profile_id);
+	update_connection_profile($profile_id);
+	print("==========\n");
+    } else {
+	print("Nothing to do on '$profile_id'\n");
+    }
+}
+
+apply_changes
+
+print "All done\n";
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2022 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+

--- a/addons/upgrade/move-logos-to-profile-templates.pl
+++ b/addons/upgrade/move-logos-to-profile-templates.pl
@@ -62,16 +62,22 @@ sub check_logo_path {
     }
 }
 
+sub check_logo_exists {
+    my ($profile_id) = @_;
+
+    if (-e "$profiles_logos{$profile_id}->{'old_logo_absolute_path'}") {
+	print("Current logo configured on '$profile_id' exists on filesystem\n");
+        return 1;
+    } else {
+	print("Current logo configured on '$profile_id' **doesn't** exist on filesystem\n");
+	return 0;
+    }
+}
+
 sub copy_logo_to_new_location {
     my ($profile_id) = @_;
     my $profile_template_dir = dirname($profiles_logos{$profile_id}->{'new_logo_absolute_path'});
 
-    if (-e "$profiles_logos{$profile_id}->{'old_logo_absolute_path'}") {
-	print("Current logo configured on '$profile_id' exists on filesystem\n");
-    } else {
-	print("Current logo configured on '$profile_id' **doesn't** exist on filesystem, stopping script\n");
-	exit 1;
-    }
     # check if target dir already exist
     if (-d "$profile_template_dir" ) {
 	print("$profile_template_dir already exists\n");
@@ -106,8 +112,13 @@ print("==========\n");
 
 for my $profile_id (keys %profiles_logos) {
     if (check_logo_path($profile_id)) {
-	copy_logo_to_new_location($profile_id);
-	update_connection_profile($profile_id);
+        if (check_logo_exists($profile_id)) {
+            copy_logo_to_new_location($profile_id);
+            update_connection_profile($profile_id);
+        } else {
+            print("==========\n");
+            next;
+        }
 	print("==========\n");
     } else {
 	print("Nothing to do on '$profile_id'\n");

--- a/conf/caddy-services/httpdispatcher.conf.example
+++ b/conf/caddy-services/httpdispatcher.conf.example
@@ -28,6 +28,14 @@
   }
 }
 
+:8889/profile-templates {
+  root /usr/local/pf/html/captive-portal/profile-templates
+  mime {
+    .crt application/x-pem-file
+    .pem application/x-pem-file
+  }
+}
+
 :8889/.well-known/acme-challenge {
   root /usr/local/pf/conf/ssl/acme-challenge
 }

--- a/conf/passthrough.lua.tt.example
+++ b/conf/passthrough.lua.tt.example
@@ -27,7 +27,7 @@ core.register_action("select", { "http-req" }, function(txn)
     else
         if (txn.sf:path() == '/' or string.match(txn.sf:path() , '/release%-parking') ) then
             txn:set_var("req.action","proxy")
-        elseif ( string.match(txn.sf:path(), '^/common') or string.match(txn.sf:path(), '^/content') or string.match(txn.sf:path(), '^/favicon.ico$') ) then
+        elseif ( string.match(txn.sf:path(), '^/common') or string.match(txn.sf:path(), '^/content') or string.match(txn.sf:path(), '^/profile%-templates') or string.match(txn.sf:path(), '^/favicon.ico$') ) then
             txn:set_var("req.action","static")
         end
     end

--- a/lib/pf/web/constants.pm
+++ b/lib/pf/web/constants.pm
@@ -146,9 +146,10 @@ Apache config.
 =cut
 
 Readonly::Hash our %CAPTIVE_PORTAL_STATIC_ALIASES => (
-    '/common/'      => '/html/common/',
-    '/content/'     => '/html/captive-portal/content/',
-    '/favicon.ico'  => '/html/common/favicon.ico',
+    '/common/'                => '/html/common/',
+    '/content/'               => '/html/captive-portal/content/',
+    '/profile-templates/'     => '/html/captive-portal/profile-templates/',
+    '/favicon.ico'            => '/html/common/favicon.ico',
 );
 
 =item CAPTIVE_PORTAL_RESOURCES

--- a/sbin/httpd.dispatcher-docker-wrapper
+++ b/sbin/httpd.dispatcher-docker-wrapper
@@ -5,6 +5,6 @@ source /usr/local/pf/containers/systemd-service
 name=httpd.dispatcher
 
 args=`base_args $name`
-args="$args -v /usr/local/pf/conf:/usr/local/pf/conf -p 8888:8888 -p 8889:8889 -p 5252:5252"
+args="$args -v /usr/local/pf/conf:/usr/local/pf/conf -v/usr/local/pf/html/captive-portal/profile-templates:/usr/local/pf/html/captive-portal/profile-templates -p 8888:8888 -p 8889:8889 -p 5252:5252"
 
 run $name "$args"


### PR DESCRIPTION
# Description
* Allow to store logo in profile-templates directory.
Logo should be configured like this on Connection profile: 

`logo=/profile-templates/default/custom_logo.png`

* Logo is visible on:
  * Portal preview
  * Captive portal

# Impacts
- haproxy-portal
- httpd.portal
- http.dispatcher

# NEW Package(s) required
Yes

# Issue
* Related to #7238 
* Fixes #7243 

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* Store logos in profile-templates directory to expose them inside containers
