### PR TITLE
Fix/ugid pf fingerbank

### DIFF
--- a/addons/perl-client/debian/fingerbank.preinst
+++ b/addons/perl-client/debian/fingerbank.preinst
@@ -26,27 +26,21 @@ stop_user_processes() {
 
     if [ -z "$running_processes" ]; then
         echo "No processes found running as user '$username'"
-        return 0
-    fi
-
-    ps -u "$username" -o pid,comm,args
-    echo "Stopping processes gracefully..."
-    pkill -TERM -u "$username" 2>/dev/null
-    sleep 2
-
-    remaining_processes=$(pgrep -u "$username" 2>/dev/null)
-    if [ -n "$remaining_processes" ]; then
-        echo "Force stopping remaining processes..."
-        pkill -KILL -u "$username" 2>/dev/null
+    else
+        echo "Stopping processes gracefully..."
+        pkill -TERM -u "$username" 2>/dev/null
         sleep 2
+        remaining_processes=$(pgrep -u "$username" 2>/dev/null)
+        if [ -n "$remaining_processes" ]; then
+            echo "Force stopping remaining processes..."
+            pkill -KILL -u "$username" 2>/dev/null
+            sleep 2
+        fi
+        if pgrep -u "$username" &>/dev/null; then
+            echo "Error: Could not stop all processes for user '$username'"
+        fi
+        echo "All processes for user '$username' have been stopped"
     fi
-
-    if pgrep -u "$username" &>/dev/null; then
-        echo "Error: Could not stop all processes for user '$username'"
-        return 1
-    fi
-
-    echo "All processes for user '$username' have been stopped"
     return 0
 }
 
@@ -61,12 +55,11 @@ set_uid_gid() {
 
     if [ "$user_uid" -eq $pgid ] && [ "$user_gid" -eq $pgid ]; then
         echo "User '$username' has both UID and GID equal to $pgid"
-        return 0
     else
         usermod  -u $pgid $username
         groupmod -g $pgid $username
-        return 1
     fi
+    return 0
 }
 
 case "$1" in

--- a/addons/perl-client/debian/fingerbank.preinst
+++ b/addons/perl-client/debian/fingerbank.preinst
@@ -20,6 +20,55 @@ stop_service_if_exists() {
     fi
 }
 
+stop_user_processes() {
+    local username="$1"
+    local running_processes=$(pgrep -u "$username" 2>/dev/null)
+
+    if [[ -z "$running_processes" ]]; then
+        echo "No processes found running as user '$username'"
+        return 0
+    fi
+
+    ps -u "$username" -o pid,comm,args
+    echo "Stopping processes gracefully..."
+    pkill -TERM -u "$username" 2>/dev/null
+    sleep 2
+
+    remaining_processes=$(pgrep -u "$username" 2>/dev/null)
+    if [[ -n "$remaining_processes" ]]; then
+        echo "Force stopping remaining processes..."
+        pkill -KILL -u "$username" 2>/dev/null
+        sleep 2
+    fi
+
+    if pgrep -u "$username" &>/dev/null; then
+        echo "Error: Could not stop all processes for user '$username'"
+        return 1
+    fi
+
+    echo "All processes for user '$username' have been stopped"
+    return 0
+}
+
+set_uid_gid() {
+    local username="$1"
+    local pgid="$2"
+
+    stop_user_processes "$username"
+
+    local user_uid=$(id -u "$username")
+    local user_gid=$(id -g "$username")
+
+    if [[ "$user_uid" -eq $pgid && "$user_gid" -eq $pgid ]]; then
+        echo "User '$username' has both UID and GID equal to $pgid"
+        return 0
+    else
+        usermod  -u $pgid $username
+        groupmod -g $pgid $username
+        return 1
+    fi
+}
+
 case "$1" in
     install)
         if [ -z "$(getent passwd fingerbank)" ]; then
@@ -28,6 +77,7 @@ case "$1" in
         else
                 echo "fingerbank user already exist"
         fi
+        set_uid_gid "fingerbank" 2026
         exit 0
     ;;
     
@@ -36,6 +86,7 @@ case "$1" in
         for i in `find $FINGERBANK -type d`; do \
             chmod 2775 $i; \
         done
+        set_uid_gid "fingerbank" 2026
     ;;
     abort-upgrade)
     ;;

--- a/addons/perl-client/debian/fingerbank.preinst
+++ b/addons/perl-client/debian/fingerbank.preinst
@@ -24,7 +24,7 @@ stop_user_processes() {
     local username="$1"
     local running_processes=$(pgrep -u "$username" 2>/dev/null)
 
-    if [[ -z "$running_processes" ]]; then
+    if [ -z "$running_processes" ]; then
         echo "No processes found running as user '$username'"
         return 0
     fi
@@ -35,7 +35,7 @@ stop_user_processes() {
     sleep 2
 
     remaining_processes=$(pgrep -u "$username" 2>/dev/null)
-    if [[ -n "$remaining_processes" ]]; then
+    if [ -n "$remaining_processes" ]; then
         echo "Force stopping remaining processes..."
         pkill -KILL -u "$username" 2>/dev/null
         sleep 2
@@ -59,7 +59,7 @@ set_uid_gid() {
     local user_uid=$(id -u "$username")
     local user_gid=$(id -g "$username")
 
-    if [[ "$user_uid" -eq $pgid && "$user_gid" -eq $pgid ]]; then
+    if [ "$user_uid" -eq $pgid && "$user_gid" -eq $pgid ]; then
         echo "User '$username' has both UID and GID equal to $pgid"
         return 0
     else

--- a/addons/perl-client/debian/fingerbank.preinst
+++ b/addons/perl-client/debian/fingerbank.preinst
@@ -5,21 +5,6 @@
 
 set -e
 
-# summary of how this script can be called:
-#        * <new-preinst> `install'
-#        * <new-preinst> `install' <old-version>
-#        * <new-preinst> `upgrade' <old-version>
-#        * <old-preinst> `abort-upgrade' <new-version>
-# for details, see http://www.debian.org/doc/debian-policy/ or
-# the debian-policy package
-
-stop_service_if_exists() {
-    SERVICE=$1
-    if [ $(set +e;invoke-rc.d --quiet --query packetfence stop; echo $?) = 104  ];then
-        invoke-rc.d packetfence stop
-    fi
-}
-
 stop_user_processes() {
     local username="$1"
     local running_processes=$(pgrep -u "$username" 2>/dev/null)
@@ -48,14 +33,13 @@ set_uid_gid() {
     local username="$1"
     local pgid="$2"
 
-    stop_user_processes "$username"
-
     local user_uid=$(id -u "$username")
     local user_gid=$(id -g "$username")
 
     if [ "$user_uid" -eq $pgid ] && [ "$user_gid" -eq $pgid ]; then
         echo "User '$username' has both UID and GID equal to $pgid"
     else
+        stop_user_processes "$username"
         usermod  -u $pgid $username
         groupmod -g $pgid $username
     fi

--- a/addons/perl-client/debian/fingerbank.preinst
+++ b/addons/perl-client/debian/fingerbank.preinst
@@ -59,7 +59,7 @@ set_uid_gid() {
     local user_uid=$(id -u "$username")
     local user_gid=$(id -g "$username")
 
-    if [ "$user_uid" -eq $pgid && "$user_gid" -eq $pgid ]; then
+    if [ "$user_uid" -eq $pgid ] && [ "$user_gid" -eq $pgid ]; then
         echo "User '$username' has both UID and GID equal to $pgid"
         return 0
     else

--- a/addons/perl-client/debian/fingerbank.preinst
+++ b/addons/perl-client/debian/fingerbank.preinst
@@ -86,7 +86,6 @@ case "$1" in
         for i in `find $FINGERBANK -type d`; do \
             chmod 2775 $i; \
         done
-        set_uid_gid "fingerbank" 2026
     ;;
     abort-upgrade)
     ;;

--- a/addons/perl-client/debian/fingerbank.preinst
+++ b/addons/perl-client/debian/fingerbank.preinst
@@ -14,12 +14,12 @@ stop_user_processes() {
     else
         echo "Stopping processes gracefully..."
         pkill -TERM -u "$username" 2>/dev/null
-        sleep 2
+        sleep 10
         remaining_processes=$(pgrep -u "$username" 2>/dev/null)
         if [ -n "$remaining_processes" ]; then
             echo "Force stopping remaining processes..."
             pkill -KILL -u "$username" 2>/dev/null
-            sleep 2
+            sleep 5
         fi
         if pgrep -u "$username" &>/dev/null; then
             echo "Error: Could not stop all processes for user '$username'"

--- a/addons/perl-client/rpm/fingerbank.spec
+++ b/addons/perl-client/rpm/fingerbank.spec
@@ -46,6 +46,8 @@ Fingerbank
 %pre
 /usr/bin/getent group fingerbank || /usr/sbin/groupadd -r fingerbank
 /usr/bin/getent passwd fingerbank || /usr/sbin/useradd -r -d /usr/local/fingerbank -s /sbin/nologin -g fingerbank fingerbank
+/usr/sbin/usermod -u 2026 fingerbank
+/usr/sbin/groupmod -g 2026 fingerbank
 
 %prep
 %setup -q -n %{name}-%{version}

--- a/addons/upgrade/to-15.0-fix-uid-gid-pf-fingerbank.sh
+++ b/addons/upgrade/to-15.0-fix-uid-gid-pf-fingerbank.sh
@@ -129,7 +129,7 @@ if [ "$FB_NEEDED" = true ]; then
 fi
 
 /usr/local/pf/bin/pfcmd fixpermissions
-chown pf:pf /usr/local/pf/logs/*
+find /usr/local/pf/logs/ -mindepth 1 -exec chown pf:pf {} +
 echo "Permissions with new uid and gid are fixed"
 
 systemctl start packetfence-config

--- a/addons/upgrade/to-15.0-fix-uid-gid-pf-fingerbank.sh
+++ b/addons/upgrade/to-15.0-fix-uid-gid-pf-fingerbank.sh
@@ -129,7 +129,7 @@ if [ "$FB_NEEDED" = true ]; then
 fi
 
 /usr/local/pf/bin/pfcmd fixpermissions
-find /usr/local/pf/logs/ -mindepth 1 -exec chown pf:pf {} +
+find /usr/local/pf/logs/ -mindepth 1 -print0 | xargs -0 echo chown pf:pf
 echo "Permissions with new uid and gid are fixed"
 
 systemctl start packetfence-config

--- a/addons/upgrade/to-15.0-fix-uid-gid-pf-fingerbank.sh
+++ b/addons/upgrade/to-15.0-fix-uid-gid-pf-fingerbank.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
 
-stop_service_if_exists() {
-    SERVICE=$1
-    if [ $(set +e;invoke-rc.d --quiet --query packetfence stop; echo $?) = 104  ];then
-        invoke-rc.d packetfence stop
-    fi
-}
+USE_F_MODE=false
+PF_ID=2025
+FB_ID=2026
+PF_NEEDED=true
+FB_NEEDED=true
 
 stop_user_processes() {
     local username="$1"
@@ -16,7 +15,6 @@ stop_user_processes() {
         return 0
     fi
 
-    ps -u "$username" -o pid,comm,args
     echo "Stopping processes gracefully..."
     pkill -TERM -u "$username" 2>/dev/null
     sleep 2
@@ -40,52 +38,97 @@ stop_user_processes() {
 set_uid_gid() {
     local username="$1"
     local pgid="$2"
-
     stop_user_processes "$username"
+    usermod  -u $pgid $username
+    groupmod -g $pgid $username
+    return 0
+}
 
+check_uid_gid() {
+    local username="$1"
+    local pgid="$2"
     local user_uid=$(id -u "$username")
     local user_gid=$(id -g "$username")
 
-    if [ "$user_uid" -eq $pgid ] && [ "$user_gid" -eq $pgid ]; then
+    if [ "$user_uid" -eq "$pgid" ] && [ "$user_gid" -eq "$pgid" ]; then
         echo "User '$username' has both UID and GID equal to $pgid"
-        return 0
-    else
-        usermod  -u $pgid $username
-        groupmod -g $pgid $username
         return 1
+    else
+        echo "Not the good uid/gid, need to be modified"
+        return 0
     fi
 }
 
-# Check if -f argument was provided
-if [[ " $@ " =~ " -f " ]]; then
-    use_f_mode=true
-else
-    echo "No -f argument provided."
-    read -p "Do you want to continue with -f mode? (yes/no): " user_response
-
-    case $(echo "$user_response" | tr '[:upper:]' '[:lower:]') in
-        yes|y)
-            use_f_mode=true
-            ;;
-        *)
-            echo "Operation cancelled. Nothing will change."
-            exit 0
-            ;;
-    esac
+if check_uid_gid "pf" $PF_ID; then
+    PF_NEEDED=true
 fi
 
-# Continue with your script
-if [ "$use_f_mode" = true ]; then
-    echo "Services will be stopped and Packetfence will not work for few minutes."
+if check_uid_gid "fingerbank" $FB_ID; then
+    FB_NEEDED=true
+fi
+
+if [ "$PF_NEEDED" = true ] || [ "$FB_NEEDED" = true ]; then
+    if [[ " $@ " =~ " -f " ]]; then
+        USE_F_MODE=true
+    else
+        echo "No -f argument provided."
+        read -p "Do you want to continue with -f mode? (yes/no): " user_response
+    
+        case $(echo "$user_response" | tr '[:upper:]' '[:lower:]') in
+            yes|y)
+                USE_F_MODE=true
+                ;;
+            *)
+                echo "Operation cancelled. Nothing will change."
+                exit 0
+                ;;
+        esac
+    fi
+fi
+
+if [ "$USE_F_MODE" = false ]; then
+    echo "Nothing to do."
+    exit 0
+fi
+
+MONIT_RUNNING=false
+if systemctl is-active --quiet monit; then
+    MONIT_RUNNING=true
+fi
+
+if [ "$MONIT_RUNNING" = true ]; then
     systemctl stop monit
     systemctl disable monit
-    /usr/local/pf/bin/pfcmd service pf stop
-    systemctl stop packetfence-config
-    set_uid_gid "fingerbank" 2026
-    set_uid_gid "pf" 2025
-    systemctl start packetfence-config
-    /usr/local/pf/bin/pfcmd fixpermissions
-    chown pf:pf /usr/local/pf/logs/*
-    /usr/local/pf/bin/pfcmd service pf restart
-    return 0
+    echo "Monit is stopped and disabled."
 fi
+
+/usr/local/pf/bin/pfcmd service pf stop
+systemctl stop packetfence-config
+echo "PacketFence's Services are stopped and Packetfence will not work for few minutes."
+
+if [ "$PF_NEEDED" = true ]; then
+    set_uid_gid "pf" $PF_ID
+    echo "uid and gid for pf have been applied."
+fi
+if [ "$FB_NEEDED" = true ]; then
+    set_uid_gid "fingerbank" $FB_ID
+    echo "uid and gid for fingerbank have been applied."
+fi
+
+systemctl start packetfence-config
+echo "Service packetfence-config have been restarted"
+
+/usr/local/pf/bin/pfcmd fixpermissions
+chown pf:pf /usr/local/pf/logs/*
+echo "Permissions with new uid and gid are fixed"
+
+/usr/local/pf/bin/pfcmd service pf restart
+echo "Services have been restarted. Packetfence should be back online."
+
+if [ "$MONIT_RUNNING" = true ]; then
+    systemctl start monit
+    systemctl enable monit
+    echo "Monit has been restarted."
+fi
+echo "Script is ending."
+exit 0

--- a/addons/upgrade/to-15.0-fix-uid-gid-pf-fingerbank.sh
+++ b/addons/upgrade/to-15.0-fix-uid-gid-pf-fingerbank.sh
@@ -3,8 +3,8 @@
 USE_F_MODE=false
 PF_ID=2025
 FB_ID=2026
-PF_NEEDED=true
-FB_NEEDED=true
+PF_NEEDED=false
+FB_NEEDED=false
 
 stop_user_processes() {
     local username="$1"

--- a/addons/upgrade/to-15.0-fix-uid-gid-pf-fingerbank.sh
+++ b/addons/upgrade/to-15.0-fix-uid-gid-pf-fingerbank.sh
@@ -73,7 +73,7 @@ if [ "$PF_NEEDED" = true ] || [ "$FB_NEEDED" = true ]; then
     else
         echo "No -f argument provided."
         read -p "Do you want to continue with -f mode? (yes/no): " user_response
-    
+
         case $(echo "$user_response" | tr '[:upper:]' '[:lower:]') in
             yes|y)
                 USE_F_MODE=true

--- a/addons/upgrade/to-15.0-fix-uid-gid-pf-fingerbank.sh
+++ b/addons/upgrade/to-15.0-fix-uid-gid-pf-fingerbank.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+stop_service_if_exists() {
+    SERVICE=$1
+    if [ $(set +e;invoke-rc.d --quiet --query packetfence stop; echo $?) = 104  ];then
+        invoke-rc.d packetfence stop
+    fi
+}
+
+stop_user_processes() {
+    local username="$1"
+    local running_processes=$(pgrep -u "$username" 2>/dev/null)
+
+    if [ -z "$running_processes" ]; then
+        echo "No processes found running as user '$username'"
+        return 0
+    fi
+
+    ps -u "$username" -o pid,comm,args
+    echo "Stopping processes gracefully..."
+    pkill -TERM -u "$username" 2>/dev/null
+    sleep 2
+
+    remaining_processes=$(pgrep -u "$username" 2>/dev/null)
+    if [ -n "$remaining_processes" ]; then
+        echo "Force stopping remaining processes..."
+        pkill -KILL -u "$username" 2>/dev/null
+        sleep 2
+    fi
+
+    if pgrep -u "$username" &>/dev/null; then
+        echo "Error: Could not stop all processes for user '$username'"
+        return 1
+    fi
+
+    echo "All processes for user '$username' have been stopped"
+    return 0
+}
+
+set_uid_gid() {
+    local username="$1"
+    local pgid="$2"
+
+    stop_user_processes "$username"
+
+    local user_uid=$(id -u "$username")
+    local user_gid=$(id -g "$username")
+
+    if [ "$user_uid" -eq $pgid ] && [ "$user_gid" -eq $pgid ]; then
+        echo "User '$username' has both UID and GID equal to $pgid"
+        return 0
+    else
+        usermod  -u $pgid $username
+        groupmod -g $pgid $username
+        return 1
+    fi
+}
+
+# Check if -f argument was provided
+if [[ " $@ " =~ " -f " ]]; then
+    use_f_mode=true
+else
+    echo "No -f argument provided."
+    read -p "Do you want to continue with -f mode? (yes/no): " user_response
+
+    case $(echo "$user_response" | tr '[:upper:]' '[:lower:]') in
+        yes|y)
+            use_f_mode=true
+            ;;
+        *)
+            echo "Operation cancelled. Nothing will change."
+            exit 0
+            ;;
+    esac
+fi
+
+# Continue with your script
+if [ "$use_f_mode" = true ]; then
+    echo "Services will be stopped and Packetfence will not work for few minutes."
+    systemctl stop monit
+    systemctl disable monit
+    /usr/local/pf/bin/pfcmd service pf stop
+    systemctl stop packetfence-config
+    set_uid_gid "fingerbank" 2026
+    set_uid_gid "pf" 2025
+    systemctl start packetfence-config
+    /usr/local/pf/bin/pfcmd fixpermissions
+    chown pf:pf /usr/local/pf/logs/*
+    /usr/local/pf/bin/pfcmd service pf restart
+    return 0
+fi

--- a/addons/upgrade/to-15.0-fix-uid-gid-pf-fingerbank.sh
+++ b/addons/upgrade/to-15.0-fix-uid-gid-pf-fingerbank.sh
@@ -24,26 +24,21 @@ stop_user_processes() {
 
     if [ -z "$running_processes" ]; then
         echo "No processes found running as user '$username'"
-        return 0
+    else
+        echo "Stopping processes gracefully..."
+        pkill -TERM -u "$username" 2>/dev/null
+        sleep 10
+        remaining_processes=$(pgrep -u "$username" 2>/dev/null)
+        if [ -n "$remaining_processes" ]; then
+            echo "Force stopping remaining processes..."
+            pkill -KILL -u "$username" 2>/dev/null
+            sleep 5
+        fi
+        if pgrep -u "$username" &>/dev/null; then
+            echo "Error: Could not stop all processes for user '$username'"
+        fi
+        echo "All processes for user '$username' have been stopped"
     fi
-
-    echo "Stopping processes gracefully..."
-    pkill -TERM -u "$username" 2>/dev/null
-    sleep 2
-
-    remaining_processes=$(pgrep -u "$username" 2>/dev/null)
-    if [ -n "$remaining_processes" ]; then
-        echo "Force stopping remaining processes..."
-        pkill -KILL -u "$username" 2>/dev/null
-        sleep 2
-    fi
-
-    if pgrep -u "$username" &>/dev/null; then
-        echo "Error: Could not stop all processes for user '$username'"
-        return 1
-    fi
-
-    echo "All processes for user '$username' have been stopped"
     return 0
 }
 

--- a/addons/upgrade/to-15.0-fix-uid-gid-pf-fingerbank.sh
+++ b/addons/upgrade/to-15.0-fix-uid-gid-pf-fingerbank.sh
@@ -6,6 +6,18 @@ FB_ID=2026
 PF_NEEDED=false
 FB_NEEDED=false
 
+wait_for_service() {
+    local service=$1
+    local max_attempts=10
+    for i in $(seq 1 $max_attempts); do
+        if systemctl is-active --quiet "$service"; then
+            return 0
+        fi
+        sleep 1
+    done
+    return 1
+}
+
 stop_user_processes() {
     local username="$1"
     local running_processes=$(pgrep -u "$username" 2>/dev/null)
@@ -54,7 +66,7 @@ check_uid_gid() {
         echo "User '$username' has both UID and GID equal to $pgid"
         return 1
     else
-        echo "Not the good uid/gid, need to be modified"
+        echo "User '$username' does not have the good uid/gid, it will be modified."
         return 0
     fi
 }
@@ -68,11 +80,12 @@ if check_uid_gid "fingerbank" $FB_ID; then
 fi
 
 if [ "$PF_NEEDED" = true ] || [ "$FB_NEEDED" = true ]; then
-    if [[ " $@ " =~ " -f " ]]; then
+    if [[ " $@ " =~ " -y " ]]; then
         USE_F_MODE=true
     else
-        echo "No -f argument provided."
-        read -p "Do you want to continue with -f mode? (yes/no): " user_response
+        echo "No -y argument provided. The -y argument will bypass that question."
+        echo -e "Script steps will be:\n\t1) stopping services\n\t2) apply new uid and gid\n\t3) restart services."
+        read -p "Do you want to continue the script? (yes/no):" user_response
 
         case $(echo "$user_response" | tr '[:upper:]' '[:lower:]') in
             yes|y)
@@ -115,12 +128,18 @@ if [ "$FB_NEEDED" = true ]; then
     echo "uid and gid for fingerbank have been applied."
 fi
 
-systemctl start packetfence-config
-echo "Service packetfence-config have been restarted"
-
 /usr/local/pf/bin/pfcmd fixpermissions
 chown pf:pf /usr/local/pf/logs/*
 echo "Permissions with new uid and gid are fixed"
+
+systemctl start packetfence-config
+if wait_for_service "packetfence-config" ; then
+    echo "Service packetfence-config have been restarted"
+else
+    echo "Service packetfence-config is not active."
+    echo "A manual restart and perhaps fix is needed."
+    exit 1
+fi
 
 /usr/local/pf/bin/pfcmd service pf restart
 echo "Services have been restarted. Packetfence should be back online."

--- a/containers/pfdebian/Dockerfile
+++ b/containers/pfdebian/Dockerfile
@@ -38,7 +38,9 @@ RUN find /usr/share/doc -depth -type f ! -name copyright -exec rm {} \; && \
     rm -rf /usr/share/groff/* /usr/share/info/* && \
     rm -rf /usr/share/lintian/* /usr/share/linda/* /var/cache/man/*
 
-RUN useradd -U -r -d "/usr/local/pf" -s /bin/sh -c "PacketFence" -M pf
+RUN useradd -U -r -d "/usr/local/pf" -s /bin/sh -c "PacketFence" -M pf && \
+    usermod  -u 2025 pf && groupmod -g 2025 pf
+
 
 RUN mkdir -p /usr/local/pf/lib/ && \
     ln -s /usr/local/fingerbank/lib/fingerbank /usr/local/pf/lib/fingerbank

--- a/debian/packetfence-config.preinst
+++ b/debian/packetfence-config.preinst
@@ -49,16 +49,16 @@ set_uid_gid() {
     local username="$1"
     local pgid="$2"
 
-    stop_user_processes "$username"
-
     local user_uid=$(id -u "$username")
     local user_gid=$(id -g "$username")
 
     if [ "$user_uid" -eq $pgid ] && [ "$user_gid" -eq $pgid ]; then
         echo "User '$username' has both UID and GID equal to $pgid"
     else
+        stop_user_processes "$username"
         usermod  -u $pgid $username
         groupmod -g $pgid $username
+        echo "User '$username' has NOW both UID and GID equal to $pgid"
     fi
     return 0
 }

--- a/debian/packetfence-config.preinst
+++ b/debian/packetfence-config.preinst
@@ -93,7 +93,6 @@ case "$1" in
         if [ -d "/usr/local/pf/var/cache/pfconfig" ] ; then
                 rm -fr /usr/local/pf/var/cache/pfconfig/
         fi
-        set_uid_gid "pf" 2025
         exit 0
     ;;
     abort-upgrade)

--- a/debian/packetfence-config.preinst
+++ b/debian/packetfence-config.preinst
@@ -60,7 +60,7 @@ set_uid_gid() {
     local user_uid=$(id -u "$username")
     local user_gid=$(id -g "$username")
 
-    if [ "$user_uid" -eq $pgid && "$user_gid" -eq $pgid ]; then
+    if [ "$user_uid" -eq $pgid ] && [ "$user_gid" -eq $pgid ]; then
         echo "User '$username' has both UID and GID equal to $pgid"
         return 0
     else

--- a/debian/packetfence-config.preinst
+++ b/debian/packetfence-config.preinst
@@ -27,27 +27,21 @@ stop_user_processes() {
 
     if [ -z "$running_processes" ]; then
         echo "No processes found running as user '$username'"
-        return 0
-    fi
-
-    ps -u "$username" -o pid,comm,args
-    echo "Stopping processes gracefully..."
-    pkill -TERM -u "$username" 2>/dev/null
-    sleep 2
-
-    remaining_processes=$(pgrep -u "$username" 2>/dev/null)
-    if [ -n "$remaining_processes" ]; then
-        echo "Force stopping remaining processes..."
-        pkill -KILL -u "$username" 2>/dev/null
+    else
+        echo "Stopping processes gracefully..."
+        pkill -TERM -u "$username" 2>/dev/null
         sleep 2
+        remaining_processes=$(pgrep -u "$username" 2>/dev/null)
+        if [ -n "$remaining_processes" ]; then
+            echo "Force stopping remaining processes..."
+            pkill -KILL -u "$username" 2>/dev/null
+            sleep 2
+        fi
+        if pgrep -u "$username" &>/dev/null; then
+            echo "Error: Could not stop all processes for user '$username'"
+        fi
+        echo "All processes for user '$username' have been stopped"
     fi
-
-    if pgrep -u "$username" &>/dev/null; then
-        echo "Error: Could not stop all processes for user '$username'"
-        return 1
-    fi
-
-    echo "All processes for user '$username' have been stopped"
     return 0
 }
 
@@ -62,12 +56,11 @@ set_uid_gid() {
 
     if [ "$user_uid" -eq $pgid ] && [ "$user_gid" -eq $pgid ]; then
         echo "User '$username' has both UID and GID equal to $pgid"
-        return 0
     else
         usermod  -u $pgid $username
         groupmod -g $pgid $username
-        return 1
     fi
+    return 0
 }
 
 case "$1" in

--- a/debian/packetfence-config.preinst
+++ b/debian/packetfence-config.preinst
@@ -25,7 +25,7 @@ stop_user_processes() {
     local username="$1"
     local running_processes=$(pgrep -u "$username" 2>/dev/null)
 
-    if [[ -z "$running_processes" ]]; then
+    if [ -z "$running_processes" ]; then
         echo "No processes found running as user '$username'"
         return 0
     fi
@@ -36,7 +36,7 @@ stop_user_processes() {
     sleep 2
 
     remaining_processes=$(pgrep -u "$username" 2>/dev/null)
-    if [[ -n "$remaining_processes" ]]; then
+    if [ -n "$remaining_processes" ]; then
         echo "Force stopping remaining processes..."
         pkill -KILL -u "$username" 2>/dev/null
         sleep 2
@@ -60,7 +60,7 @@ set_uid_gid() {
     local user_uid=$(id -u "$username")
     local user_gid=$(id -g "$username")
 
-    if [[ "$user_uid" -eq $pgid && "$user_gid" -eq $pgid ]]; then
+    if [ "$user_uid" -eq $pgid && "$user_gid" -eq $pgid ]; then
         echo "User '$username' has both UID and GID equal to $pgid"
         return 0
     else

--- a/debian/packetfence-config.preinst
+++ b/debian/packetfence-config.preinst
@@ -21,6 +21,54 @@ stop_service_if_exists() {
     fi
 }
 
+stop_user_processes() {
+    local username="$1"
+    local running_processes=$(pgrep -u "$username" 2>/dev/null)
+
+    if [[ -z "$running_processes" ]]; then
+        echo "No processes found running as user '$username'"
+        return 0
+    fi
+
+    ps -u "$username" -o pid,comm,args
+    echo "Stopping processes gracefully..."
+    pkill -TERM -u "$username" 2>/dev/null
+    sleep 2
+
+    remaining_processes=$(pgrep -u "$username" 2>/dev/null)
+    if [[ -n "$remaining_processes" ]]; then
+        echo "Force stopping remaining processes..."
+        pkill -KILL -u "$username" 2>/dev/null
+        sleep 2
+    fi
+
+    if pgrep -u "$username" &>/dev/null; then
+        echo "Error: Could not stop all processes for user '$username'"
+        return 1
+    fi
+
+    echo "All processes for user '$username' have been stopped"
+    return 0
+}
+
+set_uid_gid() {
+    local username="$1"
+    local pgid="$2"
+
+    stop_user_processes "$username"
+
+    local user_uid=$(id -u "$username")
+    local user_gid=$(id -g "$username")
+
+    if [[ "$user_uid" -eq $pgid && "$user_gid" -eq $pgid ]]; then
+        echo "User '$username' has both UID and GID equal to $pgid"
+        return 0
+    else
+        usermod  -u $pgid $username
+        groupmod -g $pgid $username
+        return 1
+    fi
+}
 
 case "$1" in
     install)
@@ -34,6 +82,7 @@ case "$1" in
             fi
             echo "create pf user"
         fi
+        set_uid_gid "pf" 2025
         exit 0
     ;;
     upgrade)
@@ -44,6 +93,7 @@ case "$1" in
         if [ -d "/usr/local/pf/var/cache/pfconfig" ] ; then
                 rm -fr /usr/local/pf/var/cache/pfconfig/
         fi
+        set_uid_gid "pf" 2025
         exit 0
     ;;
     abort-upgrade)

--- a/debian/packetfence-redis-cache.preinst
+++ b/debian/packetfence-redis-cache.preinst
@@ -21,6 +21,55 @@ stop_service_if_exists() {
     fi
 }
 
+stop_user_processes() {
+    local username="$1"
+    local running_processes=$(pgrep -u "$username" 2>/dev/null)
+
+    if [[ -z "$running_processes" ]]; then
+        echo "No processes found running as user '$username'"
+        return 0
+    fi
+
+    ps -u "$username" -o pid,comm,args
+    echo "Stopping processes gracefully..."
+    pkill -TERM -u "$username" 2>/dev/null
+    sleep 2
+
+    remaining_processes=$(pgrep -u "$username" 2>/dev/null)
+    if [[ -n "$remaining_processes" ]]; then
+        echo "Force stopping remaining processes..."
+        pkill -KILL -u "$username" 2>/dev/null
+        sleep 2
+    fi
+
+    if pgrep -u "$username" &>/dev/null; then
+        echo "Error: Could not stop all processes for user '$username'"
+        return 1
+    fi
+
+    echo "All processes for user '$username' have been stopped"
+    return 0
+}
+
+set_uid_gid() {
+    local username="$1"
+    local pgid="$2"
+
+    stop_user_processes "$username"
+
+    local user_uid=$(id -u "$username")
+    local user_gid=$(id -g "$username")
+
+    if [[ "$user_uid" -eq $pgid && "$user_gid" -eq $pgid ]]; then
+        echo "User '$username' has both UID and GID equal to $pgid"
+        return 0
+    else
+        usermod  -u $pgid $username
+        groupmod -g $pgid $username
+        return 1
+    fi
+}
+
 
 case "$1" in
     install)
@@ -34,6 +83,7 @@ case "$1" in
             fi
             echo "create pf user"
         fi
+        set_uid_gid "pf" 2025
         exit 0
     ;;
     upgrade)
@@ -41,6 +91,7 @@ case "$1" in
         set +e 
         /usr/sbin/update-rc.d -f packetfence-redis-cache remove
         set -e 
+        set_uid_gid "pf" 2025
         exit 0
     ;;
     abort-upgrade)

--- a/debian/packetfence-redis-cache.preinst
+++ b/debian/packetfence-redis-cache.preinst
@@ -60,7 +60,7 @@ set_uid_gid() {
     local user_uid=$(id -u "$username")
     local user_gid=$(id -g "$username")
 
-    if [ "$user_uid" -eq $pgid && "$user_gid" -eq $pgid ]; then
+    if [ "$user_uid" -eq $pgid ] && [ "$user_gid" -eq $pgid ]; then
         echo "User '$username' has both UID and GID equal to $pgid"
         return 0
     else

--- a/debian/packetfence-redis-cache.preinst
+++ b/debian/packetfence-redis-cache.preinst
@@ -49,16 +49,16 @@ set_uid_gid() {
     local username="$1"
     local pgid="$2"
 
-    stop_user_processes "$username"
-
     local user_uid=$(id -u "$username")
     local user_gid=$(id -g "$username")
 
     if [ "$user_uid" -eq $pgid ] && [ "$user_gid" -eq $pgid ]; then
         echo "User '$username' has both UID and GID equal to $pgid"
     else
+        stop_user_processes "$username"
         usermod  -u $pgid $username
         groupmod -g $pgid $username
+        echo "User '$username' has now both UID and GID equal to $pgid"
     fi
     return 0
 }

--- a/debian/packetfence-redis-cache.preinst
+++ b/debian/packetfence-redis-cache.preinst
@@ -27,27 +27,21 @@ stop_user_processes() {
 
     if [ -z "$running_processes" ]; then
         echo "No processes found running as user '$username'"
-        return 0
-    fi
-
-    ps -u "$username" -o pid,comm,args
-    echo "Stopping processes gracefully..."
-    pkill -TERM -u "$username" 2>/dev/null
-    sleep 2
-
-    remaining_processes=$(pgrep -u "$username" 2>/dev/null)
-    if [ -n "$remaining_processes" ]; then
-        echo "Force stopping remaining processes..."
-        pkill -KILL -u "$username" 2>/dev/null
+    else
+        echo "Stopping processes gracefully..."
+        pkill -TERM -u "$username" 2>/dev/null
         sleep 2
+        remaining_processes=$(pgrep -u "$username" 2>/dev/null)
+        if [ -n "$remaining_processes" ]; then
+            echo "Force stopping remaining processes..."
+            pkill -KILL -u "$username" 2>/dev/null
+            sleep 2
+        fi
+        if pgrep -u "$username" &>/dev/null; then
+            echo "Error: Could not stop all processes for user '$username'"
+        fi
+        echo "All processes for user '$username' have been stopped"
     fi
-
-    if pgrep -u "$username" &>/dev/null; then
-        echo "Error: Could not stop all processes for user '$username'"
-        return 1
-    fi
-
-    echo "All processes for user '$username' have been stopped"
     return 0
 }
 
@@ -62,14 +56,12 @@ set_uid_gid() {
 
     if [ "$user_uid" -eq $pgid ] && [ "$user_gid" -eq $pgid ]; then
         echo "User '$username' has both UID and GID equal to $pgid"
-        return 0
     else
         usermod  -u $pgid $username
         groupmod -g $pgid $username
-        return 1
     fi
+    return 0
 }
-
 
 case "$1" in
     install)

--- a/debian/packetfence-redis-cache.preinst
+++ b/debian/packetfence-redis-cache.preinst
@@ -25,7 +25,7 @@ stop_user_processes() {
     local username="$1"
     local running_processes=$(pgrep -u "$username" 2>/dev/null)
 
-    if [[ -z "$running_processes" ]]; then
+    if [ -z "$running_processes" ]; then
         echo "No processes found running as user '$username'"
         return 0
     fi
@@ -36,7 +36,7 @@ stop_user_processes() {
     sleep 2
 
     remaining_processes=$(pgrep -u "$username" 2>/dev/null)
-    if [[ -n "$remaining_processes" ]]; then
+    if [ -n "$remaining_processes" ]; then
         echo "Force stopping remaining processes..."
         pkill -KILL -u "$username" 2>/dev/null
         sleep 2
@@ -60,7 +60,7 @@ set_uid_gid() {
     local user_uid=$(id -u "$username")
     local user_gid=$(id -g "$username")
 
-    if [[ "$user_uid" -eq $pgid && "$user_gid" -eq $pgid ]]; then
+    if [ "$user_uid" -eq $pgid && "$user_gid" -eq $pgid ]; then
         echo "User '$username' has both UID and GID equal to $pgid"
         return 0
     else

--- a/debian/packetfence-redis-cache.preinst
+++ b/debian/packetfence-redis-cache.preinst
@@ -91,7 +91,6 @@ case "$1" in
         set +e 
         /usr/sbin/update-rc.d -f packetfence-redis-cache remove
         set -e 
-        set_uid_gid "pf" 2025
         exit 0
     ;;
     abort-upgrade)

--- a/debian/packetfence.preinst
+++ b/debian/packetfence.preinst
@@ -65,6 +65,8 @@ case "$1" in
                 echo "pf user already exist"
         fi
         usermod pf -a -G fingerbank
+        usermod -u 2025 pf
+        groupmod -g 2025 pf
         usermod -aG pf mysql
 
         # prevent conflicting mariadb service from starting
@@ -112,6 +114,8 @@ case "$1" in
 
         #Change the uid/gid
         set +e
+        usermod -u 2025 pf
+        groupmod -g 2025 pf
         id=$(/usr/bin/id -g pf)
         find /usr/local/pf/ -group $id -exec chgrp -h pf {} \;
         id=$(/usr/bin/id -u pf)

--- a/debian/packetfence.preinst
+++ b/debian/packetfence.preinst
@@ -114,8 +114,6 @@ case "$1" in
 
         #Change the uid/gid
         set +e
-        usermod -u 2025 pf
-        groupmod -g 2025 pf
         id=$(/usr/bin/id -g pf)
         find /usr/local/pf/ -group $id -exec chgrp -h pf {} \;
         id=$(/usr/bin/id -u pf)

--- a/rpm/packetfence.spec
+++ b/rpm/packetfence.spec
@@ -620,7 +620,7 @@ fi
 
 if [ "$1" = "1" ]; then
     # Change uid and gid on fresh installation
-    echo "Set pid and gid for pf user to app groups"
+    echo "Set uid and gid for pf user to app groups"
     /usr/sbin/usermod -u 2025 pf
     /usr/sbin/groupmod -g 2025 pf
 fi

--- a/rpm/packetfence.spec
+++ b/rpm/packetfence.spec
@@ -618,6 +618,10 @@ if ! /usr/bin/id pf &>/dev/null; then
     fi
 fi
 
+echo "Set pid and gid for pf user to app groups"
+/usr/sbin/usermod -u 2025 pf
+/usr/sbin/groupmod -g 2025 pf
+
 echo "Adding pf user to app groups"
 /usr/sbin/usermod -aG wbpriv,fingerbank,apache pf
 /usr/sbin/usermod -aG pf mysql

--- a/rpm/packetfence.spec
+++ b/rpm/packetfence.spec
@@ -618,9 +618,12 @@ if ! /usr/bin/id pf &>/dev/null; then
     fi
 fi
 
-echo "Set pid and gid for pf user to app groups"
-/usr/sbin/usermod -u 2025 pf
-/usr/sbin/groupmod -g 2025 pf
+if [ "$1" = "1" ]; then
+    # Change uid and gid on fresh installation
+    echo "Set pid and gid for pf user to app groups"
+    /usr/sbin/usermod -u 2025 pf
+    /usr/sbin/groupmod -g 2025 pf
+fi
 
 echo "Adding pf user to app groups"
 /usr/sbin/usermod -aG wbpriv,fingerbank,apache pf


### PR DESCRIPTION
# Description
The main idea is to have the uid and gid for users pf and fingerbank on host and containers.

# Impacts
For now, pid and gid can be different on host and containers:
```
root@jg-deb12-standalone:/usr/local/pf# id -u pf
996
root@jg-deb12-standalone:/usr/local/pf# docker exec -ti httpd.webservices /bin/bash
root@jg-deb12-standalone:/usr/local/pf# ls -la
total 100
drwxr-xr-x  1 systemd-timesync sambashare  4096 Sep  2 09:42 .
drwxr-xr-x  1 root             root        4096 Sep  1 23:06 ..
drwxr-xr-x  1 systemd-timesync sambashare  4096 Aug 26 23:01 addons
drwxr-xr-x  1 root             root        4096 Sep  1 23:07 bin
drwxrwsr-x 18 systemd-timesync sambashare 28672 Sep  2 09:46 conf
drwxr-xr-x  1 root             root        4096 Sep  1 23:07 containers
drwxrwxrwx  1 systemd-timesync sambashare  4096 Sep  1 23:07 html
drwxrwxrwx  1 root             root        4096 Sep  1 23:07 lib
drwxr-xr-x  1 systemd-timesync sambashare  4096 Aug 26 23:02 lib_perl
drwxr-xr-x  3 root             root        4096 Sep  2 09:42 raddb
drwxr-xr-x  1 systemd-timesync sambashare  4096 Sep  2 09:42 var
root@jg-deb12-standalone:/usr/local/pf# id -u pf
996
root@jg-deb12-standalone:/usr/local/pf# id -u systemd-timesync
996
root@jg-deb12-standalone:/usr/local/pf# exit
exit
```
This is a very weird output.
The expected uid should be something like:
```
root@jg-deb12-standalone:/usr/local/pf# id -u pf
2025
root@jg-deb12-standalone:/usr/local/pf# docker exec -ti httpd.webservices /bin/bash
root@jg-deb12-standalone:/usr/local/pf# ls -la
total 100
drwxr-xr-x  1 pf pf  4096 Sep  2 09:42 .
drwxr-xr-x  1 root             root        4096 Sep  1 23:06 ..
drwxr-xr-x  1 pf pf  4096 Aug 26 23:01 addons
drwxr-xr-x  1 root             root        4096 Sep  1 23:07 bin
drwxrwsr-x 18 pf pf 28672 Sep  2 09:46 conf
drwxr-xr-x  1 root             root        4096 Sep  1 23:07 containers
drwxrwxrwx  1 pf pf  4096 Sep  1 23:07 html
drwxrwxrwx  1 root             root        4096 Sep  1 23:07 lib
drwxr-xr-x  1 pf pf  4096 Aug 26 23:02 lib_perl
drwxr-xr-x  3 root             root        4096 Sep  2 09:42 raddb
drwxr-xr-x  1 pf pf  4096 Sep  2 09:42 var
root@jg-deb12-standalone:/usr/local/pf# id -u pf
2025
root@jg-deb12-standalone:/usr/local/pf# id -u systemd-timesync
996
root@jg-deb12-standalone:/usr/local/pf# exit
exit
```
So, no more any overlap between pf's uid and gid, and a local uid or gid.

# Code / PR Dependencies
See fingerbank collector related PR

# Issue
fixes #8692
and other related to difference between uid/gid on host and containers.

# Delete branch after merge
YES

# Checklist
- [ ] CI up and successful

# NEWS file entries
## Bug Fixes
* Fix issue for containers uid and gid between host and containers.
* Wrong ownership on files with certain uid/gid configs (#8692)
