### PR TITLE
Use the same method everywhere to find the latest serial number to use for a new certificate

### DIFF
--- a/go/plugin/caddy2/pfpki/models/models.go
+++ b/go/plugin/caddy2/pfpki/models/models.go
@@ -42,6 +42,7 @@ import (
 	"github.com/inverse-inc/packetfence/go/plugin/caddy2/pfpki/types"
 	_ "gorm.io/driver/mysql"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 	pkcs12 "software.sslmate.com/src/go-pkcs12"
 
 	"github.com/inverse-inc/packetfence/go/pfconfigdriver"
@@ -665,20 +666,54 @@ func (c CA) Serial(options ...string) (*big.Int, error) {
 }
 
 func (c CA) FindSerial(p Profile) (*big.Int, error) {
+	var serialNumber int
 
-	ca := &CA{}
+	err := c.DB.Transaction(func(tx *gorm.DB) error {
+		ca := &CA{}
 
-	if CaDB := c.DB.First(&ca, p.CaID).Find(&ca); CaDB.Error != nil {
-		c.DB.First(&ca)
+		// Lock the row for update to prevent race conditions
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).First(ca, p.CaID).Error; err != nil {
+			// Fallback to first CA if not found
+			if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).First(ca).Error; err != nil {
+				return err
+			}
+		}
+
+		serialNumber = ca.SerialNumber
+		ca.SerialNumber = ca.SerialNumber + 1
+		return tx.Save(ca).Error
+	})
+
+	if err != nil {
+		return nil, err
 	}
 
-	SerialNumber := big.NewInt(int64(ca.SerialNumber))
-	ca.SerialNumber = ca.SerialNumber + 1
-	ca.DB = c.DB
-	ca.DB.Save(ca)
+	return big.NewInt(int64(serialNumber)), nil
+}
 
-	return SerialNumber, nil
+// getNextSerialNumber atomically increments and returns the next serial number for a CA
+// Uses database transaction with row-level locking to prevent race conditions
+func getNextSerialNumber(db gorm.DB, caID uint) (*big.Int, error) {
+	var serialNumber int
 
+	err := db.Transaction(func(tx *gorm.DB) error {
+		ca := &CA{}
+
+		// Lock the row for update to prevent race conditions
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).First(ca, caID).Error; err != nil {
+			return err
+		}
+
+		serialNumber = ca.SerialNumber
+		ca.SerialNumber = ca.SerialNumber + 1
+		return tx.Save(ca).Error
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return big.NewInt(int64(serialNumber)), nil
 }
 
 func (c CA) HasCN(cn string, allowTime int, cert *x509.Certificate, revokeOldCertificate bool, options ...string) (bool, error) {
@@ -1215,10 +1250,12 @@ func (c Cert) New() (types.Info, error) {
 	var newcertdb []Cert
 	var SerialNumber *big.Int
 
-	SerialNumber = big.NewInt(int64(prof.Ca.SerialNumber))
-	prof.Ca.SerialNumber = prof.Ca.SerialNumber + 1
-	prof.Ca.DB = c.DB
-	prof.Ca.DB.Save(prof.Ca)
+	// Get serial number atomically using transaction with row-level locking
+	SerialNumber, err = getNextSerialNumber(c.DB, prof.Ca.ID)
+	if err != nil {
+		Information.Error = err.Error()
+		return Information, err
+	}
 	keyOut, pub, _, err := certutils.GenerateKey(*prof.KeyType, prof.KeySize)
 
 	if err != nil {
@@ -1591,11 +1628,12 @@ func (c Cert) Resign(params map[string]string) (types.Info, error) {
 	// keyOut contain the private key
 	var newcertdb []Cert
 
-	//Calculate the serial number to assign using CA counter
-	SerialNumber := big.NewInt(int64(certdb[0].Ca.SerialNumber))
-	certdb[0].Ca.SerialNumber = certdb[0].Ca.SerialNumber + 1
-	certdb[0].Ca.DB = c.DB
-	certdb[0].Ca.DB.Save(&certdb[0].Ca)
+	// Get serial number atomically using transaction with row-level locking
+	SerialNumber, err := getNextSerialNumber(c.DB, certdb[0].Ca.ID)
+	if err != nil {
+		Information.Error = err.Error()
+		return Information, err
+	}
 
 	Subject := certdb[0].MakeSubject()
 

--- a/go/plugin/caddy2/pfpki/models/models.go
+++ b/go/plugin/caddy2/pfpki/models/models.go
@@ -672,34 +672,10 @@ func (c CA) FindSerial(p Profile) (*big.Int, error) {
 		c.DB.First(&ca)
 	}
 
-	var maxSerial int64 = 0
-
-	// Check the maximum SerialNumber in Cert table
-	var certdb Cert
-	if err := c.DB.Order("CAST(serial_number AS UNSIGNED) DESC").First(&certdb); err.Error == nil {
-		if serial, err := strconv.ParseInt(certdb.SerialNumber, 10, 64); err == nil {
-			if serial > maxSerial {
-				maxSerial = serial
-			}
-		}
-	}
-
-	// Check the maximum SerialNumber in RevokedCert table
-	var revokedCertdb RevokedCert
-	if err := c.DB.Order("CAST(serial_number AS UNSIGNED) DESC").First(&revokedCertdb); err.Error == nil {
-		if serial, err := strconv.ParseInt(revokedCertdb.SerialNumber, 10, 64); err == nil {
-			if serial > maxSerial {
-				maxSerial = serial
-			}
-		}
-	}
-
-	var SerialNumber *big.Int
-	if maxSerial == 0 {
-		SerialNumber = big.NewInt(1)
-	} else {
-		SerialNumber = big.NewInt(maxSerial + 1)
-	}
+	SerialNumber := big.NewInt(int64(ca.SerialNumber))
+	ca.SerialNumber = ca.SerialNumber + 1
+	ca.DB = c.DB
+	ca.DB.Save(ca)
 
 	return SerialNumber, nil
 
@@ -1613,17 +1589,13 @@ func (c Cert) Resign(params map[string]string) (types.Info, error) {
 	}
 
 	// keyOut contain the private key
-	var certdbprevious Cert
 	var newcertdb []Cert
 
-	//Calculate the serial number to assign
-	var SerialNumber *big.Int
-
-	if CertDB := c.DB.Last(&certdbprevious); CertDB.Error != nil {
-		SerialNumber = big.NewInt(1)
-	} else {
-		SerialNumber = big.NewInt(int64(certdbprevious.ID + 1))
-	}
+	//Calculate the serial number to assign using CA counter
+	SerialNumber := big.NewInt(int64(certdb[0].Ca.SerialNumber))
+	certdb[0].Ca.SerialNumber = certdb[0].Ca.SerialNumber + 1
+	certdb[0].Ca.DB = c.DB
+	certdb[0].Ca.DB.Save(&certdb[0].Ca)
 
 	Subject := certdb[0].MakeSubject()
 

--- a/go/plugin/caddy2/pfpki/models/models.go
+++ b/go/plugin/caddy2/pfpki/models/models.go
@@ -672,15 +672,33 @@ func (c CA) FindSerial(p Profile) (*big.Int, error) {
 		c.DB.First(&ca)
 	}
 
+	var maxSerial int64 = 0
+
+	// Check the maximum SerialNumber in Cert table
 	var certdb Cert
+	if err := c.DB.Order("CAST(serial_number AS UNSIGNED) DESC").First(&certdb); err.Error == nil {
+		if serial, err := strconv.ParseInt(certdb.SerialNumber, 10, 64); err == nil {
+			if serial > maxSerial {
+				maxSerial = serial
+			}
+		}
+	}
+
+	// Check the maximum SerialNumber in RevokedCert table
+	var revokedCertdb RevokedCert
+	if err := c.DB.Order("CAST(serial_number AS UNSIGNED) DESC").First(&revokedCertdb); err.Error == nil {
+		if serial, err := strconv.ParseInt(revokedCertdb.SerialNumber, 10, 64); err == nil {
+			if serial > maxSerial {
+				maxSerial = serial
+			}
+		}
+	}
 
 	var SerialNumber *big.Int
-
-	err := c.DB.Last(&certdb).Where(&ca)
-	if err.Error != nil {
+	if maxSerial == 0 {
 		SerialNumber = big.NewInt(1)
 	} else {
-		SerialNumber = big.NewInt(int64(certdb.ID + 1))
+		SerialNumber = big.NewInt(maxSerial + 1)
 	}
 
 	return SerialNumber, nil


### PR DESCRIPTION
# Description
Allow to search in the Revoked Certificate table to find the latest serial to use

# Impacts
pfpki

# Issue
fixes #8855

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Bug Fixes
* Fixes duplicate serial number for 2 different certificates (#8855)

