### PR TITLE
Fix/pfproxysql container version

### DIFF
--- a/containers/proxysql/Dockerfile
+++ b/containers/proxysql/Dockerfile
@@ -56,6 +56,9 @@ RUN chmod +x /proxysql-read-only-handler.sh
 RUN mkdir -p /usr/local/pf/var/proxysql/
 
 # Set LD_LIBRARY_PATH to ensure OpenSSL 3.2+ is used
+# Set SSL_CERT_DIR to use system CA certificates
 ENV LD_LIBRARY_PATH=/opt/openssl/lib64:$LD_LIBRARY_PATH
+ENV SSL_CERT_DIR=/etc/ssl/certs
+ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 
 ENTRYPOINT ["proxysql", "-f", "-D", "/usr/local/pf/var/proxysql/", "-c", "/usr/local/pf/var/conf/proxysql.conf", "--initial", "--idle-threads"]

--- a/containers/proxysql/Dockerfile
+++ b/containers/proxysql/Dockerfile
@@ -32,8 +32,8 @@ FROM ${KNK_REGISTRY_URL}/pfdebian:${IMAGE_TAG}
 # Copy OpenSSL 3.2+ libraries from builder
 COPY --from=openssl-builder /opt/openssl/lib64 /opt/openssl/lib64
 
-# Configure library path so proxysql finds OpenSSL 3.2+
-RUN echo "/opt/openssl/lib64" > /etc/ld.so.conf.d/openssl.conf && ldconfig
+# Configure library path so proxysql finds OpenSSL 3.2+ (use 00 prefix for priority)
+RUN echo "/opt/openssl/lib64" > /etc/ld.so.conf.d/00-openssl.conf && ldconfig
 
 ARG PROXYSQL_VERSION
 
@@ -54,5 +54,8 @@ RUN apt-get -qq update \
 COPY bin/proxysql-read-only-handler.sh /proxysql-read-only-handler.sh
 RUN chmod +x /proxysql-read-only-handler.sh
 RUN mkdir -p /usr/local/pf/var/proxysql/
+
+# Set LD_LIBRARY_PATH to ensure OpenSSL 3.2+ is used
+ENV LD_LIBRARY_PATH=/opt/openssl/lib64:$LD_LIBRARY_PATH
 
 ENTRYPOINT ["proxysql", "-f", "-D", "/usr/local/pf/var/proxysql/", "-c", "/usr/local/pf/var/conf/proxysql.conf", "--initial", "--idle-threads"]

--- a/containers/proxysql/Dockerfile
+++ b/containers/proxysql/Dockerfile
@@ -1,12 +1,54 @@
 ARG KNK_REGISTRY_URL
 ARG IMAGE_TAG
 ARG PROXYSQL_VERSION=3.0.5
+ARG OPENSSL_VERSION=3.2.3
+
+# Stage 1: Build OpenSSL 3.2+ from source
+FROM debian:12 AS openssl-builder
+
+ARG OPENSSL_VERSION
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    wget \
+    ca-certificates \
+    perl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /tmp
+
+RUN wget -q https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz \
+    && tar xzf openssl-${OPENSSL_VERSION}.tar.gz \
+    && cd openssl-${OPENSSL_VERSION} \
+    && ./config --prefix=/opt/openssl --openssldir=/opt/openssl shared \
+    && make -j$(nproc) \
+    && make install_sw \
+    && cd .. \
+    && rm -rf openssl-${OPENSSL_VERSION}*
+
+# Stage 2: Final image with proxysql
 FROM ${KNK_REGISTRY_URL}/pfdebian:${IMAGE_TAG}
 
+# Copy OpenSSL 3.2+ libraries from builder
+COPY --from=openssl-builder /opt/openssl/lib64 /opt/openssl/lib64
+
+# Configure library path so proxysql finds OpenSSL 3.2+
+RUN echo "/opt/openssl/lib64" > /etc/ld.so.conf.d/openssl.conf && ldconfig
+
 ARG PROXYSQL_VERSION
+
+# TODO: Replace with apt-get install once proxysql deb is in the repo
+# RUN apt-get -qq update \
+#     && apt-get clean \
+#     && apt-get -qq install -y proxysql=${PROXYSQL_VERSION} default-mysql-client \
+#     && apt-get clean
+
+# For now, download and install proxysql deb with sd_notify patch
 RUN apt-get -qq update \
-    && apt-get clean \
-    && apt-get -qq install -y proxysql=${PROXYSQL_VERSION} default-mysql-client \
+    && apt-get -qq install -y wget default-mysql-client \
+    && wget -q https://support.inverse.ca/~jgoimard/proxysql/proxysql_${PROXYSQL_VERSION}-debian12_amd64.deb -O /tmp/proxysql.deb \
+    && apt-get -qq install -y -f /tmp/proxysql.deb \
+    && rm -f /tmp/proxysql.deb \
     && apt-get clean
 
 COPY bin/proxysql-read-only-handler.sh /proxysql-read-only-handler.sh

--- a/containers/proxysql/Dockerfile
+++ b/containers/proxysql/Dockerfile
@@ -1,10 +1,12 @@
 ARG KNK_REGISTRY_URL
 ARG IMAGE_TAG
+ARG PROXYSQL_VERSION=3.0.5
 FROM ${KNK_REGISTRY_URL}/pfdebian:${IMAGE_TAG}
 
+ARG PROXYSQL_VERSION
 RUN apt-get -qq update \
     && apt-get clean \
-    && apt-get -qq install -y proxysql default-mysql-client \
+    && apt-get -qq install -y proxysql=${PROXYSQL_VERSION} default-mysql-client \
     && apt-get clean
 
 COPY bin/proxysql-read-only-handler.sh /proxysql-read-only-handler.sh

--- a/debian/local_builder/proxysql/0001-sd_notify-patch-2.6.patch
+++ b/debian/local_builder/proxysql/0001-sd_notify-patch-2.6.patch
@@ -1,0 +1,205 @@
+From 47368be71ffcb70af664d751bafdae3b23087e84 Mon Sep 17 00:00:00 2001
+From: Durand Fabrice <oeufdure@gmail.com>
+Date: Mon, 25 Mar 2024 16:21:14 -0400
+Subject: [PATCH] sd_notify patch
+
+---
+ Makefile                        | 24 +++++++++++++-----------
+ src/Makefile                    |  7 +++++++
+ src/main.cpp                    | 19 +++++++++++++++++++
+ systemd/system/proxysql.service |  2 +-
+ 4 files changed, 40 insertions(+), 12 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index db72d97db..0bbe38f7e 100644
+--- a/Makefile
++++ b/Makefile
+@@ -75,6 +75,8 @@ ifeq ($(wildcard /usr/lib/systemd/system), /usr/lib/systemd/system)
+ 	SYSTEMD := 1
+ endif
+ 
++SYSTEMD := 1
++
+ ### check user/group
+ USERCHECK := $(shell getent passwd proxysql)
+ GROUPCHECK := $(shell getent group proxysql)
+@@ -152,7 +154,7 @@ build_lib_legacy: build_deps_legacy
+ 
+ .PHONY: build_src_legacy
+ build_src_legacy: build_lib_legacy
+-	cd src && OPTZ="${O2} -ggdb" CC=${CC} CXX=${CXX} ${MAKE}
++	cd src && OPTZ="${O2} -ggdb" CC=${CC} CXX=${CXX} SYSTEMD=${SYSTEMD} ${MAKE}
+ 
+ .PHONY: build_deps_debug_legacy
+ build_deps_debug_legacy:
+@@ -164,16 +166,16 @@ build_lib_debug_legacy: build_deps_debug_legacy
+ 
+ .PHONY: build_src_debug_legacy
+ build_src_debug_legacy: build_lib_debug_legacy
+-	cd src && OPTZ="${O0} -ggdb -DDEBUG" CC=${CC} CXX=${CXX} ${MAKE}
++	cd src && OPTZ="${O0} -ggdb -DDEBUG" CC=${CC} CXX=${CXX} SYSTEMD=${SYSTEMD} ${MAKE}
+ #--
+ 
+ .PHONY: build_src_testaurora
+ build_src_testaurora: build_lib_testaurora
+-	cd src && OPTZ="${O0} -ggdb -DDEBUG -DTEST_AURORA" CC=${CC} CXX=${CXX} ${MAKE}
++	cd src && OPTZ="${O0} -ggdb -DDEBUG -DTEST_AURORA" CC=${CC} CXX=${CXX} SYSTEMD=${SYSTEMD} ${MAKE}
+ 
+ .PHONY: build_src_testaurora_random
+ build_src_testaurora_random: build_lib_testaurora_random
+-	cd src && OPTZ="${O0} -ggdb -DDEBUG -DTEST_AURORA -DTEST_AURORA_RANDOM" CC=${CC} CXX=${CXX} ${MAKE}
++	cd src && OPTZ="${O0} -ggdb -DDEBUG -DTEST_AURORA -DTEST_AURORA_RANDOM" CC=${CC} CXX=${CXX} SYSTEMD=${SYSTEMD} ${MAKE}
+ 
+ .PHONY: build_lib_testaurora
+ build_lib_testaurora: build_deps_debug
+@@ -185,7 +187,7 @@ build_lib_testaurora_random: build_deps_debug
+ 
+ .PHONY: build_src_testgalera
+ build_src_testgalera: build_lib_testgalera
+-	cd src && OPTZ="${O0} -ggdb -DDEBUG -DTEST_GALERA" CC=${CC} CXX=${CXX} ${MAKE}
++	cd src && OPTZ="${O0} -ggdb -DDEBUG -DTEST_GALERA" CC=${CC} CXX=${CXX} SYSTEMD=${SYSTEMD} ${MAKE}
+ 
+ .PHONY: build_lib_testgalera
+ build_lib_testgalera: build_deps_debug
+@@ -193,7 +195,7 @@ build_lib_testgalera: build_deps_debug
+ 
+ .PHONY: build_src_testgrouprep
+ build_src_testgrouprep: build_lib_testgrouprep
+-	cd src && OPTZ="${O0} -ggdb -DDEBUG -DTEST_GROUPREP" CC=${CC} CXX=${CXX} ${MAKE}
++	cd src && OPTZ="${O0} -ggdb -DDEBUG -DTEST_GROUPREP" CC=${CC} CXX=${CXX} SYSTEMD=${SYSTEMD} ${MAKE}
+ 
+ .PHONY: build_lib_testgrouprep
+ build_lib_testgrouprep: build_deps_debug
+@@ -201,7 +203,7 @@ build_lib_testgrouprep: build_deps_debug
+ 
+ .PHONY: build_src_testreadonly
+ build_src_testreadonly: build_lib_testreadonly
+-	cd src && OPTZ="${O0} -ggdb -DDEBUG -DTEST_READONLY" CC=${CC} CXX=${CXX} ${MAKE}
++	cd src && OPTZ="${O0} -ggdb -DDEBUG -DTEST_READONLY" CC=${CC} CXX=${CXX} SYSTEMD=${SYSTEMD} ${MAKE}
+ 
+ .PHONY: build_lib_testreadonly
+ build_lib_testreadonly: build_deps_debug
+@@ -209,7 +211,7 @@ build_lib_testreadonly: build_deps_debug
+ 
+ .PHONY: build_src_testreplicationlag
+ build_src_testreplicationlag: build_lib_testreplicationlag
+-	cd src && OPTZ="${O0} -ggdb -DDEBUG -DTEST_REPLICATIONLAG" CC=${CC} CXX=${CXX} ${MAKE}
++	cd src && OPTZ="${O0} -ggdb -DDEBUG -DTEST_REPLICATIONLAG" CC=${CC} CXX=${CXX} SYSTEMD=${SYSTEMD} ${MAKE}
+ 
+ .PHONY: build_lib_testreplicationlag
+ build_lib_testreplicationlag: build_deps_debug
+@@ -217,7 +219,7 @@ build_lib_testreplicationlag: build_deps_debug
+ 
+ .PHONY: build_src_testall
+ build_src_testall: build_lib_testall
+-	cd src && OPTZ="${O0} -ggdb -DDEBUG -DTEST_AURORA -DTEST_GALERA -DTEST_GROUPREP -DTEST_READONLY -DTEST_REPLICATIONLAG" CC=${CC} CXX=${CXX} ${MAKE}
++	cd src && OPTZ="${O0} -ggdb -DDEBUG -DTEST_AURORA -DTEST_GALERA -DTEST_GROUPREP -DTEST_READONLY -DTEST_REPLICATIONLAG" CC=${CC} CXX=${CXX} SYSTEMD=${SYSTEMD} ${MAKE}
+ 
+ .PHONY: build_lib_testall
+ build_lib_testall: build_deps_debug
+@@ -274,11 +276,11 @@ build_lib_debug_default: build_deps_debug_default
+ 
+ .PHONY: build_src_default
+ build_src_default: build_lib_default
+-	cd src && OPTZ="${O2} -ggdb" PROXYSQLCLICKHOUSE=1 CC=${CC} CXX=${CXX} ${MAKE}
++	cd src && OPTZ="${O2} -ggdb" PROXYSQLCLICKHOUSE=1 CC=${CC} CXX=${CXX} SYSTEMD=${SYSTEMD} ${MAKE}
+ 
+ .PHONY: build_src_debug_default
+ build_src_debug_default: build_lib_debug_default
+-	cd src && OPTZ="${O0} -ggdb -DDEBUG" PROXYSQLCLICKHOUSE=1 CC=${CC} CXX=${CXX} ${MAKE}
++	cd src && OPTZ="${O0} -ggdb -DDEBUG" PROXYSQLCLICKHOUSE=1 CC=${CC} CXX=${CXX} SYSTEMD=${SYSTEMD} ${MAKE}
+ 
+ 
+ ### packaging targets
+diff --git a/src/Makefile b/src/Makefile
+index 52a3d626e..d6b2ae0fa 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -151,6 +151,9 @@ ifeq ($(CXX),clang++)
+ endif
+ MYCXXFLAGS += $(IDIRS) $(OPTZ) $(DEBUG) $(PSQLCH) -DGITVERSION=\"$(GIT_VERSION)\" $(WGCOV) $(WASAN)
+ 
++ifeq ($(SYSTEMD),1)
++	CXXFLAGS+= -DSYSTEMD
++endif
+ 
+ STATICMYLIBS := -Wl,-Bstatic -lconfig -lproxysql -ldaemon -lconfig++ -lre2 -lpcrecpp -lpcre -lmariadbclient -lhttpserver -lmicrohttpd -linjection -lcurl -lssl -lcrypto -lev
+ ifneq ($(NOJEMALLOC),1)
+@@ -178,6 +181,10 @@ ifeq ($(CENTOSVER),6)
+ 	MYLIBS += -lgcrypt
+ endif
+ 
++ifeq ($(SYSTEMD),1)
++	MYLIBS+= -lsystemd
++endif
++
+ LIBPROXYSQLAR := $(PROXYSQL_LDIR)/libproxysql.a
+ ifeq ($(UNAME_S),Darwin)
+ 	LIBPROXYSQLAR += $(JEMALLOC_LDIR)/libjemalloc.a
+diff --git a/src/main.cpp b/src/main.cpp
+index bd21a42d5..426559aac 100644
+--- a/src/main.cpp
++++ b/src/main.cpp
+@@ -10,6 +10,10 @@
+ #include <sys/stat.h>
+ #include <fcntl.h>
+ 
++#ifdef SYSTEMD
++#include <systemd/sd-daemon.h>
++#endif
++
+ //#define PROXYSQL_EXTERN
+ #include "cpp.h"
+ 
+@@ -2101,6 +2105,12 @@ int main(int argc, const char * argv[]) {
+ 
+ 		} else if (pid) { /* The parent */
+ 
++#ifdef SYSTEMD
++			proxy_info("Systemd sd_notify enabled\n");
++			sd_notifyf(0, "READY=1\n"
++			"STATUS=ProxySQL is now processing requests...");
++#endif
++
+ 			ProxySQL_daemonize_wait_daemon();
+ 
+ 		} else { /* The daemon */
+@@ -2161,6 +2171,11 @@ gotofork:
+ 
+ 	} else {
+ 		GloAdmin->flush_error_log();
++#ifdef SYSTEMD
++		proxy_info("Systemd sd_notify enabled\n");
++		sd_notifyf(0, "READY=1\n"
++		"STATUS=ProxySQL is now processing requests...");
++#endif
+ 		GloVars.install_signal_handler();
+ 	}
+ 
+@@ -2286,6 +2301,10 @@ __start_label:
+ 
+ __shutdown:
+ 
++#ifdef SYSTEMD
++	sd_notify(0, "STOPPING=1");
++#endif
++
+ 	proxy_info("Starting shutdown...\n");
+ 
+ 	// First shutdown step is to unload plugins
+diff --git a/systemd/system/proxysql.service b/systemd/system/proxysql.service
+index 6506a57b1..7469fe041 100644
+--- a/systemd/system/proxysql.service
++++ b/systemd/system/proxysql.service
+@@ -3,7 +3,7 @@ Description=High Performance Advanced Proxy for MySQL
+ After=network.target
+ 
+ [Service]
+-Type=forking
++Type=notify
+ RuntimeDirectory=proxysql
+ #PermissionsStartOnly=true
+ #ExecStartPre=/usr/bin/mkdir -p /var/run/proxysql /var/run/proxysql
+-- 
+2.34.1
+

--- a/debian/local_builder/proxysql/0001-sd_notify-patch-3.0.patch
+++ b/debian/local_builder/proxysql/0001-sd_notify-patch-3.0.patch
@@ -1,0 +1,205 @@
+From d75fdae7362cbb54d75796e8d0ff83e4bb9d038c Mon Sep 17 00:00:00 2001
+From: Durand Fabrice <oeufdure@gmail.com>
+Date: Mon, 25 Mar 2024 16:21:14 -0400
+Subject: [PATCH] sd_notify patch
+
+---
+ Makefile                        | 24 +++++++++++++-----------
+ src/Makefile                    |  7 +++++++
+ src/main.cpp                    | 19 +++++++++++++++++++
+ systemd/system/proxysql.service |  2 +-
+ 4 files changed, 40 insertions(+), 12 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index a20498289..8f41021ec 100644
+--- a/Makefile
++++ b/Makefile
+@@ -86,6 +86,8 @@ ifeq ($(wildcard /usr/lib/systemd/system), /usr/lib/systemd/system)
+ 	SYSTEMD := 1
+ endif
+ 
++SYSTEMD := 1
++
+ ### check user/group
+ USERCHECK := $(shell getent passwd proxysql)
+ GROUPCHECK := $(shell getent group proxysql)
+@@ -163,7 +165,7 @@ build_lib_legacy: build_deps_legacy
+ 
+ .PHONY: build_src_legacy
+ build_src_legacy: build_lib_legacy
+-	cd src && OPTZ="${O2} -ggdb" CC=${CC} CXX=${CXX} ${MAKE}
++	cd src && OPTZ="${O2} -ggdb" CC=${CC} CXX=${CXX} SYSTEMD=${SYSTEMD} ${MAKE}
+ 
+ .PHONY: build_deps_debug_legacy
+ build_deps_debug_legacy:
+@@ -175,16 +177,16 @@ build_lib_debug_legacy: build_deps_debug_legacy
+ 
+ .PHONY: build_src_debug_legacy
+ build_src_debug_legacy: build_lib_debug_legacy
+-	cd src && OPTZ="${O0} -ggdb -DDEBUG" CC=${CC} CXX=${CXX} ${MAKE}
++	cd src && OPTZ="${O0} -ggdb -DDEBUG" CC=${CC} CXX=${CXX} SYSTEMD=${SYSTEMD} ${MAKE}
+ #--
+ 
+ .PHONY: build_src_testaurora
+ build_src_testaurora: build_lib_testaurora
+-	cd src && OPTZ="${O0} -ggdb -DDEBUG -DTEST_AURORA" CC=${CC} CXX=${CXX} ${MAKE}
++	cd src && OPTZ="${O0} -ggdb -DDEBUG -DTEST_AURORA" CC=${CC} CXX=${CXX} SYSTEMD=${SYSTEMD} ${MAKE}
+ 
+ .PHONY: build_src_testaurora_random
+ build_src_testaurora_random: build_lib_testaurora_random
+-	cd src && OPTZ="${O0} -ggdb -DDEBUG -DTEST_AURORA -DTEST_AURORA_RANDOM" CC=${CC} CXX=${CXX} ${MAKE}
++	cd src && OPTZ="${O0} -ggdb -DDEBUG -DTEST_AURORA -DTEST_AURORA_RANDOM" CC=${CC} CXX=${CXX} SYSTEMD=${SYSTEMD} ${MAKE}
+ 
+ .PHONY: build_lib_testaurora
+ build_lib_testaurora: build_deps_debug
+@@ -196,7 +198,7 @@ build_lib_testaurora_random: build_deps_debug
+ 
+ .PHONY: build_src_testgalera
+ build_src_testgalera: build_lib_testgalera
+-	cd src && OPTZ="${O0} -ggdb -DDEBUG -DTEST_GALERA" CC=${CC} CXX=${CXX} ${MAKE}
++	cd src && OPTZ="${O0} -ggdb -DDEBUG -DTEST_GALERA" CC=${CC} CXX=${CXX} SYSTEMD=${SYSTEMD} ${MAKE}
+ 
+ .PHONY: build_lib_testgalera
+ build_lib_testgalera: build_deps_debug
+@@ -204,7 +206,7 @@ build_lib_testgalera: build_deps_debug
+ 
+ .PHONY: build_src_testgrouprep
+ build_src_testgrouprep: build_lib_testgrouprep
+-	cd src && OPTZ="${O0} -ggdb -DDEBUG -DTEST_GROUPREP" CC=${CC} CXX=${CXX} ${MAKE}
++	cd src && OPTZ="${O0} -ggdb -DDEBUG -DTEST_GROUPREP" CC=${CC} CXX=${CXX} SYSTEMD=${SYSTEMD} ${MAKE}
+ 
+ .PHONY: build_lib_testgrouprep
+ build_lib_testgrouprep: build_deps_debug
+@@ -212,7 +214,7 @@ build_lib_testgrouprep: build_deps_debug
+ 
+ .PHONY: build_src_testreadonly
+ build_src_testreadonly: build_lib_testreadonly
+-	cd src && OPTZ="${O0} -ggdb -DDEBUG -DTEST_READONLY" CC=${CC} CXX=${CXX} ${MAKE}
++	cd src && OPTZ="${O0} -ggdb -DDEBUG -DTEST_READONLY" CC=${CC} CXX=${CXX} SYSTEMD=${SYSTEMD} ${MAKE}
+ 
+ .PHONY: build_lib_testreadonly
+ build_lib_testreadonly: build_deps_debug
+@@ -220,7 +222,7 @@ build_lib_testreadonly: build_deps_debug
+ 
+ .PHONY: build_src_testreplicationlag
+ build_src_testreplicationlag: build_lib_testreplicationlag
+-	cd src && OPTZ="${O0} -ggdb -DDEBUG -DTEST_REPLICATIONLAG" CC=${CC} CXX=${CXX} ${MAKE}
++	cd src && OPTZ="${O0} -ggdb -DDEBUG -DTEST_REPLICATIONLAG" CC=${CC} CXX=${CXX} SYSTEMD=${SYSTEMD} ${MAKE}
+ 
+ .PHONY: build_lib_testreplicationlag
+ build_lib_testreplicationlag: build_deps_debug
+@@ -228,7 +230,7 @@ build_lib_testreplicationlag: build_deps_debug
+ 
+ .PHONY: build_src_testall
+ build_src_testall: build_lib_testall
+-	cd src && OPTZ="${O0} -ggdb -DDEBUG -DTEST_AURORA -DTEST_GALERA -DTEST_GROUPREP -DTEST_READONLY -DTEST_REPLICATIONLAG" CC=${CC} CXX=${CXX} ${MAKE}
++	cd src && OPTZ="${O0} -ggdb -DDEBUG -DTEST_AURORA -DTEST_GALERA -DTEST_GROUPREP -DTEST_READONLY -DTEST_REPLICATIONLAG" CC=${CC} CXX=${CXX} SYSTEMD=${SYSTEMD} ${MAKE}
+ 
+ .PHONY: build_lib_testall
+ build_lib_testall: build_deps_debug
+@@ -285,11 +287,11 @@ build_lib_debug_default: build_deps_debug_default
+ 
+ .PHONY: build_src_default
+ build_src_default: build_lib_default
+-	cd src && OPTZ="${O2} -ggdb" PROXYSQLCLICKHOUSE=1 CC=${CC} CXX=${CXX} ${MAKE}
++	cd src && OPTZ="${O2} -ggdb" PROXYSQLCLICKHOUSE=1 CC=${CC} CXX=${CXX} SYSTEMD=${SYSTEMD} ${MAKE}
+ 
+ .PHONY: build_src_debug_default
+ build_src_debug_default: build_lib_debug_default
+-	cd src && OPTZ="${O0} -ggdb -DDEBUG" PROXYSQLCLICKHOUSE=1 CC=${CC} CXX=${CXX} ${MAKE}
++	cd src && OPTZ="${O0} -ggdb -DDEBUG" PROXYSQLCLICKHOUSE=1 CC=${CC} CXX=${CXX} SYSTEMD=${SYSTEMD} ${MAKE}
+ 
+ 
+ ### packaging targets
+diff --git a/src/Makefile b/src/Makefile
+index d4b3fe837..a0fcd8f3d 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -78,6 +78,9 @@ ifeq ($(CXX),clang++)
+ endif
+ MYCXXFLAGS += $(IDIRS) $(OPTZ) $(DEBUG) $(PSQLCH) -DGITVERSION=\"$(GIT_VERSION)\" $(NOJEM) $(WGCOV) $(WASAN)
+ 
++ifeq ($(SYSTEMD),1)
++	CXXFLAGS+= -DSYSTEMD
++endif
+ 
+ STATICMYLIBS := -Wl,-Bstatic \
+ 				-lconfig \
+@@ -130,6 +133,10 @@ ifeq ($(CENTOSVER),6)
+ 	MYLIBS += -lgcrypt
+ endif
+ 
++ifeq ($(SYSTEMD),1)
++	MYLIBS+= -lsystemd
++endif
++
+ LIBPROXYSQLAR := $(PROXYSQL_LDIR)/libproxysql.a
+ ifeq ($(UNAME_S),Darwin)
+ 	LIBPROXYSQLAR += $(JEMALLOC_LDIR)/libjemalloc.a
+diff --git a/src/main.cpp b/src/main.cpp
+index aa78d0f79..b57a58964 100644
+--- a/src/main.cpp
++++ b/src/main.cpp
+@@ -15,6 +15,10 @@ using json = nlohmann::json;
+ #include <sys/stat.h>
+ #include <fcntl.h>
+ 
++#ifdef SYSTEMD
++#include <systemd/sd-daemon.h>
++#endif
++
+ //#define PROXYSQL_EXTERN
+ #include "cpp.h"
+ 
+@@ -2962,6 +2966,12 @@ int main(int argc, const char * argv[]) {
+ 
+ 		} else if (pid) { /* The parent */
+ 
++#ifdef SYSTEMD
++			proxy_info("Systemd sd_notify enabled\n");
++			sd_notifyf(0, "READY=1\n"
++			"STATUS=ProxySQL is now processing requests...");
++#endif
++
+ 			ProxySQL_daemonize_wait_daemon();
+ 
+ 		} else { /* The daemon */
+@@ -2984,6 +2994,11 @@ int main(int argc, const char * argv[]) {
+ 
+ 	} else {
+ 		GloAdmin->flush_error_log();
++#ifdef SYSTEMD
++		proxy_info("Systemd sd_notify enabled\n");
++		sd_notifyf(0, "READY=1\n"
++		"STATUS=ProxySQL is now processing requests...");
++#endif
+ 		GloVars.install_signal_handler();
+ 	}
+ 
+@@ -3018,6 +3033,10 @@ __start_label:
+ 
+ __shutdown:
+ 
++#ifdef SYSTEMD
++	sd_notify(0, "STOPPING=1");
++#endif
++
+ 	proxy_info("Starting shutdown...\n");
+ 
+ 	// First shutdown step is to unload plugins
+diff --git a/systemd/system/proxysql.service b/systemd/system/proxysql.service
+index 6506a57b1..7469fe041 100644
+--- a/systemd/system/proxysql.service
++++ b/systemd/system/proxysql.service
+@@ -3,7 +3,7 @@ Description=High Performance Advanced Proxy for MySQL
+ After=network.target
+ 
+ [Service]
+-Type=forking
++Type=notify
+ RuntimeDirectory=proxysql
+ #PermissionsStartOnly=true
+ #ExecStartPre=/usr/bin/mkdir -p /var/run/proxysql /var/run/proxysql
+-- 
+2.34.1
+

--- a/debian/local_builder/proxysql/Dockerfile
+++ b/debian/local_builder/proxysql/Dockerfile
@@ -1,0 +1,75 @@
+ARG KNK_REGISTRY_URL=ghcr.io/inverse-inc/packetfence
+ARG IMAGE_TAG=devel
+ARG PROXYSQL_VERSION=3.0.5
+ARG PROXYSQL_BRANCH=v3.0.5
+ARG from=${KNK_REGISTRY_URL}/pfbuild-debian-bookworm:${IMAGE_TAG}
+
+FROM ${from} AS build
+
+ARG PROXYSQL_VERSION
+ARG PROXYSQL_BRANCH
+ENV MAKE=make
+ENV CURVER=${PROXYSQL_VERSION}
+ENV PKG_RELEASE=debian12
+ENV PROXYSQL_BUILD_TYPE=clickhouse
+ENV BLD_NAME=proxysql
+ENV CC=cc
+ENV CXX=g++
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Install build dependencies based on version
+COPY generate-deps.sh install-deps.sh /tmp/
+RUN chmod +x /tmp/*.sh && \
+    /tmp/generate-deps.sh > /tmp/deps.conf && \
+    /tmp/install-deps.sh "${PROXYSQL_VERSION}" /tmp/deps.conf
+
+WORKDIR /opt
+
+# Clone and build pxc_scheduler_handler
+ARG source_pxc=https://github.com/fdurand/pxc_scheduler_handler.git
+ARG COMMIT_ID_PXC=1ee986f38e48607d1f5ed51242ebbf8fb3ec5e2e
+RUN git clone -qq ${source_pxc}
+WORKDIR pxc_scheduler_handler
+RUN git checkout $COMMIT_ID_PXC && go build
+
+# Clone proxysql from upstream
+ARG source=https://github.com/sysown/proxysql.git
+WORKDIR /opt
+RUN mkdir -p /root/ctl && git clone -qq ${source}
+WORKDIR proxysql
+RUN git checkout ${PROXYSQL_BRANCH}
+
+# Apply the sd_notify patch (version-specific)
+COPY 0001-sd_notify-patch-*.patch /tmp/
+RUN MAJOR_MINOR=$(echo ${CURVER} | cut -d. -f1,2) && \
+    PATCH_FILE="/tmp/0001-sd_notify-patch-${MAJOR_MINOR}.patch" && \
+    if [ -f "$PATCH_FILE" ]; then \
+        echo "Applying patch: $PATCH_FILE"; \
+        git apply "$PATCH_FILE"; \
+    else \
+        PATCH_FILE="/tmp/0001-sd_notify-patch-${CURVER}.patch"; \
+        if [ -f "$PATCH_FILE" ]; then \
+            echo "Applying patch: $PATCH_FILE"; \
+            git apply "$PATCH_FILE"; \
+        else \
+            echo "ERROR: No patch file found for version ${CURVER}"; \
+            exit 1; \
+        fi; \
+    fi
+
+# Build the server
+RUN if [ -d "docker/images/proxysql/deb-compliant/ctl" ]; then \
+        cp -r docker/images/proxysql/deb-compliant/ctl/* /root/ctl/; \
+    else \
+        cp -r docker/images/proxysql/deb-compliant/latest-package/ctl/* /root/ctl/; \
+    fi
+RUN MAKEOPT="-j$(nproc)" docker/images/proxysql/deb-compliant/entrypoint/entrypoint.bash
+
+# Final stage - minimal image with artifacts
+ARG KNK_REGISTRY_URL
+ARG IMAGE_TAG
+FROM ${KNK_REGISTRY_URL}/pfdebian:${IMAGE_TAG}
+
+COPY --from=build /opt/pxc_scheduler_handler/pxc_scheduler_handler /pxc_scheduler_handler
+COPY --from=build /opt/proxysql/binaries/*.deb /tmp/

--- a/debian/local_builder/proxysql/Dockerfile
+++ b/debian/local_builder/proxysql/Dockerfile
@@ -66,6 +66,31 @@ RUN if [ -d "docker/images/proxysql/deb-compliant/ctl" ]; then \
     fi
 RUN MAKEOPT="-j$(nproc)" docker/images/proxysql/deb-compliant/entrypoint/entrypoint.bash
 
+# Fix file paths for older versions (2.x has files at wrong locations in deb)
+RUN MAJOR=$(echo ${CURVER} | cut -d. -f1) && \
+    if [ "$MAJOR" = "2" ]; then \
+        DEB_FILE=$(ls binaries/proxysql_*.deb | head -1) && \
+        TMPDIR=$(mktemp -d) && \
+        dpkg-deb -R "$DEB_FILE" "$TMPDIR" && \
+        FIXED=0 && \
+        if [ -f "$TMPDIR/proxysql.cnf" ]; then \
+            mkdir -p "$TMPDIR/etc" && \
+            mv "$TMPDIR/proxysql.cnf" "$TMPDIR/etc/proxysql.cnf" && \
+            FIXED=1; \
+        fi && \
+        if [ -f "$TMPDIR/lib/proxysql.service" ]; then \
+            mkdir -p "$TMPDIR/lib/systemd/system" && \
+            mv "$TMPDIR/lib/proxysql.service" "$TMPDIR/lib/systemd/system/" && \
+            mv "$TMPDIR/lib/proxysql-initial.service" "$TMPDIR/lib/systemd/system/" 2>/dev/null || true && \
+            FIXED=1; \
+        fi && \
+        if [ "$FIXED" = "1" ]; then \
+            dpkg-deb -b "$TMPDIR" "$DEB_FILE" && \
+            echo "Fixed file paths in deb"; \
+        fi && \
+        rm -rf "$TMPDIR"; \
+    fi
+
 # Final stage - minimal image with artifacts
 ARG KNK_REGISTRY_URL
 ARG IMAGE_TAG

--- a/debian/local_builder/proxysql/Dockerfile_test
+++ b/debian/local_builder/proxysql/Dockerfile_test
@@ -1,0 +1,52 @@
+ARG OPENSSL_VERSION=3.2.3
+ARG PROXYSQL_VERSION=3.0.5
+
+# Stage 1: Build OpenSSL 3.2+ from source (only used for v3+)
+FROM debian:12 AS openssl-builder
+
+ARG OPENSSL_VERSION
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    wget \
+    ca-certificates \
+    perl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /tmp
+
+RUN wget -q https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz \
+    && tar xzf openssl-${OPENSSL_VERSION}.tar.gz \
+    && cd openssl-${OPENSSL_VERSION} \
+    && ./config --prefix=/opt/openssl --openssldir=/opt/openssl shared \
+    && make -j$(nproc) \
+    && make install_sw \
+    && cd .. \
+    && rm -rf openssl-${OPENSSL_VERSION}*
+
+# Stage 2: Test the proxysql deb
+FROM debian:12
+
+ARG PROXYSQL_VERSION
+ARG DEB_FILE
+
+# Copy OpenSSL 3.2+ libraries from builder (only for v3+)
+COPY --from=openssl-builder /opt/openssl/lib64 /opt/openssl/lib64
+
+# Configure library path for OpenSSL 3.2+ only if v3+
+RUN MAJOR_VERSION=$(echo ${PROXYSQL_VERSION} | cut -d. -f1) && \
+    if [ "$MAJOR_VERSION" -ge 3 ]; then \
+        echo "/opt/openssl/lib64" > /etc/ld.so.conf.d/openssl.conf && ldconfig; \
+    fi
+
+# Install dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libgnutls30 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy and install the proxysql deb
+COPY ${DEB_FILE} /tmp/
+RUN apt-get update && apt-get install -y -f /tmp/${DEB_FILE}
+
+# Check version
+CMD ["/usr/bin/proxysql", "--version"]

--- a/debian/local_builder/proxysql/cli.sh
+++ b/debian/local_builder/proxysql/cli.sh
@@ -5,18 +5,25 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 UPSTREAM_REPO="https://github.com/sysown/proxysql.git"
 
+PROXYSQL_VERSION=""
+PROXYSQL_TAG=""
+
 usage() {
-    echo "Usage: $0 [-f|--force] <PROXYSQL_VERSION> [PROXYSQL_TAG]"
+    echo "Usage: $0 [OPTIONS] (--proxysql VERSION | --proxysql-tag TAG)"
     echo ""
-    echo "Arguments:"
-    echo "  -f, --force       Force rebuild (no cache)"
-    echo "  PROXYSQL_VERSION  Version number for the package (e.g., 3.0.5)"
-    echo "  PROXYSQL_TAG      Git tag to build from (default: v<PROXYSQL_VERSION>)"
+    echo "Required (one of):"
+    echo "  --proxysql VERSION   ProxySQL version to build (e.g., 3.0.5) -> uses tag v3.0.5"
+    echo "  --proxysql-tag TAG   ProxySQL git tag to build (e.g., v3.0.5) -> uses version 3.0.5"
     echo ""
-    echo "Example:"
-    echo "  $0 3.0.5              # Uses tag v3.0.5"
-    echo "  $0 3.0.5 v3.0.5       # Explicit tag"
-    echo "  $0 -f 3.0.5           # Force rebuild"
+    echo "Options:"
+    echo "  -f, --force          Force rebuild (no cache)"
+    echo "  -h, --help           Show this help"
+    echo ""
+    echo "Examples:"
+    echo "  $0 --proxysql 3.0.5        # Build v3.0.5"
+    echo "  $0 --proxysql-tag v3.0.5   # Same as above (using tag)"
+    echo "  $0 --proxysql 2.6.3        # Build v2.6.3"
+    echo "  $0 -f --proxysql 3.0.5     # Force rebuild (no cache)"
     exit 1
 }
 
@@ -28,23 +35,48 @@ while [[ $# -gt 0 ]]; do
             FORCE_BUILD="--no-cache"
             shift
             ;;
+        --proxysql)
+            PROXYSQL_VERSION="$2"
+            shift 2
+            ;;
+        --proxysql-tag)
+            PROXYSQL_TAG="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            ;;
         -*)
             echo "Unknown option: $1"
             usage
             ;;
         *)
-            break
+            echo "Unknown argument: $1"
+            usage
             ;;
     esac
 done
 
-# Check arguments
-if [[ $# -lt 1 || $# -gt 2 ]]; then
+# Check required arguments - need either version or tag
+if [[ -z "${PROXYSQL_VERSION}" && -z "${PROXYSQL_TAG}" ]]; then
+    echo "Error: --proxysql VERSION or --proxysql-tag TAG is required"
+    echo ""
     usage
 fi
 
-PROXYSQL_VERSION="$1"
-PROXYSQL_TAG="${2:-v${PROXYSQL_VERSION}}"
+if [[ -n "${PROXYSQL_VERSION}" && -n "${PROXYSQL_TAG}" ]]; then
+    echo "Error: Use --proxysql VERSION or --proxysql-tag TAG, not both"
+    echo ""
+    usage
+fi
+
+# Derive the missing value
+if [[ -n "${PROXYSQL_VERSION}" ]]; then
+    PROXYSQL_TAG="v${PROXYSQL_VERSION}"
+else
+    # Extract version from tag (strip leading 'v' if present)
+    PROXYSQL_VERSION="${PROXYSQL_TAG#v}"
+fi
 
 # Check if Dockerfile exists
 DOCKERFILE="${SCRIPT_DIR}/Dockerfile"
@@ -101,20 +133,36 @@ echo ""
 echo "Done! Deb file extracted to: ${SCRIPT_DIR}/"
 ls -la "${SCRIPT_DIR}"/*.deb
 
-# Verify the build by installing in a clean Ubuntu container
-TEST_IMAGE="ubuntu:24.04"
+# Verify the build by installing in a test container
 echo ""
-echo "Verifying build in ${TEST_IMAGE}..."
+echo "Verifying build..."
 DEB_FILE=$(ls "${SCRIPT_DIR}"/proxysql_${PROXYSQL_VERSION}*.deb 2>/dev/null | head -1)
+MAJOR_VERSION="${PROXYSQL_VERSION%%.*}"
+
 if [[ -n "${DEB_FILE}" ]]; then
-    echo "Testing: ${DEB_FILE}"
-    docker run --rm -v "${DEB_FILE}:/tmp/proxysql.deb:ro" "${TEST_IMAGE}" bash -c '
-        apt-get update -qq
-        apt-get install -y -qq libssl3 libgnutls30 >/dev/null 2>&1
-        dpkg-deb -x /tmp/proxysql.deb /
-        echo "ProxySQL version:"
-        /usr/bin/proxysql --version
-    '
+    DEB_FILENAME=$(basename "${DEB_FILE}")
+    echo "Testing: ${DEB_FILENAME}"
+
+    if [[ "$MAJOR_VERSION" -ge 3 ]]; then
+        # v3+ needs OpenSSL 3.2+, use Dockerfile_test with multi-stage build
+        echo "ProxySQL v3+ detected, building with OpenSSL 3.2+"
+        docker build \
+            --build-arg DEB_FILE="${DEB_FILENAME}" \
+            --build-arg PROXYSQL_VERSION="${PROXYSQL_VERSION}" \
+            -f "${SCRIPT_DIR}/Dockerfile_test" \
+            -t proxysql-test \
+            "${SCRIPT_DIR}"
+        docker run --rm proxysql-test
+    else
+        # v2.x uses system OpenSSL, simple inline test
+        echo "ProxySQL v2.x detected, using system OpenSSL"
+        docker run --rm -v "${DEB_FILE}:/tmp/proxysql.deb:ro" debian:12 bash -c '
+            apt-get update -qq
+            apt-get install -y -qq libssl3 libgnutls30 >/dev/null 2>&1
+            apt-get install -y -f /tmp/proxysql.deb
+            /usr/bin/proxysql --version
+        '
+    fi
 else
     echo "ERROR: No deb file found for version ${PROXYSQL_VERSION}"
 fi

--- a/debian/local_builder/proxysql/cli.sh
+++ b/debian/local_builder/proxysql/cli.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+UPSTREAM_REPO="https://github.com/sysown/proxysql.git"
+
+usage() {
+    echo "Usage: $0 [-f|--force] <PROXYSQL_VERSION> [PROXYSQL_TAG]"
+    echo ""
+    echo "Arguments:"
+    echo "  -f, --force       Force rebuild (no cache)"
+    echo "  PROXYSQL_VERSION  Version number for the package (e.g., 3.0.5)"
+    echo "  PROXYSQL_TAG      Git tag to build from (default: v<PROXYSQL_VERSION>)"
+    echo ""
+    echo "Example:"
+    echo "  $0 3.0.5              # Uses tag v3.0.5"
+    echo "  $0 3.0.5 v3.0.5       # Explicit tag"
+    echo "  $0 -f 3.0.5           # Force rebuild"
+    exit 1
+}
+
+# Parse options
+FORCE_BUILD=""
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -f|--force)
+            FORCE_BUILD="--no-cache"
+            shift
+            ;;
+        -*)
+            echo "Unknown option: $1"
+            usage
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+# Check arguments
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+    usage
+fi
+
+PROXYSQL_VERSION="$1"
+PROXYSQL_TAG="${2:-v${PROXYSQL_VERSION}}"
+
+# Check if Dockerfile exists
+DOCKERFILE="${SCRIPT_DIR}/Dockerfile"
+if [[ ! -f "${DOCKERFILE}" ]]; then
+    echo "Error: Dockerfile not found: ${DOCKERFILE}"
+    exit 1
+fi
+
+# Check if patch file exists (version-specific)
+MAJOR_MINOR="${PROXYSQL_VERSION%.*}"
+PATCH_FILE="${SCRIPT_DIR}/0001-sd_notify-patch-${MAJOR_MINOR}.patch"
+if [[ ! -f "${PATCH_FILE}" ]]; then
+    # Try exact version
+    PATCH_FILE="${SCRIPT_DIR}/0001-sd_notify-patch-${PROXYSQL_VERSION}.patch"
+    if [[ ! -f "${PATCH_FILE}" ]]; then
+        echo "Error: No patch file found for version ${PROXYSQL_VERSION}"
+        echo "Expected: 0001-sd_notify-patch-${MAJOR_MINOR}.patch or 0001-sd_notify-patch-${PROXYSQL_VERSION}.patch"
+        echo "Available patches:"
+        ls -1 "${SCRIPT_DIR}"/0001-sd_notify-patch-*.patch 2>/dev/null || echo "  (none)"
+        exit 1
+    fi
+fi
+echo "Using patch: $(basename ${PATCH_FILE})"
+
+# Check if tag exists in the upstream repo
+echo "Checking if tag '${PROXYSQL_TAG}' exists in upstream..."
+if ! git ls-remote --exit-code --tags "${UPSTREAM_REPO}" "${PROXYSQL_TAG}" > /dev/null 2>&1; then
+    echo "Error: Tag '${PROXYSQL_TAG}' does not exist in ${UPSTREAM_REPO}"
+    echo ""
+    echo "Available v${PROXYSQL_VERSION%%.*}.x tags:"
+    git ls-remote --tags "${UPSTREAM_REPO}" | grep "refs/tags/v${PROXYSQL_VERSION%%.*}\." | sed 's/.*refs\/tags\//  /' | grep -v '\^{}' | tail -10
+    exit 1
+fi
+echo "Tag '${PROXYSQL_TAG}' found."
+
+# Build the image
+echo "Building Docker image with PROXYSQL_VERSION=${PROXYSQL_VERSION} PROXYSQL_TAG=${PROXYSQL_TAG}..."
+docker build ${FORCE_BUILD} \
+    --build-arg PROXYSQL_VERSION="${PROXYSQL_VERSION}" \
+    --build-arg PROXYSQL_BRANCH="${PROXYSQL_TAG}" \
+    -t local/proxysql \
+    -f "${DOCKERFILE}" \
+    "${SCRIPT_DIR}"
+
+# Extract the deb file using docker cp (distroless images have no shell)
+echo "Extracting .deb file..."
+CONTAINER_ID=$(docker create local/proxysql)
+docker cp "${CONTAINER_ID}:/tmp/." "${SCRIPT_DIR}/tmp_deb/"
+docker rm "${CONTAINER_ID}" > /dev/null
+mv "${SCRIPT_DIR}"/tmp_deb/*.deb "${SCRIPT_DIR}/"
+rm -rf "${SCRIPT_DIR}/tmp_deb"
+
+echo ""
+echo "Done! Deb file extracted to: ${SCRIPT_DIR}/"
+ls -la "${SCRIPT_DIR}"/*.deb
+
+# Verify the build by installing in a clean Ubuntu container
+TEST_IMAGE="ubuntu:24.04"
+echo ""
+echo "Verifying build in ${TEST_IMAGE}..."
+DEB_FILE=$(ls "${SCRIPT_DIR}"/proxysql_${PROXYSQL_VERSION}*.deb 2>/dev/null | head -1)
+if [[ -n "${DEB_FILE}" ]]; then
+    echo "Testing: ${DEB_FILE}"
+    docker run --rm -v "${DEB_FILE}:/tmp/proxysql.deb:ro" "${TEST_IMAGE}" bash -c '
+        apt-get update -qq
+        apt-get install -y -qq libssl3 libgnutls30 >/dev/null 2>&1
+        dpkg-deb -x /tmp/proxysql.deb /
+        echo "ProxySQL version:"
+        /usr/bin/proxysql --version
+    '
+else
+    echo "ERROR: No deb file found for version ${PROXYSQL_VERSION}"
+fi

--- a/debian/local_builder/proxysql/generate-deps.sh
+++ b/debian/local_builder/proxysql/generate-deps.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Generate deps.conf for proxysql build dependencies
+set -e
+
+usage() {
+    echo "Usage: $0 [-h|--help] [output_file]"
+    echo ""
+    echo "Generate deps.conf for proxysql build dependencies."
+    echo ""
+    echo "Options:"
+    echo "  -h, --help    Show this help message"
+    echo ""
+    echo "Arguments:"
+    echo "  output_file   Output file (default: stdout)"
+    echo ""
+    echo "Examples:"
+    echo "  $0                    # Print to stdout"
+    echo "  $0 deps.conf          # Write to deps.conf"
+    echo "  $0 /tmp/deps.conf     # Write to /tmp/deps.conf"
+    exit 0
+}
+
+case "${1:-}" in
+    -h|--help)
+        usage
+        ;;
+esac
+
+OUTPUT="${1:-/dev/stdout}"
+
+cat > "$OUTPUT" << 'EOF'
+# ProxySQL build dependencies by major version
+# Format: VERSION_PATTERN|package1 package2 package3 ...
+
+# Common base dependencies for all versions
+BASE|automake cmake equivs g++ gawk gcc gdb gdbserver git libgnutls28-dev libmariadb-dev libssl-dev libtool make python3 uuid-dev libsystemd-dev systemd
+
+# 3.x requires additional packages
+3.*|bison bzip2 flex libevent-dev libicu-dev libncurses-dev libtirpc-dev libunwind-dev libunwind8 openssl
+
+# 2.x has fewer requirements
+2.*|bzip2
+EOF
+
+if [[ "$OUTPUT" != "/dev/stdout" ]]; then
+    echo "Generated: $OUTPUT" >&2
+fi

--- a/debian/local_builder/proxysql/install-deps.sh
+++ b/debian/local_builder/proxysql/install-deps.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# Install build dependencies based on version from deps.conf
+set -e
+
+usage() {
+    echo "Usage: $0 [-h|--help] [-n|--dry-run] [-v|--verbose] <version> [deps.conf]"
+    echo ""
+    echo "Install build dependencies based on version from deps.conf."
+    echo ""
+    echo "Options:"
+    echo "  -h, --help     Show this help message"
+    echo "  -n, --dry-run  Show packages without installing"
+    echo "  -v, --verbose  Show pattern matching debug"
+    echo ""
+    echo "Arguments:"
+    echo "  version        ProxySQL version (e.g., 3.0.5, 2.6.0)"
+    echo "  deps.conf      Dependencies file (default: /tmp/deps.conf)"
+    echo ""
+    echo "Examples:"
+    echo "  $0 3.0.5                          # Install deps for 3.0.5"
+    echo "  $0 -n 3.0.5 deps.conf             # Dry-run with custom file"
+    echo "  $0 -v -n 2.6.0 /tmp/deps.conf     # Verbose dry-run"
+    exit 0
+}
+
+DRY_RUN=0
+VERBOSE=0
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -h|--help)
+            usage
+            ;;
+        -n|--dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        -v|--verbose)
+            VERBOSE=1
+            shift
+            ;;
+        -*)
+            echo "Unknown option: $1" >&2
+            echo "Usage: $0 [-h|--help] [-n|--dry-run] [-v|--verbose] <version> [deps.conf]" >&2
+            exit 1
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+VERSION="$1"
+DEPS_FILE="${2:-/tmp/deps.conf}"
+
+if [[ -z "$VERSION" ]]; then
+    echo "Usage: $0 [-n|--dry-run] [-v|--verbose] <version> [deps.conf]" >&2
+    exit 1
+fi
+
+if [[ ! -f "$DEPS_FILE" ]]; then
+    echo "Error: deps.conf not found at $DEPS_FILE" >&2
+    exit 1
+fi
+
+[[ $VERBOSE -eq 1 ]] && echo "Reading dependencies from: $DEPS_FILE"
+[[ $VERBOSE -eq 1 ]] && echo "Version: $VERSION"
+
+PACKAGES=""
+
+# Read deps.conf and collect packages
+while IFS='|' read -r pattern packages; do
+    # Skip comments and empty lines
+    [[ "$pattern" =~ ^#.*$ || -z "$pattern" ]] && continue
+
+    # Check if pattern matches
+    if [[ "$pattern" == "BASE" ]]; then
+        [[ $VERBOSE -eq 1 ]] && echo "Matched BASE: $packages"
+        PACKAGES="$PACKAGES $packages"
+    elif [[ "$VERSION" == $pattern ]]; then
+        [[ $VERBOSE -eq 1 ]] && echo "Matched $pattern: $packages"
+        PACKAGES="$PACKAGES $packages"
+    fi
+done < "$DEPS_FILE"
+
+# Remove leading/trailing whitespace and duplicates
+PACKAGES=$(echo "$PACKAGES" | tr ' ' '\n' | sort -u | tr '\n' ' ')
+
+echo "Dependencies for version $VERSION:"
+echo "$PACKAGES"
+echo ""
+
+if [[ $DRY_RUN -eq 1 ]]; then
+    echo "[DRY-RUN] Would run: apt-get install -y $PACKAGES"
+    exit 0
+fi
+
+# Check if apt-get is available
+if ! command -v apt-get &> /dev/null; then
+    echo "Warning: apt-get not found, skipping installation" >&2
+    echo "Packages needed: $PACKAGES"
+    exit 0
+fi
+
+apt-get update
+apt-get install -y $PACKAGES
+apt-get clean
+rm -rf /var/lib/apt/lists/


### PR DESCRIPTION
# Description
Add version pinning for proxysql container and a local deb builder to build proxysql packages from upstream (sysown) with the sd_notify patch applied.

This change addresses the need to:
1. Pin the proxysql package version in the container Dockerfile to ensure reproducible builds
2. Provide a local builder infrastructure to create custom proxysql deb packages with the sd_notify patch, allowing for better systemd integration

# Impacts
- **Container build**: The proxysql Dockerfile now requires a `PROXYSQL_VERSION` build argument (defaults to `3.0.5`)
- **Local builder**: New `debian/local_builder/proxysql/` directory with:
  - `cli.sh` - Main build script to build proxysql deb packages
  - `Dockerfile` - Multi-stage build to compile proxysql from source
  - `generate-deps.sh` / `install-deps.sh` - Dependency management scripts
  - `0001-sd_notify-patch-2.6.patch` and `0001-sd_notify-patch-3.0.patch` - Patches for sd_notify support

# NEW Package(s) required
None - this uses existing dependencies (Docker for building)

# Delete branch after merge
YES

# NEWS file entries
## Enhancements
* Pin proxysql package version in container for reproducible builds
* Add local deb builder for proxysql with sd_notify patch support

# Fixes
* Fixes #8342 