### PR TITLE
INV-233: skip confirmation for package installation when building styles for docs. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ MINCSS = docs/styles/app.min.css
 
 docs/styles/%.min.css: docs/styles/%.css
 	@echo "Minify CSS styles for html docs: $<"
-	npx --package clean-css-cli cleancss --inline remote $< -o $@
+	npx --yes --package clean-css-cli cleancss --inline remote $< -o $@
 
 .PHONY: css
 css: $(MINCSS)


### PR DESCRIPTION

# Description
Fixed a Makefile command to build CSS assets for a documentation. The command uses a NPM package [clean-css-cli](https://www.npmjs.com/package/clean-css-cli) to minify CSS which will then used inline in `<style>`.

By default command `npx --package clean-css-cli cleancss --inline remote $< -o $@` asks for confirmation when package was not installed.

Need to add a flag `--yes` or `-y` to skip confirmation.

# Impacts
Since `htmlappserver` already uses NPM and node, it means that NPM and node libs already present on host. No impact. 

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ ] Clean NPM cache, run proper command with `npx --yes ...` verify that confirmation skipped.

If package `clean-css-cli` already installed, need to remove it from cache by:
- run `npm config get cache` get a folder and remove it ( or remove a target package )
- run command `npx --yes ...` to verify that package installed, styles generated and confirmation skipped. 
