### PR TITLE
Fix/7490

### DIFF
--- a/addons/full-upgrade/run-upgrade.sh
+++ b/addons/full-upgrade/run-upgrade.sh
@@ -18,6 +18,11 @@ function get_libmariadb_dev() {
     fi
 }
 
+function get_packages_to_remove() {
+    packages_to_remove='packetfence-captive-portal-javascript packetfence-doc packetfence-pfappserver-javascript'
+    dpkg -s ${packages_to_remove} &>/dev/null
+}
+
 
 function backup_git_commit_id() {
   if [ `cat /usr/local/pf/conf/git_commit_id` = "%{git_commit}" ]; then
@@ -47,6 +52,13 @@ function upgrade_packetfence_package() {
   if is_rpm_based; then
     yum_upgrade_packetfence_package $include_os_update
   elif is_deb_based; then
+    if get_packages_to_remove; then
+        echo "Packages to remove detected"
+        echo "OS upgrade can't be performed until ${packages_to_remove} are removed"
+        include_os_update=no
+    else
+        echo "Unable to detect packages to remove"
+    fi
     if get_libmariadb_dev; then
         if dpkg --compare-versions "${libmariadb_version}" le "10.5.15"; then
             echo "libmariadb-dev ${libmariadb_version} detected"

--- a/docs/common/upgrade_packages.asciidoc
+++ b/docs/common/upgrade_packages.asciidoc
@@ -10,7 +10,11 @@ yum update --enablerepo=packetfence
 
 ==== Debian-based systems
 
-If `libmariadb-dev` is installed on your system at a version prior to 10.5.18, you will need to run following commands:
+ * If `libmariadb-dev` is installed on your system at a version prior to 10.5.18
+ * If `packetfence-captive-portal-javascript` or `packetfence-doc` or `packetfence-pfappserver-javascript` are installed on your system *and* your PacketFence version is 12.0 or 12.1
+
+
+You will need to run following commands:
 
 [source,bash]
 ----


### PR DESCRIPTION
# Description
- Don't perform an `apt upgrade` if packages to remove are detected because `packetfence` package will not be upgraded (behavior of `apt upgrade`)
- Perforim an `apt upgrade` (if initially requested and canceled by `run-upgrade.sh`) once PacketFence packages have been upgraded
- Adjust documentation for maintenance patches

# Impacts
- Upgrade to 12.X
- Maintenance patches to 12.X

# Issue
fixes #7490 

# Delete branch after merge
YES