### PR TITLE
Send username, ip and role to PaloAlto Firewall SSO payload

### DIFF
--- a/go/firewallsso/paloalto_test.go
+++ b/go/firewallsso/paloalto_test.go
@@ -11,13 +11,20 @@ func TestPaloAltoStartHttpPayload(t *testing.T) {
 
 	expected := `
 <uid-message>
-		<version>1.0</version>
-		<type>update</type>
-		<payload>
-				<login>
-						<entry name="lzammit" ip="1.2.3.4" timeout="1440"/>
-				</login>
-		</payload>
+	<version>1.0</version>
+	<type>update</type>
+	<payload>
+		<login>
+			<entry name="lzammit" ip="1.2.3.4" timeout="1440"/>
+		</login>
+		<register-user>
+			<entry user="lzammit">
+				<tag>
+					<member timeout="86400">default</member>
+				</tag>
+			</entry>
+		</register-user>
+	</payload>
 </uid-message>
 `
 
@@ -34,13 +41,20 @@ func TestPaloAltoStopHttpPayload(t *testing.T) {
 
 	expected := `
 <uid-message>
-		<version>1.0</version>
-		<type>update</type>
-		<payload>
-				<logout>
-						<entry name="lzammit" ip="1.2.3.4"/>
-				</logout>
-		</payload>
+	<version>1.0</version>
+	<type>update</type>
+	<payload>
+		<logout>
+			<entry name="lzammit" ip="1.2.3.4"/>
+		</logout>
+		<unregister-user>
+			<entry user="lzammit">
+				<tag>
+					<member>default</member>
+				</tag>
+			</entry>
+		</unregister-user>
+	</payload>
 </uid-message>
 `
 


### PR DESCRIPTION
# Description
Add the role of the node in the PaloAlto Firewall SSO payload

# Impacts
PaloAlto Firewall SSO

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* PaloAlto FirewallSSO, send the role of the node in the payload

