### PR TITLE
Remove set +e to stop Debian installation/upgrade at first error

### DIFF
--- a/debian/packetfence.postinst
+++ b/debian/packetfence.postinst
@@ -198,7 +198,6 @@ case "$1" in
         printf '[client-server]\nsocket = /var/lib/mysql/mysql.sock\n' > /etc/mysql/mariadb.conf.d/999-socket-override.cnf
         sed -i 's#^socket\s*=.*#socket=/var/lib/mysql/mysql.sock#' /etc/mysql/my.cnf
 
-        set +e
         /usr/local/pf/bin/pfcmd configreload
         /usr/local/pf/bin/pfcmd fixpermissions
         echo "Starting PacketFence Administration GUI..."


### PR DESCRIPTION
# Description
If you use `do-upgrade.sh` script to perform an upgrade and you got an issue in the steps **after** `set +e`, full upgrade will not stop and you got inconsistent results.

# Impacts
- Debian installation
- Debian upgrades
- Debian ISO

# Issue
I didn't open any issue but I have seen this behavior during a customer upgrade

# Delete branch after merge
YES
