### PR TITLE
RADIUS mock must listen on management interface

### DIFF
--- a/addons/vagrant/inventory/group_vars/pfservers/radius_mock.yml
+++ b/addons/vagrant/inventory/group_vars/pfservers/radius_mock.yml
@@ -1,0 +1,3 @@
+---
+radius_mock__api_port: 8183
+radius_mock__radius_port: 8184

--- a/addons/vagrant/playbooks/tasks/vagrant_iptables.yml
+++ b/addons/vagrant/playbooks/tasks/vagrant_iptables.yml
@@ -17,4 +17,8 @@
 
       # allow Smocker interface on management interface
       -A input-management-if --protocol tcp --match tcp --dport {{ smocker__port_config }} --jump ACCEPT
+
+      # allow RADIUS mock ports on management interface
+      -A input-management-if --protocol tcp --match tcp --dport {{ radius_mock__api_port }} --jump ACCEPT
+      -A input-management-if --protocol udp --match udp --dport {{ radius_mock__radius_port }} --jump ACCEPT
     marker: "# {mark} ANSIBLE MANAGED BLOCK - mailhog"

--- a/t/venom/vars/all.yml
+++ b/t/venom/vars/all.yml
@@ -664,7 +664,7 @@ smocker_dir: /opt/smocker
 # RADIUS Firewall SSO
 firewall_sso.radius.api_host: '{{.pfserver_mgmt_ip}}'
 firewall_sso.radius.api_port: 8183
-firewall_sso.radius.radius_host: '127.0.0.1'
+firewall_sso.radius.radius_host: '{{.pfserver_mgmt_ip}}'
 firewall_sso.radius.radius_port: 8184
 firewall_sso.radius.radius_secret: secret
 firewall_sso.radius.radius_user_name: foo


### PR DESCRIPTION

# Description
RADIUS mock server must listen on management interface to be reach by `pfsso` container

# Impacts
CI tests

# Issue
fixes #7553

# Delete branch after merge
YES