### PR TITLE
Fixes VPN attribute not returned each time

### DIFF
--- a/addons/upgrade/to-12.1-move-rolebyname-to-vpnbyname-fortigate.pl
+++ b/addons/upgrade/to-12.1-move-rolebyname-to-vpnbyname-fortigate.pl
@@ -1,0 +1,77 @@
+#!/usr/bin/perl
+
+=head1 NAME
+
+to-12.1-move-rolebyname-to-vpnbyname-fortigate.pl
+
+=cut
+
+=head1 DESCRIPTION
+
+Move role by name to role by vpn
+
+=cut
+
+use strict;
+use warnings;
+use lib qw(/usr/local/pf/lib /usr/local/pf/lib_perl/lib/perl5);
+use pf::IniFiles;
+use pf::file_paths qw(
+    $switches_config_file
+);
+use pf::util;
+
+run_as_pf();
+
+my $file = $switches_config_file;
+
+my $cs = pf::IniFiles->new(-file => $file, -allowempty => 1);
+
+tie my %switches_conf_file, 'pf::IniFiles', ( -file => $pf::file_paths::switches_config_file );
+
+
+
+foreach my $key (keys %switches_conf_file) {
+    if ($switches_conf_file{$key}{'type'} eq 'Fortinet::FortiGate') {
+        foreach my $role (keys %{$switches_conf_file{$key}}) {
+            if ($role =~ /(.*)Role$/) {
+                if (!$cs->exists($key, $1."Vpn")) {
+                    $cs->newval($key, $1."Vpn", $switches_conf_file{$key}{$role});
+                }
+            }
+        }
+    }
+}
+
+
+$cs->RewriteConfig();
+
+print "All done\n";
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2022 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+

--- a/lib/pf/Switch.pm
+++ b/lib/pf/Switch.pm
@@ -807,16 +807,6 @@ sub _parentRoleForVpn {
     my ($name) = @_;
     # not yet supported
     return undef;
-    if (!exists $ConfigRoles{$name}) {
-        return undef;
-    }
-
-    my $role = $ConfigRoles{$name};
-    if (isdisabled($role->{inherit_vpn} // 'disabled')) {
-        return undef;
-    }
-
-    return $role->{parent_id};
 }
 
 

--- a/lib/pf/Switch/Fortinet/FortiGate.pm
+++ b/lib/pf/Switch/Fortinet/FortiGate.pm
@@ -269,7 +269,7 @@ sub returnAuthorizeVPN {
     if ( isenabled($self->{_VpnMap}) && $self->supportsVPNRoleBasedEnforcement()) {
         $logger->debug("Network device (".$self->{'_id'}.") supports roles. Evaluating role to be returned");
         if ( defined($args->{'user_role'}) && $args->{'user_role'} ne "" ) {
-            $role = $self->getRoleByName($args->{'user_role'});
+            $role = $self->getVpnByName($args->{'user_role'});
         }
         if ( defined($role) && $role ne "" ) {
             $radius_reply_ref = {

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -1079,7 +1079,7 @@ sub mfa_pre_auth {
     $merged->{'context'} = $pf::constants::realm::RADIUS_CONTEXT;
     my $attributes;
     my $matched = pf::authentication::match2([@$sources], $merged, $$extra, \$attributes);
-
+    my $source_id = \@$sources;
     # Verify if the user succeed the MFA on the portal
     my $value = $matched->{values}{$Actions::TRIGGER_PORTAL_MFA} if $matched;
     if ($value) {
@@ -1088,7 +1088,7 @@ sub mfa_pre_auth {
         if (isenabled($args->{switch}->{_PostMfaValidation}) && $cache->get($args->{'username'}."mfapreauth") && $cache->get($args->{'username'}."mfapostauth")) {
             $cache->remove($args->{'username'}."mfapostauth");
             $cache->remove($args->{'username'}."mfapreauth");
-            return $args->{'switch'}->returnAuthorizeVPN($args);
+            return $self->returnRadiusVpn($args, $options, $sources, $source_id, $extra);
         }
         if (isenabled($args->{switch}->{_PostMfaValidation}) && $cache->get($args->{'username'}."mfapreauth") && !$cache->get($args->{'username'}."mfapostauth")) {
             return [ $RADIUS::RLM_MODULE_FAIL, ('Reply-Message' => "MFA portal verification failed") ];
@@ -1107,7 +1107,7 @@ sub mfa_pre_auth {
                     return [ $RADIUS::RLM_MODULE_FAIL, ('Reply-Message' => "MFA verification failed") ];
                 } else {
                     if ($caller eq "pf::radius::vpn") {
-                        return $args->{'switch'}->returnAuthorizeVPN($args);
+                        return $self->returnRadiusVpn($args, $options, $sources, $source_id, $extra);
                 } else {
                         return $TRUE;
                     }
@@ -1124,7 +1124,7 @@ sub mfa_pre_auth {
                         return [ $RADIUS::RLM_MODULE_FAIL, ('Reply-Message' => "MFA verification failed")];
                     } else {
                         if ($caller eq "pf::radius::vpn") {
-                            return $args->{'switch'}->returnAuthorizeVPN($args);
+                            return $self->returnRadiusVpn($args, $options, $sources, $source_id, $extra);
                         } else {
                             return $TRUE;
                         }
@@ -1136,7 +1136,7 @@ sub mfa_pre_auth {
                         return [ $RADIUS::RLM_MODULE_FAIL, ('Reply-Message' => "MFA verification failed") ];
                     } else {
                         if ($caller eq "pf::radius::vpn") {
-                            return $args->{'switch'}->returnAuthorizeVPN($args);
+                            return $self->returnRadiusVpn($args, $options, $sources, $source_id, $extra);
                         } else {
                             return $TRUE;
                         }

--- a/lib/pfconfig/namespaces/config/Switch.pm
+++ b/lib/pfconfig/namespaces/config/Switch.pm
@@ -86,11 +86,11 @@ sub build_child {
 
         $self->updateReverseLookup($name, $switch, qw(group));
         # transforming vlans and roles to hashes
-        my %merged = ( Vlan => {}, Role => {}, AccessList => {} , Url => {} );
+        my %merged = ( Vlan => {}, Role => {}, AccessList => {} , Url => {} , Vpn => {});
         my %roles;
-        foreach my $key ( grep {/(Vlan|Role|AccessList|Url)$/} keys %{$switch} ) {
+        foreach my $key ( grep {/(Vlan|Role|AccessList|Url|Vpn)$/} keys %{$switch} ) {
             next unless my $value = $switch->{$key};
-            if ( my ( $type_key, $type ) = ( $key =~ /^(.+)(Vlan|Role|AccessList|Url)$/ ) ) {
+            if ( my ( $type_key, $type ) = ( $key =~ /^(.+)(Vlan|Role|AccessList|Url|Vpn)$/ ) ) {
                 $merged{$type}{$type_key} = $value;
                 $roles{$type_key} = undef;
             }
@@ -104,6 +104,7 @@ sub build_child {
         $switch->{vlans}        = $merged{Vlan};
         $switch->{access_lists} = $merged{AccessList};
         $switch->{urls}         = $merged{Url};
+        $switch->{vpn}          = $merged{Vpn};
         $switch->{VoIPEnabled}  = (
             $switch->{VoIPEnabled} =~ /^\s*(y|yes|true|enabled|1)\s*$/i
             ? 1


### PR DESCRIPTION
# Description
In some cases the vpn attribute is not returned by PacketFence and it should.


# Impacts
RADIUS VPN workflow

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Bug Fixes
* Return radius attribute if define for each VPN request.

# UPGRADE file entries

Run to-12.1-move-rolebyname-to-vpnbyname-fortigate.pl to copy the Role attributes in the VPN one for FortiGate
