### PR TITLE
fix version npm@10 Fix build image of httpd.admin_dispatcher

### DIFF
--- a/html/pfappserver/root/Makefile
+++ b/html/pfappserver/root/Makefile
@@ -6,7 +6,7 @@ all:
 	@echo "Use 'make vendor' to update external libraries, 'make dev' to generate the static JS/CSS files and 'make dist' to commit the distribution version."
 
 vendor:
-	npm install -g npm
+	npm install -g npm@10
 	npm install --unsafe-perm
 
 dev:


### PR DESCRIPTION
# Description
Fix build image of httpd.admin_dispatcher 

# Issue fixed
Fix build image of httpd.admin_dispatcher
https://gitlab.com/inverse-inc/packetfence/-/jobs/8797219269

```
INFO[0138] Running: [/bin/bash -c if [[ "$BUILD_PFAPPSERVER_VUE" == "yes" ]]; then       apt install nodejs -y &&       cd /html/pfappserver/root &&         make vendor  &&         make light-dist &&       cd /usr/local/pf &&         make SRC_HTMLDIR=/html html  &&       cd /usr/local/pf &&         make SRC_HTMLDIR=/html html_httpd.admin_dispatcher ;     else       echo "Skipping this step..." &&       mkdir /usr/local/pf/html ;     fi] 
WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
Reading package lists...
Building dependency tree...
Reading state information...
nodejs is already the newest version (20.5.1-deb-1nodesource1).
nodejs set to manually installed.
0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
npm install -g npm
npm ERR! code EBADENGINE
npm ERR! engine Unsupported engine
npm ERR! engine Not compatible with your version of node/npm: npm@11.0.0
npm ERR! notsup Not compatible with your version of node/npm: npm@11.0.0
npm ERR! notsup Required: {"node":"^20.17.0 || >=22.9.0"}
npm ERR! notsup Actual:   {"npm":"9.8.0","node":"v20.5.1"}
npm ERR! A complete log of this run can be found in: /root/.npm/_logs/2025-01-08T13_32_32_779Z-debug-0.log
make: *** [Makefile:9: vendor] Error 1
error building image: error building stage: failed to execute command: waiting for process to exit: exit status 2
```

# Delete branch after merge
YES

