### PR TITLE
Fix/7958 better Fix nodejs 20 GPG key issue

### DIFF
--- a/addons/perl-client/vagrant/requirements.yml
+++ b/addons/perl-client/vagrant/requirements.yml
@@ -1,7 +1,8 @@
 ---
-roles:
-  - name: inverse_inc.gitlab_buildpkg_tools
-    version: v1.3.6
-
 collections:
   - name: debops.debops
+
+roles:
+  - name: inverse_inc.gitlab_buildpkg_tools
+  
+

--- a/addons/vagrant/inventory/group_vars/pfservers/nodejs.yml
+++ b/addons/vagrant/inventory/group_vars/pfservers/nodejs.yml
@@ -4,7 +4,7 @@
 ################################################################################
 # RPM
 gitlab_buildpkg_tools__rpm_keys:
-  - 'https://rpm.nodesource.com/gpgkey/nodesource.gpg.key'
+  - 'https://rpm.nodesource.com/gpgkey/ns-operations-public.key'
 
 gitlab_buildpkg_tools__rpm_deps_repos:
   - name: nodejs

--- a/addons/vagrant/requirements.yml
+++ b/addons/vagrant/requirements.yml
@@ -2,7 +2,7 @@
 # versions in roles should be equals to tags
 roles:
   - src: inverse_inc.gitlab_buildpkg_tools
-    version: v1.3.6
+    version: v1.3.5
 
 # For roles, to test locally with Vagrant (due to --force option)
 # Ansible will create an export, not a symlink to git repository

--- a/ci/packer/provisionners_cpanbuild/requirements.yml
+++ b/ci/packer/provisionners_cpanbuild/requirements.yml
@@ -1,8 +1,6 @@
 ---
 roles:
   - src: inverse_inc.gitlab_buildpkg_tools
-    version: v1.3.6
-
 collections:
   - name: community.general
     version: 7.0.1

--- a/ci/packer/provisionners_pfbuild/inventory/group_vars/common_centos/gitlab_buildpkg_tools.yml
+++ b/ci/packer/provisionners_pfbuild/inventory/group_vars/common_centos/gitlab_buildpkg_tools.yml
@@ -1,7 +1,7 @@
 ---
 gitlab_buildpkg_tools__rpm_keys:
   - 'https://inverse.ca/downloads/GPG_PUBLIC_KEY'
-  - 'https://rpm.nodesource.com/gpgkey/nodesource.gpg.key'
+  - 'https://rpm.nodesource.com/gpgkey/ns-operations-public.key'
 
 gitlab_buildpkg_tools__rpm_deps_repos:
   - name: packetfence

--- a/ci/packer/provisionners_pfbuild/requirements.yml
+++ b/ci/packer/provisionners_pfbuild/requirements.yml
@@ -1,8 +1,7 @@
 ---
 roles:
   - src: inverse_inc.gitlab_buildpkg_tools
-    version: v1.3.6
-
+    version: v1.3.5
 collections:
   - name: community.general
     version: 7.0.1

--- a/ci/packer/vagrant_img/provisioners/inventory/group_vars/pfservers/gitlab_buildpkg_tools.yml
+++ b/ci/packer/vagrant_img/provisioners/inventory/group_vars/pfservers/gitlab_buildpkg_tools.yml
@@ -7,7 +7,7 @@ gitlab_buildpkg_tools__ppa_enabled: False
 # RPM
 gitlab_buildpkg_tools__rpm_keys:
   - 'https://inverse.ca/downloads/GPG_PUBLIC_KEY'
-  - 'https://rpm.nodesource.com/gpgkey/nodesource.gpg.key'
+  - 'https://rpm.nodesource.com/gpgkey/ns-operations-public.key'    
 
 gitlab_buildpkg_tools__rpm_deps_repos:
   - name: packetfence

--- a/ci/packer/vagrant_img/provisioners/requirements.yml
+++ b/ci/packer/vagrant_img/provisioners/requirements.yml
@@ -1,7 +1,7 @@
 ---
 roles:
   - src: inverse_inc.gitlab_buildpkg_tools
-    version: v1.3.6
+    version: v1.3.5
 
 collections:
   - name: inverse_inc.utils

--- a/t/venom/requirements.yml
+++ b/t/venom/requirements.yml
@@ -1,6 +1,6 @@
 roles:
   - src: inverse_inc.gitlab_buildpkg_tools
-    version: v1.3.6
+    version: v1.3.5
 
 # For roles, to test locally
 # Ansible will create an export, not a symlink to git repository


### PR DESCRIPTION
# Description
Better and simpler fix #7958

Extract the right gpg key from https://rpm.nodesource.com/setup_20.x and update our key.

(note the debian is there: https://deb.nodesource.com/setup_20.x)

# Impacts
Need to remove v1.3.6 gitlab-buildpkg-tools

# Issue
fixes #7958 

# Delete branch after merge
YES

# Checklist
- [ ] Do a pipeline
