### PR TITLE
Add API endpoints and admin UI for sending password reset emails

### DIFF
--- a/html/pfappserver/root/src/views/Users/_api/index.js
+++ b/html/pfappserver/root/src/views/Users/_api/index.js
@@ -75,6 +75,11 @@ export default {
   unassignUserNodes: pid => {
     return apiCall.post(['user', pid, 'unassign_nodes'])
   },
+  passwordReset: pid => {
+    return apiCall.post(['user', pid, 'password_reset']).then(response => {
+      return response.data
+    })
+  },
   bulkRegisterNodes: body => {
     return apiCall.post(['users', 'bulk_register'], body).then(response => {
       return response.data.items
@@ -122,6 +127,11 @@ export default {
   },
   bulkImport: body => {
     return apiCall.post(['users', 'bulk_import'], body).then(response => {
+      return response.data.items
+    })
+  },
+  bulkPasswordReset: body => {
+    return apiCall.post(['users', 'bulk_password_reset'], body).then(response => {
       return response.data.items
     })
   }

--- a/html/pfappserver/root/src/views/Users/_components/TheFormUpdate.vue
+++ b/html/pfappserver/root/src/views/Users/_components/TheFormUpdate.vue
@@ -185,6 +185,7 @@
           <div class="mt-3">
             <div class="border-top pt-3">
              <b-button class="mr-1" variant="outline-primary" :disabled="isLoading" @click="onResetPassword">{{ $t('Reset Password') }}</b-button>
+             <b-button class="mr-1" variant="outline-primary" :disabled="isLoading || !hasEmail" @click="onSendPasswordResetEmail">{{ $t('Send Password Reset Email') }}</b-button>
             </div>
           </div>
         </base-form-tab>
@@ -397,6 +398,7 @@ const props = {
 }
 
 import { computed, onMounted, ref, toRefs, watch } from '@vue/composition-api'
+import i18n from '@/utils/locale'
 import { useDebouncedWatchHandler } from '@/composables/useDebounce'
 import {
   nodeFields as _nodeFields,
@@ -426,6 +428,7 @@ const setup = (props, context) => {
     return pid === 'default'
   })
   const hasPassword = computed(() => !!form.value.has_password)
+  const hasEmail = computed(() => !!form.value.email)
   const isLoading = computed(() => $store.getters['$_users/isLoading'])
   const isValid = useDebouncedWatchHandler(
     [form],
@@ -481,6 +484,14 @@ const setup = (props, context) => {
     return $store.dispatch('$_users/updatePassword', data)
   }
 
+  const onSendPasswordResetEmail = () => {
+    return $store.dispatch('$_users/passwordReset', pid.value).then(() => {
+      $store.dispatch('notification/info', { message: i18n.t('Password reset email sent.') })
+    }).catch(() => {
+      $store.dispatch('notification/danger', { message: i18n.t('Failed to send password reset email.') })
+    })
+  }
+
   const onInit = () => {
     $store.dispatch('$_users/getUserNodes', pid.value).then(_nodes => {
       nodes.value = _nodes
@@ -516,6 +527,7 @@ const setup = (props, context) => {
     tabIndex,
     isDefaultUser,
     hasPassword,
+    hasEmail,
     isLoading,
     isValid,
 
@@ -540,6 +552,7 @@ const setup = (props, context) => {
     onSecurityEventCloseAll,
 
     onResetPassword,
+    onSendPasswordResetEmail,
     onClose,
     onRemove,
     onReset,

--- a/html/pfappserver/root/src/views/Users/_components/TheSearch.vue
+++ b/html/pfappserver/root/src/views/Users/_components/TheSearch.vue
@@ -103,6 +103,10 @@
             <icon class="position-absolute mt-1" name="trash-alt"></icon>
             <span class="ml-4">{{ $t('Delete') }}</span>
           </b-dropdown-item>
+          <b-dropdown-item @click="onBulkPasswordReset">
+            <icon class="position-absolute mt-1" name="envelope"></icon>
+            <span class="ml-4">{{ $t('Send Password Reset Email') }}</span>
+          </b-dropdown-item>
           <b-dropdown-divider></b-dropdown-divider>
 
           <b-dropdown-header>{{ $t('Apply Role') }}</b-dropdown-header>
@@ -352,6 +356,17 @@ const setup = (props, context) => {
       })
   }
 
+  const onBulkPasswordReset = () => {
+    const items = selectedItems.value.map(item => item.pid)
+    $store.dispatch(`$_users/bulkPasswordReset`, { items })
+      .then(_items => {
+        $store.dispatch('notification/info', {
+          message: i18n.tc('Sent password reset email to 1 user. | Sent password reset emails to {userCount} users.', _items.length, { userCount: _items.length }),
+          ..._statusCounts(_items)
+        })
+      })
+  }
+
   return {
     useSearch,
     tableRef,
@@ -372,7 +387,8 @@ const setup = (props, context) => {
     onBulkRole,
     onBulkBypassRole,
     onBulkSecurityEvent,
-    onBulkCloseSecurityEvent
+    onBulkCloseSecurityEvent,
+    onBulkPasswordReset
   }
 }
 

--- a/html/pfappserver/root/src/views/Users/_components/TheSearch.vue
+++ b/html/pfappserver/root/src/views/Users/_components/TheSearch.vue
@@ -360,8 +360,9 @@ const setup = (props, context) => {
     const items = selectedItems.value.map(item => item.pid)
     $store.dispatch(`$_users/bulkPasswordReset`, { items })
       .then(_items => {
+        const { success } = _statusCounts(_items)
         $store.dispatch('notification/info', {
-          message: i18n.tc('Sent password reset email to 1 user. | Sent password reset emails to {userCount} users.', _items.length, { userCount: _items.length }),
+          message: i18n.tc('Sent password reset email to 1 user. | Sent password reset emails to {userCount} users.', success, { userCount: success }),
           ..._statusCounts(_items)
         })
       })

--- a/html/pfappserver/root/src/views/Users/_store/index.js
+++ b/html/pfappserver/root/src/views/Users/_store/index.js
@@ -303,6 +303,18 @@ const actions = {
       })
     })
   },
+  passwordReset: ({ commit }, pid) => {
+    commit('USER_REQUEST')
+    return new Promise((resolve, reject) => {
+      api.passwordReset(pid).then(response => {
+        commit('USER_SUCCESS')
+        resolve(response)
+      }).catch(err => {
+        commit('USER_ERROR', err.response)
+        reject(err)
+      })
+    })
+  },
   deleteUser: ({ commit }, pid) => {
     commit('USER_REQUEST')
     return new Promise((resolve, reject) => {
@@ -400,6 +412,15 @@ const actions = {
   bulkImport: ({ commit }, data) => {
     commit('USER_REQUEST')
     return api.bulkImport(data).then(response => {
+      commit('USER_BULK_SUCCESS', response)
+      return response
+    }).catch(err => {
+      commit('USER_ERROR', err.response)
+    })
+  },
+  bulkPasswordReset: ({ commit }, data) => {
+    commit('USER_REQUEST')
+    return api.bulkPasswordReset(data).then(response => {
       commit('USER_BULK_SUCCESS', response)
       return response
     }).catch(err => {

--- a/lib/pf/UnifiedApi.pm
+++ b/lib/pf/UnifiedApi.pm
@@ -618,7 +618,7 @@ sub setup_api_v1_users_routes {
     );
 
     $resource_route->register_sub_action({ method => 'GET', action => 'security_events' });
-    $resource_route->register_sub_actions({ method => 'POST', actions => [qw(unassign_nodes close_security_events)], auditable => 1 });
+    $resource_route->register_sub_actions({ method => 'POST', actions => [qw(unassign_nodes close_security_events password_reset)], auditable => 1 });
     $collection_route->register_sub_actions(
         {
             method  => 'POST',
@@ -627,7 +627,7 @@ sub setup_api_v1_users_routes {
                   bulk_register bulk_deregister bulk_close_security_events
                   bulk_reevaluate_access bulk_apply_security_event
                   bulk_apply_role bulk_apply_bypass_role bulk_fingerbank_refresh
-                  bulk_delete bulk_import
+                  bulk_delete bulk_import bulk_password_reset
                   )
             ],
             auditable => 1,

--- a/lib/pf/UnifiedApi/Controller/Users.pm
+++ b/lib/pf/UnifiedApi/Controller/Users.pm
@@ -29,7 +29,7 @@ use pf::constants::realm;
 use pf::error qw(is_error is_success);
 use pf::UnifiedApi::Search::Builder::Users;
 use pf::lookup::person qw();
-use pf::activation qw($PASSWORD_RESET_ACTIVATION);
+use pf::activation;
 use pf::constants::Connection::Profile qw($DEFAULT_PROFILE);
 
 has 'search_builder_class' => 'pf::UnifiedApi::Search::Builder::Users';

--- a/lib/pf/UnifiedApi/Controller/Users.pm
+++ b/lib/pf/UnifiedApi/Controller/Users.pm
@@ -30,6 +30,7 @@ use pf::error qw(is_error is_success);
 use pf::UnifiedApi::Search::Builder::Users;
 use pf::lookup::person qw();
 use pf::activation qw($PASSWORD_RESET_ACTIVATION);
+use pf::constants::Connection::Profile qw($DEFAULT_PROFILE);
 
 has 'search_builder_class' => 'pf::UnifiedApi::Search::Builder::Users';
 
@@ -685,7 +686,7 @@ sub password_reset {
 
     # Get user details
     my ($status, $iter) = pf::dal::person->search(
-        -columns => [qw(person.pid person.email)],
+        -columns => [qw(person.pid person.email person.portal)],
         -where => { 'person.pid' => $pid },
         -with_class => undef,
     );
@@ -704,18 +705,9 @@ sub password_reset {
         return $self->render_error(422, "User has no email address");
     }
 
-    # Parse optional JSON body for portal parameter
-    my $portal;
-    my ($json_status, $data) = $self->parse_json;
-    if (is_error($json_status)) {
-        return $self->render(json => $data, status => $json_status);
-    }
-    if ($data) {
-        $portal = $data->{portal};
-    }
-
     # Send password reset email (admin API - no rate limiting)
-    my ($success, $result) = pf::activation::admin_send_password_reset($pid, $email, $portal);
+    my $portal = $user->{portal} // $DEFAULT_PROFILE;
+    my ($success, $result) = pf::activation::admin_send_password_reset($pid, $email, $portal, ());
 
     if ($success) {
         $logger->info("Password reset email sent to $email for user $pid");
@@ -740,7 +732,6 @@ sub bulk_password_reset {
     }
 
     my $items = $data->{items} // [];
-    my $portal = $data->{portal};
 
     if (@$items == 0) {
         return $self->render(json => { items => [] });
@@ -748,7 +739,7 @@ sub bulk_password_reset {
 
     # Get user details for all requested pids
     ($status, my $iter) = pf::dal::person->search(
-        -columns => [qw(person.pid person.email)],
+        -columns => [qw(person.pid person.email person.portal)],
         -where => { 'person.pid' => { -in => $items } },
         -with_class => undef,
     );
@@ -757,10 +748,10 @@ sub bulk_password_reset {
         return $self->render_error(500, "Error finding users");
     }
 
-    # Build a hash of pid => email
-    my %user_emails;
+    # Build a hash of pid => user data
+    my %users;
     while (my $user = $iter->next) {
-        $user_emails{$user->{pid}} = $user->{email};
+        $users{$user->{pid}} = $user;
     }
 
     my ($indexes, $results) = bulk_init_results($items);
@@ -769,13 +760,14 @@ sub bulk_password_reset {
         my $result = $results->[$indexes->{$pid}];
 
         # Check if user exists
-        if (!exists $user_emails{$pid}) {
+        if (!exists $users{$pid}) {
             $result->{status} = 404;
             $result->{message} = "User not found";
             next;
         }
 
-        my $email = $user_emails{$pid};
+        my $user = $users{$pid};
+        my $email = $user->{email};
 
         # Check if user has email
         if (!$email) {
@@ -785,7 +777,8 @@ sub bulk_password_reset {
         }
 
         # Send password reset email (admin API - no rate limiting)
-        my ($success, $msg) = pf::activation::admin_send_password_reset($pid, $email, $portal);
+        my $portal = $user->{portal} // $DEFAULT_PROFILE;
+        my ($success, $msg) = pf::activation::admin_send_password_reset($pid, $email, $portal, ());
 
         if ($success) {
             $result->{status} = 200;

--- a/lib/pf/UnifiedApi/Controller/Users.pm
+++ b/lib/pf/UnifiedApi/Controller/Users.pm
@@ -29,6 +29,7 @@ use pf::constants::realm;
 use pf::error qw(is_error is_success);
 use pf::UnifiedApi::Search::Builder::Users;
 use pf::lookup::person qw();
+use pf::activation qw($PASSWORD_RESET_ACTIVATION);
 
 has 'search_builder_class' => 'pf::UnifiedApi::Search::Builder::Users';
 
@@ -669,6 +670,131 @@ sub post_delete {
         pf::lookup::person::clear_lookup_person($self->id, $item->{source}, $ctx);
     }
 
+}
+
+=head2 password_reset
+
+Send password reset email to a single user
+
+=cut
+
+sub password_reset {
+    my ($self) = @_;
+    my $pid = $self->id;
+    my $logger = get_logger();
+
+    # Get user details
+    my ($status, $iter) = pf::dal::person->search(
+        -columns => [qw(person.pid person.email)],
+        -where => { 'person.pid' => $pid },
+        -with_class => undef,
+    );
+
+    if (is_error($status)) {
+        return $self->render_error(500, "Error finding user");
+    }
+
+    my $user = $iter->next;
+    if (!$user) {
+        return $self->render_error(404, "User not found");
+    }
+
+    my $email = $user->{email};
+    if (!$email) {
+        return $self->render_error(422, "User has no email address");
+    }
+
+    # Parse optional JSON body for portal parameter
+    my $portal = undef;
+    my ($json_status, $data) = $self->parse_json;
+    if (is_success($json_status) && $data) {
+        $portal = $data->{portal};
+    }
+
+    # Send password reset email (admin API - no rate limiting)
+    my ($success, $result) = pf::activation::admin_send_password_reset($pid, $email, $portal);
+
+    if ($success) {
+        $logger->info("Password reset email sent to $email for user $pid");
+        return $self->render(json => { message => "Password reset email sent", pid => $pid, email => $email }, status => 200);
+    } else {
+        $logger->error("Failed to send password reset email to $email for user $pid: $result");
+        return $self->render_error(422, $result);
+    }
+}
+
+=head2 bulk_password_reset
+
+Send password reset emails to multiple users
+
+=cut
+
+sub bulk_password_reset {
+    my ($self) = @_;
+    my ($status, $data) = $self->parse_json;
+    if (is_error($status)) {
+        return $self->render(json => $data, status => $status);
+    }
+
+    my $items = $data->{items} // [];
+    my $portal = $data->{portal};
+
+    if (@$items == 0) {
+        return $self->render(json => { items => [] });
+    }
+
+    # Get user details for all requested pids
+    ($status, my $iter) = pf::dal::person->search(
+        -columns => [qw(person.pid person.email)],
+        -where => { 'person.pid' => { -in => $items } },
+        -with_class => undef,
+    );
+
+    if (is_error($status)) {
+        return $self->render_error(500, "Error finding users");
+    }
+
+    # Build a hash of pid => email
+    my %user_emails;
+    while (my $user = $iter->next) {
+        $user_emails{$user->{pid}} = $user->{email};
+    }
+
+    my ($indexes, $results) = bulk_init_results($items);
+
+    for my $pid (@$items) {
+        my $result = $results->[$indexes->{$pid}];
+
+        # Check if user exists
+        if (!exists $user_emails{$pid}) {
+            $result->{status} = 404;
+            $result->{message} = "User not found";
+            next;
+        }
+
+        my $email = $user_emails{$pid};
+
+        # Check if user has email
+        if (!$email) {
+            $result->{status} = 422;
+            $result->{message} = "User has no email address";
+            next;
+        }
+
+        # Send password reset email (admin API - no rate limiting)
+        my ($success, $msg) = pf::activation::admin_send_password_reset($pid, $email, $portal);
+
+        if ($success) {
+            $result->{status} = 200;
+            $result->{email} = $email;
+            $result->{message} = "Password reset email sent";
+        } else {
+            $result->{status} = 422;
+            $result->{message} = $msg;
+        }
+    }
+
+    return $self->render(json => { items => $results });
 }
 
 =head1 AUTHOR

--- a/lib/pf/UnifiedApi/Controller/Users.pm
+++ b/lib/pf/UnifiedApi/Controller/Users.pm
@@ -705,9 +705,12 @@ sub password_reset {
     }
 
     # Parse optional JSON body for portal parameter
-    my $portal = undef;
+    my $portal;
     my ($json_status, $data) = $self->parse_json;
-    if (is_success($json_status) && $data) {
+    if (is_error($json_status)) {
+        return $self->render(json => $data, status => $json_status);
+    }
+    if ($data) {
         $portal = $data->{portal};
     }
 

--- a/lib/pf/activation.pm
+++ b/lib/pf/activation.pm
@@ -563,6 +563,24 @@ sub create_and_send_password_reset {
         return (0, "Rate limited");
     }
 
+    return _do_password_reset($pid, $email, $portal, %info);
+}
+
+=head2 admin_send_password_reset
+
+Send password reset email from admin API (no rate limiting).
+
+=cut
+
+sub admin_send_password_reset {
+    my ($pid, $email, $portal, %info) = @_;
+    return _do_password_reset($pid, $email, $portal, %info);
+}
+
+sub _do_password_reset {
+    my ($pid, $email, $portal, %info) = @_;
+    my $logger = get_logger();
+
     # Invalidate any existing reset tokens for this user
     invalidate_codes(undef, $pid, $email, $PASSWORD_RESET_ACTIVATION);
 


### PR DESCRIPTION


# Description
Add API endpoints and admin UI for sending password reset emails

  API Changes:
  - Add POST /api/v1/user/{user_id}/password_reset for single user
  - Add POST /api/v1/users/bulk_password_reset for bulk operations
  - Admin API bypasses rate limiting (portal still limited to 3/hour/user)

  Backend Changes:
  - Add admin_send_password_reset() in pf::activation (no rate limit)
  - Refactor create_and_send_password_reset() to use shared _do_password_reset()

  Admin UI Changes:
  - Add "Send Password Reset Email" to bulk actions dropdown in Users search
  - Add "Send Password Reset Email" button in User page Password tab
  - Button disabled if user has no email address
