### PR TITLE
Support for dACLs on Cisco WLC IOS XE

### DIFF
--- a/lib/pf/Switch/Cisco/Cisco_WLC_IOS_XE.pm
+++ b/lib/pf/Switch/Cisco/Cisco_WLC_IOS_XE.pm
@@ -15,10 +15,66 @@ use strict;
 use warnings;
 
 use Net::SNMP;
+use pf::Switch::constants;
+use pf::constants qw($TRUE $FALSE);
+use pf::config qw(
+    %ConfigRoles
+);
+use pf::util;
 
 use base ('pf::Switch::Cisco::Cisco_WLC_AireOS');
 
 sub description { 'Cisco WLC (IOS XE)' }
+
+use pf::SwitchSupports qw(
+    AccessListBasedEnforcement
+);
+
+sub returnRadiusAccessAccept {
+    my ($self, $args) = @_;
+    my $logger = $self->logger;
+    $args->{'unfiltered'} = $TRUE;
+    $args->{'compute_acl'} = $FALSE;
+    $self->compute_action(\$args);
+    my @super_reply = @{$self->SUPER::returnRadiusAccessAccept($args)};
+    my $status = shift @super_reply;
+    my %radius_reply = @super_reply;
+    my $radius_reply_ref = \%radius_reply;
+    return [$status, %$radius_reply_ref] if($status == $RADIUS::RLM_MODULE_USERLOCK);
+    my @av_pairs = defined($radius_reply_ref->{'Cisco-AVPair'}) ? @{$radius_reply_ref->{'Cisco-AVPair'}} : ();
+
+    if ( isenabled($self->{_AccessListMap}) && $self->supportsAccessListBasedEnforcement ){
+        if( defined($args->{'user_role'}) && $args->{'user_role'} ne "" && defined(my $access_list = $self->getAccessListByName($args->{'user_role'}, $args->{mac})) && !($self->usePushACLs && exists $ConfigRoles{$args->{'user_role'}} )){
+            if ($access_list) {
+                my $acl_num = 101;
+                while($access_list =~ /([^\n]+)\n?/g){
+                   my $acl = $1;
+                   if ($acl !~ /^((in|out)\|)?(permit|deny)/i) {
+                       next;
+                   }
+                   my ($test, $formated_acl) = $self->returnAccessListAttribute($acl_num,$acl);
+                   if ($test) {
+                       push(@av_pairs, $formated_acl);
+                   } else {
+                       next;
+                   }
+                   $acl_num ++;
+                   $logger->info("(".$self->{'_id'}.") Adding access list : $formated_acl to the RADIUS reply");
+                   $logger->info("(".$self->{'_id'}.") Added access lists to the RADIUS reply.");
+                }
+            } else {
+                $logger->info("(".$self->{'_id'}.") No access lists defined for this role ". ( defined($args->{'user_role'}) ? $args->{'user_role'} : 'registration' ));
+            }
+        }
+    }
+
+    $radius_reply_ref->{'Cisco-AVPair'} = \@av_pairs;
+
+    my $filter = pf::access_filter::radius->new;
+    my $rule = $filter->test('returnRadiusAccessAccept', $args);
+    ($radius_reply_ref, $status) = $filter->handleAnswerInRule($rule,$args,$radius_reply_ref);
+    return [$status, %$radius_reply_ref];
+}
 
 =head1 AUTHOR
 


### PR DESCRIPTION
# Description
Added support for dynamic ACLs on cisco WLC running IOS XE (like Cisco 9800)

# Impacts
Cisco WLX IOS XE switch module

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
## New Features
* Support for dynamic ACLs for Cisco WLC 9800
