### PR TITLE
Fix packetfence maintenance branch to match related tag

### DIFF
--- a/ci/debian-installer/Makefile
+++ b/ci/debian-installer/Makefile
@@ -1,4 +1,4 @@
-PF_VERSION=$(CI_COMMIT_REF_SLUG)
+PF_VERSION=$(CI_COMMIT_REF_NAME)
 RESULT_DIR=results
 
 .PHONY: packetfence-debian-installer.iso

--- a/ci/debian-installer/build-and-upload.sh
+++ b/ci/debian-installer/build-and-upload.sh
@@ -3,6 +3,15 @@ set -o nounset -o pipefail -o errexit
 
 PF_VERSION=${PF_VERSION:-localtest}
 
+# Fix PF version if maintenance to match tag
+if [[ "$PF_VERSION" =~ ^maintenance\/([0-9]+\.[0-9]+)$ ]];
+then
+  PF_VERSION=v;
+  PF_VERSION+=${BASH_REMATCH[1]};
+  PF_VERSION+=.0;
+  echo "Maintenance Branch detected, try to match tag version with PF version = $PF_VERSION"
+fi
+
 PF_RELEASE="`echo $PF_RELEASE | sed -r 's/.*\b([0-9]+\.[0-9]+)\.[0-9]+/\1/g'`"
 
 ISO_NAME=PacketFence-ISO-${PF_VERSION}.iso

--- a/ci/packer/zen/build-and-upload.sh
+++ b/ci/packer/zen/build-and-upload.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 set -o nounset -o pipefail -o errexit
 
+# Fix PF version if maintenance to match tag
+if [[ "$PF_VERSION" =~ ^maintenance\/([0-9]+\.[0-9]+)$ ]];
+then
+  PF_VERSION=v;
+  PF_VERSION+=${BASH_REMATCH[1]};
+  PF_VERSION+=.0;
+  echo "Maintenance Branch detected, try to match tag version with PF version = $PF_VERSION"
+fi
+
 VM_NAME=${VM_NAME:-vm}
 
 VBOX_RESULT_DIR=${VBOX_RESULT_DIR:-results/virtualbox}


### PR DESCRIPTION
# Description
This will fix the tag name if we want to publish ISO or ZEN from maintenance branch.

# Impacts
Same PF_VERSION for ZEN and ISO

# Issue
fixes #8323

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* #8323 