### PR TITLE
fix 8492 - increase machine account timeout to 15s

### DIFF
--- a/go/ntlm/ntlm.go
+++ b/go/ntlm/ntlm.go
@@ -25,7 +25,7 @@ func CheckMachineAccountPassword(ctx context.Context, backendPort string) (bool,
 	url := "http://containers-gateway.internal:" + backendPort + "/ntlm/connect"
 
 	client := &http.Client{
-		Timeout: 5 * time.Second,
+		Timeout: 16 * time.Second,
 	}
 	response, err := client.Get(url)
 	if err != nil {
@@ -48,7 +48,7 @@ func CheckMachineAccountWithGivenPassword(ctx context.Context, backendPort strin
 	url := "http://containers-gateway.internal:" + backendPort + "/ntlm/connect"
 
 	client := &http.Client{
-		Timeout: 5 * time.Second,
+		Timeout: 16 * time.Second,
 	}
 
 	jsonData := map[string]string{


### PR DESCRIPTION
# Description
Fixes #8492
Gives more time to allow net.finddc to find an available DC to connect.
The timeout error should not appear if all the DCs are running fine. 
However, if the network between PacketFence and DC is unstable, or some DC nodes are down(especially more than one), it may take longer time for finddc to get an available DC and a timeout occurs.
We wait for 15s just for the worst cases.

# Impacts
changed the timeout settings for NTLM Machine account test endpoint.

# Code / PR Dependencies
N/A

# NEW Package(s) required
N/A

# Issue
fixes #8492 

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
N/A

## Enhancements
prolonged the wait time for NTLM auth machine account test.
return immediately after NTLM auth async jobs collected all the final results.

## Bug Fixes
fixes #8492 

# UPGRADE file entries
bin/pyntlm_auth/handlers.py
go/ntlm/ntlm.go
