### PR TITLE
Create a kaniko-build image to build Docker images on other projects

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,7 +33,6 @@ variables:
   KANIKOBUILD_IMG: ghcr.io/inverse-inc/packetfence/kaniko-build
   KNK_REGISTRY: ghcr.io
   KNK_REGISTRY_URL: ${KNK_REGISTRY}/inverse-inc/packetfence
-  KNK_CACHE: "true"
   PFBUILD_DEFAULT_DEV_TAG: latest
   CIDIR: ci
   CILIBDIR: ci/lib

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,6 +30,7 @@ variables:
   PFBUILD_CENTOS_8_IMG: ghcr.io/inverse-inc/packetfence/pfbuild-centos-8
   PFBUILD_DEB_BULLSEYE_IMG: ghcr.io/inverse-inc/packetfence/pfbuild-debian-bullseye
   KANIKO_DEBUG_IMG: gcr.io/kaniko-project/executor:debug
+  KANIKOBUILD_IMG: ghcr.io/inverse-inc/packetfence/kaniko-build
   KNK_REGISTRY: ghcr.io
   KNK_REGISTRY_URL: ${KNK_REGISTRY}/inverse-inc/packetfence
   KNK_CACHE: "true"
@@ -282,6 +283,14 @@ variables:
   stage: build_img_container
   dependencies: []
   image:
+    name: ${KANIKOBUILD_IMG}
+  tags:
+    - docker
+
+.build_img_container_kanikobuild_job:
+  stage: build_img_container
+  dependencies: []
+  image:
     name: ${KANIKO_DEBUG_IMG}
     entrypoint: [""]
   script:
@@ -528,10 +537,19 @@ run_pipeline_if_necessary:
 # BUILD_IMG_CONTAINER JOBS
 ########################################
 # devel
+kaniko_dev:
+  extends:
+    - .build_img_container_kanikobuild_job
+    - .build_img_container_devel_rules
+  variables:
+    IMAGE_NAME: "kaniko-build"
+    IMAGE_TAGS: "${CI_COMMIT_REF_SLUG},latest"
+
 pfdeb_dev:
   extends:
     - .build_img_container_job
     - .build_img_container_devel_rules
+  needs: ["kaniko_dev"]
   variables:
     IMAGE_NAME: "pfdebian"
     IMAGE_TAGS: "${CI_COMMIT_REF_SLUG},latest"
@@ -569,6 +587,7 @@ img_dev:
   extends:
     - .build_img_container_job
     - .build_img_container_devel_rules
+  needs: ["kaniko_dev"]
   variables:
     IMAGE_TAGS: "${CI_COMMIT_REF_SLUG},latest"
   parallel:
@@ -593,10 +612,19 @@ rad_based_dev:
           - "radiusd-eduroam"
 
 # branches and maintenance
+kaniko_br_maint:
+  extends:
+    - .build_img_container_kanikobuild_job
+    - .build_img_container_branches_and_maintenance_rules
+  variables:
+    IMAGE_NAME: "kaniko-build"
+    IMAGE_TAGS: ${CI_COMMIT_REF_SLUG}
+
 pfdeb_br_maint:
   extends:
     - .build_img_container_job
     - .build_img_container_branches_and_maintenance_rules
+  needs: ["kaniko_br_maint"]
   variables:
     IMAGE_NAME: "pfdebian"
     IMAGE_TAGS: ${CI_COMMIT_REF_SLUG}
@@ -634,6 +662,7 @@ img_br_maint:
   extends:
     - .build_img_container_job
     - .build_img_container_branches_and_maintenance_rules
+  needs: ["kaniko_br_maint"]
   variables:
     IMAGE_TAGS: ${CI_COMMIT_REF_SLUG}
   parallel:
@@ -658,10 +687,19 @@ rad_based_br_maint:
           - "radiusd-eduroam"
 
 # release
+kaniko_rel:
+  extends:
+    - .build_img_container_kanikobuild_job
+    - .release_only_rules
+  variables:
+    IMAGE_NAME: "kaniko-build"
+    IMAGE_TAGS: ${CI_COMMIT_TAG}
+
 pfdeb_rel:
   extends:
     - .build_img_container_job
     - .release_only_rules
+  needs: ["kaniko_rel"]
   variables:
     IMAGE_NAME: "pfdebian"
     IMAGE_TAGS: ${CI_COMMIT_TAG}
@@ -696,14 +734,15 @@ pfdeb_based_rel:
           - "proxysql"
 
 img_rel:
- extends:
-   - .build_img_container_job
-   - .release_only_rules
- variables:
+  extends:
+    - .build_img_container_job
+    - .release_only_rules
+  needs: ["kaniko_rel"]
+  variables:
    IMAGE_TAGS: ${CI_COMMIT_TAG}
- parallel:
-   matrix:
-     - IMAGE_NAME:
+  parallel:
+    matrix:
+      - IMAGE_NAME:
           - "fingerbank-db"
 
 rad_based_rel:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -278,11 +278,27 @@ variables:
   tags:
     - shell
 
-.build_img_container_job:
+.build_img_container_job_dev:
   stage: build_img_container
   dependencies: []
   image:
-    name: ${KANIKOBUILD_IMG}
+    name: ${KANIKOBUILD_IMG}:${CI_COMMIT_REF_SLUG}
+  tags:
+    - docker
+
+.build_img_container_job_br_maint:
+  stage: build_img_container
+  dependencies: []
+  image:
+    name: ${KANIKOBUILD_IMG}:${CI_COMMIT_REF_SLUG}
+  tags:
+    - docker
+
+.build_img_container_job_rel:
+  stage: build_img_container
+  dependencies: []
+  image:
+    name: ${KANIKOBUILD_IMG}:${CI_COMMIT_TAG}
   tags:
     - docker
 
@@ -546,7 +562,7 @@ kaniko_dev:
 
 pfdeb_dev:
   extends:
-    - .build_img_container_job
+    - .build_img_container_job_dev
     - .build_img_container_devel_rules
   needs: ["kaniko_dev"]
   variables:
@@ -555,7 +571,7 @@ pfdeb_dev:
 
 pfdeb_based_dev:
   extends:
-    - .build_img_container_job
+    - .build_img_container_job_dev
     - .build_img_container_devel_rules
   needs: ["pfdeb_dev"]
   variables:
@@ -584,7 +600,7 @@ pfdeb_based_dev:
 
 img_dev:
   extends:
-    - .build_img_container_job
+    - .build_img_container_job_dev
     - .build_img_container_devel_rules
   needs: ["kaniko_dev"]
   variables:
@@ -596,7 +612,7 @@ img_dev:
 
 rad_based_dev:
   extends:
-    - .build_img_container_job
+    - .build_img_container_job_dev
     - .build_img_container_devel_rules
   needs: ["pfdeb_based_dev"]
   variables:
@@ -621,7 +637,7 @@ kaniko_br_maint:
 
 pfdeb_br_maint:
   extends:
-    - .build_img_container_job
+    - .build_img_container_job_br_maint
     - .build_img_container_branches_and_maintenance_rules
   needs: ["kaniko_br_maint"]
   variables:
@@ -630,7 +646,7 @@ pfdeb_br_maint:
 
 pfdeb_based_br_maint:
   extends:
-    - .build_img_container_job
+    - .build_img_container_job_br_maint
     - .build_img_container_branches_and_maintenance_rules
   needs: ["pfdeb_br_maint"]
   variables:
@@ -659,7 +675,7 @@ pfdeb_based_br_maint:
 
 img_br_maint:
   extends:
-    - .build_img_container_job
+    - .build_img_container_job_br_maint
     - .build_img_container_branches_and_maintenance_rules
   needs: ["kaniko_br_maint"]
   variables:
@@ -671,7 +687,7 @@ img_br_maint:
 
 rad_based_br_maint:
   extends:
-    - .build_img_container_job
+    - .build_img_container_job_br_maint
     - .build_img_container_branches_and_maintenance_rules
   needs: ["pfdeb_based_br_maint"]
   variables:
@@ -696,7 +712,7 @@ kaniko_rel:
 
 pfdeb_rel:
   extends:
-    - .build_img_container_job
+    - .build_img_container_job_rel
     - .release_only_rules
   needs: ["kaniko_rel"]
   variables:
@@ -705,7 +721,7 @@ pfdeb_rel:
 
 pfdeb_based_rel:
   extends:
-    - .build_img_container_job
+    - .build_img_container_job_rel
     - .release_only_rules
   needs: ["pfdeb_rel"]
   variables:
@@ -734,7 +750,7 @@ pfdeb_based_rel:
 
 img_rel:
   extends:
-    - .build_img_container_job
+    - .build_img_container_job_rel
     - .release_only_rules
   needs: ["kaniko_rel"]
   variables:
@@ -746,7 +762,7 @@ img_rel:
 
 rad_based_rel:
   extends:
-    - .build_img_container_job
+    - .build_img_container_job_rel
     - .release_only_rules
   needs: ["pfdeb_based_rel"]
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -281,24 +281,27 @@ variables:
 .build_img_container_job_dev:
   stage: build_img_container
   dependencies: []
-  image:
-    name: ${KANIKOBUILD_IMG}:${CI_COMMIT_REF_SLUG}
+  image: ${KANIKOBUILD_IMG}:${CI_COMMIT_REF_SLUG}
+  script:
+    - /bin/kanikobuild
   tags:
     - docker
 
 .build_img_container_job_br_maint:
   stage: build_img_container
   dependencies: []
-  image:
-    name: ${KANIKOBUILD_IMG}:${CI_COMMIT_REF_SLUG}
+  image: ${KANIKOBUILD_IMG}:${CI_COMMIT_REF_SLUG}
+  script:
+    - /bin/kanikobuild
   tags:
     - docker
 
 .build_img_container_job_rel:
   stage: build_img_container
   dependencies: []
-  image:
-    name: ${KANIKOBUILD_IMG}:${CI_COMMIT_TAG}
+  image: ${KANIKOBUILD_IMG}:${CI_COMMIT_TAG}
+  script:
+    - /bin/kanikobuild
   tags:
     - docker
 

--- a/containers/Makefile
+++ b/containers/Makefile
@@ -22,8 +22,8 @@ endif
 .PHONY: run_kaniko
 
 run_kaniko:
-	docker pull gcr.io/kaniko-project/executor:debug
-	docker container run --entrypoint '/busybox/sh' --rm --name "kaniko" --volume="$(SRC_ROOT_DIR)":/workspace -it gcr.io/kaniko-project/executor:debug
+	docker pull ghcr.io/inverse-inc/packetfence/kaniko-build:devel
+	docker container run --entrypoint '/busybox/sh' --rm --name "kaniko" --volume="$(SRC_ROOT_DIR)":/workspace -it ghcr.io/inverse-inc/packetfence/kaniko-build:devel
 
 ### Targets for localdev
 DOCKERFILE_DIRS = $(shell find -type f -name "Dockerfile" -printf "%P\n")
@@ -43,4 +43,4 @@ $(CONTAINER_IMAGES):
 			-e "KNK_REGISTRY_URL=$(KNK_REGISTRY_URL)" \
 			-e "KNK_REGISTRY_USER" -e "KNK_REGISTRY_PASSWORD" \
 			--volume="$(SRC_ROOT_DIR)":/workspace \
-			-it gcr.io/kaniko-project/executor:debug
+			-it ghcr.io/inverse-inc/packetfence/kaniko-build:devel

--- a/containers/kaniko-build/Dockerfile
+++ b/containers/kaniko-build/Dockerfile
@@ -1,0 +1,6 @@
+FROM gcr.io/kaniko-project/executor:debug
+
+COPY containers/kanikobuild /bin/kanikobuild
+RUN chmod +x /bin/kanikobuild
+
+ENTRYPOINT /bin/kanikobuild

--- a/containers/kaniko_vars
+++ b/containers/kaniko_vars
@@ -1,0 +1,10 @@
+### collect variables needed inside Dockerfile
+
+# returns X.Y
+export PF_VERSION=$(egrep -o '[0-9]+\.[0-9]+' $CI_PROJECT_DIR/conf/pf-release)
+
+# only used for pfdebian build
+export PKGS_TO_EXCLUDE="packetfence|freeradius"
+
+# variables to pass during build
+DOCKFILE_VARS='PF_VERSION KNK_REGISTRY_URL IMAGE_TAG FINGERBANK_BUILD_API_KEY BUILD_PFAPPSERVER_VUE PKGS_TO_EXCLUDE'

--- a/containers/kanikobuild
+++ b/containers/kanikobuild
@@ -6,21 +6,21 @@ set -o nounset -o pipefail -o errexit
 # CI_PROJECT_DIR must be equal to root of PF source tree (full path)
 
 setup_vars() {
-    DOCKFILE_PATH=$CI_PROJECT_DIR/containers/$IMAGE_NAME/Dockerfile
+    # all specific variables need to be defined in kaniko_vars
+    if [ -f "$CI_PROJECT_DIR/containers/kaniko_vars" ]; then
+	source $CI_PROJECT_DIR/containers/kaniko_vars
+    else
+	echo "No specific variables added to build"
+    fi
 
-    ### collect variables needed inside Dockerfile
-    # returns X.Y
-    export PF_VERSION=$(egrep -o '[0-9]+\.[0-9]+' $CI_PROJECT_DIR/conf/pf-release)
+    # necessary if variables are not defined in kaniko_vars or in environment
+    DOCKFILE_PATH=${DOCKFILE_PATH:-"$CI_PROJECT_DIR/containers/$IMAGE_NAME/Dockerfile"}
+    DOCKFILE_VARS=${DOCKFILE_VARS:-}
+    KNK_CACHE=${KNK_CACHE:-true}
 
     # IMAGE_TAG is used inside DockerFile to reference other image
     # only one tag can be used in Dockerfile
     export IMAGE_TAG=$(echo $IMAGE_TAGS | cut -d ',' -f 1)
-
-    # only used for pfdebian build
-    export PKGS_TO_EXCLUDE="packetfence|freeradius"
-
-    # variables to pass during build
-    DOCKFILE_VARS='PF_VERSION KNK_REGISTRY_URL IMAGE_TAG FINGERBANK_BUILD_API_KEY BUILD_PFAPPSERVER_VUE PKGS_TO_EXCLUDE'
 
     echo "Building ${IMAGE_NAME} using ${DOCKFILE_PATH}"
 }
@@ -35,15 +35,17 @@ generate_knk_config() {
 # already in the environment
 generate_build_args() {
     local build_args=''
-    for var in ${DOCKFILE_VARS}; do
-      # just to handle case of first iteration
-      if [ -z "$build_args" ]; then 
-        build_args="--build-arg ${var}"
-      else
-        build_args="$build_args --build-arg ${var}"
-      fi
-    done
-    echo "$build_args"
+    if [ -n "${DOCKFILE_VARS}" ]; then
+        for var in ${DOCKFILE_VARS}; do
+          # just to handle case of first iteration
+          if [ -z "$build_args" ]; then
+            build_args="--build-arg ${var}"
+          else
+            build_args="$build_args --build-arg ${var}"
+          fi
+        done
+        echo "$build_args"
+    fi
 }
 
 detect_multi_tags() {

--- a/containers/manage-images.sh
+++ b/containers/manage-images.sh
@@ -24,6 +24,7 @@ configure_and_check() {
                            -not -path "*/pfdebian/*" \
                            -not -path "*/radiusd/*" \
                            -not -path "*/pfconnector-*/*" \
+                           -not -path "*/kaniko-build/*" \
                            -printf "%P\n")
 
     for file in ${DOCKERFILE_DIRS}; do


### PR DESCRIPTION
# Description
- Make script ./containers/kanikobuild more reusable
- Build a kaniko-build image which contains ./containers/kanikobuild script
- Usage of Kaniko cache is defined by default in script

# Impacts
Build of Docker images

# Delete branch after merge
YES