### PR TITLE
fix(vagrant): use legacy GPG key for Samba 4.16 deployment

### DIFF
--- a/addons/vagrant/playbooks/linux_servers/samba4ad.yml
+++ b/addons/vagrant/playbooks/linux_servers/samba4ad.yml
@@ -46,7 +46,7 @@
   
     - name: Download file with check (sha256)
       ansible.builtin.get_url:
-        url: http://samba.tranquil.it/tissamba-pubkey.gpg
+        url: http://samba.tranquil.it/tissamba-pubkey-2017.gpg
         dest: /root/tissamba-pubkey.gpg
         checksum: sha256:bd0f7140edd098031fcb36106b24a6837b067f1c847f72cf262fa012f14ce2dd
   


### PR DESCRIPTION
# Description
Use legacy GPG key (`tissamba-pubkey-2017.gpg`) for Samba 4.16 deployment on Debian 11 (bullseye).

Tranquil IT updated their main GPG key (`tissamba-pubkey.gpg`) for Samba 4.22+, causing checksum mismatch failures during Samba4 AD vagrant deployment. For Samba versions prior to 4.22.8, the legacy key must be used.

References:
- https://samba.tranquil.it/doc/fr/samba_config_server-server_install_samba_debian.html
- https://forum.tranquil.it/en/viewtopic.php?t=4566

# Impacts
- Vagrant Samba4 AD deployment (`addons/vagrant/playbooks/linux_servers/samba4ad.yml`)

# Issue
fixes #8925

# Delete branch after merge
YES

# Checklist
- [ ] CI tested

# NEWS file entries
## Bug Fixes
* Fixed Samba4 AD vagrant deployment failing due to updated Tranquil IT GPG key (#8925)