### PR TITLE
Adding the Downloadable and Dynamic ACL enforcement to FortiSwitch

### DIFF
--- a/lib/pf/Switch/Fortinet/FortiSwitchOS_v7_x.pm
+++ b/lib/pf/Switch/Fortinet/FortiSwitchOS_v7_x.pm
@@ -159,6 +159,39 @@ sub returnInAccessListAttribute {
     return '';
 }
 
+=head2 returnOutAccessListAttribute
+
+Returns the attribute to use when pushing an output ACL using RADIUS
+
+=cut
+
+sub returnOutAccessListAttribute {
+    my ($self) = @_;
+    return '';
+}
+
+=head2 returnAccessListAttribute
+
+Returns the attribute to use when pushing an ACL using RADIUS
+
+=cut
+
+sub returnAccessListAttribute {
+    my ($self, $acl_num, $acl) = @_;
+    if ($acl =~ /^out\|(.*)/) {
+        if ($self->supportsOutAcl) {
+            return $TRUE, $self->returnOutAccessListAttribute.$acl_num.$1;
+        } else {
+            return $FALSE, '';
+        }
+    } elsif ($acl =~ /^in\|(.*)/) {
+        return $TRUE, $self->returnInAccessListAttribute.$acl_num.$1;
+    } else {
+        return $TRUE, $self->returnInAccessListAttribute.$acl_num.$acl;
+    }
+}
+
+
 =head2 returnRoleAttribute
 
 What RADIUS Attribute (usually VSA) should the role be returned into.

--- a/lib/pf/Switch/Fortinet/FortiSwitchOS_v7_x.pm
+++ b/lib/pf/Switch/Fortinet/FortiSwitchOS_v7_x.pm
@@ -28,6 +28,7 @@ use pf::accounting qw(node_accounting_dynauth_attr);
 use pf::config qw(
     $WIRED_802_1X
     $WIRED_MAC_AUTH
+    %ConfigRoles
 );
 
 use base ('pf::Switch::Fortinet');

--- a/lib/pf/Switch/Fortinet/FortiSwitchOS_v7_x.pm
+++ b/lib/pf/Switch/Fortinet/FortiSwitchOS_v7_x.pm
@@ -42,6 +42,7 @@ use pf::SwitchSupports qw(
     WiredMacAuth
     WiredDot1x
     ~AccessListBasedEnforcement
+    RoleBasedEnforcement
 );
 
 =head2 wiredeauthTechniques
@@ -100,6 +101,18 @@ sub deauthenticateMacDefault {
     return $self->radiusDisconnect(
         $mac, { 'Acct-Session-Id' => $dynauth->{'acctsessionid'}, 'User-Name' => $dynauth->{'username'}, 'NAS-Identifier' => $dynauth->{'nasidentifier'}, 'Called-Station-Id' => $dynauth->{'calledstationid'} },
     );
+}
+
+=head2 returnRoleAttribute
+
+What RADIUS Attribute (usually VSA) should the role be returned into.
+
+=cut
+
+sub returnRoleAttribute {
+    my ($self) = @_;
+
+    return 'Filter-Id';
 }
 
 =head2 getVersion

--- a/lib/pf/Switch/Fortinet/FortiSwitchOS_v7_x.pm
+++ b/lib/pf/Switch/Fortinet/FortiSwitchOS_v7_x.pm
@@ -41,7 +41,7 @@ sub description { 'FortiSwitchOS v7.x' }
 use pf::SwitchSupports qw(
     WiredMacAuth
     WiredDot1x
-    ~AccessListBasedEnforcement
+    AccessListBasedEnforcement
     RoleBasedEnforcement
 );
 
@@ -101,6 +101,61 @@ sub deauthenticateMacDefault {
     return $self->radiusDisconnect(
         $mac, { 'Acct-Session-Id' => $dynauth->{'acctsessionid'}, 'User-Name' => $dynauth->{'username'}, 'NAS-Identifier' => $dynauth->{'nasidentifier'}, 'Called-Station-Id' => $dynauth->{'calledstationid'} },
     );
+}
+
+=head2 returnRadiusAccessAccept
+
+Prepares the RADIUS Access-Accept reponse for the network device.
+
+Overrides the default implementation to add the dynamic acls
+
+=cut
+
+sub returnRadiusAccessAccept {
+    my ($self, $args) = @_;
+    my $logger = $self->logger;
+    $args->{'unfiltered'} = $TRUE;
+    my @super_reply = @{$self->SUPER::returnRadiusAccessAccept($args)};
+    my $status = shift @super_reply;
+    my %radius_reply = @super_reply;
+    my $radius_reply_ref = \%radius_reply;
+    return [$status, %$radius_reply_ref] if($status == $RADIUS::RLM_MODULE_USERLOCK);
+    my @acls = defined($radius_reply_ref->{'NAS-Filter-Rule'}) ? @{$radius_reply_ref->{'NAS-Filter-Rule'}} : ();
+
+    if ( isenabled($self->{_AccessListMap}) && $self->supportsAccessListBasedEnforcement ){
+        if( defined($args->{'user_role'}) && $args->{'user_role'} ne "" && defined(my $access_list = $self->getAccessListByName($args->{'user_role'}, $args->{mac})) && !($self->usePushACLs && exists $ConfigRoles{$args->{'user_role'}} )){
+            if ($access_list) {
+                while($access_list =~ /([^\n]+)\n?/g){
+                    my ($test, $formated_acl) = $self->returnAccessListAttribute('',$1);
+                    if ($test) {
+                        push(@acls, $formated_acl);
+                        $logger->info("(".$self->{'_id'}.") Adding access list : $formated_acl to the RADIUS reply");
+                    }
+                }
+                $logger->info("(".$self->{'_id'}.") Added access lists to the RADIUS reply.");
+            } else {
+                $logger->info("(".$self->{'_id'}.") No access lists defined for this role ".$args->{'user_role'});
+            }
+        }
+    }
+
+    $radius_reply_ref->{'NAS-Filter-Rule'} = \@acls;
+
+    my $filter = pf::access_filter::radius->new;
+    my $rule = $filter->test('returnRadiusAccessAccept', $args);
+    ($radius_reply_ref, $status) = $filter->handleAnswerInRule($rule,$args,$radius_reply_ref);
+    return [$status, %$radius_reply_ref];
+}
+
+=head2 returnInAccessListAttribute
+
+Returns the attribute to use when pushing an input ACL using RADIUS
+
+=cut
+
+sub returnInAccessListAttribute {
+    my ($self) = @_;
+    return '';
 }
 
 =head2 returnRoleAttribute


### PR DESCRIPTION
# Description
This new code enables support for Downloadable and Dynamic ACLs on FortiSwitch Modules, allowing users to configure and send ACLs in the RADIUS response.

# Impacts
Allows users to configure and send the ACL name or content (in the role) along with the Access-Accept in the RADIUS response

# Feature
This will enables the support for Downloadable and Dynamic ACL to FortiSwitch Modules, allowing the users to configure and send ACL in the radius response.

# Delete branch after merge
YES 

# Checklist
- [ ] Document the feature

# NEWS file entries
## New Features
*  Support for Downloadable and Dynamic ACL to FortiSwitch
