### PR TITLE
Fix/8312 Having the same mariadb version on EL8 and DEB12

### DIFF
--- a/rpm/packetfence.spec
+++ b/rpm/packetfence.spec
@@ -61,8 +61,8 @@ Requires: net-snmp >= 5.3.2.2
 Requires: net-snmp-perl
 Requires: perl >= %{perl_version}
 Requires: packetfence-perl >= 1.2.4
-Requires: MariaDB-server = 10.11.6
-Requires: MariaDB-client = 10.11.6
+Requires: MariaDB-server >= 10.11
+Requires: MariaDB-client >= 10.11
 Requires: perl(DBD::mysql)
 Requires: perl(Sub::Exporter)
 Requires: perl(Cisco::AccessList::Parser)

--- a/rpm/packetfence.spec
+++ b/rpm/packetfence.spec
@@ -61,8 +61,8 @@ Requires: net-snmp >= 5.3.2.2
 Requires: net-snmp-perl
 Requires: perl >= %{perl_version}
 Requires: packetfence-perl >= 1.2.4
-Requires: MariaDB-server >= 10.5.15, MariaDB-server < 10.6.0
-Requires: MariaDB-client >= 10.5.15, MariaDB-client < 10.6.0
+Requires: MariaDB-server = 10.11.6
+Requires: MariaDB-client = 10.11.6
 Requires: perl(DBD::mysql)
 Requires: perl(Sub::Exporter)
 Requires: perl(Cisco::AccessList::Parser)


### PR DESCRIPTION
# Description
Having the same mariadb version on EL8 and DEB12

# Impacts
Having the same mariadb version on EL8 and DEB12

# Issue
fixes #8312

# Delete branch after merge
YES

# NEWS file entries
## New Features
* Having the same mariadb version on EL8 and DEB12

## Bug Fixes
* #8312
