### PR TITLE
Optimize bulk_update for roles by reusing form and config store

### DIFF
--- a/html/pfappserver/lib/pfappserver/Form/Config/Roles.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Roles.pm
@@ -109,6 +109,12 @@ has_field 'inherit_web_auth_url' => (
     default => 'disabled',
 );
 
+has 'skip_role_acl_check' => (
+    is      => 'rw',
+    isa     => 'Bool',
+    default => 0,
+);
+
 =head2 validate
 
 Make sure none of the reserved names is used.
@@ -145,6 +151,8 @@ sub validate {
     if (!defined $acls || $acls eq '' ) {
         return;
     }
+
+    return if $self->skip_role_acl_check;
 
     $acls = [split(/\n/, $acls)];
     while (my ($switch_id, $data) = each %pf::SwitchFactory::SwitchConfig) {

--- a/lib/pf/UnifiedApi/Controller/Config.pm
+++ b/lib/pf/UnifiedApi/Controller/Config.pm
@@ -513,6 +513,17 @@ sub validate_item {
     return 422, { message => "Unable to validate", errors => $self->format_form_errors($form) }, undef;
 }
 
+sub bulk_validate_item {
+    my ($self, $item, $form) = @_;
+    $item = $self->cleanupItemForValidate($item);
+    $self->reset_form($form, $item);
+    $form->process($self->form_process_parameters_for_validation($item));
+    if (!$form->has_errors) {
+        return 200, $form->value, $form;
+    }
+
+    return 422, { message => "Unable to validate", errors => $self->format_form_errors($form) }, undef;
+}
 
 sub form_process_parameters_for_validation {
     my ($self, $item) = @_;
@@ -1265,7 +1276,13 @@ sub bulk_update {
     }
 
     my $items = $data->{items} // [];
-    return $self->bulk_action($items, "bulk_update_callback");
+    my ($status, $form) = $self->form({});
+    if (is_error($status)) {
+        return $self->render_error(422, "Unable to create form");
+    }
+
+    $form->skip_role_acl_check(1) if $form->can('skip_role_acl_check');
+    return $self->bulk_action($items, "bulk_update_callback", form => $form);
 }
 
 =head2 bulk_update_callback
@@ -1275,11 +1292,18 @@ bulk_update_callback
 =cut
 
 sub bulk_update_callback {
-    my ($self, $cs, $id, $item, $results) = @_;
-    my $old_item = $self->item($id);
+    my ($self, $cs, $id, $item, $results, $ctx) = @_;
+    my $old_item = $cs->read($id, 'id');
     my $new_item = {%$old_item, %$item};
     $new_item->{id} = $id;
-    my ($status, $new_data) = $self->validate_item($new_item);
+    my $form = $ctx->{form};
+    my ($status, $new_data);
+    if ($form) {
+        ($status, $new_data) = $self->bulk_validate_item($new_item, $form);
+    } else {
+        ($status, $new_data) = $self->validate_item($new_item);
+    }
+
     if (is_error($status)) {
         %$results = (%$results, %$new_data);
         return $status;
@@ -1329,7 +1353,7 @@ sub bulk_delete_callback {
 }
 
 sub bulk_action {
-    my ($self, $items, $action) = @_;
+    my ($self, $items, $action, %ctx) = @_;
     my $cs = $self->config_store;
     my @results;
     my $i = 0;
@@ -1356,7 +1380,7 @@ sub bulk_action {
             next;
         }
 
-        my $status = $self->$action($cs, $id, $item, \%results);
+        my $status = $self->$action($cs, $id, $item, \%results, \%ctx);
         if (is_success($status)) {
             $success++;
         }


### PR DESCRIPTION
# Description
Eliminate per-item form and ConfigStore instantiation in bulk_update:
- Read old items directly from the shared ConfigStore instead of creating new ConfigStore + form per item via item()
- Reuse a single form instance across all items via bulk_validate_item
- Skip the expensive per-switch ACL warning loop (warnings were never surfaced in bulk responses anyway; ACL syntax validation still runs)

Reduces object instantiations from ~2000 forms + ~2000 ConfigStores + up to R*S switch objects down to 1 form + 1 ConfigStore + 0 switches.
Reduce the time from 1m30s to ~30s to update more than 1000 roles

# Impacts
pfperl-api

# Issue
Takes more than 1 minutes and 30s to bulk update 1000 roles

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* Faster role bulk update
