### PR TITLE
Add not_before to PKI revoked certificates, fixes #7509

### DIFF
--- a/db/pf-schema-X.Y.sql
+++ b/db/pf-schema-X.Y.sql
@@ -1499,6 +1499,7 @@ CREATE TABLE `pki_revoked_certs` (
   `profile_id` int(10) unsigned DEFAULT NULL,
   `profile_name` varchar(255) DEFAULT NULL,
   `valid_until` datetime NULL DEFAULT NULL,
+  `not_before` datetime DEFAULT NULL,
   `date` datetime NULL DEFAULT CURRENT_TIMESTAMP,
   `serial_number` varchar(255) DEFAULT NULL,
   `dns_names` varchar(255) DEFAULT NULL,

--- a/db/upgrade-X.X-X.Y.sql
+++ b/db/upgrade-X.X-X.Y.sql
@@ -76,6 +76,11 @@ ALTER TABLE `pki_certs`
     ADD COLUMN IF NOT EXISTS `not_before` datetime DEFAULT NULL AFTER `valid_until`;
 UPDATE pki_certs SET not_before = created_at WHERE 1;
 
+\! echo "Updating pki_revoked_certs table"
+ALTER TABLE `pki_revoked_certs`
+    ADD COLUMN IF NOT EXISTS `not_before` datetime DEFAULT NULL AFTER `valid_until`;
+UPDATE pki_revoked_certs SET not_before = created_at WHERE 1;
+
 \! echo "Incrementing PacketFence schema version...";
 INSERT IGNORE INTO pf_version (id, version, created_at) VALUES (@VERSION_INT, CONCAT_WS('.', @MAJOR_VERSION, @MINOR_VERSION), NOW());
 

--- a/go/caddy/pfpki/models/models.go
+++ b/go/caddy/pfpki/models/models.go
@@ -194,6 +194,7 @@ type (
 		ProfileID          uint            `json:"profile_id,omitempty" gorm:"INDEX:profile_id"`
 		ProfileName        string          `json:"profile_name,omitempty" gorm:"INDEX:profile_name"`
 		ValidUntil         time.Time       `json:"valid_until,omitempty" gorm:"INDEX:valid_until" gorm:"type:time"`
+		NotBefore          time.Time       `json:"not_before,omitempty" gorm:"INDEX:not_before" gorm:"type:time"`
 		Date               time.Time       `json:"date,omitempty" gorm:"default:CURRENT_TIMESTAMP"`
 		SerialNumber       string          `json:"serial_number,omitempty"`
 		DNSNames           string          `json:"dns_names,omitempty"`
@@ -1385,7 +1386,7 @@ func (c Cert) Revoke(params map[string]string) (types.Info, error) {
 		return Information, errors.New("Reason unsupported")
 	}
 	RevokeDate := time.Now().AddDate(0, 0, profile.RevokedValidUntil)
-	if err := c.DB.Create(&RevokedCert{Cn: cert.Cn, Mail: cert.Mail, Ca: ca, CaID: cert.CaID, CaName: cert.CaName, StreetAddress: cert.StreetAddress, Organisation: cert.Organisation, OrganisationalUnit: cert.OrganisationalUnit, Country: cert.Country, State: cert.State, Locality: cert.Locality, PostalCode: cert.Locality, Key: cert.Key, Cert: cert.Cert, Profile: profile, ProfileID: cert.ProfileID, ProfileName: cert.ProfileName, ValidUntil: cert.ValidUntil, Date: cert.Date, Revoked: RevokeDate, CRLReason: intreason, SerialNumber: cert.SerialNumber, DNSNames: cert.DNSNames, IPAddresses: cert.IPAddresses, Subject: cert.Subject}).Error; err != nil {
+	if err := c.DB.Create(&RevokedCert{Cn: cert.Cn, Mail: cert.Mail, Ca: ca, CaID: cert.CaID, CaName: cert.CaName, StreetAddress: cert.StreetAddress, Organisation: cert.Organisation, OrganisationalUnit: cert.OrganisationalUnit, Country: cert.Country, State: cert.State, Locality: cert.Locality, PostalCode: cert.Locality, Key: cert.Key, Cert: cert.Cert, Profile: profile, ProfileID: cert.ProfileID, ProfileName: cert.ProfileName, ValidUntil: cert.ValidUntil, NotBefore: crt.NotBefore, Date: cert.Date, Revoked: RevokeDate, CRLReason: intreason, SerialNumber: cert.SerialNumber, DNSNames: cert.DNSNames, IPAddresses: cert.IPAddresses, Subject: cert.Subject}).Error; err != nil {
 		Information.Error = err.Error()
 		return Information, err
 	}

--- a/html/pfappserver/root/src/views/Configuration/pki/certs/_composables/useCollection.js
+++ b/html/pfappserver/root/src/views/Configuration/pki/certs/_composables/useCollection.js
@@ -95,14 +95,14 @@ export const useSearch = makeSearch('pkiCerts', {
       visible: true
     },
     {
-      key: 'valid_until',
-      label: 'Valid Until', // i18n defer
+      key: 'not_before',
+      label: 'Not Before', // i18n defer
       sortable: true,
       visible: true
     },
     {
-      key: 'not_before',
-      label: 'Not Before', // i18n defer
+      key: 'valid_until',
+      label: 'Valid Until', // i18n defer
       sortable: true,
       visible: true
     },

--- a/html/pfappserver/root/src/views/Configuration/pki/revokedCerts/_composables/useCollection.js
+++ b/html/pfappserver/root/src/views/Configuration/pki/revokedCerts/_composables/useCollection.js
@@ -77,14 +77,14 @@ export const useSearch = makeSearch('pkiRevokedCerts', {
       visible: true
     },
     {
-      key: 'valid_until',
-      label: 'Valid Until', // i18n defer
+      key: 'not_before',
+      label: 'Not Before', // i18n defer
       sortable: true,
       visible: true
     },
     {
-      key: 'not_before',
-      label: 'Not Before', // i18n defer
+      key: 'valid_until',
+      label: 'Valid Until', // i18n defer
       sortable: true,
       visible: true
     },

--- a/html/pfappserver/root/src/views/Configuration/pki/revokedCerts/_composables/useCollection.js
+++ b/html/pfappserver/root/src/views/Configuration/pki/revokedCerts/_composables/useCollection.js
@@ -83,6 +83,12 @@ export const useSearch = makeSearch('pkiRevokedCerts', {
       visible: true
     },
     {
+      key: 'not_before',
+      label: 'Not Before', // i18n defer
+      sortable: true,
+      visible: true
+    },
+    {
       key: 'crl_reason',
       label: 'Reason', // i18n defer
       sortable: true,


### PR DESCRIPTION
# Description
Adds `not_before` to PKI revoked certs in golang and pfappserver

# Impacts
mysql schema
go/pfpki

# Issue
fixes #7509 

# Delete branch after merge
YES 