### PR TITLE
Fix/ntlm auth api service status

### DIFF
--- a/bin/pyntlm_auth/config_loader.py
+++ b/bin/pyntlm_auth/config_loader.py
@@ -65,14 +65,14 @@ def config_load():
         print(f"  Error loading config from domain.conf: {e}. Terminated.")
         sys.exit(1)
 
-    conf_db = f"/usr/local/pf/var/conf/ntlm-auth-api.d/{identifier}.env"
+    conf_db = f"/usr/local/pf/var/conf/ntlm-auth-api.d/db.ini"
     cp_db = ConfigParser(interpolation=None)
     print(f"Load database config from {conf_db}")
     try:
         with open(conf_db, 'r') as file:
             cp_db.read_file(file)
-        if identifier not in cp_db:
-            print(f"  Section {identifier} not found, ntlm-auth-api starts without NT Key caching capability.")
+        if 'DB' not in cp_db:
+            print(f"  Section [DB] not found, ntlm-auth-api starts without NT Key caching capability.")
     except FileNotFoundError:
         print(f"  {conf_db} not found, ntlm-auth-api@{identifier} starts without NT Key caching capability.")
     except configparser.Error as e:
@@ -104,12 +104,12 @@ def config_load():
     ad_reset_account_lockout_count_after = cp_dm.get(identifier, 'ad_reset_account_lockout_counter_after', fallback=0)
     ad_old_password_allowed_period = cp_dm.get(identifier, 'ad_old_password_allowed_period', fallback=60)
 
-    c_db_host = cp_db.get(identifier, "DB_HOST", fallback=None)
-    c_db_port = cp_db.get(identifier, "DB_PORT", fallback=None)
-    c_db_user = cp_db.get(identifier, "DB_USER", fallback=None)
-    c_db_pass = cp_db.get(identifier, "DB_PASS", fallback=None)
-    c_db = cp_db.get(identifier, "DB", fallback=None)
-    c_db_unix_socket = cp_db.get(identifier, 'DB_UNIX_SOCKET', fallback=None)
+    c_db_host = cp_db.get('DB', "DB_HOST", fallback=None)
+    c_db_port = cp_db.get('DB', "DB_PORT", fallback=None)
+    c_db_user = cp_db.get('DB', "DB_USER", fallback=None)
+    c_db_pass = cp_db.get('DB', "DB_PASS", fallback=None)
+    c_db = cp_db.get('DB', "DB", fallback=None)
+    c_db_unix_socket = cp_db.get('DB', 'DB_UNIX_SOCKET', fallback=None)
     print(f"  {c_db_user}:{utils.mask_password(c_db_pass)}@{c_db_host}:{c_db_port}/{c_db}")
 
     # validate domain.conf

--- a/conf/systemd/packetfence-ntlm-auth-api-domain@.service
+++ b/conf/systemd/packetfence-ntlm-auth-api-domain@.service
@@ -11,7 +11,6 @@ Type=notify
 TimeoutStopSec=60
 NotifyAccess=all
 LimitNOFILE=8192
-ExecStartPre=/bin/perl -I/usr/local/pf/lib -I/usr/local/pf/lib_perl/lib/perl5 '-Mpf::services::manager::ntlm_auth_api' -e 'pf::services::manager::ntlm_auth_api->new()->generateConfig()'
 ExecStart=/usr/local/pf/sbin/ntlm-auth-api-domain %i
 ExecStop=/bin/bash -c "docker stop ntlm-auth-api-%i; echo Stopped"
 Restart=on-failure

--- a/conf/systemd/packetfence-ntlm-auth-api.service
+++ b/conf/systemd/packetfence-ntlm-auth-api.service
@@ -7,7 +7,7 @@ Before=packetfence-httpd.portal.service
 Before=packetfence-docker-iptables.service
 
 [Service]
-Type=simple
+Type=forking
 TimeoutStopSec=60
 NotifyAccess=all
 LimitNOFILE=8192
@@ -16,7 +16,7 @@ ExecStart=/usr/local/pf/sbin/ntlm-auth-api-docker-wrapper start
 ExecStop=/usr/local/pf/sbin/ntlm-auth-api-docker-wrapper stop
 Restart=on-failure
 Slice=packetfence.slice
-PIDFile=/usr/local/pf/var/run/ntlm-auth-api-systemd-notify.pid
+PIDFile=/usr/local/pf/var/run/ntlm-auth-api.pid
 
 [Install]
 WantedBy=packetfence.target

--- a/lib/pf/services/manager/ntlm_auth_api.pm
+++ b/lib/pf/services/manager/ntlm_auth_api.pm
@@ -58,18 +58,17 @@ sub generateConfig {
             my $ntlm_auth_host = $conf{ntlm_auth_host};
             my $ntlm_auth_port = $conf{ntlm_auth_port};
 
-            pf_run("sudo echo '[$identifier]' > $generated_conf_dir/" . $self->name . '.d/' . "$identifier.env");
-
-            pf_run("sudo echo 'HOST=$ntlm_auth_host' >> $generated_conf_dir/" . $self->name . '.d/' . "$identifier.env");
+            pf_run("sudo echo 'HOST=$ntlm_auth_host' > $generated_conf_dir/" . $self->name . '.d/' . "$identifier.env");
             pf_run("sudo echo 'LISTEN=$ntlm_auth_port' >> $generated_conf_dir/" . $self->name . '.d/' . "$identifier.env");
             pf_run("sudo echo 'IDENTIFIER=$identifier' >> $generated_conf_dir/" . $self->name . '.d/' . "$identifier.env");
 
-            pf_run("sudo echo 'DB_HOST=$db_host' >> $generated_conf_dir/" . $self->name . '.d/' . "$identifier.env");
-            pf_run("sudo echo 'DB_PORT=$db_port' >> $generated_conf_dir/" . $self->name . '.d/' . "$identifier.env");
-            pf_run("sudo echo 'DB_USER=$db_user' >> $generated_conf_dir/" . $self->name . '.d/' . "$identifier.env");
-            pf_run("sudo echo 'DB_PASS=$db_pass' >> $generated_conf_dir/" . $self->name . '.d/' . "$identifier.env");
-            pf_run("sudo echo 'DB=$db' >> $generated_conf_dir/" . $self->name . '.d/' . "$identifier.env");
-            pf_run("sudo echo 'DB_UNIX_SOCKET=$db_unix_socket' >> $generated_conf_dir/" . $self->name . '.d/' . "$identifier.env");
+            pf_run("sudo echo '[DB]' > $generated_conf_dir/" . $self->name . '.d/' . "db.ini");
+            pf_run("sudo echo 'DB_HOST=$db_host' >> $generated_conf_dir/" . $self->name . '.d/' . "db.ini");
+            pf_run("sudo echo 'DB_PORT=$db_port' >> $generated_conf_dir/" . $self->name . '.d/' . "db.ini");
+            pf_run("sudo echo 'DB_USER=$db_user' >> $generated_conf_dir/" . $self->name . '.d/' . "db.ini");
+            pf_run("sudo echo 'DB_PASS=$db_pass' >> $generated_conf_dir/" . $self->name . '.d/' . "db.ini");
+            pf_run("sudo echo 'DB=$db' >> $generated_conf_dir/" . $self->name . '.d/' . "db.ini");
+            pf_run("sudo echo 'DB_UNIX_SOCKET=$db_unix_socket' >> $generated_conf_dir/" . $self->name . '.d/' . "db.ini");
         }
     }
 }

--- a/lib/pf/services/manager/ntlm_auth_api.pm
+++ b/lib/pf/services/manager/ntlm_auth_api.pm
@@ -72,21 +72,6 @@ sub generateConfig {
     }
 }
 
-sub isAlive {
-    my $alive = 1;
-
-    for my $identifier (keys(%ConfigDomain)) {
-        my %conf = %{$ConfigDomain{$identifier}};
-        if (exists($conf{ntlm_auth_host}) && exists($conf{ntlm_auth_port}) && exists($conf{machine_account_password})) {
-            my $ntlm_auth_port = $conf{ntlm_auth_port};
-            my $result = pf_run("curl -X GET http://containers-gateway.internal:$ntlm_auth_port/ping 2>/dev/null", accepted_exit_status => [ 0 ]);
-            if (!defined($result) || $result ne "pong") {
-                $alive = 0;
-            }
-        }
-    }
-    return $alive;
-}
 
 sub isManaged {
     my ($self) = @_;

--- a/lib/pf/services/manager/ntlm_auth_api.pm
+++ b/lib/pf/services/manager/ntlm_auth_api.pm
@@ -53,6 +53,7 @@ sub generateConfig {
 
 
     for my $identifier (keys(%ConfigDomain)) {
+        my $db_generated = 0;
         my %conf = %{$ConfigDomain{$identifier}};
         if (exists($conf{ntlm_auth_host}) && exists($conf{ntlm_auth_port}) && exists($conf{machine_account_password})) {
             my $ntlm_auth_host = $conf{ntlm_auth_host};
@@ -62,13 +63,16 @@ sub generateConfig {
             pf_run("sudo echo 'LISTEN=$ntlm_auth_port' >> $generated_conf_dir/" . $self->name . '.d/' . "$identifier.env");
             pf_run("sudo echo 'IDENTIFIER=$identifier' >> $generated_conf_dir/" . $self->name . '.d/' . "$identifier.env");
 
-            pf_run("sudo echo '[DB]' > $generated_conf_dir/" . $self->name . '.d/' . "db.ini");
-            pf_run("sudo echo 'DB_HOST=$db_host' >> $generated_conf_dir/" . $self->name . '.d/' . "db.ini");
-            pf_run("sudo echo 'DB_PORT=$db_port' >> $generated_conf_dir/" . $self->name . '.d/' . "db.ini");
-            pf_run("sudo echo 'DB_USER=$db_user' >> $generated_conf_dir/" . $self->name . '.d/' . "db.ini");
-            pf_run("sudo echo 'DB_PASS=$db_pass' >> $generated_conf_dir/" . $self->name . '.d/' . "db.ini");
-            pf_run("sudo echo 'DB=$db' >> $generated_conf_dir/" . $self->name . '.d/' . "db.ini");
-            pf_run("sudo echo 'DB_UNIX_SOCKET=$db_unix_socket' >> $generated_conf_dir/" . $self->name . '.d/' . "db.ini");
+            if ($db_generated ==0) {
+                pf_run("sudo echo '[DB]' > $generated_conf_dir/" . $self->name . '.d/' . "db.ini");
+                pf_run("sudo echo 'DB_HOST=$db_host' >> $generated_conf_dir/" . $self->name . '.d/' . "db.ini");
+                pf_run("sudo echo 'DB_PORT=$db_port' >> $generated_conf_dir/" . $self->name . '.d/' . "db.ini");
+                pf_run("sudo echo 'DB_USER=$db_user' >> $generated_conf_dir/" . $self->name . '.d/' . "db.ini");
+                pf_run("sudo echo 'DB_PASS=$db_pass' >> $generated_conf_dir/" . $self->name . '.d/' . "db.ini");
+                pf_run("sudo echo 'DB=$db' >> $generated_conf_dir/" . $self->name . '.d/' . "db.ini");
+                pf_run("sudo echo 'DB_UNIX_SOCKET=$db_unix_socket' >> $generated_conf_dir/" . $self->name . '.d/' . "db.ini");
+                $db_generated = 1;
+            }
         }
     }
 }

--- a/lib/pf/services/manager/ntlm_auth_api.pm
+++ b/lib/pf/services/manager/ntlm_auth_api.pm
@@ -51,9 +51,15 @@ sub generateConfig {
     my $db=$db_config->{'db'};
     my $db_unix_socket = $db_config->{'unix_socket'};
 
+    pf_run("sudo echo '[DB]' > $generated_conf_dir/" . $self->name . '.d/' . "db.ini");
+    pf_run("sudo echo 'DB_HOST=$db_host' >> $generated_conf_dir/" . $self->name . '.d/' . "db.ini");
+    pf_run("sudo echo 'DB_PORT=$db_port' >> $generated_conf_dir/" . $self->name . '.d/' . "db.ini");
+    pf_run("sudo echo 'DB_USER=$db_user' >> $generated_conf_dir/" . $self->name . '.d/' . "db.ini");
+    pf_run("sudo echo 'DB_PASS=$db_pass' >> $generated_conf_dir/" . $self->name . '.d/' . "db.ini");
+    pf_run("sudo echo 'DB=$db' >> $generated_conf_dir/" . $self->name . '.d/' . "db.ini");
+    pf_run("sudo echo 'DB_UNIX_SOCKET=$db_unix_socket' >> $generated_conf_dir/" . $self->name . '.d/' . "db.ini");
 
     for my $identifier (keys(%ConfigDomain)) {
-        my $db_generated = 0;
         my %conf = %{$ConfigDomain{$identifier}};
         if (exists($conf{ntlm_auth_host}) && exists($conf{ntlm_auth_port}) && exists($conf{machine_account_password})) {
             my $ntlm_auth_host = $conf{ntlm_auth_host};
@@ -62,17 +68,6 @@ sub generateConfig {
             pf_run("sudo echo 'HOST=$ntlm_auth_host' > $generated_conf_dir/" . $self->name . '.d/' . "$identifier.env");
             pf_run("sudo echo 'LISTEN=$ntlm_auth_port' >> $generated_conf_dir/" . $self->name . '.d/' . "$identifier.env");
             pf_run("sudo echo 'IDENTIFIER=$identifier' >> $generated_conf_dir/" . $self->name . '.d/' . "$identifier.env");
-
-            if ($db_generated ==0) {
-                pf_run("sudo echo '[DB]' > $generated_conf_dir/" . $self->name . '.d/' . "db.ini");
-                pf_run("sudo echo 'DB_HOST=$db_host' >> $generated_conf_dir/" . $self->name . '.d/' . "db.ini");
-                pf_run("sudo echo 'DB_PORT=$db_port' >> $generated_conf_dir/" . $self->name . '.d/' . "db.ini");
-                pf_run("sudo echo 'DB_USER=$db_user' >> $generated_conf_dir/" . $self->name . '.d/' . "db.ini");
-                pf_run("sudo echo 'DB_PASS=$db_pass' >> $generated_conf_dir/" . $self->name . '.d/' . "db.ini");
-                pf_run("sudo echo 'DB=$db' >> $generated_conf_dir/" . $self->name . '.d/' . "db.ini");
-                pf_run("sudo echo 'DB_UNIX_SOCKET=$db_unix_socket' >> $generated_conf_dir/" . $self->name . '.d/' . "db.ini");
-                $db_generated = 1;
-            }
         }
     }
 }

--- a/rpm/packetfence.spec
+++ b/rpm/packetfence.spec
@@ -967,6 +967,7 @@ fi
 %attr(0755, pf, pf)     /usr/local/pf/sbin/kafka-docker-wrapper
 %attr(0755, pf, pf)     /usr/local/pf/sbin/ntlm-auth-api-docker-wrapper
 %attr(0755, pf, pf)     /usr/local/pf/sbin/ntlm-auth-api-domain
+%attr(0755, pf, pf)     /usr/local/pf/sbin/ntlm-auth-api-monitor
 %attr(0755, pf, pf)     /usr/local/pf/sbin/pfconfig-docker-wrapper
 %attr(0755, pf, pf)     /usr/local/pf/sbin/pfsetacls-docker-wrapper
 %attr(0755, pf, pf)     /usr/local/pf/sbin/pfsso-docker-wrapper

--- a/sbin/ntlm-auth-api-docker-wrapper
+++ b/sbin/ntlm-auth-api-docker-wrapper
@@ -5,7 +5,10 @@ source /usr/local/pf/containers/systemd-service
 name=ntlm-auth-api
 
 conf_dir="/usr/local/pf/var/conf/${name}.d/"
-env_files=$(ls $conf_dir 2>/dev/null)
+cd $conf_dir || exit 1
+env_files=$(ls *.env 2>/dev/null)
+cd - || exit 1
+
 option=$1
 
 if [ -z "$env_files" ]; then
@@ -21,14 +24,14 @@ if [ "$option" = "start" ]; then
     for env_file in $env_files; do
         iden=$(echo $env_file | awk -F '.' '{print $1}')
         echo "starting ntlm auth api domain service for: $iden using env file: $env_file"
-        systemctl start packetfence-ntlm-auth-api-domain@"$iden"
+        systemctl start packetfence-ntlm-auth-api-domain@"$iden" &
     done
     sleep infinity
 elif [ "$option" = "stop" ]; then
     for env_file in $env_files; do
         iden=$(echo $env_file | awk -F '.' '{print $1}')
         echo "stopping ntlm auth api domain service for: $iden"
-        systemctl stop packetfence-ntlm-auth-api-domain@"$iden"
+        systemctl stop packetfence-ntlm-auth-api-domain@"$iden" &
     done
     echo "stopped"
     sleep 1

--- a/sbin/ntlm-auth-api-docker-wrapper
+++ b/sbin/ntlm-auth-api-docker-wrapper
@@ -26,13 +26,32 @@ if [ "$option" = "start" ]; then
         echo "starting ntlm auth api domain service for: $iden using env file: $env_file"
         systemctl start packetfence-ntlm-auth-api-domain@"$iden" &
     done
-    sleep infinity
+    /usr/local/pf/sbin/ntlm-auth-api-monitor &
 elif [ "$option" = "stop" ]; then
     for env_file in $env_files; do
         iden=$(echo $env_file | awk -F '.' '{print $1}')
         echo "stopping ntlm auth api domain service for: $iden"
         systemctl stop packetfence-ntlm-auth-api-domain@"$iden" &
     done
+
+    failures=0
+    while true; do
+        svcs=$(docker ps | grep "ntlm-auth-api-")
+        if [ -n "$svcs" ]; then
+            failures=$((failures+1))
+        else
+            echo "Stopped."
+            break
+        fi
+        
+        if [ $failures -gt 30 ]; then
+            echo "some of the containers failed to stop after 30s, please check for details"
+            exit 1
+        fi
+
+        sleep 1
+    done
+
     echo "stopped"
     sleep 1
 fi

--- a/sbin/ntlm-auth-api-docker-wrapper
+++ b/sbin/ntlm-auth-api-docker-wrapper
@@ -28,6 +28,13 @@ if [ "$option" = "start" ]; then
     done
     /usr/local/pf/sbin/ntlm-auth-api-monitor &
 elif [ "$option" = "stop" ]; then
+    pids=$(pgrep "ntlm-auth-api-monitor")
+
+    if [ -n "$pids" ]; then
+        echo "$pids" | xargs kill
+        echo '' >/usr/local/pf/var/run/ntlm-auth-api.pid
+    fi
+
     for env_file in $env_files; do
         iden=$(echo $env_file | awk -F '.' '{print $1}')
         echo "stopping ntlm auth api domain service for: $iden"

--- a/sbin/ntlm-auth-api-monitor
+++ b/sbin/ntlm-auth-api-monitor
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+source /usr/local/pf/containers/systemd-service
+
+name=ntlm-auth-api
+pid=$$
+
+conf_dir="/usr/local/pf/var/conf/${name}.d/"
+cd $conf_dir || exit 1
+env_files=$(ls *.env 2>/dev/null)
+
+# maximum allowed attempts, will be reduced to 3 once passed health check.
+max_failures=30
+failures=0
+
+while true; do
+    check_passed=1
+    for env_file in $env_files; do
+        full_path="$conf_dir$env_file"
+        iden=$(echo $env_file | awk -F '.' '{print $1}')
+
+        host=$(cat $full_path | grep 'HOST' | awk -F '=' '{print $2}')
+        port=$(cat $full_path | grep 'LISTEN' | awk -F '=' '{print $2}')
+
+        res=$(curl -X GET http://$host:$port/ping 2>/dev/null)
+
+        echo "Checking [$iden]: http://$host:$port/ping, response = [$res]"
+
+        if [ "$res" != "pong" ]; then
+            check_passed=0
+            break
+        fi
+    done
+
+    if [ $check_passed -eq 0 ]; then
+        failures=$((failures+1))
+        if [ $failures -gt $max_failures ]; then
+            echo "Maximum check up time exceeded. Service not ready."
+            echo '' >/usr/local/pf/var/run/ntlm-auth-api.pid
+            exit 1
+        fi
+    else
+        echo "$pid" >/usr/local/pf/var/run/ntlm-auth-api.pid
+        max_failures=3
+        failures=0
+        sleep 5
+    fi
+
+    sleep 1
+done

--- a/sbin/ntlm-auth-api-monitor
+++ b/sbin/ntlm-auth-api-monitor
@@ -9,7 +9,7 @@ conf_dir="/usr/local/pf/var/conf/${name}.d/"
 cd $conf_dir || exit 1
 env_files=$(ls *.env 2>/dev/null)
 
-# maximum allowed attempts, will be reduced to 3 once passed health check.
+# maximum allowed attempts, will be reduced to 5 once passed health check.
 max_failures=30
 failures=0
 
@@ -41,7 +41,7 @@ while true; do
         fi
     else
         echo "$pid" >/usr/local/pf/var/run/ntlm-auth-api.pid
-        max_failures=3
+        max_failures=5
         failures=0
         sleep 5
     fi


### PR DESCRIPTION
# Description
Introducing a monitor script for ntlm-auth-api
fix the "service slow start" issue
we were seeing an dead status of "ntlm-auth-api"  after we started or restarted "ntlm-auth-api" in admin panel. However, at that time, the service is being started, but the systemctl command returned before everything is ready.
Now we introduced a monitor script and changed the service from simple to forking, making sure systemd returns after everything is ready.

# Impacts
changed the ntlm-auth-api service type



# Issue
fixes #8080  

# Delete branch after merge
YES

# Checklist
- [na] Document the feature
- [na] Add OpenAPI specification
- [na] Add unit tests
- [na] Add acceptance tests (TestLink)

# NEWS file entries
sbin/ntlm-auth-api-monitor


## Bug Fixes
* Issue with wrong ntlm-auth-api status in admin UI (#8080)

