### PR TITLE
Improvement in Ruckus Unbound DPSK

### DIFF
--- a/NEWS.asciidoc
+++ b/NEWS.asciidoc
@@ -33,6 +33,7 @@ For a list of compatibility related changes see the <<PacketFence_Upgrade_Guide.
 
  * Use proxysql packages in the docker image instead of compilling from the sources (#8267)
  * PKI - Multiple certificate with same Common Name (#8310)
+ * Improved Ruckus Unbound DPSK (#8315)
 
 === Bug Fixes
 

--- a/lib/pf/Switch/Ruckus/SmartZone.pm
+++ b/lib/pf/Switch/Ruckus/SmartZone.pm
@@ -363,7 +363,7 @@ sub check_if_radius_request_psk_matches {
 
     my $pmk = $self->cache->compute(
         "Ruckus::SmartZone::check_if_radius_request_psk_matches::PMK::$radius_request->{'Ruckus-Wlan-Name'}+$psk", 
-        "1 month",
+        {expires_in => '1 month', expires_variance => '.20'},
         sub { pf::util::wpa::calculate_pmk($radius_request->{"Ruckus-Wlan-Name"}, $psk) },
     );
 


### PR DESCRIPTION
# Description
Improve the speed of Ruckus Unbound DPSK.
- Randomize the cache retention to spread the  
- Use a faster crypt library to calculate the pmk

# Impacts
-Ruckus DPSK


# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* Improvement in Ruckus Unbound DPSK
