### PR TITLE
Stop backup when not master on cluster, Remove any kind of db backup

### DIFF
--- a/addons/backup-and-maintenance.sh
+++ b/addons/backup-and-maintenance.sh
@@ -139,6 +139,7 @@ should_backup_database(){
     # to detect MariaDB remote DB
     if [ "$DB_HOST" != "localhost" ] && [ "$DB_HOST" != "100.64.0.1" ]; then
         echo "Remote database detected: backup should be done on database server itself."
+        BACKUPRC=1
         exit $BACKUPRC
     fi
 
@@ -152,6 +153,7 @@ should_backup_database(){
             MARIADB_DISABLE_GALERA=0
         elif ! ip a | grep $FIRST_SERVER > /dev/null; then
             echo "Not the first server of the cluster: database backup canceled."
+            BACKUPRC=1
             exit $BACKUPRC
         else
             echo -e "First server of the cluster : database backup will start.\n"

--- a/addons/exportable-backup.sh
+++ b/addons/exportable-backup.sh
@@ -104,8 +104,10 @@ clean_backup(){
     echo "Start backup cleaning"
     find $BACKUP_DIRECTORY -name "$BACKUP_PF_FILENAME-*.tgz" -mtime +$NB_DAYS_TO_KEEP_BACKUP -delete
     echo "Old backup cleaned"
-    find $BACKUP_DIRECTORY -name "$BACKUP_DB_FILENAME-*.gz" -mtime +$NB_DAYS_TO_KEEP_BACKUP -delete
-    find $BACKUP_DIRECTORY -name "$BACKUP_DB_FILENAME-*.gz" -mmin -120 -delete
+    find $BACKUP_DIRECTORY -name "$BACKUP_DB_FILENAME-*.sql.gz" -mtime +$NB_DAYS_TO_KEEP_BACKUP -delete
+    find $BACKUP_DIRECTORY -name "$BACKUP_DB_FILENAME-*.sql.gz" -mmin -120 -delete
+    find $BACKUP_DIRECTORY -name "$BACKUP_DB_FILENAME-*.xbstream.gz" -mtime +$NB_DAYS_TO_KEEP_BACKUP -delete
+    find $BACKUP_DIRECTORY -name "$BACKUP_DB_FILENAME-*.xbstream.gz" -mmin -120 -delete
     echo "Temp db backup cleaned"
     find $BACKUP_DIRECTORY -name "$BACKUP_CONF_FILENAME-*.tgz" -delete
     echo "Temp config backup cleaned"

--- a/addons/exportable-backup.sh
+++ b/addons/exportable-backup.sh
@@ -104,8 +104,8 @@ clean_backup(){
     echo "Start backup cleaning"
     find $BACKUP_DIRECTORY -name "$BACKUP_PF_FILENAME-*.tgz" -mtime +$NB_DAYS_TO_KEEP_BACKUP -delete
     echo "Old backup cleaned"
-    find $BACKUP_DIRECTORY -name "$BACKUP_DB_FILENAME-*.sql.gz" -mtime +$NB_DAYS_TO_KEEP_BACKUP -delete
-    find $BACKUP_DIRECTORY -name "$BACKUP_DB_FILENAME-*.sql.gz" -mmin -120 -delete
+    find $BACKUP_DIRECTORY -name "$BACKUP_DB_FILENAME-*.gz" -mtime +$NB_DAYS_TO_KEEP_BACKUP -delete
+    find $BACKUP_DIRECTORY -name "$BACKUP_DB_FILENAME-*.gz" -mmin -120 -delete
     echo "Temp db backup cleaned"
     find $BACKUP_DIRECTORY -name "$BACKUP_CONF_FILENAME-*.tgz" -delete
     echo "Temp config backup cleaned"


### PR DESCRIPTION
# Description
Stop database backup when not running on the master node in a cluster configuration. This prevents unnecessary backup attempts on secondary cluster nodes and properly sets the exit code when backup is skipped. Also fixes the backup cleanup pattern to match all database backup file extensions.

# Impacts
- Backup script logic in [addons/backup-and-maintenance.sh](addons/backup-and-maintenance.sh)
- Database backup cleanup patterns to grab also backup .xbstream from mariadb-backup in [addons/exportable-backup.sh](addons/exportable-backup.sh)
- Exit codes now properly set to 1 when backup is skipped (remote DB or non-master cluster node)

# Code / PR Dependencies
None

# Issue
fixes #8787

# Delete branch after merge
YES

# Checklist
- [n/a] Document the feature
- [n/a] Add OpenAPI specification
- [n/a] Add unit tests
- [yes] Add acceptance tests (TestLink)

# NEWS file entries

## Bug Fixes
* Database backup now properly stops on non-master cluster nodes with correct exit code (#8787)
* Fixed backup cleanup pattern to properly match all database backup file extensions

# UPGRADE file entries
None required