### PR TITLE
Added tcp_flags in Cisco acl chewer

### DIFF
--- a/lib/pf/Switch/Cisco.pm
+++ b/lib/pf/Switch/Cisco.pm
@@ -1848,7 +1848,9 @@ sub acl_chewer {
             }
 
         }
-        $acl_chewed .= ((defined($direction[$i]) && $direction[$i] ne "") ? $direction[$i]."|" : "").$acl->{'action'}." ".$acl->{'protocol'}." ".(($self->usePushACLs) ? $src : "any")." ".$dest ." ".( defined($acl->{'destination'}->{'port'}) ? $acl->{'destination'}->{'port'} : '' ) ."\n";
+        $acl_chewed .= ((defined($direction[$i]) && $direction[$i] ne "") ? $direction[$i]."|" : "").$acl->{'action'}." ".$acl->{'protocol'}." ".(($self->usePushACLs) ? $src : "any")." ".$dest ." ".(defined($acl->{'destination'}->{'port'}) ? $acl->{'destination'}->{'port'} : '')." ".( defined($acl->{'tcp_flags'}) ? $acl->{'tcp_flags'} : '' );
+        $acl_chewed =~ s/\s+$//;
+        $acl_chewed .= "\n";
         $i++;
     }
     return $acl_chewed;


### PR DESCRIPTION
# Description
Added tcp flags option in Cisco ACL chewer

# Impacts
Cisco Acls parser

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* Added tcp flags parameter from role configuration in acl for Cisco.
