### PR TITLE
haproxy-portal: listen only on interfaces configured for portal

### DIFF
--- a/lib/pf/services/manager/haproxy_portal.pm
+++ b/lib/pf/services/manager/haproxy_portal.pm
@@ -106,7 +106,7 @@ EOT
 
             $tags{'http'} .= <<"EOT";
 frontend portal-http-$cluster_ip
-        bind *:80
+        bind $cluster_ip:80
         capture request header Host len 40
         stick-table type ip size 1m expire 10s store gpc0,http_req_rate(10s)
         tcp-request connection track-sc1 src
@@ -129,7 +129,7 @@ EOT
         default_backend $cluster_ip-backend
 
 frontend portal-https-$cluster_ip
-        bind *:443 ssl no-sslv3 crt /usr/local/pf/conf/ssl/server.pem
+        bind $cluster_ip:443 ssl no-sslv3 crt /usr/local/pf/conf/ssl/server.pem
         capture request header Host len 40
         stick-table type ip size 1m expire 10s store gpc0,http_req_rate(10s)
         tcp-request connection track-sc1 src

--- a/sbin/haproxy-portal-docker-wrapper
+++ b/sbin/haproxy-portal-docker-wrapper
@@ -6,7 +6,6 @@ name=haproxy-portal
 
 args=`base_args $name`
 args="$args -v/usr/local/pf/conf/ssl/:/usr/local/pf/conf/ssl/ -v/usr/local/pf/var/conf/:/usr/local/pf/var/conf/"
-args="$args -p 80:80 -p 443:443 -p 1025:1025"
 args="$args --network=host"
 
 run $name "$args"


### PR DESCRIPTION
# Description
haproxy-portal is configured to only listen on IPs of interfaces that are configured to provide the portal. The docker wrapper script is changed to not contain ignored parameters to `--publish` ports.

# Impacts
haproxy for portal will not listen to *:80 and *:443 anymore, but to the IPs of the interfaces configured to have portals listen on them.

# Issue
fixes https://github.com/inverse-inc/packetfence/issues/8539

# Delete branch after merge
YES

# Checklist
- [x] Document the feature - changes are actually needed to make packetfence behave like the documentation suggests
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

## Enhancements
* haproxy-portal listens only to interfaces configured to provide a portal