### PR TITLE
Move from sourceforge to linode object

### DIFF
--- a/ci/debian-installer/build-and-upload.sh
+++ b/ci/debian-installer/build-and-upload.sh
@@ -11,8 +11,9 @@ ISO_NAME=PacketFence-ISO-${PF_VERSION}.iso
 SF_RESULT_DIR=results/sf/${PF_VERSION}
 
 upload_to_linode() {
-    # using rclone config
+    echo "Create directory packetfence-iso/${PF_VERSION}/"
     rclone mkdir --s3-provider="Ceph"  --s3-access-key-id=${RCLONE_ACCESS_KEY_ID}  --s3-secret-access-key=${RCLONE_SECRET_ACCESS_KEY}  --s3-endpoint="${RCLONE_LINODE_URL}"  --s3-acl=private :s3:packetfence-iso/${PF_VERSION}/
+    echo "rclone ${ISO_NAME} to packetfence-iso/${PF_VERSION}/" 
     rclone copyto  --s3-provider="Ceph"  --s3-access-key-id=${RCLONE_ACCESS_KEY_ID}  --s3-secret-access-key=${RCLONE_SECRET_ACCESS_KEY}  --s3-endpoint="${RCLONE_LINODE_URL}"  --s3-acl=private  ${SF_RESULT_DIR}/${ISO_NAME} :s3:packetfence-iso/${PF_VERSION}/${ISO_NAME}
 }
 

--- a/ci/debian-installer/build-and-upload.sh
+++ b/ci/debian-installer/build-and-upload.sh
@@ -12,8 +12,8 @@ SF_RESULT_DIR=results/sf/${PF_VERSION}
 
 upload_to_linode() {
     # using rclone config
-    rclone mkdir pfzen:packetfence-zen/${PF_VERSION}/
-    rclone copyto ${SF_RESULT_DIR}/${ISO_NAME} pfzen:packetfence-zen/${ISO_NAME}
+    rclone mkdir pfiso:packetfence-iso/${PF_VERSION}/
+    rclone copyto ${SF_RESULT_DIR}/${ISO_NAME} pfiso:packetfence-iso/${ISO_NAME}
 }
 
 mkdir -p ${SF_RESULT_DIR}

--- a/ci/debian-installer/build-and-upload.sh
+++ b/ci/debian-installer/build-and-upload.sh
@@ -12,8 +12,8 @@ SF_RESULT_DIR=results/sf/${PF_VERSION}
 
 upload_to_linode() {
     # using rclone config
-    rclone mkdir pfiso:packetfence-iso/${PF_VERSION}/
-    rclone copyto ${SF_RESULT_DIR}/${ISO_NAME} pfiso:packetfence-iso/${PF_VERSION}/${ISO_NAME}
+    rclone mkdir --s3-provider="Ceph"  --s3-access-key-id=${RCLONE_ACCESS_KEY_ID}  --s3-secret-access-key=${RCLONE_SECRET_ACCESS_KEY}  --s3-endpoint="${RCLONE_LINODE_URL}"  --s3-acl=private :s3:packetfence-iso/${PF_VERSION}/
+    rclone copyto  --s3-provider="Ceph"  --s3-access-key-id=${RCLONE_ACCESS_KEY_ID}  --s3-secret-access-key=${RCLONE_SECRET_ACCESS_KEY}  --s3-endpoint="${RCLONE_LINODE_URL}"  --s3-acl=private  ${SF_RESULT_DIR}/${ISO_NAME} :s3:packetfence-iso/${PF_VERSION}/${ISO_NAME}
 }
 
 mkdir -p ${SF_RESULT_DIR}

--- a/ci/debian-installer/build-and-upload.sh
+++ b/ci/debian-installer/build-and-upload.sh
@@ -15,6 +15,10 @@ upload_to_linode() {
     rclone mkdir --s3-provider="Ceph"  --s3-access-key-id=${RCLONE_ACCESS_KEY_ID}  --s3-secret-access-key=${RCLONE_SECRET_ACCESS_KEY}  --s3-endpoint="${RCLONE_LINODE_URL}"  --s3-acl=private :s3:packetfence-iso/${PF_VERSION}/
     echo "rclone ${ISO_NAME} to packetfence-iso/${PF_VERSION}/" 
     rclone copyto  --s3-provider="Ceph"  --s3-access-key-id=${RCLONE_ACCESS_KEY_ID}  --s3-secret-access-key=${RCLONE_SECRET_ACCESS_KEY}  --s3-endpoint="${RCLONE_LINODE_URL}"  --s3-acl=private  ${SF_RESULT_DIR}/${ISO_NAME} :s3:packetfence-iso/${PF_VERSION}/${ISO_NAME}
+    echo "Add md5sum ${ISO_NAME} in ${ISO_NAME}.md5sums.txt"
+    echo "`md5sum ${SF_RESULT_DIR}/${ISO_NAME} | cut -d ' ' -f 1` ${ISO_NAME}" | tee -a ${SF_RESULT_DIR}/${ISO_NAME}.md5sums.txt
+    rclone copyto  --s3-provider="Ceph"  --s3-access-key-id=${RCLONE_ACCESS_KEY_ID}  --s3-secret-access-key=${RCLONE_SECRET_ACCESS_KEY}  --s3-endpoint="${RCLONE_LINODE_URL}"  --s3-acl=private  ${SF_RESULT_DIR}/${ISO_NAME}.md5sums.txt :s3:packetfence-iso/${PF_VERSION}/${ISO_NAME}.md5sums.txt
+    
 }
 
 mkdir -p ${SF_RESULT_DIR}

--- a/ci/debian-installer/build-and-upload.sh
+++ b/ci/debian-installer/build-and-upload.sh
@@ -13,7 +13,7 @@ SF_RESULT_DIR=results/sf/${PF_VERSION}
 upload_to_linode() {
     # using rclone config
     rclone mkdir pfiso:packetfence-iso/${PF_VERSION}/
-    rclone copyto ${SF_RESULT_DIR}/${ISO_NAME} pfiso:packetfence-iso/${ISO_NAME}
+    rclone copyto ${SF_RESULT_DIR}/${ISO_NAME} pfiso:packetfence-iso/${PF_VERSION}/${ISO_NAME}
 }
 
 mkdir -p ${SF_RESULT_DIR}

--- a/ci/debian-installer/build-and-upload.sh
+++ b/ci/debian-installer/build-and-upload.sh
@@ -9,20 +9,11 @@ ISO_NAME=PacketFence-ISO-${PF_VERSION}.iso
 
 # upload
 SF_RESULT_DIR=results/sf/${PF_VERSION}
-PUBLIC_REPO_DIR="/home/frs/project/p/pa/packetfence/PacketFence\ ISO/${PF_VERSION}"
-DEPLOY_SF_USER=${DEPLOY_SF_USER:-inverse-bot,packetfence}
-DEPLOY_SF_HOST=${DEPLOY_SF_HOST:-frs.sourceforge.net}
 
-upload_to_sf() {
-    # warning: slashs at end of dirs are significant for rsync
-    local src_dir="${SF_RESULT_DIR}/"
-    local dst_repo="${PUBLIC_REPO_DIR}/"
-    local dst_dir="${DEPLOY_SF_USER}@${DEPLOY_SF_HOST}:${dst_repo}"
-    declare -p src_dir dst_dir
-    echo "rsync: $src_dir -> $dst_dir"
-
-    # quotes to handle space in filename
-    rsync -avz $src_dir "$dst_dir"
+upload_to_linode() {
+    # using rclone config
+    rclone mkdir pfzen:packetfence-zen/${PF_VERSION}/
+    rclone copyto ${SF_RESULT_DIR}/${ISO_NAME} pfzen:packetfence-zen/${ISO_NAME}
 }
 
 mkdir -p ${SF_RESULT_DIR}
@@ -30,5 +21,5 @@ mkdir -p ${SF_RESULT_DIR}
 echo "===> Build ISO for release $PF_RELEASE"
 docker run --rm -e PF_RELEASE=$PF_RELEASE -e ISO_OUT="${SF_RESULT_DIR}/${ISO_NAME}" -v `pwd`:/debian-installer debian:11 /debian-installer/create-debian-installer-docker.sh
 
-echo "===> Upload to Sourceforge"
-upload_to_sf
+echo "===> Upload to Linode"
+upload_to_linode

--- a/ci/debian-installer/create-debian-installer.sh
+++ b/ci/debian-installer/create-debian-installer.sh
@@ -8,7 +8,7 @@ function clean() {
   chmod a+rw $ISO_OUT
 }
 
-ISO_IN=${ISO_IN:-debian-11.8.0-amd64-netinst.iso}
+ISO_IN=${ISO_IN:-debian-11.9.0-amd64-netinst.iso}
 ISO_OUT=${ISO_OUT:-packetfence-debian-installer.iso}
 
 trap clean EXIT

--- a/ci/packer/zen/Makefile
+++ b/ci/packer/zen/Makefile
@@ -21,6 +21,7 @@ PKR_ON_ERROR=cleanup
 .PHONY: zen
 zen: zen-packer zen-build
 
+.PHONY: zen-packer
 zen-packer:
 	PKR_VAR_pf_version=$(PKR_VAR_pf_version) \
 	PKR_VAR_vm_name=$(PKR_VAR_vm_name) \
@@ -29,6 +30,7 @@ zen-packer:
 	ANSIBLE_FORCE_COLOR=$(ANSIBLE_FORCE_COLOR) \
 	packer build -only="virtualbox-iso.$(BUILD_NAME)" -on-error=$(PKR_ON_ERROR) .
 
+.PHONY: zen-build
 zen-build:
 	PF_VERSION=$(PF_VERSION) \
 	VBOX_RESULT_DIR=$(PKR_VAR_output_vbox_directory) \

--- a/ci/packer/zen/Makefile
+++ b/ci/packer/zen/Makefile
@@ -19,13 +19,17 @@ PKR_ON_ERROR=cleanup
 # Targets
 #==============================================================================
 .PHONY: zen
-zen:
+zen: zen-packer zen-build
+
+zen-packer:
 	PKR_VAR_pf_version=$(PKR_VAR_pf_version) \
 	PKR_VAR_vm_name=$(PKR_VAR_vm_name) \
 	PKR_VAR_output_vbox_directory=$(PKR_VAR_output_vbox_directory) \
 	PKR_VAR_output_vmware_directory=$(PKR_VAR_output_vmware_directory) \
 	ANSIBLE_FORCE_COLOR=$(ANSIBLE_FORCE_COLOR) \
 	packer build -only="virtualbox-iso.$(BUILD_NAME)" -on-error=$(PKR_ON_ERROR) .
+
+zen-build:
 	PF_VERSION=$(PF_VERSION) \
 	VBOX_RESULT_DIR=$(PKR_VAR_output_vbox_directory) \
 	VMWARE_RESULT_DIR=$(PKR_VAR_output_vmware_directory) \

--- a/ci/packer/zen/build-and-upload.sh
+++ b/ci/packer/zen/build-and-upload.sh
@@ -42,7 +42,9 @@ upload_to_linode() {
     rclone mkdir --s3-provider="Ceph"  --s3-access-key-id=${RCLONE_ACCESS_KEY_ID}  --s3-secret-access-key=${RCLONE_SECRET_ACCESS_KEY}  --s3-endpoint="${RCLONE_LINODE_URL}"  --s3-acl=private :s3:packetfence-zen/${PF_VERSION}/
     echo "rclone ${VMX_ZIP_NAME} to packetfence-zen/${PF_VERSION}/"
     rclone copyto  --s3-provider="Ceph"  --s3-access-key-id=${RCLONE_ACCESS_KEY_ID}  --s3-secret-access-key=${RCLONE_SECRET_ACCESS_KEY}  --s3-endpoint="${RCLONE_LINODE_URL}"  --s3-acl=private  ${SF_RESULT_DIR}/${VMX_ZIP_NAME} :s3:packetfence-zen/${PF_VERSION}/${VMX_ZIP_NAME}
-
+    echo "Add md5sum of ${VMX_ZIP_NAME} in ${VMX_ZIP_NAME}.md5sums.txt"
+    echo "`md5sum ${SF_RESULT_DIR}/${VMX_ZIP_NAME} | cut -d ' ' -f 1` ${VMX_ZIP_NAME}" | tee -a ${SF_RESULT_DIR}/${VMX_ZIP_NAME}.md5sums.txt
+    rclone copyto  --s3-provider="Ceph"  --s3-access-key-id=${RCLONE_ACCESS_KEY_ID}  --s3-secret-access-key=${RCLONE_SECRET_ACCESS_KEY}  --s3-endpoint="${RCLONE_LINODE_URL}"  --s3-acl=private  ${SF_RESULT_DIR}/${VMX_ZIP_NAME}.md5sums.txt :s3:packetfence-zen/${PF_VERSION}/${VMX_ZIP_NAME}.md5sums.txt
 }
 
 mkdir -p ${VMWARE_RESULT_DIR} ${SF_RESULT_DIR}

--- a/ci/packer/zen/build-and-upload.sh
+++ b/ci/packer/zen/build-and-upload.sh
@@ -38,7 +38,9 @@ compress_vmware_ova() {
 }
 
 upload_to_linode() {
+    echo "Create directory packetfence-zen/${PF_VERSION}/"
     rclone mkdir --s3-provider="Ceph"  --s3-access-key-id=${RCLONE_ACCESS_KEY_ID}  --s3-secret-access-key=${RCLONE_SECRET_ACCESS_KEY}  --s3-endpoint="${RCLONE_LINODE_URL}"  --s3-acl=private :s3:packetfence-zen/${PF_VERSION}/
+    echo "rclone ${VMX_ZIP_NAME} to packetfence-zen/${PF_VERSION}/"
     rclone copyto  --s3-provider="Ceph"  --s3-access-key-id=${RCLONE_ACCESS_KEY_ID}  --s3-secret-access-key=${RCLONE_SECRET_ACCESS_KEY}  --s3-endpoint="${RCLONE_LINODE_URL}"  --s3-acl=private  ${SF_RESULT_DIR}/${VMX_ZIP_NAME} :s3:packetfence-zen/${PF_VERSION}/${VMX_ZIP_NAME}
 
 }

--- a/ci/packer/zen/build-and-upload.sh
+++ b/ci/packer/zen/build-and-upload.sh
@@ -34,7 +34,7 @@ compress_vmware_ova() {
 
     echo "zip source ${ova_file} =>  dest: ${zip_file}"
 
-    zip -qdgds 100m -9 -j ${zip_file} ${ova_file}
+    zip -j ${zip_file} ${ova_file}
 }
 
 upload_to_linode() {

--- a/ci/packer/zen/build-and-upload.sh
+++ b/ci/packer/zen/build-and-upload.sh
@@ -40,7 +40,7 @@ compress_vmware_ova() {
 upload_to_linode() {
     # using rclone config
     rclone mkdir pfzen:packetfence-zen/${PF_VERSION}/
-    rclone copyto ${SF_RESULT_DIR}/${VMX_ZIP_NAME} pfzen:packetfence-zen/${VMX_ZIP_NAME}
+    rclone copyto ${SF_RESULT_DIR}/${VMX_ZIP_NAME} pfzen:packetfence-zen/${PF_VERSION}/${VMX_ZIP_NAME}
 }
 
 mkdir -p ${VMWARE_RESULT_DIR} ${SF_RESULT_DIR}

--- a/ci/packer/zen/build-and-upload.sh
+++ b/ci/packer/zen/build-and-upload.sh
@@ -38,9 +38,9 @@ compress_vmware_ova() {
 }
 
 upload_to_linode() {
-    # using rclone config
-    rclone mkdir pfzen:packetfence-zen/${PF_VERSION}/
-    rclone copyto ${SF_RESULT_DIR}/${VMX_ZIP_NAME} pfzen:packetfence-zen/${PF_VERSION}/${VMX_ZIP_NAME}
+    rclone mkdir --s3-provider="Ceph"  --s3-access-key-id=${RCLONE_ACCESS_KEY_ID}  --s3-secret-access-key=${RCLONE_SECRET_ACCESS_KEY}  --s3-endpoint="${RCLONE_LINODE_URL}"  --s3-acl=private :s3:packetfence-zen/${PF_VERSION}/
+    rclone copyto  --s3-provider="Ceph"  --s3-access-key-id=${RCLONE_ACCESS_KEY_ID}  --s3-secret-access-key=${RCLONE_SECRET_ACCESS_KEY}  --s3-endpoint="${RCLONE_LINODE_URL}"  --s3-acl=private  ${SF_RESULT_DIR}/${VMX_ZIP_NAME} :s3:packetfence-zen/${PF_VERSION}/${VMX_ZIP_NAME}
+
 }
 
 mkdir -p ${VMWARE_RESULT_DIR} ${SF_RESULT_DIR}

--- a/ci/packer/zen/build-and-upload.sh
+++ b/ci/packer/zen/build-and-upload.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-#
 set -o nounset -o pipefail -o errexit
 
 VM_NAME=${VM_NAME:-vm}

--- a/ci/packer/zen/build-and-upload.sh
+++ b/ci/packer/zen/build-and-upload.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+#
 set -o nounset -o pipefail -o errexit
 
 VM_NAME=${VM_NAME:-vm}

--- a/ci/packer/zen/sources.pkr.hcl
+++ b/ci/packer/zen/sources.pkr.hcl
@@ -17,8 +17,8 @@ source "virtualbox-iso" "debian-11" {
     ["modifyvm", "{{.Name}}", "--uartmode1", "disconnected"],
     ["storagectl", "{{.Name}}", "--name", "IDE Controller", "--remove"]
   ]
-  iso_url = "https://cdimage.debian.org/cdimage/archive/latest-oldstable/amd64/iso-cd/debian-11.8.0-amd64-netinst.iso"
-  iso_checksum = "sha256:d7a74813a734083df30c8d35784926deaa36bc41e5c0766388e9f591ab056b72"
+  iso_url = "https://cdimage.debian.org/cdimage/archive/latest-oldstable/amd64/iso-cd/debian-11.9.0-amd64-netinst.iso"
+  iso_checksum = "sha256:01c540225250d42cda3809d7130d0c27e934c8aca260d01a86d33dee19623b0f"
   # boot parameters to preseed questions
   # all parameters below can't be moved to preseed file
   boot_command = [


### PR DESCRIPTION
# Description
Get out of sourceforge due to size limitation and use linode object to store zen and iso images.

# Impacts
NEED TO:
- Change download on packetfence website too
- Add ansible rclone config for runner (currently on runner ci has the config by hand)

# NEW Package(s) required
rclone on runners nothing for packetfence

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [x] Have ansible rclone installed and configured on administrative runners
- [x] Change download link on packetfence webpages
