### PR TITLE
Retry to connect to kafka until kafka is up and running

### DIFF
--- a/go/cron/kafka_submitter.go
+++ b/go/cron/kafka_submitter.go
@@ -107,9 +107,11 @@ func (s *KafkaSubmiter) send(events []*NetworkEvent) {
 	if s.filterEvents {
 		db, err := getDb()
 		if err != nil {
+			log.LogErrorf(context.Background(), "Failed to get database connection for filtering: %v", err)
 		} else {
 			filter, err := GetFilterFromNetworkEvents(db, events)
 			if err != nil {
+				log.LogErrorf(context.Background(), "Failed to get filter from network events: %v", err)
 			} else {
 				filteredEvents = filter.FilterEvents(events)
 			}
@@ -124,10 +126,15 @@ func (s *KafkaSubmiter) send(events []*NetworkEvent) {
 	for i := 0; i < len(filteredEvents); i++ {
 		data, err := json.Marshal(events[i])
 		if err != nil {
-			//TODO log error
+			log.LogErrorf(ctx, "Failed to marshal network event: %v", err)
 			continue
 		}
 		messages = append(messages, kafka.Message{Value: data})
+	}
+
+	if len(messages) == 0 {
+		log.LogDebugf(ctx, "No messages to send to Kafka after filtering")
+		return
 	}
 
 	log.LogInfof(
@@ -136,7 +143,23 @@ func (s *KafkaSubmiter) send(events []*NetworkEvent) {
 		len(messages),
 	)
 
-	s.writer.WriteMessages(context.Background(), messages...)
+	// WriteMessages with error handling - kafka.Writer has built-in retry logic
+	// with MaxAttempts (10), WriteBackoffMin (100ms), and WriteBackoffMax (1s)
+	err := s.writer.WriteMessages(ctx, messages...)
+	if err != nil {
+		log.LogErrorf(
+			ctx,
+			"Failed to write %d messages to Kafka after retries: %v",
+			len(messages),
+			err,
+		)
+		// The kafka.Writer will automatically retry up to MaxAttempts times
+		// with exponential backoff between WriteBackoffMin and WriteBackoffMax
+		// If it still fails after all retries, the connection may be down
+		// and the writer will attempt to reconnect on the next WriteMessages call
+	} else {
+		log.LogDebugf(ctx, "Successfully sent %d messages to Kafka", len(messages))
+	}
 }
 
 func (s *KafkaSubmiter) Stop() {

--- a/go/cron/pfflowjob.go
+++ b/go/cron/pfflowjob.go
@@ -3,7 +3,6 @@ package maint
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"log"
 	"strconv"
 	"time"
@@ -96,30 +95,66 @@ func (j *PfFlowJob) kafkaDialer() *kafka.Dialer {
 }
 
 func (j *PfFlowJob) Run() {
-	r := kafka.NewReader(kafka.ReaderConfig{
-
-		Brokers:  j.Brokers,
-		Topic:    j.ReadTopic,
-		GroupID:  j.GroupID,
-		MaxBytes: 10e6, // 10MB
-		Dialer:   j.kafkaDialer(),
-	})
+	var r *kafka.Reader
+	maxReconnectDelay := 60 * time.Second
+	reconnectDelay := 1 * time.Second
+	consecutiveErrors := 0
 
 	defer func() {
-		if err := r.Close(); err != nil {
-			log.Fatal("failed to close reader:", err)
+		if r != nil {
+			if err := r.Close(); err != nil {
+				log.Printf("failed to close reader: %v", err)
+			}
 		}
 	}()
 
 	for {
+		// Create or recreate the reader
+		if r == nil {
+			log.Printf("Connecting to Kafka brokers: %v, topic: %s", j.Brokers, j.ReadTopic)
+			r = kafka.NewReader(kafka.ReaderConfig{
+				Brokers:  j.Brokers,
+				Topic:    j.ReadTopic,
+				GroupID:  j.GroupID,
+				MaxBytes: 10e6, // 10MB
+				Dialer:   j.kafkaDialer(),
+			})
+		}
+
 		m, err := r.ReadMessage(context.Background())
 		if err != nil {
-			fmt.Printf("Error : %s\n", err.Error())
-			break
+			consecutiveErrors++
+			log.Printf("Error reading from Kafka (attempt %d): %s", consecutiveErrors, err.Error())
+
+			// Close the current reader on error
+			if closeErr := r.Close(); closeErr != nil {
+				log.Printf("Error closing reader: %v", closeErr)
+			}
+			r = nil
+
+			// Exponential backoff with max delay
+			if reconnectDelay < maxReconnectDelay {
+				reconnectDelay = reconnectDelay * 2
+				if reconnectDelay > maxReconnectDelay {
+					reconnectDelay = maxReconnectDelay
+				}
+			}
+
+			log.Printf("Reconnecting to Kafka in %v...", reconnectDelay)
+			time.Sleep(reconnectDelay)
+			continue
+		}
+
+		// Reset error counter and delay on successful read
+		if consecutiveErrors > 0 {
+			log.Printf("Successfully reconnected to Kafka after %d errors", consecutiveErrors)
+			consecutiveErrors = 0
+			reconnectDelay = 1 * time.Second
 		}
 
 		pfFlows := &PfFlows{}
 		if err := json.Unmarshal(m.Value, pfFlows); err != nil {
+			log.Printf("Error unmarshaling message: %v", err)
 			continue
 		}
 


### PR DESCRIPTION
# Description
Added the reconnect logic in pfflowjob and kafka_submitter because right now if kafka is not ready then pfflow will just not retry to reconnect and nothing will happen.

# Impacts
pfcron

# Issue
if kafka is not ready when pfcron start then pfflowjob will just do nothing.

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* pfflojob do nothing if kafka start after it

