### PR TITLE
Backport trusted domain support to PF v13.2

### DIFF
--- a/bin/pyntlm_auth/handlers.py
+++ b/bin/pyntlm_auth/handlers.py
@@ -102,6 +102,11 @@ def ntlm_auth_handler():
         challenge = data['challenge']
         nt_response = data['nt-response']
 
+        if 'domain' in data:
+            domain = data['domain']
+        else:
+            domain = global_vars.c_domain
+
     except Exception as e:
         return f"Error processing JSON payload, {str(e)}", HTTPStatus.UNPROCESSABLE_ENTITY
 
@@ -114,7 +119,7 @@ def ntlm_auth_handler():
         domain = global_vars.c_domain_identifier
         nt_key, error_code, info = ncache.cached_login(domain, account_username, mac, challenge, nt_response, )
     else:
-        nt_key, error_code, info = rpc.transitive_login(account_username, challenge, nt_response)
+        nt_key, error_code, info = rpc.transitive_login(account_username, challenge, nt_response, domain = domain)
     return format_response(nt_key, error_code)
 
 

--- a/bin/pyntlm_auth/rpc.py
+++ b/bin/pyntlm_auth/rpc.py
@@ -88,9 +88,10 @@ def get_secure_channel_connection():
             return global_vars.s_secure_channel_connection, global_vars.s_machine_cred, global_vars.s_connection_id, 0, ""
 
 
-def transitive_login(account_username, challenge, nt_response):
+def transitive_login(account_username, challenge, nt_response, domain = None):
     server_name = global_vars.c_server_name
-    domain = global_vars.c_domain
+    if domain is None:
+        domain = global_vars.c_domain
     workstation = global_vars.c_workstation
     global_vars.s_secure_channel_connection, global_vars.s_machine_cred, global_vars.s_connection_id, error_code, error_message = get_secure_channel_connection()
     if error_code != 0:

--- a/src/ntlm_auth_wrap.c
+++ b/src/ntlm_auth_wrap.c
@@ -360,6 +360,8 @@ char **argv, **envp;
             cJSON_AddStringToObject(json, "nt-response", argv[i] + strlen("--nt-response="));
         } else if (strncmp(argv[i], "--mac=", strlen("--mac=")) == 0) {
             cJSON_AddStringToObject(json, "mac", argv[i] + strlen("--mac="));
+        } else if (strncmp(argv[i], "--domain=", strlen("--domain=")) == 0) {
+            cJSON_AddStringToObject(json, "domain", argv[i] + strlen("--domain="));
         }
     }
 


### PR DESCRIPTION
# Description
Backport Trusted Domain support to PF v13.2

# Impacts
Changed NTLM Auth work flow. 
When there's a "domain" key in HTTP payload, use the given domain value instead of default one.
which is the default behavior of Samba


# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

