### PR TITLE
Now or never

### DIFF
--- a/lib/pf/condition/date_after.pm
+++ b/lib/pf/condition/date_after.pm
@@ -35,7 +35,12 @@ sub match {
     my $date_format = "%Y-%m-%d %H:%M:%S";
 
     my $date_to_compare = $arg;
-    my $date_control = $self->value // strftime $date_format, localtime;
+    my $date_control;
+    if( !defined($self->value) || $self->value eq 'now' ){
+        $date_control = strftime($date_format, localtime);
+    } else {
+       $date_control = $self->value;
+    }
 
     $date_to_compare = Time::Piece->strptime($date_to_compare, $date_format);
     $date_control = Time::Piece->strptime($date_control, $date_format);

--- a/lib/pf/condition/date_before.pm
+++ b/lib/pf/condition/date_before.pm
@@ -29,15 +29,19 @@ has value => (
     required => 0,
 );
 
-
-my $date_format = "%Y-%m-%d %H:%M:%S";
-
 sub match {
     my ($self, $arg, $args) = @_;
 
-    my $date_to_compare = $arg;
-    my $date_control = $self->value // strftime $date_format, localtime;
+    my $date_format = "%Y-%m-%d %H:%M:%S";
 
+    my $date_to_compare = $arg;
+    my $date_control;
+    if( !defined($self->value) || $self->value eq 'now' ){
+        $date_control = strftime($date_format, localtime);
+    } else {
+       $date_control = $self->value;
+    }
+    
     $date_to_compare = Time::Piece->strptime($date_to_compare, $date_format);
     $date_control = Time::Piece->strptime($date_control, $date_format);
 


### PR DESCRIPTION
# Description
Allow in comparison of date/time fields to compare to the actual time of the moment of execution. 'now' is used as a placeholder for the time at execution.

# Impacts
The former behaviour is not modified, but only extended to recognize the string 'now' as a time expression.

The old code in [date_before.pm](https://github.com/inverse-inc/packetfence/blob/e2f48d107aeb15d8784682ae2675e9cc238272fd/lib/pf/condition/date_before.pm#L39) and in [date_after.pm](https://github.com/inverse-inc/packetfence/blob/e2f48d107aeb15d8784682ae2675e9cc238272fd/lib/pf/condition/date_after.pm#L38) already seems to imply that an empty value would have let to use the actual time.

The web gui doesn't allow the empty value and leaving the field empty wouldn't help to make the rules more readable.

# Issue
fixes #8066