### PR TITLE
Only manage services that start with packetfence-xyz.services and don't manage xyz-packetfence-xyz.services

### DIFF
--- a/lib/pf/services/manager.pm
+++ b/lib/pf/services/manager.pm
@@ -314,6 +314,12 @@ sub stopService {
     my ($self) = @_;
     my $name = $self->name;
     my $logger = get_logger();
+    # Check if the unit file exists before trying to stop it
+    my $exists = system("sudo systemctl cat packetfence-$name >/dev/null 2>&1") == 0;
+    unless ($exists) {
+        $logger->debug("Unit packetfence-$name does not exist, skipping stop");
+        return;
+    }
     my $pid    = $self->pid;
     $logger->info("Stopping $name with pid $pid");
     `sudo systemctl stop packetfence-$name`;
@@ -321,8 +327,8 @@ sub stopService {
         $logger->error("failed to execute: $!\n");
     }
     elsif ( $? & 127 ) {
-        $logger->error(sprintf("child died with signal %d, %s coredump\n", 
-                ( $? & 127 ), 
+        $logger->error(sprintf("child died with signal %d, %s coredump\n",
+                ( $? & 127 ),
                 (( $? & 128 ) ? 'with' : 'without')));
     }
     else {
@@ -485,7 +491,11 @@ Disable the service in systemd.
 
 sub sysdDisable {
     my $self = shift;
-    return system( "sudo systemctl disable " . $self->systemdTarget) == 0;
+    my $target = $self->systemdTarget;
+    # Check if the unit file exists before trying to disable it
+    my $exists = system("sudo systemctl cat $target >/dev/null 2>&1") == 0;
+    return $TRUE unless $exists;
+    return system( "sudo systemctl disable " . $target) == 0;
 }
 
 =head2 _build_restart_launcher

--- a/lib/pf/services/manager.pm
+++ b/lib/pf/services/manager.pm
@@ -315,8 +315,7 @@ sub stopService {
     my $name = $self->name;
     my $logger = get_logger();
     # Check if the unit file exists before trying to stop it
-    my $exists = system("sudo systemctl cat packetfence-$name >/dev/null 2>&1") == 0;
-    unless ($exists) {
+    unless ($self->_unitFileExists()) {
         $logger->debug("Unit packetfence-$name does not exist, skipping stop");
         return;
     }
@@ -472,6 +471,18 @@ sub systemdTarget {
     return "packetfence-" . $self->name;
 }
 
+=head2 _unitFileExists
+
+Check if a systemd unit file exists for the given target.
+
+=cut
+
+sub _unitFileExists {
+    my ($self, $target) = @_;
+    $target //= $self->systemdTarget;
+    return system("sudo systemctl cat $target >/dev/null 2>&1") == 0;
+}
+
 =head2 sysdEnable 
 
 Enable the service in systemd.
@@ -493,8 +504,7 @@ sub sysdDisable {
     my $self = shift;
     my $target = $self->systemdTarget;
     # Check if the unit file exists before trying to disable it
-    my $exists = system("sudo systemctl cat $target >/dev/null 2>&1") == 0;
-    return $TRUE unless $exists;
+    return $TRUE unless $self->_unitFileExists($target);
     return system( "sudo systemctl disable " . $target) == 0;
 }
 

--- a/lib/pf/services/manager/pf.pm
+++ b/lib/pf/services/manager/pf.pm
@@ -68,7 +68,7 @@ sub _build_launcher {
 sub print_status {
     my ($self) = @_;
     my $logger = get_logger();
-    my @output = `systemctl list-unit-files|grep packetfence|grep -v ntlm-auth-api-domain`;
+    my @output = `systemctl list-unit-files|grep "^packetfence"|grep -v ntlm-auth-api-domain`;
     my $colors = pf::util::console::colors();
     my $pid = 0;
     my @manager;


### PR DESCRIPTION
# Description
If another systemd script exists on the system  9like plugin-packetfence-service.services then don't try to manage it. 

# Impacts
Service manager

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* Don't manage other systemd services that contain *packetfence*
