### PR TITLE
fix 7931

### DIFF
--- a/sbin/ntlm-auth-api-docker-wrapper
+++ b/sbin/ntlm-auth-api-docker-wrapper
@@ -7,9 +7,11 @@ name=ntlm-auth-api
 conf_dir="/usr/local/pf/var/conf/${name}.d/"
 env_files=$(ls $conf_dir 2>/dev/null)
 option=$1
+check_interval=5
 
 if [ -z "$env_files" ]; then
-    exit 1
+    echo "No domain config exists. Nothing to do."
+    exit 0
 fi
 
 if [ "$option" == "" ]; then
@@ -23,7 +25,28 @@ if [ "$option" = "start" ]; then
         echo "starting ntlm auth api domain service for: $iden using env file: $env_file"
         systemctl start packetfence-ntlm-auth-api-domain@"$iden"
     done
-    sleep infinity
+    sleep 5
+
+    while true; do
+        running_containers=$(docker ps --format "{{.Names}}" | grep ntlm-auth-api)
+
+        for env_file in $env_files; do
+            iden=$(echo $env_file | awk -F '.' '{print $1}')
+            expected_container="ntlm-auth-api-$iden"
+
+            ok="n"
+            for running_container in $running_containers; do
+                if [ "$running_container" == "$expected_container" ]; then
+                    ok="y"
+                fi
+            done
+            if [ $ok == "n" ]; then
+                echo "probing $expected_container failed."
+                exit 1
+            fi
+        done
+        sleep $check_interval
+    done
 elif [ "$option" = "stop" ]; then
     for env_file in $env_files; do
         iden=$(echo $env_file | awk -F '.' '{print $1}')


### PR DESCRIPTION
Fix issue 7931 and adds a service status check for ntlm-auth-api

# Description
check ntlm-auth-api-domain regularly.
fix 7931

# Impacts
Changed: if there's nothing in domain.conf, terminate the ntlm-auth-api service, and this termination should be considered as a "normal exit" 
Changed: replaced the "infinite sleep" with "regularly check if all the "ntlm-auth-api-domain" service is running. 

# Issue
fixes #7931 

# Delete branch after merge
YES

# Checklist
- [na] Document the feature
- [na] Add OpenAPI specification
- [na] Add unit tests
- [na] Add acceptance tests (TestLink)

## Enhancements
* when there's nothing in domain.conf, ntlm-auth-api exits with code 0.
* regularly check if all the sub-services of ntlm-auth-api is running.

## Bug Fixes
fixes #7931 packetfence ntlm-auth-api starts without domain config

# UPGRADE file entries
sbin/ntlm-auth-api-docker-wrapper