### PR TITLE
Add selective test execution capability to GitLab CI pipelines via the `TEST_ONLY` variable.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -192,7 +192,7 @@ variables:
 .test_devel_and_maintenance_rules:
   rules:
     # Skip if TEST_ONLY is set and job name doesn't match pattern
-    - if: '$TEST_ONLY != "" && $CI_JOB_NAME !~ $TEST_ONLY'
+    - if: '$TEST_ONLY != "" && $CI_JOB_NAME !~ /$TEST_ONLY/'
       when: never
     # Run on any branch via web/API with TEST=yes (must be first positive rule for feature branches)
     - if: '$CI_COMMIT_TAG == null && ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ )'
@@ -210,7 +210,7 @@ variables:
 .test_branches_only_rules:
   rules:
     # Skip if TEST_ONLY is set and job name doesn't match pattern
-    - if: '$TEST_ONLY != "" && $CI_JOB_NAME !~ $TEST_ONLY'
+    - if: '$TEST_ONLY != "" && $CI_JOB_NAME !~ /$TEST_ONLY/'
       when: never
     - if: '$CI_COMMIT_REF_NAME != "devel" && $CI_COMMIT_REF_NAME !~ /^maintenance\/[[:digit:]]+\.[[:digit:]]+$/ && $CI_COMMIT_TAG == null && ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ )'
     - if: '$CI_COMMIT_REF_NAME != "devel" && $CI_COMMIT_REF_NAME !~ /^maintenance\/[[:digit:]]+\.[[:digit:]]+$/ && $CI_COMMIT_TAG == null && $CI_PIPELINE_SOURCE == "schedule" && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ )'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -187,6 +187,7 @@ variables:
 # - on devel branch (push, web, *not* schedule) if variable TEST sets to yes or if CI_COMMIT_MESSAGE contains "test=yes".
 # - on maintenance/X.Y branches only (web) if variable TEST sets to yes or if CI_COMMIT_MESSAGE contains "test=yes".
 # - on maintenance/X.Y branches and devel with a schedule, with test variable defined or test=yes in commit message
+# - on any branch (web/api) if variable TEST sets to yes or if CI_COMMIT_MESSAGE contains "test=yes".
 # don't run on tag
 .test_devel_and_maintenance_rules:
   rules:
@@ -196,6 +197,7 @@ variables:
     - if: '$CI_COMMIT_REF_NAME == "devel" && $CI_PIPELINE_SOURCE != "schedule" && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ )'
     - if: '$CI_COMMIT_REF_NAME != "devel" && $CI_COMMIT_REF_NAME =~ /^maintenance\/[[:digit:]]+\.[[:digit:]]+$/ && $CI_COMMIT_TAG == null && ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ )'
     - if: '( $CI_COMMIT_REF_NAME == "devel" || $CI_COMMIT_REF_NAME =~ /^maintenance\/[[:digit:]]+\.[[:digit:]]+$/) && $CI_PIPELINE_SOURCE == "schedule" && $CI_COMMIT_TAG == null && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ )'
+    - if: '$CI_COMMIT_TAG == null && ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ )'
 
 # run jobs only when:
 # - on all branches (except maintenance/X.Y branches) (web) if variable TEST sets to yes or if CI_COMMIT_MESSAGE contains "test=yes".

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -192,7 +192,7 @@ variables:
 .test_devel_and_maintenance_rules:
   rules:
     # Skip if TEST_ONLY is set and job name doesn't match pattern
-    - if: '$TEST_ONLY != "" && $CI_JOB_NAME !~ /$TEST_ONLY/'
+    - if: '$TEST_ONLY != "" && $CI_JOB_NAME !~ $TEST_ONLY'
       when: never
     # Run on any branch via web/API with TEST=yes (must be first positive rule for feature branches)
     - if: '$CI_COMMIT_TAG == null && ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ )'
@@ -210,7 +210,7 @@ variables:
 .test_branches_only_rules:
   rules:
     # Skip if TEST_ONLY is set and job name doesn't match pattern
-    - if: '$TEST_ONLY != "" && $CI_JOB_NAME !~ /$TEST_ONLY/'
+    - if: '$TEST_ONLY != "" && $CI_JOB_NAME !~ $TEST_ONLY'
       when: never
     - if: '$CI_COMMIT_REF_NAME != "devel" && $CI_COMMIT_REF_NAME !~ /^maintenance\/[[:digit:]]+\.[[:digit:]]+$/ && $CI_COMMIT_TAG == null && ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ )'
     - if: '$CI_COMMIT_REF_NAME != "devel" && $CI_COMMIT_REF_NAME !~ /^maintenance\/[[:digit:]]+\.[[:digit:]]+$/ && $CI_COMMIT_TAG == null && $CI_PIPELINE_SOURCE == "schedule" && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ )'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -191,8 +191,8 @@ variables:
 # don't run on tag
 .test_devel_and_maintenance_rules:
   rules:
-    # Skip if TEST_ONLY is set and job name doesn't match pattern
-    - if: '$TEST_ONLY != "" && $CI_JOB_NAME !~ $TEST_ONLY'
+    # Skip if TEST_ONLY is set and job name doesn't match pattern (including _branches variants)
+    - if: '$TEST_ONLY != "" && $CI_JOB_NAME !~ $TEST_ONLY && $CI_JOB_NAME !~ "${TEST_ONLY}_.*_branches"'
       when: never
     - if: '$CI_COMMIT_REF_NAME == "devel" && $CI_PIPELINE_SOURCE != "schedule" && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ )'
     - if: '$CI_COMMIT_REF_NAME != "devel" && $CI_COMMIT_REF_NAME =~ /^maintenance\/[[:digit:]]+\.[[:digit:]]+$/ && $CI_COMMIT_TAG == null && ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ )'
@@ -205,8 +205,8 @@ variables:
 # don't run on tag
 .test_branches_only_rules:
   rules:
-    # Skip if TEST_ONLY is set and job name doesn't match pattern
-    - if: '$TEST_ONLY != "" && $CI_JOB_NAME !~ $TEST_ONLY'
+    # Skip if TEST_ONLY is set and job name doesn't match pattern (including _branches variants)
+    - if: '$TEST_ONLY != "" && $CI_JOB_NAME !~ $TEST_ONLY && $CI_JOB_NAME !~ "${TEST_ONLY}_.*_branches"'
       when: never
     - if: '$CI_COMMIT_REF_NAME != "devel" && $CI_COMMIT_REF_NAME !~ /^maintenance\/[[:digit:]]+\.[[:digit:]]+$/ && $CI_COMMIT_TAG == null && ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ )'
     - if: '$CI_COMMIT_REF_NAME != "devel" && $CI_COMMIT_REF_NAME !~ /^maintenance\/[[:digit:]]+\.[[:digit:]]+$/ && $CI_COMMIT_TAG == null && $CI_PIPELINE_SOURCE == "schedule" && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ )'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,8 +55,8 @@ variables:
   ANSIBLE_STDOUT_CALLBACK: yaml
   VAGRANT_FORCE_COLOR: "true"
   # Selective test execution
-  # Run only tests matching this pattern (regex). Empty = all tests.
-  # Examples: "mac_auth", "configurator|pfappserver", ".*_el8"
+  # Run only tests matching this pattern (grep -E regex). Empty = all tests.
+  # Examples: configurator, mac_auth, configurator|pfappserver, .*_el8
   TEST_ONLY: ""
 
 
@@ -191,9 +191,8 @@ variables:
 # don't run on tag
 .test_devel_and_maintenance_rules:
   rules:
-    # Skip if TEST_ONLY is set and job name doesn't match pattern
-    - if: '$TEST_ONLY != "" && $CI_JOB_NAME !~ $TEST_ONLY'
-      when: never
+    # NOTE: TEST_ONLY filtering is done in .test_script_job via shell script
+    # because GitLab CI doesn't expand variables inside regex patterns
     # Run on any branch via web/API with TEST=yes (must be first positive rule for feature branches)
     - if: '$CI_COMMIT_TAG == null && ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ )'
     # Run on devel branch (push, web, not schedule)
@@ -209,9 +208,8 @@ variables:
 # don't run on tag
 .test_branches_only_rules:
   rules:
-    # Skip if TEST_ONLY is set and job name doesn't match pattern
-    - if: '$TEST_ONLY != "" && $CI_JOB_NAME !~ $TEST_ONLY'
-      when: never
+    # NOTE: TEST_ONLY filtering is done in .test_script_job via shell script
+    # because GitLab CI doesn't expand variables inside regex patterns
     - if: '$CI_COMMIT_REF_NAME != "devel" && $CI_COMMIT_REF_NAME !~ /^maintenance\/[[:digit:]]+\.[[:digit:]]+$/ && $CI_COMMIT_TAG == null && ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ )'
     - if: '$CI_COMMIT_REF_NAME != "devel" && $CI_COMMIT_REF_NAME !~ /^maintenance\/[[:digit:]]+\.[[:digit:]]+$/ && $CI_COMMIT_TAG == null && $CI_PIPELINE_SOURCE == "schedule" && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ )'
 
@@ -592,6 +590,12 @@ variables:
   variables:
     VAGRANT_COMMON_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-common-${CI_COMMIT_REF_SLUG}
   script:
+    # Check TEST_ONLY filter (shell-based since GitLab rules don't expand variables in regex)
+    - |
+      if [ -n "$TEST_ONLY" ] && ! echo "$CI_JOB_NAME" | grep -qE "$TEST_ONLY"; then
+        echo "Skipping: $CI_JOB_NAME does not match TEST_ONLY pattern: $TEST_ONLY"
+        exit 0
+      fi
     # || EXIT_CODE=$? prevents script to finish at first command
     - timeout ${PIPELINE_TIMEOUT_SCRIPT} make -e -C ${TESTDIR} MAKE_TARGET=run ${CI_JOB_NAME} || EXIT_CODE=$?
     - JOB_STATUS=$EXIT_CODE timeout ${PIPELINE_TIMEOUT_CLEANUP} ${TESTCIDIR}/clean-test-environment.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,6 +54,10 @@ variables:
   ANSIBLE_FORCE_COLOR: 1
   ANSIBLE_STDOUT_CALLBACK: yaml
   VAGRANT_FORCE_COLOR: "true"
+  # Selective test execution
+  # Run only tests matching this pattern (regex). Empty = all tests.
+  # Examples: "mac_auth", "configurator|pfappserver", ".*_el8"
+  TEST_ONLY: ""
 
 
 ################################################################################
@@ -186,6 +190,9 @@ variables:
 # don't run on tag
 .test_devel_and_maintenance_rules:
   rules:
+    # Skip if TEST_ONLY is set and job name doesn't match pattern
+    - if: '$TEST_ONLY != "" && $CI_JOB_NAME !~ $TEST_ONLY'
+      when: never
     - if: '$CI_COMMIT_REF_NAME == "devel" && $CI_PIPELINE_SOURCE != "schedule" && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ )'
     - if: '$CI_COMMIT_REF_NAME != "devel" && $CI_COMMIT_REF_NAME =~ /^maintenance\/[[:digit:]]+\.[[:digit:]]+$/ && $CI_COMMIT_TAG == null && ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ )'
     - if: '( $CI_COMMIT_REF_NAME == "devel" || $CI_COMMIT_REF_NAME =~ /^maintenance\/[[:digit:]]+\.[[:digit:]]+$/) && $CI_PIPELINE_SOURCE == "schedule" && $CI_COMMIT_TAG == null && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ )'
@@ -196,6 +203,9 @@ variables:
 # don't run on tag
 .test_branches_only_rules:
   rules:
+    # Skip if TEST_ONLY is set and job name doesn't match pattern
+    - if: '$TEST_ONLY != "" && $CI_JOB_NAME !~ $TEST_ONLY'
+      when: never
     - if: '$CI_COMMIT_REF_NAME != "devel" && $CI_COMMIT_REF_NAME !~ /^maintenance\/[[:digit:]]+\.[[:digit:]]+$/ && $CI_COMMIT_TAG == null && ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ )'
     - if: '$CI_COMMIT_REF_NAME != "devel" && $CI_COMMIT_REF_NAME !~ /^maintenance\/[[:digit:]]+\.[[:digit:]]+$/ && $CI_COMMIT_TAG == null && $CI_PIPELINE_SOURCE == "schedule" && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ )'
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -191,13 +191,17 @@ variables:
 # don't run on tag
 .test_devel_and_maintenance_rules:
   rules:
-    # Skip if TEST_ONLY is set and job name doesn't match pattern (including _branches variants)
-    - if: '$TEST_ONLY != "" && $CI_JOB_NAME !~ $TEST_ONLY && $CI_JOB_NAME !~ "${TEST_ONLY}_.*_branches"'
+    # Skip if TEST_ONLY is set and job name doesn't match pattern
+    - if: '$TEST_ONLY != "" && $CI_JOB_NAME !~ $TEST_ONLY'
       when: never
-    - if: '$CI_COMMIT_REF_NAME == "devel" && $CI_PIPELINE_SOURCE != "schedule" && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ )'
-    - if: '$CI_COMMIT_REF_NAME != "devel" && $CI_COMMIT_REF_NAME =~ /^maintenance\/[[:digit:]]+\.[[:digit:]]+$/ && $CI_COMMIT_TAG == null && ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ )'
-    - if: '( $CI_COMMIT_REF_NAME == "devel" || $CI_COMMIT_REF_NAME =~ /^maintenance\/[[:digit:]]+\.[[:digit:]]+$/) && $CI_PIPELINE_SOURCE == "schedule" && $CI_COMMIT_TAG == null && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ )'
+    # Run on any branch via web/API with TEST=yes (must be first positive rule for feature branches)
     - if: '$CI_COMMIT_TAG == null && ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ )'
+    # Run on devel branch (push, web, not schedule)
+    - if: '$CI_COMMIT_REF_NAME == "devel" && $CI_PIPELINE_SOURCE != "schedule" && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ )'
+    # Run on maintenance branches (web/api only)
+    - if: '$CI_COMMIT_REF_NAME =~ /^maintenance\/[[:digit:]]+\.[[:digit:]]+$/ && $CI_COMMIT_TAG == null && ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ )'
+    # Run on devel/maintenance with schedule
+    - if: '( $CI_COMMIT_REF_NAME == "devel" || $CI_COMMIT_REF_NAME =~ /^maintenance\/[[:digit:]]+\.[[:digit:]]+$/) && $CI_PIPELINE_SOURCE == "schedule" && $CI_COMMIT_TAG == null && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ )'
 
 # run jobs only when:
 # - on all branches (except maintenance/X.Y branches) (web) if variable TEST sets to yes or if CI_COMMIT_MESSAGE contains "test=yes".
@@ -205,8 +209,8 @@ variables:
 # don't run on tag
 .test_branches_only_rules:
   rules:
-    # Skip if TEST_ONLY is set and job name doesn't match pattern (including _branches variants)
-    - if: '$TEST_ONLY != "" && $CI_JOB_NAME !~ $TEST_ONLY && $CI_JOB_NAME !~ "${TEST_ONLY}_.*_branches"'
+    # Skip if TEST_ONLY is set and job name doesn't match pattern
+    - if: '$TEST_ONLY != "" && $CI_JOB_NAME !~ $TEST_ONLY'
       when: never
     - if: '$CI_COMMIT_REF_NAME != "devel" && $CI_COMMIT_REF_NAME !~ /^maintenance\/[[:digit:]]+\.[[:digit:]]+$/ && $CI_COMMIT_TAG == null && ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ )'
     - if: '$CI_COMMIT_REF_NAME != "devel" && $CI_COMMIT_REF_NAME !~ /^maintenance\/[[:digit:]]+\.[[:digit:]]+$/ && $CI_COMMIT_TAG == null && $CI_PIPELINE_SOURCE == "schedule" && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ )'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -592,9 +592,17 @@ variables:
   script:
     # Check TEST_ONLY filter (shell-based since GitLab rules don't expand variables in regex)
     - |
-      if [ -n "$TEST_ONLY" ] && ! echo "$CI_JOB_NAME" | grep -qE "$TEST_ONLY"; then
-        echo "Skipping: $CI_JOB_NAME does not match TEST_ONLY pattern: $TEST_ONLY"
-        exit 0
+      # Validate TEST_ONLY to prevent malicious patterns
+      if [ -n "$TEST_ONLY" ]; then
+        # Reject TEST_ONLY if it contains a newline or single quote (basic sanitization)
+        if printf '%s' "$TEST_ONLY" | grep -q "[\n']"; then
+          echo "Error: TEST_ONLY contains invalid characters (newline or single quote)."
+          exit 1
+        fi
+        if ! echo "$CI_JOB_NAME" | grep -qE "$TEST_ONLY"; then
+          echo "Skipping: $CI_JOB_NAME does not match TEST_ONLY pattern: $TEST_ONLY"
+          exit 0
+        fi
       fi
     # || EXIT_CODE=$? prevents script to finish at first command
     - timeout ${PIPELINE_TIMEOUT_SCRIPT} make -e -C ${TESTDIR} MAKE_TARGET=run ${CI_JOB_NAME} || EXIT_CODE=$?


### PR DESCRIPTION
This feature allows developers to run only specific tests matching a regex pattern when triggering pipelines manually (via web UI or API). For example, setting `TEST_ONLY=configurator` will only run tests with "configurator" in their name, while `TEST_ONLY=configurator|pfappserver` runs tests matching either pattern.

Key changes:
- Added `TEST_ONLY` variable (empty by default = run all tests)
- Extended test rules to allow any branch to run tests via web/API trigger with `TEST=yes`
- Implemented shell-based filtering in `.test_script_job` because GitLab CI doesn't expand variables inside regex patterns in rules
- Jobs not matching `TEST_ONLY` pattern exit immediately with a "Skipping" message

# Impacts
- `.gitlab-ci.yml` - CI pipeline configuration
- Test job execution flow - jobs now check `TEST_ONLY` at runtime
- Reviewers should verify:
  - Default behavior (empty `TEST_ONLY`) runs all tests as before
  - Pattern matching works correctly with grep -E regex syntax
  - Feature branch pipelines can now be triggered via web UI with `TEST=yes`

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature in wiki

# NEWS file entries
## New Features
* None

## Enhancements
* CI: Add selective test execution via `TEST_ONLY` variable - allows running only specific tests matching a regex pattern when triggering pipelines manually
* CI: Enable test execution on any branch via web UI or API trigger (with `TEST=yes`)

## Bug Fixes
* None
