### PR TITLE
Remove ip*tables.conf from config files

### DIFF
--- a/conf/ip6tables.conf.example
+++ b/conf/ip6tables.conf.example
@@ -1,3 +1,6 @@
+# Copyright (C) Inverse inc.
+# iptables template
+# This file is manipulated on PacketFence's startup before being given to iptables
 *raw
 :PREROUTING ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]

--- a/conf/iptables.conf.example
+++ b/conf/iptables.conf.example
@@ -81,9 +81,6 @@
 -A input-management-if --protocol tcp --match tcp --dport 9392 --jump ACCEPT
 # Nessus Administration Interface
 -A input-management-if --protocol tcp --match tcp --dport 8834 --jump ACCEPT
-# PacketFence-PKI
-# -A input-management-if --protocol tcp --match tcp --dport 9393 --jump ACCEPT
-# -A input-management-if --protocol tcp --match tcp --dport 9292 --jump ACCEPT
 
 # Fingerbank collector (replication, NetFlow, API, sFlow)
 -A input-management-if --protocol udp --match udp --dport 1192 --jump ACCEPT

--- a/debian/packetfence.conffiles
+++ b/debian/packetfence.conffiles
@@ -17,10 +17,8 @@
 /usr/local/pf/conf/haproxy-admin.conf
 /usr/local/pf/conf/haproxy-db.conf
 /usr/local/pf/conf/haproxy-portal.conf
-/usr/local/pf/conf/iptables.conf
 /usr/local/pf/conf/iptables-input.conf.inc
 /usr/local/pf/conf/iptables-input-management.conf.inc
-/usr/local/pf/conf/ip6tables.conf
 /usr/local/pf/conf/ip6tables-input-management.conf.inc
 /usr/local/pf/conf/keepalived.conf
 /usr/local/pf/conf/log.conf

--- a/rpm/packetfence.spec
+++ b/rpm/packetfence.spec
@@ -1188,10 +1188,10 @@ fi
 %config                 /usr/local/pf/conf/httpd.conf.d/log.conf
 %config(noreplace)      /usr/local/pf/conf/httpd.conf.d/ssl-certificates.conf
                         /usr/local/pf/conf/httpd.conf.d/ssl-certificates.conf.example
-%config(noreplace)      /usr/local/pf/conf/iptables.conf
+%config                 /usr/local/pf/conf/iptables.conf
 %config(noreplace)      /usr/local/pf/conf/iptables-input.conf.inc
 %config(noreplace)      /usr/local/pf/conf/iptables-input-management.conf.inc
-%config(noreplace)      /usr/local/pf/conf/ip6tables.conf
+%config                 /usr/local/pf/conf/ip6tables.conf
 %config(noreplace)      /usr/local/pf/conf/ip6tables-input-management.conf.inc
 %config(noreplace)      /usr/local/pf/conf/keepalived.conf
                         /usr/local/pf/conf/keepalived.conf.example


### PR DESCRIPTION
# Description
Remove iptables.conf and ip6tables.conf from config files.

All custom rules should go in .conf.inc files.

# Impacts
- Custom rules in iptables.conf or ip6tables.conf
- Upgrade to v12.0.0

# Issue
fixes #7298

# Delete branch after merge
YES