### PR TITLE
Split in 2 the search on usernameattribute value

### DIFF
--- a/lib/pf/services/manager/radiusd_child.pm
+++ b/lib/pf/services/manager/radiusd_child.pm
@@ -813,7 +813,7 @@ $edir_options
     }
     user {
         base_dn = "\${..base_dn}"
-        filter = "(&(|$searchattributes($ConfigAuthenticationLdap{$ldap}->{usernameattribute}=%{%{Stripped-User-Name}:-%{User-Name}}))$append)"
+        filter = "(&(|$searchattributes($ConfigAuthenticationLdap{$ldap}->{usernameattribute}=%{Stripped-User-Name})($ConfigAuthenticationLdap{$ldap}->{usernameattribute}=%{User-Name}))$append)"
     }
     options {
         chase_referrals = yes


### PR DESCRIPTION
# Description
Adapt the ldap search filter in freeradius to do the sAMAccountName lookup

(&(|(UserPrincipalName=bbuny@acme.com)(UserPrincipalName=bbuny)(sAMAccountName=bbuny))) -> (&(|(UserPrincipalName=bbuny@acme.com)(UserPrincipalName=bbuny)(sAMAccountName=bbuny)(sAMAccountName=bbuny@acme.com)))

# Impacts
- RADIUS authorize workflow

# Code / PR Dependencies
# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* Adap the ldap search filter in Freeradius to do the sAMAccountName lookup

