### PR TITLE
Support for a fqdn as switch id with Aruba webauth

### DIFF
--- a/html/pfappserver/lib/pfappserver/Form/Config/Switch.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Switch.pm
@@ -46,6 +46,14 @@ has_field 'id' =>
    accept => ['default'],
    required => 1,
    messages => { required => 'Please specify the IP address/MAC address/Range (CIDR) of the switch.' },
+   tags => {
+       option_pattern => sub {
+           return {
+               regex => qq{(([0-9a-fA-f]{2}([:\\.-][0-9a-fA-f]{2}){5})|([0-9a-fA-F]{4}([\\.-][0-9a-fA-F]{4}){2})|([0-9a-fA-F]{12})|(\\d{1,3}(\\.\\d{1,3}){3})|((?=^.{4,253}\$)(^((?!-)[a-zA-Z0-9-]{1,63}(?<!-)\\.)+[a-zA-Z]{2,63}\$))|default)},
+               message => "The id must be a MAC, or IP address, or a fqdn.",
+           };
+       },
+   }
   );
 has_field 'description' =>
   (

--- a/html/pfappserver/lib/pfappserver/Form/Field/SwitchID.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Field/SwitchID.pm
@@ -52,7 +52,11 @@ apply
     {
         transform => sub {
             my ($val) = @_;
-            return clean_mac( $val ) if !valid_ip($val) && valid_mac($val);
+            if (!valid_ip($val)) {
+                return clean_mac($val) if valid_mac($val);
+                return $val if pf::util::valid_fqdn($val);
+            }
+
             my $ip = NetAddr::IP->new($val);
             if ($ip->num == 1) {
                 return $ip->addr;

--- a/html/pfappserver/lib/pfappserver/Form/Field/SwitchID.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Field/SwitchID.pm
@@ -40,7 +40,7 @@ apply
             my ( $value, $field ) = @_;
             return 1 if ($field->accept && grep { $_ eq $value } @{$field->accept});
             return 1 if valid_ip_range( $value );
-            return valid_mac_or_ip( $value );
+            return valid_mac_or_ip( $value ) || valid_fqdn($value);
         }
     },
     {

--- a/lib/pf/Switch/Aruba.pm
+++ b/lib/pf/Switch/Aruba.pm
@@ -605,7 +605,7 @@ sub parseExternalPortalRequest {
     my %params = ();
 
     %params = (
-        switch_id               => valid_ip($req->param('switchip')) ? $req->param('switchip') : $req->param('apmac'),
+        switch_id               => valid_ip_fqdn($req->param('switchip')) ? $req->param('switchip') : $req->param('apmac'),
         client_mac              => clean_mac($req->param('mac')),
         client_ip               => $req->param('ip'),
         ssid                    => $req->param('essid'),

--- a/lib/pf/Switch/Aruba/Instant.pm
+++ b/lib/pf/Switch/Aruba/Instant.pm
@@ -26,6 +26,7 @@ use pf::constants qw($TRUE);
 use pf::constants::config qw($WEBAUTH_WIRELESS);
 use pf::util::radius qw(perform_disconnect perform_coa);
 use Try::Tiny;
+use pf::util;
 
 sub description { 'Aruba Instant' };
 
@@ -125,7 +126,7 @@ sub parseExternalPortalRequest {
     my %params = ();
 
     %params = (
-        switch_id               => valid_ip($req->param('switchip')) ? $req->param('switchip') : $req->param('apmac'),
+        switch_id               => valid_ip_fqdn($req->param('switchip')) ? $req->param('switchip') : $req->param('apmac'),
         client_mac              => clean_mac($req->param('mac')),
         client_ip               => $req->param('ip'),
         ssid                    => $req->param('essid'),

--- a/lib/pf/util.pm
+++ b/lib/pf/util.pm
@@ -58,7 +58,7 @@ BEGIN {
     our ( @ISA, @EXPORT );
     @ISA = qw(Exporter);
     @EXPORT = qw(
-        valid_date valid_ip valid_ips reverse_ip clean_ip
+        valid_date valid_ip valid_ips valid_ip_fqdn valid_fqdn reverse_ip clean_ip
         clean_mac valid_mac mac2nb macoui2nb format_mac_for_acct format_mac_as_cisco
         ip2int int2ip sort_ip
         isenabled isdisabled isempty
@@ -164,6 +164,7 @@ sub valid_date {
 our $VALID_IP_REGEX = qr/^(?:\d{1,3}\.){3}\d{1,3}$/;
 our $VALID_IPS_REGEX = qr/^((?:\d{1,3}\.){3}\d{1,3},*)+?$/;
 our $NON_VALID_IP_REGEX = qr/^(?:0\.){3}0$/;
+our $VALID_FQDN_REGEX = qr/(?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{1,63}(?<!-)\.)+[a-zA-Z]{2,63}$)/;
 
 sub valid_ip {
     my ($ip) = @_;
@@ -185,6 +186,29 @@ sub valid_ips {
         my $caller = ( caller(1) )[3] || basename($0);
         $caller =~ s/^(pf::\w+|main):://;
         $logger->debug("invalid IPs: $ip from $caller");
+        return (0);
+    } else {
+        return (1);
+    }
+}
+
+sub valid_ip_fqdn {
+    my ($id) = @_;
+    if (valid_ip($id)) {
+        return (1);
+    } elsif(valid_fqdn($id)) {
+        return (1);
+    }
+    return (0);
+}
+
+sub valid_fqdn {
+    my ($fqdn) = @_;
+    my $logger = get_logger();
+    if ( !$fqdn || $fqdn !~ $VALID_FQDN_REGEX) {
+        my $caller = ( caller(1) )[3] || basename($0);
+        $caller =~ s/^(pf::\w+|main):://;
+        $logger->debug("invalid FQDN: $fqdn from $caller");
         return (0);
     } else {
         return (1);

--- a/t/SwitchFactory.t
+++ b/t/SwitchFactory.t
@@ -10,7 +10,7 @@ BEGIN {
 }
 
 
-use Test::More tests => 62;
+use Test::More tests => 63;
 use Test::NoWarnings;
 use_ok('pf::SwitchFactory');
 
@@ -128,6 +128,9 @@ is($switch->{_id}, '192.168.190.217', "Proper id is set for 192.168.190.217");
 $switch = pf::SwitchFactory->instantiate('172.16.8.25');
 isa_ok($switch, 'pf::Switch::Template');
 is(ref($switch->{_template}), 'HASH', "template args are passed");
+
+$switch = pf::SwitchFactory->instantiate('aruba.com');
+isa_ok($switch, 'pf::Switch::Aruba::Instant');
 
 =head1 AUTHOR
 

--- a/t/data/switches.conf
+++ b/t/data/switches.conf
@@ -298,3 +298,6 @@ EOT
 
 [172.16.8.38]
 type=Cisco::ASA
+
+[aruba.com]
+type=Aruba::Instant

--- a/t/unittest/UnifiedApi/Controller/Config/Switches.t
+++ b/t/unittest/UnifiedApi/Controller/Config/Switches.t
@@ -22,7 +22,7 @@ BEGIN {
     use setup_test_config;
 }
 
-use Test::More tests => 78;
+use Test::More tests => 80;
 use List::Util qw(first);
 use Test::Mojo;
 use Utils;
@@ -65,6 +65,16 @@ my $defaults = $cs->read('defaults');
 {
 
     my $id =  "arubra.packetfence.org";
+    $t->post_ok(
+        $collection_base_url => json => {
+            type => 'Aruba',
+            id                     => $id,
+            voiceVlan              => '222',
+            description            => "Bob",
+
+        }
+    )->status_is(422);
+
     $t->post_ok(
         $collection_base_url => json => {
             type => 'Aruba::Instant',

--- a/t/unittest/UnifiedApi/Controller/Config/Switches.t
+++ b/t/unittest/UnifiedApi/Controller/Config/Switches.t
@@ -22,7 +22,7 @@ BEGIN {
     use setup_test_config;
 }
 
-use Test::More tests => 74;
+use Test::More tests => 78;
 use List::Util qw(first);
 use Test::Mojo;
 use Utils;
@@ -60,6 +60,23 @@ my $defaults = $cs->read('defaults');
 
         }
     )->status_is(422);
+}
+
+{
+
+    my $id =  "arubra.packetfence.org";
+    $t->post_ok(
+        $collection_base_url => json => {
+            type => 'Aruba::Instant',
+            id                     => $id,
+            voiceVlan              => '222',
+            description            => "Bob",
+
+        }
+    )->status_is(201);
+
+    $t->get_ok("$base_url/$id")
+    ->status_is(200);
 }
 
 {


### PR DESCRIPTION
# Description
Support for fqdn as switch id (Aruba)

# Impacts
Switch instanciate

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* Support for fqdn switch id (#8022)

