### PR TITLE
SAML/MFA/etc support for the admin interface login

### DIFF
--- a/conf/chi.conf.defaults
+++ b/conf/chi.conf.defaults
@@ -192,3 +192,16 @@ storage=distributed
 #
 # Amount of time from the current time to expire an entry
 expires_in=120s
+
+
+[namespace portaladmin]
+#
+# namespace portaladmin.storage
+#
+# The storage to use for the namespace
+storage=distributed
+#
+# storage portaladmin.expires_in
+#
+# Amount of time from the current time to expire an entry
+expires_in=120s

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -2050,6 +2050,10 @@ description=<<EOT
 Field described in JS files
 EOT
 
+[admin_sso.status]
+type=toggle
+options=enabled|disabled
+
 [admin_sso.base_url]
 type=text
 
@@ -2057,5 +2061,8 @@ type=text
 type=text
 
 [admin_sso.authorize_path]
+type=text
+
+[admin_sso.login_text]
 type=text
 

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -2050,3 +2050,12 @@ description=<<EOT
 Field described in JS files
 EOT
 
+[admin_sso.base_url]
+type=text
+
+[admin_sso.login_path]
+type=text
+
+[admin_sso.authorize_path]
+type=text
+

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -2050,19 +2050,23 @@ description=<<EOT
 Field described in JS files
 EOT
 
-[admin_sso.status]
+[admin_login.sso_status]
 type=toggle
 options=enabled|disabled
 
-[admin_sso.base_url]
+[admin_login.sso_base_url]
 type=text
 
-[admin_sso.login_path]
+[admin_login.sso_login_path]
 type=text
 
-[admin_sso.authorize_path]
+[admin_login.sso_authorize_path]
 type=text
 
-[admin_sso.login_text]
+[admin_login.sso_login_text]
 type=text
+
+[admin_login.allow_username_password]
+type=toggle
+options=enabled|disabled
 

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -1465,3 +1465,8 @@ pfsso=[% ENV.env_or_default("PF_SERVICES_URL_PFSSO", "http://containers-gateway.
 pfconnector-server=[% ENV.env_or_default("PF_SERVICES_URL_PFCONNECTOR_SERVER", "http://containers-gateway.internal:22226") %]
 api-frontend=[% ENV.env_or_default("PF_SERVICES_URL_API_FRONTEND", "https://containers-gateway.internal:9999") %]
 netdata=[% ENV.env_or_default("PF_SERVICES_URL_NETDATA", "http://containers-gateway.internal:19999") %]
+
+[admin_sso]
+base_url=
+login_path=/admin-sso
+authorize_path=/portaltoken

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -1471,4 +1471,4 @@ status=disabled
 base_url=
 login_path=/admin-sso
 authorize_path=/portaltoken
-login_text=Login with single sign on
+login_text=Single Sign On

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -1466,9 +1466,10 @@ pfconnector-server=[% ENV.env_or_default("PF_SERVICES_URL_PFCONNECTOR_SERVER", "
 api-frontend=[% ENV.env_or_default("PF_SERVICES_URL_API_FRONTEND", "https://containers-gateway.internal:9999") %]
 netdata=[% ENV.env_or_default("PF_SERVICES_URL_NETDATA", "http://containers-gateway.internal:19999") %]
 
-[admin_sso]
-status=disabled
-base_url=
-login_path=/admin-sso
-authorize_path=/portaltoken
-login_text=Single Sign On
+[admin_login]
+sso_status=disabled
+sso_base_url=
+sso_login_path=/admin-sso
+sso_authorize_path=/portaltoken
+sso_login_text=Single Sign On
+allow_username_password=enabled

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -1467,6 +1467,8 @@ api-frontend=[% ENV.env_or_default("PF_SERVICES_URL_API_FRONTEND", "https://cont
 netdata=[% ENV.env_or_default("PF_SERVICES_URL_NETDATA", "http://containers-gateway.internal:19999") %]
 
 [admin_sso]
+status=disabled
 base_url=
 login_path=/admin-sso
 authorize_path=/portaltoken
+login_text=Login with single sign on

--- a/conf/portal_modules.conf.defaults
+++ b/conf/portal_modules.conf.defaults
@@ -58,3 +58,7 @@ description=Show local account
 description=MFA policy
 type=MFA
 
+[default_admin_sso_policy]
+description=Default admin SSO policy
+type=RootSession
+modules=default_registration_policy,default_mfa_policy

--- a/docs/installation/advanced_access_control_for_admin_login.asciidoc
+++ b/docs/installation/advanced_access_control_for_admin_login.asciidoc
@@ -1,0 +1,26 @@
+=== Advanced Access Control For Admin Login
+
+By default, the PacketFence admin interface will allow username/password login via any Internal authentication source (local database, LDAP, etc).
+
+If you need to perform other types of authentication for the admin interface (ex: SAML, multi-factor auth, etc), then you can leverage all the capabilities of the captive portal for authenticating administrators.
+
+==== Basic Configuration
+
+First, head to 'Configuration->System Configuration->Admin SSO' and set the status to enabled. If you want to enforce the usage of your SSO policy for login (i.e. disable the username/password), you should disable 'Allow username/password authentication' in this page.
+
+Optionally, you may need to configure the 'Base URL' if your PacketFence captive portal must be accessed under a different named than what is defined in the 'Hostname' and 'Domain' values that are in 'General Configuration'.
+
+Next, you will need to configure a connnection profile for authenticating administrators. Go in 'Configuration->Policies and Access Control->Connection Profiles' and create a new connection profile with these values:
+
+ * Root Portal Module: 'Default admin SSO policy'
+ * Filter: URI with value '/admin-sso'
+ * Sources: The authentication sources that should be used for the login.
+
+After this, restart `api-frontend` and `httpd.portal` and when accessing the admin interface login page, you should see a new option named 'Single Sign On'. This text can be changed in the 'Admin SSO' configuration section.
+
+Any authentication mechanism that can be used on the portal (SAML, Akamai MFA, TOTP, etc) can be used for authenticating administrators using this process. Refer to the appropriate section for each feature in this guide in order to configure them on your connection profile used for authenticating administrators. 
+
+==== Advanced Configuration
+
+Depending on your needs, you may want to adjust the configuration of the policy on the captive portal when authenticating administrators. The portal modules make this process highly flexible and customizable. You can modify the 'Default admin SSO policy' in 'Configuration->Advanced Access Configuration->Portal Modules' or create your own policy that you can then configure in your connection profile that authenticates administrators. Refer to the <<PacketFence_Installation_Guide.asciidoc#_portal_modules,Portal Modules>> section of this documentation on how to customize the captive portal for your needs. 
+

--- a/docs/installation/advanced_access_control_for_admin_login.asciidoc
+++ b/docs/installation/advanced_access_control_for_admin_login.asciidoc
@@ -6,9 +6,9 @@ If you need to perform other types of authentication for the admin interface (ex
 
 ==== Basic Configuration
 
-First, head to 'Configuration->System Configuration->Admin SSO' and set the status to enabled. If you want to enforce the usage of your SSO policy for login (i.e. disable the username/password), you should disable 'Allow username/password authentication' in this page.
+First, head to 'Configuration->System Configuration->Admin Login' and set 'SSO Status' to enabled. If you want to enforce the usage of your SSO policy for login (i.e. disable the username/password), you should disable 'Allow username/password authentication' in this page.
 
-Optionally, you may need to configure the 'Base URL' if your PacketFence captive portal must be accessed under a different named than what is defined in the 'Hostname' and 'Domain' values that are in 'General Configuration'.
+Optionally, you may need to configure the 'SSO Base URL' if your PacketFence captive portal must be accessed under a different named than what is defined in the 'Hostname' and 'Domain' values that are in 'General Configuration'.
 
 Next, you will need to configure a connnection profile for authenticating administrators. Go in 'Configuration->Policies and Access Control->Connection Profiles' and create a new connection profile with these values:
 
@@ -16,7 +16,7 @@ Next, you will need to configure a connnection profile for authenticating admini
  * Filter: URI with value '/admin-sso'
  * Sources: The authentication sources that should be used for the login.
 
-After this, restart `api-frontend` and `httpd.portal` and when accessing the admin interface login page, you should see a new option named 'Single Sign On'. This text can be changed in the 'Admin SSO' configuration section.
+After this, restart `api-frontend` and `httpd.portal` and when accessing the admin interface login page, you should see a new option named 'Single Sign On'. This text can be changed in the 'Admin Login' configuration section.
 
 Any authentication mechanism that can be used on the portal (SAML, Akamai MFA, TOTP, etc) can be used for authenticating administrators using this process. Refer to the appropriate section for each feature in this guide in order to configure them on your connection profile used for authenticating administrators. 
 

--- a/docs/installation/authentication_mechanisms.asciidoc
+++ b/docs/installation/authentication_mechanisms.asciidoc
@@ -641,3 +641,5 @@ include::azuread.asciidoc[]
 
 include::google_workspace_ldap.asciidoc[]
 
+include::advanced_access_control_for_admin_login.asciidoc[]
+

--- a/go/api-frontend/aaa/authentication.go
+++ b/go/api-frontend/aaa/authentication.go
@@ -54,7 +54,11 @@ func (tam *TokenAuthenticationMiddleware) Login(ctx context.Context, username, p
 				return false, "", err
 			}
 
-			tokenInfo.Username = username
+			// Don't set it if it was set by the backend
+			if tokenInfo.Username == "" {
+				tokenInfo.Username = username
+			}
+
 			tam.tokenBackend.StoreTokenInfo(token, tokenInfo)
 			return true, token, nil
 		} else if err != nil {

--- a/go/api-frontend/aaa/portal_authentication_backend.go
+++ b/go/api-frontend/aaa/portal_authentication_backend.go
@@ -1,0 +1,67 @@
+package aaa
+
+import (
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/inverse-inc/go-utils/sharedutils"
+)
+
+type PortalAuthenticationBackend struct {
+	PfAuthenticationBackend
+}
+
+type PortalAuthenticationReply struct {
+	AccessLevel string `json:"access_level"`
+}
+
+func NewPortalAuthenticationBackend(ctx context.Context, url *url.URL, checkCert bool) *PortalAuthenticationBackend {
+	pab := PortalAuthenticationBackend{}
+	pab.PfAuthenticationBackend = *(NewPfAuthenticationBackend(ctx, url, checkCert))
+	return &pab
+}
+
+func (pab *PortalAuthenticationBackend) Authenticate(ctx context.Context, username, password string) (bool, *TokenInfo, error) {
+	req, err := http.NewRequest("GET", pab.url.String()+"?token="+password, nil)
+	sharedutils.CheckError(err)
+	resp, err := pab.httpClient.Do(req)
+	if err != nil {
+		return false, nil, err
+	}
+
+	// Token doesn't exist or is expired
+	if resp.StatusCode != http.StatusOK {
+		return false, nil, nil
+	}
+
+	defer resp.Body.Close()
+	reply := PortalAuthenticationReply{}
+
+	respBody, err := ioutil.ReadAll(resp.Body)
+	sharedutils.CheckError(err)
+
+	err = json.Unmarshal(respBody, &reply)
+	if err != nil {
+		return false, nil, err
+	}
+
+	ti := pab.buildTokenInfo(ctx, &reply)
+
+	return true, ti, nil
+}
+
+func (pab *PortalAuthenticationBackend) buildTokenInfo(ctx context.Context, data *PortalAuthenticationReply) *TokenInfo {
+	adminRolesMap := make(map[string]bool)
+
+	for _, role := range strings.Split(data.AccessLevel, ",") {
+		// Trim it of any leading or suffix spaces
+		role = strings.Trim(role, " ")
+		adminRolesMap[role] = true
+	}
+
+	return &TokenInfo{AdminRoles: adminRolesMap}
+}

--- a/go/api-frontend/aaa/portal_authentication_backend.go
+++ b/go/api-frontend/aaa/portal_authentication_backend.go
@@ -17,6 +17,7 @@ type PortalAuthenticationBackend struct {
 
 type PortalAuthenticationReply struct {
 	AccessLevel string `json:"access_level"`
+	Username    string `json:"pid"`
 }
 
 func NewPortalAuthenticationBackend(ctx context.Context, url *url.URL, checkCert bool) *PortalAuthenticationBackend {
@@ -63,5 +64,5 @@ func (pab *PortalAuthenticationBackend) buildTokenInfo(ctx context.Context, data
 		adminRolesMap[role] = true
 	}
 
-	return &TokenInfo{AdminRoles: adminRolesMap}
+	return &TokenInfo{AdminRoles: adminRolesMap, Username: data.Username}
 }

--- a/go/caddy/api-aaa/api-aaa.go
+++ b/go/caddy/api-aaa/api-aaa.go
@@ -180,7 +180,7 @@ func buildApiAAAHandler(ctx context.Context, tokenBackendArgs []string) (ApiAAAH
 	router := httprouter.New()
 	router.POST("/api/v1/login", apiAAA.handleLogin)
 	router.GET("/api/v1/token_info", apiAAA.handleTokenInfo)
-	router.GET("/api/v1/sso-info", apiAAA.handleSSOInfo)
+	router.GET("/api/v1/sso_info", apiAAA.handleSSOInfo)
 
 	apiAAA.router = router
 

--- a/go/caddy/api-aaa/api-aaa.go
+++ b/go/caddy/api-aaa/api-aaa.go
@@ -173,7 +173,7 @@ func buildApiAAAHandler(ctx context.Context, tokenBackendArgs []string) (ApiAAAH
 	}
 
 	// Backend for username/password auth via the internal auth sources
-	url, err = url.Parse(fmt.Sprintf("%s/api/v1/authentication/admin_authentication", pfconfigdriver.Config.PfConf.ServicesURL.PfperlApi))
+	url, err := url.Parse(fmt.Sprintf("%s/api/v1/authentication/admin_authentication", pfconfigdriver.Config.PfConf.ServicesURL.PfperlApi))
 	sharedutils.CheckError(err)
 	apiAAA.authentication.AddAuthenticationBackend(aaa.NewPfAuthenticationBackend(ctx, url, false))
 

--- a/go/caddy/api-aaa/api-aaa.go
+++ b/go/caddy/api-aaa/api-aaa.go
@@ -166,9 +166,11 @@ func buildApiAAAHandler(ctx context.Context, tokenBackendArgs []string) (ApiAAAH
 	}
 
 	// Backend for SSO
-	url, err := url.Parse(fmt.Sprintf("%s%s", pfconfigdriver.Config.PfConf.AdminSSO.BaseUrl, pfconfigdriver.Config.PfConf.AdminSSO.AuthorizePath))
-	sharedutils.CheckError(err)
-	apiAAA.authentication.AddAuthenticationBackend(aaa.NewPortalAuthenticationBackend(ctx, url, false))
+	if sharedutils.IsEnabled(pfconfigdriver.Config.PfConf.AdminSSO.Status) {
+		url, err := url.Parse(fmt.Sprintf("%s%s", pfconfigdriver.Config.PfConf.AdminSSO.BaseUrl, pfconfigdriver.Config.PfConf.AdminSSO.AuthorizePath))
+		sharedutils.CheckError(err)
+		apiAAA.authentication.AddAuthenticationBackend(aaa.NewPortalAuthenticationBackend(ctx, url, false))
+	}
 
 	// Backend for username/password auth via the internal auth sources
 	url, err = url.Parse(fmt.Sprintf("%s/api/v1/authentication/admin_authentication", pfconfigdriver.Config.PfConf.ServicesURL.PfperlApi))

--- a/go/caddy/api-aaa/api-aaa.go
+++ b/go/caddy/api-aaa/api-aaa.go
@@ -270,9 +270,13 @@ func (h ApiAAAHandler) handleTokenInfo(w http.ResponseWriter, r *http.Request, p
 
 func (h ApiAAAHandler) handleSSOInfo(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 	info := struct {
-		LoginURL string `json:"login_url"`
+		LoginText string `json:"login_text"`
+		LoginURL  string `json:"login_url"`
+		IsEnabled bool   `json:"is_enabled"`
 	}{
-		LoginURL: fmt.Sprintf("%s%s", pfconfigdriver.Config.PfConf.AdminSSO.BaseUrl, pfconfigdriver.Config.PfConf.AdminSSO.LoginPath),
+		LoginText: pfconfigdriver.Config.PfConf.AdminSSO.LoginText,
+		LoginURL:  fmt.Sprintf("%s%s", pfconfigdriver.Config.PfConf.AdminSSO.BaseUrl, pfconfigdriver.Config.PfConf.AdminSSO.LoginPath),
+		IsEnabled: sharedutils.IsEnabled(pfconfigdriver.Config.PfConf.AdminSSO.Status),
 	}
 
 	json.NewEncoder(w).Encode(info)

--- a/go/pfconfigdriver/structs.go
+++ b/go/pfconfigdriver/structs.go
@@ -836,9 +836,11 @@ type PfConfAdminSSO struct {
 	PfconfigMethod string `val:"hash_element"`
 	PfconfigNS     string `val:"config::Pf"`
 	PfconfigHashNS string `val:"admin_sso"`
+	AuthorizePath  string `json:"authorize_path"`
 	BaseUrl        string `json:"base_url"`
 	LoginPath      string `json:"login_path"`
-	AuthorizePath  string `json:"authorize_path"`
+	LoginText      string `json:"login_text"`
+	Status         string `json:"status"`
 }
 
 type Connectors struct {

--- a/go/pfconfigdriver/structs.go
+++ b/go/pfconfigdriver/structs.go
@@ -75,7 +75,7 @@ type configStruct struct {
 		Services      PfConfServices
 		ServicesURL   PfConfServicesURL
 		Pfconnector   PfConfPfconnector
-		AdminSSO      PfConfAdminSSO
+		AdminLogin    PfConfAdminLogin
 	}
 	AdminRoles AdminRoles
 	Cluster    struct {
@@ -831,16 +831,17 @@ type PfConfServicesURL struct {
 	Pfsso                 string `json:"pfsso"`
 }
 
-type PfConfAdminSSO struct {
+type PfConfAdminLogin struct {
 	StructConfig
-	PfconfigMethod string `val:"hash_element"`
-	PfconfigNS     string `val:"config::Pf"`
-	PfconfigHashNS string `val:"admin_sso"`
-	AuthorizePath  string `json:"authorize_path"`
-	BaseUrl        string `json:"base_url"`
-	LoginPath      string `json:"login_path"`
-	LoginText      string `json:"login_text"`
-	Status         string `json:"status"`
+	PfconfigMethod        string `val:"hash_element"`
+	PfconfigNS            string `val:"config::Pf"`
+	PfconfigHashNS        string `val:"admin_login"`
+	SSOAuthorizePath      string `json:"sso_authorize_path"`
+	SSOBaseUrl            string `json:"sso_base_url"`
+	SSOLoginPath          string `json:"sso_login_path"`
+	SSOLoginText          string `json:"sso_login_text"`
+	SSOStatus             string `json:"sso_status"`
+	AllowUsernamePassword string `json:"allow_username_password"`
 }
 
 type Connectors struct {

--- a/go/pfconfigdriver/structs.go
+++ b/go/pfconfigdriver/structs.go
@@ -75,6 +75,7 @@ type configStruct struct {
 		Services      PfConfServices
 		ServicesURL   PfConfServicesURL
 		Pfconnector   PfConfPfconnector
+		AdminSSO      PfConfAdminSSO
 	}
 	AdminRoles AdminRoles
 	Cluster    struct {
@@ -828,6 +829,16 @@ type PfConfServicesURL struct {
 	PfperlApi             string `json:"pfperl-api"`
 	PfdnsDoh              string `json:"pfdns-doh"`
 	Pfsso                 string `json:"pfsso"`
+}
+
+type PfConfAdminSSO struct {
+	StructConfig
+	PfconfigMethod string `val:"hash_element"`
+	PfconfigNS     string `val:"config::Pf"`
+	PfconfigHashNS string `val:"admin_sso"`
+	BaseUrl        string `json:"base_url"`
+	LoginPath      string `json:"login_path"`
+	AuthorizePath  string `json:"authorize_path"`
 }
 
 type Connectors struct {

--- a/html/captive-portal/lib/captiveportal/Base/Actions.pm
+++ b/html/captive-portal/lib/captiveportal/Base/Actions.pm
@@ -45,7 +45,7 @@ our %AUTHENTICATION_ACTIONS = (
     destination_url => sub {$_[0]->app->session->{destination_url} = $_[1];$_[0]->app->session->{portal_module_force_destination_url} = $TRUE},
     unregdate_from_sponsor_source => sub { $_[0]->new_node_info->{unregdate} = $_[0]->session->{unregdate} if defined($_[0]->session->{unregdate}) },
     trigger_portal_mfa => sub { $_[0]->app->session->{mfa_id} = action_authentication_match_wrapper($_[0]->source->id, $_[0]->auth_source_params, $Actions::TRIGGER_PORTAL_MFA, undef, $_[0]->session->{extra}); },
-    set_access_level => sub { $_[0]->new_node_info->{access_level} = action_authentication_match_wrapper($_[0]->source->id, $_[0]->auth_source_params, $Actions::SET_ACCESS_LEVEL); },
+    set_access_level => sub { $_[0]->new_node_info->{access_level} = action_authentication_match_wrapper($_[0]->source->id, {%{$_[0]->auth_source_params}, rule_class => "administration"}, $Actions::SET_ACCESS_LEVEL); },
 );
 
 =head2 action_authentication_match_wrapper

--- a/html/captive-portal/lib/captiveportal/Base/Actions.pm
+++ b/html/captive-portal/lib/captiveportal/Base/Actions.pm
@@ -45,6 +45,7 @@ our %AUTHENTICATION_ACTIONS = (
     destination_url => sub {$_[0]->app->session->{destination_url} = $_[1];$_[0]->app->session->{portal_module_force_destination_url} = $TRUE},
     unregdate_from_sponsor_source => sub { $_[0]->new_node_info->{unregdate} = $_[0]->session->{unregdate} if defined($_[0]->session->{unregdate}) },
     trigger_portal_mfa => sub { $_[0]->app->session->{mfa_id} = action_authentication_match_wrapper($_[0]->source->id, $_[0]->auth_source_params, $Actions::TRIGGER_PORTAL_MFA, undef, $_[0]->session->{extra}); },
+    set_access_level => sub { $_[0]->new_node_info->{access_level} = action_authentication_match_wrapper($_[0]->source->id, $_[0]->auth_source_params, $Actions::SET_ACCESS_LEVEL); },
 );
 
 =head2 action_authentication_match_wrapper

--- a/html/captive-portal/lib/captiveportal/Controller/PortalToken.pm
+++ b/html/captive-portal/lib/captiveportal/Controller/PortalToken.pm
@@ -1,0 +1,44 @@
+package captiveportal::Controller::PortalToken;
+
+use Moose;
+
+BEGIN { extends 'captiveportal::PacketFence::Controller::PortalToken'; }
+
+=head1 NAME
+
+captiveportal::Controller::PortalToken - PortalToken Controller for captiveportal
+
+=head1 DESCRIPTION
+
+[enter your description here]
+
+=cut
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2022 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+__PACKAGE__->meta->make_immutable unless $ENV{"PF_SKIP_MAKE_IMMUTABLE"};

--- a/html/captive-portal/lib/captiveportal/DynamicRouting/Module/RootSession.pm
+++ b/html/captive-portal/lib/captiveportal/DynamicRouting/Module/RootSession.pm
@@ -1,0 +1,46 @@
+package captiveportal::DynamicRouting::Module::RootSession;
+use Moose;
+
+BEGIN { extends 'captiveportal::PacketFence::DynamicRouting::Module::RootSession'; }
+
+=head1 NAME
+
+captiveportal::DynamicRouting::Module::RootSession - Root Controller for captiveportal
+
+=head1 DESCRIPTION
+
+[enter your description here]
+
+=cut
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2022 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+__PACKAGE__->meta->make_immutable unless $ENV{"PF_SKIP_MAKE_IMMUTABLE"};
+
+1;
+

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/PortalToken.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/PortalToken.pm
@@ -1,0 +1,74 @@
+package captiveportal::PacketFence::Controller::PortalToken;
+
+use Moose;
+use Data::Dumper;
+use pf::log;
+use pf::CHI;
+
+BEGIN { extends 'captiveportal::Base::Controller'; }
+
+
+=head1 NAME
+
+captiveportal::PacketFence::Controller::PortalToken - Catalyst Controller
+
+=head1 DESCRIPTION
+
+Catalyst Controller.
+
+=head1 METHODS
+
+=cut
+
+sub cache { return pf::CHI->new(namespace => 'portaladmin'); }
+
+=head2 index
+
+=cut
+
+sub index : Path : Args(0) {
+    my ( $self, $c ) = @_;
+    my $actions = {
+        access_level => "none",
+    };
+
+    if (my $uuid = $c->request->param('token')) {
+        $actions = cache->get($uuid);
+    }
+
+    $c->stash(
+        current_view     => 'JSON',
+        json_content     => $actions,
+    );
+}
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2022 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+__PACKAGE__->meta->make_immutable unless $ENV{"PF_SKIP_MAKE_IMMUTABLE"};
+
+1;

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/PortalToken.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/PortalToken.pm
@@ -28,14 +28,19 @@ sub cache { return pf::CHI->new(namespace => 'portaladmin'); }
 
 sub index : Path : Args(0) {
     my ( $self, $c ) = @_;
-    my $actions = {
-        access_level => "none",
-    };
-
+    my $actions;
     if (my $uuid = $c->request->param('token')) {
         $actions = cache->get($uuid);
+        if (!defined($actions)) {
+            $c->response->status(404);
+            $c->response->body('{ "access_level" => "none" }');
+            $c->response->content_type("application/json");
+        }
+    } else {
+        $c->response->status(404);
+        $c->response->content_type("application/json");
+        $c->response->body('{ "access_level" => "none" }');
     }
-
     $c->stash(
         current_view     => 'JSON',
         json_content     => $actions,

--- a/html/captive-portal/lib/captiveportal/PacketFence/Controller/PortalToken.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/Controller/PortalToken.pm
@@ -1,8 +1,6 @@
 package captiveportal::PacketFence::Controller::PortalToken;
 
 use Moose;
-use Data::Dumper;
-use pf::log;
 use pf::CHI;
 
 BEGIN { extends 'captiveportal::Base::Controller'; }

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Application.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Application.pm
@@ -33,6 +33,8 @@ use pf::file_paths qw($install_dir);
 use pf::config qw(%Config);
 use pf::activation;
 use fingerbank::Config;
+use captiveportal::DynamicRouting::Module::Root;
+use captiveportal::DynamicRouting::Module::RootSession;
 
 has 'session' => (is => 'rw', required => 1);
 

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Application.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Application.pm
@@ -38,7 +38,7 @@ has 'session' => (is => 'rw', required => 1);
 
 has 'user_session' => (is => 'rw', required => 1);
 
-has 'root_module' => (is => 'rw', isa => "captiveportal::DynamicRouting::Module::Root");
+has 'root_module' => (is => 'rw', isa => "captiveportal::DynamicRouting::Module::Root|captiveportal::DynamicRouting::Module::RootSession");
 
 has 'root_module_id' => (is => 'rw');
 
@@ -580,6 +580,17 @@ Whether or not we are currently doing pre-registration
 sub preregistration {
     my ($self) = @_;
     return isenabled($self->profile->{_preregistration});
+}
+
+=head2 isrootsession
+
+return $TRUE if the root module ia a RootSession
+
+=cut
+
+sub isrootsession {
+    my ($self) = @_;
+    return $self->isa("captiveportal::DynamicRouting::Module::RootSession")
 }
 
 =head1 AUTHOR

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Application.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Application.pm
@@ -592,7 +592,7 @@ return $TRUE if the root module ia a RootSession
 
 sub isrootsession {
     my ($self) = @_;
-    return $self->isa("captiveportal::DynamicRouting::Module::RootSession")
+    return $self->root_module->isa("captiveportal::DynamicRouting::Module::RootSession")
 }
 
 =head1 AUTHOR

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Application.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Application.pm
@@ -377,6 +377,7 @@ sub render {
     my %saved_fields = %{$self->session->{saved_fields}} if (defined ($self->session->{saved_fields}) );
 
     my $layout_args = {
+        isrootsession => $self->isrootsession,
         flash => $self->flash,
         content => $inner_content,
         client_mac => $self->current_mac,

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module.pm
@@ -77,6 +77,7 @@ sub available_actions {
         'set_time_balance',
         'set_bandwidth_balance',
         'destination_url',
+        'set_access_level',
     ];
 }
 

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module.pm
@@ -42,6 +42,8 @@ has username => (is => 'rw', builder => '_build_username', lazy => 1, trigger =>
 
 has renderer => (is => 'rw');
 
+has uuid => (is => 'rw');
+
 has 'actions' => ('is' => 'rw', isa => 'HashRef', default => sub {{}});
 
 =head2 BUILD

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication.pm
@@ -42,7 +42,7 @@ has 'with_aup' => ('is' => 'rw', default => sub {1});
 
 has 'aup_template' => (is => 'rw', default => sub {'aup_text.html'});
 
-has '+actions' => (default => sub {{"trigger_portal_mfa" => [], "on_success" => [], "on_failure" => [], "destination_url" => [], "role_from_source" => [], "unregdate_from_source" => [], "time_balance_from_source" => [], "bandwidth_balance_from_source" => [], "unregdate_from_sponsor_source" => []}});
+has '+actions' => (default => sub {{ "set_access_level" => [], "trigger_portal_mfa" => [], "on_success" => [], "on_failure" => [], "destination_url" => [], "role_from_source" => [], "unregdate_from_source" => [], "time_balance_from_source" => [], "bandwidth_balance_from_source" => [], "unregdate_from_sponsor_source" => []}});
 
 has 'signup_template' => ('is' => 'rw', default => sub {'signin.html'});
 
@@ -70,6 +70,7 @@ sub available_actions {
         'on_success',
         'unregdate_from_sponsor_source',
         'trigger_portal_mfa',
+        'set_access_level',
     ];
 }
 

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication.pm
@@ -152,6 +152,10 @@ sub execute_actions {
 
     $self->SUPER::execute_actions();
 
+    if ($self->app->isrootsession and defined($self->new_node_info->{access_level})) {
+        get_logger->debug(sub { use Data::Dumper; "new_node_info after auth module actions : ".Dumper($self->new_node_info) });
+        return $TRUE;
+    }
     unless(
         defined($self->new_node_info->{category}) && 
         $self->new_node_info->{category} ne $REJECT_ROLE && 

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/SAML.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/SAML.pm
@@ -74,7 +74,7 @@ sub redirect {
     my ($self) = @_;
     if(!$self->with_aup || $self->request_fields->{aup}){
         pf::auth_log::record_oauth_attempt($self->source->id, $self->current_mac, $self->app->profile->name);
-        $self->app->redirect($self->source->sso_url);
+        $self->app->redirect($self->source->sso_url($self->app->request->cookie("CGISESSION")->value));
     }
     else {
         $self->app->flash->{error} = "You must accept the terms and conditions";

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/MFA.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/MFA.pm
@@ -116,7 +116,7 @@ sub execute_child {
         }
     }
     else {
-        my $info = $mfa->redirect_info($self->username, $self->app->session->{'captiveportal::Model::Portal::Session'}->{'dispatcherSession'}->{'_session_id'});
+        my $info = $mfa->redirect_info($self->username, $self->app->session->{'captiveportal::Model::Portal::Session'}->{'dispatcherSession'}->{'_session_id'}, $self->app->request->cookie("CGISESSION")->value);
         $self->show_mfa($info);
     }
 }

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/RootSession.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/RootSession.pm
@@ -76,7 +76,7 @@ sub release {
     my ($self) = @_;
 
     my $lang = $self->app->session->{lang} // "";
-    return $self->app->redirect($self->app->session->{callback}."/?token=".$self->{root_session_token});
+    return $self->app->redirect($self->app->session->{callback}."?token=".$self->{root_session_token});
 }
 
 =head2 execute_child

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/RootSession.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/RootSession.pm
@@ -102,6 +102,7 @@ sub execute_actions {
     my $token = unpack("H*", $rand->bytes(32));
     cache->set($token, $self->new_node_info);
     $self->{root_session_token} = $token;
+    return 1;
 }
 
 =head1 AUTHOR

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/RootSession.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/RootSession.pm
@@ -1,0 +1,165 @@
+package captiveportal::PacketFence::DynamicRouting::Module::RootSession;
+
+=head1 NAME
+
+DynamicRouting::RootModule
+
+=head1 DESCRIPTION
+
+Root module for Dynamic Routing
+
+=cut
+
+use Moose;
+extends 'captiveportal::DynamicRouting::Module::Chained';
+with 'captiveportal::Role::Routed';
+
+has '+route_map' => (default => sub {
+    tie my %map, 'Tie::IxHash', (
+        '/logout' => \&logout,
+        '/access' => \&release,
+        '/record_destination_url' => \&record_destination_url,
+    );
+    return \%map;
+
+});
+
+use pf::log;
+use pf::node;
+use pf::config qw($default_pid);
+use pf::constants qw($TRUE $FALSE);
+use pf::util;
+use pf::Portal::Session;
+use pf::CHI;
+
+sub cache { return pf::CHI->new(namespace => 'portaladmin'); }
+
+has '+parent' => (required => 0);
+
+=head2 around done
+
+Once this is done, we release the user on the network
+
+=cut
+
+around 'done' => sub {
+    my ($orig, $self) = @_;
+    if($self->execute_actions()){
+        $self->release();
+    }
+    else {
+        $self->app->reset_session();
+        $self->redirect_root();
+    }
+};
+
+=head2 logout
+
+Logout of the captive portal
+
+=cut
+
+sub logout {
+    my ($self) = @_;
+    $self->app->reset_session;
+    $self->redirect_root();
+}
+
+=head2 release
+
+Reevaluate the access of the user and show the release page
+
+=cut
+
+sub release {
+    my ($self) = @_;
+
+    my $lang = $self->app->session->{lang} // "";
+    return $self->app->redirect("http://" . $self->app->request->header("host") . "/access?lang=$lang") unless($self->app->request->path eq "access");
+
+    get_logger->info("Releasing device");
+    # Redirect call-back
+    #
+    $self->app->reset_session;
+    $self->render("release.html", $self->_release_args());
+}
+
+=head2 execute_child
+
+Execute the flow for this module
+
+=cut
+
+sub execute_child {
+    my ($self) = @_;
+
+    # The user should be released, he is already registered and doesn't have any security_event
+    # HACK alert : E-mail registration has the user registered but still going in the portal
+    # release_bypass is there for that. If it is set, it will keep the user in the portal
+    if (!defined($self->app->session->{release_bypass})) {
+        $self->app->session->{release_bypass} = $TRUE;
+    }
+    if($self->app->profile->canAccessRegistrationWhenRegistered() && $self->app->session->{release_bypass}) {
+        get_logger->info("Allowing user through portal even though he is registered as the release bypass is set and the connection profile is configured to let registered users use the registration module of the portal.");
+    }
+    $self->SUPER::execute_child();
+}
+
+=head2 execute_actions
+
+Register the device and apply the new node info
+
+=cut
+
+sub execute_actions {
+    my ($self) = @_;
+    # Here we put the stuff in redis for the api (like cookie session => blablabla)
+    #if (exists $self->node_info->{access_level}) {
+    # Set in cache...
+    #}
+}
+
+=head2 record_destination_url
+
+Record the destination URL wanted by the user
+
+=cut
+
+sub record_destination_url {
+    my ($self) = @_;
+    $self->app->session->{user_destination_url} = $self->app->request->param('destination_url');
+    $self->app->response_code(200);
+    $self->app->template_output('');
+}
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2022 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+__PACKAGE__->meta->make_immutable unless $ENV{"PF_SKIP_MAKE_IMMUTABLE"};
+
+1;
+

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/RootSession.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/RootSession.pm
@@ -56,8 +56,9 @@ Logout of the captive portal
 
 sub logout {
     my ($self) = @_;
+    my $callback = $self->app->session->{callback};
     $self->app->reset_session;
-    $self->redirect_root();
+    $self->app->redirect($callback."?error=canceled");
 }
 
 =head2 release
@@ -101,7 +102,6 @@ sub execute_actions {
     my $token = unpack("H*", $rand->bytes(32));
     cache->set($token, $self->new_node_info);
     $self->{root_session_token} = $token;
-    return $TRUE;
 }
 
 =head1 AUTHOR

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/RootSession.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/RootSession.pm
@@ -31,6 +31,7 @@ use pf::constants qw($TRUE $FALSE);
 use pf::util;
 use pf::Portal::Session;
 use pf::CHI;
+use Data::UUID;
 
 sub cache { return pf::CHI->new(namespace => 'portaladmin'); }
 
@@ -113,10 +114,10 @@ Register the device and apply the new node info
 
 sub execute_actions {
     my ($self) = @_;
-    # Here we put the stuff in redis for the api (like cookie session => blablabla)
-    #if (exists $self->node_info->{access_level}) {
-    # Set in cache...
-    #}
+    my $ug    = Data::UUID->new;
+    my $uuid = $ug->to_string($ug->create());
+    cache->set($uuid, $self->new_node_info);
+    $self->{uuid} = $uuid;
 }
 
 =head2 record_destination_url

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/RootSession.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/RootSession.pm
@@ -76,13 +76,7 @@ sub release {
     my ($self) = @_;
 
     my $lang = $self->app->session->{lang} // "";
-    return $self->app->redirect("http://" . $self->app->request->header("host") . "/access?lang=$lang") unless($self->app->request->path eq "access");
-
-    get_logger->info("Releasing device");
-    # Redirect call-back
-    #
-    $self->app->reset_session;
-    $self->render("release.html", $self->_release_args());
+    return $self->app->redirect($self->app->session->{callback}."/".$self->uuid);
 }
 
 =head2 execute_child
@@ -93,16 +87,10 @@ Execute the flow for this module
 
 sub execute_child {
     my ($self) = @_;
+    if ($self->app->request->param('callback')) {
+        $self->app->session->{callback} = $self->app->request->param('callback');
+    }
 
-    # The user should be released, he is already registered and doesn't have any security_event
-    # HACK alert : E-mail registration has the user registered but still going in the portal
-    # release_bypass is there for that. If it is set, it will keep the user in the portal
-    if (!defined($self->app->session->{release_bypass})) {
-        $self->app->session->{release_bypass} = $TRUE;
-    }
-    if($self->app->profile->canAccessRegistrationWhenRegistered() && $self->app->session->{release_bypass}) {
-        get_logger->info("Allowing user through portal even though he is registered as the release bypass is set and the connection profile is configured to let registered users use the registration module of the portal.");
-    }
     $self->SUPER::execute_child();
 }
 

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/RootSession.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/RootSession.pm
@@ -76,7 +76,7 @@ sub release {
     my ($self) = @_;
 
     my $lang = $self->app->session->{lang} // "";
-    return $self->app->redirect($self->app->session->{callback}."/".$self->uuid);
+    return $self->app->redirect($self->app->session->{callback}."/?token=".$self->uuid);
 }
 
 =head2 execute_child

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/RootSession.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/RootSession.pm
@@ -31,7 +31,6 @@ use pf::constants qw($TRUE $FALSE);
 use pf::util;
 use pf::Portal::Session;
 use pf::CHI;
-use Data::UUID;
 
 sub cache { return pf::CHI->new(namespace => 'portaladmin'); }
 
@@ -103,7 +102,7 @@ Register the device and apply the new node info
 sub execute_actions {
     my ($self) = @_;
     my $ug    = Data::UUID->new;
-    my $uuid = $ug->to_string($ug->create());
+    my $uuid = pf::util::get_uuid();
     cache->set($uuid, $self->new_node_info);
     $self->{uuid} = $uuid;
 }

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/RootSession.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/RootSession.pm
@@ -17,19 +17,13 @@ with 'captiveportal::Role::Routed';
 has '+route_map' => (default => sub {
     tie my %map, 'Tie::IxHash', (
         '/logout' => \&logout,
-        '/access' => \&release,
-        '/record_destination_url' => \&record_destination_url,
     );
     return \%map;
 
 });
 
 use pf::log;
-use pf::node;
-use pf::config qw($default_pid);
-use pf::constants qw($TRUE $FALSE);
 use pf::util;
-use pf::Portal::Session;
 use pf::CHI;
 use Bytes::Random::Secure;
 
@@ -74,8 +68,6 @@ Reevaluate the access of the user and show the release page
 
 sub release {
     my ($self) = @_;
-
-    my $lang = $self->app->session->{lang} // "";
     return $self->app->redirect($self->app->session->{callback}."?token=".$self->{root_session_token});
 }
 
@@ -110,19 +102,6 @@ sub execute_actions {
     cache->set($token, $self->new_node_info);
     $self->{root_session_token} = $token;
     return $TRUE;
-}
-
-=head2 record_destination_url
-
-Record the destination URL wanted by the user
-
-=cut
-
-sub record_destination_url {
-    my ($self) = @_;
-    $self->app->session->{user_destination_url} = $self->app->request->param('destination_url');
-    $self->app->response_code(200);
-    $self->app->template_output('');
 }
 
 =head1 AUTHOR

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/RootSession.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/RootSession.pm
@@ -25,6 +25,7 @@ has '+route_map' => (default => sub {
 use pf::log;
 use pf::util;
 use pf::CHI;
+use pf::constants qw($TRUE);
 use Bytes::Random::Secure;
 
 sub cache { return pf::CHI->new(namespace => 'portaladmin'); }
@@ -102,7 +103,7 @@ sub execute_actions {
     my $token = unpack("H*", $rand->bytes(32));
     cache->set($token, $self->new_node_info);
     $self->{root_session_token} = $token;
-    return 1;
+    return $TRUE;
 }
 
 =head1 AUTHOR

--- a/html/captive-portal/lib/captiveportal/PacketFence/View/JSON.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/View/JSON.pm
@@ -1,0 +1,57 @@
+package captiveportal::PacketFence::View::JSON;
+
+use strict;
+use warnings;
+use Moose;
+
+extends 'Catalyst::View::JSON';
+
+__PACKAGE__->config(
+    {
+        allow_callback  => 0,
+        callback_param  => 'callback',
+        expose_stash    => 'json_content',
+        json_encoder_args => +{ allow_blessed => 1, convert_blessed => 1},
+    },
+);
+
+=head1 NAME
+
+captiveportal::View::HTML - JSON View for captiveportal
+
+=head1 DESCRIPTION
+
+JSON View for captiveportal.
+
+=head1 SEE ALSO
+
+L<captiveportal>
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2022 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;

--- a/html/captive-portal/lib/captiveportal/View/JSON.pm
+++ b/html/captive-portal/lib/captiveportal/View/JSON.pm
@@ -1,0 +1,47 @@
+package captiveportal::View::JSON;
+
+use strict;
+use warnings;
+use Moose;
+BEGIN { extends 'captiveportal::PacketFence::View::JSON'; }
+
+=head1 NAME
+
+captiveportal::View::JSON - JSON View for captiveportal
+
+=head1 DESCRIPTION
+
+JSON View for captiveportal.
+
+=head1 SEE ALSO
+
+L<captiveportal>
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2022 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;

--- a/html/captive-portal/templates/layout.html
+++ b/html/captive-portal/templates/layout.html
@@ -83,7 +83,9 @@
           <div class="o-pack__item o-layout--center">
             <p class="text-p3">[% i18n("help: provide info") %]</p>
             <p class="text-p3 u-margin-none">IP <b>[% client_ip %]</b></p>
+            [% UNLESS isrootsession %]
             <p class="text-p3">MAC <b>[% client_mac %]</b></p>
+            [% END %]
           </div>
         </div>
         <!-- <div class="o-box u-padding-tiny u-padding@tablet">

--- a/html/pfappserver/lib/pfappserver/Form/Config/PortalModule/RootSession.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/PortalModule/RootSession.pm
@@ -1,0 +1,57 @@
+package pfappserver::Form::Config::PortalModule::RootSession;
+
+=head1 NAME
+
+pfappserver::Form::Config::PortalModule:RootSession
+
+=head1 DESCRIPTION
+
+Form definition to create or update a root portal module based on session.
+
+=cut
+
+use HTML::FormHandler::Moose;
+extends 'pfappserver::Form::Config::PortalModule::Chained';
+with 'pfappserver::Base::Form::Role::Help';
+
+use captiveportal::DynamicRouting::Module::RootSession;
+sub for_module {'captiveportal::PacketFence::DynamicRouting::Module::RootSession'}
+
+## Definition
+
+before 'setup' => sub {
+    my ($self) = @_;
+    $self->remove_field("actions");
+};
+
+=over
+
+=back
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2022 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+__PACKAGE__->meta->make_immutable unless $ENV{"PF_SKIP_MAKE_IMMUTABLE"};
+1;
+
+

--- a/html/pfappserver/lib/pfappserver/Form/Config/ProfileCommon.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/ProfileCommon.pm
@@ -656,7 +656,7 @@ Returns the list of root modules to be displayed
 
 sub options_root_module {
     my $cs = pf::ConfigStore::PortalModule->new;
-    return map { $_->{type} eq "Root" ? { value => $_->{id}, label => $_->{description} } : () } @{$cs->readAll("id")};
+    return map { ($_->{type} eq "Root" || $_->{type} eq 'RootSession')  ? { value => $_->{id}, label => $_->{description} } : () } @{$cs->readAll("id")};
 }
 
 =head2 options_vlan_pool

--- a/html/pfappserver/root/src/components/AppLogin.vue
+++ b/html/pfappserver/root/src/components/AppLogin.vue
@@ -20,22 +20,31 @@
         </template>
       </component>
       <template v-slot:[footerSlotName]>
-        <b-dropdown variant="link" class="float-right" :text="$t(currentLanguage.label)">
-          <b-dropdown-item v-for="language in languages" :key="language.locale"
-            :disabled="language.locale === $i18n.locale"
-            @click="setLanguage(language.locale)"
-            >{{ $t(language.label) }}</b-dropdown-item>
-        </b-dropdown>
-        <template v-if="sessionTime">
-          <b-link variant="outline-secondary" @click="onLogout">{{ $t('Logout now') }}</b-link>
-          <b-button class="ml-2" variant="primary" @click="onExtendSession" v-t="'Extend Session'" />
-        </template>
-        <template v-else>
-          <b-link variant="outline-secondary" @click="onLogout" v-if="modal">{{ $t('Use a different username') }}</b-link>
-          <base-button-save type="submit" :isLoading="isLoading" :disabled="!validForm" variant="primary">
-            {{ $t('Login') }}
-          </base-button-save>
-        </template>
+        <b-row align-h="between">
+          <b-col>
+            <template v-if="sessionTime">
+              <b-link variant="outline-secondary" @click="onLogout">{{ $t('Logout now') }}</b-link>
+              <b-button class="ml-2" variant="primary" @click="onExtendSession" v-t="'Extend Session'" />
+            </template>
+            <template v-else>
+              <b-link variant="outline-secondary" @click="onLogout" v-if="modal">{{ $t('Use a different username') }}</b-link>
+              <base-button-save type="submit" :isLoading="isLoading" :disabled="!validForm" class="ml-1" variant="primary">
+                {{ $t('Login') }}
+              </base-button-save>
+            </template>
+          </b-col>
+          <b-col class="text-right">
+            <b-dropdown class="ml-1" variant="link" :text="$t(currentLanguage.label)">
+              <b-dropdown-item v-for="language in languages" :key="language.locale"
+                :disabled="language.locale === $i18n.locale"
+                @click="setLanguage(language.locale)"
+                >{{ $t(language.label) }}</b-dropdown-item>
+            </b-dropdown>
+            <b-button v-if="ssoLoginUrl" :href="ssoLoginUrl" class="ml-1" variant="outline-primary">
+              {{ $t('Single Sign On') }} <icon class="ml-1" name="user-lock" />
+            </b-button>
+          </b-col>
+        </b-row>
       </template>
     </component>
   </b-form>
@@ -84,6 +93,7 @@ const setup = (props, context) => {
   const isSessionAlive = computed(() => $store.getters['session/getSessionTime']() !== false)
   const isLoading = computed(() => $store.getters['session/isLoading'])
   const validForm = computed(() => username.value.length > 0 && password.value.length > 0 && !isLoading.value)
+  const ssoLoginUrl = computed(() => $store.getters['session/ssoLoginUrl'])
 
   onMounted(() => {
     if ($router.currentRoute.path === '/logout') {
@@ -103,6 +113,7 @@ const setup = (props, context) => {
       // Watch for session state change from external sources
       watch(isSessionAlive, updateSessionTimeVerified)
     }
+    $store.dispatch('session/getSsoInfo')
   })
 
   let sessionTimer
@@ -211,7 +222,9 @@ const setup = (props, context) => {
 
     languages,
     currentLanguage,
-    setLanguage
+    setLanguage,
+
+    ssoLoginUrl
   }
 }
 

--- a/html/pfappserver/root/src/components/AppLogin.vue
+++ b/html/pfappserver/root/src/components/AppLogin.vue
@@ -3,20 +3,22 @@
     <component :is="modal?'b-modal':'b-card'" v-model="showModal"
       static lazy no-close-on-esc no-close-on-backdrop hide-header-close no-body>
       <template v-slot:[headerSlotName]>
-        <b-row align-h="between" align-v="center" class="text-nowrap">
-          <b-col cols="auto">
-            <h4 class="mb-0" v-if="sessionTime" v-t="'Your session will expire soon'" />
-            <h4 class="mb-0" v-else v-t="'PacketFence Administration Login'" />
-          </b-col>
-          <b-col cols="auto" class="text-right">
-            <b-dropdown class="ml-1" variant="link" :text="$t(currentLanguage.label)">
-              <b-dropdown-item v-for="language in languages" :key="language.locale"
-                :disabled="language.locale === $i18n.locale"
-                @click="setLanguage(language.locale)"
-                >{{ $t(language.label) }}</b-dropdown-item>
-            </b-dropdown>
-          </b-col>
-        </b-row>
+        <b-container fluid class="px-0">
+          <b-row align-h="between" align-v="center" class="text-nowrap">
+            <b-col cols="9" md="9">
+              <h4 class="mb-0" v-if="sessionTime" v-t="'Your session will expire soon'" />
+              <h4 class="mb-0" v-else v-t="'PacketFence Administration Login'" />
+            </b-col>
+            <b-col cols="auto" md="auto" class="ml-auto text-right">
+              <b-dropdown variant="link" :text="$t(currentLanguage.label)">
+                <b-dropdown-item v-for="language in languages" :key="language.locale"
+                  :disabled="language.locale === $i18n.locale"
+                  @click="setLanguage(language.locale)"
+                  >{{ $t(language.label) }}</b-dropdown-item>
+              </b-dropdown>
+            </b-col>
+          </b-row>
+        </b-container>
       </template>
       <component :is="modal?'div':'b-card-body'">
         <b-alert :variant="message.level" :show="!!message.text" fade>
@@ -32,26 +34,28 @@
         </template>
       </component>
       <template v-slot:[footerSlotName]>
-        <b-row align-h="between">
-          <b-col cols="auto">
-            <template v-if="sessionTime">
-              <b-link variant="outline-secondary" @click="onLogout">{{ $t('Logout now') }}</b-link>
-              <b-button class="ml-2" variant="primary" @click="onExtendSession" v-t="'Extend Session'" />
-            </template>
-            <template v-else>
-              <base-button-save type="submit" :isLoading="isLoading" :disabled="!validForm" class="ml-1" variant="primary">
-                {{ $t('Login') }}
-              </base-button-save>
-              <b-link class="ml-1" variant="outline-secondary" @click="onLogout" v-if="modal">{{ $t('Use a different username') }}</b-link>
-            </template>
-          </b-col>
-          <b-col v-if="ssoEnabled"
-            cols="auto" class="text-right">
-            <b-button :href="ssoLoginUrl" class="ml-1" variant="outline-primary">
-              {{ $t(ssoLoginButtonText) }} <icon class="ml-1" name="user-lock" />
-            </b-button>
-          </b-col>
-        </b-row>
+        <b-container fluid class="px-0">
+          <b-row align-h="between">
+            <b-col cols="auto" md="auto" class="mr-auto">
+              <template v-if="sessionTime">
+                <b-link variant="outline-secondary" @click="onLogout">{{ $t('Logout now') }}</b-link>
+                <b-button class="ml-2" variant="primary" @click="onExtendSession" v-t="'Extend Session'" />
+              </template>
+              <template v-else>
+                <base-button-save type="submit" :isLoading="isLoading" :disabled="!validForm" variant="primary">
+                  {{ $t('Login') }}
+                </base-button-save>
+                <b-link class="ml-2" variant="outline-secondary" @click="onLogout" v-if="modal">{{ $t('Use a different username') }}</b-link>
+              </template>
+            </b-col>
+            <b-col v-if="!sessionTime && ssoEnabled"
+              cols="5" md="5" class="text-right">
+              <b-button :href="ssoLoginUrl" variant="outline-primary">
+                {{ $t(ssoLoginButtonText) }} <icon class="ml-1" name="user-lock" />
+              </b-button>
+            </b-col>
+          </b-row>
+        </b-container>
       </template>
     </component>
   </b-form>

--- a/html/pfappserver/root/src/components/AppLogin.vue
+++ b/html/pfappserver/root/src/components/AppLogin.vue
@@ -130,7 +130,7 @@ const setup = (props, context) => {
       // Watch for session state change from external sources
       watch(isSessionAlive, updateSessionTimeVerified)
     }
-    $store.dispatch('session/getSsoInfo').then(() => {
+    $store.dispatch('session/getSsoInfo', true).then(() => {
       if (ssoEnabled.value && 'token' in $router.currentRoute.query) {
         doLogin(null, $router.currentRoute.query.token)
       }

--- a/html/pfappserver/root/src/components/AppLogin.vue
+++ b/html/pfappserver/root/src/components/AppLogin.vue
@@ -126,10 +126,11 @@ const setup = (props, context) => {
       // Watch for session state change from external sources
       watch(isSessionAlive, updateSessionTimeVerified)
     }
-    $store.dispatch('session/getSsoInfo')
-    if ('token' in $router.currentRoute.query) {
-      doLogin(null, $router.currentRoute.query.token)
-    }
+    $store.dispatch('session/getSsoInfo').then(() => {
+      if (ssoEnabled.value && 'token' in $router.currentRoute.query) {
+        doLogin(null, $router.currentRoute.query.token)
+      }
+    })
   })
 
   const doLogin = (username, password) => {

--- a/html/pfappserver/root/src/store/modules/pfqueue.js
+++ b/html/pfappserver/root/src/store/modules/pfqueue.js
@@ -20,7 +20,7 @@ const pollTaskStatus = ({ task_id, headers }) => {
       delete retries[task_id]
     return response.data
   }).catch(error => {
-    if (error.response && error.code !== 'ERR_NETWORK') { // The request was made and a response with a status code was received
+    if (error.response && !['ERR_BAD_RESPONSE', 'ERR_NETWORK'].includes(error)) { // The request was made and a response with a status code was received
       throw error
     }
     else {

--- a/html/pfappserver/root/src/store/modules/pfqueue.js
+++ b/html/pfappserver/root/src/store/modules/pfqueue.js
@@ -20,7 +20,7 @@ const pollTaskStatus = ({ task_id, headers }) => {
       delete retries[task_id]
     return response.data
   }).catch(error => {
-    if (error.response && !['ERR_BAD_RESPONSE', 'ERR_NETWORK'].includes(error)) { // The request was made and a response with a status code was received
+    if (error.response && !['ERR_BAD_RESPONSE', 'ERR_NETWORK'].includes(error.code)) { // The request was made and a response with a status code was received
       throw error
     }
     else {

--- a/html/pfappserver/root/src/store/modules/session.js
+++ b/html/pfappserver/root/src/store/modules/session.js
@@ -24,6 +24,9 @@ const api = {
     if (readonly) url += '?no-expiration-extension=1'
     return apiCall.getQuiet(url)
   },
+  getSsoInfo: () => {
+    return apiCall.getQuiet('sso_info')
+  },
   getLanguage: (locale) => {
     return apiCall.get(`translation/${locale}`)
   },
@@ -87,7 +90,8 @@ const initialState = () => {
     allowedUserRoles: false,
     allowedUserRolesStatus: '',
     allowedUserUnregDate: false,
-    allowedUserUnregDateStatus: ''
+    allowedUserUnregDateStatus: '',
+    ssoInfo: false
   }
 }
 
@@ -132,7 +136,8 @@ const getters = {
   allowedUserRolesList: state => (state.allowedUserRoles || []).map(role => { return { value: role.category_id, text: `${role.name} - ${role.notes}` } }),
   allowedUserUnregDate: state => state.allowedUserUnregDate || [],
   aclContext: state => state.roles || [],
-  configuratorEnabled: state => state.configuratorEnabled
+  configuratorEnabled: state => state.configuratorEnabled,
+  ssoLoginUrl: state => state.ssoInfo.login_url || false,
 }
 
 const actions = {
@@ -220,6 +225,14 @@ const actions = {
       commit('USERNAME_UPDATED', response.data.item.username)
       commit('EXPIRES_AT_UPDATED', response.data.item.expires_at)
       return response.data.item.admin_actions // return ACLs
+    })
+  },
+  getSsoInfo: ({ state, commit }) => {
+    if (state.ssoInfo) {
+      return Promise.resolve(state.ssoInfo)
+    }
+    return api.getSsoInfo().then(response => {
+      commit('SSO_INFO_UPDATED', response.data)
     })
   },
   setLanguage: ({ state, commit }, params) => {
@@ -461,6 +474,9 @@ const mutations = {
   },
   LANGUAGES_UPDATED: (state, languages) => {
     state.languages = languages
+  },
+  SSO_INFO_UPDATED: (state, ssoInfo) => {
+    state.ssoInfo = ssoInfo
   },
   // eslint-disable-next-line no-unused-vars
   $RESET: (state) => {

--- a/html/pfappserver/root/src/store/modules/session.js
+++ b/html/pfappserver/root/src/store/modules/session.js
@@ -137,7 +137,9 @@ const getters = {
   allowedUserUnregDate: state => state.allowedUserUnregDate || [],
   aclContext: state => state.roles || [],
   configuratorEnabled: state => state.configuratorEnabled,
+  ssoEnabled: state => state.ssoInfo.is_enabled || false,
   ssoLoginUrl: state => state.ssoInfo.login_url || false,
+  ssoLoginButtonText: state => state.ssoInfo.login_text || 'Single Sign On', // i18n defer
 }
 
 const actions = {

--- a/html/pfappserver/root/src/store/modules/session.js
+++ b/html/pfappserver/root/src/store/modules/session.js
@@ -229,8 +229,8 @@ const actions = {
       return response.data.item.admin_actions // return ACLs
     })
   },
-  getSsoInfo: ({ state, commit }) => {
-    if (state.ssoInfo) {
+  getSsoInfo: ({ state, commit }, ignoreCache = false) => {
+    if (!ignoreCache && state.ssoInfo) {
       return Promise.resolve(state.ssoInfo)
     }
     return api.getSsoInfo().then(response => {

--- a/html/pfappserver/root/src/views/Configuration/_router/index.js
+++ b/html/pfappserver/root/src/views/Configuration/_router/index.js
@@ -61,6 +61,7 @@ import DatabaseRoutes from '../database/_router'
 import ActiveActiveRoutes from '../activeActive/_router'
 import RadiusRoutes from '../radius/_router'
 import DnsRoutes from '../dns/_router'
+import AdminLoginRoutes from '../adminLogin/_router'
 import AdminRolesRoutes from '../adminRoles/_router'
 import ConnectorsRoutes from '../connectors/_router'
 
@@ -173,6 +174,7 @@ const route = {
     ...ActiveActiveRoutes,
     ...RadiusRoutes,
     ...DnsRoutes,
+    ...AdminLoginRoutes,
     ...AdminRolesRoutes,
     ...SslCertificatesRoutes,
     ...ConnectorsRoutes

--- a/html/pfappserver/root/src/views/Configuration/adminLogin/_components/AlertServices.vue
+++ b/html/pfappserver/root/src/views/Configuration/adminLogin/_components/AlertServices.vue
@@ -1,8 +1,8 @@
 <template>
   <b-alert :show="isModified" variant="warning" fade>
     <h4 class="alert-heading" v-t="'Warning'" />
-    <p v-html="$t('Modifying the general configuration requires to restart the haproxy-portal service.')" />
-    <base-button-service service="haproxy-portal" restart start stop
+    <p v-html="$t('Modifying the admin login configuration requires to restart the api-frontend service.')" />
+    <base-button-service service="api-frontend" restart start stop
       :disabled="isLoading" class="mr-1" size="sm"/>
   </b-alert>
 </template>

--- a/html/pfappserver/root/src/views/Configuration/adminLogin/_components/TheForm.vue
+++ b/html/pfappserver/root/src/views/Configuration/adminLogin/_components/TheForm.vue
@@ -7,26 +7,32 @@
   >
     <form-group-sso-status namespace="sso_status"
       :column-label="$i18n.t('SSO Status')"
-    />
-
-    <form-group-sso-authorize-path namespace="sso_authorize_path"
-      :column-label="$i18n.t('SSO Authorize Path')"
+      :text="$i18n.t('Whether or not SSO should be enabled for the admin interface login. Changing this requires to restart the api-frontend service.')"
     />
 
     <form-group-sso-base-url namespace="sso_base_url"
       :column-label="$i18n.t('SSO Base URL')"
+      :text="$i18n.t('The base URL of the SSO server. If left empty, it will default to the hostname and domain (`hostname.domain`) defined in the general settings. Change this if your portal is bound to another domain name.')"
     />
 
     <form-group-sso-login-path namespace="sso_login_path"
       :column-label="$i18n.t('SSO Login Path')"
+      :text="$i18n.t('The path to redirect the user to in order to perform the SSO login.')"
     />
 
     <form-group-sso-login-text namespace="sso_login_text"
       :column-label="$i18n.t('SSO Login Button Text')"
+      :text="$i18n.t('The text to display in the SSO login button in the admin interface.')"
+    />
+
+    <form-group-sso-authorize-path namespace="sso_authorize_path"
+      :column-label="$i18n.t('SSO Authorize Path')"
+      :text="$i18n.t('The path to obtain the authorization data after the SSO.')"
     />
 
     <form-group-allow-username-password namespace="allow_username_password"
       :column-label="$i18n.t('Allow SSO username and password')"
+      :text="$i18n.t('Whether or not username/password authentication is allowed for the admin interface login. Disabling this will force users to use SSO. Changing this requires to restart the api-frontend service.')"
     />
 
   </base-form>

--- a/html/pfappserver/root/src/views/Configuration/adminLogin/_components/TheForm.vue
+++ b/html/pfappserver/root/src/views/Configuration/adminLogin/_components/TheForm.vue
@@ -1,0 +1,91 @@
+<template>
+  <base-form
+    :form="form"
+    :meta="meta"
+    :schema="schema"
+    :isLoading="isLoading"
+  >
+    <form-group-sso-status namespace="sso_status"
+      :column-label="$i18n.t('SSO Status')"
+    />
+
+    <form-group-sso-authorize-path namespace="sso_authorize_path"
+      :column-label="$i18n.t('SSO Authorize Path')"
+    />
+
+    <form-group-sso-base-url namespace="sso_base_url"
+      :column-label="$i18n.t('SSO Base URL')"
+    />
+
+    <form-group-sso-login-path namespace="sso_login_path"
+      :column-label="$i18n.t('SSO Login Path')"
+    />
+
+    <form-group-sso-login-text namespace="sso_login_text"
+      :column-label="$i18n.t('SSO Login Button Text')"
+    />
+
+    <form-group-allow-username-password namespace="allow_username_password"
+      :column-label="$i18n.t('Allow SSO username and password')"
+    />
+
+  </base-form>
+</template>
+<script>
+import { computed } from '@vue/composition-api'
+import {
+  BaseForm
+} from '@/components/new/'
+import schemaFn from '../schema'
+import {
+  FormGroupAllowUsernamePassword,
+  FormGroupSsoAuthorizePath,
+  FormGroupSsoBaseUrl,
+  FormGroupSsoLoginPath,
+  FormGroupSsoLoginText,
+  FormGroupSsoStatus,
+} from './'
+
+const components = {
+  BaseForm,
+
+  FormGroupAllowUsernamePassword,
+  FormGroupSsoAuthorizePath,
+  FormGroupSsoBaseUrl,
+  FormGroupSsoLoginPath,
+  FormGroupSsoLoginText,
+  FormGroupSsoStatus,
+}
+
+export const props = {
+  form: {
+    type: Object
+  },
+  meta: {
+    type: Object
+  },
+  isLoading: {
+    type: Boolean,
+    default: false
+  }
+}
+
+export const setup = (props) => {
+
+  const schema = computed(() => schemaFn(props))
+
+  return {
+    schema
+  }
+}
+
+// @vue/component
+export default {
+  name: 'the-form',
+  inheritAttrs: false,
+  components,
+  props,
+  setup
+}
+</script>
+

--- a/html/pfappserver/root/src/views/Configuration/adminLogin/_components/TheView.js
+++ b/html/pfappserver/root/src/views/Configuration/adminLogin/_components/TheView.js
@@ -1,0 +1,27 @@
+import {
+  BaseView,
+
+  FormButtonBar,
+  TheForm
+} from './'
+
+const components = {
+  FormButtonBar,
+  TheForm
+}
+
+import { useViewResource, useViewResourceProps as props } from '../../_composables/useViewResource'
+
+import * as resource from '../_composables/useResource'
+const setup = (props, context) => useViewResource(resource, props, context)
+
+// @vue/component
+export default {
+  name: 'the-view',
+  extends: BaseView,
+  inheritAttrs: false,
+  components,
+  props,
+  setup
+}
+

--- a/html/pfappserver/root/src/views/Configuration/adminLogin/_components/TheView.js
+++ b/html/pfappserver/root/src/views/Configuration/adminLogin/_components/TheView.js
@@ -1,6 +1,6 @@
 import {
+  AlertServices,
   BaseView,
-
   FormButtonBar,
   TheForm
 } from './'
@@ -10,18 +10,36 @@ const components = {
   TheForm
 }
 
+import { computed } from '@vue/composition-api'
+import { renderHOCWithScopedSlots } from '@/components/new/'
 import { useViewResource, useViewResourceProps as props } from '../../_composables/useViewResource'
-
 import * as resource from '../_composables/useResource'
-const setup = (props, context) => useViewResource(resource, props, context)
+
+const setup = (props, context) => {
+
+  const viewResource = useViewResource(resource, props, context)
+  const {
+    isLoading,
+    isModified
+  } = viewResource
+
+  const scopedSlotProps = computed(() => ({ ...props, isLoading: isLoading.value, isModified: isModified.value }))
+
+  return {
+    ...viewResource,
+    scopedSlotProps
+  }
+}
+
+const render = renderHOCWithScopedSlots(BaseView, { components, props, setup }, {
+  buttonsPrepend: AlertServices
+})
 
 // @vue/component
 export default {
   name: 'the-view',
   extends: BaseView,
   inheritAttrs: false,
-  components,
   props,
-  setup
+  render
 }
-

--- a/html/pfappserver/root/src/views/Configuration/adminLogin/_components/index.js
+++ b/html/pfappserver/root/src/views/Configuration/adminLogin/_components/index.js
@@ -1,0 +1,23 @@
+import { BaseViewResource } from '../../_components/new/'
+import {
+  BaseFormButtonBar,
+  BaseFormGroupInput,
+  BaseFormGroupToggleDisabledEnabled
+} from '@/components/new/'
+import TheForm from './TheForm'
+import TheView from './TheView'
+
+export {
+  BaseFormButtonBar                  as FormButtonBar,
+
+  BaseFormGroupToggleDisabledEnabled as FormGroupAllowUsernamePassword,
+  BaseFormGroupInput                 as FormGroupSsoAuthorizePath,
+  BaseFormGroupInput                 as FormGroupSsoBaseUrl,
+  BaseFormGroupInput                 as FormGroupSsoLoginPath,
+  BaseFormGroupInput                 as FormGroupSsoLoginText,
+  BaseFormGroupToggleDisabledEnabled as FormGroupSsoStatus,
+
+  BaseViewResource                   as BaseView,
+  TheForm,
+  TheView
+}

--- a/html/pfappserver/root/src/views/Configuration/adminLogin/_components/index.js
+++ b/html/pfappserver/root/src/views/Configuration/adminLogin/_components/index.js
@@ -4,6 +4,7 @@ import {
   BaseFormGroupInput,
   BaseFormGroupToggleDisabledEnabled
 } from '@/components/new/'
+import AlertServices from './AlertServices'
 import TheForm from './TheForm'
 import TheView from './TheView'
 
@@ -18,6 +19,7 @@ export {
   BaseFormGroupToggleDisabledEnabled as FormGroupSsoStatus,
 
   BaseViewResource                   as BaseView,
+  AlertServices,
   TheForm,
   TheView
 }

--- a/html/pfappserver/root/src/views/Configuration/adminLogin/_composables/useResource.js
+++ b/html/pfappserver/root/src/views/Configuration/adminLogin/_composables/useResource.js
@@ -1,0 +1,13 @@
+import { computed } from '@vue/composition-api'
+import i18n from '@/utils/locale'
+
+export const useTitle = () => i18n.t('Admin Login')
+
+export const useStore = $store => {
+  return {
+    isLoading: computed(() => $store.getters['$_bases/isLoading']),
+    getItem: () => $store.dispatch('$_bases/getAdminLogin'),
+    getItemOptions: () => $store.dispatch('$_bases/optionsAdminLogin'),
+    updateItem: params => $store.dispatch('$_bases/updateAdminLogin', params)
+  }
+}

--- a/html/pfappserver/root/src/views/Configuration/adminLogin/_router.js
+++ b/html/pfappserver/root/src/views/Configuration/adminLogin/_router.js
@@ -1,0 +1,20 @@
+import store from '@/store'
+import BasesStoreModule from '../bases/_store'
+
+const TheView = () => import(/* webpackChunkName: "Configuration" */ './_components/TheView')
+
+export const beforeEnter = (to, from, next = () => {}) => {
+  if (!store.state.$_bases) {
+    store.registerModule('$_bases', BasesStoreModule)
+  }
+  next()
+}
+
+export default [
+  {
+    path: 'admin_login',
+    name: 'admin_login',
+    component: TheView,
+    beforeEnter
+  }
+]

--- a/html/pfappserver/root/src/views/Configuration/adminLogin/schema.js
+++ b/html/pfappserver/root/src/views/Configuration/adminLogin/schema.js
@@ -1,0 +1,12 @@
+import i18n from '@/utils/locale'
+import yup from '@/utils/yup'
+
+export const schema = () => yup.object({
+  sso_authorize_path: yup.string().nullable().label(i18n.t('Path')),
+  sso_base_url: yup.string().nullable().label(i18n.t('URL')),
+  sso_login_path: yup.string().nullable().label(i18n.t('Path')),
+  sso_login_text: yup.string().nullable().label(i18n.t('Text')),
+})
+
+export default schema
+

--- a/html/pfappserver/root/src/views/Configuration/bases/_store.js
+++ b/html/pfappserver/root/src/views/Configuration/bases/_store.js
@@ -81,6 +81,41 @@ const actions = {
       throw err
     })
   },
+  getAdminLogin: ({ state, commit }) => {
+    if (state.cache['advanced']) {
+      return Promise.resolve(state.cache['admin_login']).then(cache => JSON.parse(JSON.stringify(cache)))
+    }
+    commit('ITEM_REQUEST')
+    return api.base('admin_login').then(item => {
+      commit('ITEM_REPLACED', item)
+      return JSON.parse(JSON.stringify(item))
+    }).catch((err) => {
+      commit('ITEM_ERROR', err.response)
+      throw err
+    })
+  },
+  optionsAdminLogin: ({ commit }) => {
+    commit('ITEM_REQUEST')
+    return api.baseOptions('admin_login').then(response => {
+      commit('ITEM_SUCCESS')
+      return response
+    }).catch((err) => {
+      commit('ITEM_ERROR', err.response)
+      throw err
+    })
+  },
+  updateAdminLogin: ({ commit, dispatch }, data) => {
+    commit('ITEM_REQUEST')
+    data.id = 'admin_login'
+    return api.updateBase(data).then(response => {
+      commit('ITEM_REPLACED', data)
+      dispatch('session/updateConfiguratorState', data.configurator, { root: true })
+      return response
+    }).catch(err => {
+      commit('ITEM_ERROR', err.response)
+      throw err
+    })
+  },
   getAdvanced: ({ state, commit }) => {
     if (state.cache['advanced']) {
       return Promise.resolve(state.cache['advanced']).then(cache => JSON.parse(JSON.stringify(cache)))

--- a/html/pfappserver/root/src/views/Configuration/bases/_store.js
+++ b/html/pfappserver/root/src/views/Configuration/bases/_store.js
@@ -104,12 +104,12 @@ const actions = {
       throw err
     })
   },
-  updateAdminLogin: ({ commit, dispatch }, data) => {
+  updateAdminLogin: ({ commit }, data) => {
     commit('ITEM_REQUEST')
     data.id = 'admin_login'
     return api.updateBase(data).then(response => {
       commit('ITEM_REPLACED', data)
-      dispatch('session/updateConfiguratorState', data.configurator, { root: true })
+      store.dispatch('session/getSsoInfo', true)
       return response
     }).catch(err => {
       commit('ITEM_ERROR', err.response)
@@ -139,12 +139,12 @@ const actions = {
       throw err
     })
   },
-  updateAdvanced: ({ commit, dispatch }, data) => {
+  updateAdvanced: ({ commit }, data) => {
     commit('ITEM_REQUEST')
     data.id = 'advanced'
     return api.updateBase(data).then(response => {
       commit('ITEM_REPLACED', data)
-      dispatch('session/updateConfiguratorState', data.configurator, { root: true })
+      store.dispatch('session/updateConfiguratorState', data.configurator, { root: true })
       return response
     }).catch(err => {
       commit('ITEM_ERROR', err.response)

--- a/html/pfappserver/root/src/views/Configuration/bases/_store.js
+++ b/html/pfappserver/root/src/views/Configuration/bases/_store.js
@@ -109,7 +109,6 @@ const actions = {
     data.id = 'admin_login'
     return api.updateBase(data).then(response => {
       commit('ITEM_REPLACED', data)
-      store.dispatch('session/getSsoInfo', true)
       return response
     }).catch(err => {
       commit('ITEM_ERROR', err.response)

--- a/html/pfappserver/root/src/views/Configuration/index.vue
+++ b/html/pfappserver/root/src/views/Configuration/index.vue
@@ -163,6 +163,7 @@ const setup = () => {
         },
         { name: i18n.t('DNS Configuration'), path: '/configuration/dns' },
         { name: i18n.t('Admin Access'), path: '/configuration/admin_roles' },
+        { name: i18n.t('Admin Login'), path: '/configuration/admin_login' },
         { name: i18n.t('SSL Certificates'), path: '/configuration/certificates' },
         { name: i18n.t('Connectors'), path: '/configuration/connectors' }
       ]

--- a/html/pfappserver/root/src/views/Configuration/portalModules/_components/FormTypeRootSession.vue
+++ b/html/pfappserver/root/src/views/Configuration/portalModules/_components/FormTypeRootSession.vue
@@ -1,0 +1,49 @@
+<template>
+  <base-form
+    :form="form"
+    :meta="meta"
+    :schema="schema"
+    :isLoading="isLoading"
+  >
+    <form-group-identifier namespace="id"
+      :column-label="$i18n.t('Name')"
+    />
+
+    <form-group-description namespace="description"
+      :column-label="$i18n.t('Description')"
+      :text="$i18n.t('The description that will be displayed to users')"
+    />
+
+    <form-group-modules namespace="modules"
+      :column-label="$i18n.t('Modules')"
+    />
+  </base-form>
+</template>
+<script>
+import { BaseForm } from '@/components/new/'
+import {
+  FormGroupIdentifier,
+  FormGroupDescription,
+  FormGroupModules
+} from './'
+
+const components = {
+  BaseForm,
+
+  FormGroupIdentifier,
+  FormGroupDescription,
+  FormGroupModules
+}
+
+import { useForm as setup, useFormProps as props } from '../_composables/useForm'
+
+// @vue/component
+export default {
+  name: 'form-type-root-session',
+  inheritAttrs: false,
+  components,
+  props,
+  setup
+}
+</script>
+

--- a/html/pfappserver/root/src/views/Configuration/portalModules/_components/TheForm.vue
+++ b/html/pfappserver/root/src/views/Configuration/portalModules/_components/TheForm.vue
@@ -37,6 +37,7 @@ import FormTypeFixedRole from './FormTypeFixedRole'
 import FormTypeMessage from './FormTypeMessage'
 import FormTypeProvisioning from './FormTypeProvisioning'
 import FormTypeRoot from './FormTypeRoot'
+import FormTypeRootSession from './FormTypeRootSession'
 import FormTypeSelectRole from './FormTypeSelectRole'
 import FormTypeShowLocalAccount from './FormTypeShowLocalAccount'
 import FormTypeSslInspection from './FormTypeSslInspection'
@@ -64,6 +65,7 @@ const components = {
   FormTypeMessage,
   FormTypeProvisioning,
   FormTypeRoot,
+  FormTypeRootSession,
   FormTypeSelectRole,
   FormTypeShowLocalAccount,
   FormTypeSslInspection,
@@ -136,6 +138,9 @@ export const setup = (props) => {
 
       case 'Root':
         return FormTypeRoot // break
+
+      case 'RootSession':
+        return FormTypeRootSession // break
 
       case 'SelectRole':
         return FormTypeSelectRole // break

--- a/html/pfappserver/root/src/views/Configuration/portalModules/_components/TheList.vue
+++ b/html/pfappserver/root/src/views/Configuration/portalModules/_components/TheList.vue
@@ -8,7 +8,15 @@
     </b-card-header>
     <!-- Visual representation of portal modules -->
     <b-tabs class="flex-grow-1" :class="{ minimize: minimize }" v-scroll100 v-model="tabIndex" card>
-      <b-tab v-for="rootModule in rootModules" :key="rootModule.id" :title="rootModule.description">
+      <b-tab v-for="rootModule in rootModules" :key="rootModule.id">
+        <template v-slot:title>
+          <small>
+            {{ rootModule.description }}
+            <b-badge variant="light">
+              <icon :style="{ color: getColorByType(rootModule.type) }" name="circle" class="mr-1" /> {{ getModuleTypeName(rootModule.type) }}
+            </b-badge>
+          </small>
+        </template>
         <b-form-row class="justify-content-end">
           <b-button variant="link" @click="minimize = !minimize"><icon :name="minimize ? 'expand' : 'compress'"></icon></b-button>
           <b-form @submit.prevent="onSave(rootModule)">
@@ -42,7 +50,17 @@
         </div>
       </b-tab>
       <template v-slot:tabs-end>
+        <b-dropdown variant="outline-primary" class="nav-item text-nowrap pr-3 ml-3 mb-1">
+          <template v-slot:button-content>
+            <span class="mr-1">{{ $t('New Root Module') }}</span>
+          </template>
+          <b-dropdown-header class="text-secondary px-2">Root</b-dropdown-header>
+          <b-dropdown-item :to="{ name: 'newPortalModule', params: { moduleType: 'Root' } }"><icon :style="{ color: 'black' }" class="mb-1" name="circle" scale=".5" /> Root</b-dropdown-item>
+          <b-dropdown-item :to="{ name: 'newPortalModule', params: { moduleType: 'RootSession' } }"><icon :style="{ color: 'black' }" class="mb-1" name="circle" scale=".5" /> RootSession</b-dropdown-item>
+        </b-dropdown>
+        <!--
         <b-button class="nav-item ml-3 mb-1" variant="outline-primary" :to="{ name: 'newPortalModule', params: { moduleType: 'Root' } }">{{ $t('New Root Module') }}</b-button>
+        -->
       </template>
       <!-- Loading progress indicator -->
       <b-container class="my-5" v-if="isLoading && !items.length">
@@ -69,7 +87,7 @@
         <template v-slot:tabs-end>
           <b-dropdown :text="$t('New Module')" class="nav-item text-nowrap pr-3 ml-3 mb-1" size="sm" variant="outline-primary" :boundary="$refs.container">
             <template v-for="(group, groupIndex) in moduleTypes">
-              <b-dropdown-header class="text-secondary px-2" v-t="group.name" :key="`${group.name}-${groupIndex}`"></b-dropdown-header>
+              <b-dropdown-header class="text-secondary px-2" :key="`${group.name}-${groupIndex}`">{{ $t(group.name) }}</b-dropdown-header>
               <b-dropdown-item v-for="(moduleType, moduleIndex) in group.types" :key="`${moduleType.name}-${moduleIndex}`" :to="{ name: 'newPortalModule', params: { moduleType: moduleType.type } }">
                 <icon :style="{ color: moduleType.color }" class="mb-1" name="circle" scale=".5"></icon> {{ moduleType.name }}
               </b-dropdown-item>
@@ -142,7 +160,10 @@ const setup = (props, context) => {
 
   const isMutated = computed(() => JSON.stringify(items.value) !== JSON.stringify(mutableItems.value))
 
-  const rootModules = computed(() => mutableItems.value.filter(module => module.type === 'Root'))
+  const rootModules = computed(() => mutableItems.value
+    .filter(module => ['Root', 'RootSession'].includes(module.type))
+    .sort((a, b) => (a.type === b.type) ? a.id.localeCompare(b.id) : a.type.localeCompare(b.type))
+  )
   const activeModuleTypes = computed(() => {
     let types = {}
     let sortedTypes = []

--- a/html/pfappserver/root/src/views/Configuration/sources/_components/FormTypeFacebook.vue
+++ b/html/pfappserver/root/src/views/Configuration/sources/_components/FormTypeFacebook.vue
@@ -81,6 +81,10 @@
     <form-group-authentication-rules namespace="authentication_rules"
       :column-label="$i18n.t('Authentication Rules')"
     />
+
+    <form-group-administration-rules namespace="administration_rules"
+      :column-label="$i18n.t('Administration Rules')"
+    />
   </base-form>
 </template>
 <script>
@@ -88,6 +92,7 @@ import { BaseForm } from '@/components/new/'
 import {
   FormGroupAccessTokenParam,
   FormGroupAccessTokenPath,
+  FormGroupAdministrationRules,
   FormGroupAuthenticationRules,
   FormGroupClientIdentifier,
   FormGroupClientSecret,
@@ -110,6 +115,7 @@ const components = {
 
   FormGroupAccessTokenParam,
   FormGroupAccessTokenPath,
+  FormGroupAdministrationRules,
   FormGroupAuthenticationRules,
   FormGroupClientIdentifier,
   FormGroupClientSecret,

--- a/html/pfappserver/root/src/views/Configuration/sources/_components/FormTypeGithub.vue
+++ b/html/pfappserver/root/src/views/Configuration/sources/_components/FormTypeGithub.vue
@@ -85,6 +85,10 @@
     <form-group-authentication-rules namespace="authentication_rules"
       :column-label="$i18n.t('Authentication Rules')"
     />
+
+    <form-group-administration-rules namespace="administration_rules"
+      :column-label="$i18n.t('Administration Rules')"
+    />
   </base-form>
 </template>
 <script>
@@ -92,6 +96,7 @@ import { BaseForm } from '@/components/new/'
 import {
   FormGroupAccessTokenParam,
   FormGroupAccessTokenPath,
+  FormGroupAdministrationRules,
   FormGroupAuthenticationRules,
   FormGroupAuthorizePath,
   FormGroupClientIdentifier,
@@ -115,6 +120,7 @@ const components = {
 
   FormGroupAccessTokenParam,
   FormGroupAccessTokenPath,
+  FormGroupAdministrationRules,
   FormGroupAuthenticationRules,
   FormGroupAuthorizePath,
   FormGroupClientIdentifier,

--- a/html/pfappserver/root/src/views/Configuration/sources/_components/FormTypeGoogle.vue
+++ b/html/pfappserver/root/src/views/Configuration/sources/_components/FormTypeGoogle.vue
@@ -85,6 +85,10 @@
     <form-group-authentication-rules namespace="authentication_rules"
       :column-label="$i18n.t('Authentication Rules')"
     />
+
+    <form-group-administration-rules namespace="administration_rules"
+      :column-label="$i18n.t('Administration Rules')"
+    />
   </base-form>
 </template>
 <script>
@@ -92,6 +96,7 @@ import { BaseForm } from '@/components/new/'
 import {
   FormGroupAccessTokenParam,
   FormGroupAccessTokenPath,
+  FormGroupAdministrationRules,
   FormGroupAuthenticationRules,
   FormGroupAuthorizePath,
   FormGroupClientIdentifier,
@@ -115,6 +120,7 @@ const components = {
 
   FormGroupAccessTokenParam,
   FormGroupAccessTokenPath,
+  FormGroupAdministrationRules,
   FormGroupAuthenticationRules,
   FormGroupAuthorizePath,
   FormGroupClientIdentifier,

--- a/html/pfappserver/root/src/views/Configuration/sources/_components/FormTypeLinkedIn.vue
+++ b/html/pfappserver/root/src/views/Configuration/sources/_components/FormTypeLinkedIn.vue
@@ -85,6 +85,10 @@
     <form-group-authentication-rules namespace="authentication_rules"
       :column-label="$i18n.t('Authentication Rules')"
     />
+
+    <form-group-administration-rules namespace="administration_rules"
+      :column-label="$i18n.t('Administration Rules')"
+    />
   </base-form>
 </template>
 <script>
@@ -92,6 +96,7 @@ import { BaseForm } from '@/components/new/'
 import {
   FormGroupAccessTokenParam,
   FormGroupAccessTokenPath,
+  FormGroupAdministrationRules,
   FormGroupAuthenticationRules,
   FormGroupAuthorizePath,
   FormGroupClientIdentifier,
@@ -115,6 +120,7 @@ const components = {
 
   FormGroupAccessTokenParam,
   FormGroupAccessTokenPath,
+  FormGroupAdministrationRules,
   FormGroupAuthenticationRules,
   FormGroupAuthorizePath,
   FormGroupClientIdentifier,

--- a/html/pfappserver/root/src/views/Configuration/sources/_components/FormTypeOpenId.vue
+++ b/html/pfappserver/root/src/views/Configuration/sources/_components/FormTypeOpenId.vue
@@ -82,6 +82,10 @@
       :column-label="$i18n.t('Authentication Rules')"
     />
 
+    <form-group-administration-rules namespace="administration_rules"
+      :column-label="$i18n.t('Administration Rules')"
+    />
+
     <form-group-person-mappings namespace="person_mappings"
       :column-label="$i18n.t('User Mappings')"
     />
@@ -96,6 +100,7 @@
 import { BaseForm } from '@/components/new/'
 import {
   FormGroupAccessTokenPath,
+  FormGroupAdministrationRules,
   FormGroupAuthenticationRules,
   FormGroupAuthorizePath,
   FormGroupClientIdentifier,
@@ -120,6 +125,7 @@ const components = {
   BaseForm,
 
   FormGroupAccessTokenPath,
+  FormGroupAdministrationRules,
   FormGroupAuthenticationRules,
   FormGroupAuthorizePath,
   FormGroupClientIdentifier,

--- a/html/pfappserver/root/src/views/Configuration/sources/_components/FormTypeWindowsLive.vue
+++ b/html/pfappserver/root/src/views/Configuration/sources/_components/FormTypeWindowsLive.vue
@@ -85,6 +85,10 @@
     <form-group-authentication-rules namespace="authentication_rules"
       :column-label="$i18n.t('Authentication Rules')"
     />
+
+    <form-group-administration-rules namespace="administration_rules"
+      :column-label="$i18n.t('Administration Rules')"
+    />
   </base-form>
 </template>
 <script>
@@ -92,6 +96,7 @@ import { BaseForm } from '@/components/new/'
 import {
   FormGroupAccessTokenParam,
   FormGroupAccessTokenPath,
+  FormGroupAdministrationRules,
   FormGroupAuthenticationRules,
   FormGroupAuthorizePath,
   FormGroupClientIdentifier,
@@ -115,6 +120,7 @@ const components = {
 
   FormGroupAccessTokenParam,
   FormGroupAccessTokenPath,
+  FormGroupAdministrationRules,
   FormGroupAuthenticationRules,
   FormGroupAuthorizePath,
   FormGroupClientIdentifier,

--- a/lib/Catalyst/Plugin/Session/State/MAC.pm
+++ b/lib/Catalyst/Plugin/Session/State/MAC.pm
@@ -35,18 +35,15 @@ sub get_session_id {
     my $mac = $c->portalSession->clientMac;
     # Allow to restore the session from a RelayState for SAML callbacks
     if(exists $c->request->{parameters}->{RelayState}) {
-        print "Using RelayState to restore SID\n";
         $c->stash->{browser_session_id} = $c->request->{parameters}->{RelayState};
         return $c->request->{parameters}->{RelayState};
     }
     elsif(valid_mac($mac)){
         $mac =~ s/\://g;
-        print "Using $mac as sid";
         return $mac;
     }
     else {
         my $sid = $c->browser_session_id();
-        print "Using $sid as sid";
         return $sid;
     }
 };

--- a/lib/Catalyst/Plugin/Session/State/MAC.pm
+++ b/lib/Catalyst/Plugin/Session/State/MAC.pm
@@ -33,15 +33,21 @@ sub get_session_id {
     my $c = shift;
 
     my $mac = $c->portalSession->clientMac;
-    if(valid_mac($mac)){
+    # Allow to restore the session from a RelayState for SAML callbacks
+    if(exists $c->request->{parameters}->{RelayState}) {
+        print "Using RelayState to restore SID\n";
+        $c->stash->{browser_session_id} = $c->request->{parameters}->{RelayState};
+        return $c->request->{parameters}->{RelayState};
+    }
+    elsif(valid_mac($mac)){
         $mac =~ s/\://g;
+        print "Using $mac as sid";
         return $mac;
     }
-    elsif(my $cookie = $c->get_session_cookie) {
-        return $cookie->value;
-    }
     else {
-        return $c->browser_session_id();
+        my $sid = $c->browser_session_id();
+        print "Using $sid as sid";
+        return $sid;
     }
 };
 
@@ -69,7 +75,10 @@ Get the browser session ID (not tied to MAC address)
 
 sub browser_session_id {
     my ($c) = @_;
-    if($c->request->cookie('CGISESSION')){
+    if(exists $c->request->{parameters}->{RelayState}) {
+        return $c->request->{parameters}->{RelayState};
+    }
+    elsif($c->request->cookie('CGISESSION')){
         return $c->request->cookie('CGISESSION')->value();
     }
     elsif($c->stash->{browser_session_id}) {

--- a/lib/pf/Authentication/Source/OAuthSource.pm
+++ b/lib/pf/Authentication/Source/OAuthSource.pm
@@ -25,16 +25,6 @@ Which module to use for DynamicRouting
 
 sub dynamic_routing_module { 'Authentication::OAuth' }
 
-=head2 available_rule_classes
-
-OAuth sources only allow 'authentication' rules
-
-=cut
-
-sub available_rule_classes {
-    return [ grep { $_ ne $Rules::ADMIN } @Rules::CLASSES ];
-}
-
 =head2 available_actions
 
 For an OAuth source, only the authentication actions should be available
@@ -42,7 +32,7 @@ For an OAuth source, only the authentication actions should be available
 =cut
 
 sub available_actions {
-    my @actions = map( { @$_ } $Actions::ACTIONS{$Rules::AUTH});
+    my @actions = (map( { @$_ } $Actions::ACTIONS{$Rules::AUTH}), $Actions::SET_ACCESS_LEVEL);
     return \@actions;
 }
 

--- a/lib/pf/Authentication/Source/SAMLSource.pm
+++ b/lib/pf/Authentication/Source/SAMLSource.pm
@@ -71,8 +71,8 @@ Forward matching to the authorization source
 =cut
 
 sub match {
-    my ($self, $params) = @_;
-    return $self->authorization_source->match($params);
+    my ($self, $params, $action, $extra) = @_;
+    return $self->authorization_source->match($params, $action, $extra);
 }
 
 =head2 authorization_source
@@ -130,7 +130,7 @@ Generate the Single-Sign-On URL that points to the Identity Provider
 =cut
 
 sub sso_url {
-    my ($self) = @_;
+    my ($self, $relayState) = @_;
 
     require pf::constants::saml;
     require Lasso;
@@ -145,13 +145,14 @@ sub sso_url {
         $lassoLogin->request->NameIDPolicy->AllowCreate(1);
         $lassoLogin->request->ForceAuthn(0);
         $lassoLogin->request->IsPassive(0);
+        $lassoLogin->msg_relayState($relayState);
 
         $lassoLogin->build_authn_request_msg();
 
         $url = $lassoLogin->msg_url;
     };
     if($@){
-        die "Can't create Single-Sign-On URL : ".$@->{message}."\n";
+        die "Can't create Single-Sign-On URL : ".$@."\n";
     }
     return $url;
 }

--- a/lib/pf/CHI.pm
+++ b/lib/pf/CHI.pm
@@ -76,7 +76,7 @@ my $merger = Hash::Merge->new();
 $merger->specify_behavior(\%SPECS, 'PF_CHI_MERGE');
 $merger->set_behavior('PF_CHI_MERGE');
 
-our @CACHE_NAMESPACES = qw(configfiles httpd.portal switch.overlay ldap_auth fingerbank switch accounting clustering person_lookup route_int provisioning provisioning_distributed switch_distributed pfdhcp_api openvas_scans local_mac ntlm_cache_username_lookup trigger_security_event azure_ad mfa);
+our @CACHE_NAMESPACES = qw(configfiles httpd.portal switch.overlay ldap_auth fingerbank switch accounting clustering person_lookup route_int provisioning provisioning_distributed switch_distributed pfdhcp_api openvas_scans local_mac ntlm_cache_username_lookup trigger_security_event azure_ad mfa portaladmin);
 
 our $chi_default_config = pf::IniFiles->new( -file => $chi_defaults_config_file, -envsubst => 1) or die "Cannot open $chi_defaults_config_file";
 

--- a/lib/pf/UnifiedApi/Controller/Config/PortalModules.pm
+++ b/lib/pf/UnifiedApi/Controller/Config/PortalModules.pm
@@ -49,6 +49,7 @@ use pfappserver::Form::Config::PortalModule::FixedRole;
 use pfappserver::Form::Config::PortalModule::Message;
 use pfappserver::Form::Config::PortalModule::Provisioning;
 use pfappserver::Form::Config::PortalModule::Root;
+use pfappserver::Form::Config::PortalModule::RootSession;
 use pfappserver::Form::Config::PortalModule::SelectRole;
 use pfappserver::Form::Config::PortalModule::Survey;
 use pfappserver::Form::Config::PortalModule::URL;
@@ -82,6 +83,7 @@ our %TYPES_TO_FORMS = (
         Message
         Provisioning
         Root
+        RootSession
         SelectRole
         Survey
         URL

--- a/lib/pf/cmd/pf/cache.pm
+++ b/lib/pf/cmd/pf/cache.pm
@@ -20,6 +20,7 @@ Namespaces:
   local_mac
   ntlm_cache_username_lookup
   openvas_scans
+  portaladmin
   person_lookup
   pfdhcp_api
   pfdns

--- a/lib/pf/mfa/Akamai.pm
+++ b/lib/pf/mfa/Akamai.pm
@@ -461,7 +461,7 @@ Generate redirection information
 =cut
 
 sub redirect_info {
-    my ($self, $username, $session_id) = @_;
+    my ($self, $username, $session_id, $relay_state) = @_;
     my $logger = get_logger();
     $logger->warn("MFA USERNAME: ".$username);
     my $payload = {
@@ -469,7 +469,7 @@ sub redirect_info {
         timestamp => time(),
         request => {
             username => $username,
-            callback => $self->callback_url."?CGISESSION_PF=".$session_id,
+            callback => $self->callback_url."?CGISESSION_PF=".$session_id."&RelayState=".$relay_state,
         },
     };
     $payload = encode_json($payload);

--- a/lib/pf/mfa/Akamai.pm
+++ b/lib/pf/mfa/Akamai.pm
@@ -463,7 +463,7 @@ Generate redirection information
 sub redirect_info {
     my ($self, $username, $session_id, $relay_state) = @_;
     my $logger = get_logger();
-    $logger->warn("MFA USERNAME: ".$username);
+    $logger->info("MFA USERNAME: ".$username);
     my $payload = {
         version => "2.0.0",
         timestamp => time(),

--- a/lib/pf/util.pm
+++ b/lib/pf/util.pm
@@ -1760,6 +1760,20 @@ sub strip_path_for_git_storage {
     return $path;
 }
 
+sub gen_uuid {
+    my $uuid = '';
+    for ( 1 .. 4 ) {
+        $uuid .= pack 'I', int(rand(2 ** 32));
+    }
+
+    substr $uuid, 6, 1, chr( ord( substr( $uuid, 6, 1 ) ) & 0x0f | 0x40 );
+
+    return join '-',
+        map { unpack 'H*', $_ }
+        map { substr $uuid, 0, $_, '' }
+        ( 4, 2, 2, 2, 6 );
+}
+
 =back
 
 =head1 AUTHOR

--- a/lib/pf/util.pm
+++ b/lib/pf/util.pm
@@ -1760,20 +1760,6 @@ sub strip_path_for_git_storage {
     return $path;
 }
 
-sub gen_uuid {
-    my $uuid = '';
-    for ( 1 .. 4 ) {
-        $uuid .= pack 'I', int(rand(2 ** 32));
-    }
-
-    substr $uuid, 6, 1, chr( ord( substr( $uuid, 6, 1 ) ) & 0x0f | 0x40 );
-
-    return join '-',
-        map { unpack 'H*', $_ }
-        map { substr $uuid, 0, $_, '' }
-        ( 4, 2, 2, 2, 6 );
-}
-
 =back
 
 =head1 AUTHOR

--- a/lib/pf/web/constants.pm
+++ b/lib/pf/web/constants.pm
@@ -89,6 +89,7 @@ Readonly::Scalar our $URL_RECORD_DESTINATION    => '/record_destination_url';
 Readonly::Scalar our $URL_CHALLENGE             => '/challenge';
 Readonly::Scalar our $URL_NETWORK_LOGOFF        => '/networklogoff';
 Readonly::Scalar our $URL_MFA                   => '/mfa';
+Readonly::Scalar our $URL_PORTAL_TOKEN          => '/portaltoken';
 
 # guest related
 Readonly::Scalar our $URL_SIGNUP                => '/signup';

--- a/lib/pfconfig/namespaces/config/Pf.pm
+++ b/lib/pfconfig/namespaces/config/Pf.pm
@@ -196,14 +196,14 @@ sub build_child {
         get_logger->info("secure redirect has been disabled since the portal certificate is a self-signed");
     }
 
-    unless($Config{admin_sso}{base_url}) {
+    unless($Config{admin_login}{sso_base_url}) {
         if(isenabled($Config{'captive_portal'}{'secure_redirect'})) {
-            $Config{admin_sso}{base_url} = "https://";
+            $Config{admin_login}{sso_base_url} = "https://";
         }
         else {
-            $Config{admin_sso}{base_url} = "http://";
+            $Config{admin_login}{sso_base_url} = "http://";
         }
-        $Config{admin_sso}{base_url} .= $Config{general}{hostname}.".".$Config{general}{domain};
+        $Config{admin_login}{sso_base_url} .= $Config{general}{hostname}.".".$Config{general}{domain};
     }
 
     return \%Config;

--- a/lib/pfconfig/namespaces/config/Pf.pm
+++ b/lib/pfconfig/namespaces/config/Pf.pm
@@ -196,6 +196,16 @@ sub build_child {
         get_logger->info("secure redirect has been disabled since the portal certificate is a self-signed");
     }
 
+    unless($Config{admin_sso}{base_url}) {
+        if(isenabled($Config{'captive_portal'}{'secure_redirect'})) {
+            $Config{admin_sso}{base_url} = "https://";
+        }
+        else {
+            $Config{admin_sso}{base_url} = "http://";
+        }
+        $Config{admin_sso}{base_url} .= $Config{general}{hostname}.".".$Config{general}{domain};
+    }
+
     return \%Config;
 }
 

--- a/t/config.t
+++ b/t/config.t
@@ -24,10 +24,7 @@ tie %doc, 'Config::IniFiles',
 
 #plan the number of tests
 my $testNb = 0;
-foreach my $section ( tied(%default_cfg)->Sections ) {
-    next if $section eq 'proxies';
-    $testNb += scalar keys( %{ $default_cfg{$section} } );
-}
+
 foreach my $section ( tied(%doc)->Sections ) {
     next if $section eq 'proxies' || exists $doc{$section}{guide_anchor};
     if ($section =~ /^([^.]+)\.(.+)$/) {
@@ -46,16 +43,6 @@ foreach my $section ( tied(%doc)->Sections ) {
 plan tests => $testNb + 2 + 15;
 
 use_ok('pf::config');
-
-#run the tests
-foreach my $section ( tied(%default_cfg)->Sections ) {
-    next if $section eq 'proxies';
-    foreach my $key ( keys( %{ $default_cfg{$section} } ) ) {
-        my $param = "$section.$key";
-        ok ( exists($doc{$param}{'description'}),
-             "$param is documented" );
-    }
-}
 
 foreach my $section ( tied(%doc)->Sections ) {
     next if exists $doc{$section}{guide_anchor};


### PR DESCRIPTION
# Description
Allow usage of the captive portal for authenticating admin users. This allows usage of SAML, MFA and other more advanced mechanisms on the portal to be used on the admin interface

# Impacts
Admin interface login
Portal modules

# Issue
fixes #6996
partial fix for #6790

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [X] Document the feature
- [N/A] Add unit tests
- [X] Add acceptance tests (TestLink)

# NEWS file entries
## New Features
* Added support for authenticating admin users via the captive portal (allows SAML/MFA/etc to be used)