### PR TITLE
Fixes logic when pfacct and radius-acct are enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,4 @@ Licensed under the GNU General Public License v2.
 
 
 [mailing_lists]: https://packetfence.org/support/index.html#/community "Community Mailing Lists"
+

--- a/lib/pf/services/manager/pfacct.pm
+++ b/lib/pf/services/manager/pfacct.pm
@@ -59,10 +59,9 @@ Generate the environment variables for running the container
 
 sub generate_container_environments {
     my ($self, $tt) = @_;
-    my $management_ip = $management_network->tag('ip');
 
     my $port = '1813';
-    my $listeningIp = $management_ip;
+    my $listeningIp = "";
     if ($cluster_enabled || isenabled($Config{services}{radiusd_acct})) {
         $port = '1823';
     }

--- a/lib/pf/services/manager/pfacct.pm
+++ b/lib/pf/services/manager/pfacct.pm
@@ -68,12 +68,14 @@ sub generate_container_environments {
     if ($cluster_enabled && isenabled($Config{services}{radiusd_acct})) {
         $port = '1833';
     }
+    my $listen = $port;
     if (isenabled($Config{services}{radiusd_acct})) {
         $listeningIp = '127.0.0.1';
+        $listen = "$listeningIp:$port";
     }
     my $vars = {
        env_dict => {
-           PFACCT_ADDRESS=> "$listeningIp:$port",
+           PFACCT_ADDRESS=> "$listen",
        },
     };
     $tt->process("/usr/local/pf/containers/environment.template", $vars, "/usr/local/pf/var/conf/acct.env") or die $tt->error();

--- a/lib/pf/services/manager/pfacct.pm
+++ b/lib/pf/services/manager/pfacct.pm
@@ -15,11 +15,14 @@ use warnings;
 use pf::util;
 use Moo;
 use Template;
+use pf::log;
 use pf::cluster;
 use pf::config qw(
     $management_network
     %Config
+    @radius_ints
 );
+use List::MoreUtils qw(any uniq);
 
 extends 'pf::services::manager';
 with 'pf::services::manager::roles::env_golang_service';
@@ -59,20 +62,33 @@ Generate the environment variables for running the container
 
 sub generate_container_environments {
     my ($self, $tt) = @_;
+    my $logger = get_logger();
+    my @listen_ips;
 
-    my $port = '1813';
+    my $port = '-p 1813:1813/udp';
+    my $port_save;
     my $listeningIp = "";
     if ($cluster_enabled || isenabled($Config{services}{radiusd_acct})) {
         my $management_ip = $management_network->tag('ip');
-        $port = "$management_ip:1823";
+        $port = "-p $management_ip:1823:1813/udp";
+        $port_save = "1823"
     }
     if ($cluster_enabled && isenabled($Config{services}{radiusd_acct})) {
-        $port = '1833';
+        $port = "-p 1833:1813/udp";
+        $port_save = "1833";
     }
     my $listen = $port;
     if (isenabled($Config{services}{radiusd_acct})) {
         $listeningIp = '127.0.0.1';
-        $listen = "$listeningIp:$port";
+        $listen = "-p $listeningIp:$port_save:1813/udp";
+    } else {
+         if (!$cluster_enabled) {
+            foreach my $interface ( uniq(@radius_ints) ) {
+                push @listen_ips, $interface->tag('ip');
+            }
+            my @interfaces = map { $_.":1813:1813/udp" } @listen_ips;
+            $listen = "-p " . join " -p ",@interfaces;
+         }
     }
     my $vars = {
        env_dict => {

--- a/lib/pf/services/manager/pfacct.pm
+++ b/lib/pf/services/manager/pfacct.pm
@@ -63,7 +63,8 @@ sub generate_container_environments {
     my $port = '1813';
     my $listeningIp = "";
     if ($cluster_enabled || isenabled($Config{services}{radiusd_acct})) {
-        $port = '1823';
+        my $management_ip = $management_network->tag('ip');
+        $port = "$management_ip:1823";
     }
     if ($cluster_enabled && isenabled($Config{services}{radiusd_acct})) {
         $port = '1833';

--- a/lib/pf/services/manager/radiusd_child.pm
+++ b/lib/pf/services/manager/radiusd_child.pm
@@ -1088,7 +1088,7 @@ EOT
             $port = '1833';
         }
 
-	$tags{'pfacct'} = <<"EOT";
+    $tags{'pfacct'} = <<"EOT";
 # pfacct configuration
 
 realm pfacct {

--- a/lib/pf/services/manager/radiusd_child.pm
+++ b/lib/pf/services/manager/radiusd_child.pm
@@ -1080,7 +1080,15 @@ EOT
 
     if(isenabled($Config{services}{pfacct})) {
         my $management_ip = defined($management_network->tag('vip')) ? $management_network->tag('vip') : $management_network->tag('ip');
-        $tags{'pfacct'} = <<"EOT";
+        my $port = '1813';
+        if ($cluster_enabled || isenabled($Config{services}{radiusd_acct})) {
+            $port = '1823';
+        }
+        if ($cluster_enabled && isenabled($Config{services}{radiusd_acct})) {
+            $port = '1833';
+        }
+
+	$tags{'pfacct'} = <<"EOT";
 # pfacct configuration
 
 realm pfacct {
@@ -1095,7 +1103,7 @@ home_server_pool pfacct_pool {
 home_server pfacct_local {
     type = acct
     ipaddr = 127.0.0.1
-    port = 1813
+    port = $port
     secret = '$local_secret'
     src_ipaddr = $management_ip
 }

--- a/sbin/pfacct-docker-wrapper
+++ b/sbin/pfacct-docker-wrapper
@@ -13,6 +13,6 @@ args="$args -v /usr/local/pf/conf/system_init_key:/usr/local/pf/conf/system_init
 args="$args -v /usr/local/pf/raddb:/usr/local/pf/raddb"
 args="$args -v /usr/share/freeradius:/usr/share/freeradius"
 args="$args -p 2056:2056/udp"
-args="$args -p $PFACCT_ADDRESS:1813/udp"
+args="$args $PFACCT_ADDRESS"
 
 run $name "$args"


### PR DESCRIPTION
# Description
Fixes the logic in order to run pfacct and radiusd-acct if all are enabled together 

# Impacts
Radius accounting

# Delete branch after merge
YES 

# NEWS file entries
## Bug Fixes
* Fixes the logic when pfacct and radiusd-acct are enabled together (using the same listening port)
