### PR TITLE
Removed monitor on eduroam authentication source

### DIFF
--- a/html/pfappserver/lib/pfappserver/Form/Config/Source/Eduroam.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source/Eduroam.pm
@@ -76,14 +76,6 @@ has_field 'local_realm' =>
    default => '',
   );
 
-has_field 'monitor',
-  (
-   type => 'Toggle',
-   checkbox_value => '1',
-   unchecked_value => '0',
-   default => pf::Authentication::Source::EduroamSource->meta->get_attribute('monitor')->default,
-  );
-
 has_field 'eduroam_operator_name' =>
   (
    type => 'Text',

--- a/html/pfappserver/root/src/views/Configuration/sources/_components/FormTypeEduroam.vue
+++ b/html/pfappserver/root/src/views/Configuration/sources/_components/FormTypeEduroam.vue
@@ -49,11 +49,6 @@
       :text="$i18n.t('Realms that will be authenticate locally.')"
     />
 
-    <form-group-monitor namespace="monitor"
-      :column-label="$i18n.t('Monitor')"
-      :text="$i18n.t('Do you want to monitor this source?')"
-    />
-
     <form-group-authentication-rules namespace="authentication_rules"
       :column-label="$i18n.t('Authentication Rules')"
     />
@@ -67,7 +62,6 @@ import {
   FormGroupDescription,
   FormGroupIdentifier,
   FormGroupLocalRealm,
-  FormGroupMonitor,
   FormGroupRejectRealm,
   FormGroupEduroamOptions,
   FormGroupEduroamOperatorName,
@@ -83,7 +77,6 @@ const components = {
   FormGroupDescription,
   FormGroupIdentifier,
   FormGroupLocalRealm,
-  FormGroupMonitor,
   FormGroupRejectRealm,
   FormGroupEduroamOptions,
   FormGroupEduroamOperatorName,

--- a/lib/pf/Authentication/Source/EduroamSource.pm
+++ b/lib/pf/Authentication/Source/EduroamSource.pm
@@ -27,7 +27,6 @@ has 'eduroam_operator_name'             => (isa => 'Str', is => 'rw');
 has 'auth_listening_port'               => (isa => 'Maybe[Int]', is => 'rw', default => '11812');
 has 'local_realm'                       => (isa => 'ArrayRef[Str]', is => 'rw');
 has 'reject_realm'                      => (isa => 'ArrayRef[Str]', is => 'rw');
-has 'monitor'                           => ( isa => 'Bool', is => 'rw', default => '0' );
 has '+realms'                           => (default => sub { ["eduroam"] });
 
 =head2 available_rule_classes


### PR DESCRIPTION
# Description
Since the eduroam radius authentication sources are defined as a radius source, it doesn´t make sense anymore to monitor the eduroam source but just monitor the radius one.

# Impacts
pfstats

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* Deprecated eduroam test from pfstats

