### PR TITLE
Fix "removing leading /" stderr output by tar in backup-and-maintenance.sh

### DIFF
--- a/addons/backup-and-maintenance.sh
+++ b/addons/backup-and-maintenance.sh
@@ -59,7 +59,7 @@ if ((  $BACKUPS_AVAILABLE_SPACE > (( $PF_USED_SPACE / 2 )) )); then
     # Backup complete PacketFence installation except logs
     current_tgz=$BACKUP_DIRECTORY/$BACKUP_PF_FILENAME-`date +%F_%Hh%M`.tgz
     if [ ! -f $BACKUP_DIRECTORY$BACKUP_PF_FILENAME ]; then
-        tar -czf $current_tgz --exclude=$PF_DIRECTORY'logs/*' --exclude=$PF_DIRECTORY'var/*' --exclude=$PF_DIRECTORY'.git/*' --exclude=$PF_DIRECTORY'conf/certmanager/*' $PF_DIRECTORY
+        tar -czf $current_tgz --exclude='logs/*' --exclude='var/*' --exclude='.git/*' --exclude='conf/certmanager/*' --directory $PF_DIRECTORY .
         BACKUPRC=$?
         if (( $BACKUPRC > 0 )); then
             echo "ERROR: PacketFence files backup was not successful" >&2


### PR DESCRIPTION
# Description
This fix removes the "tar: Removing leading `/' from member names" stderr output which otherwise occurs on every run

Previous stderr output:
```
$ /usr/local/pf/addons/backup-and-maintenance.sh >/dev/null
tar: Removing leading `/' from member names
$
```

New stderr output:
```
$ /usr/local/pf/addons/backup-and-maintenance.sh >/dev/null
$
```

# Impacts
This does not change functionality.

# Issue
This is a major step for #1415, as stderr output is seen as "faulty"

# Delete branch after merge
(REQUIRED)
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [n/a] Document the feature
- [n/a] Add unit tests
- [n/a] Add acceptance tests (TestLink)

# NEWS file entries
(REQUIRED, but may be optional...)
## Enhancements
* Fix "removing leading /" stderr output by tar in backup-and-maintenance.sh
