### PR TITLE
Fix/8280 Fix the material page update since moving private repo

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1153,14 +1153,14 @@ build_artifacts_website_release:
     - .release_only_rules
 
 # build_artificats_material job for development
-material_devel_and_branches:
+build_artifacts_material_devel_and_branches:
   image: ${PFBUILD_DEB_IMG}:${PFBUILD_DEFAULT_DEV_TAG}
   extends:
     - .build_artifacts_material_job
     - .build_artifacts_material_devel_and_branches_rules
 
 # build_artificats_material job for release
-material_release:
+build_artifacts_material_release:
   image: ${PFBUILD_DEB_IMG}:${CI_COMMIT_TAG}
   extends:
     - .build_artifacts_material_job

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -389,6 +389,10 @@ variables:
     DST_FILE: layouts/partials/about/material.html
   script:
     - ${BUILDDIR}/generate-material.sh
+  artifacts:
+    expire_in: 1 day
+    paths:
+      - result/material.html
   tags:
     - shell
 

--- a/ci/lib/build/generate-material.sh
+++ b/ci/lib/build/generate-material.sh
@@ -38,6 +38,7 @@ generate_material() {
     make -C ${PF_SRC_DIR} configurations
     make -C ${PF_SRC_DIR} conf/unified_api_system_pass
     make -C ${PF_SRC_DIR} conf/local_secret
+    mkdir -P ${PF_SRC_DIR}/result
 
     echo "Starting ${CONTAINER_NAME} container"
     docker run --detach --name=${CONTAINER_NAME} --rm -e PFCONFIG_PROTO=unix \
@@ -51,6 +52,7 @@ generate_material() {
            -v ${PF_SRC_DIR}/ci/lib:/usr/local/pf/ci/lib \
            -v ${PF_SRC_DIR}/config.mk:/usr/local/pf/config.mk \
            -v ${PF_SRC_DIR}/Makefile:/usr/local/pf/Makefile \
+           -v ${PF_SRC_DIR}/result:/usr/local/pf/result \
            ghcr.io/inverse-inc/packetfence/pfconfig:${IMAGE_TAG}
 
     echo "Let some time to container to start"

--- a/ci/lib/build/generate-material.sh
+++ b/ci/lib/build/generate-material.sh
@@ -38,7 +38,7 @@ generate_material() {
     make -C ${PF_SRC_DIR} configurations
     make -C ${PF_SRC_DIR} conf/unified_api_system_pass
     make -C ${PF_SRC_DIR} conf/local_secret
-    mkdir -P ${PF_SRC_DIR}/result
+    mkdir -p ${PF_SRC_DIR}/result
 
     echo "Starting ${CONTAINER_NAME} container"
     docker run --detach --name=${CONTAINER_NAME} --rm -e PFCONFIG_PROTO=unix \

--- a/ci/lib/build/generate-material.sh
+++ b/ci/lib/build/generate-material.sh
@@ -59,8 +59,8 @@ generate_material() {
     echo "Generating material.html file"
     docker exec ${CONTAINER_NAME} /usr/bin/make material
 
-    echo "Publishing material.html to git if necessary"
-    docker exec ${CONTAINER_NAME} /usr/local/pf/ci/lib/release/publish-to-git.sh ${SRC_FILE} ${DST_FILE}
+    #echo "Publishing material.html to git if necessary"
+    #docker exec ${CONTAINER_NAME} /usr/local/pf/ci/lib/release/publish-to-git.sh ${SRC_FILE} ${DST_FILE}
 }
 
 cleanup() {


### PR DESCRIPTION
# Description
Fix the material page update since moving private repo. It creates the artifact with the html page in it.
https://gitlab.com/inverse-inc/packetfence/-/jobs/8264843786

# Impacts
Create material page that can be uploaded to webiste page

# Issue
fixes #8280

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* Issue with material page that can not be uploaded directly (#8280)
