### PR TITLE
Fix/dedicated machine account for cluster

### DIFF
--- a/addons/upgrade/to-13.1-move-ntlm-auth-to-rest.pl
+++ b/addons/upgrade/to-13.1-move-ntlm-auth-to-rest.pl
@@ -18,7 +18,7 @@ use lib qw(/usr/local/pf/lib /usr/local/pf/lib_perl/lib/perl5);
 use pf::IniFiles;
 use pf::file_paths qw($authentication_config_file $domain_config_file);
 use pf::util;
-use pf::cluster qw($cluster_enabled $host_id);;
+use pf::cluster qw($cluster_enabled $host_id);
 use Digest::MD4;
 use Encode;
 use MIME::Base64;

--- a/addons/upgrade/to-14.0-update-domain-config-section.pl
+++ b/addons/upgrade/to-14.0-update-domain-config-section.pl
@@ -56,7 +56,7 @@ Inverse inc. <info@inverse.ca>
 
 =head1 COPYRIGHT
 
-Copyright (C) 2005-2023 Inverse inc.
+Copyright (C) 2005-2024 Inverse inc.
 
 =head1 LICENSE
 

--- a/addons/upgrade/to-14.0-update-domain-config-section.pl
+++ b/addons/upgrade/to-14.0-update-domain-config-section.pl
@@ -1,0 +1,79 @@
+#!/usr/bin/perl
+
+=head1 NAME
+
+addons/upgrade/to-14.0-update-domain-config-section.pl
+
+=cut
+
+=head1 DESCRIPTION
+
+changing section name from `domain_identifier` to `hostname domain_identifier`
+so PF cluster node can have individual config values.
+
+=cut
+
+use strict;
+use warnings;
+use lib qw(/usr/local/pf/lib /usr/local/pf/lib_perl/lib/perl5);
+use pf::IniFiles;
+use pf::file_paths qw($domain_config_file);
+use pf::util;
+use Sys::Hostname;
+
+my $ini = pf::IniFiles->new(-file => $domain_config_file, -allowempty => 1);
+
+unless (defined $ini) {
+    print("Error loading domain config file. Terminated. Try re-run this script or edit domain settings in admin UI manually. /\n");
+    exit;
+}
+
+my $updated = 0;
+my $hostname = hostname();
+
+for my $section (grep {/^\S+/} $ini->Sections()) {
+    print("Processing section '$section' in domain.conf: ");
+    if ($section =~ /^[a-zA-Z0-9\-\._]+ [a-zA-Z0-9]+$/) {
+        print("already up to date\n");
+    }
+    else {
+        my $new_section_name = "$hostname $section";
+        $ini->RenameSection($section, $new_section_name);
+        print("renaming '$section' -> '$new_section_name'\n");
+        $updated = 1;
+    }
+}
+
+if ($updated == 1) {
+    $ini->RewriteConfig();
+}
+
+
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2023 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+

--- a/bin/pyntlm_auth/config_generator.py
+++ b/bin/pyntlm_auth/config_generator.py
@@ -1,4 +1,9 @@
+import os
+
+
 def generate_empty_conf():
+    path = '/usr/local/pf/var/conf/'
+    os.makedirs(path, exist_ok=True)
     with open('/usr/local/pf/var/conf/default.conf', 'w') as file:
         file.write("\n")
 

--- a/bin/pyntlm_auth/config_loader.py
+++ b/bin/pyntlm_auth/config_loader.py
@@ -253,6 +253,7 @@ def config_load():
     global_vars.c_workstation = workstation
     global_vars.c_server_string = server_string
     global_vars.c_domain = domain
+    global_vars.c_dns_servers = dns_servers
 
     global_vars.c_nt_key_cache_enabled = nt_key_cache_enabled
     global_vars.c_nt_key_cache_expire = int(nt_key_cache_expire)

--- a/bin/pyntlm_auth/config_loader.py
+++ b/bin/pyntlm_auth/config_loader.py
@@ -39,7 +39,7 @@ def get_int_value(v):
 
 def config_load():
     global_vars.c_listen_port = os.getenv("LISTEN")
-    global_vars.c_domain_identifier = os.getenv("IDENTIFIER")
+    global_vars.c_domain_identifier = hostname = socket.gethostname() + " " + os.getenv("IDENTIFIER")
 
     if global_vars.c_domain_identifier == "" or global_vars.c_listen_port == "":
         print("Unable to start ntlm-auth-api: 'IDENTIFIER' or 'LISTEN' is missing.")

--- a/bin/pyntlm_auth/global_vars.py
+++ b/bin/pyntlm_auth/global_vars.py
@@ -41,6 +41,7 @@ c_username = None
 c_server_name = None
 c_listen_port = None
 c_domain_identifier = None
+c_dns_servers = None
 
 # config for domain.conf - db
 c_db_host = None

--- a/bin/pyntlm_auth/rpc.py
+++ b/bin/pyntlm_auth/rpc.py
@@ -8,6 +8,7 @@ import utils
 import datetime
 from samba.dcerpc.netlogon import (netr_Authenticator, MSV1_0_ALLOW_WORKSTATION_TRUST_ACCOUNT, MSV1_0_ALLOW_MSVCHAPV2)
 import binascii
+import random
 
 
 def init_secure_connection():
@@ -19,7 +20,13 @@ def init_secure_connection():
     password = global_vars.c_password
     domain = global_vars.c_domain
     username = global_vars.c_username
-    server_name = global_vars.c_server_name
+    server_name = global_vars.c_server_name # FQDN of Domain Controller
+
+    domain_controller_records = utils.find_ldap_servers(global_vars.c_realm, global_vars.c_dns_servers)
+    if len(domain_controller_records) > 0:
+        idx = random.randint(0, len(domain_controller_records) -1)
+        record = domain_controller_records[idx]
+        server_name = record.get('target')
 
     lp = param.LoadParm()
     try:

--- a/bin/pyntlm_auth/utils.py
+++ b/bin/pyntlm_auth/utils.py
@@ -53,6 +53,44 @@ def dns_lookup(hostname, dns_server):
         return "", str(e)
 
 
+def find_ldap_servers(domain, dns_server):
+    query_name = f'_ldap._tcp.{domain}'
+
+    if dns_server != "":
+        resolver = dns.resolver.Resolver(configure=False)
+        resolver.nameservers = dns_server.split(",")
+    else:
+        resolver = dns.resolver.Resolver()
+
+    try:
+        ldap_servers = []
+
+        answers = resolver.query(query_name, 'SRV')
+        for srv in answers:
+            priority = srv.priority
+            weight = srv.weight
+            port = srv.port
+            target = srv.target.to_text()
+            ldap_servers.append({
+                'priority': priority,
+                'weight': weight,
+                'port': port,
+                'target': target
+            })
+
+        return ldap_servers
+
+    except dns.resolver.NoAnswer:
+        print(f'No SRV records found for {query_name}')
+        return []
+    except dns.resolver.NXDOMAIN:
+        print(f'Domain {domain} does not exist')
+        return []
+    except Exception as e:
+        print(f'An error occurred: {e}')
+        return []
+
+
 def expires(in_second):
     ts = datetime.datetime.now().timestamp() + in_second
     return int(ts)

--- a/bin/pyntlm_auth/utils.py
+++ b/bin/pyntlm_auth/utils.py
@@ -54,7 +54,7 @@ def dns_lookup(hostname, dns_server):
 
 
 def find_ldap_servers(domain, dns_server):
-    query_name = f'_ldap._tcp.{domain}'
+    query_name = f'_ldap._tcp.dc._msdcs.{domain}'
 
     if dns_server != "":
         resolver = dns.resolver.Resolver(configure=False)

--- a/docs/installation/authentication_mechanisms.asciidoc
+++ b/docs/installation/authentication_mechanisms.asciidoc
@@ -58,6 +58,8 @@ NOTE: If you are using an Active/Active cluster, each member of the cluster must
 
 NOTE: If you are using PacketFence in cluster mode, you must save the domain settings on *each* of the nodes by given the same *clear-text* machine account password. By default, PacketFence will only save the NT hash of the machine account password, and it will be shown in Admin UI. However, PacketFence won't be able to create a machine account using a password hash. In order to keep the domain settings identical on all the nodes, you'll have to type in the same clear-text machine account password on each of the node and save them.
 
+NOTE: after version 14.0, the PacketFence domain.conf will be updated, domain identifier is changed from previously single identifier to "hostname + identifier". If you are running PacketFence in a cluster, please check the corresponding sections for each node.
+
 ==== Troubleshooting
 
 * In order to troubleshoot unsuccessful binds, please refer to the following file : `/usr/local/pf/log/packetfence.log`. Search for "ntlm-auth-api-domain" for all ntlm-auth-api entries.

--- a/go/plugin/caddy2/api/ntlm.go
+++ b/go/plugin/caddy2/api/ntlm.go
@@ -6,8 +6,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/inverse-inc/packetfence/go/caddy/ntlm"
+	"github.com/inverse-inc/packetfence/go/pfconfigdriver"
 	"github.com/julienschmidt/httprouter"
 	"net/http"
+	"os"
 )
 
 type PasswordChangeEvent struct {
@@ -60,7 +62,14 @@ func (h APIHandler) eventReport(w http.ResponseWriter, r *http.Request, p httpro
 		return
 	}
 
-	sectionConf, exists := domainConfig.Element[req.Domain]
+	var sectionConf interface{}
+	var exists bool
+	if pfconfigdriver.GetClusterSummary(ctx).ClusterEnabled == 1 {
+		hostname, _ := os.Hostname()
+		sectionConf, exists = domainConfig.Element[hostname+" "+req.Domain]
+	} else {
+		sectionConf, exists = domainConfig.Element[req.Domain]
+	}
 	if !exists {
 		w.WriteHeader(http.StatusNotFound)
 		res := &response{
@@ -145,7 +154,14 @@ func (h APIHandler) ntlmTest(w http.ResponseWriter, r *http.Request, p httproute
 		return
 	}
 
-	sectionConf, exists := domainConfig.Element[req.Id]
+	var sectionConf interface{}
+	var exists bool
+	if pfconfigdriver.GetClusterSummary(ctx).ClusterEnabled == 1 {
+		hostname, _ := os.Hostname()
+		sectionConf, exists = domainConfig.Element[hostname+" "+req.Id]
+	} else {
+		sectionConf, exists = domainConfig.Element[req.Id]
+	}
 	if !exists {
 		w.WriteHeader(http.StatusNotFound)
 		res := &response{

--- a/go/plugin/caddy2/api/ntlm.go
+++ b/go/plugin/caddy2/api/ntlm.go
@@ -5,11 +5,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
-
-	"github.com/inverse-inc/packetfence/go/ntlm"
+	"github.com/inverse-inc/packetfence/go/caddy/ntlm"
 	"github.com/julienschmidt/httprouter"
-	"os"
+	"net/http"
 )
 
 type PasswordChangeEvent struct {
@@ -62,8 +60,7 @@ func (h APIHandler) eventReport(w http.ResponseWriter, r *http.Request, p httpro
 		return
 	}
 
-	hostname, _ := os.Hostname()
-	sectionConf, exists := domainConfig.Element[hostname+" "+req.Domain]
+	sectionConf, exists := domainConfig.Element[req.Domain]
 	if !exists {
 		w.WriteHeader(http.StatusNotFound)
 		res := &response{
@@ -148,8 +145,7 @@ func (h APIHandler) ntlmTest(w http.ResponseWriter, r *http.Request, p httproute
 		return
 	}
 
-	hostname, _ := os.Hostname()
-	sectionConf, exists := domainConfig.Element[hostname+" "+req.Id]
+	sectionConf, exists := domainConfig.Element[req.Id]
 	if !exists {
 		w.WriteHeader(http.StatusNotFound)
 		res := &response{

--- a/go/plugin/caddy2/api/ntlm.go
+++ b/go/plugin/caddy2/api/ntlm.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/inverse-inc/packetfence/go/ntlm"
 	"github.com/julienschmidt/httprouter"
+	"os"
 )
 
 type PasswordChangeEvent struct {
@@ -61,7 +62,8 @@ func (h APIHandler) eventReport(w http.ResponseWriter, r *http.Request, p httpro
 		return
 	}
 
-	sectionConf, exists := domainConfig.Element[req.Domain]
+	hostname, _ := os.Hostname()
+	sectionConf, exists := domainConfig.Element[hostname+" "+req.Domain]
 	if !exists {
 		w.WriteHeader(http.StatusNotFound)
 		res := &response{
@@ -146,7 +148,8 @@ func (h APIHandler) ntlmTest(w http.ResponseWriter, r *http.Request, p httproute
 		return
 	}
 
-	sectionConf, exists := domainConfig.Element[req.Id]
+	hostname, _ := os.Hostname()
+	sectionConf, exists := domainConfig.Element[hostname+" "+req.Id]
 	if !exists {
 		w.WriteHeader(http.StatusNotFound)
 		res := &response{

--- a/html/pfappserver/lib/pfappserver/Form/Config/Domain.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Domain.pm
@@ -19,7 +19,6 @@ use pf::config;
 use pf::util;
 use pf::authentication;
 use Sys::Hostname;
-use pf::cluster qw($cluster_enabled);
 
 ## Definition
 has_field 'id' => (
@@ -32,19 +31,11 @@ has_field 'id' => (
         after_element => \&help,
         help => 'Specify a unique identifier for your configuration.<br/>This doesn\'t have to be related to your domain',
         option_pattern => sub {
-            if ($cluster_enabled) {
-                return {
-                    regex => "^[0-9a-zA-Z]+ [0-9a-zA-Z]+\$",
-                    message =>
-                        "The id is invalid. The id can only contain alphanumeric characters.",
-                };
-            } else {
-                return {
-                    regex => "^[0-9a-zA-Z]+\$",
-                    message =>
-                        "The id is invalid. The id can only contain alphanumeric characters.",
-                };
-            }
+            return {
+                regex => "^[0-9a-zA-Z]+\$",
+                message =>
+                    "The id is invalid. The id can only contain alphanumeric characters.",
+            };
         },
     },
 );
@@ -338,14 +329,8 @@ Validate NTLM cache fields if ntlm_cache is enabled
 sub validate {
     my ($self) = @_;
 
-    if($cluster_enabled) {
-        if (($self->field('id')->value() // '') !~ /^[0-9a-zA-Z]+ [0-9a-zA-Z]+$/) {
-            $self->field('id')->add_error("The id is invalid. The id can only contain alphanumeric characters.");
-        }
-    } else {
-        if (($self->field('id')->value() // '') !~ /^[0-9a-zA-Z]+$/) {
-            $self->field('id')->add_error("The id is invalid. The id can only contain alphanumeric characters.");
-        }
+    if (($self->field('id')->value() // '') !~ /^[0-9a-zA-Z\.\-_]+ [0-9a-zA-Z]+$/) {
+        $self->field('id')->add_error("The id is invalid. The id can only contain alphanumeric characters.");
     }
 
     if($self->field('server_name')->value() eq "%h") {

--- a/html/pfappserver/lib/pfappserver/Form/Config/Domain.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Domain.pm
@@ -19,23 +19,32 @@ use pf::config;
 use pf::util;
 use pf::authentication;
 use Sys::Hostname;
+use pf::cluster qw($cluster_enabled);
 
 ## Definition
 has_field 'id' => (
     type      => 'Text',
     label     => 'Identifier',
     required  => 1,
-    maxlength => 10,
+    maxlength => 30,
     messages  => { required => 'Please specify an identifier' },
     tags      => {
         after_element => \&help,
         help => 'Specify a unique identifier for your configuration.<br/>This doesn\'t have to be related to your domain',
         option_pattern => sub {
-            return {
-                regex => "^[0-9a-zA-Z]+\$",
-                message =>
-"The id is invalid. The id can only contain alphanumeric characters.",
-            };
+            if ($cluster_enabled) {
+                return {
+                    regex => "^[0-9a-zA-Z]+ [0-9a-zA-Z]+\$",
+                    message =>
+                        "The id is invalid. The id can only contain alphanumeric characters.",
+                };
+            } else {
+                return {
+                    regex => "^[0-9a-zA-Z]+\$",
+                    message =>
+                        "The id is invalid. The id can only contain alphanumeric characters.",
+                };
+            }
         },
     },
 );
@@ -329,8 +338,14 @@ Validate NTLM cache fields if ntlm_cache is enabled
 sub validate {
     my ($self) = @_;
 
-    if(($self->field('id')->value() // '') !~ /^[0-9a-zA-Z]+$/) {
-        $self->field('id')->add_error("The id is invalid. The id can only contain alphanumeric characters.");
+    if($cluster_enabled) {
+        if (($self->field('id')->value() // '') !~ /^[0-9a-zA-Z]+ [0-9a-zA-Z]+$/) {
+            $self->field('id')->add_error("The id is invalid. The id can only contain alphanumeric characters.");
+        }
+    } else {
+        if (($self->field('id')->value() // '') !~ /^[0-9a-zA-Z]+$/) {
+            $self->field('id')->add_error("The id is invalid. The id can only contain alphanumeric characters.");
+        }
     }
 
     if($self->field('server_name')->value() eq "%h") {

--- a/lib/pf/ConfigStore/Domain.pm
+++ b/lib/pf/ConfigStore/Domain.pm
@@ -18,13 +18,17 @@ use warnings;
 use Moo;
 use pf::file_paths qw($domain_config_file);
 use pf::constants qw($FALSE);
+use Sys::Hostname;
 extends 'pf::ConfigStore';
 with 'pf::ConfigStore::Role::ReverseLookup';
 
 sub configFile { $domain_config_file };
 
+# seems not used anywhere
 sub canDelete {
     my ($self, $id) = @_;
+    my $host_id = hostname();
+    $id =~ s/$host_id //i;
     if ($self->isInRealm('domain', $id)) {
         return "Used in a realm", $FALSE;
     }

--- a/lib/pf/UnifiedApi/Controller/Config/Domains.pm
+++ b/lib/pf/UnifiedApi/Controller/Config/Domains.pm
@@ -34,6 +34,7 @@ use Digest::MD4 qw(md4_hex);
 use Encode qw(encode);
 use Net::DNS;
 use JSON;
+use pf::constants qw($TRUE $FALSE);
 
 my $host_id = hostname();
 
@@ -61,15 +62,15 @@ sub get {
         $item = $self->cleanupItemForGet($item);
         return $self->render(json => { item => $item }, status => 200);
     }
-    return $self->render_error(500, "Unknown error getting item");;
+    return $self->render_error(500, "Unknown error getting item");
 }
 
 sub item_shown {
     my ($self, $item) = @_;
     if ($item->{id} =~ s/$host_id //i) {
-        return 1;
+        return $TRUE;
     }
-    return 0;
+    return $FALSE;
 }
 
 sub handle_search {

--- a/lib/pf/UnifiedApi/Controller/Config/Domains.pm
+++ b/lib/pf/UnifiedApi/Controller/Config/Domains.pm
@@ -64,6 +64,14 @@ sub get {
     return $self->render_error(500, "Unknown error getting item");;
 }
 
+sub item_shown {
+    my ($self, $item) = @_;
+    if ($item->{id} =~ s/$host_id //i) {
+        return 1;
+    }
+    return 0;
+}
+
 sub handle_search {
     my ($self, $search_info) = @_;
     my ($status, $response) = $self->search_builder->search($search_info);

--- a/lib/pf/services/manager/ntlm_auth_api.pm
+++ b/lib/pf/services/manager/ntlm_auth_api.pm
@@ -31,6 +31,7 @@ use pf::file_paths qw(
 );
 use pf::util;
 use pf::constants qw($TRUE $FALSE);
+use pf::cluster qw($cluster_enabled $host_id);;
 
 extends 'pf::services::manager';
 
@@ -65,8 +66,10 @@ sub generateConfig {
 
     my $host_id = hostname();
     for my $identifier (keys(%ConfigDomain)) {
-        unless ($identifier =~ /^$host_id /) {
-            next;
+        if ($cluster_enabled) {
+            unless ($identifier =~ /^$host_id /) {
+                next;
+            }
         }
         my %conf = %{$ConfigDomain{$identifier}};
         if (exists($conf{ntlm_auth_host}) && exists($conf{ntlm_auth_port}) && exists($conf{machine_account_password})) {

--- a/lib/pfconfig/namespaces/config/Domain.pm
+++ b/lib/pfconfig/namespaces/config/Domain.pm
@@ -20,7 +20,6 @@ use warnings;
 use JSON;
 
 use pfconfig::namespaces::config;
-use Data::Dumper;
 use pf::log;
 use pf::file_paths qw($domain_config_file);
 use Sys::Hostname;


### PR DESCRIPTION
# Cluster support for domain.conf 
* allow PacketFence nodes in a cluster have their own dedicated settings in domain.conf
* adds HA support when establishing secure connections.

# Impacts
* changed the domain.conf structure - For now the section name will always be `hostname domain_id`
* changed the steps when init secure connection - perform a dns query and obtain all available domain controllers, choose one to connect.

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)


## Enhancements
* allow different settings in domain.conf for each nodes in a cluster. e.g., each node has its own machine account name and password.
* supports domain controller high availibity now with a SRV query of DNS

