### PR TITLE
Don't define radius sources in the eduroam

### DIFF
--- a/lib/pf/services/manager/radiusd_child.pm
+++ b/lib/pf/services/manager/radiusd_child.pm
@@ -916,6 +916,12 @@ EOT
 }
 EOT
         }
+        #Add radius sources defined in eduroam source
+        my @eduroam_authentication_source = @{pf::authentication::getAuthenticationSourcesByType('Eduroam')};
+        if (@eduroam_authentication_source) {
+            my $eduroam_source = $eduroam_authentication_source[0];
+            push(@radius_sources, @{$eduroam_source->{'eduroam_radius_auth'}});
+        }
         if ($pf::config::ConfigRealm{$realm}->{'radius_auth'} ) {
             $tags{'config'} .= <<"EOT";
 home_server_pool auth_pool_$realm {


### PR DESCRIPTION
# Description
Don't define radius sources in the eduroam config reference them instead.

# Impacts
RADIUS eduroam config

# Issue
Fixes #7801

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ ] Document the feature
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
## Bug Fixes
* Don't define radius sources in the eduroam config reference them instead.
