### PR TITLE
Draft of Huawei WebAuth

### DIFF
--- a/docs/network/networkdevice/huawei_ap.asciidoc
+++ b/docs/network/networkdevice/huawei_ap.asciidoc
@@ -194,3 +194,186 @@ Configure VAPs and deliver configurations to the APs:
 	[AC-wlan-radio-1/0] service-set name PacketFence-WEP
 	[AC-wlan-radio-1/0] quit
 	[AC-wlan-view] commit ap 1
+
+==== S6700 Switch
+
+PacketFence supports this switch with the following technologies:
+
+[options="compact"]
+* Wireless 802.1X
+* Wireless MAC Authentication
+* Wired MAC Authentication
+* Wired 802.1X
+* Web Authentication (External Captive Portal)
+
+===== Web Authentication
+
+The Web Authentication feature uses an ACL-based approach to redirect
+unregistered devices to the PacketFence captive portal. When a device is
+in an unregistered state, the switch intercepts HTTP traffic and
+redirects the device to the external portal. Once the device is
+registered, PacketFence returns a different ACL that grants normal
+network access.
+
+This workflow is functionally equivalent to the Cisco WLC Web Auth
+approach.
+
+[NOTE]
+===============================
+In this configuration we use the following IP addresses:
+PacketFence management (VIP): 192.168.1.2;
+Registration VLAN: 145; Isolation VLAN: 146;
+PacketFence portal URL: http://192.168.1.2/Huawei::S6700
+===============================
+
+===== RADIUS server configuration
+
+Setup the RADIUS server (PacketFence IP) for authentication and accounting:
+
+	<S6700>system-view
+	[S6700] radius-server template radius_packetfence
+	[S6700-radius-radius_packetfence] radius-server authentication 192.168.1.2 1812
+	weight 80
+	[S6700-radius-radius_packetfence] radius-server accounting 192.168.1.2 1813 weight
+	80
+	[S6700-radius-radius_packetfence] radius-server shared-key cipher s3cr3t
+	[S6700-radius-radius_packetfence] undo radius-server user-name domain-included
+	[S6700-radius-radius_packetfence] quit
+	[S6700] radius-server authorization 192.168.1.2 shared-key cipher s3cr3t
+	server-group radius_packetfence
+
+Configure the AAA scheme:
+
+	[S6700] aaa
+	[S6700-aaa] authentication-scheme radius_packetfence
+	[S6700-aaa-authen-radius_packetfence] authentication-mode radius
+	[S6700-aaa-authen-radius_packetfence] quit
+	[S6700-aaa] accounting-scheme radius_packetfence
+	[S6700-aaa-accounting-radius_packetfence] accounting-mode radius
+	[S6700-aaa-accounting-radius_packetfence] quit
+
+	[S6700-aaa] domain your.domain.com
+	[S6700-aaa-domain-your.domain.com] authentication-scheme radius_packetfence
+	[S6700-aaa-domain-your.domain.com] accounting-scheme radius_packetfence
+	[S6700-aaa-domain-your.domain.com] radius-server radius_packetfence
+	[S6700-aaa-domain-your.domain.com] quit
+	[S6700-aaa] quit
+
+===== Create ACLs for Web Authentication
+
+Create a pre-authentication ACL that allows only DHCP, DNS, and traffic
+to the PacketFence server. This ACL name will be used as the
+registration role in PacketFence:
+
+	[S6700] acl name Pre-Auth-WebRedirect 3000
+	[S6700-acl-adv-Pre-Auth-WebRedirect] rule permit udp destination-port eq 67
+	[S6700-acl-adv-Pre-Auth-WebRedirect] rule permit udp destination-port eq 68
+	[S6700-acl-adv-Pre-Auth-WebRedirect] rule permit udp destination-port eq 53
+	[S6700-acl-adv-Pre-Auth-WebRedirect] rule permit ip destination 192.168.1.2 0
+	[S6700-acl-adv-Pre-Auth-WebRedirect] rule deny ip
+	[S6700-acl-adv-Pre-Auth-WebRedirect] quit
+
+Create a post-authentication ACL that allows all traffic:
+
+	[S6700] acl name Authorize_any 3001
+	[S6700-acl-adv-Authorize_any] rule permit ip
+	[S6700-acl-adv-Authorize_any] quit
+
+===== Create the Web Authentication SSID
+
+Enable MAC authentication globally:
+
+	<S6700>system-view
+	[S6700] mac-authen
+	[S6700] mac-authen username macaddress format with-hyphen
+	[S6700] mac-authen domain your.domain.com
+
+Configure a WLAN-ESS interface with MAC authentication for web
+authentication:
+
+	[S6700] interface Wlan-Ess 2
+	[S6700-Wlan-Ess2] port hybrid untagged vlan 145 to 146
+	[S6700-Wlan-Ess2] mac-authen
+	[S6700-Wlan-Ess2] mac-authen username macaddress format without-hyphen
+	[S6700-Wlan-Ess2] permit-domain name your.domain.com
+	[S6700-Wlan-Ess2] force-domain name your.domain.com
+	[S6700-Wlan-Ess2] default-domain your.domain.com
+	[S6700-Wlan-Ess2] quit
+
+Configure a security profile with an open security policy for the
+captive portal SSID:
+
+	[S6700] wlan
+	[S6700-wlan-view] security-profile name huawei-webauth
+	[S6700-wlan-sec-prof-huawei-webauth] security-policy open
+	[S6700-wlan-sec-prof-huawei-webauth] quit
+
+Configure the service set for web authentication:
+
+	[S6700-wlan-view] service-set name PacketFence-WebAuth
+	[S6700-wlan-service-set-PacketFence-WebAuth] ssid PacketFence-WebAuth
+	[S6700-wlan-service-set-PacketFence-WebAuth] wlan-ess 2
+	[S6700-wlan-service-set-PacketFence-WebAuth] service-vlan 1
+	[S6700-wlan-service-set-PacketFence-WebAuth] security-profile name huawei-webauth
+	[S6700-wlan-service-set-PacketFence-WebAuth] traffic-profile name huawei-ap
+	[S6700-wlan-service-set-PacketFence-WebAuth] forward-mode tunnel
+	[S6700-wlan-service-set-PacketFence-WebAuth] quit
+
+Bind the service set to the AP radio and commit:
+
+	[S6700-wlan-view] ap 1 radio 0
+	[S6700-wlan-radio-1/0] service-set name PacketFence-WebAuth
+	[S6700-wlan-radio-1/0] quit
+	[S6700-wlan-view] commit ap 1
+
+===== PacketFence configuration
+
+Add the Huawei S6700 switch in the PacketFence administration interface:
+
+[options="compact"]
+* Navigate to *Configuration -> Policies and Access Control -> Switches*
+* Click *New Switch*
+* Enter the IP address of the S6700
+* Set the *Type* to `Huawei::S6700`
+* Set the *Mode* to `production`
+* In the *RADIUS* tab, enter the RADIUS shared secret matching
+  the one configured on the switch
+
+Configure the external portal enforcement:
+
+[options="compact"]
+* In the *Roles* tab, enable *Role by Web Auth URL*
+* Set the *registration* URL to:
+  `http://<your_packetfence_hostname>/Huawei::S6700`
+* This URL must match the external portal URL pattern used by
+  PacketFence to identify Huawei S6700 requests
+
+Configure the roles to match the ACL names defined on the switch:
+
+[options="compact"]
+* In the *Roles* tab, configure the following role mappings:
+** *registration* role: `Pre-Auth-WebRedirect`
+** *default* role: `Authorize_any`
+
+These role values correspond to the ACL names on the switch and will be
+sent in the `Huawei-Redirect-ACL` RADIUS attribute in the
+Access-Accept response. When a device is unregistered, PacketFence
+returns the `Pre-Auth-WebRedirect` ACL along with the portal redirect
+URL (via `Huawei-Portal-UR`) and a URL redirect flag
+(`Huawei-URL-Flag` set to 1). Once the device completes registration
+through the captive portal, PacketFence sends a Change of Authorization
+(CoA) to the switch, triggering re-authentication. The subsequent
+Access-Accept will include the `Authorize_any` ACL, granting the
+device full network access.
+
+[NOTE]
+===============================
+The default CoA and disconnect port for the Huawei S6700 is 3799. If
+you need to change this, update the *CoA Port* and *Disconnect Port*
+settings in the switch configuration in PacketFence.
+
+The S6700 module uses RADIUS CoA with the vendor-specific attribute
+`HW-Ext-Specific = "user-command=1"` for re-authentication, or RADIUS
+Disconnect-Request for deauthentication when there are open security
+events.
+===============================

--- a/lib/pf/Switch/Huawei/S6700.pm
+++ b/lib/pf/Switch/Huawei/S6700.pm
@@ -1,0 +1,396 @@
+package pf::Switch::Huawei::S6700;
+
+=head1 NAME
+
+pf::Switch::Huawei::S6700 - Object oriented module to parse SNMP traps and manage
+
+=item Supports
+
+=over
+
+=item Deauthentication with RADIUS Disconnect (RFC3576)
+
+=head1 BUGS AND LIMITATIONS
+
+=over
+
+=item Version specific issues
+
+=over
+
+=cut
+
+use strict;
+use warnings;
+
+use Net::SNMP;
+use Try::Tiny;
+
+use base ('pf::Switch::Huawei');
+
+use pf::constants;
+use pf::config qw(
+    $MAC
+    $SSID
+    $WEBAUTH_WIRELESS
+);
+use pf::web::util;
+use pf::util;
+use pf::node;
+use pf::util::radius qw(perform_coa perform_disconnect);
+use pf::security_event qw(security_event_count_reevaluate_access);
+use pf::radius::constants;
+use pf::locationlog qw(locationlog_get_session);
+
+sub description { 'Huawei S6700' }
+
+=head1 SUBROUTINES
+
+=over
+
+=cut
+
+# CAPABILITIES
+# access technology supported
+use pf::SwitchSupports qw(
+    WirelessDot1x
+    WirelessMacAuth
+    WiredMacAuth
+    WiredDot1x
+    ExternalPortal
+    -SaveConfig
+);
+# inline capabilities
+sub inlineCapabilities { return ($MAC,$SSID); }
+
+=item deauthenticateMacDefault
+
+De-authenticate a MAC address from wireless network (including 802.1x).
+
+New implementation using RADIUS Disconnect-Request.
+
+=cut
+
+sub deauthenticateMacDefault {
+    my ( $self, $mac, $is_dot1x ) = @_;
+    my $logger = $self->logger;
+
+    if ( !$self->isProductionMode() ) {
+        $logger->info("not in production mode... we won't perform deauthentication");
+        return 1;
+    }
+
+    $logger->debug("deauthenticate $mac using RADIUS Disconnect-Request deauth method");
+    # TODO push Login-User => 1 (RFC2865) in pf::radius::constants if someone ever reads this
+    # (not done because it doesn't exist in current branch)
+    return $self->radiusDisconnect( $mac, { 'Service-Type' => 'Login-User'} );
+}
+
+
+=item deauthTechniques
+
+Return the reference to the deauth technique or the default deauth technique.
+
+=cut
+
+sub deauthTechniques {
+    my ($self, $method, $connection_type) = @_;
+    my $logger = $self->logger;
+    my $default = $SNMP::RADIUS;
+    my %tech = (
+        $SNMP::RADIUS => 'deauthenticateMacDefault',
+    );
+
+    if (!defined($method) || !defined($tech{$method})) {
+        $method = $default;
+    }
+    return $method,$tech{$method};
+}
+
+=item returnRadiusAccessAccept
+
+Prepares the RADIUS Access-Accept reponse for the network device.
+
+Overrides the default implementation to add the dynamic acls
+
+=cut
+
+sub returnRadiusAccessAccept {
+    my ($self, $args) = @_;
+    my $logger = $self->logger;
+
+    $args->{'unfiltered'} = $TRUE;
+    my @super_reply = @{$self->SUPER::returnRadiusAccessAccept($args)};
+    my $status = shift @super_reply;
+    my %radius_reply = @super_reply;
+    my $radius_reply_ref = \%radius_reply;
+    return [$status, %$radius_reply_ref] if($status == $RADIUS::RLM_MODULE_USERLOCK);
+    #my @av_pairs = defined($radius_reply_ref->{'Cisco-AVPair'}) ? @{$radius_reply_ref->{'Cisco-AVPair'}} : ();
+
+    my $role = $self->getRoleByName($args->{'user_role'});
+    if ( isenabled($self->{_UrlMap}) && $self->externalPortalEnforcement ) {
+        if ( defined($args->{'user_role'}) && $args->{'user_role'} ne "" && defined($self->getUrlByName($args->{'user_role'}) ) ) {
+            $args->{'session_id'} = "sid".$self->setSession($args);
+            my $redirect_url = $self->getUrlByName($args->{'user_role'});
+            $redirect_url .= '/' unless $redirect_url =~ m(\/$);
+            $redirect_url .= $args->{'session_id'};
+            # Cisco and Meraki started adding "&redirect_url=http://example.com" unconditionnaly to the redirect URL.
+            # This means that since we don't have any query parameters that generated paths like "/Huawei::S6700/sid123456&redirect_url=http://example.com" which extracts the SID as sid123456&redirect_url=http://example.com
+            # We add empty query parameters to our path as a workaround
+            $redirect_url .= "?";
+            $logger->info("Adding web authentication redirection to reply using role: '$role' and URL: '$redirect_url'");
+            $radius_reply_ref = {
+                'Huawei-Redirect-ACL' => $role,
+                'Huawei-DHCPv4-Option43' => $redirect_url,
+                'Huawei-DHCPv4-Option121' => 1,
+            };
+        }
+    }
+
+    my $filter = pf::access_filter::radius->new;
+    my $rule = $filter->test('returnRadiusAccessAccept', $args);
+    ($radius_reply_ref, $status) = $filter->handleAnswerInRule($rule,$args,$radius_reply_ref);
+    return [$status, %$radius_reply_ref];
+}
+
+=item radiusDisconnect
+
+Sends a RADIUS Disconnect-Request to the NAS with the MAC as the Calling-Station-Id to disconnect.
+
+Optionally you can provide other attributes as an hashref.
+
+Uses L<pf::util::radius> for the low-level RADIUS stuff.
+
+=cut
+
+# TODO consider whether we should handle retries or not?
+
+
+sub radiusDisconnect {
+    my ($self, $mac, $add_attributes_ref) = @_;
+    my $logger = $self->logger;
+
+    # initialize
+    $add_attributes_ref = {} if (!defined($add_attributes_ref));
+
+    if (!defined($self->{'_radiusSecret'})) {
+        $logger->warn(
+            "Unable to perform RADIUS CoA-Request on (".$self->{'_id'}."): RADIUS Shared Secret not configured"
+        );
+        return;
+    }
+
+    $logger->info("deauthenticating");
+
+    # Where should we send the RADIUS CoA-Request?
+    # to network device by default
+    my $send_disconnect_to = $self->{'_ip'};
+    # but if controllerIp is set, we send there
+    if (defined($self->{'_controllerIp'}) && $self->{'_controllerIp'} ne '') {
+        $logger->info("controllerIp is set, we will use controller $self->{_controllerIp} to perform deauth");
+        $send_disconnect_to = $self->{'_controllerIp'};
+    }
+    # On which port we have to send the CoA-Request ?
+    my $nas_port = $self->{'_disconnectPort'} || '3799';
+    my $coa_port = $self->{'_coaPort'} || '3799';
+    # allowing client code to override where we connect with NAS-IP-Address
+    $send_disconnect_to = $add_attributes_ref->{'NAS-IP-Address'}
+        if (defined($add_attributes_ref->{'NAS-IP-Address'}));
+
+    my $response;
+    try {
+        my $connection_info = {
+            nas_ip => $send_disconnect_to,
+            secret => $self->{'_radiusSecret'},
+            LocalAddr => $self->deauth_source_ip($send_disconnect_to),
+            nas_port => $coa_port,
+        };
+
+        $logger->debug("network device (".$self->{'_id'}.") supports roles. Evaluating role to be returned");
+        my $roleResolver = pf::roles::custom->instance();
+        my $role = $roleResolver->getRoleForNode($mac, $self);
+
+        my $node_info = node_view($mac);
+        # transforming MAC to the expected format 00-11-22-33-CA-FE
+        $mac = uc($mac);
+        $mac =~ s/:/-/g;
+        # Standard Attributes
+
+        my $attributes_ref = {
+            'Calling-Station-Id' => $mac,
+            'NAS-IP-Address' => $send_disconnect_to,
+            'NAS-Port' => $node_info->{'last_port'},
+        };
+
+        # merging additional attributes provided by caller to the standard attributes
+        $attributes_ref = { %$attributes_ref, %$add_attributes_ref };
+
+        # Roles are configured and the user should have one.
+        # We send a regular disconnect if there is an open trapping security_event
+        # to ensure the VLAN is actually changed to the isolation VLAN.
+        if ( $self->shouldUseCoA({role => $role}) ) {
+            $logger->info("Returning ACCEPT with Role: $role");
+
+            my $vsa = [
+                {
+                vendor => "Huawei",
+                attribute => "HW-Ext-Specific",
+                value => "user-command=1",
+                }
+            ];
+            $response = perform_coa($connection_info, $attributes_ref, $vsa);
+
+        }
+        else {
+            $connection_info = {
+                nas_ip => $send_disconnect_to,
+                secret => $self->{'_radiusSecret'},
+                LocalAddr => $self->deauth_source_ip($send_disconnect_to),
+                nas_port => $nas_port,
+            };
+            $response = perform_disconnect($connection_info, $attributes_ref);
+        }
+    } catch {
+        chomp;
+        $logger->warn("Unable to perform RADIUS CoA-Request on (".$self->{'_id'}."): $_");
+        $logger->error("Wrong RADIUS secret or unreachable network device (".$self->{'_id'}.")... On some Cisco Wireless Controllers you might have to set disconnectPort=1700 as some versions ignore the CoA requests on port 3799") if ($_ =~ /^Timeout/);
+    };
+    return if (!defined($response));
+
+    return $TRUE if ( ($response->{'Code'} eq 'Disconnect-ACK') || ($response->{'Code'} eq 'CoA-ACK') );
+
+    $logger->warn(
+        "Unable to perform RADIUS Disconnect-Request on (".$self->{'_id'}.")."
+        . ( defined($response->{'Code'}) ? " $response->{'Code'}" : 'no RADIUS code' ) . ' received'
+        . ( defined($response->{'Error-Cause'}) ? " with Error-Cause: $response->{'Error-Cause'}." : '' )
+    );
+    return;
+}
+
+=item parseRequest
+
+Redefinition of pf::Switch::parseRequest due to specific attribute being used for webauth
+
+=cut
+
+sub parseRequest {
+    my ( $self, $radius_request ) = @_;
+    my $client_mac      = ref($radius_request->{'Calling-Station-Id'}) eq 'ARRAY'
+                           ? clean_mac($radius_request->{'Calling-Station-Id'}[0])
+                           : clean_mac($radius_request->{'Calling-Station-Id'});
+    my $user_name       = $self->parseRequestUsername($radius_request);
+    my $nas_port_type   = $radius_request->{'NAS-Port-Type'};
+    my $port            = $radius_request->{'NAS-Port'};
+    my $eap_type        = ( exists($radius_request->{'EAP-Type'}) ? $radius_request->{'EAP-Type'} : 0 );
+    my $nas_port_id     = ( defined($radius_request->{'NAS-Port-Id'}) ? $radius_request->{'NAS-Port-Id'} : undef );
+    my $session_id = $self->getCiscoAvPairAttribute($radius_request, 'audit-session-id');
+
+    return ($nas_port_type, $eap_type, $client_mac, $port, $user_name, $nas_port_id, $session_id, $nas_port_id);
+}
+
+=item parseExternalPortalRequest
+
+Parse external portal request using URI and it's parameters then return an hash reference with the appropriate parameters
+
+See L<pf::web::externalportal::handle>
+
+=cut
+
+sub parseExternalPortalRequest {
+    my ( $self, $r, $req ) = @_;
+    my $logger = $self->logger;
+
+    # Using a hash to contain external portal parameters
+    my %params = ();
+
+    # Huawei S6700 uses external portal session ID handling process
+    my $uri = $r->uri;
+    return unless ($uri =~ /.*sid(\w+[^\/\&])/);
+    my $session_id = $1;
+
+    my $locationlog = pf::locationlog::locationlog_get_session($session_id);
+    my $switch_id = $locationlog->{switch};
+    my $client_mac = $locationlog->{mac};
+    my $client_ip = defined($r->headers_in->{'X-Forwarded-For'}) ? $r->headers_in->{'X-Forwarded-For'} : $r->connection->remote_ip;
+
+    my $redirect_url;
+    if ( defined($req->param('redirect')) ) {
+        $redirect_url = $req->param('redirect');
+    }
+    elsif ( defined($req->param('redirect_url')) ) {
+        $redirect_url = $req->param('redirect_url');
+    }
+    elsif ( defined($r->headers_in->{'Referer'}) ) {
+        $redirect_url = $r->headers_in->{'Referer'};
+    }
+
+    if($redirect_url !~ /^http/) {
+        $redirect_url = "http://".$redirect_url;
+    }
+
+    %params = (
+        session_id              => $session_id,
+        switch_id               => $switch_id,
+        client_mac              => $client_mac,
+        client_ip               => $client_ip,
+        redirect_url            => $redirect_url,
+        synchronize_locationlog => $FALSE,
+        connection_type         => $WEBAUTH_WIRELESS,
+    );
+
+    return \%params;
+}
+
+=item extractSsid
+
+Find RADIUS SSID parameter on the Huawei AC6605 controller
+
+=cut
+
+sub extractSsid {
+    my ($self, $radius_request) = @_;
+    my $logger = $self->logger;
+
+    if (defined($radius_request->{'Called-Station-SSID'})) {
+        return $radius_request->{'Called-Station-SSID'};
+    } else {
+        $logger->info("Unable to extract SSID of Called-Station-Id");
+        return;
+    }
+}
+
+=back
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2021 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;
+
+# vim: set shiftwidth=4:
+# vim: set expandtab:
+# vim: set backspace=indent,eol,start:
+

--- a/lib/pf/Switch/Huawei/S6700.pm
+++ b/lib/pf/Switch/Huawei/S6700.pm
@@ -134,15 +134,12 @@ sub returnRadiusAccessAccept {
             my $redirect_url = $self->getUrlByName($args->{'user_role'});
             $redirect_url .= '/' unless $redirect_url =~ m(\/$);
             $redirect_url .= $args->{'session_id'};
-            # Cisco and Meraki started adding "&redirect_url=http://example.com" unconditionnaly to the redirect URL.
-            # This means that since we don't have any query parameters that generated paths like "/Huawei::S6700/sid123456&redirect_url=http://example.com" which extracts the SID as sid123456&redirect_url=http://example.com
-            # We add empty query parameters to our path as a workaround
             $redirect_url .= "?";
             $logger->info("Adding web authentication redirection to reply using role: '$role' and URL: '$redirect_url'");
             $radius_reply_ref = {
                 'Huawei-Redirect-ACL' => $role,
-                'Huawei-DHCPv4-Option43' => $redirect_url,
-                'Huawei-DHCPv4-Option121' => 1,
+                'Huawei-Portal-UR' => $redirect_url,
+                'Huawei-URL-Flag' => 1,
             };
         }
     }

--- a/lib/pf/web/constants.pm
+++ b/lib/pf/web/constants.pm
@@ -132,6 +132,7 @@ Readonly::Scalar our $EXT_URL_F5                      => '^/F5';
 Readonly::Scalar our $EXT_URL_MERAKI_MS               => '^/Meraki::MS';
 Readonly::Scalar our $EXT_URL_RUCKUS_UNLEASHED        => '^/Ruckus::Unleashed';
 Readonly::Scalar our $EXT_URL_MIST                    => '^/MistAP';
+Readonly::Scalar our $EXT_URL_HUAWEI                  => '^/Huawei::S6700';
 
 # Ubiquiti doesn't support setting the URL so we much detect it using this URL which will then map to the Ubiquiti module in pf::web::externalportal
 Readonly::Scalar our $EXT_URL_UBIQUITI                => '^/guest/s/[a-zA-Z0-9]+/';


### PR DESCRIPTION
# Description
Support for Huawei WebAuth 

# Impacts
No impact

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
## New Features
* Support for Huawei WebAuth

# WARNING
This PR require a change in the Huawei radius dictionary (https://github.com/Huawei/OSPO/blob/main/Dictionary_FreeRadius) 

This:
```
                'Huawei-Redirect-ACL' => $role,
                'Huawei-DHCPv4-Option43' => $redirect_url,
                'Huawei-DHCPv4-Option121' => 1,
```
Should be:
```
                'Huawei-Redirect-ACL' => $role,
                'Huawei-Portal-URL' => $redirect_url,
                'Huawei-URL-Flag ' => 1,
```