### PR TITLE
Fix Search on material page for Packetfence website

### DIFF
--- a/addons/dev-helpers/bin/switch_options_table.pl
+++ b/addons/dev-helpers/bin/switch_options_table.pl
@@ -288,10 +288,10 @@ $html .= '
     var $searchBar = document.getElementById("searchBar");
     var $searchBarT = 1200;
 
-    $(window).bind("scroll", function() {
+    var adapt = function() {
       var $nameSize = $("#switches").find("th:first-child").width();
       $("#switches-fixed").find("th:first-child").width($nameSize);
-    
+
       var $fixedHeader = $("#switches-fixed");
       var $searchBarW = $("#defaultWidth").width();
       var offset = $(this).scrollTop();
@@ -301,7 +301,7 @@ $html .= '
       }
 
       if (offset >= $searchBarT && $fixedHeader.is(":hidden")) {
-        //$searchBar.classList.add("stickier", "ui", "center", "aligned", "container");
+        
         $searchBar.classList.add("stickier");
         $("#searchBar").width($searchBarW);
         $fixedHeader.show();
@@ -310,8 +310,10 @@ $html .= '
         $fixedHeader.hide();
         $("#searchBar").removeAttr("width");
       }
-    });
-    
+    }
+ 
+    window.addEventListener("scroll", adapt);
+
     $(document).ready(function() {
       var $theader = $("#switches > thead").clone();
       var $fixedHeader = $("#switches-fixed").append($theader);


### PR DESCRIPTION
# Description
Fix JavaScript syntax error in material page generator that broke the device search functionality.

The generated `about.html` page had a missing `adapt` function that handles scroll events for the sticky header. This caused a JavaScript syntax error preventing the search/filter functionality from working.

# Impacts
- Material page search functionality on packetfence.org/about.html#/material
- Device filtering by type (Wired, Access Point, Controllers, VPN, Templates)
- Text search for device models

# Issue
fixes #8832

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* Fix search not working on material page due to JavaScript syntax error (#8832)