### PR TITLE
Rewrote part of H3C's NasPortToIfIndex subroutine to fix behaviour fo…

### DIFF
--- a/lib/pf/Switch/H3C/Comware_v7.pm
+++ b/lib/pf/Switch/H3C/Comware_v7.pm
@@ -13,6 +13,8 @@ This module is currently only a placeholder, see L<pf::Switch::H3C>.
 use strict;
 use warnings;
 
+use POSIX;
+
 use base ('pf::Switch::H3C::Comware_v5');
 
 

--- a/lib/pf/Switch/constants.pm
+++ b/lib/pf/Switch/constants.pm
@@ -454,6 +454,7 @@ Used for NAS-Port to ifIndex translation
 
 Readonly::Scalar our $NAS_PORT_OFFSET => 16781312;
 Readonly::Scalar our $NAS_PORTS_PER_PORT_RANGE => 4096;
+Readonly::Scalar our $IFINDEX_OFFSET_PER_SLOT => 65;
 
 =head1 BROCADE
 


### PR DESCRIPTION
…r stacked Comware v7 switches

# Description
Fix NAS-Port translation to ifIndex in Comware v7 stacked switches rewriting H3C's NasPortToIfIndex and overriding it.
```
# For Switch slot 2/0/5 with VLAN 510:
# VLAN ID are last 3 nibbles ────────────────┐
# Port is next 2 nibbles    ────────────┐    │
# Subslot is next 1 nibble ──────────┐  │    │
# Slot is next 2 nibbles  ───────┐   │  │    │
# Example: 33575422 --to hex--> (02)(0)(05)(1FE)
```

# Impacts
Comware_v7.pm is now overriding H3C.pm's NasPortToIfIndex subroutine. ifIndex calculation logic has been changed based in issue's #8057 description.

# Issue
fixes #8057

# Delete branch after merge
YES

## Bug Fixes
* Wrong NAS-Port translation for stacked Comware v7 switches (#8057)