### PR TITLE
Move fingerbank db on pfdebian image

### DIFF
--- a/containers/fingerbank-db/Dockerfile
+++ b/containers/fingerbank-db/Dockerfile
@@ -5,7 +5,7 @@ FROM ${KNK_REGISTRY_URL}/pfdebian:${IMAGE_TAG}
 
 RUN apt-get -qq update && \
     apt-get -qq install -y fingerbank --reinstall && \
-    apt-get -qq install -y sqlite
+    apt-get -qq install -y sqlite3
 
 RUN curl --fail --retry 3 -H "Authorization: Bearer ${FINGERBANK_BUILD_API_KEY}" https://api.fingerbank.org/api/v2/download/db > /usr/local/fingerbank/db/fingerbank_Upstream.db
 

--- a/containers/fingerbank-db/Dockerfile
+++ b/containers/fingerbank-db/Dockerfile
@@ -1,22 +1,14 @@
 ARG KNK_REGISTRY_URL
 ARG IMAGE_TAG
+ARG FINGERBANK_BUILD_API_KEY
 FROM ${KNK_REGISTRY_URL}/pfdebian:${IMAGE_TAG}
 
-RUN apt update && apt install fingerbank --reinstall
-
-FROM alpine:3.19.4
-
-ARG FINGERBANK_BUILD_API_KEY
-
-RUN apk update && apk add curl sqlite
-
-RUN mkdir -p /usr/local/fingerbank/db
-
-COPY --from=0 /usr/local/fingerbank/db/fingerbank_Local.db /usr/local/fingerbank/db/fingerbank_Local.db
+RUN apt-get -qq update && \
+    apt-get -qq install -y fingerbank --reinstall && \
+    apt-get -qq install -y sqlite
 
 RUN curl --fail --retry 3 -H "Authorization: Bearer ${FINGERBANK_BUILD_API_KEY}" https://api.fingerbank.org/api/v2/download/db > /usr/local/fingerbank/db/fingerbank_Upstream.db
 
 # Delete the unknown MAC vendors, they aren't useful in this image (meant to be used for the SaaS)
 RUN sqlite3 /usr/local/fingerbank/db/fingerbank_Upstream.db "delete from mac_vendor where name like 'Unknown%';"
 RUN sqlite3 /usr/local/fingerbank/db/fingerbank_Upstream.db "VACUUM;"
-

--- a/containers/fingerbank-db/Dockerfile
+++ b/containers/fingerbank-db/Dockerfile
@@ -1,11 +1,12 @@
 ARG KNK_REGISTRY_URL
 ARG IMAGE_TAG
-ARG FINGERBANK_BUILD_API_KEY
 FROM ${KNK_REGISTRY_URL}/pfdebian:${IMAGE_TAG}
 
 RUN apt-get -qq update && \
     apt-get -qq install -y fingerbank --reinstall && \
     apt-get -qq install -y sqlite3
+
+ARG FINGERBANK_BUILD_API_KEY
 
 RUN curl --fail --retry 3 -H "Authorization: Bearer ${FINGERBANK_BUILD_API_KEY}" https://api.fingerbank.org/api/v2/download/db > /usr/local/fingerbank/db/fingerbank_Upstream.db
 


### PR DESCRIPTION
# Description
Main objective is to reduce size and sources of images used with docker.
Use the default pfdebian image used everywhere else as based image.

# Impacts
Need to check if set fingerbanck db is still working as expected is still working

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ ] Pipeline with tests: https://gitlab.com/inverse-inc/packetfence/-/pipelines/1732391464

# NEWS file entries
## Enhancements
* Reduce docker images impact 
