### PR TITLE
PR_fix-15.0-iso.md

### DIFF
--- a/addons/full-upgrade/run-upgrade.sh
+++ b/addons/full-upgrade/run-upgrade.sh
@@ -105,8 +105,18 @@ function set_upgrade_to() {
   fi
 }
 
+function install_gpg_key(){
+  if is_deb_based; then
+    apt install gnupg sudo curl
+    curl -fsSL https://inverse.ca/downloads/GPG_PUBLIC_KEY | gpg --dearmor -o /etc/apt/keyrings/packetfence.gpg
+  elif is_rpm_based; then
+    rpm --import https://inverse.ca/downloads/GPG_PUBLIC_KEY
+  fi
+}
+
 function apt_upgrade_packetfence_package() {
   set_upgrade_to
+  install_gpg_key
   echo "deb [signed-by=/etc/apt/keyrings/packetfence.gpg] http://inverse.ca/downloads/PacketFence/debian/$UPGRADE_TO bookworm bookworm" > /etc/apt/sources.list.d/packetfence.list
   apt update
   if is_enabled $1; then
@@ -128,6 +138,7 @@ function apt_upgrade_packetfence_package() {
 
 function yum_upgrade_packetfence_package() {
   set_upgrade_to
+  install_gpg_key
   yum localinstall -y https://www.inverse.ca/downloads/PacketFence/RHEL8/packetfence-release-$UPGRADE_TO.el8.noarch.rpm
   yum clean all --enablerepo=packetfence
   yum_upgrade_mariadb_server

--- a/ci/debian-installer/create-debian-installer.sh
+++ b/ci/debian-installer/create-debian-installer.sh
@@ -8,13 +8,14 @@ function clean() {
   chmod a+rw $ISO_OUT
 }
 
-ISO_IN=${ISO_IN:-debian-12.6.0-amd64-netinst.iso}
+DEBIAN_VERSION=12.12.0
+ISO_IN=${ISO_IN:-debian-$DEBIAN_VERSION-amd64-netinst.iso}
 ISO_OUT=${ISO_OUT:-packetfence-debian-installer.iso}
 
 trap clean EXIT
 
 if ! [ -f $ISO_IN ]; then
-	wget https://cdimage.debian.org/cdimage/archive/12.6.0/amd64/iso-cd/$ISO_IN
+	wget https://cdimage.debian.org/cdimage/archive/$DEBIAN_VERSION/amd64/iso-cd/$ISO_IN
 fi
 
 rm -fr isofiles/

--- a/ci/debian-installer/postinst-debian-installer.sh
+++ b/ci/debian-installer/postinst-debian-installer.sh
@@ -3,18 +3,62 @@ set -o nounset -o pipefail -o errexit
 
 PF_VERSION=${1:-}
 
-apt install packetfence -y
 sed -i '/^deb cdrom:/s/^/#/' /etc/apt/sources.list
 sed -i 's/#PermitRootLogin.*/PermitRootLogin yes/g' /etc/ssh/sshd_config
-sed -i 's/.*inverse\.ca.*//g' /etc/apt/sources.list
-apt-get update
-apt install gnupg sudo curl
+sed -i 's/#PasswordAuthentication.*/PasswordAuthentication yes/g' /etc/ssh/sshd_config
+systemctl restart sshd.service
 curl -fsSL https://inverse.ca/downloads/GPG_PUBLIC_KEY | gpg --dearmor -o /etc/apt/keyrings/packetfence.gpg
-echo "deb [signed-by=/etc/apt/keyrings/packetfence.gpg] http://inverse.ca/downloads/PacketFence/debian/14.0 bookworm bookworm" > \
+echo "deb [signed-by=/etc/apt/keyrings/packetfence.gpg] http://inverse.ca/downloads/PacketFence/debian/${PF_VERSION} bookworm bookworm" > \
 	/etc/apt/sources.list.d/packetfence.list
 echo "SET PASSWORD FOR root@'localhost' = PASSWORD('');" > /tmp/reset-root.sql
-mkdir /run/mysqld
+apt-get update
+apt-get install packetfence -y
+# Reset MariaDB root password to empty for PacketFence
+# This is required because the ISO installer environment skips this in the package postinst
+mkdir -p /run/mysqld
 chown mysql: /run/mysqld/
-timeout 10 mysqld --skip-networking --init-file /tmp/reset-root.sql --user=mysql > /var/reset-root.log 2>&1
+mysqld --skip-networking --init-file /tmp/reset-root.sql --user=mysql > /var/reset-root.log 2>&1 &
+MYSQLD_PID=$!
+# Wait for mysqld to finish processing init-file (max 10 seconds)
+TIMEOUT=10
+INTERVAL=0.5
+ELAPSED=0
+while kill -0 $MYSQLD_PID 2>/dev/null && (( $(echo "$ELAPSED < $TIMEOUT" | bc) )); do
+    sleep $INTERVAL
+    ELAPSED=$(echo "$ELAPSED + $INTERVAL" | bc)
+done
+# Shutdown mysqld gracefully if still running
+kill $MYSQLD_PID 2>/dev/null || true
+wait $MYSQLD_PID 2>/dev/null || true
 rm -f /tmp/reset-root.sql
-pkill -e docker
+
+# Detect primary non-loopback IPv4 address
+VM_IP=$(ip -4 addr show scope global | awk '/inet / {print $2}' | cut -d/ -f1 | head -n1)
+
+# Add custom message to display before login prompt
+cat > /etc/issue <<EOF
+
+================================================================================
+  This VM has been installed with PacketFence net install ISO
+
+  - SSH root access by password has been granted
+  - You can find the admin GUI on https://${VM_IP}:1443/
+
+  To update or delete this message, edit or remove /etc/issue
+================================================================================
+
+EOF
+
+# Also add to /etc/issue.net for SSH sessions
+cat > /etc/issue.net << 'EOF'
+
+================================================================================
+  This VM has been installed with PacketFence net install ISO
+
+  - SSH root access by password has been granted
+  - You can find the admin GUI on https://VM_IP:1443/
+
+  To update or delete this message, edit or remove /etc/issue.net
+================================================================================
+
+EOF

--- a/ci/debian-installer/preseed.cfg.tmpl
+++ b/ci/debian-installer/preseed.cfg.tmpl
@@ -339,12 +339,6 @@ d-i partman/confirm_nooverwrite boolean true
 # "GPG key public keyring" format, the "keybox database" format is
 # currently not supported.
 
-d-i apt-setup/local0/repository string \
-  http://inverse.ca/downloads/PacketFence/debian/%%PF_VERSION%% bookworm bookworm
-d-i apt-setup/local0/source boolean true
-d-i apt-setup/local0/key string https://inverse.ca/downloads/GPG_PUBLIC_KEY
-
-
 # By default the installer requires that repositories be authenticated
 # using a known gpg key. This setting can be used to disable that
 # authentication. Warning: Insecure, not recommended.


### PR DESCRIPTION
# Description
This PR merges fixes from the `fix/15.0-iso` branch into `maintenance/15.0`. The changes include:

1. **Fix ISO installer issues (#8819)** - Resolves problems with the ISO installation process
2. **Add the gpg key during the upgrade script (#8825)** - Ensures GPG key is properly added during system upgrades

These fixes improve the reliability and security of the PacketFence 15.0 installation and upgrade processes.

# Impacts
Reviewers should focus on:
- ISO installer workflow and postinstall scripts
- Debian installer configuration changes
- Upgrade script modifications for GPG key handling
- Preseed configuration template updates

# Files Changed
The following files have been modified:
- `addons/full-upgrade/run-upgrade.sh` - Added GPG key handling
- `ci/debian-installer/create-debian-installer.sh` - Updated installer creation process
- `ci/debian-installer/postinst-debian-installer.sh` - Enhanced postinstall script
- `ci/debian-installer/preseed.cfg.tmpl` - Modified preseed configuration

**Statistics:** 4 files changed, 66 insertions(+), 16 deletions(-)

# Code / PR Dependencies
None

# NEW Package(s) required
None

# Issue
fixes #8819
fixes #8825

# Delete branch after merge
YES

# Checklist
- [x] Document the feature
- [ ] Add OpenAPI specification (n/a)
- [ ] Add unit tests (n/a for installer fixes)
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Bug Fixes
* Fix ISO installer issues preventing proper installation (#8819)
* Add the gpg key during the upgrade script to ensure package verification (#8825)