### PR TITLE
fix pfperl-api manager exit triggered by pfperl-api worker termination

### DIFF
--- a/lib/pf/UnifiedApi/Command/prefork.pm
+++ b/lib/pf/UnifiedApi/Command/prefork.pm
@@ -14,6 +14,10 @@ sd_ready;
 
 sub run {
   my ($self, @args) = @_;
+  # init app force (important!)
+  my $app = $self->app;
+  # trigger log module and init the APP constructor
+  my $log = $app->log;
   Linux::Systemd::Daemon::sd_notify( READY => 1, STATUS => "Ready", unset => 1 );
   my $timeout = $Config{advanced}{pfperl_api_timeout} // 600;
   eval {


### PR DESCRIPTION
# Description
(REQUIRED)
Allow PacketFence to shutdown worker gracefully without causing manager exit.

# Impacts
(REQUIRED)
RESTful API request

# Issue
fixes #8628 

# Delete branch after merge
NO

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ no] Document the feature
- [ no] Add OpenAPI specification
- [ no] Add unit tests
- [ no] Add acceptance tests (TestLink)

## Bug Fixes
If an issue exists on Github, please refer to it (name) along with it's number...
* Issue with pfperl-api doesn't handle mem-leaks correctl (#3599 )
* Issue with pfperl-api main process exit triggered by pfperl-api child termination (#8628 )