### PR TITLE
Fix/iptables in venom

### DIFF
--- a/t/venom/lib/perl_iptables_restart.yml
+++ b/t/venom/lib/perl_iptables_restart.yml
@@ -1,0 +1,19 @@
+executor: perl_iptables_restart 
+input:
+  backup_file: "/root/iptables.bak"
+steps:
+- type: pf_api_service_status
+  service: "iptables"
+  retry: "{{.input.i_retry}}"
+  delay: "{{.input.i_delay}}"
+  assertions:
+    - result.pf_api_service_status_json.alive ShouldEqual 1
+
+- type: exec
+  script: /bin/perl -I/usr/local/pf/lib -I/usr/local/pf/lib_perl/lib/perl5 -Mpf::db -Mpf::services::manager::iptables -e 'pf::services::manager::iptables->getIptablesTechnique()->iptables_save("{{ input.backup_file }}")'
+  
+- type: exec
+  script: /bin/perl -I/usr/local/pf/lib -I/usr/local/pf/lib_perl/lib/perl5 -Mpf::db -Mpf::services::manager::iptables -e 'pf::services::manager::iptables->generateConfig()'
+
+- type: exec
+  script: iptables-restore < /usr/local/pf/var/conf/iptables.conf

--- a/t/venom/lib/perl_iptables_restart.yml
+++ b/t/venom/lib/perl_iptables_restart.yml
@@ -1,6 +1,8 @@
 executor: perl_iptables_restart 
 input:
   backup_file: "/root/iptables.bak"
+  i_retry: 5
+  i_delay: 3
 steps:
 - type: pf_api_service_status
   service: "iptables"

--- a/t/venom/lib/perl_iptables_restore.yml
+++ b/t/venom/lib/perl_iptables_restore.yml
@@ -1,0 +1,6 @@
+executor: perl_iptables_restore
+input:
+  backup_file: "/root/iptables.bak"
+steps:
+- type: exec
+  script: iptables-restore < "{{ input.backup_file }}"

--- a/t/venom/test_suites/common/restart_iptables_service.yml
+++ b/t/venom/test_suites/common/restart_iptables_service.yml
@@ -2,5 +2,6 @@ name: Restart iptables service
 testcases:
 - name: restart_iptables_service
   steps:
-  - type: pf_api_service_restart_async
-    service: 'iptables'
+#  - type: pf_api_service_restart_async
+#    service: 'iptables'
+  - type: perl_iptables_restart

--- a/t/venom/test_suites/inline/l2/05_setup_packetfence.yml
+++ b/t/venom/test_suites/inline/l2/05_setup_packetfence.yml
@@ -241,8 +241,7 @@ testcases:
 
 - name: restart_iptables
   steps:
-  - type: exec
-    script: systemctl restart packetfence-iptables
+  - type: perl_iptables_restart
 
     # let service restarts
   - type: exec

--- a/t/venom/test_suites/inline/l2/teardown/05_deconfigure_packetfence.yml
+++ b/t/venom/test_suites/inline/l2/teardown/05_deconfigure_packetfence.yml
@@ -71,12 +71,7 @@ testcases:
 
 - name: restart_iptables
   steps:
-  - type: exec
-    script: systemctl restart packetfence-iptables
-
-    # let service restarts
-  - type: exec
-    script: sleep 5
+  - type: perl_iptables_restart
 
 - name: restart_pfdns_service
   steps:

--- a/t/venom/test_suites/inline/l3/10_setup_packetfence.yml
+++ b/t/venom/test_suites/inline/l3/10_setup_packetfence.yml
@@ -252,12 +252,7 @@ testcases:
 
 - name: restart_iptables
   steps:
-  - type: exec
-    script: systemctl restart packetfence-iptables
-
-    # let service restarts
-  - type: exec
-    script: sleep 5
+  - type: perl_iptables_restart
 
 - name: restart_pfdns_service
   steps:

--- a/t/venom/test_suites/inline/l3/teardown/05_deconfigure_packetfence.yml
+++ b/t/venom/test_suites/inline/l3/teardown/05_deconfigure_packetfence.yml
@@ -83,12 +83,7 @@ testcases:
 
 - name: restart_iptables
   steps:
-  - type: exec
-    script: systemctl restart packetfence-iptables
-
-    # let service restarts
-  - type: exec
-    script: sleep 5
+  - type: perl_iptables_restart
 
 - name: restart_pfdns_service
   steps:

--- a/t/venom/test_suites/security_event_random_mac/05_setup_packetfence.yml
+++ b/t/venom/test_suites/security_event_random_mac/05_setup_packetfence.yml
@@ -241,8 +241,7 @@ testcases:
 
 - name: restart_iptables
   steps:
-  - type: pf_api_service_restart_async
-    service: "iptables"
+  - type: perl_iptables_restart 
 
 - name: restart_pfdns_service
   steps:

--- a/t/venom/test_suites/security_event_random_mac/teardown/05_deconfigure_packetfence.yml
+++ b/t/venom/test_suites/security_event_random_mac/teardown/05_deconfigure_packetfence.yml
@@ -78,8 +78,7 @@ testcases:
 
 - name: restart_iptables
   steps:
-  - type: pf_api_service_restart_async
-    service: "iptables"
+  - type: perl_iptables_restart
 
 - name: restart_pfdns_service
   steps:

--- a/t/venom/test_suites/security_event_suricata/05_setup_packetfence.yml
+++ b/t/venom/test_suites/security_event_suricata/05_setup_packetfence.yml
@@ -241,8 +241,7 @@ testcases:
 
 - name: restart_iptables
   steps:
-  - type: pf_api_service_restart
-    service: iptables
+  - type: perl_iptables_restart 
 
 - name: restart_pfdns
   steps:

--- a/t/venom/test_suites/security_event_suricata/teardown/05_deconfigure_packetfence.yml
+++ b/t/venom/test_suites/security_event_suricata/teardown/05_deconfigure_packetfence.yml
@@ -71,9 +71,7 @@ testcases:
 
 - name: restart_iptables
   steps:
-  - type: systemctl_service_restart
-    service: packetfence-iptables
-    time_to_sleep: 5
+  - type: perl_iptables_restart 
 
 - name: restart_pfdns_service
   steps:


### PR DESCRIPTION
# Description
(REQUIRED)
This will use perl to reniew iptables configuration.
It looks more stable than systemctl restart or the api (async or not)

# Issues
fixes #7489 

# Impacts
Should improve the pipelines
https://gitlab.com/inverse-inc/packetfence/-/pipelines/786217518

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [x] Pipeline tested

## Bug Fixes
If an issue exists on Github, please refer to it (name) along with it's number...
* https://github.com/inverse-inc/packetfence/issues/7489

