### PR TITLE
Fix GenericVPN switch module

### DIFF
--- a/lib/pf/Switch/GenericVPN.pm
+++ b/lib/pf/Switch/GenericVPN.pm
@@ -101,8 +101,9 @@ sub parseVPNRequest {
     my ( $self, $radius_request ) = @_;
     my $logger = $self->logger;
 
+    my $mac;
     my $client_ip       = $radius_request->{'Calling-Station-Id'};
-    my $mac             = '02:00:' . join(':', map { sprintf("%02x", $_) } split /\./, $radius_request->{'Calling-Station-Id'});
+    $mac                = '02:00:' . join(':', map { sprintf("%02x", $_) } split /\./, $radius_request->{'Calling-Station-Id'}) if (exists $radius_request->{'Calling-Station-Id'});
     my $user_name       = $self->parseRequestUsername($radius_request);
     my $nas_port_type   = $radius_request->{'NAS-Port-Type'};
     my $port            = $radius_request->{'NAS-Port'};


### PR DESCRIPTION
# Description
Don't create a mac address if the radius attribute is empty.

# Impacts
GenericVPN switch module

# Issue
* Don't generate all the time a mac address when using the GenericVPN switch module (The logic is going in the wrong path)

# Delete branch after merge
YES


# NEWS file entries

## Bug Fixes
* Don't generate all the time a mac address when using the GenericVPN switch module

