### PR TITLE
tests: delete/recreate iptable rule to prevent issue during sso_radius test suite

### DIFF
--- a/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_radius/30_delete_iptable_rule.yml
+++ b/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_radius/30_delete_iptable_rule.yml
@@ -1,0 +1,7 @@
+name: Delete iptable rule
+testcases:
+# temp, as a workaround
+- name: delete_iptable_rule
+  steps:
+  - type: exec
+    script: 'iptables -t nat -D PREROUTING --protocol udp -s 100.64.0.0/10 -d {{.pfserver_mgmt_ip}} --jump DNAT --to 100.64.0.1'

--- a/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_radius/teardown/96_restart_iptables.yml
+++ b/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_radius/teardown/96_restart_iptables.yml
@@ -1,0 +1,6 @@
+name: Restart iptables
+testcases:
+# temp, as a workaround
+- name: restart_iptables
+  steps:
+  - type: perl_iptables_restart


### PR DESCRIPTION
# Description
Delete the rule which prevent UDP traffic sent from pfsso to reach RADIUS mock on host.

It's only a workaround for now.

# Issue
Related to #7553 

# Delete branch after merge
YES