### PR TITLE
Allow Intune Compliance Check to handle InGracePeriod

### DIFF
--- a/html/pfappserver/root/src/views/Configuration/provisioners/_components/FormTypeIntune.vue
+++ b/html/pfappserver/root/src/views/Configuration/provisioners/_components/FormTypeIntune.vue
@@ -121,6 +121,7 @@ import {
   FormGroupProtocol,
   FormGroupRoleToApply,
   FormGroupTenantIdentifier,
+  FormGroupNonComplianceSecurityEvent,
   FormGroupWindowsAgentDownloadUri
 } from './'
 
@@ -146,6 +147,7 @@ const components = {
   FormGroupProtocol,
   FormGroupRoleToApply,
   FormGroupTenantIdentifier,
+  FormGroupNonComplianceSecurityEvent,
   FormGroupWindowsAgentDownloadUri
 }
 

--- a/html/pfappserver/root/src/views/Configuration/provisioners/_components/FormTypeIntune.vue
+++ b/html/pfappserver/root/src/views/Configuration/provisioners/_components/FormTypeIntune.vue
@@ -72,6 +72,11 @@
       :column-label="$i18n.t('Login URL')"
     />
 
+    <form-group-non-compliance-security-event namespace="non_compliance_security_event"
+     :column-label="$i18n.t('Non compliance security event')"
+     :text="$i18n.t('Which security event should be raised when non compliance is detected.')"
+   />
+
     <form-group-android-agent-download-uri namespace="android_agent_download_uri"
       :column-label="$i18n.t('Android agent download URI')"
     />

--- a/lib/pf/provisioner/intune.pm
+++ b/lib/pf/provisioner/intune.pm
@@ -285,7 +285,6 @@ sub verify_compliance {
     my $azuremac = uc($mac);
     $azuremac =~ s/://g;
 
-
     if($info != $pf::provisioner::COMMUNICATION_FAILED){
         my $not_compliant = $FALSE;
         foreach my $entry (@{$info->{value}}) {
@@ -294,7 +293,12 @@ sub verify_compliance {
                 if ($entry->{complianceState} eq 'compliant') {
                     $logger->info("Device $mac is compliant.");
                     return $TRUE;
-                } else {
+                } 
+                elsif ($entry->{complianceState} eq 'inGracePeriod') {
+					$logger->info("Device $mac is InGracePeriod.");
+                    return $TRUE;
+			    }
+                else {
                     $not_compliant = $TRUE;
                 }
             }

--- a/lib/pf/provisioner/intune.pm
+++ b/lib/pf/provisioner/intune.pm
@@ -295,9 +295,9 @@ sub verify_compliance {
                     return $TRUE;
                 } 
                 elsif ($entry->{complianceState} eq 'inGracePeriod') {
-					$logger->info("Device $mac is InGracePeriod.");
-                    return $TRUE;
-			    }
+                       $logger->info("Device $mac is InGracePeriod.");
+                       return $TRUE;
+                }
                 else {
                     $not_compliant = $TRUE;
                 }


### PR DESCRIPTION
# Description
(REQUIRED)
Describe what the new code is used for.
The current intune compliance checker does not handle the InGracePeriod returned by the Graph API.

This request added a check on the condition and if there returns as compliant.  

In addition, it gives the user the option in the provisioner setup form to select a targeted security event

# Impacts
(REQUIRED)
Describe what to reviewer should look at. Will also help for testing purposes.
Provisioner setup form and Intune Compliance Check
