### PR TITLE
Allow to call a custom script from pfupdate to handle VIP in cloud environments

### DIFF
--- a/NEWS.asciidoc
+++ b/NEWS.asciidoc
@@ -32,6 +32,7 @@ For a list of compatibility related changes see the <<PacketFence_Upgrade_Guide.
  * Upgrade coredns libraries (#7197)
  * Added Palo Alto switch module to manage web admin login using RADIUS (#7643)
  * Remove WMI (#7649)
+ * Allow to call a custom script from pfupdate to handle VIP in cloud environments (#7654)
 
 === Bug Fixes
 

--- a/bin/cluster/pfupdate
+++ b/bin/cluster/pfupdate
@@ -13,6 +13,7 @@ use Getopt::Long;
 use pf::util;
 
 my $mode;
+my $custom_script_path = '/usr/local/bin/pfupdate-packetfence.sh';
 
 GetOptions(
     "mode=s" => \$mode,
@@ -23,3 +24,8 @@ if (! ($mode =~ /^master|slave$/)) {
 }
 
 pf_run("pkill -1 pfdhcplistener");
+
+if (-e "$custom_script_path" && -x "$custom_script_path") {
+    print "Running custom script\n";
+    pf_run("$custom_script_path $mode");
+}

--- a/bin/cluster/pfupdate
+++ b/bin/cluster/pfupdate
@@ -11,10 +11,13 @@ use lib (INSTALL_DIR . "/lib", INSTALL_DIR . "/lib_perl/lib/perl5");
 
 use Getopt::Long;
 use pf::util;
+use pf::config qw(
+    %Config
+);
 
 my $mode;
 my $vip;
-my $custom_script_path = '/usr/local/bin/pfupdate-packetfence.sh';
+my $custom_script_path = $Config{'advanced'}{'pfupdate_custom_script_path'};
 
 GetOptions(
     "mode=s" => \$mode,

--- a/bin/cluster/pfupdate
+++ b/bin/cluster/pfupdate
@@ -13,10 +13,12 @@ use Getopt::Long;
 use pf::util;
 
 my $mode;
+my $vip;
 my $custom_script_path = '/usr/local/bin/pfupdate-packetfence.sh';
 
 GetOptions(
     "mode=s" => \$mode,
+    "vip=s" => \$vip,
 ) ;
 
 if (! ($mode =~ /^master|slave$/)) {
@@ -26,6 +28,6 @@ if (! ($mode =~ /^master|slave$/)) {
 pf_run("pkill -1 pfdhcplistener");
 
 if (-e "$custom_script_path" && -x "$custom_script_path") {
-    print "Running custom script\n";
-    pf_run("$custom_script_path $mode");
+    print "Running $custom_script_path\n";
+    pf_run("$custom_script_path $mode $vip");
 }

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1444,6 +1444,13 @@ description=<<EOT
 The netmask (in numerical bits value) of the Zero Trust network. Only change if you know what you are doing. Changing this value requires to restart all the PacketFence services and requires all the clients of the Zero Trust network to be restarted
 EOT
 
+[advanced.pfupdate_custom_script_path]
+type=text
+description=<<EOT
+Path to a custom script called by pfupdate
+EOT
+
+
 [provisioning.autoconfig]
 type=toggle
 options=enabled|disabled

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -1064,6 +1064,11 @@ zero_trust_network_starting_ip=100.64.0.1
 # The netmask (in numerical bits value) of the Zero Trust network. Only change if you know what you are doing. Changing this value requires to restart all the PacketFence services and requires all the clients of the Zero Trust network to be restarted
 zero_trust_network_netmask=10
 
+# advanced.pfupdate_custom_script_path
+#
+# Path to a custom script called by pfupdate
+pfupdate_custom_script_path=/usr/local/bin/pfupdate-packetfence.sh
+
 [provisioning]
 #
 # provisioning.autoconfig

--- a/html/pfappserver/root/src/views/Configuration/advanced/_components/TheForm.vue
+++ b/html/pfappserver/root/src/views/Configuration/advanced/_components/TheForm.vue
@@ -130,6 +130,11 @@
       :text="$i18n.t('Enable to bypass the operating system domain join verification.')"
     />
 
+    <form-group-pfupdate-custom-script-path namespace="pfupdate_custom_script_path"
+      :column-label="$i18n.t('Path to a custom script called by pfupdate')"
+      :text="$i18n.t('Path to a custom script called by pfupdate if present.')"
+    />
+
     <form-group-netflow-on-all-networks namespace="netflow_on_all_networks"
       :column-label="$i18n.t('NetFlow on all networks')"
       :text="$i18n.t('Listen to NetFlow on all networks. Changing this requires to restart pfacct.')"
@@ -179,6 +184,7 @@ import {
   FormGroupPfperlApiProcesses,
   FormGroupPfperlApiTimeout,
   FormGroupPortalCspSecurityHeaders,
+  FormGroupPfupdateCustomScriptPath,
   FormGroupScanOnAccounting,
   FormGroupSourceToSendSmsWhenCreatingUsers,
   FormGroupSsoOnAccessReevaluation,
@@ -210,6 +216,7 @@ const components = {
   FormGroupPfperlApiProcesses,
   FormGroupPfperlApiTimeout,
   FormGroupPortalCspSecurityHeaders,
+  FormGroupPfupdateCustomScriptPath,
   FormGroupScanOnAccounting,
   FormGroupSourceToSendSmsWhenCreatingUsers,
   FormGroupSsoOnAccessReevaluation,

--- a/html/pfappserver/root/src/views/Configuration/advanced/_components/index.js
+++ b/html/pfappserver/root/src/views/Configuration/advanced/_components/index.js
@@ -35,6 +35,7 @@ export {
   BaseFormGroupInputNumber            as FormGroupPfperlApiProcesses,
   BaseFormGroupInputNumber            as FormGroupPfperlApiTimeout,
   BaseFormGroupToggleDisabledEnabled  as FormGroupPortalCspSecurityHeaders,
+  BaseFormGroupInput                  as FormGroupPfupdateCustomScriptPath,
   BaseFormGroupToggleDisabledEnabled  as FormGroupScanOnAccounting,
   BaseFormGroupChosenOne              as FormGroupSourceToSendSmsWhenCreatingUsers,
   BaseFormGroupToggleDisabledEnabled  as FormGroupSsoOnAccessReevaluation,

--- a/lib/pf/services/manager/keepalived.pm
+++ b/lib/pf/services/manager/keepalived.pm
@@ -141,9 +141,9 @@ $active_members
 }
 EOT
             }
-            $tags{'vrrp'} .= "  notify_master \"$install_dir/bin/cluster/pfupdate --mode=master\"\n";
-            $tags{'vrrp'} .= "  notify_backup \"$install_dir/bin/cluster/pfupdate --mode=slave\"\n";
-            $tags{'vrrp'} .= "  notify_fault \"$install_dir/bin/cluster/pfupdate --mode=slave\"\n";
+            $tags{'vrrp'} .= "  notify_master \"$install_dir/bin/cluster/pfupdate --mode=master --vip=$cluster_ip\"\n";
+            $tags{'vrrp'} .= "  notify_backup \"$install_dir/bin/cluster/pfupdate --mode=slave --vip=$cluster_ip\"\n";
+            $tags{'vrrp'} .= "  notify_fault \"$install_dir/bin/cluster/pfupdate --mode=slave --vip=$cluster_ip\"\n";
 
             $tags{'vrrp'} .= <<"EOT";
   track_script {


### PR DESCRIPTION
# Description
- Call a custom script (outside PF tree), if it exists, each time keepalived is restarted or detected a change
- `pfupdate` will receive (as an argument) VIP of VRRP instance(s) when called

Custom script must be executable. Default location is `/usr/local/bin/pfupdate-packetfence.sh`. Script is not provided by default.

# Impacts
- keepalived configuration
- pfupdate call
- 
# Issue
fixes #6657 

# Delete branch after merge
YES

# NEWS file entries
## Enhancements
* Allow to call a custom script from pfupdate to handle VIP in cloud environments