### PR TITLE
Feature/track tls node

### DIFF
--- a/db/pf-schema-X.Y.sql
+++ b/db/pf-schema-X.Y.sql
@@ -1619,6 +1619,33 @@ CREATE FUNCTION ROUND_TO_MONTH (d DATETIME)
     RETURNS DATETIME DETERMINISTIC
         RETURN DATE_ADD(DATE(d),interval -DAY(d)+1 DAY);
 
+
+--
+-- Create table node_tls
+--
+
+CREATE TABLE node_tls (
+  `mac` varchar(17) NOT NULL PRIMARY KEY,
+  `TLS-Cert-Serial` varchar(255) default NULL,
+  `TLS-Cert-Expiration` varchar(255) default NULL,
+  `TLS-Cert-Valid-Since` varchar(255) default NULL,
+  `TLS-Cert-Subject` varchar(255) default NULL,
+  `TLS-Cert-Issuer` varchar(255) default NULL,
+  `TLS-Cert-Common-Name` varchar(255) default NULL,
+  `TLS-Cert-Subject-Alt-Name-Email` varchar(255) default NULL,
+  `TLS-Client-Cert-Serial` varchar(255) default NULL,
+  `TLS-Client-Cert-Expiration` varchar(255) default NULL,
+  `TLS-Client-Cert-Valid-Since` varchar(255) default NULL,
+  `TLS-Client-Cert-Subject` varchar(255) default NULL,
+  `TLS-Client-Cert-Issuer` varchar(255) default NULL,
+  `TLS-Client-Cert-Common-Name` varchar(255) default NULL,
+  `TLS-Client-Cert-Subject-Alt-Name-Email` varchar(255) default NULL,
+  `TLS-Client-Cert-X509v3-Extended-Key-Usage` varchar(255) default NULL,
+  `TLS-Client-Cert-X509v3-Subject-Key-Identifier` varchar(255) default NULL,
+  `TLS-Client-Cert-X509v3-Authority-Key-Identifier` varchar(255) default NULL,
+  `TLS-Client-Cert-X509v3-Extended-Key-Usage-OID` varchar(255) default NULL,
+) ENGINE=InnoDB DEFAULT CHARACTER SET = 'utf8mb4' COLLATE = 'utf8mb4_general_ci';
+
 --
 -- Updating to current version
 --

--- a/db/pf-schema-X.Y.sql
+++ b/db/pf-schema-X.Y.sql
@@ -1626,24 +1626,24 @@ CREATE FUNCTION ROUND_TO_MONTH (d DATETIME)
 
 CREATE TABLE node_tls (
   `mac` varchar(17) NOT NULL PRIMARY KEY,
-  `TLS-Cert-Serial` varchar(255) default NULL,
-  `TLS-Cert-Expiration` varchar(255) default NULL,
-  `TLS-Cert-Valid-Since` varchar(255) default NULL,
-  `TLS-Cert-Subject` varchar(255) default NULL,
-  `TLS-Cert-Issuer` varchar(255) default NULL,
-  `TLS-Cert-Common-Name` varchar(255) default NULL,
-  `TLS-Cert-Subject-Alt-Name-Email` varchar(255) default NULL,
-  `TLS-Client-Cert-Serial` varchar(255) default NULL,
-  `TLS-Client-Cert-Expiration` varchar(255) default NULL,
-  `TLS-Client-Cert-Valid-Since` varchar(255) default NULL,
-  `TLS-Client-Cert-Subject` varchar(255) default NULL,
-  `TLS-Client-Cert-Issuer` varchar(255) default NULL,
-  `TLS-Client-Cert-Common-Name` varchar(255) default NULL,
-  `TLS-Client-Cert-Subject-Alt-Name-Email` varchar(255) default NULL,
-  `TLS-Client-Cert-X509v3-Extended-Key-Usage` varchar(255) default NULL,
-  `TLS-Client-Cert-X509v3-Subject-Key-Identifier` varchar(255) default NULL,
-  `TLS-Client-Cert-X509v3-Authority-Key-Identifier` varchar(255) default NULL,
-  `TLS-Client-Cert-X509v3-Extended-Key-Usage-OID` varchar(255) default NULL
+  `TLSCertSerial` varchar(255) default NULL,
+  `TLSCertExpiration` varchar(255) default NULL,
+  `TLSCertValidSince` varchar(255) default NULL,
+  `TLSCertSubject` varchar(255) default NULL,
+  `TLSCertIssuer` varchar(255) default NULL,
+  `TLSCertCommonName` varchar(255) default NULL,
+  `TLSCertSubjectAltNameEmail` varchar(255) default NULL,
+  `TLSClientCertSerial` varchar(255) default NULL,
+  `TLSClientCertExpiration` varchar(255) default NULL,
+  `TLSClientCertValidSince` varchar(255) default NULL,
+  `TLSClientCertSubject` varchar(255) default NULL,
+  `TLSClientCertIssuer` varchar(255) default NULL,
+  `TLSClientCertCommonName` varchar(255) default NULL,
+  `TLSClientCertSubjectAltNameEmail` varchar(255) default NULL,
+  `TLSClientCertX509v3ExtendedKeyUsage` varchar(255) default NULL,
+  `TLSClientCertX509v3SubjectKeyIdentifier` varchar(255) default NULL,
+  `TLSClientCertX509v3AuthorityKeyIdentifier` varchar(255) default NULL,
+  `TLSClientCertX509v3ExtendedKeyUsageOID` varchar(255) default NULL
 ) ENGINE=InnoDB DEFAULT CHARACTER SET = 'utf8mb4' COLLATE = 'utf8mb4_general_ci';
 
 --

--- a/db/pf-schema-X.Y.sql
+++ b/db/pf-schema-X.Y.sql
@@ -1643,7 +1643,7 @@ CREATE TABLE node_tls (
   `TLS-Client-Cert-X509v3-Extended-Key-Usage` varchar(255) default NULL,
   `TLS-Client-Cert-X509v3-Subject-Key-Identifier` varchar(255) default NULL,
   `TLS-Client-Cert-X509v3-Authority-Key-Identifier` varchar(255) default NULL,
-  `TLS-Client-Cert-X509v3-Extended-Key-Usage-OID` varchar(255) default NULL,
+  `TLS-Client-Cert-X509v3-Extended-Key-Usage-OID` varchar(255) default NULL
 ) ENGINE=InnoDB DEFAULT CHARACTER SET = 'utf8mb4' COLLATE = 'utf8mb4_general_ci';
 
 --

--- a/db/upgrade-X.X-X.Y.sql
+++ b/db/upgrade-X.X-X.Y.sql
@@ -72,7 +72,7 @@ ALTER TABLE person ADD CONSTRAINT UNIQUE person_psk (`psk`);
 
 \! echo "Create table node_tls"
 
-CREATE TABLE node_tls (
+CREATE TABLE IF NOT EXISTS node_tls (
   `mac` varchar(17) NOT NULL PRIMARY KEY,
   `TLSCertSerial` varchar(255) default NULL,
   `TLSCertExpiration` varchar(255) default NULL,

--- a/db/upgrade-X.X-X.Y.sql
+++ b/db/upgrade-X.X-X.Y.sql
@@ -74,24 +74,24 @@ ALTER TABLE person ADD CONSTRAINT UNIQUE person_psk (`psk`);
 
 CREATE TABLE node_tls (
   `mac` varchar(17) NOT NULL PRIMARY KEY,
-  `TLS-Cert-Serial` varchar(255) default NULL,
-  `TLS-Cert-Expiration` varchar(255) default NULL,
-  `TLS-Cert-Valid-Since` varchar(255) default NULL,
-  `TLS-Cert-Subject` varchar(255) default NULL,
-  `TLS-Cert-Issuer` varchar(255) default NULL,
-  `TLS-Cert-Common-Name` varchar(255) default NULL,
-  `TLS-Cert-Subject-Alt-Name-Email` varchar(255) default NULL,
-  `TLS-Client-Cert-Serial` varchar(255) default NULL,
-  `TLS-Client-Cert-Expiration` varchar(255) default NULL,
-  `TLS-Client-Cert-Valid-Since` varchar(255) default NULL,
-  `TLS-Client-Cert-Subject` varchar(255) default NULL,
-  `TLS-Client-Cert-Issuer` varchar(255) default NULL,
-  `TLS-Client-Cert-Common-Name` varchar(255) default NULL,
-  `TLS-Client-Cert-Subject-Alt-Name-Email` varchar(255) default NULL,
-  `TLS-Client-Cert-X509v3-Extended-Key-Usage` varchar(255) default NULL,
-  `TLS-Client-Cert-X509v3-Subject-Key-Identifier` varchar(255) default NULL,
-  `TLS-Client-Cert-X509v3-Authority-Key-Identifier` varchar(255) default NULL,
-  `TLS-Client-Cert-X509v3-Extended-Key-Usage-OID` varchar(255) default NULL
+  `TLSCertSerial` varchar(255) default NULL,
+  `TLSCertExpiration` varchar(255) default NULL,
+  `TLSCertValidSince` varchar(255) default NULL,
+  `TLSCertSubject` varchar(255) default NULL,
+  `TLSCertIssuer` varchar(255) default NULL,
+  `TLSCertCommonName` varchar(255) default NULL,
+  `TLSCertSubjectAltNameEmail` varchar(255) default NULL,
+  `TLSClientCertSerial` varchar(255) default NULL,
+  `TLSClientCertExpiration` varchar(255) default NULL,
+  `TLSClientCertValidSince` varchar(255) default NULL,
+  `TLSClientCertSubject` varchar(255) default NULL,
+  `TLSClientCertIssuer` varchar(255) default NULL,
+  `TLSClientCertCommonName` varchar(255) default NULL,
+  `TLSClientCertSubjectAltNameEmail` varchar(255) default NULL,
+  `TLSClientCertX509v3ExtendedKeyUsage` varchar(255) default NULL,
+  `TLSClientCertX509v3SubjectKeyIdentifier` varchar(255) default NULL,
+  `TLSClientCertX509v3AuthorityKeyIdentifier` varchar(255) default NULL,
+  `TLSClientCertX509v3ExtendedKeyUsageOID` varchar(255) default NULL
 ) ENGINE=InnoDB DEFAULT CHARACTER SET = 'utf8mb4' COLLATE = 'utf8mb4_general_ci';
 
 \! echo "Incrementing PacketFence schema version...";

--- a/db/upgrade-X.X-X.Y.sql
+++ b/db/upgrade-X.X-X.Y.sql
@@ -70,6 +70,30 @@ ALTER TABLE radius_audit_log MODIFY created_at TIMESTAMP NOT NULL DEFAULT CURREN
 \! echo "Make psk unique";
 ALTER TABLE person ADD CONSTRAINT UNIQUE person_psk (`psk`);
 
+\! echo "Create table node_tls"
+
+CREATE TABLE node_tls (
+  `mac` varchar(17) NOT NULL PRIMARY KEY,
+  `TLS-Cert-Serial` varchar(255) default NULL,
+  `TLS-Cert-Expiration` varchar(255) default NULL,
+  `TLS-Cert-Valid-Since` varchar(255) default NULL,
+  `TLS-Cert-Subject` varchar(255) default NULL,
+  `TLS-Cert-Issuer` varchar(255) default NULL,
+  `TLS-Cert-Common-Name` varchar(255) default NULL,
+  `TLS-Cert-Subject-Alt-Name-Email` varchar(255) default NULL,
+  `TLS-Client-Cert-Serial` varchar(255) default NULL,
+  `TLS-Client-Cert-Expiration` varchar(255) default NULL,
+  `TLS-Client-Cert-Valid-Since` varchar(255) default NULL,
+  `TLS-Client-Cert-Subject` varchar(255) default NULL,
+  `TLS-Client-Cert-Issuer` varchar(255) default NULL,
+  `TLS-Client-Cert-Common-Name` varchar(255) default NULL,
+  `TLS-Client-Cert-Subject-Alt-Name-Email` varchar(255) default NULL,
+  `TLS-Client-Cert-X509v3-Extended-Key-Usage` varchar(255) default NULL,
+  `TLS-Client-Cert-X509v3-Subject-Key-Identifier` varchar(255) default NULL,
+  `TLS-Client-Cert-X509v3-Authority-Key-Identifier` varchar(255) default NULL,
+  `TLS-Client-Cert-X509v3-Extended-Key-Usage-OID` varchar(255) default NULL,
+) ENGINE=InnoDB DEFAULT CHARACTER SET = 'utf8mb4' COLLATE = 'utf8mb4_general_ci';
+
 \! echo "Incrementing PacketFence schema version...";
 INSERT IGNORE INTO pf_version (id, version, created_at) VALUES (@VERSION_INT, CONCAT_WS('.', @MAJOR_VERSION, @MINOR_VERSION), NOW());
 

--- a/db/upgrade-X.X-X.Y.sql
+++ b/db/upgrade-X.X-X.Y.sql
@@ -91,7 +91,7 @@ CREATE TABLE node_tls (
   `TLS-Client-Cert-X509v3-Extended-Key-Usage` varchar(255) default NULL,
   `TLS-Client-Cert-X509v3-Subject-Key-Identifier` varchar(255) default NULL,
   `TLS-Client-Cert-X509v3-Authority-Key-Identifier` varchar(255) default NULL,
-  `TLS-Client-Cert-X509v3-Extended-Key-Usage-OID` varchar(255) default NULL,
+  `TLS-Client-Cert-X509v3-Extended-Key-Usage-OID` varchar(255) default NULL
 ) ENGINE=InnoDB DEFAULT CHARACTER SET = 'utf8mb4' COLLATE = 'utf8mb4_general_ci';
 
 \! echo "Incrementing PacketFence schema version...";

--- a/go/cron/flush_radius_audit_log_job.go
+++ b/go/cron/flush_radius_audit_log_job.go
@@ -71,11 +71,11 @@ func (j *FlushRadiusAuditLogJob) Run() {
 					log.LogError(ctx, fmt.Sprintf("%s error running: %s", j.Name(), err.Error()))
 					continue
 				}
-
 				jsonStr = string(s)
 			}
-
+			jsonStr = strings.Replace(jsonStr, "\\", "", -1)
 			err := json.Unmarshal([]byte(jsonStr), &entry)
+
 			if err != nil {
 				log.LogError(ctx, fmt.Sprintf("%s error running: %s", j.Name(), err.Error()))
 				continue
@@ -406,7 +406,6 @@ func escapeRadiusRequest(s string) string {
 	if size == len(s) {
 		return s
 	}
-
 	out := make([]byte, size)
 	j := 0
 	for _, c := range []byte(s) {

--- a/go/cron/flush_radius_audit_log_job.go
+++ b/go/cron/flush_radius_audit_log_job.go
@@ -304,6 +304,7 @@ func (j *FlushRadiusAuditLogJob) argsFromEntryForTLS(entry []interface{}) []inte
 	args := make([]interface{}, NODE_TLS_COLUMN_COUNT)
 	var request map[string]interface{}
 	request = entry[1].(map[string]interface{})
+	request = parseRequestArgs(request)
 	args[0] = formatRequestValue(request["Calling-Station-Id"], "")
 	args[1] = formatRequestValue(request["TLS-Cert-Serial"], "N/A")
 	args[2] = formatRequestValue(request["TLS-Cert-Expiration"], "N/A")
@@ -463,114 +464,114 @@ func parseRequestArgs(request map[string]interface{}) map[string]interface{} {
 type AKMSuite int
 
 const (
-	AKMReserved AKMSuite = iota // 0 - Reserved
-	IEEE8021X           // 1 - 802.1X
-	PSK                 // 2 - PSK
-	FT_8021X            // 3 - FT over 802.1X
-	FT_PSK              // 4 - FT over PSK
-	WPA_8021X           // 5 - WPA with 802.1X
-	WPA_PSK             // 6 - WPA with PSK
-	OWE                 // 7 - OWE
-	OWE_Transition      // 8 - OWE Transition Mode
-	SAE                 // 9 - Simultaneous Authentication of Equals
-	FT_SAE              // 10 - FT over SAE
-	FILS_SHA256         // 11 - FILS-SHA256
-	FILS_SHA384         // 12 - FILS-SHA384
-	FT_FILS_SHA256      // 13 - FT over FILS-SHA256
-	FT_FILS_SHA384      // 14 - FT over FILS-SHA384
-	OWE_transition_mode // 15 - OWE transition mode
+	AKMReserved         AKMSuite = iota // 0 - Reserved
+	IEEE8021X                           // 1 - 802.1X
+	PSK                                 // 2 - PSK
+	FT_8021X                            // 3 - FT over 802.1X
+	FT_PSK                              // 4 - FT over PSK
+	WPA_8021X                           // 5 - WPA with 802.1X
+	WPA_PSK                             // 6 - WPA with PSK
+	OWE                                 // 7 - OWE
+	OWE_Transition                      // 8 - OWE Transition Mode
+	SAE                                 // 9 - Simultaneous Authentication of Equals
+	FT_SAE                              // 10 - FT over SAE
+	FILS_SHA256                         // 11 - FILS-SHA256
+	FILS_SHA384                         // 12 - FILS-SHA384
+	FT_FILS_SHA256                      // 13 - FT over FILS-SHA256
+	FT_FILS_SHA384                      // 14 - FT over FILS-SHA384
+	OWE_transition_mode                 // 15 - OWE transition mode
 )
 
 type CipherSuite int
 
 const (
-	CipherReserved CipherSuite = iota // 0 - Reserved
-	WEP40            // 1 - WEP-40
-	TKIP             // 2 - TKIP
-	CipherReserved3  // 3 - Reserved
-	CCMP128          // 4 - CCMP-128
-	WEP104           // 5 - WEP-104
-	BIPCMAC128       // 6 - BIP-CMAC-128
-	GCMP128          // 7 - GCMP-128
-	GCMP256          // 8 - GCMP-256
-	CCMP256          // 9 - CCMP-256
-	BIPGMAC128       // 10 - BIP-GMAC-128
-	BIPGMAC256       // 11 - BIP-GMAC-256
-	SMS4             // 12 - SMS4
-	CKIP128          // 13 - CKIP-128
-	CKIP128_PMK      // 14 - CKIP-128 with PMK caching
-	CipherReserved15 // 15 - Reserved
+	CipherReserved   CipherSuite = iota // 0 - Reserved
+	WEP40                               // 1 - WEP-40
+	TKIP                                // 2 - TKIP
+	CipherReserved3                     // 3 - Reserved
+	CCMP128                             // 4 - CCMP-128
+	WEP104                              // 5 - WEP-104
+	BIPCMAC128                          // 6 - BIP-CMAC-128
+	GCMP128                             // 7 - GCMP-128
+	GCMP256                             // 8 - GCMP-256
+	CCMP256                             // 9 - CCMP-256
+	BIPGMAC128                          // 10 - BIP-GMAC-128
+	BIPGMAC256                          // 11 - BIP-GMAC-256
+	SMS4                                // 12 - SMS4
+	CKIP128                             // 13 - CKIP-128
+	CKIP128_PMK                         // 14 - CKIP-128 with PMK caching
+	CipherReserved15                    // 15 - Reserved
 )
 
-func(c CipherSuite) String() string {
+func (c CipherSuite) String() string {
 	switch c {
-		case WEP40:
-			return "WEP-40"
-		case TKIP:
-			return "TKIP"
-		case CCMP128:
-			return "CCMP-128"
-		case WEP104:
-			return "WEP-104"
-		case GCMP128:
-			return "GCMP-128"
-		case GCMP256:
-			return "GCMP-256"
-		case CCMP256:
-			return "CCMP-256"
-		case BIPCMAC128:
-			return "BIP-CMAC-128"
-		case BIPGMAC128:
-			return "BIP-GMAC-128"
-		case BIPGMAC256:
-			return "BIP-GMAC-256"
-		case SMS4:
-			return "SMS4"
-		case CKIP128:
-			return "CKIP-128"
-		case CKIP128_PMK:
-			return "CKIP-128 with PMK caching"
-		case CipherReserved3, CipherReserved15:
-			return "Reserved"
-		default:
-			return fmt.Sprintf("Unknown cipher suite (Value: %d)", c)
+	case WEP40:
+		return "WEP-40"
+	case TKIP:
+		return "TKIP"
+	case CCMP128:
+		return "CCMP-128"
+	case WEP104:
+		return "WEP-104"
+	case GCMP128:
+		return "GCMP-128"
+	case GCMP256:
+		return "GCMP-256"
+	case CCMP256:
+		return "CCMP-256"
+	case BIPCMAC128:
+		return "BIP-CMAC-128"
+	case BIPGMAC128:
+		return "BIP-GMAC-128"
+	case BIPGMAC256:
+		return "BIP-GMAC-256"
+	case SMS4:
+		return "SMS4"
+	case CKIP128:
+		return "CKIP-128"
+	case CKIP128_PMK:
+		return "CKIP-128 with PMK caching"
+	case CipherReserved3, CipherReserved15:
+		return "Reserved"
+	default:
+		return fmt.Sprintf("Unknown cipher suite (Value: %d)", c)
 	}
 }
 
-func(a AKMSuite) String() string {
+func (a AKMSuite) String() string {
 	switch a {
-		case IEEE8021X:
-			return "802.1X"
-		case PSK:
-			return "PSK"
-		case FT_8021X:
-			return "FT over 802.1X"
-		case FT_PSK:
-			return "FT over PSK"
-		case WPA_8021X:
-			return "WPA with 802.1X"
-		case WPA_PSK:
-			return "WPA with PSK"
-		case OWE:
-			return "OWE"
-		case OWE_Transition:
-			return "OWE Transition Mode"
-		case SAE:
-			return "SAE"
-		case FT_SAE:
-			return "FT over SAE"
-		case FILS_SHA256:
-			return "FILS-SHA256"
-		case FILS_SHA384:
-			return "FILS-SHA384"
-		case FT_FILS_SHA256:
-			return "FT over FILS-SHA256"
-		case FT_FILS_SHA384:
-			return "FT over FILS-SHA384"
-		case OWE_transition_mode:
-			return "OWE transition mode"
-		default:
-			return fmt.Sprintf("Unknown or Reserved AKM suite (Value: %d)", a)
+	case IEEE8021X:
+		return "802.1X"
+	case PSK:
+		return "PSK"
+	case FT_8021X:
+		return "FT over 802.1X"
+	case FT_PSK:
+		return "FT over PSK"
+	case WPA_8021X:
+		return "WPA with 802.1X"
+	case WPA_PSK:
+		return "WPA with PSK"
+	case OWE:
+		return "OWE"
+	case OWE_Transition:
+		return "OWE Transition Mode"
+	case SAE:
+		return "SAE"
+	case FT_SAE:
+		return "FT over SAE"
+	case FILS_SHA256:
+		return "FILS-SHA256"
+	case FILS_SHA384:
+		return "FILS-SHA384"
+	case FT_FILS_SHA256:
+		return "FT over FILS-SHA256"
+	case FT_FILS_SHA384:
+		return "FT over FILS-SHA384"
+	case OWE_transition_mode:
+		return "OWE transition mode"
+	default:
+		return fmt.Sprintf("Unknown or Reserved AKM suite (Value: %d)", a)
 	}
 }
 

--- a/go/plugin/caddy2/pfpki/models/models.go
+++ b/go/plugin/caddy2/pfpki/models/models.go
@@ -1243,7 +1243,10 @@ func (c Cert) New() (types.Info, error) {
 
 	Subject := c.MakeSubject()
 
-	NotAfter := time.Now().AddDate(0, 0, prof.Validity)
+	NotAfter := c.ValidUntil
+	if c.ValidUntil.IsZero() {
+		NotAfter = time.Now().AddDate(0, 0, prof.Validity)
+	}
 
 	// Prepare certificate
 	cert := &x509.Certificate{
@@ -1268,6 +1271,7 @@ func (c Cert) New() (types.Info, error) {
 	if len(c.Mail) > 0 {
 		Email = c.Mail
 	}
+
 	if len(Email) > 0 {
 		for _, mail := range strings.Split(Email, ",") {
 			cert.EmailAddresses = append(cert.EmailAddresses, mail)

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/TLSEnrollment.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/TLSEnrollment.pm
@@ -195,7 +195,7 @@ sub get_bundle {
     my $mac           = $self->current_mac;
     my $user_cache = $self->app->user_cache;
     my $pki_session = $user_cache->compute("pki_session", sub {});
-    my $cert_content = $pki_provider->get_bundle({ certificate_email => $pki_session->{certificate_email}, certificate_cn => $pki_session->{certificate_cn}, certificate_pwd => $pki_session->{certificate_pwd} });
+    my $cert_content = $pki_provider->get_bundle({ certificate_email => $pki_session->{certificate_email}, certificate_cn => $pki_session->{certificate_cn}, certificate_pwd => $pki_session->{certificate_pwd}, unregdate => $self->new_node_info->{'unregdate'}});
     get_logger->debug(sub { "cert_content from pki service $cert_content" });
 
     unless(defined($cert_content)){

--- a/html/pfappserver/root/src/views/Configuration/pkiProviders/_components/FormTypePacketfencePki.vue
+++ b/html/pfappserver/root/src/views/Configuration/pkiProviders/_components/FormTypePacketfencePki.vue
@@ -62,6 +62,13 @@
                                        disabled-value="N"
     />
 
+    <form-group-certificate-validity-time-from-unreg-date namespace="certificate_validity_time_from_unreg_date"
+                                       :column-label="$i18n.t('Set the certificate validity date to the unreg date value')"
+                                       :text="$i18n.t('Enable to apply the same expiration date of the certificate as the unregistration date of the node.')"
+                                       enabled-value="Y"
+                                       disabled-value="N"
+    />
+
     <form-group-ca-cert-path namespace="ca_cert_path"
                              :column-label="$i18n.t('CA certificate file')"
                              :title="$i18n.t('Upload CA certificate file')"
@@ -88,6 +95,7 @@ import {
   FormGroupPostalCode,
   FormGroupProfile,
   FormGroupRevokeOnRegistration,
+  FormGroupCertificateValidityTimeFromUnregDate,
   FormGroupServerCertPath,
   FormGroupState,
   FormGroupStreetAddress
@@ -107,6 +115,7 @@ const components = {
   FormGroupPostalCode,
   FormGroupProfile,
   FormGroupRevokeOnRegistration,
+  FormGroupCertificateValidityTimeFromUnregDate,
   FormGroupServerCertPath,
   FormGroupState,
   FormGroupStreetAddress

--- a/html/pfappserver/root/src/views/Configuration/pkiProviders/_components/index.js
+++ b/html/pfappserver/root/src/views/Configuration/pkiProviders/_components/index.js
@@ -32,6 +32,7 @@ export {
   BaseFormGroupInput            as FormGroupPostalCode,
   BaseFormGroupChosenOneProfile as FormGroupProfile,
   BaseFormGroupSwitch           as FormGroupRevokeOnRegistration,
+  BaseFormGroupSwitch           as FormGroupCertificateValidityTimeFromUnregDate,
   BaseFormGroupFileUpload       as FormGroupServerCertPath,
   BaseFormGroupInput            as FormGroupState,
   BaseFormGroupInput            as FormGroupStreetAddress,

--- a/lib/pf/pki_provider.pm
+++ b/lib/pf/pki_provider.pm
@@ -33,6 +33,8 @@ has cn_format => (is => 'rw', default => '%s');
 
 has revoke_on_unregistration => (is => 'rw', default => 'N');
 
+has certificate_validity_time_from_unreg_date => (is => 'rw', default => 'N');
+
 =head2 country
 
 What country to use for the certificate

--- a/lib/pf/pki_provider/packetfence_pki.pm
+++ b/lib/pf/pki_provider/packetfence_pki.pm
@@ -71,7 +71,7 @@ sub get_bundle {
             "profile_id"     => $profile,
     };
 
-    if (defined($expiration) && $expiration ne "" && isenabled($pki_provider->certificate_validity_time_from_unreg_date) ) {
+    if (defined($expiration) && $expiration ne "" && isenabled($self->certificate_validity_time_from_unreg_date) ) {
         my $tz = $ENV{TZ} || DateTime::TimeZone->new( name => 'local' )->name();
         my $formatter = DateTime::Format::Strptime->new(pattern => "%F %T",time_zone=>$tz);
         my $dt_obj    = $formatter->parse_datetime($expiration);


### PR DESCRIPTION
# Description
Track TLS certificate attributes per node. It helps to identify duplicate use of certificate and also track random mac address.

Set the expire date of the cert the same as the unregdate.

# Impacts
PacketFence PKI

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
## New Features
* New SQL Table to track EAP-TLS authentication


## Enhancements
* Expire certificate on unreg date (packetfece pki)
