### PR TITLE
Added Acct-Session-Id = $last_accounting.acctsessionid in Mist.def

### DIFF
--- a/lib/pf/Switch/Juniper/Mist.def
+++ b/lib/pf/Switch/Juniper/Mist.def
@@ -17,6 +17,7 @@ EOT
 disconnect=<<EOT
 Calling-Station-Id = ${macToEUI48($mac)}
 NAS-IP-Address = $disconnectIp
+Acct-Session-Id = $last_accounting.acctsessionid
 EOT
 voip = <<EOT
 Tunnel-Medium-Type  = 6


### PR DESCRIPTION
# Description
Added a extra radius attribute for the Mist deauth

# Impacts
Mist switch template

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* Fixed Mist deauth
