### PR TITLE
Fix unbound dpsk in Ruckus and OpenWifi switch module

### DIFF
--- a/lib/pf/Switch/OpenWiFi.pm
+++ b/lib/pf/Switch/OpenWiFi.pm
@@ -108,10 +108,10 @@ sub check_if_radius_request_psk_matches {
         $pmk,
         pack("H*", $bssid),
         pack("H*", $radius_request->{"User-Name"}),
-        pack("H*", pf::util::wpa::strip_hex_prefix($radius_request->{"FreeRADIUS-802.1X-Anonce"})),
-        pf::util::wpa::snonce_from_eapol_key_frame(pack("H*", pf::util::wpa::strip_hex_prefix($radius_request->{"FreeRADIUS-802.1X-EAPoL-Key-Msg"}))),
-      ),      
-      pack("H*", pf::util::wpa::strip_hex_prefix($radius_request->{"FreeRADIUS-802.1X-EAPoL-Key-Msg"})),
+        pack("H*", sprintf("%v02x", $radius_request->{"FreeRADIUS-802.1X-Anonce"})=~ s/\.//rg),
+        pf::util::wpa::snonce_from_eapol_key_frame(pack("H*", sprintf("%v02x", $radius_request->{"FreeRADIUS-802.1X-EAPoL-Key-Msg"}) =~ s/\.//rg)),
+      ),
+      pack("H*", sprintf("%v02x", $radius_request->{"FreeRADIUS-802.1X-EAPoL-Key-Msg"}) =~ s/\.//rg),
     );
 }
 

--- a/lib/pf/Switch/Ruckus/SmartZone.pm
+++ b/lib/pf/Switch/Ruckus/SmartZone.pm
@@ -325,7 +325,6 @@ sub generate_dpsk_attribute_value {
     return "0x00".$hash;
 }
 
-
 sub find_user_by_psk {
     my ($self, $radius_request, $args) = @_;
     my $pid;
@@ -335,11 +334,11 @@ sub find_user_by_psk {
     }
 
     my $ssid = $radius_request->{'Ruckus-Wlan-Name'};
-    my $bssid = pack("H*", pf::util::wpa::strip_hex_prefix($radius_request->{"Ruckus-BSSID"}));
+    my $bssid = pack("H*", sprintf("%v02x", $radius_request->{"Ruckus-BSSID"}) =~ s/\.//rg);
     my $username = pack("H*", $radius_request->{'User-Name'});
-    my $anonce = pack('H*', pf::util::wpa::strip_hex_prefix($radius_request->{'Ruckus-DPSK-Anonce'}));
-    my $snonce = pf::util::wpa::snonce_from_eapol_key_frame(pack("H*", pf::util::wpa::strip_hex_prefix($radius_request->{"Ruckus-DPSK-EAPOL-Key-Frame"})));
-    my $eapol_key_frame = pack("H*", pf::util::wpa::strip_hex_prefix($radius_request->{"Ruckus-DPSK-EAPOL-Key-Frame"}));
+    my $anonce = pack('H*', sprintf("%v02x",$radius_request->{'Ruckus-DPSK-Anonce'}) =~ s/\.//rg);
+    my $snonce = pf::util::wpa::snonce_from_eapol_key_frame(pack("H*",sprintf("%v02x",$radius_request->{"Ruckus-DPSK-EAPOL-Key-Frame"}) =~ s/\.//rg));
+    my $eapol_key_frame = pack("H*", sprintf("%v02x",$radius_request->{"Ruckus-DPSK-EAPOL-Key-Frame"}) =~ s/\.//rg);
     my $cache = $self->cache;
     # Try first the pid of the mac address
     if (exists $args->{'owner'} && $args->{'owner'}->{'pid'} ne "" && exists $args->{'owner'}->{'psk'} && defined $args->{'owner'}->{'psk'} && $args->{'owner'}->{'psk'} ne "") {


### PR DESCRIPTION
# Description
With the newest version of FreeRADIUS the attributes are not encoded as before, so have to transform them.

# Impacts
Unbound DPSK

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Bug Fixes
* Fix unbound DPSK for the newest version of FreeRADIUS

