### PR TITLE
Update _search.js

### DIFF
--- a/html/pfappserver/root/src/views/Auditing/radiusLogs/_search.js
+++ b/html/pfappserver/root/src/views/Auditing/radiusLogs/_search.js
@@ -299,7 +299,7 @@ export const useSearch = makeSearch('radiusLogs', {
     },
     {
       value: 'computer_name',
-      text: 'Computer name', // i18n defer
+      text: 'Computer Name', // i18n defer
       types: [conditionType.SUBSTRING]
     },
     {
@@ -354,7 +354,7 @@ export const useSearch = makeSearch('radiusLogs', {
     },
     {
       value: 'nas_identifier',
-      text: 'NAS identifier', // i18n defer
+      text: 'NAS Identifier', // i18n defer
       types: [conditionType.SUBSTRING]
     },
     {


### PR DESCRIPTION
# Description
This is a grammatical fix. In the RADIUS audit log, there is a search field and custom search options. When you click the first dropdown box to search for a specific field, all of the options with two or more words have the first letters capitalized. Two of the fields were missing capitalization on the second word. Used to filter the RADIUS audit log when searching for entries

# Impacts
Cosmetic view when searching the RADIUS Audit Log

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)
