### PR TITLE
[Vagrant] Increase PF disk size

### DIFF
--- a/addons/vagrant/inventory/hosts
+++ b/addons/vagrant/inventory/hosts
@@ -120,7 +120,7 @@ all:
               ansible_python_interpreter: '/usr/bin/python3'
               cpus: 8
               memory: 16384
-              disk_size: 30
+              disk_size: 130
             pf2el8dev:
               box: generic/rhel8
               box_version: '4.2.16'
@@ -130,7 +130,7 @@ all:
               ansible_python_interpreter: '/usr/bin/python3'
               cpus: 8
               memory: 16384
-              disk_size: 30
+              disk_size: 130
             pf3el8dev:
               box: generic/rhel8
               box_version: '4.2.16'
@@ -140,7 +140,7 @@ all:
               ansible_python_interpreter: '/usr/bin/python3'
               cpus: 8
               memory: 16384
-              disk_size: 30
+              disk_size: 130
             pf1deb11dev:
               box: inverse-inc/pfdeb11dev
               box_version: 13.1.20231107151133
@@ -150,7 +150,7 @@ all:
               ansible_python_interpreter: '/usr/bin/python3'
               cpus: 8
               memory: 16384
-              disk_size: 30
+              disk_size: 130
             pf2deb11dev:
               box: inverse-inc/pfdeb11dev
               box_version: 13.1.20231107151133
@@ -160,7 +160,7 @@ all:
               ansible_python_interpreter: '/usr/bin/python3'
               cpus: 8
               memory: 16384
-              disk_size: 30
+              disk_size: 130
             pf3deb11dev:
               box: inverse-inc/pfdeb11dev
               box_version: 13.1.20231107151133
@@ -170,7 +170,7 @@ all:
               ansible_python_interpreter: '/usr/bin/python3'
               cpus: 8
               memory: 16384
-              disk_size: 30
+              disk_size: 130
             pf1el8localdev:
               box: generic/rhel8
               box_version: '4.2.16'
@@ -180,7 +180,7 @@ all:
               ansible_python_interpreter: '/usr/bin/python3'
               cpus: 8
               memory: 16384
-              disk_size: 30
+              disk_size: 130
             pf2el8localdev:
               box: generic/rhel8
               box_version: '4.2.16'
@@ -190,7 +190,7 @@ all:
               ansible_python_interpreter: '/usr/bin/python3'
               cpus: 8
               memory: 16384
-              disk_size: 30
+              disk_size: 130
             pf3el8localdev:
               box: generic/rhel8
               box_version: '4.2.16'
@@ -200,7 +200,7 @@ all:
               ansible_python_interpreter: '/usr/bin/python3'
               cpus: 8
               memory: 16384
-              disk_size: 30
+              disk_size: 130
             pf1deb11localdev:
               box: inverse-inc/pfdeb11dev
               box_version: 13.1.20231107151133
@@ -210,7 +210,7 @@ all:
               ansible_python_interpreter: '/usr/bin/python3'
               cpus: 8
               memory: 16384
-              disk_size: 30
+              disk_size: 130
             pf2deb11localdev:
               box: inverse-inc/pfdeb11dev
               box_version: 13.1.20231107151133
@@ -220,7 +220,7 @@ all:
               ansible_python_interpreter: '/usr/bin/python3'
               cpus: 8
               memory: 16384
-              disk_size: 30
+              disk_size: 130
             pf3deb11localdev:
               box: inverse-inc/pfdeb11dev
               box_version: 13.1.20231107151133
@@ -230,7 +230,7 @@ all:
               ansible_python_interpreter: '/usr/bin/python3'
               cpus: 8
               memory: 16384
-              disk_size: 30
+              disk_size: 130
 
         standalones:
           hosts:
@@ -243,7 +243,7 @@ all:
               ansible_python_interpreter: '/usr/bin/python3'
               cpus: 8
               memory: 16384
-              disk_size: 60
+              disk_size: 130
             pfdeb11dev:
               box: inverse-inc/pfdeb11dev
               box_version: 13.1.20231107151133
@@ -253,7 +253,7 @@ all:
               ansible_python_interpreter: '/usr/bin/python3'
               cpus: 8
               memory: 16384
-              disk_size: 60
+              disk_size: 130
             el8dev:
               box: generic/rhel8
               box_version: '4.2.16'
@@ -263,7 +263,7 @@ all:
               ansible_python_interpreter: '/usr/bin/python3'
               cpus: 8
               memory: 16384
-              disk_size: 60
+              disk_size: 130
             deb11dev:
               box: debian/bullseye64
               box_version: 11.20221219.1
@@ -273,7 +273,7 @@ all:
               ansible_python_interpreter: '/usr/bin/python3'
               cpus: 8
               memory: 16384
-              disk_size: 60
+              disk_size: 130
             localhost:
               mgmt_ip: "{{ users_vars[dict_name]['vms']['localhost']['ip'] }}"
               mgmt_netmask: "{{ users_vars[dict_name]['vms']['localhost']['netmask'] }}"
@@ -287,7 +287,7 @@ all:
               ansible_python_interpreter: '/usr/bin/python3'
               cpus: 8
               memory: 16384
-              disk_size: 60
+              disk_size: 130
             pfdeb11localdev:
               box: inverse-inc/pfdeb11dev
               box_version: 13.1.20231107151133
@@ -297,7 +297,7 @@ all:
               ansible_python_interpreter: '/usr/bin/python3'
               cpus: 8
               memory: 16384
-              disk_size: 60
+              disk_size: 130
             el8localdev:
               box: generic/rhel8
               box_version: '4.2.16'
@@ -307,7 +307,7 @@ all:
               ansible_python_interpreter: '/usr/bin/python3'
               cpus: 8
               memory: 16384
-              disk_size: 60
+              disk_size: 130
             deb11localdev:
               box: debian/bullseye64
               box_version: 11.20221219.1
@@ -317,7 +317,7 @@ all:
               ansible_python_interpreter: '/usr/bin/python3'
               cpus: 8
               memory: 16384
-              disk_size: 60
+              disk_size: 130
             pfel8stable:
               box: generic/rhel8
               box_version: '4.2.16'
@@ -327,7 +327,7 @@ all:
               ansible_python_interpreter: '/usr/bin/python3'
               cpus: 8
               memory: 16384
-              disk_size: 60
+              disk_size: 130
             # to test upgrades
             pfdeb9stable:
               box: inverse-inc/pfdeb9stable
@@ -337,7 +337,7 @@ all:
               ansible_host: "{{ mgmt_ip }}"
               cpus: 8
               memory: 16384
-              disk_size: 60
+              disk_size: 130
             pfdeb11stable:
               box: debian/bullseye64
               box_version: 11.20221219.1
@@ -347,7 +347,7 @@ all:
               ansible_python_interpreter: '/usr/bin/python3'
               cpus: 8
               memory: 16384
-              disk_size: 60
+              disk_size: 130
 
 
     dev:

--- a/addons/vagrant/inventory/hosts
+++ b/addons/vagrant/inventory/hosts
@@ -120,6 +120,7 @@ all:
               ansible_python_interpreter: '/usr/bin/python3'
               cpus: 8
               memory: 16384
+              disk_size: 30
             pf2el8dev:
               box: generic/rhel8
               box_version: '4.2.16'
@@ -129,6 +130,7 @@ all:
               ansible_python_interpreter: '/usr/bin/python3'
               cpus: 8
               memory: 16384
+              disk_size: 30
             pf3el8dev:
               box: generic/rhel8
               box_version: '4.2.16'
@@ -138,6 +140,7 @@ all:
               ansible_python_interpreter: '/usr/bin/python3'
               cpus: 8
               memory: 16384
+              disk_size: 30
             pf1deb11dev:
               box: inverse-inc/pfdeb11dev
               box_version: 13.1.20231107151133
@@ -147,6 +150,7 @@ all:
               ansible_python_interpreter: '/usr/bin/python3'
               cpus: 8
               memory: 16384
+              disk_size: 30
             pf2deb11dev:
               box: inverse-inc/pfdeb11dev
               box_version: 13.1.20231107151133
@@ -156,6 +160,7 @@ all:
               ansible_python_interpreter: '/usr/bin/python3'
               cpus: 8
               memory: 16384
+              disk_size: 30
             pf3deb11dev:
               box: inverse-inc/pfdeb11dev
               box_version: 13.1.20231107151133
@@ -165,6 +170,7 @@ all:
               ansible_python_interpreter: '/usr/bin/python3'
               cpus: 8
               memory: 16384
+              disk_size: 30
             pf1el8localdev:
               box: generic/rhel8
               box_version: '4.2.16'
@@ -174,6 +180,7 @@ all:
               ansible_python_interpreter: '/usr/bin/python3'
               cpus: 8
               memory: 16384
+              disk_size: 30
             pf2el8localdev:
               box: generic/rhel8
               box_version: '4.2.16'
@@ -183,6 +190,7 @@ all:
               ansible_python_interpreter: '/usr/bin/python3'
               cpus: 8
               memory: 16384
+              disk_size: 30
             pf3el8localdev:
               box: generic/rhel8
               box_version: '4.2.16'
@@ -192,6 +200,7 @@ all:
               ansible_python_interpreter: '/usr/bin/python3'
               cpus: 8
               memory: 16384
+              disk_size: 30
             pf1deb11localdev:
               box: inverse-inc/pfdeb11dev
               box_version: 13.1.20231107151133
@@ -201,6 +210,7 @@ all:
               ansible_python_interpreter: '/usr/bin/python3'
               cpus: 8
               memory: 16384
+              disk_size: 30
             pf2deb11localdev:
               box: inverse-inc/pfdeb11dev
               box_version: 13.1.20231107151133
@@ -210,6 +220,7 @@ all:
               ansible_python_interpreter: '/usr/bin/python3'
               cpus: 8
               memory: 16384
+              disk_size: 30
             pf3deb11localdev:
               box: inverse-inc/pfdeb11dev
               box_version: 13.1.20231107151133
@@ -219,6 +230,7 @@ all:
               ansible_python_interpreter: '/usr/bin/python3'
               cpus: 8
               memory: 16384
+              disk_size: 30
 
         standalones:
           hosts:
@@ -231,6 +243,7 @@ all:
               ansible_python_interpreter: '/usr/bin/python3'
               cpus: 8
               memory: 16384
+              disk_size: 60
             pfdeb11dev:
               box: inverse-inc/pfdeb11dev
               box_version: 13.1.20231107151133
@@ -240,6 +253,7 @@ all:
               ansible_python_interpreter: '/usr/bin/python3'
               cpus: 8
               memory: 16384
+              disk_size: 60
             el8dev:
               box: generic/rhel8
               box_version: '4.2.16'
@@ -249,6 +263,7 @@ all:
               ansible_python_interpreter: '/usr/bin/python3'
               cpus: 8
               memory: 16384
+              disk_size: 60
             deb11dev:
               box: debian/bullseye64
               box_version: 11.20221219.1
@@ -258,6 +273,7 @@ all:
               ansible_python_interpreter: '/usr/bin/python3'
               cpus: 8
               memory: 16384
+              disk_size: 60
             localhost:
               mgmt_ip: "{{ users_vars[dict_name]['vms']['localhost']['ip'] }}"
               mgmt_netmask: "{{ users_vars[dict_name]['vms']['localhost']['netmask'] }}"
@@ -271,6 +287,7 @@ all:
               ansible_python_interpreter: '/usr/bin/python3'
               cpus: 8
               memory: 16384
+              disk_size: 60
             pfdeb11localdev:
               box: inverse-inc/pfdeb11dev
               box_version: 13.1.20231107151133
@@ -280,6 +297,7 @@ all:
               ansible_python_interpreter: '/usr/bin/python3'
               cpus: 8
               memory: 16384
+              disk_size: 60
             el8localdev:
               box: generic/rhel8
               box_version: '4.2.16'
@@ -289,6 +307,7 @@ all:
               ansible_python_interpreter: '/usr/bin/python3'
               cpus: 8
               memory: 16384
+              disk_size: 60
             deb11localdev:
               box: debian/bullseye64
               box_version: 11.20221219.1
@@ -298,6 +317,7 @@ all:
               ansible_python_interpreter: '/usr/bin/python3'
               cpus: 8
               memory: 16384
+              disk_size: 60
             pfel8stable:
               box: generic/rhel8
               box_version: '4.2.16'
@@ -307,6 +327,7 @@ all:
               ansible_python_interpreter: '/usr/bin/python3'
               cpus: 8
               memory: 16384
+              disk_size: 60
             # to test upgrades
             pfdeb9stable:
               box: inverse-inc/pfdeb9stable
@@ -316,6 +337,7 @@ all:
               ansible_host: "{{ mgmt_ip }}"
               cpus: 8
               memory: 16384
+              disk_size: 60
             pfdeb11stable:
               box: debian/bullseye64
               box_version: 11.20221219.1
@@ -325,6 +347,7 @@ all:
               ansible_python_interpreter: '/usr/bin/python3'
               cpus: 8
               memory: 16384
+              disk_size: 60
 
 
     dev:

--- a/addons/vagrant/pfservers/Vagrantfile
+++ b/addons/vagrant/pfservers/Vagrantfile
@@ -69,7 +69,16 @@ Vagrant.configure("2") do |config|
         srv.vm.provider "libvirt" do |v|
           v.cpus = details['cpus']
           v.memory = details['memory']
+          v.machine_virtual_size = details['disk_size']
         end
+
+        # extend disk partition
+        srv.vm.provision "shell", inline: <<-SHELL
+          apt update
+          apt install -y cloud-guest-utils
+          growpart /dev/vda 1
+          resize2fs -p /dev/vda1
+        SHELL
 
         # provisionners
         # Sync timezone with host

--- a/addons/vagrant/pfservers/Vagrantfile
+++ b/addons/vagrant/pfservers/Vagrantfile
@@ -72,13 +72,20 @@ Vagrant.configure("2") do |config|
           v.machine_virtual_size = details['disk_size']
         end
 
+        ###########################
         # extend disk partition
+        ###########################
         srv.vm.provision "shell", inline: <<-SHELL
-          apt update
-          apt install -y cloud-guest-utils
-          growpart /dev/vda 1
-          resize2fs -p /dev/vda1
-        SHELL
+            if [ -f /etc/redhat-release ] ; then
+              lvextend -l +100%FREE /dev/rhel_rhel8/root
+              xfs_growfs /dev/rhel_rhel8/root
+            else
+              apt update
+              apt install -y cloud-guest-utils
+              growpart /dev/vda 1
+              resize2fs -p /dev/vda1
+            fi
+          SHELL
 
         # provisionners
         # Sync timezone with host


### PR DESCRIPTION
# Description
Increase disk size for PF vms in tests

# Impacts
For cluster bump from 20G to 30G
For standalone bump from 20G to 60G
Could be set by type of VMs in inventory/hosts
Could be used for other VMs if needed

FROM NOW could not be backported to maintenance/13.0 or below due to old runners issues

# Issue
fixes #7898 

# Delete branch after merge
YES

# Checklist
- [x] Update runners 7_0
- [ ] Update runners default (could not be done from now due to dependencies issues)
- [ ] Run a pipeline

# NEWS file entries
## New Features
* Allow bigger disk size on PF vagrant VM tests  

## Bug Fixes
* Issues with disk size for e2e (#7898)