### PR TITLE
Fix/8978 fix golang unit test

### DIFF
--- a/addons/dev-helpers/bin/switch_options_json.pl
+++ b/addons/dev-helpers/bin/switch_options_json.pl
@@ -73,7 +73,7 @@ for my $g (@groups) {
  
         my $name   = $switch_info->{value};
         my $module = "pf::Switch::${name}";
-	
+
         my $file = pod_where({-inc => 1}, $module);
         my $snmp = '';
         open(my $fh, '>', \$snmp);

--- a/bin/pf-check-requirements
+++ b/bin/pf-check-requirements
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -T
+#!/usr/bin/perl 
 =head1 NAME
 
 pf-check-requirements - Check system hardware requirements for PacketFence

--- a/t/venom/scenarios/unit_tests/playbooks/configure.yml
+++ b/t/venom/scenarios/unit_tests/playbooks/configure.yml
@@ -5,6 +5,13 @@
   collections:
     - inverse_inc.packetfence
 
+  tasks:
+    - name: Install tcpdump on EL8
+      yum:
+        name: tcpdump
+        state: present
+      when: ansible_distribution_major_version == "8"
+
   roles:
     - role: packetfence_go
       tags: go


### PR DESCRIPTION
# Description
Fix Golang unit tests on EL8 by installing the missing `tcpdump` dependency, fixing a compile error in `pf-check-requirements` caused by Perl taint mode (`-T` flag), and cleaning up whitespace (tabs) in `switch_options_json.pl`.

# Impacts
- Golang unit test execution on EL8 (tcpdump is now installed via Ansible)
- `pf-check-requirements` script compilation (removed `-T` taint mode flag)
- No functional changes to `switch_options_json.pl` (whitespace only)

# Issue
fixes #8978

# Delete branch after merge
YES

# Checklist
- [x] Document the feature - n/a
- [x] Add OpenAPI specification - n/a
- [x] Add unit tests - n/a (this PR fixes unit test infrastructure)
- [x] Add acceptance tests (TestLink) - n/a

# NEWS file entries
## Bug Fixes
* Fix Golang unit tests failing on EL8 due to missing tcpdump package (#8978)
* Fix compile error in pf-check-requirements by removing Perl taint mode flag