### PR TITLE
fix/8486

### DIFF
--- a/lib/pf/Switch/Template.pm
+++ b/lib/pf/Switch/Template.pm
@@ -584,6 +584,12 @@ sub returnCliAuthorize {
     return [$RADIUS::RLM_MODULE_OK, %radius_reply];
 }
 
+sub _setVlan {
+    my ( $self, $ifIndex, $newVlan, $oldVlan, $switch_locker_ref ) = @_;
+    my $logger = $self->logger;
+    return $self->_setVlanByOnlyModifyingPvid( $ifIndex, $newVlan, $oldVlan, $switch_locker_ref );
+}
+
 =head1 AUTHOR
 
 Inverse inc. <info@inverse.ca>


### PR DESCRIPTION
# Description
For PacketFence::SNMP set the vlan using dot1qPvid

# Issue
fixes #8486

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
## Bug Fixes
* PacketFence::SNMP cannot use SNMP to set vlan (#8486)
