### PR TITLE
Fix/8300: Remove radiusd from building in docker and use the one on repos

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -630,7 +630,6 @@ pfdeb_based_dev:
           - "httpd.aaa"
           - "httpd.admin_dispatcher"
           - "httpd.webservices"
-          - "radiusd"
           - "pfsetacls"
           - "pfsso"
           - "pfperl-api"
@@ -661,7 +660,20 @@ rad_based_dev:
   extends:
     - .build_img_container_job_dev
     - .build_img_container_devel_rules
-  needs: ["pfdeb_based_dev"]
+  needs: ["pfdeb_dev"]
+  variables:
+    IMAGE_TAGS: "${CI_COMMIT_REF_SLUG},latest"
+  parallel:
+    # /!\ Be sure to update this list in all other matrix /!\
+    matrix:
+      - IMAGE_NAME:
+          - "radiusd"
+
+rad_extend_dev:
+  extends:
+    - .build_img_container_job_dev
+    - .build_img_container_devel_rules
+  needs: ["rad_based_dev"]
   variables:
     IMAGE_TAGS: "${CI_COMMIT_REF_SLUG},latest"
   parallel:
@@ -713,7 +725,6 @@ pfdeb_based_br_maint:
           - "httpd.aaa"
           - "httpd.admin_dispatcher"
           - "httpd.webservices"
-          - "radiusd"
           - "pfsetacls"
           - "pfsso"
           - "pfperl-api"
@@ -744,7 +755,20 @@ rad_based_br_maint:
   extends:
     - .build_img_container_job_br_maint
     - .build_img_container_branches_and_maintenance_rules
-  needs: ["pfdeb_based_br_maint"]
+  needs: ["pfdeb_br_maint"]
+  variables:
+    IMAGE_TAGS: ${CI_COMMIT_REF_SLUG}
+  parallel:
+    # /!\ Be sure to update this list in all other matrix /!\
+    matrix:
+      - IMAGE_NAME:
+          - "radiusd"
+
+rad_extend_br_maint:
+  extends:
+    - .build_img_container_job_br_maint
+    - .build_img_container_branches_and_maintenance_rules
+  needs: ["rad_based_br_maint"]
   variables:
     IMAGE_TAGS: ${CI_COMMIT_REF_SLUG}
   parallel:
@@ -796,7 +820,6 @@ pfdeb_based_cloud_nac:
           - "httpd.aaa"
           - "httpd.admin_dispatcher"
           - "httpd.webservices"
-          - "radiusd"
           - "pfsetacls"
           - "pfsso"
           - "pfperl-api"
@@ -827,7 +850,20 @@ rad_based_cloud_nac:
   extends:
     - .build_img_container_job_cloud_nac
     - .build_img_container_cloud_nac_rules
-  needs: ["pfdeb_based_cloud_nac"]
+  needs: ["pfdeb_cloud_nac"]
+  variables:
+    IMAGE_TAGS: ${CI_COMMIT_REF_SLUG}-${CI_PIPELINE_ID}
+  parallel:
+    # /!\ Be sure to update this list in all other matrix /!\
+    matrix:
+      - IMAGE_NAME:
+          - "radiusd"
+
+rad_extend_cloud_nac:
+  extends:
+    - .build_img_container_job_cloud_nac
+    - .build_img_container_cloud_nac_rules
+  needs: ["rad_based_cloud_nac"]
   variables:
     IMAGE_TAGS: ${CI_COMMIT_REF_SLUG}-${CI_PIPELINE_ID}
   parallel:
@@ -879,7 +915,6 @@ pfdeb_based_rel:
           - "httpd.aaa"
           - "httpd.admin_dispatcher"
           - "httpd.webservices"
-          - "radiusd"
           - "pfsetacls"
           - "pfsso"
           - "pfperl-api"
@@ -910,7 +945,20 @@ rad_based_rel:
   extends:
     - .build_img_container_job_rel
     - .release_only_rules
-  needs: ["pfdeb_based_rel"]
+  needs: ["pfdeb_rel"]
+  variables:
+   IMAGE_TAGS: ${CI_COMMIT_TAG}
+  parallel:
+    # /!\ Be sure to update this list in all other matrix /!\
+    matrix:
+      - IMAGE_NAME:
+          - "radiusd"
+
+rad_extend_rel:
+  extends:
+    - .build_img_container_job_rel
+    - .release_only_rules
+  needs: ["rad_based_rel"]
   variables:
     IMAGE_TAGS: ${CI_COMMIT_TAG}
   parallel:

--- a/containers/radiusd/Dockerfile
+++ b/containers/radiusd/Dockerfile
@@ -4,7 +4,7 @@ FROM ${KNK_REGISTRY_URL}/pfdebian:${IMAGE_TAG}
 
 RUN apt-get -qq update \
     && apt-get clean \
-    && apt-get -qq install -y freeradius=3.2.2+git-2 \
+    && apt-get -qq install -y freeradius=3:3.2.6+git \
     && apt-get clean 
 
 WORKDIR /usr/local/pf/

--- a/containers/radiusd/Dockerfile
+++ b/containers/radiusd/Dockerfile
@@ -1,65 +1,11 @@
-ARG from=debian:bookworm
 ARG KNK_REGISTRY_URL
 ARG IMAGE_TAG
-
-FROM ${from} as build
-
-ARG DEBIAN_FRONTEND=noninteractive
-
-#
-#  Install build tools
-#
-RUN apt-get -qq update
-RUN apt-get -qq install -y devscripts equivs git quilt gcc libcollectdclient-dev
-
-#
-#  Create build directory
-#
-RUN mkdir -p /usr/local/src/repositories
-WORKDIR /usr/local/src/repositories
-
-#
-#  Shallow clone the FreeRADIUS source
-#
-ARG source=https://github.com/inverse-inc/freeradius-server.git
-ARG release=feature/PacketFence_3.2.6
-
-RUN git clone -qq --depth 1 --single-branch --branch ${release} ${source}
-WORKDIR freeradius-server
-
-#
-#  Install build dependencies
-#
-RUN git checkout ${release}; \
-    if [ -e ./debian/control.in ]; then \
-        debian/rules debian/control; \
-    fi; \
-    echo 'y' | mk-build-deps -irt'apt-get -yV' debian/control
-
-#
-#  Build the server
-#
-# RUN make -j2 deb >/dev/null || make -j2 deb
-RUN make -j2 deb
-
-#
-#  Clean environment and run the server
-#
 FROM ${KNK_REGISTRY_URL}/pfdebian:${IMAGE_TAG}
-
-# Copy debian packages
-COPY --from=build /usr/local/src/repositories/*.deb /tmp/
-
-RUN apt-get -qq -y remove freeradius-common
-
 
 RUN apt-get -qq update \
     && apt-get clean \
-    && apt-get -qq install -y /tmp/*.deb \
-    && apt-get clean \
-    && rm -r /var/lib/apt/lists/* /tmp/*.deb \
-    \
-    && ln -s /etc/freeradius /etc/raddb
+    && apt-get -qq install -y freeradius=3.2.2+git-2 \
+    && apt-get clean 
 
 WORKDIR /usr/local/pf/
 

--- a/rpm/packetfence.spec
+++ b/rpm/packetfence.spec
@@ -480,7 +480,7 @@ done
 %{__install} -d %{buildroot}/usr/local/pf/html/captive-portal
 touch %{buildroot}/usr/local/pf/var/cache_control
 cp Makefile %{buildroot}/usr/local/pf/
-cp .dockerignore %{buildroot}/usr/local/pf/
+cp .dockerignore %{buildroot}/usr/local/pf/ 2>/dev/null
 cp config.mk %{buildroot}/usr/local/pf/
 cp -r bin %{buildroot}/usr/local/pf/
 cp -r addons/pfconfig/ %{buildroot}/usr/local/pf/addons/

--- a/rpm/packetfence.spec
+++ b/rpm/packetfence.spec
@@ -480,7 +480,7 @@ done
 %{__install} -d %{buildroot}/usr/local/pf/html/captive-portal
 touch %{buildroot}/usr/local/pf/var/cache_control
 cp Makefile %{buildroot}/usr/local/pf/
-cp .dockerignore %{buildroot}/usr/local/pf/ 2>/dev/null
+cp .dockerignore %{buildroot}/usr/local/pf/
 cp config.mk %{buildroot}/usr/local/pf/
 cp -r bin %{buildroot}/usr/local/pf/
 cp -r addons/pfconfig/ %{buildroot}/usr/local/pf/addons/


### PR DESCRIPTION
# Description
Remove radiusd from building in docker and use the one on repos

# Impacts
Radius containers will build faster on the CI 

# Code / PR Dependencies
None

# Issue
fixes #8300 

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ x ] CI build -> done https://gitlab.com/inverse-inc/packetfence/-/pipelines/1450992702
- [ ] CI with tests

## Bug Fixes
Take zammit way to build it shortly