### PR TITLE
Update mobileconfig.pm to avoid error on portal page

### DIFF
--- a/lib/pf/provisioner/mobileconfig.pm
+++ b/lib/pf/provisioner/mobileconfig.pm
@@ -346,7 +346,7 @@ sub generate_dpsk {
         person_modify($username,psk => $password->{password});
         return $password->{password};
     }
-    elsif (defined $person->{psk} && $person->{psk} ne '') {
+    elsif (ref($person) eq 'HASH' && defined $person->{psk} && $person->{psk} ne '') {
         get_logger->debug("Returning psk key $person->{psk} for user $username");
         return $person->{psk};
     }


### PR DESCRIPTION
check if a variable used as a hash ref really is a hash ref before using it as a hash ref

# Description
The function called to fill a variable with a hashref does not necessarily return a hashref. This checks whether the variable returned is a hashref before using it as a hashref which would lead to a perl error displayed on a portal page.

# Impacts
Probably no impact at all beside avoiding a perl error.

# Issue
fixes #8068

# Delete branch after merge
YES