### PR TITLE
Fix / Add sameorigin in haproxy admin for netdata

### DIFF
--- a/lib/pf/services/manager/haproxy_admin.pm
+++ b/lib/pf/services/manager/haproxy_admin.pm
@@ -108,6 +108,7 @@ backend 127.0.0.1-netdata
         server service $netdata_service_host:$netdata_service_port
         http-request set-uri %[var(req.path)]?%[query] if paramsquery
         http-request set-uri %[var(req.path)] unless paramsquery
+	http-response add-header X-Frame-Options SAMEORIGIN
 EOT
 
         my $mgmt_api_backend;
@@ -140,6 +141,7 @@ backend $mgmt_back_ip-netdata
         server service $mgmt_back_ip:19999
         http-request set-uri %[var(req.path)]?%[query] if paramsquery
         http-request set-uri %[var(req.path)] unless paramsquery
+	http-response add-header X-Frame-Options SAMEORIGIN
 EOT
             }
             $mgmt_api_backend .= <<"EOT";


### PR DESCRIPTION
# Description
Add X-Frame-Options SAMEORIGIN in haproxy-admin
(source: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options#configuring_haproxy)

# Impacts
x-frame-options: SAMEORIGIN is now in header

# Delete branch after merge
YES

## Bug Fixes
Possible Clickjacking for netdata reverse proxy