### PR TITLE
Use sharedutils.IsEnabled for consistency

### DIFF
--- a/go/cmd/pfacct/pfacct.go
+++ b/go/cmd/pfacct/pfacct.go
@@ -145,7 +145,7 @@ func (pfAcct *PfAcct) SetupConfig(ctx context.Context) {
 	keyConfAdvanced.PfconfigNS = "config::Pf"
 	keyConfAdvanced.PfconfigHostnameOverlay = "yes"
 	pfconfigdriver.FetchDecodeSocket(ctx, &keyConfAdvanced)
-	pfAcct.AllNetworks = keyConfAdvanced.NetFlowOnAllNetworks == "enabled"
+	pfAcct.AllNetworks = sharedutils.IsEnabled(keyConfAdvanced.NetFlowOnAllNetworks)
 	var ports pfconfigdriver.PfConfPorts
 	pfconfigdriver.FetchDecodeSocket(ctx, &ports)
 	pfAcct.TimeDuration = time.Duration(keyConfAdvanced.AccountingTimebucketSize) * time.Second

--- a/go/cmd/pfdhcp/config.go
+++ b/go/cmd/pfdhcp/config.go
@@ -156,7 +156,7 @@ func (d *Interfaces) readConfig(ctx context.Context, MyDB *sql.DB) {
 					}
 
 					// IP per role
-					if ConfNet.SplitNetwork == "enabled" {
+					if sharedutils.IsEnabled(ConfNet.SplitNetwork) {
 						var keyConfRoles pfconfigdriver.PfconfigKeys
 						keyConfRoles.PfconfigNS = "config::Roles"
 
@@ -284,7 +284,7 @@ func (d *Interfaces) readConfig(ctx context.Context, MyDB *sql.DB) {
 							options[dhcp.OptionDomainNameServer] = []byte(DHCPScope.ip.To4())
 							options[dhcp.OptionRouter] = []byte(DHCPScope.ip.To4())
 							options[dhcp.OptionDomainName] = []byte(ConfNet.DomainName)
-							if portal.SecureRedirect == "enabled" {
+							if sharedutils.IsEnabled(portal.SecureRedirect) {
 								options[dhcp.OptionCaptivePortal] = []byte(detectPortalURL(ConfNet, general))
 							}
 							DHCPScope.options = options
@@ -365,7 +365,7 @@ func (d *Interfaces) readConfig(ctx context.Context, MyDB *sql.DB) {
 						options[dhcp.OptionDomainNameServer] = ShuffleDNS(ctx, ConfNet)
 						options[dhcp.OptionRouter] = ShuffleGateway(ctx, ConfNet)
 						options[dhcp.OptionDomainName] = []byte(ConfNet.DomainName)
-						if portal.SecureRedirect == "enabled" {
+						if sharedutils.IsEnabled(portal.SecureRedirect) {
 							options[dhcp.OptionCaptivePortal] = []byte(detectPortalURL(ConfNet, general))
 						}
 						DHCPScope.options = options

--- a/go/cmd/pfstats/main.go
+++ b/go/cmd/pfstats/main.go
@@ -304,7 +304,7 @@ func main() {
 				source.PfconfigNS = "resource::authentication_sources_ldap"
 				source.PfconfigHashNS = src
 				pfconfigdriver.FetchDecodeSocket(ctx, &source)
-				if source.Monitor == "1" {
+				if sharedutils.IsEnabled(source.Monitor) {
 					var Source = TestSource{LDAP}
 					go Source.SourceType.Test(source, ctx)
 				}
@@ -324,7 +324,7 @@ func main() {
 				source.PfconfigNS = "resource::authentication_sources_radius"
 				source.PfconfigHashNS = src
 				pfconfigdriver.FetchDecodeSocket(ctx, &source)
-				if source.Monitor == "1" {
+				if sharedutils.IsEnabled(source.Monitor) {
 					var Source = TestSource{RADIUS}
 					go Source.SourceType.Test(source, ctx)
 				}

--- a/go/cron/config.go
+++ b/go/cron/config.go
@@ -76,7 +76,7 @@ func GetConfiguredJobs(maintConfig map[string]interface{}) []JobSetupConfig {
 	jobs := []JobSetupConfig{}
 	for name, config := range maintConfig {
 		data := config.(map[string]interface{})
-		if data["status"].(string) == "enabled" {
+		if sharedutils.IsEnabled(data["status"].(string)) {
 			if job := BuildJob(name, data); job != nil {
 				jobs = append(jobs, job)
 			}

--- a/go/firewallsso/base.go
+++ b/go/firewallsso/base.go
@@ -111,25 +111,25 @@ func (fw *FirewallSSO) GetFirewallSSO(ctx context.Context) *FirewallSSO {
 
 // Check whether or not the cached updates are enabled for this firewall
 func (fw *FirewallSSO) ShouldCacheUpdates(ctx context.Context) bool {
-	return fw.CacheUpdates == "enabled"
+	return sharedutils.IsEnabled(fw.CacheUpdates)
 }
 
 // Check if sso needs to be triggered on accounting stop
 func (fw *FirewallSSO) SendOnAcctStop(ctx context.Context) bool {
-	return fw.ActOnAccountingStop == "1"
+	return sharedutils.IsEnabled(fw.ActOnAccountingStop)
 }
 
 // Check if sso needs to be triggered on accounting
 func (fw *FirewallSSO) SendOnAcct(ctx context.Context) bool {
-	return fw.SsoOnAccounting == "1"
+	return sharedutils.IsEnabled(fw.SsoOnAccounting)
 }
 
 // Check if sso needs to be triggered on Access Reevaluation
 func (fw *FirewallSSO) SendOnAccessReevaluation(ctx context.Context) bool {
-	return fw.SsoOnAccessReevaluation == "1"
+	return sharedutils.IsEnabled(fw.SsoOnAccessReevaluation)
 }
 func (fw *FirewallSSO) SendOnDhcp(ctx context.Context) bool {
-	return fw.SsoOnDhcp == "1"
+	return sharedutils.IsEnabled(fw.SsoOnDhcp)
 }
 
 // Get the cache_timeout configured in the firewall as an int

--- a/go/httpdispatcher/proxy.go
+++ b/go/httpdispatcher/proxy.go
@@ -330,11 +330,7 @@ func (p *Proxy) Configure(ctx context.Context) {
 
 	parking := pfconfigdriver.GetType[pfconfigdriver.PfConfParking](ctx)
 
-	if parking.ShowParkingPortal == "enabled" {
-		p.ShowParkingPortal = true
-	} else {
-		p.ShowParkingPortal = false
-	}
+	p.ShowParkingPortal = sharedutils.IsEnabled(parking.ShowParkingPortal)
 
 	go func() {
 		for {
@@ -371,24 +367,19 @@ func (p *passthrough) readConfig(ctx context.Context) {
 		p.addOtherDomainsToList(ctx, v)
 	}
 
-	p.DetectionMecanismBypass = portal.DetectionMecanismBypass == "enabled"
+	p.DetectionMecanismBypass = sharedutils.IsEnabled(portal.DetectionMecanismBypass)
 
 	rgx, _ := regexp.Compile("CaptiveNetworkSupport")
 	p.URIException = rgx
 
-	if portal.SecureRedirect == "enabled" {
-		p.SecureRedirect = true
+	p.SecureRedirect = sharedutils.IsEnabled(portal.SecureRedirect)
+	if p.SecureRedirect {
 		scheme = "https"
 	} else {
-		p.SecureRedirect = false
 		scheme = "http"
 	}
 
-	if portal.WisprRedirection == "enabled" {
-		p.Wispr = true
-	} else {
-		p.Wispr = false
-	}
+	p.Wispr = sharedutils.IsEnabled(portal.WisprRedirection)
 
 	index := 0
 

--- a/go/plugin/coredns/pfdns/pfconfig.go
+++ b/go/plugin/coredns/pfdns/pfconfig.go
@@ -39,7 +39,7 @@ func newPfconfigRefreshableConfig(ctx context.Context) *pfdnsRefreshableConfig {
 	pfconfigdriver.FetchDecodeSocket(ctx, &rc.PfConfDns)
 	rc.PassthroughsInit(ctx)
 	rc.PassthroughsIsolationInit(ctx)
-	rc.recordDNS = rc.PfConfDns.RecordDNS == "enabled"
+	rc.recordDNS = sharedutils.IsEnabled(rc.PfConfDns.RecordDNS)
 	return rc
 }
 
@@ -86,7 +86,7 @@ func (rc *pfdnsRefreshableConfig) Refresh(ctx context.Context) {
 	rc.PassthroughsInit(ctx)
 	rc.PassthroughsIsolationInit(ctx)
 
-	rc.recordDNS = rc.PfConfDns.RecordDNS == "enabled"
+	rc.recordDNS = sharedutils.IsEnabled(rc.PfConfDns.RecordDNS)
 }
 
 func (rc *pfdnsRefreshableConfig) Clone() pfconfigdriver.Refresh {

--- a/go/plugin/coredns/pfdns/pfdns.go
+++ b/go/plugin/coredns/pfdns/pfdns.go
@@ -736,10 +736,7 @@ func (pf *pfdns) MakeDetectionMecanism(ctx context.Context) error {
 
 	pfconfigdriver.FetchDecodeSocket(ctx, &portal)
 
-	pf.detectionBypass = false
-	if portal.DetectionMecanismBypass == "enabled" {
-		pf.detectionBypass = true
-	}
+	pf.detectionBypass = sharedutils.IsEnabled(portal.DetectionMecanismBypass)
 
 	pf.detectionMechanisms = make([]*regexp.Regexp, 0)
 	var err error


### PR DESCRIPTION
# Description
Use sharedutils.IsEnabled for consistency in the golang code
A missconfiguration in the configuration file by using enabled instead of 1 can cause a feature to be disabled.

# Impacts
Golang services


# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
## Enhancements
* Use sharedutils.IsEnabled for consistency
