### PR TITLE
Better detection of the unifi controller and rely on the cookie to reconnect.

### DIFF
--- a/lib/pf/Switch/Ubiquiti/Unifi.pm
+++ b/lib/pf/Switch/Ubiquiti/Unifi.pm
@@ -268,6 +268,10 @@ sub _deauthenticateMacWithHTTP {
 
     my $response = $ua->get("$base_url/api/self/sites");
 
+    if ($response->code == 404) {
+        $response = $ua->get("$base_url/proxy/network/api/self/sites");
+    }
+
     unless($response->is_success) {
         $logger->error("Can't have the site list from the Unifi controller: ".$response->status_line);
         return;
@@ -384,12 +388,14 @@ sub populateAccessPointMACIP {
 
     my $response = $ua->get("$base_url/api/self/sites");
 
+    if ($response->code == 404) {
+        $response = $ua->get("$base_url/proxy/network/api/self/sites");
+    }
+
     unless($response->is_success) {
         $logger->error("Can't have the site list from the Unifi controller: ".$response->status_line);
         return;
     }
-
-    $response = $ua->get("$base_url/api/self/sites");
 
     my $json_data = decode_json($response->decoded_content());
 

--- a/lib/pf/Switch/Ubiquiti/Unifi.pm
+++ b/lib/pf/Switch/Ubiquiti/Unifi.pm
@@ -206,32 +206,23 @@ sub _connect {
         # New UniFi OS controller (UDM, UDM Pro, etc.)
         $login_path = "/api/auth/login";
         $api_prefix = "/proxy/network";
-        $cookie_invalid = ($response->code == 401);
+        $cookie_invalid = ($response->code == 401) ? $TRUE : $FALSE;
     } else {
         # Old controller on port 8443
         $base_url .= ":8443";
         # Check if cookie is still valid for old controller
         $response = $ua->get($base_url."/api/self");
-        $cookie_invalid = ($response->code == 401);
+        $cookie_invalid = ($response->code == 401) ? $TRUE : $FALSE;
     }
-
-    my $cache = $self->cache;
-
-    # Check if we need to authenticate:
-    # - No cached auth or auth is FALSE
-    # - Or cookie is expired/invalid (even if cache says authenticated)
-    my $auth = $cache->get("Ubiquiti-" . $controllerIp ."-auth");
-    my $need_auth = (!defined($auth) || $auth == $FALSE || $cookie_invalid);
-
-    if ($need_auth) {
+    if ($cookie_invalid) {
+        # Clear old cookies before re-authenticating to avoid sending invalid session
+        $ua->cookie_jar->clear();
         $response = $ua->post($base_url.$login_path, Content => '{"username":"'.$username.'", "password":"'.$password.'", "remember": "true"}');
 
         unless($response->is_success) {
             $logger->error("Can't login on the Unifi controller: ".$response->status_line);
-            $cache->set("Ubiquiti-" . $controllerIp ."-auth" , $FALSE );
             die;
         }
-        $cache->set("Ubiquiti-" . $controllerIp ."-auth" , $TRUE ,{ expires_in => "10m" } );
     }
     return ($ua, $base_url.$api_prefix);
 }

--- a/lib/pf/Switch/Ubiquiti/Unifi.pm
+++ b/lib/pf/Switch/Ubiquiti/Unifi.pm
@@ -200,18 +200,30 @@ sub _connect {
     my $api_prefix = "";
 
     my $response = $ua->get($base_url."/proxy/network/status");
+    my $cookie_invalid = $FALSE;
 
-    if ($response->code == 401) {
+    if ($response->code == 401 || $response->is_success) {
+        # New UniFi OS controller (UDM, UDM Pro, etc.)
         $login_path = "/api/auth/login";
         $api_prefix = "/proxy/network";
+        $cookie_invalid = ($response->code == 401);
     } else {
+        # Old controller on port 8443
         $base_url .= ":8443";
+        # Check if cookie is still valid for old controller
+        $response = $ua->get($base_url."/api/self");
+        $cookie_invalid = ($response->code == 401);
     }
 
     my $cache = $self->cache;
 
+    # Check if we need to authenticate:
+    # - No cached auth or auth is FALSE
+    # - Or cookie is expired/invalid (even if cache says authenticated)
     my $auth = $cache->get("Ubiquiti-" . $controllerIp ."-auth");
-    if (!defined($auth) || $auth == $FALSE) {
+    my $need_auth = (!defined($auth) || $auth == $FALSE || $cookie_invalid);
+
+    if ($need_auth) {
         $response = $ua->post($base_url.$login_path, Content => '{"username":"'.$username.'", "password":"'.$password.'", "remember": "true"}');
 
         unless($response->is_success) {


### PR DESCRIPTION
# Description
Reworked the connection code in the Unifi module in order to detect correctly the old and new controller.
Removed the cache usage and just rely on the cookie.

# Impacts
Ubiquiti webauth reevaluation

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* Better detection between old and new unifi controller and rely on the cookie to handle re-connection.