### PR TITLE
Update microsoft.asciidoc to avoid creating vulnerability in AD

### DIFF
--- a/docs/installation/pki/microsoft.asciidoc
+++ b/docs/installation/pki/microsoft.asciidoc
@@ -114,6 +114,14 @@ Right-click new template, select `Properties`. In `Subject Name` tab, select
 `Supplied in the request` over `Built from information in Active Directory` to
 prevent NDES from overwriting requested CN.
 
+IMPORTANT: In order to avoid creating an ESC1 privilege escalation vulnerability 
+in your AD domain, you must modify the enrollment rights for this template.
+Navigate to the security tab of the duplicate template, and remove the "domain users"
+group from the ACL. Next, add your NDES service account, and grant "read" and "enroll"
+rights. This ensures that NDES can request certificates for the authenticating users. 
+If you skip this step, any user in your AD domain can request an authentication certificate
+for a domain admin or domain controller, fully compromising your AD environment.
+
 Allow NDES template usage: navigate to `Server Manager->Roles->Active Directory
 Certificates Services`, expand `<ServerDNSName>`, right-click `Certificate
 template`, choose `New template to issue`, select the created template.


### PR DESCRIPTION
# Description
This is a change to the documentation for integrating with Active Directory Certificate Services for PKI, specifically in regards to configuring your ADCS certificate template. The current documentation instructs users to duplicate the "users" template, then modify the template to allow requests to specify the SAN in the request. If the instructions are followed to the letter, this creates a severe privilege escalation vulnerability in the user's AD domain. To maintain security, the user must remove enrollment rights form the "domain users" group, instead allowing only the NDES service principle to enroll.

# Impacts
The change specifically updates the documentation for duplicating the ADCS certificate. In the current state, an authenticated user in the AD domain would be able to enroll in the certificate template, as domain users have enrollment rights. However, they can also supply the SAN in the request. This means a malicious actor in control of a low level user account, could request a certificate for a domain administrator or domain controller, which can be used for authentication. This means ANY user would have the ability to fully take over the AD domain. Instead, only the service principle for NDES should have enrollment rights. PacketFence will send the request for a certificate for a particular user to NDES, and NDES will specify the SAN of that user in the request, thus obtaining the certificate.

For further reference on the exploitability and severity of this vulnerability, please reference the following link: https://www.blackhillsinfosec.com/abusing-active-directory-certificate-services-part-one/

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [n/a ] Document the feature
- [n/a ] Add OpenAPI specification
- [n/a ] Add unit tests
- [ n/a] Add acceptance tests (TestLink)