### PR TITLE
Add remove packetfence-export on recent installation > pf 10.3. So, should be removed (not be installed) on recent version as mentioned in doc.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -24,8 +24,8 @@ Pre-Depends:  ca-certificates,
  packetfence-perl (>= 1.2.4),
 # Removed for now
 # libmariadbd-dev (>= 10.1), libmariadbd-dev (<< 10.5.18)
-Breaks: libdata-alias-perl
-Conflicts: packetfence-captive-portal-javascript, packetfence-doc, packetfence-pfappserver-javascript
+Breaks: libdata-alias-perl, packetfence-export
+Conflicts: packetfence-captive-portal-javascript, packetfence-doc, packetfence-pfappserver-javascript, packetfence-export
 Replaces: packetfence-captive-portal-javascript, packetfence-doc, packetfence-pfappserver-javascript
 Depends: ${misc:Depends}, vlan,
  packetfence-ntlm-wrapper (>= ${source:Version}), packetfence-golang-daemon (>= ${source:Version}),

--- a/patch.diff
+++ b/patch.diff
@@ -1,0 +1,29 @@
+diff --git a/debian/control b/debian/control                                                                                                                                                                 
+index a557078390..15c2a652e1 100644                                                                                                                                                                          
+--- a/debian/control                                                                                                                                                                                         
++++ b/debian/control                                                                                                                                                                                         
+@@ -24,8 +24,8 @@ Pre-Depends:  ca-certificates,                                                                                                                                                             
+  packetfence-perl (>= 1.2.4),                                                                                                                                                                               
+ # Removed for now                                                                                                                                                                                           
+ # libmariadbd-dev (>= 10.1), libmariadbd-dev (<< 10.5.18)                                                                                                                                                   
+-Breaks: libdata-alias-perl                                                                                                                                                                                  
+-Conflicts: packetfence-captive-portal-javascript, packetfence-doc, packetfence-pfappserver-javascript                                                                                                       
++Breaks: libdata-alias-perl, packetfence-export                                                                                                                                                              
++Conflicts: packetfence-captive-portal-javascript, packetfence-doc, packetfence-pfappserver-javascript, packetfence-export
+ Replaces: packetfence-captive-portal-javascript, packetfence-doc, packetfence-pfappserver-javascript
+ Depends: ${misc:Depends}, vlan,
+  packetfence-ntlm-wrapper (>= ${source:Version}), packetfence-golang-daemon (>= ${source:Version}),
+diff --git a/rpm/packetfence.spec b/rpm/packetfence.spec
+index 30bbcf09c4..6905a19f97 100644
+--- a/rpm/packetfence.spec
++++ b/rpm/packetfence.spec
+@@ -43,6 +43,8 @@ Obsoletes: %{name}-config <= 9.1.0
+  
+ AutoReqProv: 0
+  
++Conflicts: packetfence-export
++
+ Requires: firewalld
+ Requires: chkconfig, coreutils, grep, openssl, sed, tar, wget, gettext, conntrack-tools, patch, git
+ # for process management
+

--- a/rpm/packetfence.spec
+++ b/rpm/packetfence.spec
@@ -43,6 +43,8 @@ Obsoletes: %{name}-config <= 9.1.0
 
 AutoReqProv: 0
 
+Conflicts: packetfence-export
+
 Requires: firewalld
 Requires: chkconfig, coreutils, grep, openssl, sed, tar, wget, gettext, conntrack-tools, patch, git
 # for process management


### PR DESCRIPTION
# Fix package conflict with packetfence-export during upgrades

## Summary

- Added `packetfence-export` to Breaks and Conflicts in Debian control file
- Added `packetfence-export` to Conflicts in RPM spec file

## Issue

Fixes #8734

## Problem

When upgrading PacketFence from version 14.1 to 15.0, the upgrade fails due to a file conflict. The file `/usr/local/pf/addons/full-import/find-extra-files.pl` exists in both:
- The new PacketFence 15.0 package
- The existing packetfence-export 14.x package

This causes the package manager to abort the upgrade.

## Solution

This PR resolves the issue by declaring explicit package conflicts in the packaging metadata:

### Debian (debian/control)
- Added `packetfence-export` to both `Breaks` and `Conflicts` fields
- This ensures that during upgrade, the package manager will automatically remove `packetfence-export` before installing the new PacketFence version

### RPM (rpm/packetfence.spec)
- Added `Conflicts: packetfence-export`
- This prevents installation if `packetfence-export` is present and ensures proper upgrade handling

## Test plan

- [ ] Test upgrade from PF 14.1 to 15.0 on Debian-based systems
- [ ] Test upgrade from PF 14.1 to 15.0 on RPM-based systems
- [ ] Verify packetfence-export is automatically removed during upgrade
- [ ] Verify no file conflicts occur during upgrade
- [ ] Verify PacketFence functions correctly after upgrade

