### PR TITLE
Fix/friendly log message for ntlm auth api service 8079

### DIFF
--- a/addons/functions/database.functions
+++ b/addons/functions/database.functions
@@ -10,7 +10,7 @@ function get_db_name() {
   if [ -z "$db_name" ]; then
     db_name=pf
   fi
-  
+
   echo $db_name
 }
 
@@ -53,10 +53,10 @@ function import_mysqldump() {
 
     sub_splitter
     echo "Replacing create statements from the dump and removing drop statements"
-    # This is done so that tables aren't dropped 
+    # This is done so that tables aren't dropped
     sed -i "s/^DROP TABLE IF EXISTS /---DROP TABLE IF EXISTS /g" $dump_file
     sed -i "s/CREATE TABLE /CREATE TABLE IF NOT EXISTS /g" $dump_file
-  
+
     # Delete this statement if its there because this table isn't in our schema anymore but some old deployments have it
     sed -i 's/DELETE IGNORE FROM `dhcp_fingerprint`;//g' $dump_file
     sed -i 's/DELETE IGNORE FROM `action`;//g' $dump_file
@@ -70,7 +70,6 @@ function import_mysqldump() {
     mysql ${mariadb_args} $db_name -e 'delete ignore from pf_version;'
     mysql ${mariadb_args} $db_name -e 'delete ignore from radreply;'
     mysql ${mariadb_args} $db_name -e 'delete ignore from sms_carrier;'
-    mysql ${mariadb_args} $db_name -e 'delete ignore from tenant;'
   else
     echo "Dump file includes triggers and procedures"
   fi
@@ -79,7 +78,7 @@ function import_mysqldump() {
   echo "Importing $dump_file into $db_name"
   mysql ${mariadb_args} $db_name < $dump_file
   check_code $?
-  
+
   sub_splitter
   echo "Importing grants"
   mysql ${mariadb_args} < $grants_file
@@ -169,7 +168,7 @@ function upgrade_database() {
   fi
 
   db_name="$1"
-  db_version=`mysql ${mariadb_args} $db_name -e "select version from pf_version order by id desc limit 1;" | egrep -o '^[0-9]+\.[0-9]+'`  
+  db_version=`mysql ${mariadb_args} $db_name -e "select version from pf_version order by id desc limit 1;" | egrep -o '^[0-9]+\.[0-9]+'`
   echo "Database $db_name runs version $db_version"
   if [ -z "$db_version" ]; then
     echo "Unable to find DB version"
@@ -183,7 +182,7 @@ function upgrade_database() {
     mysql ${mariadb_args} -v $db_name < $script
     check_code $?
   done
-  
+
   sub_splitter
   echo "Deleting content of keyed table"
   mysql ${mariadb_args} $db_name -e 'truncate keyed'

--- a/bin/pyntlm_auth/handlers.py
+++ b/bin/pyntlm_auth/handlers.py
@@ -31,9 +31,6 @@ def format_response(nt_key_or_error_msg, error_code):
     if error_code == ntstatus.NT_STATUS_ACCOUNT_LOCKED_OUT or error_code == ntstatus.NT_STATUS_ACCOUNT_DISABLED:
         return nt_key_or_error_msg, HTTPStatus.LOCKED
 
-    if error_code == ntstatus.NT_STATUS_PASSWORD_EXPIRED:
-        return nt_key_or_error_msg, HTTPStatus.LOCKED
-
     if error_code == flags.STATUS_DEVICE_BLOCKED:
         return nt_key_or_error_msg, HTTPStatus.UNAUTHORIZED
 

--- a/bin/pyntlm_auth/handlers.py
+++ b/bin/pyntlm_auth/handlers.py
@@ -13,6 +13,10 @@ import flags
 
 from samba import param, NTSTATUSError, ntstatus
 
+# For NTSTATUS, see:
+# https://github.com/samba-team/samba/blob/master/libcli/util/ntstatus_err_table.txt
+# or
+# https://github.com/samba-team/samba/blob/master/examples/pcap2nbench/main.cpp
 
 def format_response(nt_key_or_error_msg, error_code):
     if error_code == 0:
@@ -25,6 +29,9 @@ def format_response(nt_key_or_error_msg, error_code):
         return nt_key_or_error_msg, HTTPStatus.NOT_FOUND
 
     if error_code == ntstatus.NT_STATUS_ACCOUNT_LOCKED_OUT or error_code == ntstatus.NT_STATUS_ACCOUNT_DISABLED:
+        return nt_key_or_error_msg, HTTPStatus.LOCKED
+
+    if error_code == ntstatus.NT_STATUS_PASSWORD_EXPIRED:
         return nt_key_or_error_msg, HTTPStatus.LOCKED
 
     if error_code == flags.STATUS_DEVICE_BLOCKED:

--- a/lib/pf/services/manager/ntlm_auth_api.pm
+++ b/lib/pf/services/manager/ntlm_auth_api.pm
@@ -50,7 +50,7 @@ sub generateConfig {
     my $db = $db_config->{'db'};
     my $db_unix_socket = $db_config->{'unix_socket'};
 
-    if (!defined($db_host) || !defined($db_port) || !defined($db_user) || !defined($db_pass) || !defined($db) || !defined($db_unix_socket) || $db_host == "" || $db_port == "" || $db_user == "" || $db_pass == "" || $db == "" || $db_unix_socket == "") {
+    if (!defined($db_host) || !defined($db_port) || !defined($db_user) || !defined($db_pass) || !defined($db) || !defined($db_unix_socket) || $db_host eq "" || $db_port eq "" || $db_user eq "" || $db_pass eq "" || $db eq "" || $db_unix_socket eq "") {
         print("Warning: Some of the database settings are missing while generating db.ini, ntlm-auth-api might not able to start properly\n")
     }
 

--- a/lib/pf/services/manager/ntlm_auth_api.pm
+++ b/lib/pf/services/manager/ntlm_auth_api.pm
@@ -41,15 +41,18 @@ sub generateConfig {
     pf_run("sudo mkdir -p $generated_conf_dir/" . $self->name() . ".d/");
     pf_run("sudo rm -rf $generated_conf_dir/" . $self->name() . ".d/*.env");
 
-
     my $db_config = pf::db::db_config();
 
-    my $db_host=$db_config->{'host'};
-    my $db_port=$db_config->{'port'};
-    my $db_user=$db_config->{'user'};
-    my $db_pass=$db_config->{'pass'};
-    my $db=$db_config->{'db'};
+    my $db_host = $db_config->{'host'};
+    my $db_port = $db_config->{'port'};
+    my $db_user = $db_config->{'user'};
+    my $db_pass = $db_config->{'pass'};
+    my $db = $db_config->{'db'};
     my $db_unix_socket = $db_config->{'unix_socket'};
+
+    if (!defined($db_host) || !defined($db_port) || !defined($db_user) || !defined($db_pass) || !defined($db) || !defined($db_unix_socket) || $db_host == "" || $db_port == "" || $db_user == "" || $db_pass == "" || $db == "" || $db_unix_socket == "") {
+        print("Warning: Some of the database settings are missing while generating db.ini, ntlm-auth-api might not able to start properly\n")
+    }
 
     pf_run("sudo echo '[DB]' > $generated_conf_dir/" . $self->name . '.d/' . "db.ini");
     pf_run("sudo echo 'DB_HOST=$db_host' >> $generated_conf_dir/" . $self->name . '.d/' . "db.ini");
@@ -71,7 +74,6 @@ sub generateConfig {
         }
     }
 }
-
 
 sub isManaged {
     my ($self) = @_;

--- a/sbin/ntlm-auth-api-docker-wrapper
+++ b/sbin/ntlm-auth-api-docker-wrapper
@@ -5,13 +5,17 @@ source /usr/local/pf/containers/systemd-service
 name=ntlm-auth-api
 
 conf_dir="/usr/local/pf/var/conf/${name}.d/"
-cd $conf_dir || exit 1
+cd $conf_dir || {
+    echo "Can not locate config dir: /usr/local/pf/var/conf/${name}.d/. Service unable to start."
+    exit 1
+}
 env_files=$(ls *.env 2>/dev/null)
 cd - || exit 1
 
 option=$1
 
 if [ -z "$env_files" ]; then
+    echo "No .env file found in /usr/local/pf/var/conf/${name}.d/. Service unable to start. Do you have a valid domain.conf, or manually edited domain.conf without a pfcmd configreload ?"
     exit 1
 fi
 
@@ -23,7 +27,7 @@ fi
 if [ "$option" = "start" ]; then
     for env_file in $env_files; do
         iden=$(echo $env_file | awk -F '.' '{print $1}')
-        echo "starting ntlm auth api domain service for: $iden using env file: $env_file"
+        echo "Starting ntlm auth api domain service for: $iden using env file: $env_file"
         systemctl start packetfence-ntlm-auth-api-domain@"$iden" &
     done
     /usr/local/pf/sbin/ntlm-auth-api-monitor &
@@ -37,7 +41,7 @@ elif [ "$option" = "stop" ]; then
 
     for env_file in $env_files; do
         iden=$(echo $env_file | awk -F '.' '{print $1}')
-        echo "stopping ntlm auth api domain service for: $iden"
+        echo "Stopping ntlm auth api domain service for: $iden"
         systemctl stop packetfence-ntlm-auth-api-domain@"$iden" &
     done
 
@@ -45,14 +49,14 @@ elif [ "$option" = "stop" ]; then
     while true; do
         svcs=$(docker ps | grep "ntlm-auth-api-")
         if [ -n "$svcs" ]; then
-            failures=$((failures+1))
+            failures=$((failures + 1))
         else
             echo "Stopped."
             break
         fi
-        
+
         if [ $failures -gt 30 ]; then
-            echo "some of the containers failed to stop after 30s, please check for details"
+            echo "Some sub services failed to stop after 30s. Please check running containers docker ps | grep ntlm-auth-api for sub service details"
             exit 1
         fi
 

--- a/sbin/ntlm-auth-api-monitor
+++ b/sbin/ntlm-auth-api-monitor
@@ -15,6 +15,7 @@ failures=0
 
 while true; do
     check_passed=1
+
     for env_file in $env_files; do
         full_path="$conf_dir$env_file"
         iden=$(echo $env_file | awk -F '.' '{print $1}')
@@ -22,32 +23,39 @@ while true; do
         host=$(cat $full_path | grep 'HOST' | awk -F '=' '{print $2}')
         port=$(cat $full_path | grep 'LISTEN' | awk -F '=' '{print $2}')
 
-        res=$(curl -X GET http://$host:$port/ping 2>/dev/null)
+        res=$(curl -X GET http://"$host:$port"/ping 2>/dev/null)
 
-        echo -n "Checking sub service for domain [$iden]: http://$host:$port/ping, response = [$res]. "
-
-        if [ "$res" != "pong" ]; then
-            check_passed=0
-            echo "Not ready. Skipped checking for other domains."
-            break
+        if [ $max_failures -gt 5 ]; then
+            echo -n "Checking sub service for domain [$iden]: http://$host:$port/ping, response = [$res]. "
+            if [ "$res" != "pong" ]; then
+                check_passed=0
+                echo "Not ready. Skipped checking for other domains."
+                break
+            else
+                echo "Ready."
+            fi
         else
-            echo "Ready."
+            if [ "$res" != "pong" ]; then
+                check_passed=0
+                echo -n "Checking sub service for domain [$iden]: http://$host:$port/ping, response = [$res]. "
+                echo "Not ready. Skipped checking for other domains."
+                break
+            fi
         fi
     done
 
     if [ $check_passed -eq 0 ]; then
-        failures=$((failures+1))
+        failures=$((failures + 1))
         if [ $failures -gt $max_failures ]; then
             echo "Maximum service check time exceeded. Service not ready. Please check logs during start up for sub service failures."
             echo '' >/usr/local/pf/var/run/ntlm-auth-api.pid
             exit 1
         fi
+        sleep 1
     else
         echo "$pid" >/usr/local/pf/var/run/ntlm-auth-api.pid
         max_failures=5
         failures=0
-        sleep 5
+        sleep 10
     fi
-
-    sleep 1
 done

--- a/sbin/ntlm-auth-api-monitor
+++ b/sbin/ntlm-auth-api-monitor
@@ -24,18 +24,21 @@ while true; do
 
         res=$(curl -X GET http://$host:$port/ping 2>/dev/null)
 
-        echo "Checking [$iden]: http://$host:$port/ping, response = [$res]"
+        echo -n "Checking sub service for domain [$iden]: http://$host:$port/ping, response = [$res]. "
 
         if [ "$res" != "pong" ]; then
             check_passed=0
+            echo "Not ready. Skipped checking for other domains."
             break
+        else
+            echo "Ready."
         fi
     done
 
     if [ $check_passed -eq 0 ]; then
         failures=$((failures+1))
         if [ $failures -gt $max_failures ]; then
-            echo "Maximum check up time exceeded. Service not ready."
+            echo "Maximum service check time exceeded. Service not ready. Please check logs during start up for sub service failures."
             echo '' >/usr/local/pf/var/run/ntlm-auth-api.pid
             exit 1
         fi


### PR DESCRIPTION
# Description
adds detailed info during ntlm-auth-api start / stop

# Impacts
changed ntlm-auth-api-docker-wrapper and ntlm-auth-api-monitor, 
detailed debug info are now outputed for admin to troubleshoot service startup failures.

# Issue
fixes #8079 

# Delete branch after merge
YES

# Checklist
- [na] Document the feature
- [na] Add OpenAPI specification
- [na] Add unit tests
- [na] Add acceptance tests (TestLink)

## Bug Fixes
* issue with no detail infomation is displayed when ntlm-auth-api failed to start #8079 
