### PR TITLE
fix: use WPA2 in place of WPA for Apple devices only + automatically trust server certificate provided by PF

### DIFF
--- a/html/captive-portal/templates/wireless-profile-noeap.xml
+++ b/html/captive-portal/templates/wireless-profile-noeap.xml
@@ -9,7 +9,11 @@
                         <key>AutoJoin</key>
                         <true/>
                         <key>EncryptionType</key>
+                        [% IF for_ios AND provisioner.security_type == 'WPA' %]
+                        <string>WPA2</string>
+                        [% ELSE %]
                         <string>[% provisioner.security_type %]</string>
+                        [% END %]
                         <key>HIDDEN_NETWORK</key>
                         [% IF provisioner.broadcast %]
                         <false/>

--- a/html/captive-portal/templates/wireless-profile-peap.xml
+++ b/html/captive-portal/templates/wireless-profile-peap.xml
@@ -28,7 +28,11 @@
                                 <string>[% username %]</string>
                         </dict>
                         <key>EncryptionType</key>
+                        [% IF for_ios AND provisioner.security_type == 'WPA' %]
+                        <string>WPA2</string>
+                        [% ELSE %]
                         <string>[% provisioner.security_type %]</string>
+                        [% END %]
                         <key>HIDDEN_NETWORK</key>
                         [% IF provisioner.broadcast %]
                         <false/>

--- a/html/captive-portal/templates/wireless-profile-tls.xml
+++ b/html/captive-portal/templates/wireless-profile-tls.xml
@@ -16,7 +16,11 @@
                                 </array>
                         </dict>
                         <key>EncryptionType</key>
+                        [% IF for_ios AND provisioner.security_type == 'WPA' %]
+                        <string>WPA2</string>
+                        [% ELSE %]
                         <string>[% provisioner.security_type %]</string>
+                        [% END %]
                         <key>HIDDEN_NETWORK</key>
                         [% IF provisioner.broadcast %]
                         <false/>

--- a/html/captive-portal/templates/wireless-profile-tls.xml
+++ b/html/captive-portal/templates/wireless-profile-tls.xml
@@ -14,6 +14,10 @@
                                 <array>
                                         <integer>[% provisioner.eap_type %]</integer>
                                 </array>
+                                <key>PayloadCertificateAnchorUUID</key>
+                                <array>
+                                        <string>c83817c4-d7c4-11e4-b9d6-1681e6b88ec1</string>
+                                </array>
                         </dict>
                         <key>EncryptionType</key>
                         [% IF for_ios AND provisioner.security_type == 'WPA' %]


### PR DESCRIPTION
# Description
Generate a mobileconfig file for Apple devices which always contains 'WPA2' in place of 'WPA' when provisioner contains WPA or WPA2.

# Impacts
Apple provisioning

# Issue
fixes #7425

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
FIXME
