### PR TITLE
Ldap explorer fixes

### DIFF
--- a/html/pfappserver/root/src/globals/pfField.js
+++ b/html/pfappserver/root/src/globals/pfField.js
@@ -105,20 +105,32 @@ export const pfFieldTypeComponent = {
   [pfFieldType.YESNO]:                 pfComponentType.TOGGLE
 }
 
+export const operatorMap = {
+  is: 'is',
+  is_not: 'is not',
+  starts: 'starts',
+  equals: 'equals',
+  not_equals: 'not equals',
+  contains: 'contains',
+  ends: 'ends',
+  matches_regexp: 'matches regexp',
+  is_member_of: 'is member of',
+}
+
 export const pfFieldTypeOperators = {
   [pfFieldType.CONNECTION]: [
-    { text: 'is', value: 'is' },
-    { text: 'is not', value: 'is not' }
+    { text: 'is', value: operatorMap.is },
+    { text: 'is not', value: operatorMap.is_not }
   ],
   [pfFieldType.LDAPATTRIBUTE]: [
-    { text: 'is', value: 'is' },
-    { text: 'starts', value: 'starts' },
-    { text: 'equals', value: 'equals' },
-    { text: 'not_equals', value: 'not_equals' },
-    { text: 'contains', value: 'contains' },
-    { text: 'ends', value: 'ends' },
-    { text: 'matches regexp', value: 'matches regexp' },
-    { text: 'is member of', value: 'is member of' }
+    { text: 'is', value: operatorMap.is },
+    { text: 'starts', value: operatorMap.starts },
+    { text: 'equals', value: operatorMap.equals },
+    { text: 'not_equals', value: operatorMap.not_equals },
+    { text: 'contains', value: operatorMap.contains },
+    { text: 'ends', value: operatorMap.ends },
+    { text: 'matches regexp', value: operatorMap.matches_regexp },
+    { text: 'is member of', value: operatorMap.is_member_of }
   ],
   [pfFieldType.LDAPFILTER]: [
     { text: 'match filter', value: 'match filter' }

--- a/html/pfappserver/root/src/views/Configuration/sources/_components/FormTypeLdap.vue
+++ b/html/pfappserver/root/src/views/Configuration/sources/_components/FormTypeLdap.vue
@@ -140,7 +140,7 @@
   </base-form>
 </template>
 <script>
-import { BaseForm, BaseFormTab} from '@/components/new/'
+import {BaseForm, BaseFormTab} from '@/components/new/'
 import {
   FormGroupAdministrationRules,
   FormGroupAuthenticationRules,
@@ -164,11 +164,19 @@ import {
   FormGroupSearchAttributes,
   FormGroupSearchAttributesAppend,
   FormGroupShuffle,
-  FormGroupUsernameAttribute,
   FormGroupUseConnector,
+  FormGroupUsernameAttribute,
   FormGroupVerify,
   FormGroupWriteTimeout,
 } from './'
+import {useForm as setupForm, useFormProps as props} from '../_composables/useForm'
+import useLdapAttributes
+  from '@/views/Configuration/sources/_components/ldapCondition/useLdapAttributes';
+import BaseRuleFormGroupLdapConditions
+  from '@/views/Configuration/sources/_components/BaseRuleFormGroupLdapConditions';
+import {provide} from '@vue/composition-api';
+import ProvidedKeys from '@/views/Configuration/sources/_components/ldapCondition/ProvidedKeys';
+import {ldapFormsSupported} from '@/views/Configuration/sources/_components/ldapCondition/common';
 
 const components = {
   BaseForm,
@@ -201,15 +209,6 @@ const components = {
   FormGroupVerify,
   FormGroupWriteTimeout,
 }
-
-import { useForm as setupForm, useFormProps as props } from '../_composables/useForm'
-import useLdapAttributes
-  from '@/views/Configuration/sources/_components/ldapCondition/useLdapAttributes';
-import BaseRuleFormGroupLdapConditions
-  from '@/views/Configuration/sources/_components/BaseRuleFormGroupLdapConditions';
-import {provide} from '@vue/composition-api';
-import ProvidedKeys from '@/views/Configuration/sources/_components/ldapCondition/ProvidedKeys';
-import {ldapFormsSupported} from '@/views/Configuration/sources/_components/ldapCondition/common';
 
 function setup(props){
   const ret = setupForm(props)

--- a/html/pfappserver/root/src/views/Configuration/sources/_components/LdapRuleCondition.vue
+++ b/html/pfappserver/root/src/views/Configuration/sources/_components/LdapRuleCondition.vue
@@ -17,9 +17,10 @@
   </div>
 </template>
 <script>
-import {BaseInputChosenOne} from '@/components/new'
+import {BaseInput, BaseInputChosenOne} from '@/components/new'
 import {computed, nextTick, ref, unref, watch} from '@vue/composition-api'
 import {
+  operatorMap,
   pfComponentType,
   pfFieldType,
   pfFieldTypeOperators as fieldTypeOperators,
@@ -35,6 +36,7 @@ import LdapAttributeSelector
 const components = {
   BaseInputChosenOne,
   LdapAttributeSelector,
+  BaseInput,
 }
 
 const props = {
@@ -43,6 +45,8 @@ const props = {
 }
 
 const setup = (props, context) => {
+
+  const ldapSearchOperators = [operatorMap.is, operatorMap.equals, operatorMap.not_equals]
 
   const metaProps = useInputMeta(props, context)
 
@@ -107,7 +111,10 @@ const setup = (props, context) => {
 
   const valueComponent = computed(() => {
     if (attributeValue.value) {
-      return LdapSearchInput
+      if (ldapSearchOperators.includes(operatorValue.value))
+        return LdapSearchInput
+      else
+        return BaseInput
     } else {
       return undefined
     }

--- a/html/pfappserver/root/src/views/Configuration/sources/_components/ldapCondition/LdapSearchInput.vue
+++ b/html/pfappserver/root/src/views/Configuration/sources/_components/ldapCondition/LdapSearchInput.vue
@@ -43,20 +43,8 @@ export const props = {
 
 }
 
-function parseLdapResponse(response, ldapAttribute) {
-  const ldapEntries = Object.values(response.data)
-  let parsedEntries = new Set()
-  for (let i = 0; i < ldapEntries.length; i++) {
-    let value = ldapEntries[i][ldapAttribute]
-    if (Array.isArray(value)) {
-      parsedEntries = new Set([...parsedEntries, ...value])
-    } else {
-      parsedEntries.add(value)
-    }
-  }
-  return Array.from(parsedEntries).filter((item) => {
-    return Boolean(item)
-  }).map((item) => {
+function attributesToSelectValues(attributes) {
+  return attributes.map((item) => {
     return valueToSelectValue(item)
   })
 }
@@ -111,8 +99,8 @@ function setup(props, context) { // eslint-disable-line
 
   function performSearch(query) {
     const filter = createFilter(query, ldapFilterAttribute.value)
-    sendLdapSearchRequest(filter).then((searchResponse) => {
-      inputOptions.value = parseLdapResponse(searchResponse, ldapFilterAttribute.value)
+    sendLdapSearchRequest(filter).then((attributes) => {
+      inputOptions.value = attributesToSelectValues(attributes)
       addAlreadySelectedValueToOptions()
     }).finally(() => {
       isLoading.value = false

--- a/html/pfappserver/root/src/views/Configuration/sources/_components/ldapCondition/common.js
+++ b/html/pfappserver/root/src/views/Configuration/sources/_components/ldapCondition/common.js
@@ -1,5 +1,6 @@
-import apiCall from '@/utils/api';
-import {intsToStrings} from '@/utils/convert';
+import apiCall from '@/utils/api'
+import {intsToStrings} from '@/utils/convert'
+import _ from 'lodash'
 
 export const ldapFormsSupported = ['LDAP', 'AD', 'EDIR']
 
@@ -13,11 +14,67 @@ export const parseLdapStringToArray = (ldapString) => {
   }
 }
 
+export const parseLdapResponseToAttributeArray = (ldapResponse, ldapAttribute) => {
+  const ldapEntries = Object.values(ldapResponse)
+  let parsedEntries = new Set()
+  for (let i = 0; i < ldapEntries.length; i++) {
+    let value = ldapEntries[i][ldapAttribute]
+    if (Array.isArray(value)) {
+      parsedEntries = new Set([...parsedEntries, ...value])
+    } else {
+      parsedEntries.add(value)
+    }
+  }
+  return Array.from(parsedEntries).filter((item) => {
+    return Boolean(item)
+  })
+}
+
+export const extractAttributeFromFilter = (filter) => {
+  return _.trim(filter.split('=')[0], '(')
+}
+
+const getAllAttributes = (server, filter, scope, base_dn, limit) => {
+  let searchAttribute = extractAttributeFromFilter(filter)
+  let allAttributeSearchQuery = `(${searchAttribute}=*)`
+  return sendLdapSearchRequest(server, allAttributeSearchQuery,
+    scope, [searchAttribute], base_dn, limit)
+}
+
+export const isAttributeDn = (server, filter, scope, base_dn) => {
+  return getAllAttributes(server, filter, scope, base_dn, 1).then((exampleEntry) => {
+    if(_.isEmpty(exampleEntry)) {
+      return false
+    }
+    exampleEntry = exampleEntry[Object.keys(exampleEntry)[0]]
+    exampleEntry = exampleEntry[Object.keys(exampleEntry)[0]]
+    if(Array.isArray(exampleEntry)) {
+      exampleEntry = exampleEntry[0]
+    }
+    return (exampleEntry.search('=') !== -1 && exampleEntry.search(',') !== -1)
+  })
+}
+
+export const searchDn = (server, filter, scope, base_dn) => {
+  return getAllAttributes(server, filter, scope, base_dn).then((allEntries) => {
+    let attributeSet = new Set();
+    for (let dn in allEntries) {
+      let entry = allEntries[dn]
+      let attribute = entry[Object.keys(entry)[0]]
+      if(!Array.isArray(attribute)) attribute = [attribute]
+      attribute.forEach((item) => attributeSet.add(item))
+    }
+    let regexQuery = new RegExp(_.trim(filter.split('=')[1], ')(*'), "i")
+    return [...attributeSet].filter((item) => regexQuery.test(item))
+  })
+}
+
 export const sendLdapSearchRequest = (server,
                                       filter = null,
                                       scope = null,
                                       attributes = null,
-                                      base_dn = null) => {
+                                      base_dn = null,
+                                      limit = null) => {
   server = intsToStrings(server)
   return apiCall.postQuiet('ldap/search',
     {
@@ -27,10 +84,11 @@ export const sendLdapSearchRequest = (server,
         scope: scope,
         attributes: attributes,
         base_dn: base_dn,
+        size_limit: limit,
       }
     }
   ).then(response => {
     delete response.data.quiet;
-    return response
+    return response.data
   })
 }

--- a/html/pfappserver/root/src/views/Configuration/sources/_components/ldapCondition/useAdLdap.js
+++ b/html/pfappserver/root/src/views/Configuration/sources/_components/ldapCondition/useAdLdap.js
@@ -1,5 +1,9 @@
 import _ from 'lodash';
 import {
+  extractAttributeFromFilter,
+  isAttributeDn,
+  parseLdapResponseToAttributeArray,
+  searchDn,
   sendLdapSearchRequest
 } from '@/views/Configuration/sources/_components/ldapCondition/common';
 
@@ -7,24 +11,40 @@ import {
 function useAdLdap(form) {
 
   const performSearch = (filter, scope, attributes, base_dn) => {
-    return sendLdapSearchRequest({...form.value}, filter, scope, attributes, base_dn)
+    let server = {...form.value}
+    // This also handles the case where we filter a DN attribute
+    return sendLdapSearchRequest(server , filter, scope, attributes, base_dn)
+        .then((result) => {
+            if (_.isEmpty(result)) {
+              return isAttributeDn(server, filter, scope, attributes, base_dn).then((isDn) => {
+                if (isDn) {
+                  return searchDn(server, filter, scope, attributes, base_dn)
+                } else {
+                  return []
+                }
+              })
+            } else {
+              return parseLdapResponseToAttributeArray(result, extractAttributeFromFilter(filter))
+            }
+          }
+        )
   }
 
   const getSubSchemaDN = () => {
-    return performSearch(null, 'base', ['subschemaSubentry'], '')
-      .then((response) => {
-        let firstAttribute = response.data[Object.keys(response.data)[0]]
+    return sendLdapSearchRequest({...form.value}, null, 'base', ['subschemaSubentry'], '')
+      .then((result) => {
+        let firstAttribute = result[Object.keys(result)[0]]
         return firstAttribute['subSchemaSubEntry']
       })
   }
 
   const fetchAttributeTypes = (subSchemaDN) => {
-    return performSearch('(objectclass=subschema)',
+    return sendLdapSearchRequest({...form.value}, '(objectclass=subschema)',
       'base',
       ['attributetypes'],
       subSchemaDN)
-      .then((response) => {
-        return response.data[Object.keys(response.data)[0]]['attributeTypes']
+      .then((result) => {
+        return result[Object.keys(result)[0]]['attributeTypes']
       })
   }
 

--- a/html/pfappserver/root/src/views/Configuration/sources/_components/ldapCondition/useOpenLdap.js
+++ b/html/pfappserver/root/src/views/Configuration/sources/_components/ldapCondition/useOpenLdap.js
@@ -1,6 +1,9 @@
 import _ from 'lodash';
 import {
-  parseLdapStringToArray, sendLdapSearchRequest
+  extractAttributeFromFilter,
+  parseLdapResponseToAttributeArray,
+  parseLdapStringToArray,
+  sendLdapSearchRequest
 } from '@/views/Configuration/sources/_components/ldapCondition/common';
 
 
@@ -8,23 +11,27 @@ function useOpenLdap(form) {
 
   const performSearch = (filter, scope, attributes, base_dn) => {
     return sendLdapSearchRequest({...form.value}, filter, scope, attributes, base_dn)
+      .then((result) => {
+          return parseLdapResponseToAttributeArray(result, extractAttributeFromFilter(filter))
+        }
+      )
   }
 
   const getSubSchemaDN = () => {
-    return performSearch(null, 'base', ['subSchemaSubEntry'], form.value.basedn)
+    return sendLdapSearchRequest({...form.value}, null, 'base', ['subSchemaSubEntry'], form.value.basedn)
       .then((response) => {
-        let firstAttribute = response.data[Object.keys(response.data)[0]]
+        let firstAttribute = response[Object.keys(response)[0]]
         return firstAttribute['subschemaSubentry']
       })
   }
 
   const fetchAttributeTypes = (subSchemaDN) => {
-    return performSearch('(objectclass=subschema)',
+    return sendLdapSearchRequest({...form.value}, '(objectclass=subschema)',
       'base',
       ['attributeTypes'],
       subSchemaDN)
       .then((response) => {
-        return response.data[Object.keys(response.data)[0]]['attributeTypes']
+        return response[Object.keys(response)[0]]['attributeTypes']
       })
   }
 


### PR DESCRIPTION
## Fixes
- MemberOf and other DN search
- Operators use proper inputs (e.g. "starts with" doesn't need ldap search)
- Remove front end attribute validation (not sure if this is mandatory)

## Showcase
![ldap_fixes](https://github.com/inverse-inc/packetfence/assets/36815064/00ef3958-948f-47ea-887c-28bbe9ee2daf)


## Known limitations
Can't search for path/int values, like `123` or `/home/vakaris`. In those cases use other operators, like "starts with" or regex match.
Not all DN's might show up if there are a lot of entries in the ldap server. This will be mitigated in another PR.