### PR TITLE
Fix Aruba DACL

### DIFF
--- a/lib/pf/Switch/Aruba/2930M.pm
+++ b/lib/pf/Switch/Aruba/2930M.pm
@@ -55,7 +55,7 @@ sub returnRadiusAccessAccept {
     my %radius_reply = @super_reply;
     my $radius_reply_ref = \%radius_reply;
     return [$status, %$radius_reply_ref] if($status == $RADIUS::RLM_MODULE_USERLOCK);
-    my @acls = defined($radius_reply_ref->{'NAS-Filter-Rule'}) ? @{$radius_reply_ref->{'NAS-Filter-Rule'}} : ();
+    my @acls = defined($radius_reply_ref->{'Aruba-NAS-Filter-Rule'}) ? @{$radius_reply_ref->{'Aruba-NAS-Filter-Rule'}} : ();
 
     if ( isenabled($self->{_UrlMap}) ) {
         if ( defined($args->{'user_role'}) && $args->{'user_role'} ne "" && defined($self->getUrlByName($args->{'user_role'}) ) ) {
@@ -81,7 +81,7 @@ sub returnRadiusAccessAccept {
         }
     }
 
-    $radius_reply_ref->{'NAS-Filter-Rule'} = \@acls;
+    $radius_reply_ref->{'Aruba-NAS-Filter-Rule'} = \@acls;
 
     my $filter = pf::access_filter::radius->new;
     my $rule = $filter->test('returnRadiusAccessAccept', $args);

--- a/lib/pf/Switch/Aruba/5400.pm
+++ b/lib/pf/Switch/Aruba/5400.pm
@@ -122,7 +122,7 @@ sub returnRadiusAccessAccept {
     my %radius_reply = @super_reply;
     my $radius_reply_ref = \%radius_reply;
     return [$status, %$radius_reply_ref] if($status == $RADIUS::RLM_MODULE_USERLOCK);
-    my @acls = defined($radius_reply_ref->{'NAS-Filter-Rule'}) ? @{$radius_reply_ref->{'NAS-Filter-Rule'}} : ();
+    my @acls = defined($radius_reply_ref->{'Aruba-NAS-Filter-Rule'}) ? @{$radius_reply_ref->{'Aruba-NAS-Filter-Rule'}} : ();
 
     if ( isenabled($self->{_AccessListMap}) && $self->supportsAccessListBasedEnforcement ){
         if( defined($args->{'user_role'}) && $args->{'user_role'} ne "" && defined(my $access_list = $self->getAccessListByName($args->{'user_role'}, $args->{mac}))){
@@ -138,7 +138,7 @@ sub returnRadiusAccessAccept {
         }
     }
 
-    $radius_reply_ref->{'NAS-Filter-Rule'} = \@acls;
+    $radius_reply_ref->{'Aruba-NAS-Filter-Rule'} = \@acls;
 
     my $filter = pf::access_filter::radius->new;
     my $rule = $filter->test('returnRadiusAccessAccept', $args);


### PR DESCRIPTION
# Description
Use Aruba-NAS-Filter-Rule instead of NAS-Filter-Rule to push the DACL in Aruba switches.

# Impacts
Aruba switches

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Bug Fixes
* Issue with Aruba DACL, only the first acl was shown in the port
