### PR TITLE
Added feature to change Computername on node creation

### DIFF
--- a/html/pfappserver/root/src/views/Nodes/_components/TheFormCreate.vue
+++ b/html/pfappserver/root/src/views/Nodes/_components/TheFormCreate.vue
@@ -7,6 +7,9 @@
     >
       <form-group-mac namespace="mac"
         :column-label="$t('MAC')"
+      />      
+      <form-group-computername namespace="computername"
+        :column-label="$t('ComputerName')"
       />
       <form-group-pid namespace="pid"
         :column-label="$i18n.t('Owner')"
@@ -49,6 +52,7 @@ import {
 } from '@/components/new/'
 import {
   FormGroupMac,
+  FormGroupComputername,
   FormGroupPid,
   FormGroupStatus,
   FormGroupRole,
@@ -61,6 +65,7 @@ const components = {
   BaseFormButtonBar,
 
   FormGroupMac,
+  FormGroupComputername,
   FormGroupPid,
   FormGroupStatus,
   FormGroupRole,

--- a/html/pfappserver/root/src/views/Nodes/_components/index.js
+++ b/html/pfappserver/root/src/views/Nodes/_components/index.js
@@ -28,5 +28,6 @@ export {
   BaseFormGroupTextarea         as FormGroupNotes,
   
   BaseFormGroupInput            as FormGroupMac,
+  BaseFormGroupInput            as FormGroupComputername,
   
 }


### PR DESCRIPTION
# Description
I added another form field to the Create Node form in the web interface. Our company would really like this feature for adding new devices to Packetfence. Ideally, we would want an editable field as described in #4890, but this was easy enough to implement. I tested this change on our server and it works as expected. Sorry, this is my first Github pull request, so let me know if I am doing something wrong

# Impacts
This impacts the Create Node form under /nodes/create

# Issue
Helps with but doesn't fix #4890

# Delete branch after merge
YES

# NEWS file entries
## New Features
* Ability to add computername on node creation
