### PR TITLE
fix ntlm trust domain issue (#8094)

### DIFF
--- a/bin/pyntlm_auth/handlers.py
+++ b/bin/pyntlm_auth/handlers.py
@@ -1,17 +1,17 @@
-from http import HTTPStatus
-from flask import Flask, request, g
-import ncache
-import re
-import hashlib
 import binascii
-import json
-import utils
-import ms_event
-import global_vars
-import rpc
-import flags
+import hashlib
+import re
+from http import HTTPStatus
 
-from samba import param, NTSTATUSError, ntstatus
+from flask import request, g
+from samba import ntstatus
+
+import flags
+import global_vars
+import ms_event
+import ncache
+import rpc
+
 
 # For NTSTATUS, see:
 # https://github.com/samba-team/samba/blob/master/libcli/util/ntstatus_err_table.txt
@@ -89,6 +89,7 @@ def test_password_handler():
 def ntlm_auth_handler():
     try:
         required_keys = {'username', 'mac', 'request-nt-key', 'challenge', 'nt-response'}
+        optional_keys = {'domain'}
 
         data = request.get_json()
         if data is None:
@@ -102,6 +103,11 @@ def ntlm_auth_handler():
         challenge = data['challenge']
         nt_response = data['nt-response']
 
+        if 'domain' in data:
+            domain = data['domain']
+        else:
+            domain = global_vars.c_domain
+
     except Exception as e:
         return f"Error processing JSON payload, {str(e)}", HTTPStatus.UNPROCESSABLE_ENTITY
 
@@ -114,7 +120,7 @@ def ntlm_auth_handler():
         domain = global_vars.c_domain_identifier
         nt_key, error_code, info = ncache.cached_login(domain, account_username, mac, challenge, nt_response, )
     else:
-        nt_key, error_code, info = rpc.transitive_login(account_username, challenge, nt_response)
+        nt_key, error_code, info = rpc.transitive_login(account_username, challenge, nt_response, domain=domain)
     return format_response(nt_key, error_code)
 
 
@@ -162,4 +168,3 @@ def ntlm_expire_handler():
         return "OK", HTTPStatus.OK
     except Exception as e:
         return f"Error processing JSON payload, {str(e)}", HTTPStatus.UNPROCESSABLE_ENTITY
-

--- a/bin/pyntlm_auth/handlers.py
+++ b/bin/pyntlm_auth/handlers.py
@@ -1,17 +1,17 @@
-import binascii
-import hashlib
-import re
 from http import HTTPStatus
-
-from flask import request, g
-from samba import ntstatus
-
-import flags
-import global_vars
-import ms_event
+from flask import Flask, request, g
 import ncache
+import re
+import hashlib
+import binascii
+import json
+import utils
+import ms_event
+import global_vars
 import rpc
+import flags
 
+from samba import param, NTSTATUSError, ntstatus
 
 # For NTSTATUS, see:
 # https://github.com/samba-team/samba/blob/master/libcli/util/ntstatus_err_table.txt

--- a/bin/pyntlm_auth/rpc.py
+++ b/bin/pyntlm_auth/rpc.py
@@ -1,17 +1,14 @@
-import binascii
-import datetime
-import random
-
-from samba import param, NTSTATUSError
-from samba.credentials import Credentials, DONT_USE_KERBEROS
-from samba.dcerpc import netlogon
-from samba.dcerpc.misc import SEC_CHAN_WKSTA
-from samba.dcerpc.netlogon import (netr_Authenticator, MSV1_0_ALLOW_WORKSTATION_TRUST_ACCOUNT, MSV1_0_ALLOW_MSVCHAPV2)
-
-import config_generator
 import global_vars
+import config_generator
+from samba import param, NTSTATUSError, ntstatus
+from samba.credentials import Credentials, DONT_USE_KERBEROS
+from samba.dcerpc.misc import SEC_CHAN_WKSTA
+from samba.dcerpc import netlogon
 import utils
-
+import datetime
+from samba.dcerpc.netlogon import (netr_Authenticator, MSV1_0_ALLOW_WORKSTATION_TRUST_ACCOUNT, MSV1_0_ALLOW_MSVCHAPV2)
+import binascii
+import random
 
 def init_secure_connection():
     netbios_name = global_vars.c_netbios_name

--- a/bin/pyntlm_auth/rpc.py
+++ b/bin/pyntlm_auth/rpc.py
@@ -1,14 +1,16 @@
-import global_vars
-import config_generator
-from samba import param, NTSTATUSError, ntstatus
-from samba.credentials import Credentials, DONT_USE_KERBEROS
-from samba.dcerpc.misc import SEC_CHAN_WKSTA
-from samba.dcerpc import netlogon
-import utils
-import datetime
-from samba.dcerpc.netlogon import (netr_Authenticator, MSV1_0_ALLOW_WORKSTATION_TRUST_ACCOUNT, MSV1_0_ALLOW_MSVCHAPV2)
 import binascii
+import datetime
 import random
+
+from samba import param, NTSTATUSError
+from samba.credentials import Credentials, DONT_USE_KERBEROS
+from samba.dcerpc import netlogon
+from samba.dcerpc.misc import SEC_CHAN_WKSTA
+from samba.dcerpc.netlogon import (netr_Authenticator, MSV1_0_ALLOW_WORKSTATION_TRUST_ACCOUNT, MSV1_0_ALLOW_MSVCHAPV2)
+
+import config_generator
+import global_vars
+import utils
 
 
 def init_secure_connection():
@@ -20,11 +22,11 @@ def init_secure_connection():
     password = global_vars.c_password
     domain = global_vars.c_domain
     username = global_vars.c_username
-    server_name = global_vars.c_server_name # FQDN of Domain Controller
+    server_name = global_vars.c_server_name  # FQDN of Domain Controller
 
     domain_controller_records = utils.find_ldap_servers(global_vars.c_realm, global_vars.c_dns_servers)
     if len(domain_controller_records) > 0:
-        idx = random.randint(0, len(domain_controller_records) -1)
+        idx = random.randint(0, len(domain_controller_records) - 1)
         record = domain_controller_records[idx]
         server_name = record.get('target')
 
@@ -95,9 +97,11 @@ def get_secure_channel_connection():
             return global_vars.s_secure_channel_connection, global_vars.s_machine_cred, global_vars.s_connection_id, 0, ""
 
 
-def transitive_login(account_username, challenge, nt_response):
+def transitive_login(account_username, challenge, nt_response, domain=None):
+    if domain is None:
+        domain = global_vars.c_domain
+
     server_name = global_vars.c_server_name
-    domain = global_vars.c_domain
     workstation = global_vars.c_workstation
     global_vars.s_secure_channel_connection, global_vars.s_machine_cred, global_vars.s_connection_id, error_code, error_message = get_secure_channel_connection()
     if error_code != 0:

--- a/src/ntlm_auth_wrap.c
+++ b/src/ntlm_auth_wrap.c
@@ -360,6 +360,8 @@ char **argv, **envp;
             cJSON_AddStringToObject(json, "nt-response", argv[i] + strlen("--nt-response="));
         } else if (strncmp(argv[i], "--mac=", strlen("--mac=")) == 0) {
             cJSON_AddStringToObject(json, "mac", argv[i] + strlen("--mac="));
+        } else if (strncmp(argv[i], "--domain=", strlen("--domain=")) == 0) {
+            cJSON_AddStringToObject(json, "domain", argv[i] + strlen("--domain="));
         }
     }
 


### PR DESCRIPTION
# Description
This enables trusted domain login for NTLM Auth

# Impacts
current NTLM Auth Auth flow. 
by default. the user will be authenticated on its own domain, 
when a --domain is specified, the user will be authenticated using a trusted relation.

# Issue
fixes #8094 

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [no] Document the feature
- [no] Add OpenAPI specification
- [no] Add unit tests
- [no] Add acceptance tests (TestLink)


## Enhancements
support trusted relation to be authenticated when using EAP PEAP

## Bug Fixes
issue with a trusted domain relation #8094 
