### PR TITLE
don't delete a node from pfdhcp if it is disabled

### DIFF
--- a/lib/pf/node.pm
+++ b/lib/pf/node.pm
@@ -739,12 +739,14 @@ sub node_deregister {
         return (0);
     }
 
-    eval {
-        pf::api::unifiedapiclient->default_client->call("DELETE", "/api/v1/dhcp/mac/".$mac,{});
-    };
+    if (isenabled($Config{services}{pfdhcp})) {
+        eval {
+            pf::api::unifiedapiclient->default_client->call("DELETE", "/api/v1/dhcp/mac/".$mac,{});
+        };
 
-    if ($@) {
-        $logger->error("Error releasing ip for $mac : $@");
+        if ($@) {
+            $logger->error("Error releasing ip for $mac : $@");
+        }
     }
 
     return (1);


### PR DESCRIPTION
# Description

Don't delete a node from pfdhcp if it is disabled on node deregister.

# Issue
Fixes #7525

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Bug Fixes
* Don't delete a node from pfdhcp if it is disabled on node deregister. (#7525)
