### PR TITLE
Remove unused ldap search query attributes

### DIFF
--- a/go/common/ldapSearchClient/LdapSearchClient.go
+++ b/go/common/ldapSearchClient/LdapSearchClient.go
@@ -16,17 +16,12 @@ import (
 )
 
 type SearchQuery struct {
-	Server     string   `json:"server"`
 	Filter     string   `json:"filter"`
 	BaseDN     string   `json:"base_dn"`
 	Scope      string   `json:"scope"`
 	SizeLimit  int      `json:"size_limit"`
 	TimeLimit  int      `json:"time_limit"`
 	Attributes []string `json:"attributes,omitempty"`
-	// Server info
-
-	BindDN       string `json:"bind_dn,omitempty"`
-	BindPassword string `json:"bind_password,omitempty"`
 	// TODO take a look at how this is used
 	Context context.Context `json:"context"`
 }

--- a/go/common/ldapSearchClient/ldapSearch_test.go
+++ b/go/common/ldapSearchClient/ldapSearch_test.go
@@ -31,7 +31,6 @@ var _ = Describe("LdapSearch", func() {
 				DialResponse = nil
 				DialError = errors.New("fake error")
 				searchQuery = &ldapSearchClient.SearchQuery{
-					Server:     "fake_configured_server",
 					Filter:     "(uid=test_human)",
 					Attributes: []string{"userPrincipalName"},
 				}


### PR DESCRIPTION
# Description
Remove unused query parameters in ldap explorer to simplify/cleanup the API
