### PR TITLE
fix/7830

### DIFF
--- a/lib/pf/password.pm
+++ b/lib/pf/password.pm
@@ -118,6 +118,25 @@ sub view_email {
 }
 
 
+sub view_expired {
+    my ($pid) = @_;
+    my ($status, $iter) = pf::dal::password->search(
+        -where => {
+            'password.pid' => $pid,
+            'password.expiration' => {'<' => \"NOW()"},
+        },
+        -limit => 1,
+    );
+
+    if (is_error($status)) {
+        return (undef);
+
+    }
+
+    return $iter->next(undef);
+}
+
+
 =item _delete
 
 _delete a temporary password record

--- a/lib/pf/pfcron/task/password_of_the_day.pm
+++ b/lib/pf/pfcron/task/password_of_the_day.pm
@@ -49,15 +49,10 @@ sub run {
             $self->send_email(pid => $source->{id}, password => $new_password, email => $source->{password_email_update}, expiration => pf::config::access_duration($source->{password_rotation}));
             next;
         }
-        my $password = pf::password::view($source->{id});
-        if(defined($password)){
-            my $expiration = $password->{expiration};
-            $expiration = DateTime::Format::MySQL->parse_datetime($expiration);
-            $expiration->set_time_zone("local");
-            if ( $now->epoch > $expiration->epoch) {
-                $new_password = pf::password::generate($source->{id},[{type => 'valid_from', value => $now},{type => 'expiration', value => pf::config::access_duration($source->{password_rotation})}],undef,'0',$source);
-                $self->send_email(pid => $source->{id},password => $new_password, email => $source->{password_email_update}, expiration => pf::config::access_duration($source->{password_rotation}));
-            }
+        my $password = pf::password::view_expired($source->{id});
+        if (defined($password)) {
+            $new_password = pf::password::generate($source->{id},[{type => 'valid_from', value => $now},{type => 'expiration', value => pf::config::access_duration($source->{password_rotation})}],undef,'0',$source);
+            $self->send_email(pid => $source->{id},password => $new_password, email => $source->{password_email_update}, expiration => pf::config::access_duration($source->{password_rotation}));
         }
     }
 }

--- a/t/data/authentication.conf
+++ b/t/data/authentication.conf
@@ -435,7 +435,7 @@ action1=set_unreg_date=2037-12-31
 
 [potd]
 type=Potd
-password_rotation=2s
+password_rotation=2m
 password_email_update=info@inverse.ca
 
 [potd rule match_test]

--- a/t/unittest/pfcron/task.t
+++ b/t/unittest/pfcron/task.t
@@ -12,6 +12,7 @@ unit test for task
 
 use strict;
 use warnings;
+use POSIX ":sys_wait_h";
 
 our @TESTS;
 
@@ -195,7 +196,6 @@ sub passwordExpired {
         close($writer);
         my $line = <$reader>;
         close($reader);
-        #        pf::password::_delete('potd');
         pf::password::modify_actions(
             { pid => 'potd'},
             [{ type => 'expiration', value => \'NOW()' }]
@@ -226,6 +226,7 @@ sub passwordExpired {
 sub kill_smtp_servers {
     for my $pid (@smtp_server_pid) {
         kill 9, $pid;
+        waitpid($pid, WNOHANG);
     }
 
     @smtp_server_pid = ();

--- a/t/unittest/pfcron/task.t
+++ b/t/unittest/pfcron/task.t
@@ -161,8 +161,6 @@ sub noEmail {
         close($writer);
         my $line = <$reader>;
         close($reader);
-        #        pf::password::_delete('potd');
-        #pf::person::person_delete('potd');
         push @smtp_server_pid, $pid;
         return;
     }


### PR DESCRIPTION
# Description

Use the database to calculate the expiration for POTD rotation.

# Issue
Fixes #7830

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ ] Document the feature
- [x] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
## Bug Fixes
* Use the database to calculate the expiration for POTD rotation.
