### PR TITLE
fix/rapid7-population-issue

### DIFF
--- a/html/pfappserver/lib/pfappserver/Form/Config/Scan/Rapid7.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Scan/Rapid7.pm
@@ -105,6 +105,11 @@ sub update_fields {
     my $params = $self->params;
     my $id = defined $params ?  $params->{id} : undef;
     if (!defined $id) {
+        my $init_object = $self->init_object;
+        $id = defined $init_object ? $init_object->{id} : undef;
+    }
+
+    if (!defined $id) {
         foreach my $field_name (qw(engine_id template_id site_id)) {
             my $field = $self->field($field_name);
             $field->options([{label => $params->{$field_name} // '', value => $params->{$field_name} // ''}]);
@@ -115,7 +120,7 @@ sub update_fields {
     }
 
     my $scan = eval {
-        pf::factory::scan->new($params->{id});
+        pf::factory::scan->new($id);
     };
 
     if (!defined $scan) {

--- a/lib/pf/scan/rapid7.pm
+++ b/lib/pf/scan/rapid7.pm
@@ -210,7 +210,6 @@ sub listScanEngines {
 
     my $req = HTTP::Request->new(GET => $self->buildApiUri("scan_engines"));
     my $response = $self->doRequest($req);
-    
     return $response->is_success ? decode_json($response->decoded_content)->{"resources"} : undef;
 }
 

--- a/t/data/scan.conf
+++ b/t/data/scan.conf
@@ -58,4 +58,18 @@ oses=
 nessus_clientpolicy=test
 type=nessus6
 
-
+[rapid7]
+scannername=Local Scanner
+duration=5m
+categories=guest
+host=localhost
+port=8834
+registration=0
+username=test
+post_registration=0
+password=test
+pre_registration=0
+oses=1,193
+nessus_clientpolicy=test
+type=rapid7
+verify_hostname=disabled

--- a/t/mock_servers/rapid7.pl
+++ b/t/mock_servers/rapid7.pl
@@ -1,0 +1,132 @@
+#!/usr/bin/perl
+
+=head1 NAME
+
+rapid7 -
+
+=head1 DESCRIPTION
+
+rapid7
+
+=cut
+
+use strict;
+use warnings;
+use lib qw(/usr/local/pf/lib);
+use lib qw(/usr/local/pf/lib_perl/lib/perl5);
+use Mojolicious::Lite;
+
+any '/*dapath' => sub {
+    my ($c) = @_;
+    my $req = $c->req;
+    return $c->rendered( 204 ) if $req->method eq 'OPTIONS';
+    my $variant = variant($req);
+    return $c->render(
+        template => join( '/', uc $req->method, $c->stash('dapath') ),
+        variant  => $variant,
+        format   => 'json',
+    );
+
+};
+
+sub variant {
+    my ($req) = @_;
+    my $query_params = $req->query_params;
+    for my $k (qw(pageToken query)) {
+        my $value = $query_params->param($k);
+        if ($value) {
+            return "$k=" . uri_escape($value);
+        }
+    }
+
+    return undef;
+}
+
+app->start;
+
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2023 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+__DATA__
+@@ GET/api/3/scan_templates.json.ep
+
+%# Test authorize pass
+
+{
+  "links": [
+    {
+      "href": "https://hostname:3780/api/3/...",
+      "rel": "self"
+    }
+  ],
+  "resources": [
+    {
+      "id": "full-audit-without-web-spider",
+      "name": "Full audit"
+    }
+  ]
+}
+
+@@ GET/api/3/scan_engines.json.ep
+
+%# Test authorize pass
+
+{
+  "links": [
+    {
+      "href": "https://hostname:3780/api/3/...",
+      "rel": "self"
+    }
+  ],
+  "resources": [
+    {
+      "id": 6,
+      "name": "Corporate Scan Engine 001"
+    }
+  ]
+}
+
+@@ GET/api/3/sites.json.ep
+
+%# Test authorize pass
+
+{
+  "links": [
+    {
+      "href": "https://hostname:3780/api/3/...",
+      "rel": "self"
+    }
+  ],
+  "resources": [
+    {
+      "id": 5,
+      "name": "Site Name"
+    }
+  ]
+}
+

--- a/t/unittest/UnifiedApi/Controller/Config/Scans.t
+++ b/t/unittest/UnifiedApi/Controller/Config/Scans.t
@@ -22,8 +22,12 @@ BEGIN {
     use setup_test_config;
 }
 
-use Test::More tests => 7;
+use Test::More tests => 12;
 use Test::Mojo;
+use IPC::Open3;
+use IO::Handle;
+use pf::defer;
+use Symbol 'gensym';
 
 #This test will running last
 use Test::NoWarnings;
@@ -33,6 +37,21 @@ my $collection_base_url = '/api/v1/config/scans';
 
 my $base_url = '/api/v1/config/scan';
 
+my $child_err = gensym;
+my $pid = open3(my $chld_out, my $chld_in, $child_err, "/usr/local/pf/t/mock_servers/rapid7.pl", "daemon", "-l", "https://localhost:8834");
+my $defer = pf::defer::defer(
+    sub {
+        kill( 'INT', $pid );
+        waitpid( $pid, 0 );
+    }
+);
+
+$t->options_ok("$base_url/rapid7")
+  ->status_is(200)
+  ->json_is("/meta/site_id/allowed/0/value", 5)
+  ->json_is("/meta/engine_id/allowed/0/value", 6)
+  ->json_is("/meta/template_id/allowed/0/value", 'full-audit-without-web-spider' );
+
 $t->get_ok($collection_base_url)
   ->status_is(200);
 
@@ -41,6 +60,8 @@ $t->post_ok($collection_base_url => json => {})
 
 $t->post_ok($collection_base_url, {'Content-Type' => 'application/json'} => '{')
   ->status_is(400);
+
+#use Data::Dumper;print Dumper($t->tx->res->json);
 
 =head1 AUTHOR
 


### PR DESCRIPTION
# Description
Fix options not populating template_id, site_id, engine_id.

# Impacts
Rapid7

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ ] Document the feature
- [x] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Bug Fixes
* Rapid7 Options properly populating template_id, site_id, engine_id.

