### PR TITLE
Fix/cluster ugid fix

### DIFF
--- a/addons/upgrade/to-15.0-fix-uid-gid-pf-fingerbank.sh
+++ b/addons/upgrade/to-15.0-fix-uid-gid-pf-fingerbank.sh
@@ -124,13 +124,14 @@ if [ "$FB_NEEDED" = true ]; then
     echo "uid and gid for fingerbank have been applied."
 fi
 
-/usr/local/pf/bin/pfcmd fixpermissions
-find /usr/local/pf/logs/ -mindepth 1 -print0 | xargs -0 chown pf:pf
+find /usr/local/pf/ '(' -type d -or -type f ')' -not -name pfcmd -not -path "$PACKETFENCE/logs*" -print0 | xargs -0 chown pf:pf
+find /usr/local/pf/logs/ -mindepth 1 -print0 | xargs -0 chown root:pf
 find /usr/local/pf -path '/usr/local/pf/var/*' -prune -o -exec chown pf:pf {} +
 chown root:root /usr/local/pf/bin/pfcmd
 chmod ug+s /usr/local/pf/bin/pfcmd
 chown root:root /usr/local/pf/bin/pfcrypt
 chown root:root /usr/local/pf/bin/pfkafka
+/usr/local/pf/bin/pfcmd fixpermissions
 echo "Permissions with new uid and gid are fixed"
 
 systemctl start packetfence-config

--- a/addons/upgrade/to-15.0-fix-uid-gid-pf-fingerbank.sh
+++ b/addons/upgrade/to-15.0-fix-uid-gid-pf-fingerbank.sh
@@ -126,7 +126,6 @@ fi
 
 find /usr/local/pf/ '(' -type d -or -type f ')' -not -name pfcmd -not -path "$PACKETFENCE/logs*" -print0 | xargs -0 chown pf:pf
 find /usr/local/pf/logs/ -mindepth 1 -print0 | xargs -0 chown root:pf
-find /usr/local/pf -path '/usr/local/pf/var/*' -prune -o -exec chown pf:pf {} +
 chown root:root /usr/local/pf/bin/pfcmd
 chmod ug+s /usr/local/pf/bin/pfcmd
 chown root:root /usr/local/pf/bin/pfcrypt

--- a/addons/upgrade/to-15.0-fix-uid-gid-pf-fingerbank.sh
+++ b/addons/upgrade/to-15.0-fix-uid-gid-pf-fingerbank.sh
@@ -113,7 +113,7 @@ fi
 
 /usr/local/pf/bin/pfcmd service pf stop
 systemctl stop packetfence-config
-echo "PacketFence's Services are stopped and Packetfence will not work for few minutes."
+echo "PacketFence's Services are stopped."
 
 if [ "$PF_NEEDED" = true ]; then
     set_uid_gid "pf" $PF_ID
@@ -126,6 +126,11 @@ fi
 
 /usr/local/pf/bin/pfcmd fixpermissions
 find /usr/local/pf/logs/ -mindepth 1 -print0 | xargs -0 chown pf:pf
+find /usr/local/pf -path '/usr/local/pf/var/*' -prune -o -exec chown pf:pf {} +
+chown root:root /usr/local/pf/bin/pfcmd
+chmod ug+s /usr/local/pf/bin/pfcmd
+chown root:root /usr/local/pf/bin/pfcrypt
+chown root:root /usr/local/pf/bin/pfkafka
 echo "Permissions with new uid and gid are fixed"
 
 systemctl start packetfence-config

--- a/conf/systemd/packetfence-radiusd-load_balancer.service
+++ b/conf/systemd/packetfence-radiusd-load_balancer.service
@@ -16,6 +16,7 @@ StartLimitInterval=10
 ExecStartPre=/usr/bin/perl -I/usr/local/pf/lib -I/usr/local/pf/lib_perl/lib/perl5 '-Mpf::services::manager::radiusd' -e 'pf::services::manager::radiusd->new()->generateConfig()'
 ExecStart=/usr/local/pf/sbin/radiusd-load-balancer-docker-wrapper
 ExecStop=/bin/bash -c "docker stop radiusd-load-balancer ; echo Stopped"
+ExecStopPost=rm -rf /usr/local/pf/var/run/radiusd-load-balancer-systemd-notify.pid ; rm -rf /usr/local/pf/var/run/radiusd-load_balancer.sock
 Restart=on-failure
 Slice=packetfence.slice
 PIDFile=/usr/local/pf/var/run/radiusd-load-balancer-systemd-notify.pid


### PR DESCRIPTION
# Description
Fix UID/GID ownership restoration issues during cluster upgrades and service management.

This PR addresses two critical issues:
1. Corrects the ownership restoration process in the UID/GID upgrade script to properly restore file ownership for both `pf:pf` and `root:root` files
2. Ensures proper cleanup of PID and socket files for the radiusd-load-balancer service when stopped

# Impacts
Reviewers should focus on:
- **Upgrade workflow**: The `to-15.0-fix-uid-gid-pf-fingerbank.sh` script execution during UID/GID migration
- **File ownership**: Verification that files maintain correct ownership (`pf:pf` for PacketFence files, `root:root` for system binaries)
- **Service management**: radiusd-load-balancer service stop/start behavior and cleanup of runtime files
- **Cluster environments**: Behavior in clustered deployments during upgrades

# Code / PR Dependencies
None

# NEW Package(s) required
None

# Issue
This PR addresses ownership restoration issues identified during cluster UID/GID migration.

# Delete branch after merge
YES