### PR TITLE
Add development support for Debian 12

### DIFF
--- a/addons/dev-helpers/setup-dev-env.sh
+++ b/addons/dev-helpers/setup-dev-env.sh
@@ -19,21 +19,50 @@ fi
 
 log_section "Cleanup previous dev setup directories"
 rm -fr /usr/local/go
-rm -fr /usr/local/pf-pkg
+if [ ! -d "/usr/local/pf-pkg/lib_perl" ]; then
+    echo "Directory /usr/local/pf-pkg/lib_perl not found. Removing /usr/local/pf-pkg/..."
+    rm -rf /usr/local/pf-pkg/
+else
+    echo "Directory /usr/local/pf-pkg/lib_perl exists. No action taken."
+fi
 
 log_section "Stop services"
 systemctl isolate multi-user
 
 log_section "Replace /usr/local/pf by git repository"
-mv /usr/local/pf /usr/local/pf-pkg
-git clone https://github.com/inverse-inc/packetfence /usr/local/pf
+if [ ! -d "/usr/local/pf-pkg/lib_perl" ]; then
+    echo "Directory /usr/local/pf-pkg/lib_perl not found. Move /usr/local/pf/ to /usr/local/pf-pkg"
+    mv /usr/local/pf /usr/local/pf-pkg
+    git clone https://github.com/inverse-inc/packetfence /usr/local/pf
+else
+    echo "Directory /usr/local/pf-pkg/lib_perl exists. Git pull only."
+    cd /usr/local/pf
+    git pull
+fi
 
 log_section "Set the safe.directory in git"
 git config --global --add safe.directory /usr/local/pf
 
 log_section "install required header files from PF repo"
-#apt install -y libcurl4-openssl-dev libcjson-dev
-dnf install -y --enablerepo=packetfence libcurl-devel cjson-devel
+
+if [ -f /etc/os-release ]; then
+    . /etc/os-release
+    case "$ID" in
+        debian|ubuntu)
+            echo "Detected Debian-based system: $PRETTY_NAME"
+            apt install -y libcurl4-openssl-dev libcjson-dev
+            ;;
+        rhel|centos|rocky|almalinux|fedora)
+            echo "Detected Red Hat-based system: $PRETTY_NAME"
+            dnf install -y --enablerepo=packetfence libcurl-devel cjson-devel
+            ;;
+        *)
+            echo "Unknown Linux distribution: $PRETTY_NAME"
+            ;;
+    esac
+else
+    echo "/etc/os-release not found; unsupported OS"
+fi
 
 cd /usr/local/pf/
 
@@ -56,6 +85,32 @@ cp /usr/local/pf-pkg/conf/pf.conf conf/
 cp /usr/local/pf-pkg/conf/pfconfig.conf conf/
 cp /usr/local/pf-pkg/conf/networks.conf conf/
 cp /usr/local/pf-pkg/sbin/sdnotify-proxy sbin/sdnotify-proxy
+cp /usr/local/pf-pkg/conf/system_init_key /usr/local/pf/conf/system_init_key
+
+log_section "Install asciidoc*"
+
+if [ -f /etc/os-release ]; then
+    . /etc/os-release
+    case "$ID" in
+        debian|ubuntu)
+            echo "Detected Debian-based system: $PRETTY_NAME"
+            apt install ruby ruby-dev build-essential
+            ;;
+        rhel|centos|rocky|almalinux|fedora)
+            echo "Detected Red Hat-based system: $PRETTY_NAME"
+            dnf module reset ruby -y
+            yum install @ruby:2.6
+            ;;
+        *)
+            echo "Unknown Linux distribution: $PRETTY_NAME"
+            ;;
+    esac
+else
+    echo "/etc/os-release not found; unsupported OS"
+fi
+gem install asciidoctor
+gem install asciidoctor-pdf
+gem install rouge -f
 
 log_section "Build web admin"
 cd /usr/local/pf/html/pfappserver/root/
@@ -72,6 +127,13 @@ cd /usr/local/pf/go
 make go-env
 make all
 make copy
+
+log_section "Build Artifacts DOCS devel"
+cd /usr/local/pf
+make -C html/pfappserver/root/ vendor
+make -C html/pfappserver/root/ light-dist
+make pdf
+make html
 
 log_section "Setup container files"
 cd /usr/local/pf
@@ -106,3 +168,4 @@ systemctl restart rsyslog
 
 log_section "Start all PF services"
 /usr/local/pf/bin/pfcmd service pf restart
+

--- a/addons/dev-helpers/setup-dev-env.sh
+++ b/addons/dev-helpers/setup-dev-env.sh
@@ -311,14 +311,31 @@ make html
 
 log_section "Setup container files"
 cd /usr/local/pf
-TAG_OR_BRANCH_NAME=`git rev-parse --abbrev-ref HEAD | sed 's#[/|.]#-#g'`
-echo -n TAG_OR_BRANCH_NAME=$TAG_OR_BRANCH_NAME > conf/build_id
-echo LOCAL_DEV=$LOCAL_DEV > containers/.local_env
 
-for img in pfbuild-debian-bookworm pfdebian radiusd; do
-  docker pull ghcr.io/inverse-inc/packetfence/$img:$TAG_OR_BRANCH_NAME
-  docker tag ghcr.io/inverse-inc/packetfence/$img:$TAG_OR_BRANCH_NAME packetfence/$img:$TAG_OR_BRANCH_NAME
-done
+if [ "$LOCAL_DEV" = true ]; then
+    # Use current branch for local development (containers will be built locally)
+    TAG_OR_BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD | sed 's#[/|.]#-#g')
+    echo "LOCAL_DEV enabled: using branch tag $TAG_OR_BRANCH_NAME"
+    echo -n "TAG_OR_BRANCH_NAME=$TAG_OR_BRANCH_NAME" > conf/build_id
+    echo "LOCAL_DEV=$LOCAL_DEV" > containers/.local_env
+
+    # Pull base images for local builds
+    for img in pfbuild-debian-bookworm pfdebian radiusd; do
+        docker pull ghcr.io/inverse-inc/packetfence/$img:$TAG_OR_BRANCH_NAME || \
+            docker pull ghcr.io/inverse-inc/packetfence/$img:devel
+        docker tag ghcr.io/inverse-inc/packetfence/$img:$TAG_OR_BRANCH_NAME packetfence/$img:$TAG_OR_BRANCH_NAME 2>/dev/null || \
+            docker tag ghcr.io/inverse-inc/packetfence/$img:devel packetfence/$img:$TAG_OR_BRANCH_NAME
+    done
+else
+    # Use devel images from registry
+    TAG_OR_BRANCH_NAME="devel"
+    echo "LOCAL_DEV disabled: using devel images from registry"
+    echo -n "TAG_OR_BRANCH_NAME=$TAG_OR_BRANCH_NAME" > conf/build_id
+    echo "LOCAL_DEV=$LOCAL_DEV" > containers/.local_env
+
+    # Use manage-images.sh to pull and tag all images from devel
+    /usr/local/pf/containers/manage-images.sh
+fi
 
 log_section "Fix permissions and start unmanaged services"
 cd /usr/local/pf

--- a/addons/dev-helpers/setup-dev-env.sh
+++ b/addons/dev-helpers/setup-dev-env.sh
@@ -153,8 +153,8 @@ case "$OS_TYPE" in
         ;;
 esac
 
-## Check and install Node.js if needed
-log_section "Checking Node.js installation"
+## Install Node.js
+log_section "Installing Node.js"
 
 # Get required Node.js version from debian/control, default to 20 if not found
 NODEJS_VERSION="20"
@@ -173,30 +173,23 @@ else
     echo "debian/control not found, using default Node.js version: $NODEJS_VERSION"
 fi
 
-if ! type node 2>/dev/null || ! type npm 2>/dev/null; then
-    echo "Node.js or npm is not installed. Installing Node.js $NODEJS_VERSION..."
-    case "$OS_TYPE" in
-        debian)
-            curl -fsSL "https://deb.nodesource.com/setup_${NODEJS_VERSION}.x" | bash -
-            apt install -y nodejs
-            ;;
-        rhel)
-            dnf module install "nodejs:${NODEJS_VERSION}" -y
-            ;;
-    esac
+echo "Installing Node.js $NODEJS_VERSION..."
+case "$OS_TYPE" in
+    debian)
+        curl -fsSL "https://deb.nodesource.com/setup_${NODEJS_VERSION}.x" | bash -
+        apt install -y nodejs
+        ;;
+    rhel)
+        dnf module reset nodejs -y
+        dnf module install "nodejs:${NODEJS_VERSION}" -y
+        ;;
+esac
 
-    # Verify installation
-    if ! type node 2>/dev/null || ! type npm 2>/dev/null; then
-        die "Failed to install Node.js. Please install it manually."
-    fi
-    echo "Node.js installed successfully."
-else
-    INSTALLED_NODE_VERSION=$(node --version | grep -oP 'v\K[0-9]+')
-    echo "Node.js is already installed (version: $(node --version))"
-    if [ "$INSTALLED_NODE_VERSION" -lt "$NODEJS_VERSION" ]; then
-        echo "Warning: Installed Node.js version is older than required ($NODEJS_VERSION). Consider upgrading."
-    fi
+# Verify installation
+if ! type node 2>/dev/null || ! type npm 2>/dev/null; then
+    die "Failed to install Node.js. Please install it manually."
 fi
+echo "Node.js $NODEJS_VERSION installed successfully."
 
 log_section "Cleanup previous dev setup directories"
 rm -fr /usr/local/go

--- a/addons/dev-helpers/setup-dev-env.sh
+++ b/addons/dev-helpers/setup-dev-env.sh
@@ -58,10 +58,11 @@ if [ -f /etc/os-release ]; then
             ;;
         *)
             echo "Unknown Linux distribution: $PRETTY_NAME"
+            die "Unsupported Linux distribution: $ID"
             ;;
     esac
 else
-    echo "/etc/os-release not found; unsupported OS"
+    die "/etc/os-release not found; unsupported OS"
 fi
 
 cd /usr/local/pf/
@@ -94,23 +95,40 @@ if [ -f /etc/os-release ]; then
     case "$ID" in
         debian|ubuntu)
             echo "Detected Debian-based system: $PRETTY_NAME"
-            apt install ruby ruby-dev build-essential
+            apt install -y ruby ruby-dev build-essential
             ;;
         rhel|centos|rocky|almalinux|fedora)
             echo "Detected Red Hat-based system: $PRETTY_NAME"
             dnf module reset ruby -y
-            yum install @ruby:2.6
+            yum install -y @ruby:2.6
             ;;
         *)
             echo "Unknown Linux distribution: $PRETTY_NAME"
+            die "Unsupported Linux distribution: $ID"
             ;;
     esac
 else
-    echo "/etc/os-release not found; unsupported OS"
+    die "/etc/os-release not found; unsupported OS"
 fi
-gem install asciidoctor
-gem install asciidoctor-pdf
-gem install rouge -f
+
+# Check if gems are already installed to avoid reinstalling
+if ! gem list -i asciidoctor > /dev/null 2>&1; then
+    gem install asciidoctor
+else
+    echo "asciidoctor already installed, skipping..."
+fi
+
+if ! gem list -i asciidoctor-pdf > /dev/null 2>&1; then
+    gem install asciidoctor-pdf
+else
+    echo "asciidoctor-pdf already installed, skipping..."
+fi
+
+if ! gem list -i rouge > /dev/null 2>&1; then
+    gem install rouge -f
+else
+    echo "rouge already installed, skipping..."
+fi
 
 log_section "Build web admin"
 cd /usr/local/pf/html/pfappserver/root/

--- a/addons/dev-helpers/setup-dev-env.sh
+++ b/addons/dev-helpers/setup-dev-env.sh
@@ -41,6 +41,9 @@ OPTIONS:
     --local-dev         Enable local development mode (sets LOCAL_DEV=true in
                         containers/.local_env). This configures containers to use
                         local builds instead of pulling from the registry.
+                        WARNING: When enabled, starting any dockerized service will
+                        rebuild it from scratch, including pfdebian (~3.5GB).
+                        This requires significant disk space and CPU resources.
 
 ENVIRONMENT VARIABLES:
     BRANCH              Git branch to checkout (default: devel)

--- a/addons/dev-helpers/setup-dev-env.sh
+++ b/addons/dev-helpers/setup-dev-env.sh
@@ -10,11 +10,113 @@ log_section() {
    printf "=\t%s\n" "" "$@" ""
 }
 
-## Is npm Installed
-if ! type npm 2> /dev/null ; then
-  echo "Install npm before running this script"
-  echo "Currently, the nodejs version that should be used is 20.x which can be installed using: \`dnf module install nodejs:20\`"
-  exit 1
+# Detect OS type
+detect_os() {
+    if [ -f /etc/os-release ]; then
+        . /etc/os-release
+        case "$ID" in
+            debian|ubuntu)
+                OS_TYPE="debian"
+                ;;
+            rhel|centos|rocky|almalinux|fedora)
+                OS_TYPE="rhel"
+                ;;
+            *)
+                die "Unsupported Linux distribution: $ID"
+                ;;
+        esac
+    else
+        die "/etc/os-release not found; unsupported OS"
+    fi
+}
+
+detect_os
+
+## Check if PacketFence is installed
+log_section "Checking if PacketFence is installed"
+PF_INSTALLED=false
+case "$OS_TYPE" in
+    debian)
+        if dpkg -l packetfence 2>/dev/null | grep -q "^ii"; then
+            PF_INSTALLED=true
+        fi
+        ;;
+    rhel)
+        if rpm -q packetfence >/dev/null 2>&1; then
+            PF_INSTALLED=true
+        fi
+        ;;
+esac
+
+if [ "$PF_INSTALLED" = false ]; then
+    echo "PacketFence is not installed."
+    echo "Please install PacketFence first and complete the configuration wizard before running this script."
+    echo "Visit https://www.packetfence.org/doc/PacketFence_Installation_Guide.html for installation instructions."
+    exit 1
+fi
+echo "PacketFence is installed."
+
+## Check if wizard has been completed (management interface configured)
+log_section "Checking if configuration wizard has been completed"
+PF_CONF="/usr/local/pf/conf/pf.conf"
+if [ ! -f "$PF_CONF" ]; then
+    echo "Configuration file $PF_CONF not found."
+    echo "Please complete the PacketFence configuration wizard to set up a basic installation."
+    exit 1
+fi
+
+# Check for management interface in pf.conf
+if ! grep -q "^\[interface " "$PF_CONF" || ! grep -q "type=.*management" "$PF_CONF"; then
+    echo "No management interface configured in $PF_CONF."
+    echo "Please complete the PacketFence configuration wizard to set up the management interface."
+    echo "You can access the wizard at https://<your-server-ip>:1443/configurator"
+    exit 1
+fi
+echo "Management interface is configured."
+
+## Check and install Node.js if needed
+log_section "Checking Node.js installation"
+
+# Get required Node.js version from debian/control, default to 20 if not found
+NODEJS_VERSION="20"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEBIAN_CONTROL="$SCRIPT_DIR/../../debian/control"
+if [ -f "$DEBIAN_CONTROL" ]; then
+    # Extract version from nodejs (>= X.Y) pattern
+    EXTRACTED_VERSION=$(grep -oP 'nodejs \(>= \K[0-9]+' "$DEBIAN_CONTROL" 2>/dev/null || echo "")
+    if [ -n "$EXTRACTED_VERSION" ]; then
+        NODEJS_VERSION="$EXTRACTED_VERSION"
+        echo "Found Node.js version requirement in debian/control: $NODEJS_VERSION"
+    else
+        echo "Could not extract Node.js version from debian/control, using default: $NODEJS_VERSION"
+    fi
+else
+    echo "debian/control not found, using default Node.js version: $NODEJS_VERSION"
+fi
+
+if ! type node 2>/dev/null || ! type npm 2>/dev/null; then
+    echo "Node.js or npm is not installed. Installing Node.js $NODEJS_VERSION..."
+    case "$OS_TYPE" in
+        debian)
+            curl -fsSL "https://deb.nodesource.com/setup_${NODEJS_VERSION}.x" | bash -
+            apt install -y nodejs
+            ;;
+        rhel)
+            dnf module install "nodejs:${NODEJS_VERSION}" -y
+            ;;
+    esac
+
+    # Verify installation
+    if ! type node 2>/dev/null || ! type npm 2>/dev/null; then
+        die "Failed to install Node.js. Please install it manually."
+    fi
+    echo "Node.js installed successfully."
+else
+    INSTALLED_NODE_VERSION=$(node --version | grep -oP 'v\K[0-9]+')
+    echo "Node.js is already installed (version: $(node --version))"
+    if [ "$INSTALLED_NODE_VERSION" -lt "$NODEJS_VERSION" ]; then
+        echo "Warning: Installed Node.js version is older than required ($NODEJS_VERSION). Consider upgrading."
+    fi
 fi
 
 log_section "Cleanup previous dev setup directories"
@@ -45,25 +147,16 @@ git config --global --add safe.directory /usr/local/pf
 
 log_section "install required header files from PF repo"
 
-if [ -f /etc/os-release ]; then
-    . /etc/os-release
-    case "$ID" in
-        debian|ubuntu)
-            echo "Detected Debian-based system: $PRETTY_NAME"
-            apt install -y libcurl4-openssl-dev libcjson-dev
-            ;;
-        rhel|centos|rocky|almalinux|fedora)
-            echo "Detected Red Hat-based system: $PRETTY_NAME"
-            dnf install -y --enablerepo=packetfence libcurl-devel cjson-devel
-            ;;
-        *)
-            echo "Unknown Linux distribution: $PRETTY_NAME"
-            die "Unsupported Linux distribution: $ID"
-            ;;
-    esac
-else
-    die "/etc/os-release not found; unsupported OS"
-fi
+case "$OS_TYPE" in
+    debian)
+        echo "Installing header files for Debian-based system"
+        apt install -y libcurl4-openssl-dev libcjson-dev
+        ;;
+    rhel)
+        echo "Installing header files for Red Hat-based system"
+        dnf install -y --enablerepo=packetfence libcurl-devel cjson-devel
+        ;;
+esac
 
 cd /usr/local/pf/
 
@@ -90,26 +183,17 @@ cp /usr/local/pf-pkg/conf/system_init_key /usr/local/pf/conf/system_init_key
 
 log_section "Install asciidoc*"
 
-if [ -f /etc/os-release ]; then
-    . /etc/os-release
-    case "$ID" in
-        debian|ubuntu)
-            echo "Detected Debian-based system: $PRETTY_NAME"
-            apt install -y ruby ruby-dev build-essential
-            ;;
-        rhel|centos|rocky|almalinux|fedora)
-            echo "Detected Red Hat-based system: $PRETTY_NAME"
-            dnf module reset ruby -y
-            yum install -y @ruby:2.6
-            ;;
-        *)
-            echo "Unknown Linux distribution: $PRETTY_NAME"
-            die "Unsupported Linux distribution: $ID"
-            ;;
-    esac
-else
-    die "/etc/os-release not found; unsupported OS"
-fi
+case "$OS_TYPE" in
+    debian)
+        echo "Installing Ruby for Debian-based system"
+        apt install -y ruby ruby-dev build-essential
+        ;;
+    rhel)
+        echo "Installing Ruby for Red Hat-based system"
+        dnf module reset ruby -y
+        yum install -y @ruby:2.6
+        ;;
+esac
 
 # Check if gems are already installed to avoid reinstalling
 if ! gem list -i asciidoctor > /dev/null 2>&1; then

--- a/addons/dev-helpers/setup-dev-env.sh
+++ b/addons/dev-helpers/setup-dev-env.sh
@@ -1,6 +1,23 @@
 #!/bin/bash
 set -o nounset -o pipefail -o errexit
 
+#
+# setup-dev-env.sh - Set up a PacketFence development environment
+#
+# This script prepares a PacketFence installation for development by:
+# - Replacing /usr/local/pf with a git clone of the PacketFence repository
+# - Installing build dependencies (Node.js, Ruby, Go, etc.)
+# - Building the web admin, captive portal, and documentation
+# - Setting up container files for local development
+#
+# Prerequisites:
+# - PacketFence must be installed
+# - The configuration wizard must be completed (management interface configured)
+#
+
+# Default values
+LOCAL_DEV=false
+
 die() {
     echo "$(basename $0): $@" >&2 ; exit 1
 }
@@ -9,6 +26,53 @@ log_section() {
    printf '=%.0s' {1..72} ; printf "\n"
    printf "=\t%s\n" "" "$@" ""
 }
+
+show_help() {
+    cat << EOF
+Usage: $(basename $0) [OPTIONS]
+
+Set up a PacketFence development environment.
+
+This script transforms a PacketFence installation into a development environment
+by cloning the git repository, installing build tools, and compiling all components.
+
+OPTIONS:
+    -h, --help          Show this help message and exit
+    --local-dev         Enable local development mode (sets LOCAL_DEV=true in
+                        containers/.local_env). This configures containers to use
+                        local builds instead of pulling from the registry.
+
+ENVIRONMENT VARIABLES:
+    BRANCH              Git branch to checkout (default: devel)
+
+PREREQUISITES:
+    - PacketFence must be installed (package: packetfence)
+    - Configuration wizard must be completed (management interface configured)
+
+EXAMPLES:
+    $(basename $0)                  # Standard setup with LOCAL_DEV=false
+    $(basename $0) --local-dev      # Setup with local development mode enabled
+    BRANCH=feature/xyz $(basename $0)   # Setup using a specific branch
+
+EOF
+    exit 0
+}
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -h|--help)
+            show_help
+            ;;
+        --local-dev)
+            LOCAL_DEV=true
+            shift
+            ;;
+        *)
+            die "Unknown option: $1. Use --help for usage information."
+            ;;
+    esac
+done
 
 # Detect OS type
 detect_os() {
@@ -253,7 +317,7 @@ log_section "Setup container files"
 cd /usr/local/pf
 TAG_OR_BRANCH_NAME=`git rev-parse --abbrev-ref HEAD | sed 's#[/|.]#-#g'`
 echo -n TAG_OR_BRANCH_NAME=$TAG_OR_BRANCH_NAME > conf/build_id
-echo LOCAL_DEV=true > containers/.local_env
+echo LOCAL_DEV=$LOCAL_DEV > containers/.local_env
 
 for img in pfbuild-debian-bookworm pfdebian radiusd; do
   docker pull ghcr.io/inverse-inc/packetfence/$img:$TAG_OR_BRANCH_NAME

--- a/addons/dev-helpers/setup-dev-env.sh
+++ b/addons/dev-helpers/setup-dev-env.sh
@@ -74,6 +74,18 @@ if ! grep -q "^\[interface " "$PF_CONF" || ! grep -q "type=.*management" "$PF_CO
 fi
 echo "Management interface is configured."
 
+## Install build dependencies
+log_section "Installing build dependencies"
+case "$OS_TYPE" in
+    debian)
+        apt install -y build-essential devscripts dpkg-dev fakeroot git tmux vim gnupg sudo curl
+        ;;
+    rhel)
+        dnf groupinstall -y 'Development Tools'
+        dnf install -y curl-devel git rpm-build tmux vim gnupg2 sudo curl
+        ;;
+esac
+
 ## Check and install Node.js if needed
 log_section "Checking Node.js installation"
 


### PR DESCRIPTION
 Description
Add development support for Debian 12 and improve the setup-dev-env script to allow multiple executions without errors. The script now properly handles idempotent operations, making it safe to restart the setup process if interrupted or if additional configuration is needed.

# Impacts
- Development environment setup workflow for Debian 12
- `addons/dev-helpers/setup-dev-env.sh` script behavior
- Developers using the setup script will be able to re-run it without issues

# Code / PR Dependencies
None

# NEW Package(s) required
No new packages required for this PR.

# Delete branch after merge
YES

# NEWS file entries
## New Features
* Added Debian 12 support for development environment setup

## Enhancements
* Improved `setup-dev-env.sh` script to be idempotent - can now be safely restarted multiple times
* Enhanced error handling in development environment setup process

## Bug Fixes
* Fixed issues with re-running setup-dev-env script that previously caused errors on subsequent executions

# UPGRADE file entries
None required - this is a development tooling improvement only.