### PR TITLE
Fix/7438 for maintenance patches and major/minor upgrades

### DIFF
--- a/addons/full-upgrade/run-upgrade.sh
+++ b/addons/full-upgrade/run-upgrade.sh
@@ -76,6 +76,7 @@ function apt_upgrade_packetfence_package() {
   else
     DEBIAN_FRONTEND=noninteractive apt install -q -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" packetfence -y
   fi
+  DEBIAN_FRONTEND=noninteractive apt autoremove -q -y
 }
 
 function yum_upgrade_packetfence_package() {

--- a/docs/common/upgrade_packages.asciidoc
+++ b/docs/common/upgrade_packages.asciidoc
@@ -1,17 +1,32 @@
 In order to upgrade your PacketFence packages to latest version, you can run following commands:
 
-.RHEL-based systems
+==== RHEL-based systems
+
 [source,bash]
 ----
 yum clean all --enablerepo=packetfence
 yum update --enablerepo=packetfence
 ----
 
-.Debian-based systems
+==== Debian-based systems
+
+If `libmariadb-dev` is installed on your system at a version prior to 10.5.18, you will need to run following commands:
+
+[source,bash]
+----
+apt update
+apt install packetfence
+apt autoremove
+apt upgrade
+----
+
+In all other cases, you can simply run:
+
 [source,bash]
 ----
 apt update
 apt upgrade
 ----
 
-
+NOTE: In order to get `libmariadb-dev` package version, you can run following command: `dpkg -l | grep libmariadb-dev`.
+If previous command doesn't return anything, `libmariadb-dev` is not installed.


### PR DESCRIPTION
# Description
Perform PacketFence and Debian upgrades on Debian in several steps:
- upgrade to PacketFence packages **only**. These packages doesn't depend anymore to libmariadb(d)-dev packages.
- remove libmariadb(d)-dev packages (using `apt autoremove`)
- upgrade Debian packages (including mariadb-* packages)

Expected state at end of a maintenance patch or at end of major/minor upgrade:
- latest PacketFence version of maintenance/11.X or maintenance/12.X version
- MariaDB packages at version 10.5.18
- libmariadb(d)-dev packages removed

# Impacts
- Maintenance patches
- Major/minor upgrades
- Fresh installations

# Code / PR Dependencies
- [x] Fixes on all maintenance/11.X and maintenance/12.X branches to remove libmariadbd-dev dependency (see https://github.com/inverse-inc/packetfence/commit/10cdce9dc27a8dd7b8e714bce1e060f8c7ac103b)
- [x] Rebuild documentation on website to provide instructions for maintenance patches

# Issue
fixes #7438 

# Delete branch after merge
YES

# Checklist
## Bug Fixes
If an issue exists on Github, please refer to it (name) along with it's number...
* Unable to upgrade to Debian 11.6 with PF 11.X and 12.X 