### PR TITLE
ZEN: Call make in raddb/certs only once

### DIFF
--- a/ci/packer/zen/provisioners/inventory/group_vars/pfservers/rc_local.yml
+++ b/ci/packer/zen/provisioners/inventory/group_vars/pfservers/rc_local.yml
@@ -11,7 +11,14 @@ rc_local_commands:
     fi
     make -C /usr/local/pf conf/ssl/server.pem
     make -C /usr/local/pf conf/local_secret
-    make -C /usr/local/pf/raddb/certs
+
+    if [ ! -f /usr/local/pf/raddb/certs/dh ]; then
+        echo "Building default RADIUS certificates..."
+        make -C /usr/local/pf/raddb/certs
+    else
+       echo "DH already exists, won't touch it!"
+    fi
+
     /usr/local/pf/bin/pfcmd fixpermissions
 
     echo "" > /etc/issue


### PR DESCRIPTION
# Description
Don't modify RADIUS private key if key has been already generated.

# Impacts
ZEN build

# Issue
fixes #7568
Related PR #7353

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
If an issue exists on Github, please refer to it (name) along with it's number...
* Don't generate new RADIUS private key after a ZEN reboot (#7568)