### PR TITLE
Option for sso stop on accounting stop

### DIFF
--- a/go/firewallsso/base.go
+++ b/go/firewallsso/base.go
@@ -53,12 +53,13 @@ type FirewallSSO struct {
 	PfconfigHashNS string `val:"-"`
 	RoleBasedFirewallSSO
 	pfconfigdriver.TypedConfig
-	Networks       []*FirewallSSONetwork `json:"networks"`
-	CacheUpdates   string                `json:"cache_updates"`
-	CacheTimeout   string                `json:"cache_timeout"`
-	UsernameFormat string                `json:"username_format"`
-	DefaultRealm   string                `json:"default_realm"`
-	UseConnector   string                `json:"use_connector"`
+	Networks            []*FirewallSSONetwork `json:"networks"`
+	CacheUpdates        string                `json:"cache_updates"`
+	CacheTimeout        string                `json:"cache_timeout"`
+	UsernameFormat      string                `json:"username_format"`
+	DefaultRealm        string                `json:"default_realm"`
+	UseConnector        string                `json:"use_connector"`
+	ActOnAccountingStop string                `json:"act_on_accounting_stop"`
 }
 
 func (fw *FirewallSSO) setPfconfigHashNS(id string) {

--- a/html/pfappserver/lib/pfappserver/Form/Config/Firewall_SSO.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Firewall_SSO.pm
@@ -121,9 +121,17 @@ has_field 'use_connector',
    default => $META->get_attribute('use_connector')->default,
   );
 
+has_field 'act_on_accounting_stop',
+  (
+   type => 'Toggle',
+   checkbox_value => '1',
+   unchecked_value => '0',
+   default => '1',
+  );
+
 has_block 'definition' =>
   (
-   render_list => [ qw(id type password port categories networks cache_updates cache_timeout username_format default_realm) ],
+   render_list => [ qw(id type password port categories networks cache_updates cache_timeout username_format default_realm act_on_accounting_stop) ],
   );
 
 =head2 Methods

--- a/html/pfappserver/lib/pfappserver/Form/Config/Firewall_SSO/BarracudaNG.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Firewall_SSO/BarracudaNG.pm
@@ -42,7 +42,7 @@ has_field 'type' =>
 
 has_block definition =>
   (
-   render_list => [ qw(id type username password port categories networks cache_updates cache_timeout username_format default_realm) ],
+   render_list => [ qw(id type username password port categories networks cache_updates cache_timeout username_format default_realm act_on_accounting_stop) ],
   );
 
 =over

--- a/html/pfappserver/lib/pfappserver/Form/Config/Firewall_SSO/CiscoIsePic.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Firewall_SSO/CiscoIsePic.pm
@@ -29,7 +29,7 @@ has_field 'password' =>
 
 has_block definition =>
   (
-   render_list => [ qw(id type port categories networks cache_updates cache_timeout username_format default_realm) ],
+   render_list => [ qw(id type port categories networks cache_updates cache_timeout username_format default_realm act_on_accounting_stop) ],
   );
 
 =head1 COPYRIGHT

--- a/html/pfappserver/lib/pfappserver/Form/Config/Firewall_SSO/ContentKeeper.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Firewall_SSO/ContentKeeper.pm
@@ -30,7 +30,7 @@ has_field 'type' =>
 
 has_block definition =>
   (
-   render_list => [ qw(id type password port categories networks cache_updates cache_timeout username_format default_realm) ],
+   render_list => [ qw(id type password port categories networks cache_updates cache_timeout username_format default_realm act_on_accounting_stop) ],
   );
 
 =head1 COPYRIGHT

--- a/html/pfappserver/lib/pfappserver/Form/Config/Firewall_SSO/FamilyZone.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Firewall_SSO/FamilyZone.pm
@@ -46,7 +46,7 @@ has_field 'deviceid' =>
 
 has_block definition =>
   (
-   render_list => [ qw(id type deviceid password categories networks cache_updates cache_timeout username_format default_realm) ],
+   render_list => [ qw(id type deviceid password categories networks cache_updates cache_timeout username_format default_realm act_on_accounting_stop) ],
   );
 
 =head1 COPYRIGHT

--- a/html/pfappserver/lib/pfappserver/Form/Config/Firewall_SSO/FortiGate.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Firewall_SSO/FortiGate.pm
@@ -30,7 +30,7 @@ has_field 'type' =>
 
 has_block definition =>
   (
-   render_list => [ qw(id type password port categories networks cache_updates cache_timeout username_format default_realm) ],
+   render_list => [ qw(id type password port categories networks cache_updates cache_timeout username_format default_realm act_on_accounting_stop) ],
   );
 
 =head1 COPYRIGHT

--- a/html/pfappserver/lib/pfappserver/Form/Config/Firewall_SSO/Iboss.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Firewall_SSO/Iboss.pm
@@ -44,7 +44,7 @@ has_field 'type' =>
 
 has_block definition =>
   (
-   render_list => [ qw(id type password port nac_name categories networks cache_updates cache_timeout username_format default_realm) ],
+   render_list => [ qw(id type password port nac_name categories networks cache_updates cache_timeout username_format default_realm act_on_accounting_stop) ],
   );
 
 =head1 COPYRIGHT

--- a/html/pfappserver/lib/pfappserver/Form/Config/Firewall_SSO/JSONRPC.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Firewall_SSO/JSONRPC.pm
@@ -44,7 +44,7 @@ has_field 'type' =>
 
 has_block definition =>
   (
-   render_list => [ qw(id type username password port categories networks cache_updates cache_timeout username_format default_realm) ],
+   render_list => [ qw(id type username password port categories networks cache_updates cache_timeout username_format default_realm act_on_accounting_stop) ],
   );
 
 =head1 COPYRIGHT

--- a/html/pfappserver/lib/pfappserver/Form/Config/Firewall_SSO/JuniperSRX.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Firewall_SSO/JuniperSRX.pm
@@ -49,7 +49,7 @@ has_field 'port' =>
   );
 has_block definition =>
   (
-   render_list => [ qw(id type username password port categories networks cache_updates cache_timeout username_format default_realm) ],
+   render_list => [ qw(id type username password port categories networks cache_updates cache_timeout username_format default_realm act_on_accounting_stop) ],
   );
 
 has_field 'type' =>

--- a/html/pfappserver/lib/pfappserver/Form/Config/Firewall_SSO/PaloAlto.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Firewall_SSO/PaloAlto.pm
@@ -59,7 +59,7 @@ has_field 'vsys' =>
 
 has_block definition =>
   (
-   render_list => [ qw(id type vsys transport port password categories networks cache_updates cache_timeout username_format default_realm) ],
+   render_list => [ qw(id type vsys transport port password categories networks cache_updates cache_timeout username_format default_realm act_on_accounting_stop) ],
   );
 
 =head1 COPYRIGHT

--- a/html/pfappserver/lib/pfappserver/Form/Config/Firewall_SSO/WatchGuard.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Firewall_SSO/WatchGuard.pm
@@ -30,7 +30,7 @@ has_field 'type' =>
 
 has_block definition =>
   (
-   render_list => [ qw(id type password port categories networks cache_updates cache_timeout username_format default_realm) ],
+   render_list => [ qw(id type password port categories networks cache_updates cache_timeout username_format default_realm act_on_accounting_stop) ],
   );
 
 =head1 COPYRIGHT

--- a/html/pfappserver/root/src/views/Configuration/firewalls/_components/FormTypeBarracudaNg.vue
+++ b/html/pfappserver/root/src/views/Configuration/firewalls/_components/FormTypeBarracudaNg.vue
@@ -62,11 +62,19 @@
                               namespace="use_connector"
     />
 
+    <form-group-act-on-accounting-stop :column-label="$i18n.t('Act on accounting stop')"
+                              :text="$i18n.t('Send SSO stop on accounting stop.')"
+                              disabled-value="0"
+                              enabled-value="1"
+                              namespace="act_on_accounting_stop"
+    />
+
   </base-form>
 </template>
 <script>
 import {BaseForm} from '@/components/new/'
 import {
+  FormGroupActOnAccountingStop,
   FormGroupCacheTimeout,
   FormGroupCacheUpdates,
   FormGroupCategories,
@@ -77,13 +85,14 @@ import {
   FormGroupPort,
   FormGroupUseConnector,
   FormGroupUsername,
-  FormGroupUsernameFormat,
+  FormGroupUsernameFormat
 } from './'
 import {useForm as setup, useFormProps as props} from '../_composables/useForm'
 
 const components = {
   BaseForm,
 
+  FormGroupActOnAccountingStop,
   FormGroupCacheTimeout,
   FormGroupCacheUpdates,
   FormGroupCategories,
@@ -94,7 +103,7 @@ const components = {
   FormGroupPort,
   FormGroupUseConnector,
   FormGroupUsername,
-  FormGroupUsernameFormat,
+  FormGroupUsernameFormat
 }
 
 // @vue/component

--- a/html/pfappserver/root/src/views/Configuration/firewalls/_components/FormTypeCheckpoint.vue
+++ b/html/pfappserver/root/src/views/Configuration/firewalls/_components/FormTypeCheckpoint.vue
@@ -57,11 +57,19 @@
                               enabled-value="1"
                               namespace="use_connector"
     />
+
+    <form-group-act-on-accounting-stop :column-label="$i18n.t('Act on accounting stop')"
+                              :text="$i18n.t('Send SSO stop on accounting stop.')"
+                              disabled-value="0"
+                              enabled-value="1"
+                              namespace="act_on_accounting_stop"
+    />
   </base-form>
 </template>
 <script>
 import {BaseForm} from '@/components/new/'
 import {
+  FormGroupActOnAccountingStop,
   FormGroupCacheTimeout,
   FormGroupCacheUpdates,
   FormGroupCategories,
@@ -80,6 +88,7 @@ import {useForm as setup, useFormProps as props} from '../_composables/useForm'
 const components = {
   BaseForm,
 
+  FormGroupActOnAccountingStop,
   FormGroupCacheTimeout,
   FormGroupCacheUpdates,
   FormGroupCategories,

--- a/html/pfappserver/root/src/views/Configuration/firewalls/_components/FormTypeCiscoIsePic.vue
+++ b/html/pfappserver/root/src/views/Configuration/firewalls/_components/FormTypeCiscoIsePic.vue
@@ -53,11 +53,19 @@
                               enabled-value="1"
                               namespace="use_connector"
     />
+
+    <form-group-act-on-accounting-stop :column-label="$i18n.t('Act on accounting stop')"
+                              :text="$i18n.t('Send SSO stop on accounting stop.')"
+                              disabled-value="0"
+                              enabled-value="1"
+                              namespace="act_on_accounting_stop"
+    />
   </base-form>
 </template>
 <script>
 import {BaseForm} from '@/components/new/'
 import {
+  FormGroupActOnAccountingStop,
   FormGroupCacheTimeout,
   FormGroupCacheUpdates,
   FormGroupCategories,
@@ -73,6 +81,7 @@ import {useForm as setup, useFormProps as props} from '../_composables/useForm'
 const components = {
   BaseForm,
 
+  FormGroupActOnAccountingStop,
   FormGroupCacheTimeout,
   FormGroupCacheUpdates,
   FormGroupCategories,

--- a/html/pfappserver/root/src/views/Configuration/firewalls/_components/FormTypeContentKeeper.vue
+++ b/html/pfappserver/root/src/views/Configuration/firewalls/_components/FormTypeContentKeeper.vue
@@ -50,11 +50,19 @@
                               :text="$i18n.t('The default realm to be used while formatting the username when no realm can be extracted from the username.')"
                               namespace="default_realm"
     />
+
+    <form-group-act-on-accounting-stop :column-label="$i18n.t('Act on accounting stop')"
+                              :text="$i18n.t('Send SSO stop on accounting stop.')"
+                              disabled-value="0"
+                              enabled-value="1"
+                              namespace="act_on_accounting_stop"
+    />
   </base-form>
 </template>
 <script>
 import {BaseForm} from '@/components/new/'
 import {
+  FormGroupActOnAccountingStop,
   FormGroupCacheTimeout,
   FormGroupCacheUpdates,
   FormGroupCategories,
@@ -70,6 +78,7 @@ import {useForm as setup, useFormProps as props} from '../_composables/useForm'
 const components = {
   BaseForm,
 
+  FormGroupActOnAccountingStop,
   FormGroupCacheTimeout,
   FormGroupCacheUpdates,
   FormGroupCategories,

--- a/html/pfappserver/root/src/views/Configuration/firewalls/_components/FormTypeFamilyZone.vue
+++ b/html/pfappserver/root/src/views/Configuration/firewalls/_components/FormTypeFamilyZone.vue
@@ -62,11 +62,19 @@
                               enabled-value="1"
                               namespace="use_connector"
     />
+
+    <form-group-act-on-accounting-stop :column-label="$i18n.t('Act on accounting stop')"
+                              :text="$i18n.t('Send SSO stop on accounting stop.')"
+                              disabled-value="0"
+                              enabled-value="1"
+                              namespace="act_on_accounting_stop"
+    />
   </base-form>
 </template>
 <script>
 import {BaseForm} from '@/components/new/'
 import {
+  FormGroupActOnAccountingStop,
   FormGroupCacheTimeout,
   FormGroupCacheUpdates,
   FormGroupCategories,
@@ -84,6 +92,7 @@ import {useForm as setup, useFormProps as props} from '../_composables/useForm'
 const components = {
   BaseForm,
 
+  FormGroupActOnAccountingStop,
   FormGroupCacheTimeout,
   FormGroupCacheUpdates,
   FormGroupCategories,

--- a/html/pfappserver/root/src/views/Configuration/firewalls/_components/FormTypeFortiGate.vue
+++ b/html/pfappserver/root/src/views/Configuration/firewalls/_components/FormTypeFortiGate.vue
@@ -57,11 +57,19 @@
                               enabled-value="1"
                               namespace="use_connector"
     />
+
+    <form-group-act-on-accounting-stop :column-label="$i18n.t('Act on accounting stop')"
+                              :text="$i18n.t('Send SSO stop on accounting stop.')"
+                              disabled-value="0"
+                              enabled-value="1"
+                              namespace="act_on_accounting_stop"
+    />
   </base-form>
 </template>
 <script>
 import {BaseForm} from '@/components/new/'
 import {
+  FormGroupActOnAccountingStop,
   FormGroupCacheTimeout,
   FormGroupCacheUpdates,
   FormGroupCategories,
@@ -78,6 +86,7 @@ import {useForm as setup, useFormProps as props} from '../_composables/useForm'
 const components = {
   BaseForm,
 
+  FormGroupActOnAccountingStop,
   FormGroupCacheTimeout,
   FormGroupCacheUpdates,
   FormGroupCategories,

--- a/html/pfappserver/root/src/views/Configuration/firewalls/_components/FormTypeIboss.vue
+++ b/html/pfappserver/root/src/views/Configuration/firewalls/_components/FormTypeIboss.vue
@@ -62,11 +62,19 @@
                               enabled-value="1"
                               namespace="use_connector"
     />
+
+    <form-group-act-on-accounting-stop :column-label="$i18n.t('Act on accounting stop')"
+                              :text="$i18n.t('Send SSO stop on accounting stop.')"
+                              disabled-value="0"
+                              enabled-value="1"
+                              namespace="act_on_accounting_stop"
+    />
   </base-form>
 </template>
 <script>
 import {BaseForm} from '@/components/new/'
 import {
+  FormGroupActOnAccountingStop,
   FormGroupCacheTimeout,
   FormGroupCacheUpdates,
   FormGroupCategories,
@@ -84,6 +92,7 @@ import {useForm as setup, useFormProps as props} from '../_composables/useForm'
 const components = {
   BaseForm,
 
+  FormGroupActOnAccountingStop,
   FormGroupCacheTimeout,
   FormGroupCacheUpdates,
   FormGroupCategories,

--- a/html/pfappserver/root/src/views/Configuration/firewalls/_components/FormTypeJsonRpc.vue
+++ b/html/pfappserver/root/src/views/Configuration/firewalls/_components/FormTypeJsonRpc.vue
@@ -61,11 +61,19 @@
                               enabled-value="1"
                               namespace="use_connector"
     />
+
+    <form-group-act-on-accounting-stop :column-label="$i18n.t('Act on accounting stop')"
+                              :text="$i18n.t('Send SSO stop on accounting stop.')"
+                              disabled-value="0"
+                              enabled-value="1"
+                              namespace="act_on_accounting_stop"
+    />
   </base-form>
 </template>
 <script>
 import {BaseForm} from '@/components/new/'
 import {
+  FormGroupActOnAccountingStop,
   FormGroupCacheTimeout,
   FormGroupCacheUpdates,
   FormGroupCategories,
@@ -83,6 +91,7 @@ import {useForm as setup, useFormProps as props} from '../_composables/useForm'
 const components = {
   BaseForm,
 
+  FormGroupActOnAccountingStop,
   FormGroupCacheTimeout,
   FormGroupCacheUpdates,
   FormGroupCategories,

--- a/html/pfappserver/root/src/views/Configuration/firewalls/_components/FormTypeJuniperSrx.vue
+++ b/html/pfappserver/root/src/views/Configuration/firewalls/_components/FormTypeJuniperSrx.vue
@@ -61,11 +61,19 @@
                               enabled-value="1"
                               namespace="use_connector"
     />
+
+    <form-group-act-on-accounting-stop :column-label="$i18n.t('Act on accounting stop')"
+                              :text="$i18n.t('Send SSO stop on accounting stop.')"
+                              disabled-value="0"
+                              enabled-value="1"
+                              namespace="act_on_accounting_stop"
+    />
   </base-form>
 </template>
 <script>
 import {BaseForm} from '@/components/new/'
 import {
+  FormGroupActOnAccountingStop,
   FormGroupCacheTimeout,
   FormGroupCacheUpdates,
   FormGroupCategories,
@@ -83,6 +91,7 @@ import {useForm as setup, useFormProps as props} from '../_composables/useForm'
 const components = {
   BaseForm,
 
+  FormGroupActOnAccountingStop,
   FormGroupCacheTimeout,
   FormGroupCacheUpdates,
   FormGroupCategories,

--- a/html/pfappserver/root/src/views/Configuration/firewalls/_components/FormTypeLightSpeedRocket.vue
+++ b/html/pfappserver/root/src/views/Configuration/firewalls/_components/FormTypeLightSpeedRocket.vue
@@ -57,11 +57,19 @@
                               enabled-value="1"
                               namespace="use_connector"
     />
+
+    <form-group-act-on-accounting-stop :column-label="$i18n.t('Act on accounting stop')"
+                              :text="$i18n.t('Send SSO stop on accounting stop.')"
+                              disabled-value="0"
+                              enabled-value="1"
+                              namespace="act_on_accounting_stop"
+    />
   </base-form>
 </template>
 <script>
 import {BaseForm} from '@/components/new/'
 import {
+  FormGroupActOnAccountingStop,
   FormGroupCacheTimeout,
   FormGroupCacheUpdates,
   FormGroupCategories,
@@ -78,6 +86,7 @@ import {useForm as setup, useFormProps as props} from '../_composables/useForm'
 const components = {
   BaseForm,
 
+  FormGroupActOnAccountingStop,
   FormGroupCacheTimeout,
   FormGroupCacheUpdates,
   FormGroupCategories,

--- a/html/pfappserver/root/src/views/Configuration/firewalls/_components/FormTypePaloAlto.vue
+++ b/html/pfappserver/root/src/views/Configuration/firewalls/_components/FormTypePaloAlto.vue
@@ -67,11 +67,19 @@
                               enabled-value="1"
                               namespace="use_connector"
     />
+
+    <form-group-act-on-accounting-stop :column-label="$i18n.t('Act on accounting stop')"
+                              :text="$i18n.t('Send SSO stop on accounting stop.')"
+                              disabled-value="0"
+                              enabled-value="1"
+                              namespace="act_on_accounting_stop"
+    />
   </base-form>
 </template>
 <script>
 import {BaseForm} from '@/components/new/'
 import {
+  FormGroupActOnAccountingStop,
   FormGroupCacheTimeout,
   FormGroupCacheUpdates,
   FormGroupCategories,
@@ -90,6 +98,7 @@ import {useForm as setup, useFormProps as props} from '../_composables/useForm'
 const components = {
   BaseForm,
 
+  FormGroupActOnAccountingStop,
   FormGroupCacheTimeout,
   FormGroupCacheUpdates,
   FormGroupCategories,

--- a/html/pfappserver/root/src/views/Configuration/firewalls/_components/FormTypeSmoothWall.vue
+++ b/html/pfappserver/root/src/views/Configuration/firewalls/_components/FormTypeSmoothWall.vue
@@ -57,11 +57,19 @@
                               enabled-value="1"
                               namespace="use_connector"
     />
+
+    <form-group-act-on-accounting-stop :column-label="$i18n.t('Act on accounting stop')"
+                              :text="$i18n.t('Send SSO stop on accounting stop.')"
+                              disabled-value="0"
+                              enabled-value="1"
+                              namespace="act_on_accounting_stop"
+    />
   </base-form>
 </template>
 <script>
 import {BaseForm} from '@/components/new/'
 import {
+  FormGroupActOnAccountingStop,
   FormGroupCacheTimeout,
   FormGroupCacheUpdates,
   FormGroupCategories,
@@ -78,6 +86,7 @@ import {useForm as setup, useFormProps as props} from '../_composables/useForm'
 const components = {
   BaseForm,
 
+  FormGroupActOnAccountingStop,
   FormGroupCacheTimeout,
   FormGroupCacheUpdates,
   FormGroupCategories,

--- a/html/pfappserver/root/src/views/Configuration/firewalls/_components/FormTypeWatchGuard.vue
+++ b/html/pfappserver/root/src/views/Configuration/firewalls/_components/FormTypeWatchGuard.vue
@@ -57,11 +57,19 @@
                               enabled-value="1"
                               namespace="use_connector"
     />
+
+    <form-group-act-on-accounting-stop :column-label="$i18n.t('Act on accounting stop')"
+                              :text="$i18n.t('Send SSO stop on accounting stop.')"
+                              disabled-value="0"
+                              enabled-value="1"
+                              namespace="act_on_accounting_stop"
+    />
   </base-form>
 </template>
 <script>
 import {BaseForm} from '@/components/new/'
 import {
+  FormGroupActOnAccountingStop,
   FormGroupCacheTimeout,
   FormGroupCacheUpdates,
   FormGroupCategories,
@@ -78,6 +86,7 @@ import {useForm as setup, useFormProps as props} from '../_composables/useForm'
 const components = {
   BaseForm,
 
+  FormGroupActOnAccountingStop,
   FormGroupCacheTimeout,
   FormGroupCacheUpdates,
   FormGroupCategories,

--- a/html/pfappserver/root/src/views/Configuration/firewalls/_components/index.js
+++ b/html/pfappserver/root/src/views/Configuration/firewalls/_components/index.js
@@ -15,6 +15,7 @@ export {
   BaseViewCollectionItem as BaseView,
   BaseFormButtonBar as FormButtonBar,
 
+  BaseFormGroupSwitch as FormGroupActOnAccountingStop,
   BaseFormGroupInputNumber as FormGroupCacheTimeout,
   BaseFormGroupSwitch as FormGroupCacheUpdates,
   BaseFormGroupChosenMultiple as FormGroupCategories,

--- a/lib/pf/api.pm
+++ b/lib/pf/api.pm
@@ -1572,14 +1572,14 @@ sub firewallsso_accounting : Public {
             }
             my $oldip  = pf::ip4log::mac2ip($mac);
             if ( $oldip && $oldip ne $ip ) {
-                $client->notify( 'firewallsso', (method => 'Stop', mac => $mac, ip => $oldip, timeout => undef) );
+                $client->notify( 'firewallsso', (method => 'Stop', mac => $mac, ip => $oldip, timeout => undef, source => 'accounting') );
             }
         }
 
         $firewallsso_method = ($RAD_REQUEST{'Acct-Status-Type'} == $ACCOUNTING::STOP) ? "Stop" : "Update";
 
         $logger->warn("Firewall SSO Notify");
-        $client->notify( 'firewallsso', (method => $firewallsso_method, mac => $mac, ip => $ip, timeout => $timeout, username => $username) );
+        $client->notify( 'firewallsso', (method => $firewallsso_method, mac => $mac, ip => $ip, timeout => $timeout, username => $username, source => 'accounting') );
     }
 }
 
@@ -1598,7 +1598,7 @@ sub firewall_sso_call : Public :AllowedAsAction(mac, $mac, ip, $ip, timeout, $ti
     my $timeout = $postdata{'timeout'} || '3600';
     my $node = pf::node::node_view($postdata{'mac'});
     my $client = pf::client::getClient();
-    $client->notify( 'firewallsso', (method => "Update", mac => $postdata{'mac'}, ip => $postdata{'ip'}, timeout => $timeout, username => $node->{'pid'}) );
+    $client->notify( 'firewallsso', (method => "Update", mac => $postdata{'mac'}, ip => $postdata{'ip'}, timeout => $timeout, username => $node->{'pid'}, source => 'api') );
 }
 
 =head2 services_status

--- a/lib/pf/dhcp/processor.pm
+++ b/lib/pf/dhcp/processor.pm
@@ -135,10 +135,10 @@ sub processIPTasks {
     # Firewall SSO
     if (isenabled($pf::config::Config{advanced}{sso_on_dhcp}) && scalar keys %ConfigFirewallSSO != 0) {
         if ( $iptasks_arguments{'oldip'} && $iptasks_arguments{'oldip'} ne $iptasks_arguments{'ip'} ) {
-            $self->apiClient->notify( 'firewallsso', (method => 'Stop', mac => $iptasks_arguments{'mac'}, ip => $iptasks_arguments{'oldip'}, timeout => undef) );
-            $self->apiClient->notify( 'firewallsso', (method => 'Start', mac => $iptasks_arguments{'mac'}, ip => $iptasks_arguments{'ip'}, timeout => $iptasks_arguments{'lease_length'} || $DEFAULT_LEASE_LENGTH) );
+            $self->apiClient->notify( 'firewallsso', (method => 'Stop', mac => $iptasks_arguments{'mac'}, ip => $iptasks_arguments{'oldip'}, timeout => undef, source => 'DHCP') );
+            $self->apiClient->notify( 'firewallsso', (method => 'Start', mac => $iptasks_arguments{'mac'}, ip => $iptasks_arguments{'ip'}, timeout => $iptasks_arguments{'lease_length'} || $DEFAULT_LEASE_LENGTH, source => 'DHCP') );
         }
-        $self->apiClient->notify( 'firewallsso', (method => 'Update', mac => $iptasks_arguments{'mac'}, ip => $iptasks_arguments{'ip'}, timeout => $iptasks_arguments{'lease_length'} || $DEFAULT_LEASE_LENGTH) );
+        $self->apiClient->notify( 'firewallsso', (method => 'Update', mac => $iptasks_arguments{'mac'}, ip => $iptasks_arguments{'ip'}, timeout => $iptasks_arguments{'lease_length'} || $DEFAULT_LEASE_LENGTH, source => 'DHCP') );
     }
 
     # Inline enforcement

--- a/lib/pf/firewallsso.pm
+++ b/lib/pf/firewallsso.pm
@@ -78,6 +78,7 @@ sub do_sso {
         device_class      => $node->{device_class} || $UNKNOWN,
         device_type       => $node->{device_type} || $UNKNOWN,
         computername      => $node->{computername} || $UNKNOWN,
+        source            => ($postdata{source} // "" ) ."",
     });
 
     return $TRUE;


### PR DESCRIPTION
# Description
Allow to disable SSO on accounting stop.


# Impacts
SSO Firewall

# Issue
In some cases when a device roam between APs, packetfence receive a stop after the start , so it trigger a sso stop on the firewall.

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
## New Features
* Allow to disable SSO on accounting stop.
