### PR TITLE
Disable CLI by default in fortigate switch module

### DIFF
--- a/lib/pf/Connection.pm
+++ b/lib/pf/Connection.pm
@@ -11,6 +11,8 @@ use pf::config qw(
     $WIRED_802_1X
     $VIRTUAL_CLI
     $VIRTUAL_VPN
+    $WEBAUTH_WIRELESS
+    $WEBAUTH_WIRED
 );
 use pf::log;
 
@@ -20,6 +22,7 @@ has 'transport'         => (is => 'rw', isa => 'Str');                  # Wired 
 has 'isEAP'             => (is => 'rw', isa => 'Bool', default => 0);   # 0: NoEAP / 1: EAP
 has 'isSNMP'            => (is => 'rw', isa => 'Bool', default => 0);   # 0: NoSNMP | 1: SNMP
 has 'isMacAuth'         => (is => 'rw', isa => 'Bool', default => 0);   # 0: NoMacAuth | 1: MacAuth
+has 'isWebAuth'         => (is => 'rw', isa => 'Bool', default => 0);   # 0: NoWebAuth | 1: WebAuth
 has 'is8021X'           => (is => 'rw', isa => 'Bool', default => 0);   # 0: No8021X | 1: 8021X
 has 'isVPN'             => (is => 'rw', isa => 'Bool', default => 0);   # 0: NoVPN | 1: VPN
 has 'isCLI'             => (is => 'rw', isa => 'Bool', default => 0);   # 0: NoCLI | 1: CLI
@@ -70,6 +73,9 @@ sub _attributesToString {
     # Handling ACLDownload
     $type .= ( $self->isACLDownload ) ? "-ACLDownload" : "";
 
+    # Handling Web-Auth
+    $type .= ( $self->isWebAuth ) ? "-Web-Auth" : "";
+
     $self->type($type);
 }
 
@@ -113,6 +119,9 @@ sub _stringToAttributes {
 
     # We check if ACLDownload
     ( lc($type) =~ /^acldownload/ ) ? $self->isACLDownload($TRUE) : $self->isServiceTemplate($FALSE);
+
+    # We check if WebAuth
+    ( lc($type) =~ /^web-auth/ ) ? $self->isWebAuth($TRUE) : $self->isWebAuth($FALSE);
 
 }
 
@@ -169,6 +178,9 @@ sub backwardCompatibleToAttributes {
     if ( lc($type) =~ /acldownload$/ ) {
         $self->isACLDownload($TRUE);
     }
+    if ( lc($type) =~ /webauth$/ ) {
+        $self->isWebAuth($TRUE);
+    }
 }
 
 =head2 attributesToBackwardCompatible
@@ -197,6 +209,12 @@ sub attributesToBackwardCompatible {
 
     # Virtual CLI
     return $VIRTUAL_CLI if ( (lc($self->transport) eq "virtual") && ($self->isCLI) );
+
+    # Wireless WebAuth
+    return $WEBAUTH_WIRELESS if ( (lc($self->transport) eq "wireless") && ($self->isWebAuth) );
+
+    # Wired WebAuth
+    return $WEBAUTH_WIRED if ( (lc($self->transport) eq "wired") && ($self->isWebAuth) );
 
     # Default
     return;

--- a/lib/pf/Switch/Fortinet/FortiGate.pm
+++ b/lib/pf/Switch/Fortinet/FortiGate.pm
@@ -240,10 +240,13 @@ sub identifyConnectionType {
     } elsif ( (@require == @found) && $radius_request->{'Connect-Info'} =~ /^(admin-login)$/i ) {
         $connection->isVPN($FALSE);
         $connection->isCLI($TRUE);
+    } elsif ( (@require == @found) && $radius_request->{'Connect-Info'} =~ /^(web-auth)$/i ) {
+        $connection->isVPN($FALSE);
+        $connection->isCLI($FALSE);
     } else {
         # Default to CLI
         $connection->isVPN($FALSE);
-        $connection->isCLI($TRUE);
+        $connection->isCLI($FALSE);
     }
 }
 

--- a/lib/pf/Switch/Fortinet/FortiGate.pm
+++ b/lib/pf/Switch/Fortinet/FortiGate.pm
@@ -254,7 +254,6 @@ sub identifyConnectionType {
             $connection->transport("Wired");
         }
     } else {
-        # Default to CLI
         $connection->isVPN($FALSE);
         $connection->isCLI($FALSE);
     }

--- a/lib/pf/Switch/Fortinet/FortiGate.pm
+++ b/lib/pf/Switch/Fortinet/FortiGate.pm
@@ -207,7 +207,7 @@ sub deauthenticateMacDefault {
 
     $logger->debug("deauthenticate $mac using RADIUS Disconnect-Request deauth method");
     return $self->radiusDisconnect(
-        $mac, { 'Acct-Session-Id' => $dynauth->{'acctsessionid'}, 'User-Name' => $dynauth->{'username'} },
+        $mac, { 'Acct-Session-Id' => $dynauth->{'acctsessionid'}, 'User-Name' => $dynauth->{'username'},'Framed-IP-Address' => $ipAddress },
     );
 }
 

--- a/lib/pf/Switch/Fortinet/FortiGate.pm
+++ b/lib/pf/Switch/Fortinet/FortiGate.pm
@@ -49,6 +49,7 @@ use pf::SwitchSupports qw(
     WiredMacAuth
     WirelessDot1x
     WirelessWebAuth
+    WiredWebAuth
     RoleBasedEnforcement
     VPNRoleBasedEnforcement
     VPN
@@ -241,11 +242,15 @@ sub identifyConnectionType {
     } elsif ( (@require == @found) && $radius_request->{'Connect-Info'} =~ /^(admin-login)$/i ) {
         $connection->isVPN($FALSE);
         $connection->isCLI($TRUE);
-    } elsif ( (@require == @found) && $radius_request->{'Connect-Info'} =~ /^(web-auth)$/i && exists $radius_request->{'Fortinet-SSID'}) {
+    } elsif ( (@require == @found) && $radius_request->{'Connect-Info'} =~ /^(web-auth)$/i) {
         $connection->isVPN($FALSE);
         $connection->isCLI($FALSE);
         $connection->isWebAuth($TRUE);
-        $connection->transport("Wireless");
+        if (exists $radius_request->{'Fortinet-SSID'}) {
+            $connection->transport("Wireless");
+        } else {
+            $connection->transport("Wired");
+        }
     } else {
         # Default to CLI
         $connection->isVPN($FALSE);

--- a/lib/pf/Switch/Fortinet/FortiGate.pm
+++ b/lib/pf/Switch/Fortinet/FortiGate.pm
@@ -33,6 +33,7 @@ use pf::constants;
 use pf::accounting qw(node_accounting_dynauth_attr);
 use pf::config qw ($WEBAUTH_WIRELESS $WEBAUTH_WIRED $WIRED_802_1X $WIRED_MAC_AUTH);
 use pf::constants::role qw($REJECT_ROLE);
+use pf::ip4log qw(mac2ip);
 
 use base ('pf::Switch::Fortinet');
 
@@ -204,6 +205,7 @@ sub deauthenticateMacDefault {
 
     #Fetching the acct-session-id
     my $dynauth = node_accounting_dynauth_attr($mac);
+    my $ipAddress = pf::ip4log::mac2ip($mac);
 
     $logger->debug("deauthenticate $mac using RADIUS Disconnect-Request deauth method");
     return $self->radiusDisconnect(

--- a/lib/pf/Switch/Fortinet/FortiGate.pm
+++ b/lib/pf/Switch/Fortinet/FortiGate.pm
@@ -48,6 +48,7 @@ use pf::SwitchSupports qw(
     WirelessMacAuth
     WiredMacAuth
     WirelessDot1x
+    WirelessWebAuth
     RoleBasedEnforcement
     VPNRoleBasedEnforcement
     VPN
@@ -240,9 +241,11 @@ sub identifyConnectionType {
     } elsif ( (@require == @found) && $radius_request->{'Connect-Info'} =~ /^(admin-login)$/i ) {
         $connection->isVPN($FALSE);
         $connection->isCLI($TRUE);
-    } elsif ( (@require == @found) && $radius_request->{'Connect-Info'} =~ /^(web-auth)$/i ) {
+    } elsif ( (@require == @found) && $radius_request->{'Connect-Info'} =~ /^(web-auth)$/i && exists $radius_request->{'Fortinet-SSID'}) {
         $connection->isVPN($FALSE);
         $connection->isCLI($FALSE);
+        $connection->isWebAuth($TRUE);
+        $connection->transport("Wireless");
     } else {
         # Default to CLI
         $connection->isVPN($FALSE);

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -45,6 +45,8 @@ use pf::config qw(
     $WIRELESS_MAC_AUTH
     $WIRELESS_802_1X
     $VIRTUAL_VPN
+    $WEBAUTH_WIRED
+    $WEBAUTH_WIRELESS
 );
 use pf::client;
 use pf::locationlog;
@@ -193,7 +195,7 @@ sub authorize {
 
     $logger->info("handling radius autz request: from switch_ip => ($switch_ip), "
         . "connection_type => " . connection_type_to_str($connection_type) . ","
-        . "switch_mac => ".( defined($switch_mac) ? "($switch_mac)" : "(Unknown)" ).", mac => [$mac], port => $port, username => \"$user_name\""
+        . " switch_mac => ".( defined($switch_mac) ? "($switch_mac)" : "(Unknown)" ).", mac => [$mac], port => $port, username => \"$user_name\""
         . ( defined $ssid ? ", ssid => $ssid" : '' ) );
 
     my ($status_code, $node_obj) = pf::dal::node->find_or_create({"mac" => $mac});
@@ -646,6 +648,10 @@ sub _isSwitchSupported {
         return $args->{'switch'}->supportsWiredMacAuth();
     } elsif ($args->{'connection_type'} == $WIRED_802_1X) {
         return $args->{'switch'}->supportsWiredDot1x();
+    } elsif ($args->{'connection_type'} == $WEBAUTH_WIRED) {
+        return $args->{'switch'}->supportsWiredWebAuth();
+    } elsif ($args->{'connection_type'} == $WEBAUTH_WIRELESS) {
+        return $args->{'switch'}->supportsWirelessWebAuth();
     } elsif ($args->{'connection_type'} == $WIRELESS_MAC_AUTH) {
         # TODO implement supportsWirelessMacAuth (or supportsWireless)
         $logger->trace("Wireless doesn't have a supports...() call for now, always say it's supported");


### PR DESCRIPTION
# Description
In Fortigate radius request the nasporttype is defined as Virtual and it changes the connection type to CLI-Access.
Disabled by default CLI for fortigate switch and also disable it when Connect-Info is equals to web-auth.

# Impacts
Fortigate connection type detection

# Issue
fixes #7402

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
## Bug Fixes
* Captive-Portal with FortiGate does not work #7402

