### PR TITLE
fix failure of packetfence-tracking-config

### DIFF
--- a/conf/.gitignore.example
+++ b/conf/.gitignore.example
@@ -4,3 +4,4 @@
 !.gitignore
 
 conf/domain.conf
+.gitattributes

--- a/conf/systemd/packetfence-tracking-config.service
+++ b/conf/systemd/packetfence-tracking-config.service
@@ -6,7 +6,7 @@ Documentation=http://packetfence.org
 [Service]
 Type=oneshot
 WorkingDirectory=/usr/local/pf/conf
-ExecStartPre=/bin/sh -c "if [ ! -d \"/usr/local/pf/conf/.git\" ]; then /usr/bin/git init /usr/local/pf/conf/;cd /usr/local/pf/conf/;/usr/bin/git add /usr/local/pf/conf/*;fi"
+ExecStartPre=/bin/sh -c "if [ ! -d \"/usr/local/pf/conf/.git\" ]; then /usr/bin/git init /usr/local/pf/conf/;git config --system --add safe.directory /usr/local/pf/conf;cd /usr/local/pf/conf/;/usr/bin/git add .gitignore .gitignore.example /usr/local/pf/conf/*;fi"
 ExecStart=/bin/bash -c "/usr/bin/git -c user.name=\'PacketFence Tracking\' -c user.email=\'tracking@packetfence.org\' --git-dir=/usr/local/pf/conf/.git commit -a -m \"Commit `date +%%F-%%T`\""
 
 


### PR DESCRIPTION
https://github.com/inverse-inc/packetfence/issues/7600#issuecomment-1999224937

The git for /usr/local/pf/conf is not being initialized because of a change in gits behaviour:

https://github.blog/2022-04-18-highlights-from-git-2-36/#stricter-repository-ownership-checks

Added the missing files `.gitignore` and `.gitattributes` to the initialization.

# Description
(REQUIRED)
Describe what the new code is used for.
ie: Allow PacketFence to trigger the coffee machine on wireless EAP 802.1X connection to brew a fresh espresso.

# Impacts
(REQUIRED)
Describe what to reviewer should look at. Will also help for testing purposes.
ie: - RADIUS authorize workflow

# Code / PR Dependencies
(OPTIONAL. REMOVE IF NOT NEEDED)
List the PRs or other factors on which this PR depends

# NEW Package(s) required
(OPTIONAL. REMOVE IF NOT NEEDED)
Which new package(s) (all supported distributions) are required for this PR to work.

# Issue
(OPTIONAL. REMOVE IF NOT NEEDED)
The following syntax 'fixes #ISSUE_NUMBER' will automatically closes a Github issue on pull-request merge time.
Modify the ISSUE_NUMBER in order to reflect the Github issue that need to be closed
fixes #ISSUE_NUMBER

# Delete branch after merge
(REQUIRED)
YES | NO

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
(REQUIRED, but may be optional...)
## New Features
* Feature 1
* Feature 2

## Enhancements
* Enhancement 1
* Enhancement 2

## Bug Fixes
If an issue exists on Github, please refer to it (name) along with it's number...
* Issue with Zammitbug in sandwich context (#42)
* Issue with Zammitbug in dinde context (#43)

# UPGRADE file entries
(OPTIONAL, but may be required...)
