### PR TITLE
Restore original config file if patch is failing

### DIFF
--- a/addons/full-upgrade/run-upgrade.sh
+++ b/addons/full-upgrade/run-upgrade.sh
@@ -177,7 +177,8 @@ function handle_pkgnew_file() {
   cp -a $pkgnew_file $non_pkgnew_file
   echo "Attempting a dry-run of the patch on $non_pkgnew_file"
   if ! patch -p1 -f --dry-run < $patch_file; then
-    echo "Patching $non_pkgnew_file failed. You will keep the current configuration file ($non_pkgnew_file) BUT, please, check $pkgnew_file file if some modifications are needed in your config file $non_pkgnew_file.\nThis should be addressed manually after the upgrade is completed. Press enter to continue..."
+    echo "Patching $non_pkgnew_file failed. You will keep the current configuration file ($non_pkgnew_file) BUT, please, check $pkgnew_file file if some modifications are needed in your config file $non_pkgnew_file.\nThis should be addressed manually after the upgrade is completed. Previous configuration is restored. Press enter to continue..."
+    cp -a $backup_file $non_pkgnew_file
     read
   else
     echo "Dry-run completed successfully, applying the patch"


### PR DESCRIPTION
# Description
This should fix #8045 

# Impacts
Restore the config file from backup by default if the dry patch is failing.

# Issue
fixes #8045 

# Delete branch after merge
YES

## Bug Fixes
If an issue exists on Github, please refer to it (name) along with it's number...
* #8045 config cleaned after upgrade script
