### PR TITLE
Update iso rebuild to be EFI bootable

### DIFF
--- a/ci/debian-installer/create-debian-installer-docker.sh
+++ b/ci/debian-installer/create-debian-installer-docker.sh
@@ -4,7 +4,7 @@ set -o nounset -o pipefail -o errexit
 cd /debian-installer
 
 apt update
-apt install xorriso wget cpio genisoimage -yqq
+apt install xorriso wget cpio -yqq
 
 ./create-debian-installer.sh
 

--- a/ci/debian-installer/create-debian-installer.sh
+++ b/ci/debian-installer/create-debian-installer.sh
@@ -41,6 +41,6 @@ find -follow -type f ! -name md5sum.txt -print0 | xargs -0 md5sum > md5sum.txt |
 chmod -w md5sum.txt
 cd ..
 
-genisoimage -r -J -b isolinux/isolinux.bin -c isolinux/boot.cat -no-emul-boot -boot-load-size 4 -boot-info-table -o $ISO_OUT isofiles
+xorriso -as mkisofs -r -J -joliet-long -b isolinux/isolinux.bin -c isolinux/boot.cat -boot-load-size 4 -boot-info-table -no-emul-boot -o $ISO_OUT -eltorito-alt-boot -e boot/grub/efi.img -no-emul-boot -isohybrid-gpt-basdat -isohybrid-apm-hfsplus -V "Packetfence $PF_RELEASE" isofiles
 
 clean


### PR DESCRIPTION
# Description
This updates the ISO rebuild process to include the bits for EFI booting

# Impacts
Test booting from UEFI on physical, VMware and/or Hyper-V Gen 2 VM

# Issue
fixes #7599 

# Delete branch after merge
YES

# Checklist
- [n/a] Document the feature
- [n/a] Add unit tests
- [n/a] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* ISO supports UEFI booting
