### PR TITLE
Fix/fingerbank collector rules

### DIFF
--- a/lib/pf/iptables.pm
+++ b/lib/pf/iptables.pm
@@ -1542,6 +1542,7 @@ sub iptables_fingerbank_collector_rules {
         util_safe_push( "-i $tint -p udp -m udp --dport 4739 --jump ACCEPT", $chains->{'filter'}{'INPUT'} );
         # Add rules for interfaces with radius additional daemon
         foreach my $tint ( @radius_ints ) {
+            my $tint = $network->{Tint};
             util_safe_push( "-i $tint -p udp -m udp --dport 1192 --jump ACCEPT", $chains->{'filter'}{'INPUT'} );
             util_safe_push( "-i $tint -p udp -m udp --dport 2055 --jump ACCEPT", $chains->{'filter'}{'INPUT'} );
             util_safe_push( "-i $tint -p tcp -m tcp --dport 4723 --jump ACCEPT", $chains->{'filter'}{'INPUT'} );

--- a/lib/pf/iptables.pm
+++ b/lib/pf/iptables.pm
@@ -1540,6 +1540,15 @@ sub iptables_fingerbank_collector_rules {
         util_safe_push( "-i $tint -p tcp -m tcp --dport 4723 --jump ACCEPT", $chains->{'filter'}{'INPUT'} );
         util_safe_push( "-i $tint -p udp -m udp --dport 6343 --jump ACCEPT", $chains->{'filter'}{'INPUT'} );
         util_safe_push( "-i $tint -p udp -m udp --dport 4739 --jump ACCEPT", $chains->{'filter'}{'INPUT'} );
+        # Add rules for interfaces with dhcp_listener daemon
+        foreach my $network ( @dhcplistener_ints ) {
+            my $tint = $network->{Tint};
+            util_safe_push( "-i $tint -p udp -m udp --dport 1192 --jump ACCEPT", $chains->{'filter'}{'INPUT'} );
+            util_safe_push( "-i $tint -p udp -m udp --dport 2055 --jump ACCEPT", $chains->{'filter'}{'INPUT'} );
+            util_safe_push( "-i $tint -p tcp -m tcp --dport 4723 --jump ACCEPT", $chains->{'filter'}{'INPUT'} );
+            util_safe_push( "-i $tint -p udp -m udp --dport 6343 --jump ACCEPT", $chains->{'filter'}{'INPUT'} );
+            util_safe_push( "-i $tint -p udp -m udp --dport 4739 --jump ACCEPT", $chains->{'filter'}{'INPUT'} );
+        }
         # Convert to JSON and save to file
         util_create_service_rules($chains);
     } else {

--- a/lib/pf/iptables.pm
+++ b/lib/pf/iptables.pm
@@ -1540,9 +1540,8 @@ sub iptables_fingerbank_collector_rules {
         util_safe_push( "-i $tint -p tcp -m tcp --dport 4723 --jump ACCEPT", $chains->{'filter'}{'INPUT'} );
         util_safe_push( "-i $tint -p udp -m udp --dport 6343 --jump ACCEPT", $chains->{'filter'}{'INPUT'} );
         util_safe_push( "-i $tint -p udp -m udp --dport 4739 --jump ACCEPT", $chains->{'filter'}{'INPUT'} );
-        # Add rules for interfaces with dhcp_listener daemon
-        foreach my $network ( @dhcplistener_ints ) {
-            my $tint = $network->{Tint};
+        # Add rules for interfaces with radius additional daemon
+        foreach my $tint ( @radius_ints ) {
             util_safe_push( "-i $tint -p udp -m udp --dport 1192 --jump ACCEPT", $chains->{'filter'}{'INPUT'} );
             util_safe_push( "-i $tint -p udp -m udp --dport 2055 --jump ACCEPT", $chains->{'filter'}{'INPUT'} );
             util_safe_push( "-i $tint -p tcp -m tcp --dport 4723 --jump ACCEPT", $chains->{'filter'}{'INPUT'} );


### PR DESCRIPTION
# Description
Iptables only allow ipfix/sflow/netflow poet to be accessible from the management interface.
It makes sense to open those ports also when a interface is defined with the additional daemon radius (facing a switch)

# Impacts
Iptables and fingerbank-collector

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* Allow  fingerbank-collector port on radius interfaces
