### PR TITLE
Fix NT errors when dealing NTLM authentication in a Windows DC cluster

### DIFF
--- a/bin/pyntlm_auth/config_loader.py
+++ b/bin/pyntlm_auth/config_loader.py
@@ -377,6 +377,7 @@ def config_load():
     print(f"  max_allowed_password_attempts_per_device             : {max_allowed_attempts_per_device}")
 
     global_vars.c_server_name = ad_fqdn
+    global_vars.c_ad_server = ad_server
     global_vars.c_realm = realm
     global_vars.c_workgroup = workgroup
     global_vars.c_username = username

--- a/bin/pyntlm_auth/global_vars.py
+++ b/bin/pyntlm_auth/global_vars.py
@@ -44,6 +44,7 @@ c_additional_machine_accounts = None
 c_domain = None
 c_username = None
 c_server_name = None
+c_ad_server = None
 c_listen_port = None
 c_domain_identifier = None
 c_dns_servers = None

--- a/bin/pyntlm_auth/rpc.py
+++ b/bin/pyntlm_auth/rpc.py
@@ -1,14 +1,51 @@
 import global_vars
-import config_generator
 from samba import param, NTSTATUSError, ntstatus
 from samba.credentials import Credentials, DONT_USE_KERBEROS
 from samba.dcerpc.misc import SEC_CHAN_WKSTA
-from samba.dcerpc import netlogon
+from samba.dcerpc import netlogon, nbt
 import utils
 import datetime
 from samba.dcerpc.netlogon import (netr_Authenticator, MSV1_0_ALLOW_WORKSTATION_TRUST_ACCOUNT, MSV1_0_ALLOW_MSVCHAPV2)
 import binascii
-import random
+from samba.net import Net
+
+
+def find_dc(lp):
+    error_code = -1
+    error_message = "unknown error"
+
+    if global_vars.c_dns_servers.strip() != "":
+        try:
+            net = Net(Credentials(), lp)
+            dc = net.finddc(domain=lp.get('realm'), flags=nbt.NBT_SERVER_LDAP | nbt.NBT_SERVER_DS)
+            return 0, "", dc.pdc_dns_name
+        except NTSTATUSError as e:
+            error_code = e.args[0]
+            error_message = e.args[1]
+        except Exception as e:
+            try:
+                error_code = e.args[0]
+            except Exception:
+                pass
+            error_message = str(e)
+
+    if global_vars.c_server_name.strip() != "" and global_vars.c_ad_server.strip() != "":
+        try:
+            net = Net(Credentials(), lp)
+            dc = net.finddc(address=global_vars.c_ad_server, flags=nbt.NBT_SERVER_LDAP | nbt.NBT_SERVER_DS)
+            return 0, "", dc.pdc_dns_name
+        except NTSTATUSError as e:
+            error_code = e.args[0]
+            error_message = e.args[1]
+        except Exception as e:
+            try:
+                error_code = e.args[0]
+            except Exception:
+                pass
+            error_message = str(e)
+
+    return error_code, error_message, None
+
 
 def init_secure_connection():
     netbios_name = global_vars.c_netbios_name
@@ -19,25 +56,22 @@ def init_secure_connection():
     password = global_vars.c_password
     domain = global_vars.c_domain
     username = global_vars.c_username
-    server_name = global_vars.c_server_name  # FQDN of Domain Controller
-
-    domain_controller_records = utils.find_ldap_servers(global_vars.c_realm, global_vars.c_dns_servers)
-    if len(domain_controller_records) > 0:
-        idx = random.randint(0, len(domain_controller_records) - 1)
-        record = domain_controller_records[idx]
-        server_name = record.get('target')
 
     lp = param.LoadParm()
-    try:
-        config_generator.generate_empty_conf()
-        lp.load("/usr/local/pf/var/conf/default.conf")
-    except KeyError:
-        raise KeyError("SMB_CONF_PATH not set")
+    lp.load_default()
 
     lp.set('netbios name', netbios_name)
     lp.set('realm', realm)
     lp.set('server string', server_string)
     lp.set('workgroup', workgroup)
+
+    error_code, error_message, pdc_dns_name = find_dc(lp)
+    if error_code != 0:
+        return global_vars.s_secure_channel_connection, global_vars.s_machine_cred, error_code, error_message
+    else:
+        global_vars.c_server_name = pdc_dns_name
+
+    server_name = global_vars.c_server_name  # FQDN of Domain Controller
 
     global_vars.s_machine_cred = Credentials()
 
@@ -98,8 +132,6 @@ def transitive_login(account_username, challenge, nt_response, domain=None):
     if domain is None:
         domain = global_vars.c_domain
 
-    server_name = global_vars.c_server_name
-    workstation = global_vars.c_workstation
     global_vars.s_secure_channel_connection, global_vars.s_machine_cred, global_vars.s_connection_id, error_code, error_message = get_secure_channel_connection()
     if error_code != 0:
         return f"Error while establishing secure channel connection: {error_message}", error_code, None
@@ -134,11 +166,12 @@ def transitive_login(account_username, challenge, nt_response, domain=None):
         logon.identity_info = netlogon.netr_IdentityInfo()
         logon.identity_info.domain_name.string = domain
         logon.identity_info.account_name.string = account_username
-        logon.identity_info.workstation.string = workstation
+        logon.identity_info.workstation.string = global_vars.c_workstation
         logon.identity_info.parameter_control = MSV1_0_ALLOW_WORKSTATION_TRUST_ACCOUNT | MSV1_0_ALLOW_MSVCHAPV2
 
         try:
-            result = global_vars.s_secure_channel_connection.netr_LogonSamLogonWithFlags(server_name, workstation,
+            result = global_vars.s_secure_channel_connection.netr_LogonSamLogonWithFlags(global_vars.c_server_name,
+                                                                                         global_vars.c_workstation,
                                                                                          current, subsequent,
                                                                                          logon_level, logon,
                                                                                          validation_level,


### PR DESCRIPTION
# Description
Fix NT error exception when trying to establish secure connection in an Active Domain cluster
authenticate users using the same server that established the secure connection

# Impacts
changed the way of establishing secure channel
1. removed the old SRV record name resolution introduced in 13.2, use samba's finddc instead
2. writes back the pdc_dns_name to global server name. 

# Issue
fixes #8345 
 
# Delete branch after merge
YES


# Checklist
- [no] Document the feature
- [no] Add OpenAPI specification
- [no] Add unit tests
- [no] Add acceptance tests (TestLink)


## Enhancements
use samba's built-in finddc to determine the right DC to connect to.

## Bug Fixes
fixes NT Error exception when authenticating users on a Active Directory Cluster.
fixes #8345 
