### PR TITLE
Fixing missing OU in DN when creating machine account

### DIFF
--- a/html/pfappserver/root/src/composables/useInputValidator.js
+++ b/html/pfappserver/root/src/composables/useInputValidator.js
@@ -40,7 +40,10 @@ export const useInputValidator = (props, value, recursive = false) => {
   let localState = ref(unref(state))
   let localInvalidFeedback = ref(unref(invalidFeedback))
   let localValidFeedback = ref(unref(validFeedback))
-  let localApiFeedback = ref(unref(apiFeedback))
+  let localApiFeedback = ref(undefined)
+  watch(apiFeedback, () => {
+    localApiFeedback.value = apiFeedback.value
+  }, { immediate: true })
 
   // yup | https://github.com/jquense/yup
   let localValidator = validator

--- a/html/pfappserver/root/src/views/Configuration/domains/_components/TheForm.vue
+++ b/html/pfappserver/root/src/views/Configuration/domains/_components/TheForm.vue
@@ -52,6 +52,7 @@
         <form-group-ou namespace="ou"
                        :column-label="$i18n.t('OU')"
                        :text="$i18n.t(`Use a specific OU for the PacketFence account. The OU string read from top to bottom without RDNs and delimited by a '/'. (ex: Computers/Servers/Unix).`)"
+                       :api-feedback="ouFeedback"
         />
 
 
@@ -289,12 +290,27 @@ export const setup = (props, context) => {
     )
   })
 
+  const isDefaultOU = computed(() => {
+    const { ou } = form.value
+    return !!ou && /^computers$/i.test(ou) || !ou
+  })
+
+  const ouFeedback = computed(() => {
+    if (isDefaultOU.value) {
+      return undefined
+    }
+    return i18n.t(`Non-default OU is defined. LDAPS service on port 636 is required in Domain Controller.`)
+  })
+
+
   return {
     schema,
     formGroupComputedMachineAccountPassword,
     isMachineAccountHash,
     machineAccountFeedback,
-    machineAccountBind
+    machineAccountBind,
+    isDefaultOU,
+    ouFeedback
   }
 }
 

--- a/lib/pf/UnifiedApi/Controller/Config/Domains.pm
+++ b/lib/pf/UnifiedApi/Controller/Config/Domains.pm
@@ -134,7 +134,7 @@ sub create {
                 }
                 ($add_status, $add_result) = pf::domain::add_computer(" ", $real_computer_name, $computer_password, $ad_server_ip, $ad_server_host, $dns_name, $workgroup, $ou, $bind_dn, $bind_pass);
                 if ($add_status == $FALSE) {
-                    $self->render_error(422, "Unable to add maching account: recreating machine account with following error: $add_result");
+                    $self->render_error(422, "Unable to add machine account: recreating machine account with following error: $add_result");
                     return 0;
                 }
             }
@@ -231,7 +231,7 @@ sub update {
         my ($add_status, $add_result) = pf::domain::add_computer("-delete", $real_computer_name, $computer_password, $ad_server_ip, $ad_server_host, $dns_name, $workgroup, $ou, $bind_dn, $bind_pass);
         if ($add_status == $FALSE) {
             unless ($add_result =~ /Account (.+) not found in/) {
-                $self->render_error(422, "Unable to update - remove existing maching account with following error: $add_result");
+                $self->render_error(422, "Unable to update - remove existing machine account with following error: $add_result");
                 return 0;
             }
         }

--- a/lib/pf/UnifiedApi/Controller/Config/Domains.pm
+++ b/lib/pf/UnifiedApi/Controller/Config/Domains.pm
@@ -35,9 +35,9 @@ use Encode qw(encode);
 use Net::DNS;
 
 use JSON;
-=head2 test_join
+=head2 create
 
-Test if a domain is properly joined
+create machine account and domain config file.
 
 =cut
 

--- a/lib/pf/domain.pm
+++ b/lib/pf/domain.pm
@@ -26,7 +26,7 @@ use Encode qw(encode);
 use File::Slurp;
 
 # This is to create the templates for the domain info
-our $TT_OPTIONS = {ABSOLUTE => 1};
+our $TT_OPTIONS = { ABSOLUTE => 1 };
 our $template = Template->new($TT_OPTIONS);
 
 our $ADD_COMPUTERS_BIN = '/usr/local/pf/bin/impacket-addcomputer';
@@ -43,7 +43,7 @@ sub run {
     my $result = `$cmd`;
     my $code = $? >> 8;
 
-    return ($code , $result);
+    return ($code, $result);
 }
 
 =head2 test_join
@@ -54,16 +54,29 @@ Executes the command in the OS to test the domain join
 
 sub add_computer {
     my $option = shift;
-    my ($computer_name, $computer_password, $domain_controller_ip, $domain_controller_host, $baseDN, $computer_group, $workgroup, $bind_dn, $bind_pass) = @_;
+    my ($computer_name, $computer_password, $domain_controller_ip, $domain_controller_host, $dns_name, $workgroup, $ou, $bind_dn, $bind_pass) = @_;
+
+    $ou =~ s/^\s+|\s+$//g;
+    $ou =~ s/^['"]|['"]$//g;
+
+    my $method = "LDAPS";
+    if (!defined($ou) || uc($ou) eq "COMPUTERS" || $ou == "") {
+        $method = "SAMR"
+    }
 
     $computer_name = escape_bind_user_string($computer_name) . "\$";
     $computer_password = escape_bind_user_string($computer_password);
     my $domain_auth = escape_bind_user_string("$workgroup/$bind_dn");
     my $nt_hash = md4_hex(encode("utf-16le", $bind_pass));
 
+    my $baseDN = generate_base_dn($dns_name);
+    my $computer_group = generate_computer_group($dns_name, $ou);
+
     my $result;
     eval {
-        my $command = "$ADD_COMPUTERS_BIN -computer-name $computer_name -computer-pass '$computer_password' -dc-ip $domain_controller_ip -dc-host '$domain_controller_host' -baseDN '$baseDN' -computer-group $computer_group '$domain_auth' -hashes ':$nt_hash' $option";
+        my $command = "$ADD_COMPUTERS_BIN -computer-name $computer_name -computer-pass '$computer_password' -dc-ip $domain_controller_ip -dc-host '$domain_controller_host' -baseDN '$baseDN' -computer-group '$computer_group' '$domain_auth' -hashes ':$nt_hash' $option -method=$method";
+        print($command, "\n");
+
         $result = pf_run($command, accepted_exit_status => [ 0 ]);
     };
     if ($@) {
@@ -101,7 +114,45 @@ sub escape_bind_user_string {
     return $s;
 }
 
+sub generate_base_dn {
+    my $ret = "";
 
+    my ($dns_name) = @_;
+    my @array = split(/\./, $dns_name);
+
+    foreach my $element (@array) {
+        $ret .= "DC=$element,";
+    }
+    $ret =~ s/,$//;
+    return $ret;
+}
+
+sub generate_computer_group {
+    my $ret = "";
+
+    my ($dns_name, $ou) = @_;
+    my @array = split(/\./, $dns_name);
+
+    foreach my $element (@array) {
+        $ret .= "DC=$element,";
+    }
+    $ret =~ s/,$//;
+
+    $ret .= "CN=Computers," . $ret;
+
+    if (defined($ou)) {
+        $ou =~ s/^\s+|\s+$//g;
+        $ou =~ s/^['"]|['"]$//g;
+
+        if ($ou eq "COMPUTERS" || $ou eq "") {
+            $ret .= ",OU=Computers"
+        }
+        else {
+            $ret .= ",OU=" . $ou
+        }
+    }
+    return $ret;
+}
 
 
 

--- a/lib/pf/domain.pm
+++ b/lib/pf/domain.pm
@@ -67,14 +67,15 @@ sub add_computer {
     $computer_name = escape_bind_user_string($computer_name) . "\$";
     $computer_password = escape_bind_user_string($computer_password);
     my $domain_auth = escape_bind_user_string("$dns_name/$bind_dn:$bind_pass");
-    my $nt_hash = md4_hex(encode("utf-16le", $bind_pass));
-
     my $baseDN = generate_base_dn($dns_name);
     my $computer_group = generate_computer_group($dns_name, $ou);
 
+    $baseDN = escape_bind_user_string($baseDN);
+    $computer_group = escape_bind_user_string($computer_group);
+
     my $result;
     eval {
-        my $command = "$ADD_COMPUTERS_BIN -computer-name $computer_name -computer-pass '$computer_password' -dc-ip $domain_controller_ip -dc-host '$domain_controller_host' -baseDN '$baseDN' -computer-group '$computer_group' '$domain_auth' $option -method=$method";
+        my $command = "$ADD_COMPUTERS_BIN -computer-name '$computer_name' -computer-pass '$computer_password' -dc-ip $domain_controller_ip -dc-host '$domain_controller_host' -baseDN '$baseDN' -computer-group '$computer_group' '$domain_auth' $option -method=$method";
         $result = pf_run($command, accepted_exit_status => [ 0 ]);
     };
     if ($@) {

--- a/lib/pf/domain.pm
+++ b/lib/pf/domain.pm
@@ -56,11 +56,15 @@ sub add_computer {
     my $option = shift;
     my ($computer_name, $computer_password, $domain_controller_ip, $domain_controller_host, $dns_name, $workgroup, $ou, $bind_dn, $bind_pass) = @_;
 
+    if (!defined($ou)) {
+        $ou = ""
+    }
+
     $ou =~ s/^\s+|\s+$//g;
     $ou =~ s/^['"]|['"]$//g;
 
     my $method = "LDAPS";
-    if (!defined($ou) || uc($ou) eq "COMPUTERS" || $ou eq "") {
+    if (uc($ou) eq "COMPUTERS" || $ou eq "") {
         $method = "SAMR"
     }
 
@@ -133,18 +137,8 @@ sub generate_computer_group {
     my $base_dn = generate_base_dn($dns_name);
 
     # for OU=Computer or OU="", we put the machine account to CN=Computers.
-    if (!defined($ou)) {
-        $ou = ""
-    }
-    $ou =~ s/^\s+|\s+$//g;
-    $ou =~ s/^['"]|['"]$//g;
-    if (uc($ou) eq "COMPUTERS") {
-        $ou = ""
-    }
-
-    if ($ou eq "") {
-        $ret = "CN=Computers," . $base_dn;
-        return $ret
+    if (!defined($ou) || uc($ou) eq "COMPUTERS" || $ou eq "") {
+        return "CN=Computers," . $base_dn;
     }
 
     # Handle real OU strings


### PR DESCRIPTION
# Description
Fix missing OU settings when creating machine account,
when OU presents, add computers using LDAPS instead of SAMR. 

# Impacts
changed the logic of adding / updating machine account, will not do "-no-add", will do "delete" and "add" instead
changed protocols used in adding machine account. LDAPS will be chosen if OU presents. 
LDAPS service is required on Windows Domain Controller (Port 636 with MS AD Cert Service)
changed NT Hash authentication back to password auth because LDAPS failed to bind when using NT Hash.
escapes multiple possible strings to allow special characters such as ", ', or \, etc...

# Issue
fixes #8112 

# Delete branch after merge
YES

# Checklist
- [n/a] Document the feature
- [n/a] Add OpenAPI specification
- [n/a] Add unit tests
- [n/a] Add acceptance tests (TestLink)



## Bug Fixes
* Issue with OU parameter not taken when creating machine account. (#8112)

