### PR TITLE
Add ldapexplorer configuration to api.conf.example

### DIFF
--- a/conf/caddy-services/api.conf.example
+++ b/conf/caddy-services/api.conf.example
@@ -64,6 +64,11 @@
     transparent
   }
 
+  # ldapexplorer API access
+  proxy /api/v1/ldap/search {$PF_SERVICES_URL_PFLDAPEXPLORER} {
+    transparent
+  }
+
   # pfpki API access
   proxy /api/v1/pki/ {$PF_SERVICES_URL_PFPKI} {
     transparent


### PR DESCRIPTION
# Description
Small fix to the config file of the `api.conf.example`

