### PR TITLE
Fix/dyn reverse reconnect

### DIFF
--- a/go/chisel/main.go
+++ b/go/chisel/main.go
@@ -412,7 +412,7 @@ func client(args []string) {
 	flags.StringVar(&config.SrcIP, "src-ip", "", "")
 	hostname := flags.String("hostname", "", "")
 	pid := flags.Bool("pid", false, "")
-	verbose := flags.Bool("v", false, "")
+	verbose := flags.Bool("v", (strings.ToLower(os.Getenv("LOG_LEVEL")) == "debug"), "")
 	flags.Usage = func() {
 		fmt.Print(clientHelp)
 		os.Exit(0)

--- a/go/chisel/server/server_handler.go
+++ b/go/chisel/server/server_handler.go
@@ -196,6 +196,8 @@ func (s *Server) handleWebsocket(w http.ResponseWriter, req *http.Request) {
 		return tunnel.BindRemotes(ctx, serverInbound)
 	})
 	if user != nil {
+		l.Infof("Connector %s has just connected to this server", user.Name)
+		settings.ClearActiveDynReverseConnector(ctx, user.Name)
 		activeTunnels.Store(user.Name, tunnel)
 		res := s.redis.Set(fmt.Sprintf("%s%s", s.redisTunnelsNamespace, user.Name), fmt.Sprintf("%s://%s", s.listenProto, req.Context().Value(http.LocalAddrContextKey).(net.Addr).String()), 0)
 		if res.Err() != nil {

--- a/go/chisel/share/settings/active_dyn_reverse.go
+++ b/go/chisel/share/settings/active_dyn_reverse.go
@@ -1,7 +1,12 @@
 package settings
 
 import (
+	"context"
+	"fmt"
+	"strings"
 	"sync"
+
+	"github.com/inverse-inc/go-utils/log"
 )
 
 var ActiveDynReverse = sync.Map{}
@@ -18,4 +23,15 @@ func ClearFromActiveDynReverse(r *Remote) bool {
 		return true
 	})
 	return cleared
+}
+
+func ClearActiveDynReverseConnector(ctx context.Context, id string) {
+	ActiveDynReverse.Range(func(kInt, v interface{}) bool {
+		k := kInt.(string)
+		if strings.HasPrefix(k, id) {
+			log.LoggerWContext(ctx).Debug(fmt.Sprintf("Clearing %s from ActiveDynReverse", k))
+			ActiveDynReverse.Delete(k)
+		}
+		return true
+	})
 }


### PR DESCRIPTION
# Description
Clears the active dynamic reverses that exist when a pfconnector reconnects (these reverses are tied to a tunnel that is dead)

# Impacts
pfconnector


# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* Clear the active dynamic reverses that exist when a pfconnector reconnects

