### PR TITLE
feat: add AllMySMS authentication module support

### DIFF
--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/SMS.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/SMS.pm
@@ -25,7 +25,7 @@ use pf::auth_log;
 has '+pid_field' => (default => sub { "telephone" });
 
 has '+source' => (
-    isa => 'pf::Authentication::Source::SMSSource|pf::Authentication::Source::TwilioSource|pf::Authentication::Source::ClickatellSource',
+    isa => 'pf::Authentication::Source::SMSSource|pf::Authentication::Source::TwilioSource|pf::Authentication::Source::ClickatellSource|pf::Authentication::Source::AllMySMSSource',
     lazy => 1,
     builder => '_build_source',
 );

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source/AllMySMS.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source/AllMySMS.pm
@@ -1,0 +1,80 @@
+package pfappserver::Form::Config::Source::AllMySMS;
+
+=head1 NAME
+
+pfappserver::Form::Config::Source::AllMySMS
+
+=cut
+
+=head1 DESCRIPTION
+
+Form definition to create or update a AllMySMS authentication source.
+
+=cut
+
+use strict;
+use warnings;
+
+use HTML::FormHandler::Moose;
+
+extends 'pfappserver::Form::Config::Source';
+with 'pfappserver::Base::Form::Role::Help';
+with 'pfappserver::Base::Form::Role::SourceLocalAccount';
+
+has_field 'api_key' => (
+    type        => 'Text',
+    label       => 'API Key',
+    required    => 1,
+    # Default value needed for creating dummy source
+    default     => '',
+    tags        => {
+        after_element   => \&help,
+        help            => 'AllMySMS API Key',
+    },
+);
+
+has_field 'message' => (
+    type => 'TextArea',
+    label => 'SMS text message ($pin will be replaced by the PIN number)',
+    default => pf::Authentication::Source::SMSSource->meta->get_attribute('message')->default,
+);
+
+has_field 'pin_code_length' => (
+    type => 'PosInteger',
+    label => 'PIN Code Length',
+    default => pf::Authentication::Source::AllMySMSSource->meta->get_attribute('pin_code_length')->default,
+    tags => {
+        after_element => \&help,
+        help => 'The length of the PIN code to be sent over sms',
+    },
+);
+
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2024 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;

--- a/html/pfappserver/root/src/views/Configuration/sources/_components/FormTypeAllMySMS.vue
+++ b/html/pfappserver/root/src/views/Configuration/sources/_components/FormTypeAllMySMS.vue
@@ -1,0 +1,112 @@
+<template>
+  <base-form
+    :form="form"
+    :meta="meta"
+    :schema="schema"
+    :isLoading="isLoading"
+  >
+    <form-group-identifier namespace="id"
+                           :column-label="$i18n.t('Name')"
+                           :disabled="!isNew && !isClone"
+    />
+
+    <form-group-description namespace="description"
+                            :column-label="$i18n.t('Description')"
+    />
+
+    <form-group-api-key namespace="api_key"
+                        :column-label="$i18n.t('AllMySMS API Key')"
+                        :text="$i18n.t('Concatenate username and API key (separated by colon \':\'), then encode it in base64. e.g. amRvZTphYXh4eHh4eHh4eHh4MDA= for jdoe:aaxxxxxxxxxxx00')"
+    />
+
+    <form-group-message namespace="message"
+                        :column-label="$i18n.t('SMS text message ($pin will be replaced by the PIN number)')"
+    />
+
+    <form-group-pin-code-length namespace="pin_code_length"
+                                :column-label="$i18n.t('PIN length')"
+                                :text="$i18n.t('The amount of digits of the PIN number.')"
+    />
+
+    <form-group-from namespace="from"
+                        :column-label="$i18n.t('Message expeditor')"
+                        :text="$i18n.t('Must start with letter, contains only (a-zA-Z0-9) and one whitespace, no special key, length between 3 and 11.')"
+    />
+
+    <form-group-create-local-account namespace="create_local_account"
+                                     :column-label="$i18n.t('Create Local Account')"
+                                     :text="$i18n.t('Create a local account on the PacketFence system based on the username provided.')"
+                                     enabled-value="yes"
+                                     disabled-value="no"
+    />
+
+    <form-group-hash-passwords namespace="hash_passwords"
+                               :column-label="$i18n.t('Database passwords hashing method')"
+                               :text="$i18n.t('The algorithm used to hash the passwords in the database.This will only affect newly created or reset passwords.')"
+    />
+
+    <form-group-password-length namespace="password_length"
+                                :column-label="$i18n.t('Password length')"
+                                :text="$i18n.t('The length of the password to generate.')"
+    />
+
+    <form-group-local-account-logins namespace="local_account_logins"
+                                     :column-label="$i18n.t('Amount of logins for the local account')"
+                                     :text="$i18n.t('The amount of times, the local account can be used after its created. 0 means infinite.')"
+    />
+
+    <form-group-local-account-expiration namespace="local_account_expiration"
+                                         :column-label="$i18n.t('Local account expiration')"
+                                         :text="$i18n.t('The amount of time after which the local account will expire. A value of 0 will use the access duration that is found via the authentication rules for the user.')"
+    />
+
+    <form-group-authentication-rules namespace="authentication_rules"
+                                     :column-label="$i18n.t('Authentication Rules')"
+    />
+  </base-form>
+</template>
+<script>
+import {BaseForm} from '@/components/new/'
+import {
+  FormGroupApiKey,
+  FormGroupAuthenticationRules,
+  FormGroupCreateLocalAccount,
+  FormGroupDescription,
+  FormGroupFrom,
+  FormGroupHashPasswords,
+  FormGroupIdentifier,
+  FormGroupLocalAccountExpiration,
+  FormGroupLocalAccountLogins,
+  FormGroupMessage,
+  FormGroupPasswordLength,
+  FormGroupPinCodeLength,
+} from './'
+
+const components = {
+  BaseForm,
+
+  FormGroupApiKey,
+  FormGroupAuthenticationRules,
+  FormGroupCreateLocalAccount,
+  FormGroupDescription,
+  FormGroupFrom,
+  FormGroupHashPasswords,
+  FormGroupIdentifier,
+  FormGroupLocalAccountExpiration,
+  FormGroupLocalAccountLogins,
+  FormGroupMessage,
+  FormGroupPasswordLength,
+  FormGroupPinCodeLength,
+}
+
+import {useForm as setup, useFormProps as props} from '../_composables/useForm'
+
+// @vue/component
+export default {
+  name: 'form-type-allmysms',
+  inheritAttrs: false,
+  components,
+  props,
+  setup
+}
+</script>

--- a/html/pfappserver/root/src/views/Configuration/sources/_components/TheForm.vue
+++ b/html/pfappserver/root/src/views/Configuration/sources/_components/TheForm.vue
@@ -26,6 +26,7 @@ import FormTypeAuthorization from './FormTypeAuthorization'
 import FormTypeAzureAD from './FormTypeAzureAD'
 import FormTypeBlackhole from './FormTypeBlackhole'
 import FormTypeClickatell from './FormTypeClickatell'
+import FormTypeAllMySMS from './FormTypeAllMySMS'
 import FormTypeEapTls from './FormTypeEapTls'
 import FormTypeEdir from './FormTypeEdir'
 import FormTypeEduroam from './FormTypeEduroam'
@@ -59,6 +60,7 @@ const components = {
   FormTypeAzureAD,
   FormTypeBlackhole,
   FormTypeClickatell,
+  FormTypeAllMySMS,
   FormTypeEapTls,
   FormTypeEdir,
   FormTypeEduroam,
@@ -100,6 +102,7 @@ export const setup = (props) => {
       case 'AzureAD':             return FormTypeAzureAD // break
       case 'Blackhole':           return FormTypeBlackhole //break
       case 'Clickatell':          return FormTypeClickatell //break
+      case 'AllMySMS':            return FormTypeAllMySMS //break
       case 'EAPTLS':              return FormTypeEapTls //break
       case 'EDIR':                return FormTypeEdir // break
       case 'Eduroam':             return FormTypeEduroam // break

--- a/html/pfappserver/root/src/views/Configuration/sources/_components/index.js
+++ b/html/pfappserver/root/src/views/Configuration/sources/_components/index.js
@@ -67,6 +67,7 @@ export {
   BaseFormGroupInput                        as FormGroupEmailAddress,
   BaseFormGroupInput                        as FormGroupEmailAttribute,
   BaseFormGroupSwitch                       as FormGroupEmailRequired,
+  BaseFormGroupInput                        as FormGroupFrom,
   BaseFormGroupInput                        as FormGroupGroupHeader,
   BaseFormGroupChosenOne                    as FormGroupHashPasswords,
   BaseFormGroupInput                        as FormGroupHost,

--- a/html/pfappserver/root/src/views/Configuration/sources/config.js
+++ b/html/pfappserver/root/src/views/Configuration/sources/config.js
@@ -19,6 +19,7 @@ export const internalTypes = {
 
 export const externalTypes = {
   Clickatell:     'Clickatell',
+  AllMySMS:       'AllMySMS',
   Email:          i18n.t('Email'),
   Facebook:       'Facebook',
   Github:         'Github',

--- a/lib/pf/Authentication/Source/AllMySMSSource.pm
+++ b/lib/pf/Authentication/Source/AllMySMSSource.pm
@@ -1,0 +1,144 @@
+package pf::Authentication::Source::AllMySMSSource;
+
+=head1 NAME
+
+pf::Authentication::Source::AllMySMSSource
+
+=head1 DESCRIPTION
+
+=cut
+
+use pf::Authentication::constants;
+use pf::constants qw($TRUE $FALSE);
+use pf::error qw(is_success);
+use pf::log;
+use URI::Escape::XS qw(uri_escape);
+use JSON;
+
+use Moose;
+
+extends 'pf::Authentication::Source';
+with qw(pf::Authentication::CreateLocalAccountRole pf::Authentication::SMSRole);
+
+
+has '+type'                     => (default => 'AllMySMS');
+has '+class'                    => (isa => 'Str', is => 'ro', default => 'external');
+has '+dynamic_routing_module'   => (is => 'rw', default => 'Authentication::SMS');
+has 'api_key'                   => (isa => 'Str', is => 'rw');
+has 'message'                   => (isa => 'Maybe[Str]', is => 'rw', default => 'PIN: $pin');
+
+=head2 available_rule_classes
+
+Only allow 'authentication' rules
+
+=cut
+
+sub available_rule_classes {
+    return [ grep { $_ ne $Rules::ADMIN } @Rules::CLASSES ];
+}
+
+
+=head2 available_actions
+
+Only allow 'authentication' actions
+
+=cut
+
+sub available_actions {
+    my @actions = map( { @$_ } $Actions::ACTIONS{$Rules::AUTH});
+    return \@actions;
+}
+
+
+=head2 available_attributes
+
+Allow to make a condition on the provided phone number
+
+=cut
+
+sub available_attributes {
+  my $self = shift;
+
+  my $super_attributes = $self->SUPER::available_attributes;
+
+  return [@$super_attributes];
+}
+
+=head2 match_in_subclass
+
+=cut
+
+sub match_in_subclass {
+    my ($self, $params, $rule, $own_conditions, $matching_conditions) = @_;
+    return ($params->{'username'}, undef);
+}
+
+
+=head2 sendSMS
+
+Use AllMySMS url to send an SMS
+
+=cut
+
+sub sendSMS {
+    my ($self, $info) = @_;
+    my $to = $info->{to};
+    my $message = $info->{message};
+    my $api_key = $self->api_key;
+    my $logger = pf::log::get_logger;
+
+    use LWP::UserAgent;
+
+    my $url = "https://api.allmysms.com/sms/send/";
+    my %params = (
+        'to' => $to,
+        'text' => "$message\r\nSTOP au 36180",
+    );
+
+    my $json_params = encode_json(\%params);
+
+    my $ua = LWP::UserAgent->new;
+    my $response = $ua->post($url, Content => $json_params, Authorization => "Basic $api_key", 'Content-Type' => 'application/json');
+
+    unless($response->is_success) {
+        $logger->error("Can't send SMS to '$to': " . $response->{'message'});
+        return $FALSE;
+    }
+
+    $logger->info("SMS sent to '$to' (Network Activation)");
+    return $TRUE;
+}
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2024 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+__PACKAGE__->meta->make_immutable unless $ENV{"PF_SKIP_MAKE_IMMUTABLE"};
+1;
+
+# vim: set shiftwidth=4:
+# vim: set expandtab:
+# vim: set backspace=indent,eol,start:

--- a/lib/pf/ConfigStore/Source.pm
+++ b/lib/pf/ConfigStore/Source.pm
@@ -48,6 +48,7 @@ our %TYPE_TO_FLATTEN = (
     SMS => [qw(message)],
     Twilio => [qw(message)],
     Clickatell => [qw(message)],
+    AllMySMS => [qw(message)],
     Email => [qw(allowed_domains banned_domains)],
     RADIUS => [qw(options)],
 );

--- a/lib/pf/UnifiedApi/Controller/Config/Sources.pm
+++ b/lib/pf/UnifiedApi/Controller/Config/Sources.pm
@@ -30,6 +30,7 @@ use pfappserver::Form::Config::Source::AzureAD;
 use pfappserver::Form::Config::Source::Blackhole;
 use pfappserver::Form::Config::Source::Authorization;
 use pfappserver::Form::Config::Source::Clickatell;
+use pfappserver::Form::Config::Source::AllMySMS;
 use pfappserver::Form::Config::Source::EAPTLS;
 use pfappserver::Form::Config::Source::Eduroam;
 use pfappserver::Form::Config::Source::EDIR;
@@ -65,6 +66,7 @@ our %TYPES_TO_FORMS = (
       AzureAD
       Blackhole
       Clickatell
+      AllMySMS
       EAPTLS
       Eduroam
       EDIR


### PR DESCRIPTION
# Description
Add the AllMySMS authentication module, to use SMS as an authentication factor using the AllMySMS service, as Twilio or Clickatell already do.

# Impacts
- Admin web interface now shows a AllMySMS external authentication source.
- New field allows for SMS expeditor setting.

# Delete branch after merge
YES

# Checklist
- [x] Document the feature