### PR TITLE
Fix UEFI Install Option

### DIFF
--- a/ci/debian-installer/grub.cfg
+++ b/ci/debian-installer/grub.cfg
@@ -29,6 +29,11 @@ menuentry --hotkey=i 'Install Debian Only' {
     linux    /install.amd/vmlinuz vga=788 net.ifnames=0 --- quiet 
     initrd   /install.amd/initrd.gz
 }
+menuentry --hotkey=p 'Install Debian with PacketFence' {
+    set background_color=black
+    linux    /install.amd/vmlinuz vga=788 net.ifnames=0 initrd=/install.amd/initrd.gz --- quiet
+    initrd   /install.amd/initrd.gz
+}
 submenu --hotkey=a 'Advanced options ...' {
     set menu_color_normal=cyan/blue
     set menu_color_highlight=white/blue


### PR DESCRIPTION
# Description
Not entirely sure this is totally the correct way to do this. Just thought I'd take a stab at it.
Adds menu entry for installing debian with Packetfence when booting the ISO in UEFI

# Impacts
UEFI boot preseed

# Issue
#8143 

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [n/a] Document the feature
- [n/a] Add OpenAPI specification
- [n/a] Add unit tests
- [n/a] Add acceptance tests (TestLink)
