### PR TITLE
feature/smaller go docker images

### DIFF
--- a/containers/api-frontend/Dockerfile
+++ b/containers/api-frontend/Dockerfile
@@ -13,7 +13,7 @@ COPY ./lib /usr/local/pf/lib
 COPY ./config.mk /usr/local/pf/config.mk
 RUN cd /usr/local/pf/go/ &&  make pfhttpd
 
-FROM scratch
+FROM busybox:latest
 
 WORKDIR /usr/local/pf/
 

--- a/containers/api-frontend/Dockerfile
+++ b/containers/api-frontend/Dockerfile
@@ -13,7 +13,7 @@ COPY ./lib /usr/local/pf/lib
 COPY ./config.mk /usr/local/pf/config.mk
 RUN cd /usr/local/pf/go/ &&  make pfhttpd
 
-FROM ${KNK_REGISTRY_URL}/pfdebian:${IMAGE_TAG}
+FROM scratch
 
 WORKDIR /usr/local/pf/
 

--- a/containers/httpd.admin_dispatcher/Dockerfile
+++ b/containers/httpd.admin_dispatcher/Dockerfile
@@ -47,7 +47,7 @@ RUN if [[ "$BUILD_PFAPPSERVER_VUE" == "yes" ]]; then \
       mkdir -p /usr/local/pf/html ; \
     fi
 
-FROM ${KNK_REGISTRY_URL}/pfdebian:${IMAGE_TAG}
+FROM scratch
 WORKDIR /usr/local/pf/
 COPY --from=0 /usr/local/pf/go/pfhttpd /usr/local/pf/sbin/pfhttpd
 COPY --from=0 /usr/local/pf/go/httpdispatcher /usr/local/pf/sbin/httpdispatcher

--- a/containers/httpd.admin_dispatcher/Dockerfile
+++ b/containers/httpd.admin_dispatcher/Dockerfile
@@ -47,7 +47,7 @@ RUN if [[ "$BUILD_PFAPPSERVER_VUE" == "yes" ]]; then \
       mkdir -p /usr/local/pf/html ; \
     fi
 
-FROM scratch
+FROM busybox:latest
 WORKDIR /usr/local/pf/
 COPY --from=0 /usr/local/pf/go/pfhttpd /usr/local/pf/sbin/pfhttpd
 COPY --from=0 /usr/local/pf/go/httpdispatcher /usr/local/pf/sbin/httpdispatcher

--- a/containers/httpd.dispatcher/Dockerfile
+++ b/containers/httpd.dispatcher/Dockerfile
@@ -24,7 +24,7 @@ RUN apt install nodejs -y && \
     make vendor  && \
     make light-dist
 
-FROM ${KNK_REGISTRY_URL}/pfdebian:${IMAGE_TAG}
+FROM scratch
 WORKDIR /usr/local/pf/
 COPY --from=0 /usr/local/pf/html /usr/local/pf/html
 COPY --from=0 /usr/local/pf/go/pfhttpd /usr/local/pf/sbin/pfhttpd

--- a/containers/httpd.dispatcher/Dockerfile
+++ b/containers/httpd.dispatcher/Dockerfile
@@ -24,7 +24,7 @@ RUN apt install nodejs -y && \
     make vendor  && \
     make light-dist
 
-FROM scratch
+FROM busybox:latest
 WORKDIR /usr/local/pf/
 COPY --from=0 /usr/local/pf/html /usr/local/pf/html
 COPY --from=0 /usr/local/pf/go/pfhttpd /usr/local/pf/sbin/pfhttpd

--- a/containers/pfacct/Dockerfile
+++ b/containers/pfacct/Dockerfile
@@ -13,7 +13,7 @@ COPY ./lib /usr/local/pf/lib
 COPY ./config.mk /usr/local/pf/config.mk
 RUN cd /usr/local/pf/go/ &&  make pfacct
 
-FROM ${KNK_REGISTRY_URL}/pfdebian:${IMAGE_TAG}
+FROM scratch
 
 WORKDIR /usr/local/pf/
 

--- a/containers/pfacct/Dockerfile
+++ b/containers/pfacct/Dockerfile
@@ -11,15 +11,17 @@ RUN cd /usr/local/pf/go/ && go mod download
 COPY ./go /usr/local/pf/go
 COPY ./lib /usr/local/pf/lib
 COPY ./config.mk /usr/local/pf/config.mk
+RUN apt update && apt install freeradius-utils -y
+
 RUN cd /usr/local/pf/go/ &&  make pfacct
 
 FROM busybox:latest
 
 WORKDIR /usr/local/pf/
 
+COPY --from=0 /usr/share/freeradius/dictionary /usr/share/freeradius/dictionary
 COPY --from=0 /usr/local/pf/go/pfacct /usr/local/pf/sbin/pfacct
 
-RUN apt update && apt install freeradius-utils -y
 
 ENTRYPOINT /usr/local/pf/sbin/pfacct
 

--- a/containers/pfacct/Dockerfile
+++ b/containers/pfacct/Dockerfile
@@ -13,7 +13,7 @@ COPY ./lib /usr/local/pf/lib
 COPY ./config.mk /usr/local/pf/config.mk
 RUN cd /usr/local/pf/go/ &&  make pfacct
 
-FROM scratch
+FROM busybox:latest
 
 WORKDIR /usr/local/pf/
 

--- a/containers/pfconnector/Dockerfile
+++ b/containers/pfconnector/Dockerfile
@@ -13,7 +13,7 @@ COPY ./lib /usr/local/pf/lib
 COPY ./config.mk /usr/local/pf/config.mk
 RUN cd /usr/local/pf/go/ &&  make pfconnector
 
-FROM scratch
+FROM busybox:latest
 WORKDIR /usr/local/pf/
 COPY ./config.mk /usr/local/pf/config.mk
 COPY --from=0 /usr/local/pf/go/pfconnector /usr/local/pf/sbin/pfconnector

--- a/containers/pfconnector/Dockerfile
+++ b/containers/pfconnector/Dockerfile
@@ -13,7 +13,7 @@ COPY ./lib /usr/local/pf/lib
 COPY ./config.mk /usr/local/pf/config.mk
 RUN cd /usr/local/pf/go/ &&  make pfconnector
 
-FROM ${KNK_REGISTRY_URL}/pfdebian:${IMAGE_TAG}
+FROM scratch
 WORKDIR /usr/local/pf/
 COPY ./config.mk /usr/local/pf/config.mk
 COPY --from=0 /usr/local/pf/go/pfconnector /usr/local/pf/sbin/pfconnector

--- a/containers/pfcron/Dockerfile
+++ b/containers/pfcron/Dockerfile
@@ -13,7 +13,7 @@ COPY ./lib /usr/local/pf/lib
 COPY ./config.mk /usr/local/pf/config.mk
 RUN cd /usr/local/pf/go/ &&  make pfcron
 
-FROM scratch
+FROM busybox:latest
 WORKDIR /usr/local/pf/
 COPY --from=0 /usr/local/pf/go/pfcron /usr/local/pf/sbin/pfcron
 ENTRYPOINT /usr/local/pf/sbin/pfcron

--- a/containers/pfcron/Dockerfile
+++ b/containers/pfcron/Dockerfile
@@ -13,7 +13,7 @@ COPY ./lib /usr/local/pf/lib
 COPY ./config.mk /usr/local/pf/config.mk
 RUN cd /usr/local/pf/go/ &&  make pfcron
 
-FROM ${KNK_REGISTRY_URL}/pfdebian:${IMAGE_TAG}
+FROM scratch
 WORKDIR /usr/local/pf/
 COPY --from=0 /usr/local/pf/go/pfcron /usr/local/pf/sbin/pfcron
 ENTRYPOINT /usr/local/pf/sbin/pfcron

--- a/containers/pfdebian/Dockerfile
+++ b/containers/pfdebian/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:11
+FROM debian:11-slim
 
 RUN apt-get update && apt-get install -y aptitude wget gnupg
 

--- a/containers/pfldapexplorer/Dockerfile
+++ b/containers/pfldapexplorer/Dockerfile
@@ -13,7 +13,7 @@ COPY ./lib /usr/local/pf/lib
 COPY ./config.mk /usr/local/pf/config.mk
 RUN cd /usr/local/pf/go/ &&  make pfhttpd
 
-FROM ${KNK_REGISTRY_URL}/pfdebian:${IMAGE_TAG}
+FROM scratch
 WORKDIR /usr/local/pf/
 COPY ./config.mk /usr/local/pf/config.mk
 COPY --from=0 /usr/local/pf/go/pfhttpd /usr/local/pf/sbin/pfhttpd

--- a/containers/pfldapexplorer/Dockerfile
+++ b/containers/pfldapexplorer/Dockerfile
@@ -13,7 +13,7 @@ COPY ./lib /usr/local/pf/lib
 COPY ./config.mk /usr/local/pf/config.mk
 RUN cd /usr/local/pf/go/ &&  make pfhttpd
 
-FROM scratch
+FROM busybox:latest
 WORKDIR /usr/local/pf/
 COPY ./config.mk /usr/local/pf/config.mk
 COPY --from=0 /usr/local/pf/go/pfhttpd /usr/local/pf/sbin/pfhttpd

--- a/containers/pfpki/Dockerfile
+++ b/containers/pfpki/Dockerfile
@@ -15,7 +15,7 @@ COPY ./Makefile /usr/local/pf/Makefile
 RUN cd /usr/local/pf/go/ && \
     make pfhttpd
 
-FROM ${KNK_REGISTRY_URL}/pfdebian:${IMAGE_TAG}
+FROM scratch
 WORKDIR /usr/local/pf/
 COPY --from=0 /usr/local/pf/go/pfhttpd /usr/local/pf/sbin/pfhttpd
 ENTRYPOINT /usr/local/pf/sbin/pfhttpd -conf /usr/local/pf/conf/caddy-services/pfpki.conf -log-name=pfpki

--- a/containers/pfpki/Dockerfile
+++ b/containers/pfpki/Dockerfile
@@ -15,7 +15,7 @@ COPY ./Makefile /usr/local/pf/Makefile
 RUN cd /usr/local/pf/go/ && \
     make pfhttpd
 
-FROM scratch
+FROM busybox:latest
 WORKDIR /usr/local/pf/
 COPY --from=0 /usr/local/pf/go/pfhttpd /usr/local/pf/sbin/pfhttpd
 ENTRYPOINT /usr/local/pf/sbin/pfhttpd -conf /usr/local/pf/conf/caddy-services/pfpki.conf -log-name=pfpki

--- a/containers/pfsso/Dockerfile
+++ b/containers/pfsso/Dockerfile
@@ -13,7 +13,7 @@ COPY ./lib /usr/local/pf/lib
 COPY ./config.mk /usr/local/pf/config.mk
 RUN cd /usr/local/pf/go/ &&  make pfhttpd
 
-FROM ${KNK_REGISTRY_URL}/pfdebian:${IMAGE_TAG}
+FROM scratch
 WORKDIR /usr/local/pf/
 COPY ./config.mk /usr/local/pf/config.mk
 COPY --from=0 /usr/local/pf/go/pfhttpd /usr/local/pf/sbin/pfhttpd

--- a/containers/pfsso/Dockerfile
+++ b/containers/pfsso/Dockerfile
@@ -13,7 +13,7 @@ COPY ./lib /usr/local/pf/lib
 COPY ./config.mk /usr/local/pf/config.mk
 RUN cd /usr/local/pf/go/ &&  make pfhttpd
 
-FROM scratch
+FROM busybox:latest
 WORKDIR /usr/local/pf/
 COPY ./config.mk /usr/local/pf/config.mk
 COPY --from=0 /usr/local/pf/go/pfhttpd /usr/local/pf/sbin/pfhttpd

--- a/go/Makefile
+++ b/go/Makefile
@@ -1,6 +1,6 @@
 include ../config.mk
 GO ?= go
-build_cmd = $(GO) build $(ARGS)
+build_cmd = CGO_ENABLED=0 $(GO) build $(ARGS)
 
 .PHONY: clean-caddy-src
 clean-caddy-src:


### PR DESCRIPTION
# Description
Use the smaller base image for golang services.

# Issue
fixes #7949

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
## Enhancements
* Reduce the size of golang images.
