### PR TITLE
Added support for Wired port on Ruckus AP and for Disconnect

### DIFF
--- a/lib/pf/Switch/Ruckus/SmartZone.pm
+++ b/lib/pf/Switch/Ruckus/SmartZone.pm
@@ -35,6 +35,8 @@ use pf::config qw (
     $WEBAUTH_WIRELESS
     $WIRELESS_MAC_AUTH
     %connection_type_to_str
+    $WIRED_802_1X
+    $WIRED_MAC_AUTH
 );
 use pf::util::radius qw(perform_disconnect);
 use pf::log;

--- a/lib/pf/Switch/Ruckus/SmartZone.pm
+++ b/lib/pf/Switch/Ruckus/SmartZone.pm
@@ -46,6 +46,8 @@ sub description { 'Ruckus SmartZone Wireless Controllers' }
 use pf::SwitchSupports qw(
     WirelessMacAuth
     -WebFormRegistration
+    WiredMacAuth
+    WirelessDot1x
 );
 
 =over
@@ -369,6 +371,69 @@ sub check_if_radius_request_psk_matches {
         pf::util::wpa::snonce_from_eapol_key_frame(pack("H*", pf::util::wpa::strip_hex_prefix($radius_request->{"Ruckus-DPSK-EAPOL-Key-Frame"}))),
       ),      
       pack("H*", pf::util::wpa::strip_hex_prefix($radius_request->{"Ruckus-DPSK-EAPOL-Key-Frame"})),
+    );
+}
+
+=head2 wiredeauthTechniques
+
+Return the reference to the deauth technique or the default deauth technique.
+
+=cut
+
+sub wiredeauthTechniques {
+   my ($self, $method, $connection_type) = @_;
+   my $logger = $self->logger;
+
+    if ($connection_type == $WIRED_802_1X) {
+        my $default = $SNMP::RADIUS;
+        my %tech = (
+            $SNMP::RADIUS => 'deauthenticateMacDefault',
+        );
+
+        if (!defined($method) || !defined($tech{$method})) {
+            $method = $default;
+        }
+        return $method,$tech{$method};
+    }
+    elsif ($connection_type == $WIRED_MAC_AUTH) {
+        my $default = $SNMP::RADIUS;
+        my %tech = (
+            $SNMP::RADIUS => 'deauthenticateMacDefault',
+        );
+        if (!defined($method) || !defined($tech{$method})) {
+            $method = $default;
+        }
+        return $method,$tech{$method};
+    }
+    else{
+        $logger->error("This authentication mode is not supported");
+    }
+
+}
+
+=item deauthenticateMacDefault
+
+De-authenticate a MAC address from wire network (including 802.1x).
+
+New implementation using RADIUS Disconnect-Request.
+
+=cut
+
+sub deauthenticateMacDefault {
+    my ( $self, $ifindex, $mac, $is_dot1x ) = @_;
+    my $logger = $self->logger;
+
+    if ( !$self->isProductionMode() ) {
+        $logger->info("not in production mode... we won't perform deauthentication");
+        return 1;
+    }
+
+    #Fetching the acct-session-id
+    my $dynauth = node_accounting_dynauth_attr($mac);
+
+    $logger->debug("deauthenticate $mac using RADIUS Disconnect-Request deauth method");
+    return $self->radiusDisconnect(
+        $mac, { 'User-Name' => $dynauth->{'username'} },
     );
 }
 


### PR DESCRIPTION
# Description
Support for wired connections on Ruckus SmartZone and disconnect.

# Impacts
SmartZone switch module

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* Support for wired connection on Ruckus SmartZone
