### PR TITLE
Fixes #7399

### DIFF
--- a/lib/pf/Authentication/Source/OAuthSource.pm
+++ b/lib/pf/Authentication/Source/OAuthSource.pm
@@ -42,7 +42,7 @@ sub available_actions {
 
 sub available_attributes {
     my $self = shift;
-    return([@{$self->SUPER::available_attributes}, {value => 'username', type => $Conditions::SUBSTRING }]);
+    return([@{$self->SUPER::available_attributes}]);
 }
 
 =head2 match_in_subclass


### PR DESCRIPTION
# Description
Removed extra username attribute in the OAuth/OpenID authentication sources. 

# Impacts
No impact


# Issue
fixes #7399

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
## Bug Fixes
* OpenID Authentication Source -Duplicated Username #7399

