### PR TITLE
Add better error handling if the calling station cannot be parsed properly

### DIFF
--- a/go/cmd/pfacct/radius.go
+++ b/go/cmd/pfacct/radius.go
@@ -92,7 +92,12 @@ func (h *PfAcct) HandleAccounting(w radius.ResponseWriter, r *radius.Request) {
 
 	switchInfo := iSwitchInfo.(*SwitchInfo)
 	callingStation := rfc2865.CallingStationID_GetString(r.Packet)
-	mac, _ := mac.NewFromString(callingStation)
+	mac, err := mac.NewFromString(callingStation)
+	if err != nil {
+		logError(ctx, fmt.Sprintf("Calling Station is invalid: '%s' error: %s", callingStation, err.Error()))
+		return
+	}
+
 	rr := radiusRequest{
 		r:          r,
 		status:     status,


### PR DESCRIPTION
# Description
Improve error handling if the calling station cannot be parsed in pfacct.

# Impacts
pfacct

# Issue
fixes #7871

# Delete branch after merge
(REQUIRED)
YES | NO

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
## Bug Fixes
If an issue exists on Github, please refer to it (name) along with it's number...
* Improve error handling if the calling station cannot be parsed in pfacct. (#7871) 
