### PR TITLE
Disable DNS lookup made by sudo

### DIFF
--- a/debian/packetfence.conffiles
+++ b/debian/packetfence.conffiles
@@ -1,4 +1,5 @@
 /etc/sudoers.d/packetfence
+/etc/sudoers.d/disable-dns-lookup
 /usr/local/pf/conf/adminroles.conf
 /usr/local/pf/conf/authentication.conf
 /usr/local/pf/conf/billing_tiers.conf

--- a/debian/rules
+++ b/debian/rules
@@ -147,6 +147,7 @@ install: build
 	#Sudoer
 	install -oroot -groot -d -m0750 $(CURDIR)/debian/packetfence/etc/sudoers.d
 	install -oroot -groot -m0440 $(CURDIR)/debian/packetfence.sudoers $(CURDIR)/debian/packetfence/etc/sudoers.d/packetfence
+	install -oroot -groot -m0440 $(CURDIR)/disable-dns-lookup.sudoers $(CURDIR)/debian/packetfence/etc/sudoers.d/disable-dns-lookup
 	#PacketFence Mariadb plugin
 	make src/mariadb_udf/pf_udf.so
 	install -D -m0755 src/mariadb_udf/pf_udf.so $(CURDIR)/debian/packetfence/$$(pkg-config mariadb --variable=plugindir)/pf_udf.so

--- a/disable-dns-lookup.sudoers
+++ b/disable-dns-lookup.sudoers
@@ -1,0 +1,1 @@
+Defaults        !fqdn

--- a/disable-dns-lookup.sudoers
+++ b/disable-dns-lookup.sudoers
@@ -1,1 +1,2 @@
 Defaults        !fqdn
+

--- a/rpm/packetfence.spec
+++ b/rpm/packetfence.spec
@@ -494,6 +494,7 @@ cp -r sbin %{buildroot}/usr/local/pf/
 cp -r conf %{buildroot}/usr/local/pf/
 cp -r raddb %{buildroot}/usr/local/pf/
 mv packetfence.sudoers %{buildroot}/etc/sudoers.d/packetfence
+mv disable-dns-lookup.sudoers %{buildroot}/etc/sudoers.d/disable-dns-lookup
 mv packetfence.cron.d %{buildroot}/etc/cron.d/packetfence
 mv containers/daemon.json %{buildroot}/etc/docker/daemon.json
 cp -r ChangeLog %{buildroot}/usr/local/pf/
@@ -857,6 +858,7 @@ fi
 
 %dir %attr(0750,root,root) %{_sysconfdir}/sudoers.d
 %config %attr(0440,root,root) %{_sysconfdir}/sudoers.d/packetfence
+%config %attr(0440,root,root) %{_sysconfdir}/sudoers.d/disable-dns-lookup
 %config %attr(0644,root,root) %{_sysconfdir}/logrotate.d/packetfence
 %config %attr(0600,root,root) %{_sysconfdir}/cron.d/packetfence
 %config %attr(0644,root,root) %{_sysconfdir}/docker/daemon.json


### PR DESCRIPTION
# Description
Disable DNS lookup made by sudo.

On Debian, if there is no entry in `/etc/hosts` which match current hostname of server, sudo will display error like:

`
sudo: unable to resolve host pfdeb11dev: Name or service not known
`

and can generate API timeouts because it is not able to resolve hostname of server.

Because `/etc/hosts` is not shared between containers and host, containers need to have this entry too in their own `/etc/hosts` file.

Currently, `/etc/sudoers` is shared with all containers so I take the decision to disable that feature in `sudo` according to this [bug report](https://bugzilla.sudo.ws/show_bug.cgi?id=916). According to my tests, it was not necessary on EL systems but I prefer to enforce that parameter on both distributions.

I create a dedicated file in order to simplify backport and upgrades.

# Impacts
- sudo configuration on host and containers
- upgrade


# Issue
fixes #7403 
fixes #7335
fixes #7552

# Delete branch after merge
YES


# NEWS file entries
## Bug Fixes
* Disable DNS lookup in sudo to prevent API timeouts
