### PR TITLE
Fix 8105 handle previous PF export file version (11.x, 12.x and 13.0 )

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,4 +95,3 @@ Licensed under the GNU General Public License v2.
 
 [mailing_lists]: https://packetfence.org/support/index.html#/community "Community Mailing Lists"
 
-

--- a/README.md
+++ b/README.md
@@ -95,3 +95,4 @@ Licensed under the GNU General Public License v2.
 
 [mailing_lists]: https://packetfence.org/support/index.html#/community "Community Mailing Lists"
 
+

--- a/addons/full-import/import.sh
+++ b/addons/full-import/import.sh
@@ -49,7 +49,7 @@ prepare_import() {
 
     # fix path issue from old pf version
     if [ -f "$extract_dir/usr/local/pf/usr/local/pf/conf/pf-release" ]; then
-        echo "Your version is comming from packetfence < 13.1"
+        echo "Your version is comming from Packetfence < 13.1"
         mv "$extract_dir/usr/local/pf/usr/local/pf/*" "$extract_dir/usr/local/pf"
         rm -rf "$extract_dir/usr/local/pf/usr/"
     fi

--- a/addons/full-import/import.sh
+++ b/addons/full-import/import.sh
@@ -47,6 +47,13 @@ prepare_import() {
     mkdir -p $extract_dir/usr/local/pf
     tar -xf $files_dump -C $extract_dir/usr/local/pf
 
+    # fix path issue from old pf version
+    if [ -f "$extract_dir/usr/local/pf/usr/local/pf/conf/pf-release" ]; then
+        echo "Your version is comming from packetfence < 13.1"
+        mv "$extract_dir/usr/local/pf/usr/local/pf/*" "$extract_dir/usr/local/pf"
+        rm -rf "$extract_dir/usr/local/pf/usr/"
+    fi
+
     main_splitter
 
     db_dump=`ls packetfence-db-dump-*`

--- a/addons/full-import/import.sh
+++ b/addons/full-import/import.sh
@@ -50,7 +50,7 @@ prepare_import() {
     # fix path issue from old pf version
     if [ -f "$extract_dir/usr/local/pf/usr/local/pf/conf/pf-release" ]; then
         echo "Your version is comming from Packetfence < 13.1"
-        mv "$extract_dir/usr/local/pf/usr/local/pf/*" "$extract_dir/usr/local/pf"
+        mv $extract_dir/usr/local/pf/usr/local/pf/* $extract_dir/usr/local/pf
         rm -rf "$extract_dir/usr/local/pf/usr/"
     fi
 


### PR DESCRIPTION
# Description
Should fix 8105 for version previous 13.1 that have the export with complete path.

# Impacts
Fix import in 13.2 and after

# Issue
fixes #8105 

# Delete branch after merge
YES

# NEED TO BE BACK PORTED TO 13.2 AND 13.1