### PR TITLE
Adds cluster mode detection

### DIFF
--- a/addons/upgrade/to-13.1-move-ntlm-auth-to-rest.pl
+++ b/addons/upgrade/to-13.1-move-ntlm-auth-to-rest.pl
@@ -75,7 +75,7 @@ for my $section (grep {/^\S+$/} $ini->Sections()) {
 
     my $samba_conf_path = "/etc/samba/$section.conf";
     unless (-e $samba_conf_path) {
-        print("  $samba_conf_path not found, skipped.");
+        print("  $samba_conf_path not found, skipped.\n");
         next;
     }
 
@@ -96,10 +96,10 @@ for my $section (grep {/^\S+$/} $ini->Sections()) {
 
     if ($cluster_enabled) {
         if ($samba_server_name ne $host_id) {
-            print("  In a cluster mode the Samba server ($samba_server_name) name needs to match the hostname of the server ($host_id)");
-            print("  The configuration will be migrated but the server name in the domain configuration will be replaced by %h (the return of the hostname command)");
-            print("  You have to manually rejoin the server to the domain from the Admin UI in Configuration -> Policies and Access Control -> Active Directory Domains");
-            print("  By editing the domain configuration, fill in the domain administrator username and password, and save the configuration.");
+            print("  In a cluster mode the Samba server ($samba_server_name) name needs to match the hostname of the server ($host_id)\n");
+            print("  The configuration will be migrated but the server name in the domain configuration will be replaced by %h (the return of the hostname command)\n");
+            print("  You have to manually rejoin the server to the domain from the Admin UI in Configuration -> Policies and Access Control -> Active Directory Domains\n");
+            print("  By editing the domain configuration, fill in the domain administrator username and password, and save the configuration.\n");
             $ini->setval($section, 'server_name', "%h");
         }
         my $parsedPh = parsePh();
@@ -257,7 +257,7 @@ sub umount_winbindd {
     pf_run("sudo systemctl stop packetfence-winbindd");
     sleep(3);
     pf_run("mount | awk '{print \$3}' | grep chroots --color | xargs umount");
-    print("/chroots/* has been umounted. Some sub directories are stinn in use. They will be removed at the next reboot")
+    print("/chroots/* has been umounted. Some sub directories are still in use. They will be removed at the next reboot")
 }
 
 sub parsePh {

--- a/addons/upgrade/to-13.1-move-ntlm-auth-to-rest.pl
+++ b/addons/upgrade/to-13.1-move-ntlm-auth-to-rest.pl
@@ -257,7 +257,7 @@ sub umount_winbindd {
     pf_run("sudo systemctl stop packetfence-winbindd");
     sleep(3);
     pf_run("mount | awk '{print \$3}' | grep chroots --color | xargs umount");
-    print("/chroots/* has been umounted. Some sub directories are still in use. They will be removed at the next reboot")
+    print("/chroots/* has been umounted. Some sub directories are still in use. They will be removed at the next reboot\n")
 }
 
 sub parsePh {

--- a/addons/upgrade/to-13.1-move-ntlm-auth-to-rest.pl
+++ b/addons/upgrade/to-13.1-move-ntlm-auth-to-rest.pl
@@ -56,7 +56,7 @@ for my $section (grep {/^\S+$/} $ini->Sections()) {
     pf_run("mkdir -p $target_dir/chroots/$section/etc && cp -R /chroots/$section/etc/samba $target_dir/chroots/$section/etc");
     pf_run("mkdir -p $target_dir/chroots/$section/var/cache && cp -R /chroots/$section/var/cache/samba $target_dir/chroots/$section/var/cache");
 }
-pf_run("cd /usr/local/pf/archive && tar -cvzf $tmp_dirname.tgz $tmp_dirname && rm -rf $tmp_dirname");
+pf_run("cd /usr/local/pf/archive && tar --warning=no-file-ignored -cvzf $tmp_dirname.tgz $tmp_dirname && rm -rf $tmp_dirname");
 
 for my $section (grep {/^\S+$/} $ini->Sections()) {
     print("Generating config for section: $section\n");


### PR DESCRIPTION
# Description
Add cluster detection in migration script, migration will stop if PacketFence node is in cluster mode.

# Impacts
Changed ntlm auth migration scrip, trigger full stop when PacketFence node is a member of a cluster.
 

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [n/a] Document the feature
- [n/a] Add OpenAPI specification
- [n/a] Add unit tests
- [n/a] Add acceptance tests (TestLink)


## Enhancements
* Changed ntlm auth migration flow to avoid having different domain.conf file.


