### PR TITLE
tests: cancel jobs and halt VM differently

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,6 @@ stages:
 variables:
   # synced with Pipeline timeout in GitLab UI
   PIPELINE_TIMEOUT_SCRIPT: 160m
-  PIPELINE_TIMEOUT_AFTER_SCRIPT: 10m
   BUILD_PFAPPSERVER_VUE: "yes"
   PFBUILD_CENTOS_8_IMG: ghcr.io/inverse-inc/packetfence/pfbuild-centos-8
   PFBUILD_DEB_BULLSEYE_IMG: ghcr.io/inverse-inc/packetfence/pfbuild-debian-bullseye
@@ -349,8 +348,9 @@ variables:
     BOX_DESC: ${CI_PIPELINE_URL}
   script:
     - timeout ${PIPELINE_TIMEOUT_SCRIPT} make -e -C ${VAGRANT_IMG_DIR} ${BOX_NAME}
+  # implicit timeout = 5 minutes, see https://gitlab.com/gitlab-org/gitlab-runner/-/issues/2716
   after_script:
-    - timeout ${PIPELINE_TIMEOUT_AFTER_SCRIPT} make -e -C ${VAGRANT_IMG_DIR} clean
+    - make -e -C ${VAGRANT_IMG_DIR} clean
   tags:
     - shell
     - inverse.ca
@@ -518,8 +518,9 @@ variables:
   environment:
     name: sourceforge
     url: ${SF_ZEN_REPO_URL}/${CI_COMMIT_REF_NAME}
+  # implicit timeout = 5 minutes, see https://gitlab.com/gitlab-org/gitlab-runner/-/issues/2716
   after_script:
-    - timeout ${PIPELINE_TIMEOUT_AFTER_SCRIPT} make -e -C ${ZENDIR} clean_all
+    - make -e -C ${ZENDIR} clean_all
   dependencies: []
   tags:
     - shell
@@ -528,8 +529,9 @@ variables:
   stage: build_pf_img
   environment:
     name: sourceforge
+  # implicit timeout = 5 minutes, see https://gitlab.com/gitlab-org/gitlab-runner/-/issues/2716
   after_script:
-    - timeout ${PIPELINE_TIMEOUT_AFTER_SCRIPT} make -e -C ${ISODIR} clean
+    - make -e -C ${ISODIR} clean
   dependencies: []
   tags:
     - shell
@@ -541,8 +543,9 @@ variables:
     BOX_DESC: ${CI_PIPELINE_URL}
   script:
     - timeout ${PIPELINE_TIMEOUT_SCRIPT} make -e -C ${VAGRANT_IMG_DIR} ${BOX_NAME}
+  # implicit timeout = 5 minutes, see https://gitlab.com/gitlab-org/gitlab-runner/-/issues/2716
   after_script:
-    - timeout ${PIPELINE_TIMEOUT_AFTER_SCRIPT} make -e -C ${VAGRANT_IMG_DIR} clean
+    - make -e -C ${VAGRANT_IMG_DIR} clean
   dependencies: []
   tags:
     - inverse.ca
@@ -560,9 +563,9 @@ variables:
   variables:
     VAGRANT_COMMON_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-common-${CI_COMMIT_REF_SLUG}
   script:
-    - timeout ${PIPELINE_TIMEOUT_SCRIPT} make -e -C ${TESTDIR} MAKE_TARGET=run ${CI_JOB_NAME}
-  after_script:
-    - timeout ${PIPELINE_TIMEOUT_AFTER_SCRIPT} ${TESTCIDIR}/clean-test-environment.sh
+    # || EXIT_CODE=$? prevents script to finish at first command
+    - timeout ${PIPELINE_TIMEOUT_SCRIPT} make -e -C ${TESTDIR} MAKE_TARGET=run ${CI_JOB_NAME} || EXIT_CODE=$?
+    - JOB_STATUS=$EXIT_CODE ${TESTCIDIR}/clean-test-environment.sh
 
 ################################################################################
 # JOBS

--- a/ci/lib/check/run-pipeline-if-necessary.sh
+++ b/ci/lib/check/run-pipeline-if-necessary.sh
@@ -23,7 +23,7 @@ configure_and_check() {
     COMMIT_REF_NAME_ENCODED=$(urlencode "$CI_COMMIT_REF_NAME")
     COMMIT_SHA=$(git rev-parse HEAD~0)
 
-    [ -z "${GITLAB_API_TOKEN}" ] && die "not set: GITLAB_API_TOKEN"
+    [ -n "${GITLAB_API_TOKEN}" ] && die "not set: GITLAB_API_TOKEN"
     
     # get SHA of latest pipeline scheduled with status=succes for that branch
     SHA_LATEST_PIPELINE=$(curl --header "PRIVATE-TOKEN: ${GITLAB_API_TOKEN}" \

--- a/ci/lib/test/cancel-created-jobs.sh
+++ b/ci/lib/test/cancel-created-jobs.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -o nounset -o pipefail -o errexit
+
+# full path to dir of current script
+SCRIPT_DIR=$(readlink -e $(dirname ${BASH_SOURCE[0]}))
+
+# full path to root of PF sources
+PF_SRC_DIR=$(echo ${SCRIPT_DIR} | grep -oP '.*?(?=\/ci\/)')
+
+# path to all functions
+FUNCTIONS_FILE=${PF_SRC_DIR}/ci/lib/common/functions.sh
+
+source ${FUNCTIONS_FILE}
+
+# GitLab API: https://docs.gitlab.com/ee/api/
+
+configure_and_check() {
+    CI_PROJECT_ID=${CI_PROJECT_ID:-}
+    CI_PIPELINE_ID=${CI_PIPELINE_ID:-}
+    GITLAB_API_TOKEN=${GITLAB_API_TOKEN:-}
+
+    [ -n "${GITLAB_API_TOKEN}" ] || die "not set: GITLAB_API_TOKEN"
+}
+
+get_created_jobs() {
+    curl --header "PRIVATE-TOKEN: ${GITLAB_API_TOKEN}" \
+         -s "https://gitlab.com/api/v4/projects/${CI_PROJECT_ID}/pipelines/${CI_PIPELINE_ID}/jobs?scope[]=pending&per_page=100" \
+        | jq -r '.[].id'
+}
+
+cancel_job() {
+    local job_id=$1
+    curl --request POST \
+         --header "PRIVATE-TOKEN: ${GITLAB_API_TOKEN}" \
+         -s "https://gitlab.com/api/v4/projects/${CI_PROJECT_ID}/jobs/${job_id}/cancel" \
+         | jq -r '.status'
+}
+
+cancel_jobs() {
+    jobs_id=$(get_created_jobs)
+    if [ -z "$jobs_id" ]; then
+	echo "No jobs to cancel"
+    else
+	for job_id in $jobs_id; do
+            if [ $(cancel_job $job_id) = "canceled" ]; then
+		echo "$job_id canceled"
+            else
+		echo "Unable to cancel $job_id"
+            fi
+	done
+    fi
+}
+
+log_section "Configure and check"
+configure_and_check
+
+log_section "Cancelling jobs not started"
+cancel_jobs

--- a/ci/lib/test/cancel-pending-jobs.sh
+++ b/ci/lib/test/cancel-pending-jobs.sh
@@ -22,7 +22,8 @@ configure_and_check() {
     [ -n "${GITLAB_API_TOKEN}" ] || die "not set: GITLAB_API_TOKEN"
 }
 
-get_created_jobs() {
+# get ID of 100 pending jobs of current pipeline
+get_pending_jobs() {
     curl --header "PRIVATE-TOKEN: ${GITLAB_API_TOKEN}" \
          -s "https://gitlab.com/api/v4/projects/${CI_PROJECT_ID}/pipelines/${CI_PIPELINE_ID}/jobs?scope[]=pending&per_page=100" \
         | jq -r '.[].id'
@@ -37,7 +38,7 @@ cancel_job() {
 }
 
 cancel_jobs() {
-    jobs_id=$(get_created_jobs)
+    jobs_id=$(get_pending_jobs)
     if [ -z "$jobs_id" ]; then
 	echo "No jobs to cancel"
     else

--- a/ci/lib/test/clean-test-environment.sh
+++ b/ci/lib/test/clean-test-environment.sh
@@ -31,7 +31,8 @@ configure_and_check() {
             MAKE_TARGET=clean make -e -C ${TEST_DIR} ${CI_JOB_NAME}
         fi
     else
-        echo 'Failed tests, only halting VM'
+        echo 'Failed tests: cancelling jobs not started and halting VM'
+        ${PF_SRC_DIR}/ci/lib/test/cancel-created-jobs.sh
         MAKE_TARGET=halt make -e -C ${TEST_DIR} ${CI_JOB_NAME}
     fi
 

--- a/ci/lib/test/clean-test-environment.sh
+++ b/ci/lib/test/clean-test-environment.sh
@@ -21,7 +21,12 @@ configure_and_check() {
     CI_JOB_NAME=${CI_JOB_NAME:-}
     KEEP_VMS=${KEEP_VMS:-no}
 
-    if [ "$JOB_STATUS" -eq 0 ]; then
+    declare -p JOB_STATUS CI_JOB_NAME
+    declare -p TEST_DIR
+
+    # if test was a success, JOB_STATUS is unset
+    # so we test is has zero length
+    if [ -z "$JOB_STATUS" ]; then
         echo "Passed tests"
         if [ "$KEEP_VMS" = "yes" ]; then
             echo "Keeping VM according to 'KEEP_VMS' value"
@@ -31,14 +36,12 @@ configure_and_check() {
             MAKE_TARGET=clean make -e -C ${TEST_DIR} ${CI_JOB_NAME}
         fi
     else
-        echo 'Failed tests: cancelling jobs not started and halting VM'
+        echo "Failed tests: cancelling jobs not started and halting VM"
         ${PF_SRC_DIR}/ci/lib/test/cancel-pending-jobs.sh
+        echo "Stopping VM"
         MAKE_TARGET=halt make -e -C ${TEST_DIR} ${CI_JOB_NAME}
         exit $JOB_STATUS
     fi
-
-    declare -p JOB_STATUS CI_JOB_NAME
-    declare -p TEST_DIR
 }
 
 

--- a/ci/lib/test/clean-test-environment.sh
+++ b/ci/lib/test/clean-test-environment.sh
@@ -17,13 +17,13 @@ source ${FUNCTIONS_FILE}
 
 
 configure_and_check() {
-    CI_JOB_STATUS=${CI_JOB_STATUS:-}
+    JOB_STATUS=${JOB_STATUS:-}
     CI_JOB_NAME=${CI_JOB_NAME:-}
     KEEP_VMS=${KEEP_VMS:-no}
 
-    if [ "$CI_JOB_STATUS" = "success" ]; then
+    if [ "$JOB_STATUS" -eq 0 ]; then
         echo "Passed tests"
-        if [ "KEEP_VMS" = "yes" ]; then
+        if [ "$KEEP_VMS" = "yes" ]; then
             echo "Keeping VM according to 'KEEP_VMS' value"
             MAKE_TARGET=halt make -e -C ${TEST_DIR} ${CI_JOB_NAME}
         else
@@ -34,9 +34,10 @@ configure_and_check() {
         echo 'Failed tests: cancelling jobs not started and halting VM'
         ${PF_SRC_DIR}/ci/lib/test/cancel-created-jobs.sh
         MAKE_TARGET=halt make -e -C ${TEST_DIR} ${CI_JOB_NAME}
+        exit $JOB_STATUS
     fi
 
-    declare -p CI_JOB_STATUS CI_JOB_NAME
+    declare -p JOB_STATUS CI_JOB_NAME
     declare -p TEST_DIR
 }
 

--- a/ci/lib/test/clean-test-environment.sh
+++ b/ci/lib/test/clean-test-environment.sh
@@ -32,7 +32,7 @@ configure_and_check() {
         fi
     else
         echo 'Failed tests: cancelling jobs not started and halting VM'
-        ${PF_SRC_DIR}/ci/lib/test/cancel-created-jobs.sh
+        ${PF_SRC_DIR}/ci/lib/test/cancel-pending-jobs.sh
         MAKE_TARGET=halt make -e -C ${TEST_DIR} ${CI_JOB_NAME}
         exit $JOB_STATUS
     fi


### PR DESCRIPTION
# Description
- Cancel all **pending** jobs if an error has been detected during a test job. We don't cancel all jobs because if a shell job is running and canceled by API, job will not be stopped (GitLab bug)
- Don't use `after_script` instruction for test jobs because implicit timeout (5 minutes) is not enough to perform all tasks (especially stopping VM)
- Handle error in test jobs differently to shutdown VM using `script` instruction
- Adjust wrong test on `GITLAB_API_TOKEN`

# Issue
fixes #7488 
fixes #7475 

# Delete branch after merge
YES