### PR TITLE
Note that since 12.1, other KSPs work

### DIFF
--- a/docs/installation/pki/packetfence.asciidoc
+++ b/docs/installation/pki/packetfence.asciidoc
@@ -223,7 +223,7 @@ Last step is to "Grant admin", just click on "Grant admin consent for ..." and c
 
 image::Intune-8-Grant-Admin.png[scaledwidth="100%",alt="Grant-Admin"]
 
-CAUTION: Key storage provider (KSP) needs to be set to *Enroll to Software KSP*
+CAUTION: Before Packetfence version 12.1, Key storage provider (KSP) needs to be set to *Enroll to Software KSP*
 
 image::Intune_KSP.png[scaledwidth="100%",alt="KSP"]
 


### PR DESCRIPTION
# Description
Update docs to note that other KSPs (TPM is what I've tested) work now.

# Impacts
Test an Intune SCEP profile with TPM or WHfB enrollment.

# Code / PR Dependencies
I'm pretty sure https://github.com/inverse-inc/packetfence/commit/083d4e616f593c52ccdc70b1b7ecc50641629631 is what made it work.

# Delete branch after merge
NO

# Checklist
- [yes] Document the feature
- [n/a] Add unit tests
- [n/a] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* Supports storing certificates issued by Intune in TPM
