### PR TITLE
Fix/pfqueue start order

### DIFF
--- a/conf/systemd/packetfence-pfqueue-backend.service
+++ b/conf/systemd/packetfence-pfqueue-backend.service
@@ -5,7 +5,7 @@ Wants=packetfence-redis_queue.service
 After=packetfence-redis_queue.service
 Wants=packetfence-base.target packetfence-config.service packetfence-iptables.service
 After=packetfence-base.target packetfence-config.service packetfence-iptables.service
-Before=packetfence-docker-iptables.service
+Before=packetfence-docker-iptables.service packetfence-pfqueue-go.service
 Requires=packetfence-docker-iptables.service
 PartOf=packetfence-docker-iptables.service
 

--- a/conf/systemd/packetfence-pfqueue-go.service
+++ b/conf/systemd/packetfence-pfqueue-go.service
@@ -8,8 +8,8 @@ After=packetfence-base.target packetfence-config.service packetfence-iptables.se
 Wants=packetfence-pfqueue-backend.service
 After=packetfence-pfqueue-backend.service
 Before=packetfence-docker-iptables.service
-Requires=packetfence-docker-iptables.service
-PartOf=packetfence-docker-iptables.service
+Requires=packetfence-docker-iptables.service packetfence-pfqueue-backend.service
+PartOf=packetfence-docker-iptables.service packetfence-pfqueue-backend.service
 
 [Service]
 Type=notify

--- a/conf/systemd/packetfence-pfqueue-go.service
+++ b/conf/systemd/packetfence-pfqueue-go.service
@@ -1,6 +1,6 @@
 # Copyright (C) Inverse inc.
 [Unit]
-Description=PacketFence pfqueue Service
+Description=PacketFence pfqueue go Service
 Wants=packetfence-redis_queue.service
 After=packetfence-redis_queue.service
 Wants=packetfence-base.target packetfence-config.service packetfence-iptables.service


### PR DESCRIPTION
# Description
Be sure that packetfence-pfqueue-go is started before packetfence-pfqueue-backend
Prevent error when the socket is not available.

# Impacts
pfqueue

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* Force packetfence-pfqueue-go to be started before packetfence-pfqueue-backend

