### PR TITLE
allow retry while downloading images

### DIFF
--- a/containers/manage-images.sh
+++ b/containers/manage-images.sh
@@ -106,8 +106,21 @@ configure_and_check() {
 }
 
 pull_images() {
-    for img in ${CONTAINERS_IMAGES}; do
-	docker pull -q ${KNK_REGISTRY_URL}/${img}:${TAG_OR_BRANCH_NAME}
+    RETRY_LIMIT=2
+    for attempt in $(seq 1 $RETRY_LIMIT); do
+        for img in ${CONTAINERS_IMAGES}; do
+            docker pull -q ${KNK_REGISTRY_URL}/${img}:${TAG_OR_BRANCH_NAME}
+            if [ $? -eq 0 ]; then
+                break
+            else
+                if [ $attempt -le $RETRY_LIMIT ]; then
+                    echo "Retry downloading image: ${KNK_REGISTRY_URL}/${img}:${TAG_OR_BRANCH_NAME}"
+                    sleep 3
+                else
+                    echo "Failed downloading image: ${KNK_REGISTRY_URL}/${img}:${TAG_OR_BRANCH_NAME}"
+                fi
+            fi
+        done
     done
     echo "$(date) - Pull of images finished"
 }

--- a/containers/manage-images.sh
+++ b/containers/manage-images.sh
@@ -114,8 +114,8 @@ pull_images() {
                 break
             else
                 if [ $attempt -le $RETRY_LIMIT ]; then
-                    echo "Retry downloading image: ${KNK_REGISTRY_URL}/${img}:${TAG_OR_BRANCH_NAME}"
                     sleep 3
+                    echo "Retry downloading image: ${KNK_REGISTRY_URL}/${img}:${TAG_OR_BRANCH_NAME}"
                 else
                     echo "Failed downloading image: ${KNK_REGISTRY_URL}/${img}:${TAG_OR_BRANCH_NAME}"
                 fi


### PR DESCRIPTION
# Description
Fixes #8019, adds additional retries and message when failing docker image downloading.

# Impacts
added 3 retries in docker image downloading.

# Issue
fixes #8019 docker image downloading status

# Delete branch after merge
YES

# Checklist
- [n/a] Document the feature
- [n/a] Add OpenAPI specification
- [n/a] Add unit tests
- [n/a] Add acceptance tests (TestLink)

## Bug Fixes
fixes #8019, adds more retries when downloading docker images
