### PR TITLE
Fix/machine account no update on hash password, fix admin UI cache enabled/disabled status

### DIFF
--- a/html/pfappserver/lib/pfappserver/Form/Config/Domain.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Domain.pm
@@ -156,15 +156,17 @@ has_field 'registration' =>
              help => 'If this option is enabled, the device will be able to reach the Active Directory from the registration VLAN.' },
   );
 
-has_field 'nt_key_cache_enabled' =>
-    (
-        type => 'Toggle',
-        checkbox_value => "enabled",
-        unchecked_value => "disabled",
-        label => 'NT Key cache',
-        tags => { after_element => \&help,
-            help => 'Should the NT Key cache be enabled for this domain?' },
-    );
+has_field 'nt_key_cache_enabled' => (
+    type            => 'Toggle',
+    label           => 'NT Key cache',
+    checkbox_value  => 'enabled',
+    unchecked_value => 'disabled',
+    default => 'disabled',
+    tags => {
+        after_element => \&help,
+        help => 'Should the NT Key cache be enabled for this domain?'
+    },
+);
 
 has_field 'nt_key_cache_expire' =>
     (

--- a/html/pfappserver/root/src/views/Configuration/domains/_components/TheForm.vue
+++ b/html/pfappserver/root/src/views/Configuration/domains/_components/TheForm.vue
@@ -99,6 +99,8 @@
         <form-group-nt-key-cache-enabled namespace="nt_key_cache_enabled"
                                :column-label="$i18n.t('Enable NT Key cache')"
                                :text="$i18n.t('Enable NT Key cache for this domain.')"
+                               enabled-value="enabled"
+                               disabled-value="disabled"
         />
         <form-group-nt-key-cache-expire namespace="nt_key_cache_expire"
                                         :column-label="$i18n.t('Cache key expiration')"
@@ -135,6 +137,8 @@
         <form-group-ntlm-cache namespace="ntlm_cache"
                                :column-label="$i18n.t('NTLM cache')"
                                :text="$i18n.t('Enable the NTLM cache for this domain.')"
+                               enabled-value="enabled"
+                               disabled-value="disabled"
         />
 
         <form-group-ntlm-cache-source namespace="ntlm_cache_source"

--- a/html/pfappserver/root/src/views/Configuration/domains/_components/TheForm.vue
+++ b/html/pfappserver/root/src/views/Configuration/domains/_components/TheForm.vue
@@ -59,7 +59,7 @@
           <component namespace="machine_account_password"
                      :is="formGroupComputedMachineAccountPassword"
                      :column-label="$i18n.t('Machine account password')"
-                     :text="$i18n.t(`Password / password hash of the machine account, password will be hashed and stored in config files, you won't be able to retrieve your plain text password once click create or save. Type another value to change the password, or leave it as-is. If you added new node to a PacketFence cluster, you'll have to specify the original password / or set a new password here to force sync machine account.`)"
+                     :text="$i18n.t(`Password for machine account, Password will be hashed after you save your configuration. To change password, replace the password hash with a different one or leave it as-is. If you added new node to a PacketFence cluster, you'll have to specify the original password / or set a new password here to force sync machine account. A hash-like password will NOT be accepted.`)"
                      :buttonLabel="$i18n.t('Test')"
                      testLabel="Processing"
                      :test="testMachineAccount"


### PR DESCRIPTION
# Description
fix domain settings update requires DC admin password issue
fix nt key cache tab's "enabled" status

# Impacts
changed domain settings update logic
before:
  when there's a %h as machine account name, always try to join / update / create the machine account when **updating** domain settings. 
after:
  on a domain settings update, no matter it's enabling or disabling nt key cache or updating other attributes of a domain configuration, if the changes does **not** include a machine account password change. we only update the domain.conf settings without interacting with domain controller - so no DC admin's password is required.

we also updated the backend validation of machine account password.
on creating a domain, or updating a domain's machine account password, 
a hash-like password (32 chars, a-f A-F 0-9) now will be rejected.


# Issue
fixes #8075 
fixes #8073 

# Delete branch after merge
YES

# Checklist
- [n/a] Document the feature
- [n/a] Add OpenAPI specification
- [n/a] Add unit tests
- [n/a] Add acceptance tests (TestLink)


## Bug Fixes
fixes #8075 - the nt key cache status was not displayed properly.
fixes #8073 - unable to modify domain configuration even if it's not related to machine account.

