### PR TITLE
Move increase disk size for pf vms before any installation

### DIFF
--- a/addons/vagrant/pfservers/Vagrantfile
+++ b/addons/vagrant/pfservers/Vagrantfile
@@ -72,21 +72,6 @@ Vagrant.configure("2") do |config|
           v.machine_virtual_size = details['disk_size']
         end
 
-        ###########################
-        # extend disk partition
-        ###########################
-        srv.vm.provision "shell", inline: <<-SHELL
-            if [ -f /etc/redhat-release ] ; then
-              lvextend -l +100%FREE /dev/rhel_rhel8/root
-              xfs_growfs /dev/rhel_rhel8/root
-            else
-              apt update
-              apt install -y cloud-guest-utils
-              growpart /dev/vda 1
-              resize2fs -p /dev/vda1
-            fi
-          SHELL
-
         # provisionners
         # Sync timezone with host
         srv.vm.provision "shell", inline: "sudo rm /etc/localtime && sudo ln -s /usr/share/zoneinfo/#{inventory['all']['vars']['tz']} /etc/localtime", run: "always"

--- a/addons/vagrant/playbooks/increase_disk_size_pf.yml
+++ b/addons/vagrant/playbooks/increase_disk_size_pf.yml
@@ -1,0 +1,17 @@
+- hosts: pfservers
+  name: increase pf disk size on standalone
+  become: True
+
+  tasks:
+
+    - name: increase disk size
+      ansible.builtin.shell: |
+        if [ -f /etc/redhat-release ] ; then
+          lvextend -l +100%FREE /dev/rhel_rhel8/root
+          xfs_growfs /dev/rhel_rhel8/root
+        else
+          apt update
+          apt install -y cloud-guest-utils
+          growpart /dev/vda 1
+          resize2fs -p /dev/vda1
+        fi

--- a/addons/vagrant/site.yml
+++ b/addons/vagrant/site.yml
@@ -4,6 +4,8 @@
 - import_playbook: playbooks/env_vars.yml
   tags: env
 
+- import_playbook: playbooks/increase_disk_size_pf.yml
+
 - import_playbook: playbooks/utils/psonoci.yml
 
 - import_playbook: playbooks/register_rhel_subscription.yml


### PR DESCRIPTION
# Description
This will increase disk size before any installation on the PF vm

# Impacts
Disk size increased before installation
```
~$ ssh 192.168.121.21
Linux pfdeb11dev 5.10.0-30-amd64 #1 SMP Debian 5.10.218-1 (2024-06-01) x86_64

The programs included with the Debian GNU/Linux system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.
Last login: Mon Jul  8 18:51:11 2024 from 192.168.121.1
vagrant@pfdeb11dev:~$ df -h
Filesystem      Size  Used Avail Use% Mounted on
udev            7.8G     0  7.8G   0% /dev
tmpfs           1.6G  2.0M  1.6G   1% /run
/dev/vda1       128G  6.4G  116G   6% /
tmpfs           7.9G     0  7.9G   0% /dev/shm
tmpfs           5.0M     0  5.0M   0% /run/lock
tmpfs           1.6G     0  1.6G   0% /run/user/1000
```

# Delete branch after merge
YES