### PR TITLE
Draft of Azure group membership url

### DIFF
--- a/html/pfappserver/lib/pfappserver/Form/Config/Source/AzureAD.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source/AzureAD.pm
@@ -42,6 +42,16 @@ has_field 'tenant_id' =>
    default => '',
   );
 
+has_field 'user_groups_url' =>
+  (
+   type => 'Text',
+   required => 1,
+    element_attr => {
+        'placeholder' => $META->get_attribute('user_groups_url')->default
+    },
+    default => $META->get_attribute('user_groups_url')->default,
+  );
+
 has_field 'user_groups_cache' =>
   (
     type         => 'PosInteger',

--- a/html/pfappserver/root/src/views/Configuration/sources/_components/FormTypeAzureAD.vue
+++ b/html/pfappserver/root/src/views/Configuration/sources/_components/FormTypeAzureAD.vue
@@ -26,6 +26,12 @@
       :column-label="$i18n.t('Tenant ID')"
     />
 
+    <form-group-user-groups-url namespace="user_groups_url"
+      :column-label="$i18n.t('User Groups Url')"
+      :text="$i18n.t('What is the API Url where to check the groupmembership.')"
+    />
+
+
     <form-group-timeout namespace="timeout"
       :column-label="$i18n.t('Timeout')"
       :text="$i18n.t('Timeout while sending HTTP requests to Azure AD.')"
@@ -60,6 +66,7 @@ import {
   FormGroupDescription,
   FormGroupIdentifier,
   FormGroupTenantIdentifier,
+  FormGroupUserGroupsUrl,
   FormGroupTimeout,
   FormGroupRealms,
   FormGroupUserGroupsCache,
@@ -75,6 +82,7 @@ const components = {
   FormGroupDescription,
   FormGroupIdentifier,
   FormGroupTenantIdentifier,
+  FormGroupUserGroupsUrl,
   FormGroupTimeout,
   FormGroupRealms,
   FormGroupUserGroupsCache,

--- a/html/pfappserver/root/src/views/Configuration/sources/_components/index.js
+++ b/html/pfappserver/root/src/views/Configuration/sources/_components/index.js
@@ -128,6 +128,7 @@ export {
   BaseFormGroupInput                        as FormGroupTwilioPhoneNumber,
   BaseFormGroupSwitch                       as FormGroupUseConnector,
   BaseFormGroupInputNumber                  as FormGroupUserGroupsCache,
+  BaseFormGroupInput                        as FormGroupUserGroupsUrl,
   BaseFormGroupInput                        as FormGroupUserHeader,
   BaseFormGroupChosenOne                    as FormGroupUsernameAttribute,
   BaseFormGroupInput                        as FormGroupUsernameAttributeString,


### PR DESCRIPTION
# Description
Add the ability to change the User Groups Url of the Azure authentication to be able to use a different Graph endpoint for group membership (like checking device group membership)
![image](https://github.com/inverse-inc/packetfence/assets/1553962/ff1181cc-f9ba-47c7-9411-dcfb71eca0b4)

# Impacts
Azure AD source

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* Ability to change the User Groups Url for Azure AD source
