### PR TITLE
Add support for serverAuth and DNS SAN in CSR

### DIFF
--- a/html/pfappserver/root/src/views/Configuration/sslCertificates/_components/TheCsr.vue
+++ b/html/pfappserver/root/src/views/Configuration/sslCertificates/_components/TheCsr.vue
@@ -34,6 +34,10 @@
           <form-group-csr-common-name namespace="common_name"
             :column-label="$t('Common Name')"
           />
+          <form-group-csr-subject-alt-names namespace="subject_alt_names"
+            :column-label="$t('Subject Alternative Names (DNS only)')"
+            :text="$i18n.t('Comma-delimited list of DNS names who should be added as Subject Alternative Names. When left empty, the common name will be used.')"
+          />
         </base-form>
       </b-form>
       <b-form-textarea v-else
@@ -57,7 +61,8 @@ import {
   FormGroupCsrState,
   FormGroupCsrLocality,
   FormGroupCsrOrganizationName,
-  FormGroupCsrCommonName
+  FormGroupCsrCommonName,
+  FormGroupCsrSubjectAltNames
 } from './'
 
 const components = {
@@ -66,7 +71,8 @@ const components = {
   FormGroupCsrState,
   FormGroupCsrLocality,
   FormGroupCsrOrganizationName,
-  FormGroupCsrCommonName
+  FormGroupCsrCommonName,
+  FormGroupCsrSubjectAltNames
 }
 
 import { useCsr as setup, useCsrProps as props } from '../_composables/useCsr'

--- a/html/pfappserver/root/src/views/Configuration/sslCertificates/_components/index.js
+++ b/html/pfappserver/root/src/views/Configuration/sslCertificates/_components/index.js
@@ -31,6 +31,7 @@ export {
   BaseFormGroupInput                              as FormGroupCsrLocality,
   BaseFormGroupInput                              as FormGroupCsrOrganizationName,
   BaseFormGroupInput                              as FormGroupCsrCommonName,
+  BaseFormGroupInput                              as FormGroupCsrSubjectAltNames,
 
   TheCsr,
   TheForm,

--- a/html/pfappserver/root/src/views/Configuration/sslCertificates/_composables/useCsr.js
+++ b/html/pfappserver/root/src/views/Configuration/sslCertificates/_composables/useCsr.js
@@ -9,7 +9,8 @@ const defaults = () => ({ // use function to avoid reactive poisoning of default
   state: undefined,
   locality: undefined,
   organization_name: undefined,
-  common_name: undefined
+  common_name: undefined,
+  subject_alt_names: undefined
 })
 
 const schema = yup.object({
@@ -17,7 +18,8 @@ const schema = yup.object({
   state: yup.string().required(i18n.t('State required.')),
   locality: yup.string().required(i18n.t('Locality required.')),
   organization_name: yup.string().required(i18n.t('Organization name required.')),
-  common_name: yup.string().required(i18n.t('Common name required.'))
+  common_name: yup.string().required(i18n.t('Common name required.')),
+  subject_alt_names: yup.string().nullable().label(i18n.t('Subject Alternative Names (DNS only)'))
 })
 
 const useCsrProps = {

--- a/lib/pf/ssl.pm
+++ b/lib/pf/ssl.pm
@@ -311,6 +311,7 @@ sub generate_csr {
     my ($rsa, $info) = @_;
 
     my $required = ["country", "state", "locality", "organization_name", "common_name"];
+    my $optional = ["subject_alt_names"];
 
     foreach my $field (@$required) {
         my $value = $info->{$field};
@@ -331,8 +332,18 @@ sub generate_csr {
 
     my $csr = Crypt::OpenSSL::PKCS10->new_from_rsa($rsa);
     $csr->set_subject($subject);
-    $csr->add_ext(Crypt::OpenSSL::PKCS10::NID_subject_alt_name, "DNS:".$info->{common_name});
     $csr->add_ext(Crypt::OpenSSL::PKCS10::NID_ext_key_usage, "serverAuth");
+
+    # default behavior; we always want CN to be part of SAN
+    my @san_dns = "DNS: $info->{common_name}";
+
+    if (defined($info->{subject_alt_names})) {
+	foreach my $san_dns (split('\s*,\s*', $info->{subject_alt_names})) {
+	    push @san_dns, "DNS: ".$san_dns;
+	}
+    }
+
+    $csr->add_ext(Crypt::OpenSSL::PKCS10::NID_subject_alt_name, join(',', @san_dns));
     $csr->add_ext_final();
     $csr->sign();
     

--- a/lib/pf/ssl.pm
+++ b/lib/pf/ssl.pm
@@ -332,6 +332,7 @@ sub generate_csr {
     my $csr = Crypt::OpenSSL::PKCS10->new_from_rsa($rsa);
     $csr->set_subject($subject);
     $csr->add_ext(Crypt::OpenSSL::PKCS10::NID_subject_alt_name, "DNS:".$info->{common_name});
+    $csr->add_ext(Crypt::OpenSSL::PKCS10::NID_ext_key_usage, "serverAuth");
     $csr->add_ext_final();
     $csr->sign();
     

--- a/t/unittest/UnifiedApi/Controller/Config/Certificates.t
+++ b/t/unittest/UnifiedApi/Controller/Config/Certificates.t
@@ -56,7 +56,7 @@ my ($fh, $filename) = Utils::tempfileForConfigStore("pf::ConfigStore::Pf");
 
 #insert known data
 #run tests
-use Test::More tests => 32;
+use Test::More tests => 34;
 use Test::Mojo;
 use Test::NoWarnings;
 
@@ -362,6 +362,17 @@ $t->post_ok("/api/v1/config/certificate/radius/generate_csr" => json => {
         "locality" => "Montreal", 
         "organization_name" => "Inverse Inc.", 
         "common_name" => "csrtest.inverse.ca",
+    })
+  ->status_is(200);
+
+# test CSR with extra information
+$t->post_ok("/api/v1/config/certificate/radius/generate_csr" => json => {
+        "country" => "CA",
+        "state" => "Quebec",
+        "locality" => "Montreal",
+        "organization_name" => "Inverse Inc.",
+        "common_name" => "csrtest.inverse.ca",
+        "subject_alt_names" => "csrtest1.inverse.ca,csrtest2.inverse.ca",
     })
   ->status_is(200);
 


### PR DESCRIPTION
# Description
Make CSR generated from webadmin to follow certificate requirements

# Impacts
CSR generation (webadmin + Let's Encrypt)

# Issue
fixes #5990

# Delete branch after merge
YES

# Checklist
- [X] Add unit tests

# NEWS file entries
## Enhancements
* CSR generation follow certificate requirements