### PR TITLE
Add GPG key installation during upgrade script

### DIFF
--- a/addons/full-upgrade/run-upgrade.sh
+++ b/addons/full-upgrade/run-upgrade.sh
@@ -105,8 +105,18 @@ function set_upgrade_to() {
   fi
 }
 
+function install_gpg_key(){
+  if is_deb_based; then
+    apt install gnupg sudo curl
+    curl -fsSL https://inverse.ca/downloads/GPG_PUBLIC_KEY | gpg --dearmor -o /etc/apt/keyrings/packetfence.gpg
+  elif is_rpm_based; then
+    rpm --import https://inverse.ca/downloads/GPG_PUBLIC_KEY
+  fi
+}
+
 function apt_upgrade_packetfence_package() {
   set_upgrade_to
+  install_gpg_key
   echo "deb [signed-by=/etc/apt/keyrings/packetfence.gpg] http://inverse.ca/downloads/PacketFence/debian/$UPGRADE_TO bookworm bookworm" > /etc/apt/sources.list.d/packetfence.list
   apt update
   if is_enabled $1; then
@@ -128,6 +138,7 @@ function apt_upgrade_packetfence_package() {
 
 function yum_upgrade_packetfence_package() {
   set_upgrade_to
+  install_gpg_key
   yum localinstall -y https://www.inverse.ca/downloads/PacketFence/RHEL8/packetfence-release-$UPGRADE_TO.el8.noarch.rpm
   yum clean all --enablerepo=packetfence
   yum_upgrade_mariadb_server


### PR DESCRIPTION
# Description
Add GPG key installation during the PacketFence upgrade process to ensure proper package verification. The upgrade script now downloads and installs the Inverse Inc. GPG public key before attempting to upgrade PacketFence packages on both Debian-based and RPM-based systems.

# Impacts
- UPGRADE workflow for both Debian and RPM-based systems
- The `run-upgrade.sh` script in `addons/full-upgrade/` directory
- Package verification and security during upgrades

# Code / PR Dependencies
N/A

# NEW Package(s) required
No new packages required. The script uses existing tools:
- Debian/Ubuntu: `gnupg`, `sudo`, `curl` (installed via apt)
- RHEL/CentOS: Uses built-in `rpm` command

# Issue
N/A

# Delete branch after merge
YES

# NEWS file entries
## Enhancements
* Add GPG key installation step in the upgrade script to ensure proper package verification for both Debian-based and RPM-based systems

## Bug Fixes
* Fix potential GPG key verification issues during PacketFence upgrades by explicitly installing the Inverse Inc. GPG public key before package updates

# UPGRADE file entries
N/A - The change is transparent to users and handles GPG key installation automatically during the upgrade process.
