### PR TITLE
Move pfsetacl on pfdebian image

### DIFF
--- a/containers/pfsetacls/Dockerfile
+++ b/containers/pfsetacls/Dockerfile
@@ -1,3 +1,5 @@
+ARG KNK_REGISTRY_URL
+ARG IMAGE_TAG
 FROM golang:1.24.1-bookworm AS build
 
 ENV SEMAPHORE_VERSION="development" SEMAPHORE_ARCH="linux_amd64" \
@@ -43,7 +45,7 @@ RUN git clone -qq --depth 1 --single-branch --branch ${release} ${source} ./
 RUN deployment/docker/ci/bin/install
 
 # Prepapre the VM
-FROM debian:12
+FROM ${KNK_REGISTRY_URL}/pfdebian:${IMAGE_TAG}
 
 COPY --from=build /usr/lib /usr/lib
 COPY --from=build /usr/local/lib /usr/local/lib


### PR DESCRIPTION
# Description
Main objective is to reduce size and sources of images used with docker.
Use the default pfdebian image used everywhere else as based image.

# Impacts
Need to check if set pfsetacl is still working

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ ] Pipeline with tests: https://gitlab.com/inverse-inc/packetfence/-/pipelines/1732097679

# NEWS file entries
## Enhancements
* Reduce docker images impact 
