### PR TITLE
Create a tag for sourceforge

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -531,7 +531,7 @@ variables:
     - make -e -C ${ZENDIR} clean_all
   dependencies: []
   tags:
-    - shell
+    - shell-sourceforge
 
 .build_pf_img_iso_job:
   stage: build_pf_img
@@ -542,7 +542,7 @@ variables:
     - make -e -C ${ISODIR} clean
   dependencies: []
   tags:
-    - shell
+    - shell-sourceforge
 
 .build_pf_img_vagrant_release_job:
   stage: build_pf_img


### PR DESCRIPTION
# Description
Add tag shell-sourceforge to be applied on shell runners out of runner access 

# Impacts
Fixes #7728 
Needs to be backported if we create new iso or zen on maintenance branch until 11.0
Needs to be done in relation with https://git.inverse.ca/inverse/debops/issues/2

# Delete branch after merge
YES