### PR TITLE
feature/radius-proxy-pfconnector

### DIFF
--- a/go/chisel/server/server_handler.go
+++ b/go/chisel/server/server_handler.go
@@ -178,6 +178,16 @@ func (s *Server) handleWebsocket(w http.ResponseWriter, req *http.Request) {
 
 	localSecret := pfconfigdriver.LocalSecret{}
 	pfconfigdriver.FetchDecodeSocket(req.Context(), &localSecret)
+	pfconnectorStaticConnections := pfconfigdriver.PfconnectorStaticConnections{}
+	pfconfigdriver.FetchDecodeSocket(req.Context(), &pfconnectorStaticConnections)
+	additionalRemotes := chshare.Remotes{}
+	if remotes, found := pfconnectorStaticConnections.Element[user.Name]; found {
+		for _, remoteDef := range remotes {
+			if remote, err := settings.DecodeRemote(remoteDef); err == nil {
+				additionalRemotes = append(additionalRemotes, remote)
+			}
+		}
+	}
 	//successfuly validated config!
 	r.Reply(true, nil)
 	//tunnel per ssh connection
@@ -195,9 +205,10 @@ func (s *Server) handleWebsocket(w http.ResponseWriter, req *http.Request) {
 		//connected, handover ssh connection for tunnel to use, and block
 		return tunnel.BindSSH(ctx, sshConn, reqs, chans)
 	})
+	//connected, setup reversed-remotes?
+	serverInbound := c.Remotes.Reversed(true)
+	serverInbound = append(serverInbound, additionalRemotes...)
 	eg.Go(func() error {
-		//connected, setup reversed-remotes?
-		serverInbound := c.Remotes.Reversed(true)
 		if len(serverInbound) == 0 {
 			return nil
 		}

--- a/go/pfconfigdriver/structs.go
+++ b/go/pfconfigdriver/structs.go
@@ -428,6 +428,14 @@ type RolesChildren struct {
 	Element                 map[string][]string
 }
 
+type PfconnectorStaticConnections struct {
+	StructConfig
+	PfconfigMethod          string `val:"element"`
+	PfconfigNS              string `val:"resource::pfconnector_static_connections"`
+	PfconfigDecodeInElement string `val:"yes"`
+	Element                 map[string][]string
+}
+
 type ClusterName struct {
 	StructConfig
 	PfconfigMethod          string `val:"hash_element"`
@@ -579,34 +587,34 @@ type ClusterSummary struct {
 
 type PfConfAdvanced struct {
 	StructConfig
-	PfconfigMethod                   string      `val:"hash_element"`
-	PfconfigNS                       string      `val:"config::Pf"`
-	PfconfigHashNS                   string      `val:"advanced"`
-	HashingCost                      string      `json:"hashing_cost"`
-	ScanOnAccounting                 string      `json:"scan_on_accounting"`
-	PffilterProcesses                string      `json:"pffilter_processes"`
-	UpdateIplogWithAccounting        string      `json:"update_iplog_with_accounting"`
-	UpdateIplogWithAuthentication    string      `json:"update_iplog_with_authentication"`
-	AdminCspSecurityHeaders          string      `json:"admin_csp_security_headers"`
-	Multihost                        string      `json:"multihost"`
-	SsoOnAccessReevaluation          string      `json:"sso_on_access_reevaluation"`
-	DisablePfDomainAuth              string      `json:"disable_pf_domain_auth"`
-	TimingStatsLevel                 string      `json:"timing_stats_level"`
-	SsoOnDhcp                        string      `json:"sso_on_dhcp"`
-	Language                         string      `json:"language"`
-	StatsdListenPort                 string      `json:"statsd_listen_port"`
-	SsoOnAccounting                  string      `json:"sso_on_accounting"`
-	LocationlogCloseOnAccountingStop string      `json:"locationlog_close_on_accounting_stop"`
-	PortalCspSecurityHeaders         string      `json:"portal_csp_security_headers"`
-	HashPasswords                    string      `json:"hash_passwords"`
-	SourceToSendSmsWhenCreatingUsers string      `json:"source_to_send_sms_when_creating_users"`
-	ActiveDirectoryOsJoinCheckBypass string      `json:"active_directory_os_join_check_bypass"`
-	PfperlApiTimeout                 string      `json:"pfperl_api_timeout"`
-	LdapAttributes                   []string    `json:"ldap_attributes"`
-	ApiInactivityTimeout             int         `json:"api_inactivity_timeout"`
-	ApiMaxExpiration                 int         `json:"api_max_expiration"`
-	NetFlowOnAllNetworks             string      `json:"netflow_on_all_networks"`
-	AccountingTimebucketSize         int         `json:"accounting_timebucket_size"`
+	PfconfigMethod                   string   `val:"hash_element"`
+	PfconfigNS                       string   `val:"config::Pf"`
+	PfconfigHashNS                   string   `val:"advanced"`
+	HashingCost                      string   `json:"hashing_cost"`
+	ScanOnAccounting                 string   `json:"scan_on_accounting"`
+	PffilterProcesses                string   `json:"pffilter_processes"`
+	UpdateIplogWithAccounting        string   `json:"update_iplog_with_accounting"`
+	UpdateIplogWithAuthentication    string   `json:"update_iplog_with_authentication"`
+	AdminCspSecurityHeaders          string   `json:"admin_csp_security_headers"`
+	Multihost                        string   `json:"multihost"`
+	SsoOnAccessReevaluation          string   `json:"sso_on_access_reevaluation"`
+	DisablePfDomainAuth              string   `json:"disable_pf_domain_auth"`
+	TimingStatsLevel                 string   `json:"timing_stats_level"`
+	SsoOnDhcp                        string   `json:"sso_on_dhcp"`
+	Language                         string   `json:"language"`
+	StatsdListenPort                 string   `json:"statsd_listen_port"`
+	SsoOnAccounting                  string   `json:"sso_on_accounting"`
+	LocationlogCloseOnAccountingStop string   `json:"locationlog_close_on_accounting_stop"`
+	PortalCspSecurityHeaders         string   `json:"portal_csp_security_headers"`
+	HashPasswords                    string   `json:"hash_passwords"`
+	SourceToSendSmsWhenCreatingUsers string   `json:"source_to_send_sms_when_creating_users"`
+	ActiveDirectoryOsJoinCheckBypass string   `json:"active_directory_os_join_check_bypass"`
+	PfperlApiTimeout                 string   `json:"pfperl_api_timeout"`
+	LdapAttributes                   []string `json:"ldap_attributes"`
+	ApiInactivityTimeout             int      `json:"api_inactivity_timeout"`
+	ApiMaxExpiration                 int      `json:"api_max_expiration"`
+	NetFlowOnAllNetworks             string   `json:"netflow_on_all_networks"`
+	AccountingTimebucketSize         int      `json:"accounting_timebucket_size"`
 }
 
 type PfConfDns struct {

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source/RADIUS.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source/RADIUS.pm
@@ -141,7 +141,7 @@ sub validate {
         my $p = $source->{connect_through_port};
         if ( defined $p && $p == $port ) {
             $self->field('connect_through_port')
-              ->add_error('Only a single port should be defined');
+              ->add_error('Port should be unique');
         }
     }
 }

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source/RADIUS.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source/RADIUS.pm
@@ -125,12 +125,11 @@ sub _options_set_role_from_source {
 }
 
 sub validate {
-    my ($self)          = @_;
-    my $value           = $self->value;
-    my $connect_through = $value->{connect_through};
-    return if !defined $connect_through || length($connect_through) == 0;
+    my ($self) = @_;
+    my $value  = $self->value;
+    my $port   = $value->{connect_through_port};
+    return if !defined $port || length($port) == 0;
     my $id      = $value->{id};
-    my $port    = $value->{connect_through_port};
     my $sources = pf::authentication::getAuthenticationSourcesByType('RADIUS');
 
     for my $source (@$sources) {

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source/RADIUS.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source/RADIUS.pm
@@ -11,7 +11,6 @@ Form definition to create or update a RADIUS user source.
 =cut
 
 use HTML::FormHandler::Moose;
-use pf::ConfigStore::Connector;
 use pf::config qw(%Config);
 use pf::authentication;
 use pf::Authentication::Source::RADIUSSource;
@@ -83,24 +82,9 @@ has_field 'use_connector',
     default         => $META->get_attribute('use_connector')->default,
   );
 
-has_field 'connect_through' => (
-    type           => 'Select',
-    options_method => \&options_connectors,
-);
-
 has_field 'connect_through_port' => (
     type          => 'Port',
-    required_when => {
-        connect_through => sub {
-            defined $_[0] && length( $_[0] );
-        },
-    },
 );
-
-sub options_connectors {
-    return map { { value => $_, label => $_ } } '',
-      @{ pf::ConfigStore::Connector->new->readAllIds }, 'local_connector';
-}
 
 has_field 'options' => (
     type  => 'TextArea',

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source/RADIUS.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source/RADIUS.pm
@@ -11,84 +11,117 @@ Form definition to create or update a RADIUS user source.
 =cut
 
 use HTML::FormHandler::Moose;
+use pf::ConfigStore::Connector;
 use pf::config qw(%Config);
 extends 'pfappserver::Form::Config::Source';
-with 'pfappserver::Base::Form::Role::Help', 'pfappserver::Base::Form::Role::InternalSource';
+with 'pfappserver::Base::Form::Role::Help',
+  'pfappserver::Base::Form::Role::InternalSource';
 
 # Form fields
-has_field 'host' =>
-  (
-   type => 'Text',
-   label => 'Host',
-   element_class => ['input-small'],
-   element_attr => {'placeholder' => '127.0.0.1'},
-   default => '127.0.0.1',
-   required => 1,
-  );
-has_field 'port' =>
-  (
-   type => 'Port',
-   label => 'Port',
-   element_class => ['input-mini'],
-   element_attr => {'placeholder' => '1812'},
-   default => 1812,
-   required => 1,
-   tags => { after_element => \&help,
-             help => 'If you use this source in the realm configuration the accounting port will be this port + 1' },
-  );
-has_field 'secret' =>
-  (
-   type => 'ObfuscatedText',
-   label => 'Secret',
-   required => 1,
-   # Default value needed for creating dummy source
-   default => '',
-  );
-has_field 'timeout' =>
-  (
-   type => 'PosInteger',
-   label => 'Timeout',
-   required => 1,
-   element_class => ['input-mini'],
-   element_attr => {'placeholder' => '1'},
-   default => 1,
-  );
-has_field 'monitor',
-  (
-   type => 'Toggle',
-   label => 'Monitor',
-   checkbox_value => '1',
-   unchecked_value => '0',
-   tags => { after_element => \&help,
-             help => 'Do you want to monitor this source?' },
-   default => pf::Authentication::Source::RADIUSSource->meta->get_attribute('monitor')->default,
+has_field 'host' => (
+    type          => 'Text',
+    label         => 'Host',
+    element_class => ['input-small'],
+    element_attr  => { 'placeholder' => '127.0.0.1' },
+    default       => '127.0.0.1',
+    required      => 1,
 );
+
+has_field 'port' => (
+    type          => 'Port',
+    label         => 'Port',
+    element_class => ['input-mini'],
+    element_attr  => { 'placeholder' => '1812' },
+    default       => 1812,
+    required      => 1,
+    tags          => {
+        after_element => \&help,
+        help          =>
+'If you use this source in the realm configuration the accounting port will be this port + 1'
+    },
+);
+
+has_field 'secret' => (
+    type     => 'ObfuscatedText',
+    label    => 'Secret',
+    required => 1,
+
+    # Default value needed for creating dummy source
+    default => '',
+);
+
+has_field 'timeout' => (
+    type          => 'PosInteger',
+    label         => 'Timeout',
+    required      => 1,
+    element_class => ['input-mini'],
+    element_attr  => { 'placeholder' => '1' },
+    default       => 1,
+);
+
+has_field 'monitor' => (
+    type            => 'Toggle',
+    label           => 'Monitor',
+    checkbox_value  => '1',
+    unchecked_value => '0',
+    tags            => {
+        after_element => \&help,
+        help          => 'Do you want to monitor this source?'
+    },
+    default =>
+      pf::Authentication::Source::RADIUSSource->meta->get_attribute('monitor')
+      ->default,
+);
+
 has_field 'use_connector',
   (
-   type => 'Toggle',
-   checkbox_value => '1',
-   unchecked_value => '0',
-   default => pf::Authentication::Source::RADIUSSource->meta->get_attribute('use_connector')->default,
-);
-
-has_field 'options',
-  (
-   type => 'TextArea',
-   label => 'Options',
-   tags => { after_element => \&help,
-             help => 'Define options for FreeRADIUS home_server definition (if you use the source in the realm configuration). Need a radius restart.' },
-   default => 'type = auth+acct',
-);
-
-has_field 'nas_ip_address' =>
-  (
-   type => 'Text',
-   default => pf::Authentication::Source::RADIUSSource->meta->get_attribute('nas_ip_address')->default,
+    type            => 'Toggle',
+    checkbox_value  => '1',
+    unchecked_value => '0',
+    default => pf::Authentication::Source::RADIUSSource->meta->get_attribute(
+        'use_connector')->default,
   );
+
+has_field 'connect_through' => (
+    type           => 'Select',
+    options_method => \&options_connectors,
+);
+
+has_field 'connect_through_port' => (
+    type          => 'Port',
+    required_when => {
+        connect_through => sub {
+            defined $_[0] && length( $_[0] );
+        },
+    },
+);
+
+sub options_connectors {
+    return map { { value => $_, label => $_ } } '',
+      @{ pf::ConfigStore::Connector->new->readAllIds }, 'local_connector';
+}
+
+has_field 'options' => (
+    type  => 'TextArea',
+    label => 'Options',
+    tags  => {
+        after_element => \&help,
+        help          =>
+'Define options for FreeRADIUS home_server definition (if you use the source in the realm configuration). Need a radius restart.'
+    },
+    default => 'type = auth+acct',
+);
+
+has_field 'nas_ip_address' => (
+    type    => 'Text',
+    default => pf::Authentication::Source::RADIUSSource->meta->get_attribute(
+        'nas_ip_address')->default,
+);
 
 sub _options_set_role_from_source {
     my ($self) = @_;
-    return map { $_ => $_} @{$Config{radius_configuration}{radius_attributes}};
+    return
+      map { $_ => $_ } @{ $Config{radius_configuration}{radius_attributes} };
 }
 
 =head1 COPYRIGHT

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source/RADIUS.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source/RADIUS.pm
@@ -13,7 +13,11 @@ Form definition to create or update a RADIUS user source.
 use HTML::FormHandler::Moose;
 use pf::ConfigStore::Connector;
 use pf::config qw(%Config);
+use pf::authentication;
+use pf::Authentication::Source::RADIUSSource;
+my $META = pf::Authentication::Source::RADIUSSource->meta;
 extends 'pfappserver::Form::Config::Source';
+
 with 'pfappserver::Base::Form::Role::Help',
   'pfappserver::Base::Form::Role::InternalSource';
 
@@ -68,9 +72,7 @@ has_field 'monitor' => (
         after_element => \&help,
         help          => 'Do you want to monitor this source?'
     },
-    default =>
-      pf::Authentication::Source::RADIUSSource->meta->get_attribute('monitor')
-      ->default,
+    default => $META->get_attribute('monitor')->default,
 );
 
 has_field 'use_connector',
@@ -78,8 +80,7 @@ has_field 'use_connector',
     type            => 'Toggle',
     checkbox_value  => '1',
     unchecked_value => '0',
-    default => pf::Authentication::Source::RADIUSSource->meta->get_attribute(
-        'use_connector')->default,
+    default         => $META->get_attribute('use_connector')->default,
   );
 
 has_field 'connect_through' => (
@@ -114,14 +115,35 @@ has_field 'options' => (
 
 has_field 'nas_ip_address' => (
     type    => 'Text',
-    default => pf::Authentication::Source::RADIUSSource->meta->get_attribute(
-        'nas_ip_address')->default,
+    default => $META->get_attribute('nas_ip_address')->default,
 );
 
 sub _options_set_role_from_source {
     my ($self) = @_;
     return
       map { $_ => $_ } @{ $Config{radius_configuration}{radius_attributes} };
+}
+
+sub validate {
+    my ($self)          = @_;
+    my $value           = $self->value;
+    my $connect_through = $value->{connect_through};
+    return if !defined $connect_through || length($connect_through) == 0;
+    my $id      = $value->{id};
+    my $port    = $value->{connect_through_port};
+    my $sources = pf::authentication::getAuthenticationSourcesByType('RADIUS');
+
+    for my $source (@$sources) {
+        if ( $id eq $source->{id} ) {
+            next;
+        }
+
+        my $p = $source->{connect_through_port};
+        if ( defined $p && $p == $port ) {
+            $self->field('connect_through_port')
+              ->add_error('Only a single port should be defined');
+        }
+    }
 }
 
 =head1 COPYRIGHT

--- a/html/pfappserver/root/src/utils/yup.js
+++ b/html/pfappserver/root/src/utils/yup.js
@@ -421,11 +421,11 @@ yup.addMethod(yup.string, 'isMAC', function (message) {
   })
 })
 
-yup.addMethod(yup.string, 'isPort', function (message) {
+yup.addMethod(yup.string, 'isPort', function (min = 1, max = 65535, message) {
   return this.test({
     name: 'isPort',
-    message: message || i18n.t('Invalid port.'),
-    test: value => ['', null, undefined].includes(value) || (+value === parseInt(value) && +value >= 1 && +value <= 65535)
+    message: message || i18n.t(`Invalid port range (${min}-${max}).`),
+    test: value => ['', null, undefined].includes(value) || (+value === parseInt(value) && +value >= min && +value <= max)
   })
 })
 

--- a/html/pfappserver/root/src/views/Configuration/sources/_components/FormTypeRadius.vue
+++ b/html/pfappserver/root/src/views/Configuration/sources/_components/FormTypeRadius.vue
@@ -45,6 +45,16 @@
                               :disabled-value="0"
     />
 
+    <form-group-connect-through namespace="connect_through"
+                              :column-label="$i18n.t('Connect Through')"
+                              :text="$i18n.t('Specify which connector to use to connect to this authentication source.')"
+    />
+
+    <form-group-connect-port namespace="connect_through_port"
+                              :column-label="$i18n.t('Connect Through Port')"
+                              :text="$i18n.t('Which port to use.')"
+    />
+
     <form-group-nas-ip-address namespace="nas_ip_address"
                                :column-label="$i18n.t('NAS IP Address')"
                                :text="$i18n.t('Which NAS IP Address to use when communicating with the RADIUS server. Leaving this empty will make the source use the management IP of the server (management VIP in a cluster).')"
@@ -74,6 +84,8 @@ import {BaseForm} from '@/components/new/'
 import {
   FormGroupAdministrationRules,
   FormGroupAuthenticationRules,
+  FormGroupConnectThrough,
+  FormGroupConnectThroughPort,
   FormGroupDescription,
   FormGroupHost,
   FormGroupIdentifier,
@@ -92,6 +104,8 @@ const components = {
 
   FormGroupAdministrationRules,
   FormGroupAuthenticationRules,
+  FormGroupConnectThrough,
+  FormGroupConnectThroughPort,
   FormGroupDescription,
   FormGroupHost,
   FormGroupIdentifier,

--- a/html/pfappserver/root/src/views/Configuration/sources/_components/FormTypeRadius.vue
+++ b/html/pfappserver/root/src/views/Configuration/sources/_components/FormTypeRadius.vue
@@ -46,13 +46,13 @@
     />
 
     <form-group-connect-through namespace="connect_through"
-                              :column-label="$i18n.t('Connect Through')"
-                              :text="$i18n.t('Specify which connector to use to connect to this authentication source.')"
+                                :column-label="$i18n.t('Connect Through')"
+                                :text="$i18n.t('Specify which connector to use to connect to this authentication source.')"
     />
 
-    <form-group-connect-port namespace="connect_through_port"
-                              :column-label="$i18n.t('Connect Through Port')"
-                              :text="$i18n.t('Which port to use.')"
+    <form-group-connect-through-port namespace="connect_through_port"
+                                     :column-label="$i18n.t('Connect Through Port')"
+                                     :text="$i18n.t('Which port to use.')"
     />
 
     <form-group-nas-ip-address namespace="nas_ip_address"

--- a/html/pfappserver/root/src/views/Configuration/sources/_components/FormTypeRadius.vue
+++ b/html/pfappserver/root/src/views/Configuration/sources/_components/FormTypeRadius.vue
@@ -45,11 +45,6 @@
                               :disabled-value="0"
     />
 
-    <form-group-connect-through namespace="connect_through"
-                                :column-label="$i18n.t('Connect Through')"
-                                :text="$i18n.t('Specify which connector to use to connect to this authentication source.')"
-    />
-
     <form-group-connect-through-port namespace="connect_through_port"
                                      :column-label="$i18n.t('Connect Through Port')"
                                      :text="$i18n.t('Which port to use.')"
@@ -84,7 +79,6 @@ import {BaseForm} from '@/components/new/'
 import {
   FormGroupAdministrationRules,
   FormGroupAuthenticationRules,
-  FormGroupConnectThrough,
   FormGroupConnectThroughPort,
   FormGroupDescription,
   FormGroupHost,
@@ -104,7 +98,6 @@ const components = {
 
   FormGroupAdministrationRules,
   FormGroupAuthenticationRules,
-  FormGroupConnectThrough,
   FormGroupConnectThroughPort,
   FormGroupDescription,
   FormGroupHost,

--- a/html/pfappserver/root/src/views/Configuration/sources/_components/index.js
+++ b/html/pfappserver/root/src/views/Configuration/sources/_components/index.js
@@ -56,7 +56,6 @@ export {
   BaseFormGroupInput                        as FormGroupClientIdentifier,
   BaseFormGroupFileUpload                   as FormGroupClientKeyFile,
   BaseFormGroupInput                        as FormGroupClientSecret,
-  BaseFormGroupChosenOne                    as FormGroupConnectThrough,
   BaseFormGroupInputNumber                  as FormGroupConnectThroughPort,
   BaseFormGroupInputNumber                  as FormGroupConnectionTimeout,
   BaseFormGroupSwitch                       as FormGroupCreateLocalAccount,

--- a/html/pfappserver/root/src/views/Configuration/sources/_components/index.js
+++ b/html/pfappserver/root/src/views/Configuration/sources/_components/index.js
@@ -56,6 +56,8 @@ export {
   BaseFormGroupInput                        as FormGroupClientIdentifier,
   BaseFormGroupFileUpload                   as FormGroupClientKeyFile,
   BaseFormGroupInput                        as FormGroupClientSecret,
+  BaseFormGroupChosenOne                    as FormGroupConnectThrough,
+  BaseFormGroupInputNumber                  as FormGroupConnectThroughPort,
   BaseFormGroupInputNumber                  as FormGroupConnectionTimeout,
   BaseFormGroupSwitch                       as FormGroupCreateLocalAccount,
   BaseFormGroupChosenOne                    as FormGroupCurrency,

--- a/html/pfappserver/root/src/views/Configuration/sources/config.js
+++ b/html/pfappserver/root/src/views/Configuration/sources/config.js
@@ -103,3 +103,6 @@ export const recomposeSource = (item) => {
 export const analytics = {
   track: ['sourceType']
 }
+
+export const connectThroughPortMin = 2001
+export const connectThroughPortMax = 3000

--- a/html/pfappserver/root/src/views/Configuration/sources/schema.js
+++ b/html/pfappserver/root/src/views/Configuration/sources/schema.js
@@ -103,7 +103,6 @@ export const schema = (props) => {
 
   const {
     cert_file_upload,
-    connect_through,
     idp_ca_cert_path_upload,
     idp_cert_path_upload,
     idp_metadata_path_upload,
@@ -152,18 +151,6 @@ export const schema = (props) => {
     client_id: yup.string().label(i18n.t('Client ID')),
     client_key_file: yup.string().nullable().label(i18n.t('Client key')),
     client_secret: yup.string().label(i18n.t('Secret')),
-    connect_through: yup.string().nullable().label(i18n.t('Connector')),
-    connect_through_port: yup.string()
-      .when('connect_through', () => {
-        return (!connect_through)
-          ? yup.string().nullable()
-          : yup.string()
-            .nullable()
-            .required(i18n.t('Port required.'))
-            .label(i18n.t('Port'))
-            .isPort(connectThroughPortMin, connectThroughPortMax)
-            .sourceConnectThroughPortNotExistsExcept((!isNew && !isClone) ? id : undefined, i18n.t('Port exists.'))
-      }),
     description: yup.string().label(i18n.t('Description')).required(i18n.t('Description required.')),
     domains: yup.string().label(i18n.t('Domains')),
     email_address: yup.string().label(i18n.t('Email')),

--- a/html/pfappserver/root/src/views/Configuration/sources/schema.js
+++ b/html/pfappserver/root/src/views/Configuration/sources/schema.js
@@ -2,6 +2,10 @@ import store from '@/store'
 import { pfActionsSchema as schemaActions } from '@/globals/pfActions'
 import i18n from '@/utils/locale'
 import yup from '@/utils/yup'
+import {
+  connectThroughPortMin,
+  connectThroughPortMax
+} from './config'
 
 yup.addMethod(yup.string, 'sourceIdExists', function (message) {
   return this.test({
@@ -26,6 +30,21 @@ yup.addMethod(yup.string, 'sourceIdNotExistsExcept', function (exceptId = '', me
       if (!value || value.toLowerCase() === exceptId.toLowerCase()) return true
       return store.dispatch('config/getSources').then(response => {
         return response.filter(source => source.id.toLowerCase() === value.toLowerCase()).length === 0
+      }).catch(() => {
+        return true
+      })
+    }
+  })
+})
+
+yup.addMethod(yup.string, 'sourceConnectThroughPortNotExistsExcept', function (exceptName = '', message) {
+  return this.test({
+    name: 'sourceConnectThroughPortNotExistsExcept',
+    message: message || i18n.t('Name exists.'),
+    test: (value) => {
+      if (!value) return true
+      return store.dispatch('config/getSources').then(response => {
+        return response.filter(source =>  source.id.toLowerCase() !== exceptName.toLowerCase() && source.connect_through_port.toLowerCase() === value.toLowerCase()).length === 0
       }).catch(() => {
         return true
       })
@@ -95,6 +114,11 @@ export const schema = (props) => {
     sp_key_path_upload,
   } = form || {}
 
+  //eslint-disable-next-line
+  console.log({connectThroughPortMin, connectThroughPortMax})
+
+  const connectThroughPortRangeMessage = i18n.t('Port out of range ({min}-{max}).', { min: connectThroughPortMin, max: connectThroughPortMax } )
+
   return yup.object({
     id: yup.string()
       .nullable()
@@ -128,12 +152,17 @@ export const schema = (props) => {
     client_id: yup.string().label(i18n.t('Client ID')),
     client_key_file: yup.string().nullable().label(i18n.t('Client key')),
     client_secret: yup.string().label(i18n.t('Secret')),
-    connect_through: yup.string().nullable().label(i18n.t('Connect Through')),
+    connect_through: yup.string().nullable().label(i18n.t('Connector')),
     connect_through_port: yup.string()
       .when('connect_through', () => {
         return (!connect_through)
           ? yup.string().nullable()
-          : yup.string().nullable().required(i18n.t('Port required.'))
+          : yup.string()
+            .nullable()
+            .required(i18n.t('Port required.'))
+            .label(i18n.t('Port'))
+            .isPort(connectThroughPortMin, connectThroughPortMax)
+            .sourceConnectThroughPortNotExistsExcept((!isNew && !isClone) ? id : undefined, i18n.t('Port exists.'))
       }),
     description: yup.string().label(i18n.t('Description')).required(i18n.t('Description required.')),
     domains: yup.string().label(i18n.t('Domains')),
@@ -143,7 +172,7 @@ export const schema = (props) => {
     hash_passwords: yup.string().nullable().label(i18n.t('Hash')),
     host: schemaHosts,
     identity_token: yup.string().label(i18n.t('Token')),
-    idp_ca_cert_path: yup.string()
+    idp_ca_cert_path: yup.string() .isPort()
       .when('idp_ca_cert_path_upload', () => {
         return (!idp_ca_cert_path_upload)
           ? yup.string().nullable().required(i18n.t('Certificate required.'))
@@ -193,7 +222,7 @@ export const schema = (props) => {
     redirect_url: yup.string().label(i18n.t('URL')),
     scope: yup.string().nullable().label(i18n.t('Scope')),
     secret_key: yup.string().label(i18n.t('Key')),
-    secret: yup.string().label(i18n.t('Secret')),
+    secret: yup.string().label(i18n.t('Secret')).required(i18n.t('Secret required.')),
     server1_address: yup.string().label(i18n.t('Address')),
     server2_address: yup.string().label(i18n.t('Address')),
     shared_secret_direct: yup.string().label(i18n.t('Secret')),

--- a/html/pfappserver/root/src/views/Configuration/sources/schema.js
+++ b/html/pfappserver/root/src/views/Configuration/sources/schema.js
@@ -84,6 +84,7 @@ export const schema = (props) => {
 
   const {
     cert_file_upload,
+    connect_through,
     idp_ca_cert_path_upload,
     idp_cert_path_upload,
     idp_metadata_path_upload,
@@ -92,7 +93,6 @@ export const schema = (props) => {
     paypal_cert_file_upload,
     sp_cert_path_upload,
     sp_key_path_upload,
-
   } = form || {}
 
   return yup.object({
@@ -128,6 +128,13 @@ export const schema = (props) => {
     client_id: yup.string().label(i18n.t('Client ID')),
     client_key_file: yup.string().nullable().label(i18n.t('Client key')),
     client_secret: yup.string().label(i18n.t('Secret')),
+    connect_through: yup.string().nullable().label(i18n.t('Connect Through')),
+    connect_through_port: yup.string()
+      .when('connect_through', () => {
+        return (!connect_through)
+          ? yup.string().nullable()
+          : yup.string().nullable().required(i18n.t('Port required.'))
+      }),
     description: yup.string().label(i18n.t('Description')).required(i18n.t('Description required.')),
     domains: yup.string().label(i18n.t('Domains')),
     email_address: yup.string().label(i18n.t('Email')),

--- a/lib/pf/Authentication/Source/RADIUSSource.pm
+++ b/lib/pf/Authentication/Source/RADIUSSource.pm
@@ -36,7 +36,6 @@ has 'monitor' => ( isa => 'Bool',       is => 'rw', default  => 1 );
 has 'options' => ( isa => 'Str',        is => 'rw', required => 1 );
 has 'use_connector'  => ( isa => 'Bool',       is => 'rw', default => 1 );
 has 'nas_ip_address' => ( isa => 'Maybe[Str]', is => 'rw', default => '' );
-has 'connect_through'      => ( isa => 'Maybe[Str]', is => 'rw' );
 has 'connect_through_port' => ( isa => 'Maybe[Int]', is => 'rw' );
 
 =head2 dynamic_routing_module

--- a/lib/pf/Authentication/Source/RADIUSSource.pm
+++ b/lib/pf/Authentication/Source/RADIUSSource.pm
@@ -8,16 +8,16 @@ pf::Authentication::Source::RADIUSSource
 
 =cut
 
-use pf::constants qw($TRUE $FALSE);
+use pf::constants                 qw($TRUE $FALSE);
 use pf::Authentication::constants qw($LOGIN_CHALLENGE);
 use pf::constants::authentication::messages;
 use pf::log;
-use pf::config qw(%Config);
+use pf::config          qw(%Config);
 use pf::config::cluster qw($cluster_enabled);
 
-our $RADIUS_STATE = 'State';
+our $RADIUS_STATE         = 'State';
 our $RADIUS_REPLY_MESSAGE = 'Reply-Message';
-our $RADIUS_ERROR_NONE = 'ENONE';
+our $RADIUS_ERROR_NONE    = 'ENONE';
 
 use Authen::Radius;
 Authen::Radius->load_dictionary("/usr/share/freeradius/dictionary");
@@ -27,15 +27,17 @@ use List::Util qw(first);
 extends 'pf::Authentication::Source';
 with qw(pf::Authentication::InternalRole);
 
-has '+type' => ( default => 'RADIUS' );
-has 'host' => (isa => 'Maybe[Str]', is => 'rw', default => '127.0.0.1');
-has 'port' => (isa => 'Maybe[Int]', is => 'rw', default => 1812);
-has 'timeout' => (isa => 'Maybe[Int]', is => 'rw', default => 1);
-has 'secret' => (isa => 'Str', is => 'rw', required => 1);
-has 'monitor' => ( isa => 'Bool', is => 'rw', default => 1 );
-has 'options' => (isa => 'Str', is => 'rw', required => 1);
-has 'use_connector' => (isa => 'Bool', is => 'rw', default => 1);
-has 'nas_ip_address' => (isa => 'Maybe[Str]', is => 'rw', default => '');
+has '+type'   => ( default => 'RADIUS' );
+has 'host'    => ( isa => 'Maybe[Str]', is => 'rw', default  => '127.0.0.1' );
+has 'port'    => ( isa => 'Maybe[Int]', is => 'rw', default  => 1812 );
+has 'timeout' => ( isa => 'Maybe[Int]', is => 'rw', default  => 1 );
+has 'secret'  => ( isa => 'Str',        is => 'rw', required => 1 );
+has 'monitor' => ( isa => 'Bool',       is => 'rw', default  => 1 );
+has 'options' => ( isa => 'Str',        is => 'rw', required => 1 );
+has 'use_connector'  => ( isa => 'Bool',       is => 'rw', default => 1 );
+has 'nas_ip_address' => ( isa => 'Maybe[Str]', is => 'rw', default => '' );
+has 'connect_through'      => ( isa => 'Maybe[Str]', is => 'rw' );
+has 'connect_through_port' => ( isa => 'Maybe[Int]', is => 'rw' );
 
 =head2 dynamic_routing_module
 
@@ -52,12 +54,15 @@ Add additional available attributes
 =cut
 
 sub available_attributes {
-  my $self = shift;
+    my $self = shift;
 
-  my $super_attributes = $self->SUPER::available_attributes;
-  my @attributes = @{$Config{radius_configuration}->{radius_attributes} // []};
-  my @radius_attributes = map { { value => "radius_request.".$_, type => $Conditions::SUBSTRING } } @attributes;
-  return [@$super_attributes, @radius_attributes];
+    my $super_attributes = $self->SUPER::available_attributes;
+    my @attributes =
+      @{ $Config{radius_configuration}->{radius_attributes} // [] };
+    my @radius_attributes = map {
+        { value => "radius_request." . $_, type => $Conditions::SUBSTRING }
+    } @attributes;
+    return [ @$super_attributes, @radius_attributes ];
 }
 
 =head2  authenticate
@@ -65,8 +70,8 @@ sub available_attributes {
 =cut
 
 sub authenticate {
-    my ($self, $username, $password) = @_;
-    return $self->_send_radius_auth($username, $password);
+    my ( $self, $username, $password ) = @_;
+    return $self->_send_radius_auth( $username, $password );
 }
 
 =head2 challenge
@@ -76,44 +81,50 @@ Send the a radius authentication with challenge state
 =cut
 
 sub challenge {
-    my ($self, $username, $password, $challenge_data) = @_;
+    my ( $self, $username, $password, $challenge_data ) = @_;
     my $attribute = {
         Name  => $challenge_data->{state_code},
         Value => $challenge_data->{state},
         Type  => 'string'
     };
-    return $self->_send_radius_auth($username, $password, $attribute);
+    return $self->_send_radius_auth( $username, $password, $attribute );
 }
-
 
 =head2 _send_radius_auth
 
 =cut
 
 sub _send_radius_auth {
-    my ($self, $username, $password, @attributes) = @_;
-    my $logger = get_logger();
-    
+    my ( $self, $username, $password, @attributes ) = @_;
+    my $logger    = get_logger();
     my $host_port = "$self->{'host'}:$self->{'port'}";
-    if($self->use_connector) {
+    if ( $self->connect_through && $self->connect_through_port ) {
+        $host_port = "100.64.0.1:" . $self->connect_through_port;
+    }
+    elsif ( $self->use_connector ) {
         require pf::factory::connector;
-        my $connector_conn = pf::factory::connector->for_ip($self->{'host'})->dynreverse("$self->{'host'}:$self->{'port'}/udp");
-        $host_port = $connector_conn->{host}.":".$connector_conn->{port};
+        my $connector_conn = pf::factory::connector->for_ip( $self->{'host'} )
+          ->dynreverse("$self->{'host'}:$self->{'port'}/udp");
+        $host_port = $connector_conn->{host} . ":" . $connector_conn->{port};
     }
 
     my $radius = Authen::Radius->new(
-        Host   => $host_port,
-        Secret => $self->{'secret'},
+        Host    => $host_port,
+        Secret  => $self->{'secret'},
         TimeOut => $self->{'timeout'},
     );
 
-    if (!defined $radius) {
-        $logger->error("Unable to perform RADIUS authentication on any server: " . Authen::Radius::get_error());
-        return ($FALSE, $COMMUNICATION_ERROR_MSG);
+    if ( !defined $radius ) {
+        $logger->error(
+            "Unable to perform RADIUS authentication on any server: "
+              . Authen::Radius::get_error() );
+        return ( $FALSE, $COMMUNICATION_ERROR_MSG );
     }
 
-    my $result = $self->check_radius_password($radius, $username, $password, undef, @attributes);
-    return $self->_handle_radius_request($radius, $result);
+    my $result =
+      $self->check_radius_password( $radius, $username, $password, undef,
+        @attributes );
+    return $self->_handle_radius_request( $radius, $result );
 }
 
 =head2 challenge_handle_radius_request
@@ -121,19 +132,23 @@ sub _send_radius_auth {
 =cut
 
 sub _handle_radius_request {
-    my ($self, $radius, $result) = @_;
+    my ( $self, $radius, $result ) = @_;
     my $logger = get_logger();
-    if ($radius->get_error() ne $RADIUS_ERROR_NONE) {
-        $logger->error("Unable to perform RADIUS authentication on any server: " . Authen::Radius::get_error());
-        return ($FALSE, $COMMUNICATION_ERROR_MSG);
+    if ( $radius->get_error() ne $RADIUS_ERROR_NONE ) {
+        $logger->error(
+            "Unable to perform RADIUS authentication on any server: "
+              . Authen::Radius::get_error() );
+        return ( $FALSE, $COMMUNICATION_ERROR_MSG );
     }
-    if ($result == ACCESS_ACCEPT) {
-        return ($TRUE, $AUTH_SUCCESS_MSG, $self->_fetch_attributes($result, $radius));
+    if ( $result == ACCESS_ACCEPT ) {
+        return ( $TRUE, $AUTH_SUCCESS_MSG,
+            $self->_fetch_attributes( $result, $radius ) );
     }
-    elsif ($result == ACCESS_CHALLENGE) {
-        return ($LOGIN_CHALLENGE, $self->_make_challenge_data($result, $radius));
+    elsif ( $result == ACCESS_CHALLENGE ) {
+        return ( $LOGIN_CHALLENGE,
+            $self->_make_challenge_data( $result, $radius ) );
     }
-    return ($FALSE, $AUTH_FAIL_MSG);
+    return ( $FALSE, $AUTH_FAIL_MSG );
 }
 
 =head2 _make_challenge_data
@@ -141,10 +156,11 @@ sub _handle_radius_request {
 =cut
 
 sub _make_challenge_data {
-    my ($self, $result, $radius) = @_;
+    my ( $self, $result, $radius ) = @_;
     my @attributes = $radius->get_attributes;
-    my ($state_attribute) = grep { $_->{Name} eq  $RADIUS_STATE} @attributes;
-    my ($message_attribute) = grep { $_->{Name} eq $RADIUS_REPLY_MESSAGE } @attributes;
+    my ($state_attribute) = grep { $_->{Name} eq $RADIUS_STATE } @attributes;
+    my ($message_attribute) =
+      grep { $_->{Name} eq $RADIUS_REPLY_MESSAGE } @attributes;
     return {
         id         => $self->id,
         result     => $result,
@@ -160,11 +176,9 @@ sub _make_challenge_data {
 =cut
 
 sub _fetch_attributes {
-    my ($self, $result, $radius) = @_;
+    my ( $self, $result, $radius ) = @_;
     my @attributes = $radius->get_attributes;
-    return {
-        attributes => \@attributes,
-    };
+    return { attributes => \@attributes, };
 }
 
 =head2 check_radius_password
@@ -172,23 +186,26 @@ sub _fetch_attributes {
 =cut
 
 sub check_radius_password {
-    my ($self, $radius, $name, $pwd, $nas, @extra) = @_;
+    my ( $self, $radius, $name, $pwd, $nas, @extra ) = @_;
 
     require pf::cluster;
     require pf::config;
-    if(!defined($nas)) {
-        if($self->nas_ip_address) {
+    if ( !defined($nas) ) {
+        if ( $self->nas_ip_address ) {
             $nas = $self->nas_ip_address;
         }
         else {
-            $nas = $cluster_enabled ? pf::cluster::management_cluster_ip() : $pf::config::management_network->{Tip};
+            $nas =
+              $cluster_enabled
+              ? pf::cluster::management_cluster_ip()
+              : $pf::config::management_network->{Tip};
         }
     }
     $radius->clear_attributes;
     $radius->add_attributes(
-        {Name => 1, Value => $name, Type => 'string'},
-        {Name => 2, Value => $pwd,  Type => 'string'},
-        {Name => 4, Value => $nas || '127.0.0.1', Type => 'ipaddr'},
+        { Name => 1, Value => $name,               Type => 'string' },
+        { Name => 2, Value => $pwd,                Type => 'string' },
+        { Name => 4, Value => $nas || '127.0.0.1', Type => 'ipaddr' },
         @extra
     );
 
@@ -202,32 +219,39 @@ sub check_radius_password {
 =cut
 
 sub match_in_subclass {
-    my ($self, $params, $rule, $own_conditions, $matching_conditions, $extra) = @_;
-    my $username =  $params->{'username'};
+    my ( $self, $params, $rule, $own_conditions, $matching_conditions, $extra )
+      = @_;
+    my $username = $params->{'username'};
 
-    foreach my $condition (@{ $own_conditions }) {
+    foreach my $condition ( @{$own_conditions} ) {
         my $name = $condition->{'attribute'};
-        if ($name eq "username") {
-            if ( $condition->matches("username", $username, $params) ) {
-                push(@{ $matching_conditions }, $condition);
+        if ( $name eq "username" ) {
+            if ( $condition->matches( "username", $username, $params ) ) {
+                push( @{$matching_conditions}, $condition );
             }
-        } elsif (defined($extra)) {
-            my $attribute = first { $_->{Name} eq $name } @{ $extra->{attributes}};
-            if ($attribute && $condition->matches($name, $attribute->{'Value'}) ) {
-                push(@{ $matching_conditions }, $condition);
+        }
+        elsif ( defined($extra) ) {
+            my $attribute =
+              first { $_->{Name} eq $name } @{ $extra->{attributes} };
+            if (   $attribute
+                && $condition->matches( $name, $attribute->{'Value'} ) )
+            {
+                push( @{$matching_conditions}, $condition );
             }
         }
     }
-    return ($username, undef);
+    return ( $username, undef );
 }
 
 sub lookupRole {
-    my ($self, $rule, $role_info, $params, $extra, $attributes) = @_;
-    for my $attribute (@{ $extra->{attributes}} ) {
-        $$attributes->{"radius_attribute"}->{$attribute->{'Name'}} = $attribute->{'RawValue'};
+    my ( $self, $rule, $role_info, $params, $extra, $attributes ) = @_;
+    for my $attribute ( @{ $extra->{attributes} } ) {
+        $$attributes->{"radius_attribute"}->{ $attribute->{'Name'} } =
+          $attribute->{'RawValue'};
     }
-    if (defined $extra) {
-        my $attribute = first { $_->{Name} eq $role_info } @{ $extra->{attributes}};
+    if ( defined $extra ) {
+        my $attribute =
+          first { $_->{Name} eq $role_info } @{ $extra->{attributes} };
         if ($attribute) {
             return $attribute->{Value};
         }

--- a/lib/pf/Authentication/Source/RADIUSSource.pm
+++ b/lib/pf/Authentication/Source/RADIUSSource.pm
@@ -98,8 +98,12 @@ sub _send_radius_auth {
     my ( $self, $username, $password, @attributes ) = @_;
     my $logger    = get_logger();
     my $host_port = "$self->{'host'}:$self->{'port'}";
-    if ( $self->connect_through && $self->connect_through_port ) {
-        $host_port = "100.64.0.1:" . $self->connect_through_port;
+    if ( $self->use_connector && $self->connect_through_port ) {
+        my $host =
+          exists $ENV{PFCONNECTOR_SERVICE_HOST}
+          ? $ENV{PFCONNECTOR_SERVICE_HOST}
+          : "100.64.0.1";
+        $host_port = "$host:" . $self->connect_through_port;
     }
     elsif ( $self->use_connector ) {
         require pf::factory::connector;

--- a/lib/pf/factory/connector.pm
+++ b/lib/pf/factory/connector.pm
@@ -16,20 +16,22 @@ use strict;
 use warnings;
 use pf::connector;
 use pf::config qw(%ConfigConnector);
+use NetAddr::IP;
 
-tie my @connectors_ordered, 'pfconfig::cached_array', 'resource::connectors_ordered';
+tie my @connectors_ordered, 'pfconfig::cached_array',
+  'resource::connectors_ordered';
 
 sub factory_for { 'pf::connector' }
 
 sub new {
-    my ($class,$name) = @_;
+    my ( $class, $name ) = @_;
     my $object;
-    if (!exists $ConfigConnector{$name}) {
+    if ( !exists $ConfigConnector{$name} ) {
         return undef;
     }
 
     my $data = $ConfigConnector{$name};
-    if (!defined $data) {
+    if ( !defined $data ) {
         return undef;
     }
 
@@ -44,16 +46,16 @@ sub local_connector {
 }
 
 sub for_ip {
-    my ($class, $ip) = @_;
+    my ( $class, $ip ) = @_;
     $ip = NetAddr::IP->new($ip);
     for my $connector_id (@connectors_ordered) {
-        for my $net (@{$ConfigConnector{$connector_id}{networks}}) {
+        for my $net ( @{ $ConfigConnector{$connector_id}{networks} } ) {
             $net = NetAddr::IP->new($net);
-            if($net->contains($ip)) {
+            if ( $net->contains($ip) ) {
                 return $class->new($connector_id);
             }
         }
-    } 
+    }
     return $class->local_connector();
 }
 

--- a/lib/pf/services/manager/radiusd_child.pm
+++ b/lib/pf/services/manager/radiusd_child.pm
@@ -1039,11 +1039,17 @@ EOT
         my @ips = map { inet_ntoa($_) } @addresses[4 .. $#addresses];
         my $src_ip = pf::util::find_outgoing_srcip($ips[0]);
         $source->{'options'} =~ s/\$src_ip/$src_ip/;
+        my $host = $source->{'host'};
+        my $port = $source->{'port'};
+        if ($source->{'use_connector'}) {
+            $host = exists($ENV{PFCONNECTOR_SERVICE_HOST}}) ? $ENV{PFCONNECTOR_SERVICE_HOST} : "100.64.0.1";
+            $port = $source->{'connect_through_port'};
+        }
         $tags{'radius_sources'} .= <<"EOT";
 
 home_server $radius {
-ipaddr = $source->{'host'}
-port = $source->{'port'}
+ipaddr = $host
+port = $port
 secret = '$source->{'secret'}'
 $source->{'options'}
 }

--- a/lib/pf/services/manager/radiusd_child.pm
+++ b/lib/pf/services/manager/radiusd_child.pm
@@ -1042,7 +1042,7 @@ EOT
         my $host = $source->{'host'};
         my $port = $source->{'port'};
         if ($source->{'use_connector'} && $source->{'connect_through_port'} ne "") {
-            $host = exists($ENV{PFCONNECTOR_SERVICE_HOST}}) ? $ENV{PFCONNECTOR_SERVICE_HOST} : "100.64.0.1";
+            $host = exists $ENV{PFCONNECTOR_SERVICE_HOST} ? $ENV{PFCONNECTOR_SERVICE_HOST} : "100.64.0.1";
             $port = $source->{'connect_through_port'};
         }
         $tags{'radius_sources'} .= <<"EOT";

--- a/lib/pf/services/manager/radiusd_child.pm
+++ b/lib/pf/services/manager/radiusd_child.pm
@@ -1041,7 +1041,7 @@ EOT
         $source->{'options'} =~ s/\$src_ip/$src_ip/;
         my $host = $source->{'host'};
         my $port = $source->{'port'};
-        if ($source->{'use_connector'}) {
+        if ($source->{'use_connector'} && $source->{'connect_through_port'} ne "") {
             $host = exists($ENV{PFCONNECTOR_SERVICE_HOST}}) ? $ENV{PFCONNECTOR_SERVICE_HOST} : "100.64.0.1";
             $port = $source->{'connect_through_port'};
         }

--- a/lib/pfconfig/namespaces/config/Authentication.pm
+++ b/lib/pfconfig/namespaces/config/Authentication.pm
@@ -21,7 +21,7 @@ use warnings;
 
 use pfconfig::namespaces::config;
 use pf::file_paths qw($authentication_config_file);
-use pf::util qw(isdisabled);
+use pf::util       qw(isdisabled);
 use pf::constants::authentication;
 use pf::config::crypt;
 use pf::Authentication::constants;
@@ -49,6 +49,7 @@ sub init {
         'resource::authentication_sources_ldap',
         'resource::authentication_sources_radius',
         'resource::RolesReverseLookup',
+        'resource::pfconnector_static_connections',
     ];
 }
 
@@ -61,13 +62,13 @@ sub build_child {
         $self->cleanup_after_read( $key, $cfg{$key} );
     }
 
-    my @authentication_sources = ();
-    my %authentication_lookup  = ();
+    my @authentication_sources     = ();
+    my %authentication_lookup      = ();
     my %authentication_config_hash = ();
     my %roleReverseLookup;
     foreach my $source_id ( @{ $self->{ordered_sections} } ) {
 
-        my $current_source_config = { %{$cfg{$source_id}} };
+        my $current_source_config = { %{ $cfg{$source_id} } };
 
         # We skip groups from our ini files
         if ( $source_id =~ m/\s/ ) {
@@ -79,33 +80,37 @@ sub build_child {
         delete $cfg{$source_id}{type};
 
         # Instantiate the source object
-        my $current_source = $self->newAuthenticationSource( $type, $source_id, $cfg{$source_id} );
+        my $current_source =
+          $self->newAuthenticationSource( $type, $source_id, $cfg{$source_id} );
         my @ldap_attributes;
 
         # Parse rules
         foreach my $rule_id ( $self->GroupMembers($source_id) ) {
-            my ($id) = $rule_id =~ m/$source_id rule (\S+)$/;
+            my ($id)        = $rule_id =~ m/$source_id rule (\S+)$/;
             my $rule_config = $cfg{$rule_id};
-            my $class = $rule_config->{class};
-            if (ref($class) || (defined $class && $class =~ /\n/s)) {
-                print STDERR "rule '$rule_id' seems to be defined multiple times skipping rule\n";
+            my $class       = $rule_config->{class};
+            if ( ref($class) || ( defined $class && $class =~ /\n/s ) ) {
+                print STDERR
+"rule '$rule_id' seems to be defined multiple times skipping rule\n";
                 next;
             }
             my $status = $rule_config->{status} // 'enabled';
-            if (isdisabled($status)) {
+            if ( isdisabled($status) ) {
                 next;
             }
 
-            my $current_rule = pf::Authentication::Rule->new( { match => $Rules::ANY, id => $id } );
+            my $current_rule = pf::Authentication::Rule->new(
+                { match => $Rules::ANY, id => $id } );
             my %current_rule_config = ();
-            my $cache_key = '';
-            foreach my $parameter ( nsort keys( %$rule_config ) ) {
+            my $cache_key           = '';
+            foreach my $parameter ( nsort keys(%$rule_config) ) {
                 my $config_value = $rule_config->{$parameter};
                 if ( $parameter =~ m/condition(\d+)/ ) {
-                    my ( $attribute, $operator, $value ) = split( ',', $config_value, 3 );
+                    my ( $attribute, $operator, $value ) =
+                      split( ',', $config_value, 3 );
                     my $type;
-                    if ($attribute =~ /^(.*?):(.*)$/) {
-                        $type = $1;
+                    if ( $attribute =~ /^(.*?):(.*)$/ ) {
+                        $type      = $1;
                         $attribute = $2;
                         if ( $type eq 'ldap' ) {
                             push @ldap_attributes, $attribute;
@@ -114,7 +119,8 @@ sub build_child {
 
                     $current_rule->add_condition(
                         pf::Authentication::Condition->new(
-                            {   attribute => $attribute,
+                            {
+                                attribute => $attribute,
                                 operator  => $operator,
                                 value     => $value,
                                 type      => $type,
@@ -123,56 +129,67 @@ sub build_child {
                     );
 
                     $cache_key .= $config_value;
-                    $current_rule_config{'conditions'}{$parameter} = $config_value;
+                    $current_rule_config{'conditions'}{$parameter} =
+                      $config_value;
                 }
                 elsif ( $parameter =~ m/action(\d+)/ ) {
                     my ( $type, $value ) = split( '=', $config_value, 2 );
                     $current_rule->add_action(
                         pf::Authentication::Action->new(
                             {
-                                type  => $type,
-                                (defined $value ? (value => $value) : ()),
-                                class => pf::Authentication::Action->getRuleClassForAction($type),
+                                type => $type,
+                                ( defined $value ? ( value => $value ) : () ),
+                                class => pf::Authentication::Action
+                                  ->getRuleClassForAction(
+                                    $type),
                             },
                         )
                     );
-                    if ( $type eq 'set_role') {
-                        push @{$roleReverseLookup{$value}{authentication}}, $rule_id;
+                    if ( $type eq 'set_role' ) {
+                        push @{ $roleReverseLookup{$value}{authentication} },
+                          $rule_id;
                     }
 
                     $current_rule_config{'actions'}{$parameter} = $config_value;
-                } else {
-                    $current_rule->{$parameter} = $current_rule_config{$parameter} = $config_value;
+                }
+                else {
+                    $current_rule->{$parameter} =
+                      $current_rule_config{$parameter} = $config_value;
                 }
             }
 
-            if ($current_source->isa("pf::Authentication::Source::LDAPSource")) {
+            if (
+                $current_source->isa("pf::Authentication::Source::LDAPSource") )
+            {
                 my $usernameattribute = $current_source->usernameattribute;
                 if ($usernameattribute) {
                     push @ldap_attributes, $usernameattribute;
                 }
 
                 my %seen;
-                @ldap_attributes = map {  { value => $_, type => $Conditions::LDAP_ATTRIBUTE } } sort {$a cmp $b} uniq @ldap_attributes;
-                $current_source->_ldap_attributes(\@ldap_attributes);
+                @ldap_attributes =
+                  map { { value => $_, type => $Conditions::LDAP_ATTRIBUTE } }
+                  sort { $a cmp $b } uniq @ldap_attributes;
+                $current_source->_ldap_attributes( \@ldap_attributes );
             }
 
             $current_rule->cache_key($cache_key);
             $current_rule_config{cache_key} = $cache_key;
             $current_source->add_rule($current_rule);
-            $current_source_config->{'rules'}->{$rule_id} = \%current_rule_config;
+            $current_source_config->{'rules'}->{$rule_id} =
+              \%current_rule_config;
         }
 
         push( @authentication_sources, $current_source );
-        $authentication_lookup{$source_id} = $current_source;
+        $authentication_lookup{$source_id}      = $current_source;
         $authentication_config_hash{$source_id} = $current_source_config;
     }
 
     my %resources;
-    $resources{authentication_sources} = \@authentication_sources;
-    $resources{authentication_lookup}  = \%authentication_lookup;
-    $resources{authentication_config_hash}  = \%authentication_config_hash;
-    $self->{roleReverseLookup} = \%roleReverseLookup;
+    $resources{authentication_sources}     = \@authentication_sources;
+    $resources{authentication_lookup}      = \%authentication_lookup;
+    $resources{authentication_config_hash} = \%authentication_config_hash;
+    $self->{roleReverseLookup}             = \%roleReverseLookup;
     return \%resources;
 
 }
@@ -189,7 +206,8 @@ sub newAuthenticationSource {
     my $source;
     $type = lc($type);
     if ( exists $pf::constants::authentication::TYPE_TO_SOURCE{$type} ) {
-        my $source_module = $pf::constants::authentication::TYPE_TO_SOURCE{$type};
+        my $source_module =
+          $pf::constants::authentication::TYPE_TO_SOURCE{$type};
         $source = $source_module->new( { id => $source_id, %{$attrs} } );
     }
 
@@ -199,11 +217,21 @@ sub newAuthenticationSource {
 sub cleanup_after_read {
     my ( $self, $id, $data ) = @_;
     my $type = $data->{type};
-    if (defined $type && $type eq 'OpenID') {
+    if ( defined $type && $type eq 'OpenID' ) {
         pf::Authentication::utils::inflatePersonMappings($data);
     }
 
-    $self->expand_list( $data, qw(realms local_realm reject_realm searchattributes sources eduroam_radius_auth), (defined $type && ($type eq 'LDAP' || $type eq 'AD' || $type eq 'EDIR' || $type eq 'GoogleWorkspaceLDAP' || $type eq "Eduroam")) ? ('host') : () );
+    $self->expand_list(
+        $data,
+        qw(realms local_realm reject_realm searchattributes sources eduroam_radius_auth),
+        (
+            defined $type && ( $type eq 'LDAP'
+                || $type eq 'AD'
+                || $type eq 'EDIR'
+                || $type eq 'GoogleWorkspaceLDAP'
+                || $type eq "Eduroam" )
+        ) ? ('host') : ()
+    );
 }
 
 =head1 AUTHOR

--- a/lib/pfconfig/namespaces/resource/pfconnector_static_connections.pm
+++ b/lib/pfconfig/namespaces/resource/pfconnector_static_connections.pm
@@ -20,6 +20,10 @@ sub init {
       $self->{cache}->get_cache('config::Authentication');
 }
 
+sub find_connector {
+
+}
+
 sub build {
     my ($self) = @_;
     my %hash;
@@ -27,9 +31,10 @@ sub build {
         each %{ $self->{_authentication_config}{authentication_config_hash} } )
     {
         next unless $data->{'type'} eq 'RADIUS';
-        my $connector = $data->{'connect_through'};
-        my $r =
-"100.64.0.1:$data->{'connect_through_port'}:$data->{host}:$data->{port}/udp";
+        my $port = $data->{'connect_through_port'};
+        next unless defined $port;
+        my $connector = $self->find_connector( $data->{host} );
+        my $r         = "100.64.0.1:${port}:$data->{host}:$data->{port}/udp";
         push @{ $hash{$connector} }, $r;
     }
     return \%hash;

--- a/lib/pfconfig/namespaces/resource/pfconnector_static_connections.pm
+++ b/lib/pfconfig/namespaces/resource/pfconnector_static_connections.pm
@@ -29,7 +29,7 @@ sub build {
         next unless $data->{'type'} eq 'RADIUS';
         my $connector = $data->{'connect_through'};
         my $r =
-"100.64.0.1:$data->{'connect_through_port'}:$data->{host}:$data->{port}";
+"100.64.0.1:$data->{'connect_through_port'}:$data->{host}:$data->{port}/udp";
         push @{ $hash{$connector} }, $r;
     }
     return \%hash;

--- a/lib/pfconfig/namespaces/resource/pfconnector_static_connections.pm
+++ b/lib/pfconfig/namespaces/resource/pfconnector_static_connections.pm
@@ -1,0 +1,65 @@
+package pfconfig::namespaces::resource::pfconnector_static_connections;
+
+=head1 NAME
+
+pfconfig::namespaces::resource::pfconnector_static_connections -
+
+=head1 DESCRIPTION
+
+pfconfig::namespaces::resource::pfconnector_static_connections
+
+=cut
+
+use strict;
+use warnings;
+use base 'pfconfig::namespaces::resource';
+
+sub init {
+    my ($self) = @_;
+    $self->{_authentication_config} =
+      $self->{cache}->get_cache('config::Authentication');
+}
+
+sub build {
+    my ($self) = @_;
+    my %hash;
+    while ( my ( $id, $data ) =
+        each %{ $self->{_authentication_config}{authentication_config_hash} } )
+    {
+        next unless $data->{'type'} eq 'RADIUS';
+        my $connector = $data->{'connect_through'};
+        my $r =
+"100.64.0.1:$data->{'connect_through_port'}:$data->{host}:$data->{port}";
+        push @{ $hash{$connector} }, $r;
+    }
+    return \%hash;
+}
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2025 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;

--- a/lib/pfconfig/namespaces/resource/pfconnector_static_connections.pm
+++ b/lib/pfconfig/namespaces/resource/pfconnector_static_connections.pm
@@ -13,15 +13,32 @@ pfconfig::namespaces::resource::pfconnector_static_connections
 use strict;
 use warnings;
 use base 'pfconfig::namespaces::resource';
+use NetAddr::IP;
 
 sub init {
     my ($self) = @_;
     $self->{_authentication_config} =
       $self->{cache}->get_cache('config::Authentication');
+    $self->{_connector_config} =
+      $self->{cache}->get_cache('config::Connector');
+    $self->{_connectors_ordered} =
+      $self->{cache}->get_cache('resource::connectors_ordered');
 }
 
 sub find_connector {
+    my ( $self, $ip ) = @_;
+    $ip = NetAddr::IP->new($ip);
+    my $config = $self->{_connector_config};
+    for my $connector_id ( @{ $self->{_connectors_ordered} // [] } ) {
+        for my $net ( @{ $config->{$connector_id}{networks} } ) {
+            $net = NetAddr::IP->new($net);
+            if ( $net->contains($ip) ) {
+                return $connector_id;
+            }
+        }
+    }
 
+    return 'local_connector';
 }
 
 sub build {

--- a/t/data/authentication.conf
+++ b/t/data/authentication.conf
@@ -540,7 +540,6 @@ line2
 EOT
 
 [RADIUS_CONNECT_THROUGH_TEST]
-connect_through=local_connector
 connect_through_port=1234
 type=RADIUS
 port=1812

--- a/t/data/authentication.conf
+++ b/t/data/authentication.conf
@@ -538,3 +538,14 @@ message=<<EOT
 line1 $pin
 line2
 EOT
+
+[RADIUS_CONNECT_THROUGH_TEST]
+connect_through=local_connector
+connect_through_port=1234
+type=RADIUS
+port=1812
+host=1.2.3.4
+timeout=1000
+description=Blag balh
+secret=bob
+options=

--- a/t/unittest/UnifiedApi/Controller/Config/Sources/RADIUS.t
+++ b/t/unittest/UnifiedApi/Controller/Config/Sources/RADIUS.t
@@ -1,0 +1,96 @@
+#!/usr/bin/perl
+
+=head1 NAME
+
+RADIUS
+
+=head1 DESCRIPTION
+
+unit test for RADIUS
+
+=cut
+
+use strict;
+use warnings;
+
+BEGIN {
+    #include test libs
+    use lib qw(/usr/local/pf/t);
+
+    #Module for overriding configuration paths
+    use setup_test_config;
+}
+
+use Test::More tests => 4;
+use Test::Mojo;
+use Utils;
+
+#This test will running last
+use Test::NoWarnings;
+use pf::ConfigStore::Source;
+
+my ( $fh, $filename ) =
+  Utils::tempfileForConfigStore("pf::ConfigStore::Source");
+
+my $t = Test::Mojo->new('pf::UnifiedApi');
+
+my $collection_base_url = '/api/v1/config/sources';
+
+my %options = (
+    connect_through      => 'local_connector',
+    connect_through_port => 1234,
+    type                 => 'RADIUS',
+    port                 => 1812,
+    host                 => '1.2.3.4',
+    timeout              => 1000,
+    description          => 'Blag balh',
+    secret               => 'bob',
+);
+
+$t->post_ok(
+    $collection_base_url => json => {
+        id => 'RADIUS_CONNECT_THROUGH_TEST2',
+        %options,
+    }
+)->status_is(422)->json_is(
+    {
+        status => 422,
+        errors => [
+            {
+                field   => 'connect_through_port',
+                message => 'Only a single port should be defined',
+            }
+        ],
+        message => 'Unable to validate',
+    }
+);
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2025 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;
+

--- a/t/unittest/UnifiedApi/Controller/Config/Sources/RADIUS.t
+++ b/t/unittest/UnifiedApi/Controller/Config/Sources/RADIUS.t
@@ -37,7 +37,6 @@ my $t = Test::Mojo->new('pf::UnifiedApi');
 my $collection_base_url = '/api/v1/config/sources';
 
 my %options = (
-    connect_through      => 'local_connector',
     connect_through_port => 1234,
     type                 => 'RADIUS',
     port                 => 1812,

--- a/t/unittest/UnifiedApi/Controller/Config/Sources/RADIUS.t
+++ b/t/unittest/UnifiedApi/Controller/Config/Sources/RADIUS.t
@@ -58,7 +58,7 @@ $t->post_ok(
         errors => [
             {
                 field   => 'connect_through_port',
-                message => 'Only a single port should be defined',
+                message => 'Port should be unique',
             }
         ],
         message => 'Unable to validate',


### PR DESCRIPTION
# Description
Allow RADIUS sources to define a static port to use when behind a connector.

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [*] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
## Enhancements
* Allow RADIUS sources to define a static port to use when behind a connector.

