### PR TITLE
fix(services): fix _unitFileExists() for Docker and fix log string interpolation

### DIFF
--- a/lib/pf/services/manager.pm
+++ b/lib/pf/services/manager.pm
@@ -173,7 +173,7 @@ sub postStartCleanup {
     my ($self,$quick) = @_;
     my $logger = get_logger();
     unless ($self->pid) { 
-        $logger->error("$self->name died or has failed to start");
+        $logger->error($self->name . " died or has failed to start");
         return $FALSE;
     }
     return $TRUE;
@@ -346,7 +346,7 @@ sub postStopCleanup {
     my ($self,$quick) = @_;
     my $logger = get_logger();
     if ($self->pid) { 
-        $logger->error("$self->name failed to stop");
+        $logger->error($self->name . " failed to stop");
         return $FALSE;
     }
     return $TRUE;

--- a/lib/pf/services/manager.pm
+++ b/lib/pf/services/manager.pm
@@ -480,7 +480,13 @@ Check if a systemd unit file exists for the given target.
 sub _unitFileExists {
     my ($self, $target) = @_;
     $target //= $self->systemdTarget;
-    return system("sudo systemctl cat $target >/dev/null 2>&1") == 0;
+    # Use 'systemctl show' instead of 'systemctl cat' because
+    # 'systemctl cat' fails inside Docker containers while
+    # 'systemctl show' works via the D-Bus socket.
+    my $output = `sudo systemctl show -p LoadState $target 2>/dev/null`;
+    chomp $output;
+    my $load_state = (split(/=/, $output))[1];
+    return defined $load_state && $load_state ne 'not-found';
 }
 
 =head2 sysdEnable 

--- a/lib/pf/services/manager/netdata.pm
+++ b/lib/pf/services/manager/netdata.pm
@@ -55,7 +55,7 @@ sub postStartCleanup {
     my $logger = get_logger();
     sleep 40;
     unless ($self->pid) {
-        $logger->error("$self->name died or has failed to start");
+        $logger->error($self->name . " died or has failed to start");
         return $FALSE;
     }
     return $TRUE;


### PR DESCRIPTION
# Description
Fix `_unitFileExists()` method in the services manager to work inside Docker containers, and fix broken string interpolation in log messages.

The `systemctl cat` command fails inside Docker containers because it attempts to read unit files from disk. This replaces it with `systemctl show -p LoadState` which works via the D-Bus socket and is compatible with Docker environments.

Additionally, Perl log messages using `"$self->name ..."` do not interpolate method calls correctly. This fixes them to use proper concatenation: `$self->name . " ..."`.

# Impacts
- `lib/pf/services/manager.pm`: `_unitFileExists()` now uses `systemctl show` instead of `systemctl cat`
- `lib/pf/services/manager.pm`: Fixed string interpolation in `postStartCleanup` and `postStopCleanup` log messages
- `lib/pf/services/manager/netdata.pm`: Fixed string interpolation in `postStartCleanup` log message

# Issue
fixes #INV-196

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [n/a] Document the feature
- [n/a] Add OpenAPI specification
- [n/a] Add unit tests
- [n/a] Add acceptance tests (TestLink)

# NEWS file entries
## Bug Fixes
* Fixed `_unitFileExists()` failing inside Docker containers by using `systemctl show` instead of `systemctl cat` (INV-196)
* Fixed broken Perl string interpolation in service manager log messages
