### PR TITLE
Remove useless Debian packages to avoid conflicts during upgrades

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -25,6 +25,8 @@ Pre-Depends:  ca-certificates,
 # Removed for now
 # libmariadbd-dev (>= 10.1), libmariadbd-dev (<< 10.5.18)
 Breaks: libdata-alias-perl
+Conflicts: packetfence-captive-portal-javascript, packetfence-doc, packetfence-pfappserver-javascript
+Replaces: packetfence-captive-portal-javascript, packetfence-doc, packetfence-pfappserver-javascript
 Depends: ${misc:Depends}, vlan,
  packetfence-ntlm-wrapper (>= ${source:Version}), packetfence-golang-daemon (>= ${source:Version}),
  openssl,


### PR DESCRIPTION
# Description
Remove useless Debian packages to avoid conflicts during upgrades

# Impacts
Upgrades

# Issue
fixes #7246 
fixes #7473

# Delete branch after merge
YES

# TODO
- [ ] backport to all `maintenance/12.X` branches