### PR TITLE
USB bootable ISO: self-contained PacketFence installer for Debian 12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -320,3 +320,8 @@ containers/.local_env
 # venom test planning files (for local use only)
 t/venom/scenarios/*/PLAN_A.md
 t/venom/scenarios/*/PLAN_B.md
+
+# Temporary documentation files
+ISO_INSTALLATION_COMPARISON.md
+ci/usb-bootable-iso/PLAN.md
+ci/usb-bootable-iso/TROUBLESHOOTING.md

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -183,6 +183,7 @@ variables:
     - if: '$CI_COMMIT_TAG'
     - if: '($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ )'
     - if: '$CI_PIPELINE_SOURCE == "schedule" && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ )'
+    - if: '$BUILD_PF_IMG_USB_ISO == "yes" || $CI_COMMIT_MESSAGE =~ /build_pf_img_usb_iso=yes/'
 
 # run jobs only when:
 # - on devel branch (push, web, *not* schedule) if variable TEST sets to yes or if CI_COMMIT_MESSAGE contains "test=yes".
@@ -237,13 +238,9 @@ variables:
     - if: '$CI_COMMIT_REF_NAME != "devel" && $CI_COMMIT_REF_NAME !~ /^maintenance\/[[:digit:]]+\.[[:digit:]]+$/ && $CI_COMMIT_TAG == null && ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && ( $BUILD_PF_IMG_ISO == "yes" || $CI_COMMIT_MESSAGE =~ /build_pf_img_iso=yes/ )'
 
 # run this job on any branch with BUILD_PF_IMG_USB_ISO variable defined or build_pf_img_usb_iso=yes in commit message
-# AND when publish_ppa job is also triggered (PUBLISH_PPA=yes, TEST=yes, or release tag)
 .build_pf_img_usb_iso_any_branch_rules:
   rules:
-    - if: '($BUILD_PF_IMG_USB_ISO == "yes" || $CI_COMMIT_MESSAGE =~ /build_pf_img_usb_iso=yes/) && ($PUBLISH_PPA == "yes" || $CI_COMMIT_MESSAGE =~ /publish_ppa=yes/)'
-    - if: '($BUILD_PF_IMG_USB_ISO == "yes" || $CI_COMMIT_MESSAGE =~ /build_pf_img_usb_iso=yes/) && $CI_COMMIT_TAG'
-    - if: '($BUILD_PF_IMG_USB_ISO == "yes" || $CI_COMMIT_MESSAGE =~ /build_pf_img_usb_iso=yes/) && ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && ($TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/)'
-    - if: '($BUILD_PF_IMG_USB_ISO == "yes" || $CI_COMMIT_MESSAGE =~ /build_pf_img_usb_iso=yes/) && $CI_PIPELINE_SOURCE == "schedule" && ($TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/)'
+    - if: '$BUILD_PF_IMG_USB_ISO == "yes" || $CI_COMMIT_MESSAGE =~ /build_pf_img_usb_iso=yes/'
 
 # run this job on:
 # - devel branch with BUILD_ARTIFACTS_WEBSITE variable defined or build_artifacts_website=yes in commit message

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2013,6 +2013,7 @@ build_pf_img_usb_iso:
     - job: "publish_ppa_devel_release_branches_and_maintenance:"
   variables:
     PF_VERSION: ${CI_COMMIT_REF_SLUG}
+    PF_REPO_TYPE: gitlab/${CI_PIPELINE_ID}
   environment:
     url: ${SF_ISO_REPO_URL}/${CI_COMMIT_REF_SLUG}-usb
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -50,7 +50,6 @@ variables:
   CONTAINER_DIR: containers
   UPLOAD_DIR: $CILIBDIR/upload
   SF_ZEN_REPO_URL: https://sourceforge.net/projects/packetfence/files/PacketFence%20ZEN
-  SF_ISO_REPO_URL: https://sourceforge.net/projects/packetfence/files/PacketFence%20ISO
   # env variables
   ANSIBLE_FORCE_COLOR: 1
   ANSIBLE_STDOUT_CALLBACK: yaml
@@ -1982,7 +1981,7 @@ build_pf_img_iso_devel_branches_and_maintenance:
     - .build_pf_img_iso_job
     - .build_pf_img_iso_devel_branches_and_maintenance_rules
   environment:
-    url: ${SF_ISO_REPO_URL}/${CI_COMMIT_REF_SLUG}
+    url: ${RCLONE_LINODE_URL}/packetfence-iso/${CI_COMMIT_REF_SLUG}
   script:
     - timeout ${PIPELINE_TIMEOUT_SCRIPT} make -e -C ${ISODIR} iso
 
@@ -1992,7 +1991,7 @@ build_pf_img_iso_release:
   variables:
     PF_VERSION: ${CI_COMMIT_TAG}
   environment:
-    url: ${SF_ISO_REPO_URL}/${CI_COMMIT_TAG}
+    url: ${RCLONE_LINODE_URL}/packetfence-iso/${CI_COMMIT_TAG}
   script:
     - timeout ${PIPELINE_TIMEOUT_SCRIPT} make -e -C ${ISODIR} iso
   # workaround for https://forum.gitlab.com/t/specify-when-at-job-level-with-a-job-that-has-rules/4769
@@ -2015,7 +2014,7 @@ build_pf_img_usb_iso:
     PF_VERSION: ${CI_COMMIT_REF_SLUG}
     PF_REPO_TYPE: gitlab/${CI_PIPELINE_ID}
   environment:
-    url: ${SF_ISO_REPO_URL}/${CI_COMMIT_REF_SLUG}-usb
+    url: ${RCLONE_LINODE_URL}/packetfence-iso/${CI_COMMIT_REF_SLUG}-usb
   script:
     - timeout ${PIPELINE_TIMEOUT_SCRIPT} make -e -C ${USB_ISODIR} upload
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2010,6 +2010,7 @@ build_pf_img_usb_iso:
     - .build_pf_img_usb_iso_any_branch_rules
   needs:
     - job: "publish_ppa_devel_release_branches_and_maintenance:"
+      optional: true
   variables:
     PF_VERSION: ${CI_COMMIT_REF_SLUG}
   environment:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,14 +44,13 @@ variables:
   PACKERDIR: $CIDIR/packer
   ZENDIR: $CIDIR/packer/zen
   ISODIR: $CIDIR/debian-installer
-  USBISODIR: $CIDIR/usb-bootable-iso
+  USB_ISODIR: $CIDIR/usb-bootable-iso
   VAGRANT_IMG_DIR: $CIDIR/packer/vagrant_img
   TESTDIR: t/venom
   CONTAINER_DIR: containers
   UPLOAD_DIR: $CILIBDIR/upload
   SF_ZEN_REPO_URL: https://sourceforge.net/projects/packetfence/files/PacketFence%20ZEN
   SF_ISO_REPO_URL: https://sourceforge.net/projects/packetfence/files/PacketFence%20ISO
-  SF_USB_ISO_REPO_URL: https://sourceforge.net/projects/packetfence/files/PacketFence%20USB%20Bootable%20ISO
   # env variables
   ANSIBLE_FORCE_COLOR: 1
   ANSIBLE_STDOUT_CALLBACK: yaml
@@ -237,15 +236,10 @@ variables:
     - if: '$CI_COMMIT_REF_NAME =~ /^maintenance\/[[:digit:]]+\.[[:digit:]]+$/ && $CI_COMMIT_TAG == null && ( $BUILD_PF_IMG_ISO == "yes" || $CI_COMMIT_MESSAGE =~ /build_pf_img_iso=yes/ ) && ($CI_PIPELINE_SOURCE == "schedule" || $CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api")'
     - if: '$CI_COMMIT_REF_NAME != "devel" && $CI_COMMIT_REF_NAME !~ /^maintenance\/[[:digit:]]+\.[[:digit:]]+$/ && $CI_COMMIT_TAG == null && ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && ( $BUILD_PF_IMG_ISO == "yes" || $CI_COMMIT_MESSAGE =~ /build_pf_img_iso=yes/ )'
 
-# USB Bootable ISO Rules
-# - devel branch with BUILD_PF_IMG_USB_ISO variable defined or build_pf_img_usb_iso=yes in commit message
-# - all branches (maintenance include), except and devel (web) if variable BUILD_PF_IMG_USB_ISO sets to yes or if CI_COMMIT_MESSAGE contains "build_pf_img_usb_iso=yes".
-.build_pf_img_usb_iso_devel_branches_and_maintenance_rules:
+# run this job on any branch with BUILD_PF_IMG_USB_ISO variable defined or build_pf_img_usb_iso=yes in commit message
+.build_pf_img_usb_iso_any_branch_rules:
   rules:
-    - if: '$CI_COMMIT_REF_NAME == "devel" && ( $BUILD_PF_IMG_USB_ISO == "yes" || $CI_COMMIT_MESSAGE =~ /build_pf_img_usb_iso=yes/ )'
-    - if: '$CI_COMMIT_REF_NAME =~ /^maintenance\/[[:digit:]]+\.[[:digit:]]+$/ && $CI_COMMIT_TAG == null && ( $BUILD_PF_IMG_USB_ISO == "yes" || $CI_COMMIT_MESSAGE =~ /build_pf_img_usb_iso=yes/ ) && ($CI_PIPELINE_SOURCE == "schedule" || $CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api")'
-    - if: '$CI_COMMIT_REF_NAME != "devel" && $CI_COMMIT_REF_NAME !~ /^maintenance\/[[:digit:]]+\.[[:digit:]]+$/ && $CI_COMMIT_TAG == null && ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && ( $BUILD_PF_IMG_USB_ISO == "yes" || $CI_COMMIT_MESSAGE =~ /build_pf_img_usb_iso=yes/ )'
-
+    - if: '$BUILD_PF_IMG_USB_ISO == "yes" || $CI_COMMIT_MESSAGE =~ /build_pf_img_usb_iso=yes/'
 
 # run this job on:
 # - devel branch with BUILD_ARTIFACTS_WEBSITE variable defined or build_artifacts_website=yes in commit message
@@ -581,7 +575,7 @@ variables:
     name: sourceforge
   # implicit timeout = 5 minutes, see https://gitlab.com/gitlab-org/gitlab-runner/-/issues/2716
   after_script:
-    - make -e -C ${USBISODIR} clean
+    - make -e -C ${USB_ISODIR} clean
   dependencies: []
   tags:
     - shell-sourceforge
@@ -2007,29 +2001,18 @@ build_pf_img_iso_release:
       allow_failure: true
 
 ### build_pf_img_usb_iso jobs
-build_pf_img_usb_iso_devel_branches_and_maintenance:
+# USB bootable offline installer ISO - works on any branch
+# Triggered by BUILD_PF_IMG_USB_ISO=yes variable or build_pf_img_usb_iso=yes in commit message
+build_pf_img_usb_iso:
   extends:
     - .build_pf_img_usb_iso_job
-    - .build_pf_img_usb_iso_devel_branches_and_maintenance_rules
-  environment:
-    url: ${SF_USB_ISO_REPO_URL}/${CI_COMMIT_REF_SLUG}
-  script:
-    - timeout ${PIPELINE_TIMEOUT_SCRIPT} make -e -C ${USBISODIR} iso
-
-build_pf_img_usb_iso_release:
-  extends:
-    - .build_pf_img_usb_iso_job
+    - .build_pf_img_usb_iso_any_branch_rules
   variables:
-    PF_VERSION: ${CI_COMMIT_TAG}
+    PF_VERSION: ${CI_COMMIT_REF_SLUG}
   environment:
-    url: ${SF_USB_ISO_REPO_URL}/${CI_COMMIT_TAG}
+    url: ${SF_ISO_REPO_URL}/${CI_COMMIT_REF_SLUG}-usb
   script:
-    - timeout ${PIPELINE_TIMEOUT_SCRIPT} make -e -C ${USBISODIR} iso
-  # workaround for https://forum.gitlab.com/t/specify-when-at-job-level-with-a-job-that-has-rules/4769
-  rules:
-    - if: '$CI_COMMIT_TAG'
-      when: manual
-      allow_failure: true
+    - timeout ${PIPELINE_TIMEOUT_SCRIPT} make -e -C ${USB_ISODIR} iso
 
 ### build_pf_img_vagrant jobs
 # build_pf_img_vagrant_release_el_8:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -183,7 +183,7 @@ variables:
     - if: '$CI_COMMIT_TAG'
     - if: '($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ )'
     - if: '$CI_PIPELINE_SOURCE == "schedule" && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ )'
-    - if: '$BUILD_PF_IMG_USB_ISO == "yes" || $CI_COMMIT_MESSAGE =~ /build_pf_img_usb_iso=yes/'
+    - if: '($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && ($BUILD_PF_IMG_USB_ISO == "yes" || $CI_COMMIT_MESSAGE =~ /build_pf_img_usb_iso=yes/)'
 
 # run jobs only when:
 # - on devel branch (push, web, *not* schedule) if variable TEST sets to yes or if CI_COMMIT_MESSAGE contains "test=yes".
@@ -237,10 +237,10 @@ variables:
     - if: '$CI_COMMIT_REF_NAME =~ /^maintenance\/[[:digit:]]+\.[[:digit:]]+$/ && $CI_COMMIT_TAG == null && ( $BUILD_PF_IMG_ISO == "yes" || $CI_COMMIT_MESSAGE =~ /build_pf_img_iso=yes/ ) && ($CI_PIPELINE_SOURCE == "schedule" || $CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api")'
     - if: '$CI_COMMIT_REF_NAME != "devel" && $CI_COMMIT_REF_NAME !~ /^maintenance\/[[:digit:]]+\.[[:digit:]]+$/ && $CI_COMMIT_TAG == null && ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && ( $BUILD_PF_IMG_ISO == "yes" || $CI_COMMIT_MESSAGE =~ /build_pf_img_iso=yes/ )'
 
-# run this job on any branch with BUILD_PF_IMG_USB_ISO variable defined or build_pf_img_usb_iso=yes in commit message
+# run this job on any branch (web/api only) with BUILD_PF_IMG_USB_ISO variable defined or build_pf_img_usb_iso=yes in commit message
 .build_pf_img_usb_iso_any_branch_rules:
   rules:
-    - if: '$BUILD_PF_IMG_USB_ISO == "yes" || $CI_COMMIT_MESSAGE =~ /build_pf_img_usb_iso=yes/'
+    - if: '($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && ($BUILD_PF_IMG_USB_ISO == "yes" || $CI_COMMIT_MESSAGE =~ /build_pf_img_usb_iso=yes/)'
 
 # run this job on:
 # - devel branch with BUILD_ARTIFACTS_WEBSITE variable defined or build_artifacts_website=yes in commit message

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2009,7 +2009,7 @@ build_pf_img_usb_iso:
     - .build_pf_img_usb_iso_job
     - .build_pf_img_usb_iso_any_branch_rules
   needs:
-    - job: publish_ppa_devel_release_branches_and_maintenance
+    - job: "publish_ppa_devel_release_branches_and_maintenance:"
   variables:
     PF_VERSION: ${CI_COMMIT_REF_SLUG}
   environment:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2003,10 +2003,13 @@ build_pf_img_iso_release:
 ### build_pf_img_usb_iso jobs
 # USB bootable offline installer ISO - works on any branch
 # Triggered by BUILD_PF_IMG_USB_ISO=yes variable or build_pf_img_usb_iso=yes in commit message
+# Requires PPA to be published first (like tests)
 build_pf_img_usb_iso:
   extends:
     - .build_pf_img_usb_iso_job
     - .build_pf_img_usb_iso_any_branch_rules
+  needs:
+    - job: publish_ppa_devel_release_branches_and_maintenance
   variables:
     PF_VERSION: ${CI_COMMIT_REF_SLUG}
   environment:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2017,7 +2017,7 @@ build_pf_img_usb_iso:
   environment:
     url: ${SF_ISO_REPO_URL}/${CI_COMMIT_REF_SLUG}-usb
   script:
-    - timeout ${PIPELINE_TIMEOUT_SCRIPT} make -e -C ${USB_ISODIR} iso
+    - timeout ${PIPELINE_TIMEOUT_SCRIPT} make -e -C ${USB_ISODIR} upload
 
 ### build_pf_img_vagrant jobs
 # build_pf_img_vagrant_release_el_8:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -237,9 +237,13 @@ variables:
     - if: '$CI_COMMIT_REF_NAME != "devel" && $CI_COMMIT_REF_NAME !~ /^maintenance\/[[:digit:]]+\.[[:digit:]]+$/ && $CI_COMMIT_TAG == null && ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && ( $BUILD_PF_IMG_ISO == "yes" || $CI_COMMIT_MESSAGE =~ /build_pf_img_iso=yes/ )'
 
 # run this job on any branch with BUILD_PF_IMG_USB_ISO variable defined or build_pf_img_usb_iso=yes in commit message
+# AND when publish_ppa job is also triggered (PUBLISH_PPA=yes, TEST=yes, or release tag)
 .build_pf_img_usb_iso_any_branch_rules:
   rules:
-    - if: '$BUILD_PF_IMG_USB_ISO == "yes" || $CI_COMMIT_MESSAGE =~ /build_pf_img_usb_iso=yes/'
+    - if: '($BUILD_PF_IMG_USB_ISO == "yes" || $CI_COMMIT_MESSAGE =~ /build_pf_img_usb_iso=yes/) && ($PUBLISH_PPA == "yes" || $CI_COMMIT_MESSAGE =~ /publish_ppa=yes/)'
+    - if: '($BUILD_PF_IMG_USB_ISO == "yes" || $CI_COMMIT_MESSAGE =~ /build_pf_img_usb_iso=yes/) && $CI_COMMIT_TAG'
+    - if: '($BUILD_PF_IMG_USB_ISO == "yes" || $CI_COMMIT_MESSAGE =~ /build_pf_img_usb_iso=yes/) && ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && ($TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/)'
+    - if: '($BUILD_PF_IMG_USB_ISO == "yes" || $CI_COMMIT_MESSAGE =~ /build_pf_img_usb_iso=yes/) && $CI_PIPELINE_SOURCE == "schedule" && ($TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/)'
 
 # run this job on:
 # - devel branch with BUILD_ARTIFACTS_WEBSITE variable defined or build_artifacts_website=yes in commit message
@@ -2010,7 +2014,6 @@ build_pf_img_usb_iso:
     - .build_pf_img_usb_iso_any_branch_rules
   needs:
     - job: "publish_ppa_devel_release_branches_and_maintenance:"
-      optional: true
   variables:
     PF_VERSION: ${CI_COMMIT_REF_SLUG}
   environment:

--- a/ci/debian-installer/create-debian-installer.sh
+++ b/ci/debian-installer/create-debian-installer.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -o nounset -o pipefail -o errexit
 
+# Get script directory and source shared config
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "${SCRIPT_DIR}/../debian-version.conf"
+
 function clean() {
   rm -fr isofiles/
   rm -f preseed.cfg
@@ -8,7 +12,6 @@ function clean() {
   chmod a+rw $ISO_OUT
 }
 
-DEBIAN_VERSION=12.12.0
 ISO_IN=${ISO_IN:-debian-$DEBIAN_VERSION-amd64-netinst.iso}
 ISO_OUT=${ISO_OUT:-packetfence-debian-installer.iso}
 

--- a/ci/debian-version.conf
+++ b/ci/debian-version.conf
@@ -1,0 +1,8 @@
+# Shared Debian version configuration for ISO builders
+# Used by: debian-installer and usb-bootable-iso
+#
+# When updating, verify both ISOs exist at:
+#   https://cdimage.debian.org/cdimage/archive/${DEBIAN_VERSION}/amd64/iso-cd/
+#   https://cdimage.debian.org/cdimage/archive/${DEBIAN_VERSION}/amd64/iso-dvd/
+
+DEBIAN_VERSION=12.12.0

--- a/ci/usb-bootable-iso/.gitignore
+++ b/ci/usb-bootable-iso/.gitignore
@@ -1,21 +1,19 @@
-# Build artifacts
-build/
-results/
+# Generated files
+preseed-offline.cfg
 *.iso
-*.iso.sha256
-*.iso.md5
-*.log
+*.md5
 
-# Live-build cache
-cache/
-chroot/
-chroot.packages.install
-chroot.packages.live
-binary/
-.build/
-*.list
+# Work directories
+work/
+results/
+isofiles/
 
-# Temporary files
-*.tmp
-*~
-.*.swp
+# Downloaded files
+debian-*.iso
+
+# Local repository
+pool/
+dists/
+
+# Docker images
+docker-images/

--- a/ci/usb-bootable-iso/.gitignore
+++ b/ci/usb-bootable-iso/.gitignore
@@ -1,5 +1,5 @@
 # Generated files
-preseed-offline.cfg
+preseed.cfg
 *.iso
 *.md5
 

--- a/ci/usb-bootable-iso/Makefile
+++ b/ci/usb-bootable-iso/Makefile
@@ -1,7 +1,7 @@
 .PHONY: iso clean upload
 
 # Default values
-PF_VERSION ?= $(shell cat ../../conf/pf-release | cut -d' ' -f2)
+PF_VERSION ?= $(shell cut -d' ' -f2 < ../../conf/pf-release)
 PF_RELEASE ?= $(shell cat ../../conf/pf-release)
 ISO_OUT ?= PacketFence-USB-ISO-$(PF_VERSION).iso
 
@@ -10,12 +10,14 @@ export PF_VERSION
 export PF_RELEASE
 export ISO_OUT
 
+# Build ISO only (no upload)
 iso:
+	./build-usb-bootable-iso.sh
+
+# Build and upload ISO
+upload:
 	./build-and-upload.sh
 
 clean:
 	chmod -R +w work/ isofiles/ 2>/dev/null || true
 	rm -rf work/ results/ *.iso *.md5 isofiles/ pool/ dists/ docker-images/
-
-upload:
-	./build-and-upload.sh

--- a/ci/usb-bootable-iso/Makefile
+++ b/ci/usb-bootable-iso/Makefile
@@ -1,23 +1,20 @@
-PF_VERSION=$(CI_COMMIT_REF_NAME)
-RESULT_DIR=results
+.PHONY: iso clean upload
 
-.PHONY: iso
+# Default values
+PF_VERSION ?= $(shell cat ../../conf/pf-release | cut -d' ' -f2)
+PF_RELEASE ?= $(shell cat ../../conf/pf-release)
+ISO_OUT ?= PacketFence-USB-ISO-$(PF_VERSION).iso
+
+# Export for sub-scripts
+export PF_VERSION
+export PF_RELEASE
+export ISO_OUT
+
 iso:
-	echo "Building PacketFence USB Bootable ISO for $(PF_VERSION)"
-	PF_RELEASE='$(shell cat ../../conf/pf-release)' \
-	PF_VERSION='$(PF_VERSION)' \
-	 ./build-and-upload.sh
+	./build-and-upload.sh
 
-.PHONY: local
-local:
-	echo "Building PacketFence USB Bootable ISO locally"
-	PF_RELEASE='$(shell cat ../../conf/pf-release)' \
-	PF_VERSION='localtest' \
-	ISO_OUT='PacketFence-USB-Bootable-localtest.iso' \
-	 ./build-usb-bootable-iso.sh
-
-.PHONY: clean
 clean:
-	rm -rf $(RESULT_DIR)
-	rm -rf build
-	rm -f PacketFence-USB-Bootable-*.iso*
+	rm -rf work/ results/ *.iso *.md5 isofiles/ pool/ dists/ docker-images/
+
+upload:
+	./build-and-upload.sh

--- a/ci/usb-bootable-iso/Makefile
+++ b/ci/usb-bootable-iso/Makefile
@@ -1,4 +1,4 @@
-.PHONY: iso clean upload
+.PHONY: iso upload clean stage1 stage2 stage3 help
 
 # Default values
 PF_VERSION ?= $(shell cut -d' ' -f2 < ../../conf/pf-release)
@@ -10,14 +10,42 @@ export PF_VERSION
 export PF_RELEASE
 export ISO_OUT
 
-# Build ISO only (no upload)
+# Build ISO only (no upload). Runs the full containerized pipeline:
+# stage 0 (host wget) -> stage 1 (host docker pull) ->
+# stage 2 (debian:bookworm: debootstrap + apt) -> stage 3 (debian:bookworm: xorriso)
 iso:
 	./build-usb-bootable-iso.sh
 
-# Build and upload ISO
+# Build and upload ISO to Linode (CI target)
 upload:
 	./build-and-upload.sh
+
+# Run individual build stages (for debugging). Each stage assumes the
+# previous ones have already produced their outputs in work/.
+stage1:
+	./step1-pull-docker-images.sh
+
+stage2:
+	./step2-create-local-repo.sh
+
+stage3:
+	./step3-assemble-iso.sh
 
 clean:
 	chmod -R +w work/ isofiles/ 2>/dev/null || true
 	rm -rf work/ results/ *.iso *.md5 isofiles/ pool/ dists/ docker-images/
+
+help:
+	@echo "Targets:"
+	@echo "  iso      Build the USB bootable ISO (full pipeline)"
+	@echo "  upload   Build and upload the ISO to Linode (CI target)"
+	@echo "  stage1   Stage 1: pre-pull Docker images (host)"
+	@echo "  stage2   Stage 2: build offline APT repo (in debian:bookworm)"
+	@echo "  stage3   Stage 3: assemble final ISO (in debian:bookworm)"
+	@echo "  clean    Remove all build artifacts"
+	@echo ""
+	@echo "Useful overrides:"
+	@echo "  PF_VERSION=...        Override the PacketFence version"
+	@echo "  ISO_OUT=...           Output ISO path"
+	@echo "  BUILDER_IMAGE=...     Override builder image (default: debian:bookworm)"
+	@echo "  SKIP_CLEAN=1          Keep work/ between builds (faster rebuilds)"

--- a/ci/usb-bootable-iso/Makefile
+++ b/ci/usb-bootable-iso/Makefile
@@ -14,6 +14,7 @@ iso:
 	./build-and-upload.sh
 
 clean:
+	chmod -R +w work/ isofiles/ 2>/dev/null || true
 	rm -rf work/ results/ *.iso *.md5 isofiles/ pool/ dists/ docker-images/
 
 upload:

--- a/ci/usb-bootable-iso/README.md
+++ b/ci/usb-bootable-iso/README.md
@@ -1,381 +1,236 @@
 # PacketFence USB Bootable ISO
 
-This directory contains scripts to build a **bootable Debian 12 ISO** with PacketFence pre-installed. Unlike the net-install ISO in `ci/debian-installer/`, this creates a complete live system that can run directly from USB or be installed to disk with all dependencies included offline.
+Build a self-contained, offline USB installer for PacketFence on Debian 12 (Bookworm).
 
-## Features
+The ISO bundles the Debian DVD, all PacketFence packages, dependencies, and pre-downloaded Docker images so that no internet connection is required during installation.
 
-### Boot Options
-The ISO provides multiple boot modes via GRUB menu:
+## Requirements
 
-1. **Live System** - Run PacketFence directly from USB/DVD without installation
-2. **Live System with Persistence** - Run from USB with ability to save changes
-3. **Install to Hard Drive** - Full installation wizard (graphical)
-4. **Install to Hard Drive (Text Mode)** - Text-based installation
-5. **Recovery Mode** - Debug mode for troubleshooting
+### Build machine
 
-### System Features
-- ✅ **PacketFence pre-installed** with all dependencies
-- ✅ **Offline installation** - No internet required
-- ✅ **Persistence support** - Save changes on USB stick
-- ✅ **System requirements check** - Validates RAM, CPU, and disk
-- ✅ **Auto-configured** - Ready to use after boot
-- ✅ **Admin GUI notification** - Shows URL on first login
+- **OS:** Debian 12 / Ubuntu 22.04+ (amd64)
+- **Disk space:** ~30 GB free (base ISO ~3.8 GB + work directories + final ISO)
+- **RAM:** 4 GB minimum
+- **Internet:** Required during build to download packages and Docker images
+- **Root/sudo:** Required for `debootstrap` and package operations
 
-## System Requirements
+#### Required packages
 
-### Recommended (Production)
-- **RAM**: 8 GB minimum
-- **CPU**: 8 cores minimum  
-- **Disk**: 50 GB minimum
-- **Network**: 2+ NICs recommended
+Installed automatically by the build script if missing:
 
-### Minimum (Testing)
-- **RAM**: 4 GB
-- **CPU**: 2 cores
-- **Disk**: 20 GB
+- `debootstrap`
+- `xorriso`
+- `dpkg-dev`
+- `cpio`
+- `gnupg`
+- `docker` (Docker Engine, from docker.com or `docker.io`)
 
-The system will display warnings if requirements are not met.
+### Target server (installation)
+
+- **Architecture:** x86_64 / amd64
+- **RAM:** 8 GB minimum (16 GB recommended)
+- **Disk:** 100 GB minimum
+- **Boot:** BIOS (Legacy) or UEFI (Secure Boot must be disabled)
+- **USB port:** USB 2.0 or higher
+
+### USB key
+
+- **Capacity:** 16 GB minimum (the ISO is typically 6-8 GB)
 
 ## Building the ISO
 
-### Prerequisites
-- Linux system (Debian/Ubuntu preferred)
-- Docker installed
-- 10+ GB free disk space
-- Root/sudo access
+### From a local checkout
 
-### Build Methods
-
-#### Method 1: Using Docker (Recommended)
 ```bash
 cd ci/usb-bootable-iso
 make iso
 ```
 
-This builds the ISO in a clean Debian 12 container and uploads it to storage.
+The output file is `PacketFence-USB-ISO-<version>.iso`.
 
-#### Method 2: Local Build (For Testing)
-```bash
-cd ci/usb-bootable-iso
-make local
-```
-
-This builds locally without Docker. Requires Debian 12 or similar system.
-
-#### Method 3: Manual Build
-```bash
-cd ci/usb-bootable-iso
-sudo PF_RELEASE="12.0" PF_VERSION="devel" ./build-usb-bootable-iso.sh
-```
-
-### Build Output
-- **ISO File**: `PacketFence-USB-Bootable-<version>.iso`
-- **Checksums**: `.sha256` and `.md5` files
-- **Size**: ~2-4 GB (includes all dependencies)
-
-## Using the ISO
-
-### 1. Write to USB Drive
-
-**Linux:**
-```bash
-sudo dd if=PacketFence-USB-Bootable.iso of=/dev/sdX bs=4M status=progress
-sudo sync
-```
-
-**Windows:** Use [Rufus](https://rufus.ie/) or [Etcher](https://www.balena.io/etcher/)
-
-**macOS:**
-```bash
-sudo dd if=PacketFence-USB-Bootable.iso of=/dev/diskX bs=4m
-```
-
-⚠️ Replace `/dev/sdX` or `/dev/diskX` with your actual USB device!
-
-### 2. Boot from USB/DVD
-
-1. Insert USB drive or DVD
-2. Boot system and select boot device (usually F12, F2, or DEL)
-3. Select USB/DVD from boot menu
-4. Choose boot option from GRUB menu
-
-### 3. First Boot
-
-After booting (live or installed), you'll see:
-
-```
-==========================================
-  PacketFence Administration
-==========================================
-
-PacketFence has been installed successfully!
-
-The administration GUI is available at:
-  https://192.168.1.10:1443/
-
-You will need to complete the initial configuration
-through the web setup wizard.
-
-To check system requirements:
-  /usr/local/pf/bin/pfcmd checkrequirements
-
-==========================================
-```
-
-### 4. Check System Requirements
+### Override version or output name
 
 ```bash
-/usr/local/pf/bin/pfcmd checkrequirements
+make iso PF_VERSION=15.1.0 ISO_OUT=packetfence-custom.iso
 ```
 
-This will display:
-```
-==========================================
-PacketFence System Requirements Check
-==========================================
+### Skip work directory cleanup (faster rebuilds while debugging)
 
-System Specifications:
-  RAM:  8 GB (Recommended: 8 GB)
-  CPU:  8 cores (Recommended: 8 cores)
-  Disk: 50 GB (Recommended: 50 GB)
-
-✓ All requirements met!
-==========================================
-```
-
-## Live System Usage
-
-### Running Without Installation
-1. Select "**PacketFence - Live System**" from boot menu
-2. Wait for system to boot (2-3 minutes)
-3. Login as `root` with password `packetfence`
-4. Access admin GUI at `https://<IP>:1443/`
-
-### Running With Persistence (USB Only)
-1. Select "**PacketFence - Live System with Persistence**"
-2. Changes are saved to USB drive
-3. Configuration persists across reboots
-
-**Creating Persistence Partition:**
-After first boot with persistence option:
 ```bash
-# Create persistence partition on USB
-sudo fdisk /dev/sdX  # Create new partition
-sudo mkfs.ext4 -L persistence /dev/sdX3
-sudo mkdir -p /mnt/persistence
-sudo mount /dev/sdX3 /mnt/persistence
-echo "/ union" | sudo tee /mnt/persistence/persistence.conf
-sudo umount /mnt/persistence
+SKIP_CLEAN=1 make iso
 ```
 
-## Installation to Hard Drive
+### Clean all build artifacts
 
-### Graphical Installation
-1. Select "**PacketFence - Install to Hard Drive**"
-2. Follow Debian installer wizard
-3. PacketFence is already pre-installed
-4. Reboot after installation completes
-
-### Text Mode Installation
-1. Select "**PacketFence - Install to Hard Drive (Text Mode)**"
-2. Follow text-based installer
-3. Useful for remote installations via serial console
-
-## Recovery Mode
-
-For troubleshooting:
-1. Select "**PacketFence - Recovery Mode**"
-2. Boot with verbose logging and debug options
-3. Useful for system repair or investigation
-
-## Architecture Details
-
-### Build Process
-1. **live-build** configuration for Debian 12
-2. **Hooks** install PacketFence from Inverse repository
-3. **Packages** include all dependencies offline
-4. **Bootloader** GRUB2 with custom menu
-5. **Hybrid ISO** supports USB and DVD
-
-### Included Components
-- Debian 12 (Bookworm) base system
-- PacketFence latest stable release
-- MariaDB database server
-- Redis cache server
-- All network tools (tcpdump, nmap, etc.)
-- System utilities (vim, tmux, htop)
-- Development tools (gcc, make, perl)
-
-### File Structure
-```
-ci/usb-bootable-iso/
-├── build-usb-bootable-iso.sh       # Main build script
-├── build-usb-bootable-iso-docker.sh # Docker wrapper
-├── build-and-upload.sh              # Build & upload orchestrator
-├── Makefile                         # Build automation
-├── README.md                        # This file
-├── .gitignore                       # Git ignore patterns
-└── config/                          # Live-build configuration
-    ├── bootloaders/                 # GRUB menu configs
-    ├── hooks/                       # Installation hooks
-    │   └── normal/
-    │       ├── 0100-install-packetfence.hook.chroot
-    │       └── 0200-system-configuration.hook.chroot
-    └── includes.chroot/             # Files to include
-        └── usr/local/pf/bin/
-            ├── pf-check-requirements    # System requirements checker
-            └── pf-first-boot-message    # First boot message script
-```
-
-## Differences from Net-Install ISO
-
-| Feature | Net-Install ISO | USB Bootable ISO |
-|---------|----------------|------------------|
-| **Size** | ~400 MB | ~2-4 GB |
-| **Internet Required** | Yes | No |
-| **Live Boot** | No | Yes |
-| **Persistence** | No | Yes (USB) |
-| **Installation Time** | 15-30 min | 5-10 min |
-| **Use Case** | Server deployment | Demo, testing, quick deploy |
-
-## Troubleshooting
-
-### Build Issues
-
-**Error: Not enough disk space**
 ```bash
-# Check available space
-df -h
-# Clean previous builds
 make clean
 ```
 
-**Error: Permission denied**
+### From GitLab CI
+
+Trigger a pipeline with the variable `BUILD_PF_IMG_USB_ISO=yes`, or include `build_pf_img_usb_iso=yes` in the commit message. The PPA must be published first.
+
+## Writing the ISO to a USB key
+
+**Warning:** This will erase all data on the USB device.
+
+### 1. Identify the USB device
+
+Plug in the USB key, then find its device name:
+
 ```bash
-# Run with sudo (for local builds)
-sudo make local
+lsblk
 ```
 
-**Error: Docker not found**
+Look for the USB device (e.g., `/dev/sdb`). Make sure you identify the correct device — **not** your system disk.
+
+### 2. Write the ISO
+
+Use `dd` to write a raw copy of the ISO to the USB device. The ISO is built as a hybrid image (isohybrid), so it is directly bootable when written this way:
+
 ```bash
-# Install Docker
-sudo apt-get install docker.io
-sudo systemctl start docker
+sudo dd if=PacketFence-USB-ISO-<version>.iso of=/dev/sdX bs=4M status=progress oflag=sync
 ```
 
-### Boot Issues
+Replace `/dev/sdX` with your actual USB device (e.g., `/dev/sdb`).
 
-**USB not bootable**
-- Verify BIOS/UEFI boot mode
-- Try different USB port
-- Rewrite ISO with different tool
+**Important:**
+- Write to the **device** (`/dev/sdX`), not a partition (`/dev/sdX1`).
+- Do **not** simply copy the ISO file onto a FAT/NTFS formatted USB key — it will not boot.
 
-**Kernel panic on boot**
-- Verify ISO checksum
-- Try "Recovery Mode" option
-- Check hardware compatibility
+#### Alternative tools
 
-### Runtime Issues
+- **[balenaEtcher](https://etcher.balena.io/)** — graphical, works on Linux/macOS/Windows
+- **[Ventoy](https://www.ventoy.net/)** — multi-ISO USB tool, copy the `.iso` file onto a Ventoy-prepared USB key
 
-**Can't access admin GUI**
+## Installing PacketFence from the USB key
+
+1. Plug the USB key into the target server.
+2. Boot from the USB key (press F2/F10/F11/F12/Del during POST to access the boot menu, depending on hardware).
+3. Select **Install PacketFence (USB Offline)** from the boot menu.
+4. Follow the Debian installer prompts:
+   - Choose language, keyboard layout, and timezone.
+   - Configure the network (DHCP or manual).
+   - Set the root password.
+   - Partition the disk (guided or manual).
+   - Select the boot loader disk.
+5. The installer runs the post-installation script automatically (Phase A: installs all dependencies from the ISO).
+6. **Remove the USB key** when prompted to reboot.
+7. On first boot, a systemd service completes the installation (Phase B: starts Docker, loads container images, installs PacketFence). This takes 10–40 minutes depending on hardware. Progress is shown on the login screen.
+8. Once complete, log in as root and run:
+   ```bash
+   /usr/local/pf/bin/pfcmd configreload hard
+   ```
+9. Access the web interface at `https://<server-ip>:1443`.
+
+## Testing with QEMU/KVM
+
+You can test the ISO in a virtual machine without a physical server or USB key.
+
+### Requirements
+
 ```bash
-# Check PacketFence status
-sudo systemctl status packetfence
-
-# Check network configuration
-ip addr show
-
-# Check firewall
-sudo iptables -L
+sudo apt install qemu-system-x86 ovmf
 ```
 
-**Low performance warnings**
+### Create a virtual disk
+
 ```bash
-# Run requirements check
-/usr/local/pf/bin/pfcmd checkrequirements
-
-# Upgrade hardware or use full installation
+qemu-img create -f qcow2 /tmp/pf-test.qcow2 40G
 ```
 
-## CI/CD Integration
+### Boot in UEFI mode
 
-### GitLab CI
-
-The USB bootable ISO is integrated into the GitLab CI pipeline with its own trigger variable.
-
-**Trigger Variable**: `BUILD_PF_IMG_USB_ISO=yes`
-
-**Automatic builds on**:
-- `devel` branch (when `BUILD_PF_IMG_USB_ISO=yes` variable is set or commit message contains `build_pf_img_usb_iso=yes`)
-- `maintenance/X.Y` branches (schedule, web, or API triggers with variable set)
-- Release tags (manual trigger)
-
-**Example - Trigger via commit message**:
 ```bash
-git commit -m "Update USB ISO configuration
-
-build_pf_img_usb_iso=yes"
+qemu-system-x86_64 \
+  -m 4096 \
+  -smp 2 \
+  -enable-kvm \
+  -bios /usr/share/ovmf/OVMF.fd \
+  -cdrom PacketFence-USB-ISO-<version>.iso \
+  -drive file=/tmp/pf-test.qcow2,format=qcow2 \
+  -boot d \
+  -net nic -net user
 ```
 
-**Example - Trigger via GitLab Web UI**:
-1. Go to CI/CD → Pipelines → Run Pipeline
-2. Add variable: `BUILD_PF_IMG_USB_ISO` = `yes`
-3. Run pipeline
+### Boot in BIOS (Legacy) mode
 
-**CI Configuration**:
-Add to `.gitlab-ci.yml`:
-```yaml
-build:usb-iso:
-  stage: build
-  script:
-    - cd ci/usb-bootable-iso
-    - make iso
-  artifacts:
-    paths:
-      - ci/usb-bootable-iso/results/
-  rules:
-    - if: '$BUILD_PF_IMG_USB_ISO == "yes"'
-```
-
-### Manual Upload
 ```bash
-# Build
-make iso
-
-# Find ISO
-ls -lh results/sf/*/PacketFence-USB-Bootable-*.iso
-
-# Upload manually
-scp results/sf/v12.0.0/PacketFence-USB-Bootable-v12.0.0.iso user@server:/path/
+qemu-system-x86_64 \
+  -m 4096 \
+  -smp 2 \
+  -enable-kvm \
+  -cdrom PacketFence-USB-ISO-<version>.iso \
+  -drive file=/tmp/pf-test.qcow2,format=qcow2 \
+  -boot d \
+  -net nic -net user
 ```
 
-## Security Notes
+### Simulate USB boot
 
-- **Default root password**: `packetfence` - CHANGE THIS!
-- SSH root login enabled for initial setup
-- Complete the PacketFence setup wizard to configure admin credentials
-- Firewall rules should be configured post-installation
-- Use persistence with caution on shared systems
+Since the ISO is a hybrid image, you can also boot it as a raw disk to simulate what happens when it is `dd`'d onto a USB key:
 
-## Contributing
+```bash
+qemu-system-x86_64 \
+  -m 4096 \
+  -smp 2 \
+  -enable-kvm \
+  -bios /usr/share/ovmf/OVMF.fd \
+  -drive file=PacketFence-USB-ISO-<version>.iso,format=raw,if=virtio,readonly=on \
+  -drive file=/tmp/pf-test.qcow2,format=qcow2,if=virtio \
+  -boot c \
+  -net nic -net user
+```
 
-To improve the USB bootable ISO:
+## Troubleshooting
 
-1. Edit build scripts in `ci/usb-bootable-iso/`
-2. Test locally: `make local`
-3. Commit changes to feature branch
-4. Submit pull request
+### USB key does not boot
 
-## Support
+- **Secure Boot:** Disable Secure Boot in the server BIOS/UEFI settings.
+- **Boot mode mismatch:** Ensure the server boot mode (BIOS or UEFI) is compatible. The ISO supports both.
+- **Wrong write method:** The ISO must be written as a raw image (`dd` or Etcher), not copied as a file.
+- **Wrong device:** Verify you wrote to the device (`/dev/sdX`), not a partition (`/dev/sdX1`).
 
-- **Documentation**: https://packetfence.org/doc/
-- **Community**: https://packetfence.org/support/community.html
-- **Commercial**: https://inverse.ca/
+### First boot takes a long time
 
-## License
+This is expected. Phase B loads all Docker images and installs PacketFence. Monitor progress:
 
-Same license as PacketFence project.
+```bash
+tail -f /var/log/packetfence-first-boot.log
+```
 
----
+### First boot failed
 
-**Built with ❤️ by Inverse Inc.**
+Check the log and retry:
+
+```bash
+cat /var/log/packetfence-first-boot.log
+/usr/local/bin/packetfence-first-boot.sh
+```
+
+## Build process overview
+
+1. Download base Debian 12 DVD ISO (~3.8 GB)
+2. Create local APT repository with PacketFence packages and dependencies
+3. Pre-download all PacketFence Docker images (~30 containers)
+4. Extract the base Debian ISO
+5. Generate and inject the preseed configuration into the installer initrd
+6. Add the local APT repository and Docker images to the ISO
+7. Update boot menu configurations (ISOLINUX for BIOS, GRUB for UEFI)
+8. Build the final hybrid ISO with `xorriso`
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `Makefile` | Build targets: `iso`, `upload`, `clean` |
+| `build-usb-bootable-iso.sh` | Main build orchestration script |
+| `create-local-repo.sh` | Downloads and assembles the offline APT repository |
+| `predownload-docker-images.sh` | Pulls and archives all Docker images |
+| `preseed-offline.cfg.tmpl` | Debian preseed template for unattended installation |
+| `postinst-offline.sh` | Post-installation script (Phase A + Phase B first-boot) |
+| `grub.cfg` | GRUB boot menu (UEFI) |
+| `menu.cfg` | ISOLINUX boot menu (BIOS) |
+| `gtk.cfg` | ISOLINUX graphical installer menu |
+| `drkgtk.cfg` | ISOLINUX dark contrast menu |
+| `build-and-upload.sh` | Build and upload to Linode S3 |

--- a/ci/usb-bootable-iso/assemble-iso.sh
+++ b/ci/usb-bootable-iso/assemble-iso.sh
@@ -85,7 +85,7 @@ chmod 0444 "${ISOFILES_DIR}"/isolinux/* || true
 echo "===> Step 8: Updating MD5 checksums"
 ( cd "${ISOFILES_DIR}"
   chmod +w md5sum.txt
-  find . -type f ! -name md5sum.txt -print0 | xargs -0 md5sum > md5sum.txt 2>&1 || true
+  find . -type f ! -name md5sum.txt -print0 | xargs -0 md5sum > md5sum.txt
   chmod -w md5sum.txt
 )
 

--- a/ci/usb-bootable-iso/assemble-iso.sh
+++ b/ci/usb-bootable-iso/assemble-iso.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# Stage 3 internals: assemble the final USB-bootable ISO.
+# Designed to run inside a debian:bookworm container as root, but works on
+# the host too. Inputs (base DVD, repo, docker images) must already exist.
+#
+# Required env / args:
+#   ISO_IN           base Debian DVD ISO path (file)
+#   REPO_DIR         offline APT repo (directory) — produced by stage 2
+#   DOCKER_IMAGES_DIR  pre-pulled Docker image archive directory — produced by stage 1
+#   ISOFILES_DIR     scratch directory for extracted ISO contents
+#   ISO_OUT          output ISO path
+#   PF_VERSION, PF_RELEASE, PF_RELEASE_VERSION   version info
+#   SCRIPT_DIR       directory containing preseed-offline.cfg.tmpl, *.cfg, postinst-offline.sh
+set -o nounset -o pipefail -o errexit
+
+: "${ISO_IN:?ISO_IN must be set}"
+: "${REPO_DIR:?REPO_DIR must be set}"
+: "${DOCKER_IMAGES_DIR:?DOCKER_IMAGES_DIR must be set}"
+: "${ISOFILES_DIR:?ISOFILES_DIR must be set}"
+: "${ISO_OUT:?ISO_OUT must be set}"
+: "${PF_VERSION:?PF_VERSION must be set}"
+: "${PF_RELEASE:?PF_RELEASE must be set}"
+: "${PF_RELEASE_VERSION:?PF_RELEASE_VERSION must be set}"
+: "${SCRIPT_DIR:?SCRIPT_DIR must be set}"
+
+echo "=============================================="
+echo "Assembling USB Bootable ISO"
+echo "=============================================="
+echo "ISO_IN:             ${ISO_IN}"
+echo "REPO_DIR:           ${REPO_DIR}"
+echo "DOCKER_IMAGES_DIR:  ${DOCKER_IMAGES_DIR}"
+echo "ISOFILES_DIR:       ${ISOFILES_DIR}"
+echo "ISO_OUT:            ${ISO_OUT}"
+echo "=============================================="
+
+mkdir -p "${ISOFILES_DIR}"
+
+# Step 1: Extract base ISO
+echo "===> Step 1: Extracting base ISO"
+rm -rf "${ISOFILES_DIR:?}"/*
+xorriso -osirrox on -indev "${ISO_IN}" -extract / "${ISOFILES_DIR}"
+
+# Step 2: Generate preseed configuration
+# Write to a writable scratch dir — SCRIPT_DIR may be a read-only bind mount in CI.
+PRESEED_STAGING=$(mktemp -d)
+trap 'rm -rf "${PRESEED_STAGING}"' EXIT
+echo "===> Step 2: Generating preseed configuration"
+sed -e "s/%%PF_VERSION%%/${PF_RELEASE_VERSION}/g" \
+    -e "s/%%PF_RELEASE%%/${PF_RELEASE}/g" \
+    "${SCRIPT_DIR}/preseed-offline.cfg.tmpl" > "${PRESEED_STAGING}/preseed.cfg"
+
+# Step 3: Inject preseed into initrd
+echo "===> Step 3: Injecting preseed into initrd"
+chmod +w -R "${ISOFILES_DIR}/install.amd/"
+gunzip "${ISOFILES_DIR}/install.amd/initrd.gz"
+( cd "${PRESEED_STAGING}" && echo preseed.cfg | cpio -H newc -o -A -F "${ISOFILES_DIR}/install.amd/initrd" )
+gzip "${ISOFILES_DIR}/install.amd/initrd"
+chmod -w -R "${ISOFILES_DIR}/install.amd/"
+
+# Step 4: Add local repository to ISO
+echo "===> Step 4: Adding local repository to ISO"
+mkdir -p "${ISOFILES_DIR}/pf-repo"
+cp -r "${REPO_DIR}"/* "${ISOFILES_DIR}/pf-repo/"
+
+# Step 5: Add Docker images to ISO
+echo "===> Step 5: Adding Docker images to ISO"
+mkdir -p "${ISOFILES_DIR}/docker-images"
+cp -r "${DOCKER_IMAGES_DIR}"/* "${ISOFILES_DIR}/docker-images/"
+
+# Step 6: Copy post-installation script
+echo "===> Step 6: Adding post-installation script"
+cp "${SCRIPT_DIR}/postinst-offline.sh" "${ISOFILES_DIR}/"
+
+# Step 7: Update boot configurations
+echo "===> Step 7: Updating boot configurations"
+chmod a+w "${ISOFILES_DIR}/isolinux/gtk.cfg" "${ISOFILES_DIR}/isolinux/drkgtk.cfg" \
+    "${ISOFILES_DIR}/isolinux/menu.cfg" "${ISOFILES_DIR}/boot/grub/grub.cfg" || true
+cp "${SCRIPT_DIR}/gtk.cfg"    "${ISOFILES_DIR}/isolinux/gtk.cfg"
+cp "${SCRIPT_DIR}/drkgtk.cfg" "${ISOFILES_DIR}/isolinux/drkgtk.cfg"
+cp "${SCRIPT_DIR}/menu.cfg"   "${ISOFILES_DIR}/isolinux/menu.cfg"
+cp "${SCRIPT_DIR}/grub.cfg"   "${ISOFILES_DIR}/boot/grub/grub.cfg"
+chmod 0444 "${ISOFILES_DIR}"/isolinux/* || true
+
+# Step 8: Update MD5 checksums
+echo "===> Step 8: Updating MD5 checksums"
+( cd "${ISOFILES_DIR}"
+  chmod +w md5sum.txt
+  find . -type f ! -name md5sum.txt -print0 | xargs -0 md5sum > md5sum.txt 2>&1 || true
+  chmod -w md5sum.txt
+)
+
+# Step 9: Build final ISO (hybrid, BIOS+UEFI bootable)
+echo "===> Step 9: Building final ISO"
+# Volume ID: max 16 chars for Joliet (PF- prefix + 13 chars)
+VERSION_SHORT="${PF_VERSION##*/}"
+VERSION_SHORT="${VERSION_SHORT:0:13}"
+VOLID="PF-${VERSION_SHORT}"
+xorriso -as mkisofs \
+    -r -J -joliet-long \
+    -b isolinux/isolinux.bin \
+    -c isolinux/boot.cat \
+    -boot-load-size 4 \
+    -boot-info-table \
+    -no-emul-boot \
+    -eltorito-alt-boot \
+    -e boot/grub/efi.img \
+    -no-emul-boot \
+    -isohybrid-gpt-basdat \
+    -isohybrid-apm-hfsplus \
+    -V "${VOLID}" \
+    -o "${ISO_OUT}" \
+    "${ISOFILES_DIR}"
+
+echo "=============================================="
+echo "USB Bootable ISO created: ${ISO_OUT}"
+echo "Size: $(du -h "${ISO_OUT}" | cut -f1)"
+echo "=============================================="

--- a/ci/usb-bootable-iso/assemble-iso.sh
+++ b/ci/usb-bootable-iso/assemble-iso.sh
@@ -45,7 +45,7 @@ xorriso -osirrox on -indev "${ISO_IN}" -extract / "${ISOFILES_DIR}"
 PRESEED_STAGING=$(mktemp -d)
 trap 'rm -rf "${PRESEED_STAGING}"' EXIT
 echo "===> Step 2: Generating preseed configuration"
-sed -e "s/%%PF_VERSION%%/${PF_RELEASE_VERSION}/g" \
+sed -e "s/%%PF_RELEASE_VERSION%%/${PF_RELEASE_VERSION}/g" \
     -e "s/%%PF_RELEASE%%/${PF_RELEASE}/g" \
     "${SCRIPT_DIR}/preseed-offline.cfg.tmpl" > "${PRESEED_STAGING}/preseed.cfg"
 

--- a/ci/usb-bootable-iso/build-and-upload.sh
+++ b/ci/usb-bootable-iso/build-and-upload.sh
@@ -8,9 +8,9 @@ PF_ROOT=$(cd "${SCRIPT_DIR}/../.." && pwd)
 # Version handling
 PF_VERSION=${PF_VERSION:-localtest}
 
-# Fix PF version if maintenance branch to match tag format
+# Fix PF version if maintenance branch to match tag format (e.g., maintenance/15.0 -> v15.0.0)
 if [[ "$PF_VERSION" =~ ^maintenance\/([0-9]+\.[0-9]+)$ ]]; then
-    PF_VERSION="maintenance-${BASH_REMATCH[1]}"
+    PF_VERSION="v${BASH_REMATCH[1]}.0"
     echo "Maintenance branch detected, using version: $PF_VERSION"
 elif [[ "$PF_VERSION" =~ ^.*\/.*$ ]]; then
     # Replace slashes with dashes for any other branch format

--- a/ci/usb-bootable-iso/build-and-upload.sh
+++ b/ci/usb-bootable-iso/build-and-upload.sh
@@ -1,60 +1,36 @@
 #!/bin/bash
 set -o nounset -o pipefail -o errexit
 
-# Get script directory
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 PF_ROOT=$(cd "${SCRIPT_DIR}/../.." && pwd)
 
 # Version handling
 PF_VERSION=${PF_VERSION:-localtest}
-
-# Fix PF version if maintenance branch to match tag format (e.g., maintenance/15.0 -> v15.0.0)
 if [[ "$PF_VERSION" =~ ^maintenance\/([0-9]+\.[0-9]+)$ ]]; then
     PF_VERSION="v${BASH_REMATCH[1]}.0"
-    echo "Maintenance branch detected, using version: $PF_VERSION"
-elif [[ "$PF_VERSION" =~ ^.*\/.*$ ]]; then
-    # Replace slashes with dashes for any other branch format
-    PF_VERSION="$(echo $PF_VERSION | sed -r 's/\//-/g')"
-    echo "Branch detected, using version: $PF_VERSION"
+elif [[ "$PF_VERSION" == */* ]]; then
+    PF_VERSION="${PF_VERSION//\//-}"
 fi
 
-# Get PF release version for package repository
-PF_RELEASE=${PF_RELEASE:-$(cat "${PF_ROOT}/conf/pf-release")}
-PF_RELEASE_VERSION="$(echo $PF_RELEASE | sed -r 's/.*\b([0-9]+\.[0-9]+)\.[0-9]+/\1/g')"
+PF_RELEASE=${PF_RELEASE:-$(< "${PF_ROOT}/conf/pf-release")}
+PF_RELEASE_VERSION=$(sed -r 's/.*\b([0-9]+\.[0-9]+)\.[0-9]+/\1/g' <<< "$PF_RELEASE")
 
-# ISO naming with -usb suffix for directory
 ISO_NAME=PacketFence-USB-ISO-${PF_VERSION}.iso
 UPLOAD_DIR=${PF_VERSION}-usb
-
-# Results directory
 SF_RESULT_DIR=${SCRIPT_DIR}/results/sf/${UPLOAD_DIR}
 
+# Common rclone options
+RCLONE_OPTS="--s3-provider=Ceph --s3-access-key-id=${RCLONE_ACCESS_KEY_ID:-} --s3-secret-access-key=${RCLONE_SECRET_ACCESS_KEY:-} --s3-endpoint=${RCLONE_LINODE_URL:-} --s3-acl=public-read"
+
 upload_to_linode() {
-    echo "Create directory packetfence-iso/${UPLOAD_DIR}/"
-    rclone mkdir --s3-provider="Ceph" \
-        --s3-access-key-id=${RCLONE_ACCESS_KEY_ID} \
-        --s3-secret-access-key=${RCLONE_SECRET_ACCESS_KEY} \
-        --s3-endpoint="${RCLONE_LINODE_URL}" \
-        --s3-acl=public-read \
-        :s3:packetfence-iso/${UPLOAD_DIR}/
+    local bucket=":s3:packetfence-iso/${UPLOAD_DIR}"
 
-    echo "rclone ${ISO_NAME} to packetfence-iso/${UPLOAD_DIR}/"
-    rclone copyto --s3-provider="Ceph" \
-        --s3-access-key-id=${RCLONE_ACCESS_KEY_ID} \
-        --s3-secret-access-key=${RCLONE_SECRET_ACCESS_KEY} \
-        --s3-endpoint="${RCLONE_LINODE_URL}" \
-        --s3-acl=public-read \
-        ${SF_RESULT_DIR}/${ISO_NAME} :s3:packetfence-iso/${UPLOAD_DIR}/${ISO_NAME}
+    echo "Uploading to ${bucket}/"
+    rclone mkdir ${RCLONE_OPTS} "${bucket}/"
+    rclone copyto ${RCLONE_OPTS} "${SF_RESULT_DIR}/${ISO_NAME}" "${bucket}/${ISO_NAME}"
 
-    echo "Add md5sum ${ISO_NAME} in ${ISO_NAME}.md5sums.txt"
-    echo "$(md5sum ${SF_RESULT_DIR}/${ISO_NAME} | cut -d ' ' -f 1) ${ISO_NAME}" | tee -a ${SF_RESULT_DIR}/${ISO_NAME}.md5sums.txt
-
-    rclone copyto --s3-provider="Ceph" \
-        --s3-access-key-id=${RCLONE_ACCESS_KEY_ID} \
-        --s3-secret-access-key=${RCLONE_SECRET_ACCESS_KEY} \
-        --s3-endpoint="${RCLONE_LINODE_URL}" \
-        --s3-acl=public-read \
-        ${SF_RESULT_DIR}/${ISO_NAME}.md5sums.txt :s3:packetfence-iso/${UPLOAD_DIR}/${ISO_NAME}.md5sums.txt
+    md5sum "${SF_RESULT_DIR}/${ISO_NAME}" | cut -d' ' -f1 | xargs -I{} echo "{} ${ISO_NAME}" > "${SF_RESULT_DIR}/${ISO_NAME}.md5sums.txt"
+    rclone copyto ${RCLONE_OPTS} "${SF_RESULT_DIR}/${ISO_NAME}.md5sums.txt" "${bucket}/${ISO_NAME}.md5sums.txt"
 }
 
 # Create results directory

--- a/ci/usb-bootable-iso/build-and-upload.sh
+++ b/ci/usb-bootable-iso/build-and-upload.sh
@@ -1,58 +1,78 @@
 #!/bin/bash
 set -o nounset -o pipefail -o errexit
 
-PF_VERSION=${PF_VERSION:-localtest}
-PF_RELEASE=${PF_RELEASE:-12.0}
+# Get script directory
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PF_ROOT=$(cd "${SCRIPT_DIR}/../.." && pwd)
 
-# Fix PF version if maintenance to match tag
-if [[ "$PF_VERSION" =~ ^maintenance\/([0-9]+\.[0-9]+)$ ]];
-then
-  PF_VERSION=v;
-  PF_VERSION+=${BASH_REMATCH[1]};
-  PF_VERSION+=.0;
-  echo "Maintenance Branch detected, try to match tag version with PF version = $PF_VERSION"
-elif [[ "$PF_VERSION" =~ ^.*\/.*$ ]];
-then
-  PF_VERSION="`echo $PF_VERSION | sed -r 's/\//-/g'`"
+# Version handling
+PF_VERSION=${PF_VERSION:-localtest}
+
+# Fix PF version if maintenance branch to match tag format
+if [[ "$PF_VERSION" =~ ^maintenance\/([0-9]+\.[0-9]+)$ ]]; then
+    PF_VERSION="maintenance-${BASH_REMATCH[1]}"
+    echo "Maintenance branch detected, using version: $PF_VERSION"
+elif [[ "$PF_VERSION" =~ ^.*\/.*$ ]]; then
+    # Replace slashes with dashes for any other branch format
+    PF_VERSION="$(echo $PF_VERSION | sed -r 's/\//-/g')"
+    echo "Branch detected, using version: $PF_VERSION"
 fi
 
-PF_RELEASE="`echo $PF_RELEASE | sed -r 's/.*\b([0-9]+\.[0-9]+)\.[0-9]+/\1/g'`"
+# Get PF release version for package repository
+PF_RELEASE=${PF_RELEASE:-$(cat "${PF_ROOT}/conf/pf-release")}
+PF_RELEASE_VERSION="$(echo $PF_RELEASE | sed -r 's/.*\b([0-9]+\.[0-9]+)\.[0-9]+/\1/g')"
 
-ISO_NAME=PacketFence-USB-Bootable-${PF_VERSION}.iso
+# ISO naming with -usb suffix for directory
+ISO_NAME=PacketFence-USB-ISO-${PF_VERSION}.iso
+UPLOAD_DIR=${PF_VERSION}-usb
 
-# Upload settings
-SF_RESULT_DIR=results/sf/${PF_VERSION}
+# Results directory
+SF_RESULT_DIR=${SCRIPT_DIR}/results/sf/${UPLOAD_DIR}
 
 upload_to_linode() {
-    echo "Create directory packetfence-iso-usb/${PF_VERSION}/"
-    rclone mkdir --s3-provider="Ceph" --s3-access-key-id=${RCLONE_ACCESS_KEY_ID} --s3-secret-access-key=${RCLONE_SECRET_ACCESS_KEY} --s3-endpoint="${RCLONE_LINODE_URL}" --s3-acl=public-read :s3:packetfence-iso-usb/${PF_VERSION}/
-    
-    echo "rclone ${ISO_NAME} to packetfence-iso-usb/${PF_VERSION}/" 
-    rclone copyto --s3-provider="Ceph" --s3-access-key-id=${RCLONE_ACCESS_KEY_ID} --s3-secret-access-key=${RCLONE_SECRET_ACCESS_KEY} --s3-endpoint="${RCLONE_LINODE_URL}" --s3-acl=public-read ${SF_RESULT_DIR}/${ISO_NAME} :s3:packetfence-iso-usb/${PF_VERSION}/${ISO_NAME}
-    
-    echo "Add sha256sum ${ISO_NAME} in ${ISO_NAME}.sha256sums.txt"
-    echo "`sha256sum ${SF_RESULT_DIR}/${ISO_NAME} | cut -d ' ' -f 1` ${ISO_NAME}" | tee -a ${SF_RESULT_DIR}/${ISO_NAME}.sha256sums.txt
-    rclone copyto --s3-provider="Ceph" --s3-access-key-id=${RCLONE_ACCESS_KEY_ID} --s3-secret-access-key=${RCLONE_SECRET_ACCESS_KEY} --s3-endpoint="${RCLONE_LINODE_URL}" --s3-acl=public-read ${SF_RESULT_DIR}/${ISO_NAME}.sha256sums.txt :s3:packetfence-iso-usb/${PF_VERSION}/${ISO_NAME}.sha256sums.txt
-    
+    echo "Create directory packetfence-iso/${UPLOAD_DIR}/"
+    rclone mkdir --s3-provider="Ceph" \
+        --s3-access-key-id=${RCLONE_ACCESS_KEY_ID} \
+        --s3-secret-access-key=${RCLONE_SECRET_ACCESS_KEY} \
+        --s3-endpoint="${RCLONE_LINODE_URL}" \
+        --s3-acl=public-read \
+        :s3:packetfence-iso/${UPLOAD_DIR}/
+
+    echo "rclone ${ISO_NAME} to packetfence-iso/${UPLOAD_DIR}/"
+    rclone copyto --s3-provider="Ceph" \
+        --s3-access-key-id=${RCLONE_ACCESS_KEY_ID} \
+        --s3-secret-access-key=${RCLONE_SECRET_ACCESS_KEY} \
+        --s3-endpoint="${RCLONE_LINODE_URL}" \
+        --s3-acl=public-read \
+        ${SF_RESULT_DIR}/${ISO_NAME} :s3:packetfence-iso/${UPLOAD_DIR}/${ISO_NAME}
+
     echo "Add md5sum ${ISO_NAME} in ${ISO_NAME}.md5sums.txt"
-    echo "`md5sum ${SF_RESULT_DIR}/${ISO_NAME} | cut -d ' ' -f 1` ${ISO_NAME}" | tee -a ${SF_RESULT_DIR}/${ISO_NAME}.md5sums.txt
-    rclone copyto --s3-provider="Ceph" --s3-access-key-id=${RCLONE_ACCESS_KEY_ID} --s3-secret-access-key=${RCLONE_SECRET_ACCESS_KEY} --s3-endpoint="${RCLONE_LINODE_URL}" --s3-acl=public-read ${SF_RESULT_DIR}/${ISO_NAME}.md5sums.txt :s3:packetfence-iso-usb/${PF_VERSION}/${ISO_NAME}.md5sums.txt
+    echo "$(md5sum ${SF_RESULT_DIR}/${ISO_NAME} | cut -d ' ' -f 1) ${ISO_NAME}" | tee -a ${SF_RESULT_DIR}/${ISO_NAME}.md5sums.txt
+
+    rclone copyto --s3-provider="Ceph" \
+        --s3-access-key-id=${RCLONE_ACCESS_KEY_ID} \
+        --s3-secret-access-key=${RCLONE_SECRET_ACCESS_KEY} \
+        --s3-endpoint="${RCLONE_LINODE_URL}" \
+        --s3-acl=public-read \
+        ${SF_RESULT_DIR}/${ISO_NAME}.md5sums.txt :s3:packetfence-iso/${UPLOAD_DIR}/${ISO_NAME}.md5sums.txt
 }
 
+# Create results directory
 mkdir -p ${SF_RESULT_DIR}
 
-echo "===> Build USB Bootable ISO for release $PF_RELEASE"
-docker run --rm --privileged \
-    -e PF_RELEASE=$PF_RELEASE \
-    -e PF_VERSION=$PF_VERSION \
-    -e ISO_OUT="${SF_RESULT_DIR}/${ISO_NAME}" \
-    -v `pwd`:/usb-bootable-iso \
-    debian:12 \
-    /usb-bootable-iso/build-usb-bootable-iso-docker.sh
+echo "===> Build USB Bootable ISO for release $PF_RELEASE (version: $PF_VERSION)"
+echo "===> ISO will be uploaded to: packetfence-iso/${UPLOAD_DIR}/"
+
+# Export variables for build script
+export PF_VERSION
+export PF_RELEASE
+export PF_RELEASE_VERSION
+export ISO_OUT="${SF_RESULT_DIR}/${ISO_NAME}"
+
+# Run the build script
+${SCRIPT_DIR}/build-usb-bootable-iso.sh
 
 echo "===> Upload to Linode"
 upload_to_linode
 
-echo "===> Build and upload completed!"
-echo "ISO: ${SF_RESULT_DIR}/${ISO_NAME}"
-echo "Size: $(du -h ${SF_RESULT_DIR}/${ISO_NAME} | cut -f1)"
+echo "===> Done! ISO available at: packetfence-iso/${UPLOAD_DIR}/${ISO_NAME}"

--- a/ci/usb-bootable-iso/build-and-upload.sh
+++ b/ci/usb-bootable-iso/build-and-upload.sh
@@ -17,7 +17,7 @@ PF_RELEASE_VERSION=$(sed -r 's/.*\b([0-9]+\.[0-9]+)\.[0-9]+/\1/g' <<< "$PF_RELEA
 
 ISO_NAME=PacketFence-USB-ISO-${PF_VERSION}.iso
 UPLOAD_DIR=${PF_VERSION}-usb
-SF_RESULT_DIR=${SCRIPT_DIR}/results/sf/${UPLOAD_DIR}
+RESULT_DIR=${SCRIPT_DIR}/results/${UPLOAD_DIR}
 
 # Common rclone options
 RCLONE_OPTS="--s3-provider=Ceph --s3-access-key-id=${RCLONE_ACCESS_KEY_ID:-} --s3-secret-access-key=${RCLONE_SECRET_ACCESS_KEY:-} --s3-endpoint=${RCLONE_LINODE_URL:-} --s3-acl=public-read"
@@ -27,14 +27,14 @@ upload_to_linode() {
 
     echo "Uploading to ${bucket}/"
     rclone mkdir ${RCLONE_OPTS} "${bucket}/"
-    rclone copyto ${RCLONE_OPTS} "${SF_RESULT_DIR}/${ISO_NAME}" "${bucket}/${ISO_NAME}"
+    rclone copyto ${RCLONE_OPTS} "${RESULT_DIR}/${ISO_NAME}" "${bucket}/${ISO_NAME}"
 
-    md5sum "${SF_RESULT_DIR}/${ISO_NAME}" | cut -d' ' -f1 | xargs -I{} echo "{} ${ISO_NAME}" > "${SF_RESULT_DIR}/${ISO_NAME}.md5sums.txt"
-    rclone copyto ${RCLONE_OPTS} "${SF_RESULT_DIR}/${ISO_NAME}.md5sums.txt" "${bucket}/${ISO_NAME}.md5sums.txt"
+    md5sum "${RESULT_DIR}/${ISO_NAME}" | cut -d' ' -f1 | xargs -I{} echo "{} ${ISO_NAME}" > "${RESULT_DIR}/${ISO_NAME}.md5sums.txt"
+    rclone copyto ${RCLONE_OPTS} "${RESULT_DIR}/${ISO_NAME}.md5sums.txt" "${bucket}/${ISO_NAME}.md5sums.txt"
 }
 
 # Create results directory
-mkdir -p ${SF_RESULT_DIR}
+mkdir -p ${RESULT_DIR}
 
 echo "===> Build USB Bootable ISO for release $PF_RELEASE (version: $PF_VERSION)"
 echo "===> ISO will be uploaded to: packetfence-iso/${UPLOAD_DIR}/"
@@ -43,7 +43,7 @@ echo "===> ISO will be uploaded to: packetfence-iso/${UPLOAD_DIR}/"
 export PF_VERSION
 export PF_RELEASE
 export PF_RELEASE_VERSION
-export ISO_OUT="${SF_RESULT_DIR}/${ISO_NAME}"
+export ISO_OUT="${RESULT_DIR}/${ISO_NAME}"
 
 # Run the build script
 ${SCRIPT_DIR}/build-usb-bootable-iso.sh

--- a/ci/usb-bootable-iso/build-usb-bootable-iso.sh
+++ b/ci/usb-bootable-iso/build-usb-bootable-iso.sh
@@ -8,7 +8,8 @@ PF_ROOT=$(cd "${SCRIPT_DIR}/../.." && pwd)
 # Install required packages if not present
 echo "===> Checking/installing required packages..."
 # Note: docker.io not listed - CI runner has Docker from docker.com repo
-REQUIRED_PKGS="debootstrap xorriso dpkg-dev cpio gnupg"
+# Note: debootstrap not listed - runs inside Docker container
+REQUIRED_PKGS="xorriso dpkg-dev cpio gnupg"
 MISSING_PKGS=""
 for pkg in ${REQUIRED_PKGS}; do
     if ! dpkg -s "${pkg}" >/dev/null 2>&1; then
@@ -74,10 +75,17 @@ fi
 
 # Step 2: Create local APT repository with all packages
 echo "===> Step 2: Creating local APT repository"
-# debootstrap requires root privileges
-sudo ${SCRIPT_DIR}/create-local-repo.sh ${REPO_DIR} ${PF_RELEASE_VERSION}
-# Fix ownership after running as root
-sudo chown -R $(id -u):$(id -g) ${REPO_DIR}
+# Run in Docker container since debootstrap requires root privileges
+# Mount the script directory and repo directory, run as root inside container
+docker run --rm \
+    -v ${SCRIPT_DIR}:/build:ro \
+    -v ${REPO_DIR}:/repo \
+    -e REPO_DIR=/repo \
+    -e PF_RELEASE_VERSION=${PF_RELEASE_VERSION} \
+    debian:bookworm \
+    bash -c "apt-get update -qq && apt-get install -y -qq debootstrap curl dpkg-dev && /build/create-local-repo.sh /repo ${PF_RELEASE_VERSION}"
+# Fix ownership after running as root in container
+docker run --rm -v ${REPO_DIR}:/repo debian:bookworm chown -R $(id -u):$(id -g) /repo
 
 # Step 3: Pre-download Docker images
 echo "===> Step 3: Pre-downloading Docker images"

--- a/ci/usb-bootable-iso/build-usb-bootable-iso.sh
+++ b/ci/usb-bootable-iso/build-usb-bootable-iso.sh
@@ -27,7 +27,7 @@ if ! command -v docker >/dev/null 2>&1; then
 fi
 
 # Configuration
-ISO_IN=${ISO_IN:-debian-12.6.0-amd64-netinst.iso}
+ISO_IN=${ISO_IN:-debian-12.6.0-amd64-DVD-1.iso}
 ISO_OUT=${ISO_OUT:-packetfence-usb-installer.iso}
 WORK_DIR=${SCRIPT_DIR}/work
 ISOFILES_DIR=${WORK_DIR}/isofiles
@@ -62,14 +62,14 @@ mkdir -p ${ISOFILES_DIR}
 mkdir -p ${REPO_DIR}
 mkdir -p ${DOCKER_IMAGES_DIR}
 
-# Step 1: Download base Debian ISO if not present
-echo "===> Step 1: Checking base Debian ISO"
+# Step 1: Download base Debian DVD ISO if not present
+echo "===> Step 1: Checking base Debian DVD ISO"
 if ! [ -f ${SCRIPT_DIR}/${ISO_IN} ]; then
-    echo "Downloading ${ISO_IN}... (this may take a few minutes)"
-    wget -q https://cdimage.debian.org/cdimage/archive/12.6.0/amd64/iso-cd/${ISO_IN} -O ${SCRIPT_DIR}/${ISO_IN}
+    echo "Downloading ${ISO_IN}... (this will take several minutes - ~3.8 GB)"
+    wget --progress=dot:giga https://cdimage.debian.org/cdimage/archive/12.6.0/amd64/iso-dvd/${ISO_IN} -O ${SCRIPT_DIR}/${ISO_IN}
     echo "Download complete: $(du -h ${SCRIPT_DIR}/${ISO_IN} | cut -f1)"
 else
-    echo "Base ISO already present: ${ISO_IN}"
+    echo "Base DVD ISO already present: ${ISO_IN} ($(du -h ${SCRIPT_DIR}/${ISO_IN} | cut -f1))"
 fi
 
 # Step 2: Create local APT repository with all packages

--- a/ci/usb-bootable-iso/build-usb-bootable-iso.sh
+++ b/ci/usb-bootable-iso/build-usb-bootable-iso.sh
@@ -1,694 +1,133 @@
 #!/bin/bash
 set -o nounset -o pipefail -o errexit
 
-# PacketFence USB Bootable ISO Builder
-# Creates a Debian 12 Live system with PacketFence pre-installed
-# Supports: Live mode, Live with persistence, Full installation, Recovery mode
+# Get script directory
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PF_ROOT=$(cd "${SCRIPT_DIR}/../.." && pwd)
 
-PF_VERSION=${PF_VERSION:-devel}
-PF_RELEASE=${PF_RELEASE:-12.0}
-ISO_OUT=${ISO_OUT:-PacketFence-USB-Bootable.iso}
-WORK_DIR=${WORK_DIR:-$(pwd)/build}
+# Configuration
+ISO_IN=${ISO_IN:-debian-12.6.0-amd64-netinst.iso}
+ISO_OUT=${ISO_OUT:-packetfence-usb-installer.iso}
+WORK_DIR=${SCRIPT_DIR}/work
+ISOFILES_DIR=${WORK_DIR}/isofiles
+REPO_DIR=${WORK_DIR}/repo
+DOCKER_IMAGES_DIR=${WORK_DIR}/docker-images
 
-echo "=========================================="
-echo "PacketFence USB Bootable ISO Builder"
-echo "=========================================="
-echo "PF Version: ${PF_VERSION}"
-echo "PF Release: ${PF_RELEASE}"
-echo "Output ISO: ${ISO_OUT}"
-echo "Work Directory: ${WORK_DIR}"
-echo "=========================================="
+# Version info
+PF_VERSION=${PF_VERSION:-$(cat "${PF_ROOT}/conf/pf-release" | cut -d' ' -f2)}
+PF_RELEASE=${PF_RELEASE:-$(cat "${PF_ROOT}/conf/pf-release")}
+PF_RELEASE_VERSION=${PF_RELEASE_VERSION:-$(echo $PF_RELEASE | sed -r 's/.*\b([0-9]+\.[0-9]+)\.[0-9]+/\1/g')}
 
-# Clean previous builds
-clean_build() {
-    echo "==> Cleaning previous build..."
-    rm -rf "${WORK_DIR}"
-    mkdir -p "${WORK_DIR}"
+echo "=============================================="
+echo "Building USB Bootable ISO"
+echo "=============================================="
+echo "PF_VERSION: ${PF_VERSION}"
+echo "PF_RELEASE: ${PF_RELEASE}"
+echo "PF_RELEASE_VERSION: ${PF_RELEASE_VERSION}"
+echo "ISO_OUT: ${ISO_OUT}"
+echo "=============================================="
+
+# Cleanup function
+cleanup() {
+    echo "Cleaning up..."
+    rm -f ${SCRIPT_DIR}/preseed-offline.cfg
+    # Keep work directory for debugging if build fails
 }
+trap cleanup EXIT
 
-# Install build dependencies
-install_dependencies() {
-    echo "==> Installing build dependencies..."
-    apt-get update
-    apt-get install -y \
-        live-build \
-        debootstrap \
-        xorriso \
-        squashfs-tools \
-        syslinux-utils \
-        isolinux \
-        rsync \
-        wget \
-        curl \
-        gnupg2
-}
+# Create work directories
+mkdir -p ${WORK_DIR}
+mkdir -p ${ISOFILES_DIR}
+mkdir -p ${REPO_DIR}
+mkdir -p ${DOCKER_IMAGES_DIR}
 
-# Configure live-build
-configure_live_build() {
-    echo "==> Configuring live-build..."
-    cd "${WORK_DIR}"
-    
-    lb config noauto \
-        --mode debian \
-        --distribution bookworm \
-        --archive-areas "main contrib non-free non-free-firmware" \
-        --architectures amd64 \
-        --linux-flavours amd64 \
-        --bootappend-live "boot=live components quiet splash persistence net.ifnames=0 apparmor=0" \
-        --bootappend-install "net.ifnames=0 apparmor=0" \
-        --bootloaders "grub-efi grub-pc" \
-        --binary-images iso-hybrid \
-        --iso-application "PacketFence" \
-        --iso-publisher "Inverse Inc." \
-        --iso-volume "PacketFence-${PF_VERSION}" \
-        --debian-installer live \
-        --debian-installer-gui true \
-        --win32-loader false \
-        --checksums sha256 \
-        --zsync false
-        
-    echo "==> Live-build configured successfully"
-}
-
-# Create package lists
-create_package_lists() {
-    echo "==> Creating package lists..."
-    
-    mkdir -p config/package-lists
-    
-    # Base system packages
-    cat > config/package-lists/base.list.chroot <<EOF
-# Base system
-systemd
-systemd-sysv
-udev
-dbus
-
-# Networking
-network-manager
-iproute2
-iptables
-ipset
-bridge-utils
-vlan
-net-tools
-tcpdump
-nmap
-ethtool
-curl
-wget
-
-# File systems and storage
-lvm2
-cryptsetup
-btrfs-progs
-dosfstools
-ntfs-3g
-
-# Kernel and hardware
-linux-image-amd64
-linux-headers-amd64
-firmware-linux
-firmware-linux-nonfree
-firmware-misc-nonfree
-
-# Basic utilities
-sudo
-vim
-nano
-tmux
-screen
-lnav
-htop
-sysstat
-less
-rsync
-bzip2
-gzip
-xz-utils
-zip
-unzip
-git
-gnupg2
-apt-transport-https
-ca-certificates
-
-# System tools
-acpid
-dkms
-make
-build-essential
-cgroupfs-mount
-sysfsutils
-usbutils
-pciutils
-
-# Monitoring and logging
-rsyslog
-logrotate
-
-# Mail utilities
-bsd-mailx
-
-# Password generation
-apg
-
-# NFS support
-nfs-common
-
-# SSH
-openssh-server
-openssh-client
-
-# Man pages
-man-db
-manpages
-EOF
-
-    # PacketFence and dependencies - will be installed via hooks
-    cat > config/package-lists/packetfence.list.chroot <<EOF
-# MariaDB will be pulled by PacketFence dependencies
-# Redis will be pulled by PacketFence dependencies
-# All other PF dependencies will be installed
-EOF
-
-    echo "==> Package lists created"
-}
-
-# Create hooks for PacketFence installation
-create_hooks() {
-    echo "==> Creating installation hooks..."
-    
-    mkdir -p config/hooks/normal
-    
-    # Hook to add PacketFence repository and install PacketFence
-    cat > config/hooks/normal/0100-install-packetfence.hook.chroot <<'EOFHOOK'
-#!/bin/bash
-set -e
-
-echo "=========================================="
-echo "Installing PacketFence..."
-echo "=========================================="
-
-# Create marker file to signal we're in an installer-like environment
-# This prevents the postinst script from trying to start Docker
-mkdir -p /media/cdrom
-touch /media/cdrom/postinst-debian-installer.sh
-chmod +x /media/cdrom/postinst-debian-installer.sh
-
-# Create policy-rc.d to prevent service starts during installation
-cat > /usr/sbin/policy-rc.d <<'EOFPOLICY'
-#!/bin/bash
-exit 101
-EOFPOLICY
-chmod +x /usr/sbin/policy-rc.d
-
-# Add PacketFence GPG key
-curl -fsSL https://inverse.ca/downloads/GPG_PUBLIC_KEY | gpg --dearmor -o /etc/apt/keyrings/packetfence.gpg
-
-# Add PacketFence repository
-PF_RELEASE="%%PF_RELEASE%%"
-echo "deb [signed-by=/etc/apt/keyrings/packetfence.gpg] https://inverse.ca/downloads/PacketFence/debian/${PF_RELEASE} bookworm bookworm" > \
-    /etc/apt/sources.list.d/packetfence.list
-
-# Update package lists
-apt-get update
-
-# Install PacketFence dependencies first to ensure everything needed is available
-echo "Installing PacketFence dependencies..."
-apt-get install -y --no-install-recommends \
-    mariadb-server \
-    mariadb-client \
-    redis-server \
-    docker.io \
-    docker-compose
-
-# Install PacketFence - let it fail during postinst (expected in chroot)
-# apt-get will handle dependencies and unpack all files first
-echo "Installing PacketFence (postinst failure expected in chroot)..."
-set +e
-DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends packetfence
-INSTALL_RESULT=$?
-set -e
-
-echo "Initial install exit code: $INSTALL_RESULT"
-
-# Now the files are on disk (even though postinst may have failed), replace Docker scripts
-echo "Replacing Docker installer scripts..."
-if [ -f /usr/local/pf/containers/run-docker-in-debian-installer.sh ]; then
-    cat > /usr/local/pf/containers/run-docker-in-debian-installer.sh <<'EOFDOCKER'
-#!/bin/bash
-# Dummy script for live-build chroot environment
-# Docker operations will be performed on first boot
-echo "INFO: Docker operations skipped in live-build chroot"
-echo "INFO: Docker will be started properly on first boot"
-exit 0
-EOFDOCKER
-    chmod +x /usr/local/pf/containers/run-docker-in-debian-installer.sh
-    echo "Docker installer script replaced successfully"
+# Step 1: Download base Debian ISO if not present
+echo "===> Step 1: Checking base Debian ISO"
+if ! [ -f ${SCRIPT_DIR}/${ISO_IN} ]; then
+    echo "Downloading ${ISO_IN}..."
+    wget -q --show-progress https://cdimage.debian.org/cdimage/archive/12.6.0/amd64/iso-cd/${ISO_IN} -O ${SCRIPT_DIR}/${ISO_IN}
 else
-    echo "ERROR: Docker installer script not found after install!"
-    ls -la /usr/local/pf/containers/ || echo "Directory does not exist"
-    exit 1
+    echo "Base ISO already present: ${ISO_IN}"
 fi
 
-# Also replace manage-images.sh to skip Docker operations in chroot
-if [ -f /usr/local/pf/containers/manage-images.sh ]; then
-    cat > /usr/local/pf/containers/manage-images.sh <<'EOFMANAGE'
-#!/bin/bash
-# Dummy script for live-build chroot environment
-# Image management will be performed on first boot
-echo "INFO: Container image management skipped in live-build chroot"
-echo "INFO: Images will be loaded properly on first boot"
-exit 0
-EOFMANAGE
-    chmod +x /usr/local/pf/containers/manage-images.sh
-    echo "manage-images.sh script replaced successfully"
-else
-    echo "ERROR: manage-images.sh not found after install!"
-    exit 1
-fi
-
-# Now reconfigure the package with the dummy Docker script in place
-echo "Reconfiguring PacketFence with dummy Docker script..."
-dpkg --configure -a
-
-# Clean up marker files
-rm -f /media/cdrom/postinst-debian-installer.sh
-rmdir /media/cdrom 2>/dev/null || true
-
-# Remove policy-rc.d
-rm -f /usr/sbin/policy-rc.d
-
-# Stop all PacketFence services to ensure clean state
-echo "Stopping PacketFence services..."
-systemctl stop packetfence-mariadb || true
-systemctl stop packetfence-redis-cache || true
-systemctl stop packetfence || true
-
-# Disable services so they don't start during live-build operations
-# They will be re-enabled in the system configuration hook
-systemctl disable packetfence-mariadb || true
-systemctl disable packetfence-redis-cache || true
-systemctl disable packetfence || true
-
-# Kill any remaining processes that might hold /sys
-# This is a last resort cleanup before live-build tries to unmount
-echo "Performing final cleanup..."
-killall -9 mysqld mariadbd 2>/dev/null || true
-killall -9 redis-server 2>/dev/null || true
-killall -9 perl 2>/dev/null || true
-
-# Sync to ensure all writes are complete
-sync
-sleep 2
-
-echo "=========================================="
-echo "PacketFence installed successfully"
-echo "=========================================="
-EOFHOOK
-    
-    chmod +x config/hooks/normal/0100-install-packetfence.hook.chroot
-    
-    # Replace PF_RELEASE placeholder
-    sed -i "s/%%PF_RELEASE%%/${PF_RELEASE}/g" config/hooks/normal/0100-install-packetfence.hook.chroot
-    
-    # Hook to configure system
-    cat > config/hooks/normal/0200-system-configuration.hook.chroot <<'EOFHOOK'
-#!/bin/bash
-set -e
-
-echo "=========================================="
-echo "Configuring system..."
-echo "=========================================="
-
-# Enable SSH root login (for initial setup)
-sed -i 's/#PermitRootLogin.*/PermitRootLogin yes/g' /etc/ssh/sshd_config
-sed -i 's/#PasswordAuthentication.*/PasswordAuthentication yes/g' /etc/ssh/sshd_config
-
-# Set default root password (user should change this)
-echo "root:packetfence" | chpasswd
-
-# Disable cdrom in sources.list
-sed -i '/^deb cdrom:/s/^/#/' /etc/apt/sources.list
-
-# Enable systemd services for PacketFence
-systemctl enable packetfence-mariadb || true
-systemctl enable packetfence-redis-cache || true
-systemctl enable packetfence || true
-
-# Load pre-downloaded Docker images if they exist
-if [ -f /usr/local/pf/bin/load-predownloaded-images.sh ]; then
-    echo "Loading pre-downloaded Docker images..."
-    /usr/local/pf/bin/load-predownloaded-images.sh || echo "Warning: Some images failed to load"
-fi
-
-echo "=========================================="
-echo "System configuration completed"
-echo "=========================================="
-EOFHOOK
-    
-    chmod +x config/hooks/normal/0200-system-configuration.hook.chroot
-    
-    # Binary hook to patch live-build's unmount behavior to use lazy unmount
-    mkdir -p config/hooks/live
-    cat > config/hooks/live/0010-patch-sysfs-unmount.binary <<'EOFBINARY'
-#!/bin/bash
-
-echo "==> Patching live-build to use lazy unmount for /sys"
-
-# Patch the chroot_sysfs script to use lazy unmount
-SYSFS_SCRIPT="/usr/lib/live/build/chroot_sysfs"
-
-if [ -f "$SYSFS_SCRIPT" ]; then
-    # Backup original
-    cp "$SYSFS_SCRIPT" "${SYSFS_SCRIPT}.orig"
-    
-    # Replace 'umount' with 'umount -l' (lazy unmount) for /sys
-    sed -i 's/umount "\${_DIRECTORY}"/umount -l "${_DIRECTORY}" || umount "${_DIRECTORY}" || true/g' "$SYSFS_SCRIPT"
-    
-    echo "Live-build chroot_sysfs patched to use lazy unmount"
-else
-    echo "Warning: chroot_sysfs script not found, lazy unmount not applied"
-fi
-
-exit 0
-EOFBINARY
-    
-    chmod +x config/hooks/live/0010-patch-sysfs-unmount.binary
-    
-    echo "==> Hooks created"
-}
-
-# Create includes (files to be copied to the live system)
-create_includes() {
-    echo "==> Creating includes..."
-    
-    mkdir -p config/includes.chroot/usr/local/pf/bin
-    mkdir -p config/includes.chroot/etc/profile.d
-    
-    # System requirements checker script
-    cat > config/includes.chroot/usr/local/pf/bin/pf-check-requirements <<'EOFSCRIPT'
-#!/bin/bash
-
-echo "=========================================="
-echo "PacketFence System Requirements Check"
-echo "=========================================="
-echo ""
-
-# Recommended requirements
-RECOMMENDED_RAM_GB=8
-RECOMMENDED_CPU=8
-RECOMMENDED_DISK_GB=50
-
-# Get actual system specs
-TOTAL_RAM_GB=$(free -g | awk '/^Mem:/{print $2}')
-TOTAL_CPU=$(nproc)
-TOTAL_DISK_GB=$(df -BG / | awk 'NR==2 {print $2}' | sed 's/G//')
-
-echo "System Specifications:"
-echo "  RAM:  ${TOTAL_RAM_GB} GB (Recommended: ${RECOMMENDED_RAM_GB} GB)"
-echo "  CPU:  ${TOTAL_CPU} cores (Recommended: ${RECOMMENDED_CPU} cores)"
-echo "  Disk: ${TOTAL_DISK_GB} GB (Recommended: ${RECOMMENDED_DISK_GB} GB)"
-echo ""
-
-WARNINGS=0
-
-if [ "$TOTAL_RAM_GB" -lt "$RECOMMENDED_RAM_GB" ]; then
-    echo "WARNING: RAM is below recommended specifications!"
-    WARNINGS=$((WARNINGS + 1))
-fi
-
-if [ "$TOTAL_CPU" -lt "$RECOMMENDED_CPU" ]; then
-    echo "WARNING: CPU cores are below recommended specifications!"
-    WARNINGS=$((WARNINGS + 1))
-fi
-
-if [ "$TOTAL_DISK_GB" -lt "$RECOMMENDED_DISK_GB" ]; then
-    echo "WARNING: Disk space is below recommended specifications!"
-    WARNINGS=$((WARNINGS + 1))
-fi
-
-if [ "$WARNINGS" -eq 0 ]; then
-    echo "✓ All requirements met!"
-else
-    echo ""
-    echo "⚠ $WARNINGS warning(s) found. PacketFence may not perform optimally."
-    echo "  For production use, please ensure the recommended specifications."
-fi
-
-echo "=========================================="
-EOFSCRIPT
-    
-    chmod +x config/includes.chroot/usr/local/pf/bin/pf-check-requirements
-    
-    # First boot message script
-    cat > config/includes.chroot/usr/local/pf/bin/pf-first-boot-message <<'EOFSCRIPT'
-#!/bin/bash
-
-# Get primary IP address (excluding loopback)
-IP_ADDRESS=$(ip -4 addr show | grep -oP '(?<=inet\s)\d+(\.\d+){3}' | grep -v '127.0.0.1' | head -n1)
-
-if [ -z "$IP_ADDRESS" ]; then
-    IP_ADDRESS="<YOUR_IP_ADDRESS>"
-fi
-
-cat <<EOF
-
-=========================================="
-  PacketFence Administration
-=========================================="
-
-PacketFence has been installed successfully!
-
-The administration GUI is available at:
-  https://${IP_ADDRESS}:1443/
-
-You will need to complete the initial configuration
-through the web setup wizard.
-
-To check system requirements:
-  /usr/local/pf/bin/pfcmd checkrequirements
-
-=========================================="
-
-EOF
-EOFSCRIPT
-    
-    chmod +x config/includes.chroot/usr/local/pf/bin/pf-first-boot-message
-    
-    # Add first boot message to profile
-    cat > config/includes.chroot/etc/profile.d/pf-welcome.sh <<'EOFPROFILE'
-#!/bin/bash
-
-# Show welcome message only once per session
-if [ -z "$PF_WELCOME_SHOWN" ]; then
-    export PF_WELCOME_SHOWN=1
-    /usr/local/pf/bin/pf-first-boot-message
-fi
-EOFPROFILE
-    
-    chmod +x config/includes.chroot/etc/profile.d/pf-welcome.sh
-    
-    echo "==> Includes created"
-}
-
-# Create custom GRUB menu
-create_grub_menu() {
-    echo "==> Creating custom GRUB menu..."
-    
-    mkdir -p config/bootloaders/grub-pc
-    
-    cat > config/bootloaders/grub-pc/grub.cfg <<'EOFGRUB'
-set default=0
-set timeout=30
-
-loadfont unicode
-
-insmod all_video
-insmod gfxterm
-insmod png
-
-set gfxmode=auto
-set gfxpayload=keep
-
-terminal_output gfxterm
-
-set menu_color_normal=cyan/blue
-set menu_color_highlight=white/blue
-
-menuentry "PacketFence - Live System" {
-    linux /live/vmlinuz boot=live components quiet splash persistence net.ifnames=0 apparmor=0
-    initrd /live/initrd.img
-}
-
-menuentry "PacketFence - Live System with Persistence" {
-    linux /live/vmlinuz boot=live components quiet splash persistence persistence-encryption=none net.ifnames=0 apparmor=0
-    initrd /live/initrd.img
-}
-
-menuentry "PacketFence - Install to Hard Drive" {
-    linux /live/vmlinuz boot=live components quiet splash net.ifnames=0 apparmor=0
-    initrd /live/initrd.img
-}
-
-menuentry "PacketFence - Install to Hard Drive (Text Mode)" {
-    linux /live/vmlinuz boot=live components noprompt net.ifnames=0 apparmor=0 vga=normal
-    initrd /live/initrd.img
-}
-
-menuentry "PacketFence - Recovery Mode" {
-    linux /live/vmlinuz boot=live components debug verbose net.ifnames=0 apparmor=0
-    initrd /live/initrd.img
-}
-
-menuentry "Memory Test (memtest86+)" {
-    linux /live/memtest
-}
-EOFGRUB
-    
-    echo "==> GRUB menu created"
-}
-
-# Pre-download Docker images
-predownload_docker_images() {
-    echo "==> Pre-downloading Docker images..."
-    
-    # Check if Docker is available on the build host
-    if ! command -v docker &> /dev/null; then
-        echo "WARNING: Docker not available on build host. Images will be downloaded on first boot."
-        return 0
-    fi
-    
-    # Create directory for saved images
-    mkdir -p config/includes.chroot/usr/local/pf/var/docker-images
-    mkdir -p config/includes.chroot/usr/local/pf/bin
-    
-    # Determine paths relative to the script location
-    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-    PACKETFENCE_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
-    
-    # Read the build_id to get the tag/branch name
-    if [ -f "${PACKETFENCE_ROOT}/conf/build_id" ]; then
-        source "${PACKETFENCE_ROOT}/conf/build_id"
-    else
-        TAG_OR_BRANCH_NAME="${PF_VERSION}"
-    fi
-    
-    # Read registry URL from config
-    if [ -f "${PACKETFENCE_ROOT}/config.mk" ]; then
-        KNK_REGISTRY_URL=$(grep 'KNK_REGISTRY_URL' "${PACKETFENCE_ROOT}/config.mk" | cut -d'=' -f2 | tr -d ' ')
-    else
-        echo "WARNING: config.mk not found at ${PACKETFENCE_ROOT}/config.mk. Skipping image pre-download."
-        return 0
-    fi
-    
-    # List of container images to download
-    CONTAINER_IMAGES="pfconfig pfsetacls pfcmd radiusd-cli pfcron pfpki radiusd-eduroam pfqueue pfdns-connector api-frontend kafka httpd.admin_dispatcher radiusd-load-balancer pfconnector radiusd-auth ntlm-auth-api pfsso fingerbank-db haproxy-portal httpd.portal httpd.webservices pfperl-api pfldapexplorer proxysql radiusd-acct pfacct haproxy-admin httpd.dispatcher httpd.aaa pfstats netdata"
-    
-    echo "Downloading Docker images with tag: ${TAG_OR_BRANCH_NAME}"
-    
-    IMAGES_SAVED=0
-    for img in ${CONTAINER_IMAGES}; do
-        IMAGE_NAME="${KNK_REGISTRY_URL}/${img}:${TAG_OR_BRANCH_NAME}"
-        echo "  Pulling ${img}..."
-        
-        if docker pull -q "${IMAGE_NAME}" 2>/dev/null; then
-            # Save the image to a tar file
-            docker save "${IMAGE_NAME}" | gzip > "config/includes.chroot/usr/local/pf/var/docker-images/${img}.tar.gz"
-            IMAGES_SAVED=$((IMAGES_SAVED + 1))
-            echo "    ✓ Saved ${img}"
-        else
-            echo "    ✗ Failed to download ${img} (will be downloaded on first boot)"
-        fi
-    done
-    
-    if [ $IMAGES_SAVED -gt 0 ]; then
-        echo "==> Successfully pre-downloaded ${IMAGES_SAVED} Docker images"
-        
-        # Create a script to load images on first boot
-        cat > config/includes.chroot/usr/local/pf/bin/load-predownloaded-images.sh <<'EOFLOAD'
-#!/bin/bash
-# Load pre-downloaded Docker images
-
-IMAGE_DIR="/usr/local/pf/var/docker-images"
-
-if [ ! -d "$IMAGE_DIR" ]; then
-    echo "No pre-downloaded images found"
-    exit 0
-fi
-
-echo "Loading pre-downloaded Docker images..."
-IMAGE_COUNT=0
-
-for img_file in "$IMAGE_DIR"/*.tar.gz; do
-    if [ -f "$img_file" ]; then
-        echo "  Loading $(basename $img_file)..."
-        gunzip -c "$img_file" | docker load
-        IMAGE_COUNT=$((IMAGE_COUNT + 1))
-        # Remove the file after loading to save space
-        rm -f "$img_file"
-    fi
-done
-
-echo "Loaded $IMAGE_COUNT Docker images"
-
-# Remove the directory if empty
-rmdir "$IMAGE_DIR" 2>/dev/null || true
-
-exit 0
-EOFLOAD
-        chmod +x config/includes.chroot/usr/local/pf/bin/load-predownloaded-images.sh
-        
-    else
-        echo "==> No images were pre-downloaded"
-        rm -rf config/includes.chroot/usr/local/pf/var/docker-images
-    fi
-}
-
-# Build the ISO
-build_iso() {
-    echo "==> Building ISO image..."
-    cd "${WORK_DIR}"
-    
-    # Build
-    lb build 2>&1 | tee build.log
-    
-    # Copy the resulting ISO
-    if [ -f live-image-amd64.hybrid.iso ]; then
-        cp live-image-amd64.hybrid.iso "${ISO_OUT}"
-        echo "==> ISO created successfully: ${ISO_OUT}"
-        
-        # Generate checksums
-        sha256sum "${ISO_OUT}" > "${ISO_OUT}.sha256"
-        md5sum "${ISO_OUT}" > "${ISO_OUT}.md5"
-        
-        echo "==> Checksums generated"
-    else
-        echo "ERROR: ISO build failed!"
-        exit 1
-    fi
-}
-
-# Main execution
-main() {
-    clean_build
-    install_dependencies
-    configure_live_build
-    create_package_lists
-    create_hooks
-    create_includes
-    create_grub_menu
-    predownload_docker_images
-    build_iso
-    
-    echo ""
-    echo "=========================================="
-    echo "Build completed successfully!"
-    echo "ISO: ${ISO_OUT}"
-    echo "Size: $(du -h ${ISO_OUT} | cut -f1)"
-    echo "=========================================="
-}
-
-# Run main function
-main
+# Step 2: Create local APT repository with all packages
+echo "===> Step 2: Creating local APT repository"
+${SCRIPT_DIR}/create-local-repo.sh ${REPO_DIR} ${PF_RELEASE_VERSION}
+
+# Step 3: Pre-download Docker images
+echo "===> Step 3: Pre-downloading Docker images"
+${SCRIPT_DIR}/predownload-docker-images.sh ${DOCKER_IMAGES_DIR}
+
+# Step 4: Extract base ISO
+echo "===> Step 4: Extracting base ISO"
+rm -rf ${ISOFILES_DIR}/*
+xorriso -osirrox on -indev ${SCRIPT_DIR}/${ISO_IN} -extract / ${ISOFILES_DIR}
+
+# Step 5: Generate preseed configuration
+echo "===> Step 5: Generating preseed configuration"
+cat ${SCRIPT_DIR}/preseed-offline.cfg.tmpl | \
+    sed "s/%%PF_VERSION%%/${PF_RELEASE_VERSION}/g" | \
+    sed "s/%%PF_RELEASE%%/${PF_RELEASE}/g" > ${SCRIPT_DIR}/preseed-offline.cfg
+
+# Step 6: Inject preseed into initrd
+echo "===> Step 6: Injecting preseed into initrd"
+chmod +w -R ${ISOFILES_DIR}/install.amd/
+gunzip ${ISOFILES_DIR}/install.amd/initrd.gz
+echo preseed-offline.cfg | cpio -H newc -o -A -F ${ISOFILES_DIR}/install.amd/initrd
+gzip ${ISOFILES_DIR}/install.amd/initrd
+chmod -w -R ${ISOFILES_DIR}/install.amd/
+
+# Step 7: Add local repository to ISO
+echo "===> Step 7: Adding local repository to ISO"
+mkdir -p ${ISOFILES_DIR}/pf-repo
+cp -r ${REPO_DIR}/* ${ISOFILES_DIR}/pf-repo/
+
+# Step 8: Add Docker images to ISO
+echo "===> Step 8: Adding Docker images to ISO"
+mkdir -p ${ISOFILES_DIR}/docker-images
+cp -r ${DOCKER_IMAGES_DIR}/* ${ISOFILES_DIR}/docker-images/
+
+# Step 9: Copy post-installation script
+echo "===> Step 9: Adding post-installation script"
+cp ${SCRIPT_DIR}/postinst-offline.sh ${ISOFILES_DIR}/
+
+# Step 10: Update boot configurations
+echo "===> Step 10: Updating boot configurations"
+chmod a+w ${ISOFILES_DIR}/isolinux/gtk.cfg ${ISOFILES_DIR}/isolinux/drkgtk.cfg ${ISOFILES_DIR}/boot/grub/grub.cfg || true
+cp ${SCRIPT_DIR}/gtk.cfg ${ISOFILES_DIR}/isolinux/gtk.cfg
+cp ${SCRIPT_DIR}/drkgtk.cfg ${ISOFILES_DIR}/isolinux/drkgtk.cfg
+cp ${SCRIPT_DIR}/menu.cfg ${ISOFILES_DIR}/isolinux/menu.cfg
+cp ${SCRIPT_DIR}/grub.cfg ${ISOFILES_DIR}/boot/grub/grub.cfg
+chmod 0444 ${ISOFILES_DIR}/isolinux/* || true
+
+# Step 11: Update MD5 checksums
+echo "===> Step 11: Updating MD5 checksums"
+cd ${ISOFILES_DIR}
+chmod +w md5sum.txt
+find -follow -type f ! -name md5sum.txt -print0 | xargs -0 md5sum > md5sum.txt || echo "MD5 generation completed with warnings"
+chmod -w md5sum.txt
+cd ${SCRIPT_DIR}
+
+# Step 12: Build final ISO
+echo "===> Step 12: Building final ISO"
+xorriso -as mkisofs \
+    -r -J -joliet-long \
+    -b isolinux/isolinux.bin \
+    -c isolinux/boot.cat \
+    -boot-load-size 4 \
+    -boot-info-table \
+    -no-emul-boot \
+    -eltorito-alt-boot \
+    -e boot/grub/efi.img \
+    -no-emul-boot \
+    -isohybrid-gpt-basdat \
+    -isohybrid-apm-hfsplus \
+    -V "PacketFence USB ${PF_VERSION}" \
+    -o ${ISO_OUT} \
+    ${ISOFILES_DIR}
+
+echo "=============================================="
+echo "USB Bootable ISO created successfully!"
+echo "Output: ${ISO_OUT}"
+echo "Size: $(du -h ${ISO_OUT} | cut -f1)"
+echo "=============================================="

--- a/ci/usb-bootable-iso/build-usb-bootable-iso.sh
+++ b/ci/usb-bootable-iso/build-usb-bootable-iso.sh
@@ -54,12 +54,27 @@ PF_VERSION=${PF_VERSION:-$(cat "${PF_ROOT}/conf/pf-release" | cut -d' ' -f2)}
 PF_RELEASE=${PF_RELEASE:-$(cat "${PF_ROOT}/conf/pf-release")}
 PF_RELEASE_VERSION=${PF_RELEASE_VERSION:-$(echo $PF_RELEASE | sed -r 's/.*\b([0-9]+\.[0-9]+)\.[0-9]+/\1/g')}
 
+# Docker image tag - use CI environment or source from build_id if available
+if [ -z "${TAG_OR_BRANCH_NAME:-}" ]; then
+    if [ -n "${CI_COMMIT_TAG:-}" ]; then
+        export TAG_OR_BRANCH_NAME="${CI_COMMIT_TAG}"
+    elif [ -n "${CI_COMMIT_REF_SLUG:-}" ]; then
+        export TAG_OR_BRANCH_NAME="${CI_COMMIT_REF_SLUG}"
+    elif [ -f "${PF_ROOT}/conf/build_id" ]; then
+        source "${PF_ROOT}/conf/build_id"
+        export TAG_OR_BRANCH_NAME
+    else
+        export TAG_OR_BRANCH_NAME="devel"
+    fi
+fi
+
 echo "=============================================="
 echo "Building USB Bootable ISO"
 echo "=============================================="
 echo "PF_VERSION: ${PF_VERSION}"
 echo "PF_RELEASE: ${PF_RELEASE}"
 echo "PF_RELEASE_VERSION: ${PF_RELEASE_VERSION}"
+echo "TAG_OR_BRANCH_NAME: ${TAG_OR_BRANCH_NAME}"
 echo "ISO_OUT: ${ISO_OUT}"
 echo "=============================================="
 

--- a/ci/usb-bootable-iso/build-usb-bootable-iso.sh
+++ b/ci/usb-bootable-iso/build-usb-bootable-iso.sh
@@ -156,12 +156,13 @@ chmod 0444 ${ISOFILES_DIR}/isolinux/* || true
 
 # Step 11: Update MD5 checksums
 echo "===> Step 11: Updating MD5 checksums"
-cd ${ISOFILES_DIR}
+cd "${ISOFILES_DIR}"
 chmod +w md5sum.txt
 # Don't follow symlinks (-follow causes filesystem loops)
-find . -type f ! -name md5sum.txt -print0 | xargs -0 md5sum > md5sum.txt 2>/dev/null || echo "MD5 generation completed with warnings"
+# Some files may fail (symlinks, special files) - continue anyway
+find . -type f ! -name md5sum.txt -print0 | xargs -0 md5sum > md5sum.txt 2>&1 || true
 chmod -w md5sum.txt
-cd ${SCRIPT_DIR}
+cd "${SCRIPT_DIR}"
 
 # Step 12: Build final ISO
 echo "===> Step 12: Building final ISO"

--- a/ci/usb-bootable-iso/build-usb-bootable-iso.sh
+++ b/ci/usb-bootable-iso/build-usb-bootable-iso.sh
@@ -74,7 +74,10 @@ fi
 
 # Step 2: Create local APT repository with all packages
 echo "===> Step 2: Creating local APT repository"
-${SCRIPT_DIR}/create-local-repo.sh ${REPO_DIR} ${PF_RELEASE_VERSION}
+# debootstrap requires root privileges
+sudo ${SCRIPT_DIR}/create-local-repo.sh ${REPO_DIR} ${PF_RELEASE_VERSION}
+# Fix ownership after running as root
+sudo chown -R $(id -u):$(id -g) ${REPO_DIR}
 
 # Step 3: Pre-download Docker images
 echo "===> Step 3: Pre-downloading Docker images"

--- a/ci/usb-bootable-iso/build-usb-bootable-iso.sh
+++ b/ci/usb-bootable-iso/build-usb-bootable-iso.sh
@@ -51,7 +51,7 @@ echo "=============================================="
 # Cleanup function
 cleanup() {
     echo "Cleaning up..."
-    rm -f ${SCRIPT_DIR}/preseed-offline.cfg
+    rm -f ${SCRIPT_DIR}/preseed.cfg
     # Keep work directory for debugging if build fails
 }
 trap cleanup EXIT
@@ -87,15 +87,17 @@ xorriso -osirrox on -indev ${SCRIPT_DIR}/${ISO_IN} -extract / ${ISOFILES_DIR}
 
 # Step 5: Generate preseed configuration
 echo "===> Step 5: Generating preseed configuration"
+# Generate as preseed.cfg (standard name) for auto-detection by installer
 cat ${SCRIPT_DIR}/preseed-offline.cfg.tmpl | \
     sed "s/%%PF_VERSION%%/${PF_RELEASE_VERSION}/g" | \
-    sed "s/%%PF_RELEASE%%/${PF_RELEASE}/g" > ${SCRIPT_DIR}/preseed-offline.cfg
+    sed "s/%%PF_RELEASE%%/${PF_RELEASE}/g" > ${SCRIPT_DIR}/preseed.cfg
 
 # Step 6: Inject preseed into initrd
 echo "===> Step 6: Injecting preseed into initrd"
+# Inject as preseed.cfg (standard name) - installer will auto-detect it
 chmod +w -R ${ISOFILES_DIR}/install.amd/
 gunzip ${ISOFILES_DIR}/install.amd/initrd.gz
-echo preseed-offline.cfg | cpio -H newc -o -A -F ${ISOFILES_DIR}/install.amd/initrd
+echo preseed.cfg | cpio -H newc -o -A -F ${ISOFILES_DIR}/install.amd/initrd
 gzip ${ISOFILES_DIR}/install.amd/initrd
 chmod -w -R ${ISOFILES_DIR}/install.amd/
 

--- a/ci/usb-bootable-iso/build-usb-bootable-iso.sh
+++ b/ci/usb-bootable-iso/build-usb-bootable-iso.sh
@@ -44,8 +44,9 @@ mkdir -p ${DOCKER_IMAGES_DIR}
 # Step 1: Download base Debian ISO if not present
 echo "===> Step 1: Checking base Debian ISO"
 if ! [ -f ${SCRIPT_DIR}/${ISO_IN} ]; then
-    echo "Downloading ${ISO_IN}..."
-    wget -q --show-progress https://cdimage.debian.org/cdimage/archive/12.6.0/amd64/iso-cd/${ISO_IN} -O ${SCRIPT_DIR}/${ISO_IN}
+    echo "Downloading ${ISO_IN}... (this may take a few minutes)"
+    wget -q https://cdimage.debian.org/cdimage/archive/12.6.0/amd64/iso-cd/${ISO_IN} -O ${SCRIPT_DIR}/${ISO_IN}
+    echo "Download complete: $(du -h ${SCRIPT_DIR}/${ISO_IN} | cut -f1)"
 else
     echo "Base ISO already present: ${ISO_IN}"
 fi

--- a/ci/usb-bootable-iso/build-usb-bootable-iso.sh
+++ b/ci/usb-bootable-iso/build-usb-bootable-iso.sh
@@ -40,6 +40,14 @@ if [ -z "${TAG_OR_BRANCH_NAME:-}" ]; then
         # shellcheck disable=SC1091
         source "${PF_ROOT}/conf/build_id"
         export TAG_OR_BRANCH_NAME
+    elif [ -z "${CI:-}" ] && command -v git >/dev/null 2>&1 && \
+         _git_branch=$(git -C "${PF_ROOT}" rev-parse --abbrev-ref HEAD 2>/dev/null) && \
+         [ -n "${_git_branch}" ] && [ "${_git_branch}" != "HEAD" ]; then
+        # Local build fallback (skipped in CI): derive the tag from the
+        # current git branch, slugified the same way GitLab's
+        # CI_COMMIT_REF_SLUG is, so 'feature/foo' becomes 'feature-foo'.
+        export TAG_OR_BRANCH_NAME=$(echo "${_git_branch}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g')
+        unset _git_branch
     else
         export TAG_OR_BRANCH_NAME="devel"
     fi

--- a/ci/usb-bootable-iso/build-usb-bootable-iso.sh
+++ b/ci/usb-bootable-iso/build-usb-bootable-iso.sh
@@ -8,8 +8,7 @@ PF_ROOT=$(cd "${SCRIPT_DIR}/../.." && pwd)
 # Install required packages if not present
 echo "===> Checking/installing required packages..."
 # Note: docker.io not listed - CI runner has Docker from docker.com repo
-# Note: debootstrap not listed - runs inside Docker container
-REQUIRED_PKGS="xorriso dpkg-dev cpio gnupg"
+REQUIRED_PKGS="debootstrap xorriso dpkg-dev cpio gnupg"
 MISSING_PKGS=""
 for pkg in ${REQUIRED_PKGS}; do
     if ! dpkg -s "${pkg}" >/dev/null 2>&1; then
@@ -75,17 +74,10 @@ fi
 
 # Step 2: Create local APT repository with all packages
 echo "===> Step 2: Creating local APT repository"
-# Run in Docker container since debootstrap requires root privileges
-# Mount the script directory and repo directory, run as root inside container
-docker run --rm \
-    -v ${SCRIPT_DIR}:/build:ro \
-    -v ${REPO_DIR}:/repo \
-    -e REPO_DIR=/repo \
-    -e PF_RELEASE_VERSION=${PF_RELEASE_VERSION} \
-    debian:bookworm \
-    bash -c "apt-get update -qq && apt-get install -y -qq debootstrap curl dpkg-dev && /build/create-local-repo.sh /repo ${PF_RELEASE_VERSION}"
-# Fix ownership after running as root in container
-docker run --rm -v ${REPO_DIR}:/repo debian:bookworm chown -R $(id -u):$(id -g) /repo
+# debootstrap requires root privileges
+sudo ${SCRIPT_DIR}/create-local-repo.sh ${REPO_DIR} ${PF_RELEASE_VERSION}
+# Fix ownership after running as root
+sudo chown -R $(id -u):$(id -g) ${REPO_DIR}
 
 # Step 3: Pre-download Docker images
 echo "===> Step 3: Pre-downloading Docker images"

--- a/ci/usb-bootable-iso/build-usb-bootable-iso.sh
+++ b/ci/usb-bootable-iso/build-usb-bootable-iso.sh
@@ -50,9 +50,9 @@ else
 fi
 
 # Version info
-PF_VERSION=${PF_VERSION:-$(cat "${PF_ROOT}/conf/pf-release" | cut -d' ' -f2)}
-PF_RELEASE=${PF_RELEASE:-$(cat "${PF_ROOT}/conf/pf-release")}
-PF_RELEASE_VERSION=${PF_RELEASE_VERSION:-$(echo $PF_RELEASE | sed -r 's/.*\b([0-9]+\.[0-9]+)\.[0-9]+/\1/g')}
+PF_VERSION=${PF_VERSION:-$(cut -d' ' -f2 < "${PF_ROOT}/conf/pf-release")}
+PF_RELEASE=${PF_RELEASE:-$(< "${PF_ROOT}/conf/pf-release")}
+PF_RELEASE_VERSION=${PF_RELEASE_VERSION:-$(sed -r 's/.*\b([0-9]+\.[0-9]+)\.[0-9]+/\1/g' <<< "$PF_RELEASE")}
 
 # Docker image tag - use CI environment or source from build_id if available
 if [ -z "${TAG_OR_BRANCH_NAME:-}" ]; then

--- a/ci/usb-bootable-iso/build-usb-bootable-iso.sh
+++ b/ci/usb-bootable-iso/build-usb-bootable-iso.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 set -o nounset -o pipefail -o errexit
 
-# Get script directory
+# Get script directory and source shared config
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 PF_ROOT=$(cd "${SCRIPT_DIR}/../.." && pwd)
+source "${SCRIPT_DIR}/../debian-version.conf"
 
 # Install required packages if not present
 echo "===> Checking/installing required packages..."
@@ -27,12 +28,22 @@ if ! command -v docker >/dev/null 2>&1; then
 fi
 
 # Configuration
-ISO_IN=${ISO_IN:-debian-12.6.0-amd64-DVD-1.iso}
+# DEBIAN_VERSION sourced from ../debian-version.conf
+ISO_IN=${ISO_IN:-debian-${DEBIAN_VERSION}-amd64-DVD-1.iso}
 ISO_OUT=${ISO_OUT:-packetfence-usb-installer.iso}
 WORK_DIR=${SCRIPT_DIR}/work
 ISOFILES_DIR=${WORK_DIR}/isofiles
 REPO_DIR=${WORK_DIR}/repo
 DOCKER_IMAGES_DIR=${WORK_DIR}/docker-images
+
+# Clean work directory to avoid stale package conflicts
+# Set SKIP_CLEAN=1 to skip cleaning (for faster rebuilds when debugging)
+if [ "${SKIP_CLEAN:-0}" != "1" ]; then
+    echo "===> Cleaning work directory to avoid stale package conflicts"
+    rm -rf ${WORK_DIR}
+else
+    echo "===> Skipping work directory cleanup (SKIP_CLEAN=1)"
+fi
 
 # Version info
 PF_VERSION=${PF_VERSION:-$(cat "${PF_ROOT}/conf/pf-release" | cut -d' ' -f2)}
@@ -66,7 +77,7 @@ mkdir -p ${DOCKER_IMAGES_DIR}
 echo "===> Step 1: Checking base Debian DVD ISO"
 if ! [ -f ${SCRIPT_DIR}/${ISO_IN} ]; then
     echo "Downloading ${ISO_IN}... (this will take several minutes - ~3.8 GB)"
-    wget --progress=dot:giga https://cdimage.debian.org/cdimage/archive/12.6.0/amd64/iso-dvd/${ISO_IN} -O ${SCRIPT_DIR}/${ISO_IN}
+    wget --progress=dot:giga https://cdimage.debian.org/cdimage/archive/${DEBIAN_VERSION}/amd64/iso-dvd/${ISO_IN} -O ${SCRIPT_DIR}/${ISO_IN}
     echo "Download complete: $(du -h ${SCRIPT_DIR}/${ISO_IN} | cut -f1)"
 else
     echo "Base DVD ISO already present: ${ISO_IN} ($(du -h ${SCRIPT_DIR}/${ISO_IN} | cut -f1))"

--- a/ci/usb-bootable-iso/build-usb-bootable-iso.sh
+++ b/ci/usb-bootable-iso/build-usb-bootable-iso.sh
@@ -1,65 +1,43 @@
 #!/bin/bash
+# Top-level USB bootable ISO build orchestrator.
+#
+# Runs the build in stages, with the privileged + tooling-heavy parts
+# isolated inside debian:bookworm containers so the host needs only:
+#   - docker (engine + client)
+#   - wget (for the base DVD download, on host)
+#
+# Stage 0 (host):       Download base Debian DVD ISO if not cached
+# Stage 1 (host):       Pre-pull PacketFence Docker images (uses host's docker daemon)
+# Stage 2 (container):  Build offline APT repository (debootstrap + apt download)
+# Stage 3 (container):  Assemble the final hybrid ISO (xorriso)
 set -o nounset -o pipefail -o errexit
 
-# Get script directory and source shared config
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 PF_ROOT=$(cd "${SCRIPT_DIR}/../.." && pwd)
 source "${SCRIPT_DIR}/../debian-version.conf"
 
-# Install required packages if not present
-echo "===> Checking/installing required packages..."
-# Note: docker.io not listed - CI runner has Docker from docker.com repo
-REQUIRED_PKGS="debootstrap xorriso dpkg-dev cpio gnupg"
-MISSING_PKGS=""
-for pkg in ${REQUIRED_PKGS}; do
-    if ! dpkg -s "${pkg}" >/dev/null 2>&1; then
-        MISSING_PKGS="${MISSING_PKGS} ${pkg}"
-    fi
-done
-if [ -n "${MISSING_PKGS}" ]; then
-    echo "Installing missing packages:${MISSING_PKGS}"
-    sudo apt-get update -qq
-    sudo apt-get install -y -qq ${MISSING_PKGS}
-fi
-# Verify docker is available (from any source)
-if ! command -v docker >/dev/null 2>&1; then
-    echo "ERROR: docker command not found. Please install Docker."
-    exit 1
-fi
-
 # Configuration
-ISO_IN=${ISO_IN:-debian-${DEBIAN_VERSION}-amd64-DVD-1.iso}
-ISO_OUT=${ISO_OUT:-packetfence-usb-installer.iso}
-WORK_DIR=${SCRIPT_DIR}/work
-ISOFILES_DIR=${WORK_DIR}/isofiles
-REPO_DIR=${WORK_DIR}/repo
-DOCKER_IMAGES_DIR=${WORK_DIR}/docker-images
-
-# Clean work directory to avoid stale package conflicts
-# Set SKIP_CLEAN=1 to skip cleaning (for faster rebuilds when debugging)
-# Make files writable first because extracted ISO files have read-only permissions
-if [ "${SKIP_CLEAN:-0}" != "1" ]; then
-    echo "===> Cleaning work directory to avoid stale package conflicts"
-    if [ -d "${WORK_DIR}" ]; then
-        chmod -R +w "${WORK_DIR}"
-    fi
-    rm -rf "${WORK_DIR}"
-else
-    echo "===> Skipping work directory cleanup (SKIP_CLEAN=1)"
-fi
+ISO_IN="${ISO_IN:-debian-${DEBIAN_VERSION}-amd64-DVD-1.iso}"
+ISO_OUT="${ISO_OUT:-packetfence-usb-installer.iso}"
+WORK_DIR="${SCRIPT_DIR}/work"
+ISOFILES_DIR="${WORK_DIR}/isofiles"
+REPO_DIR="${WORK_DIR}/repo"
+DOCKER_IMAGES_DIR="${WORK_DIR}/docker-images"
+BUILDER_IMAGE="${BUILDER_IMAGE:-debian:bookworm}"
 
 # Version info
-PF_VERSION=${PF_VERSION:-$(cut -d' ' -f2 < "${PF_ROOT}/conf/pf-release")}
-PF_RELEASE=${PF_RELEASE:-$(< "${PF_ROOT}/conf/pf-release")}
-PF_RELEASE_VERSION=${PF_RELEASE_VERSION:-$(sed -r 's/.*\b([0-9]+\.[0-9]+)\.[0-9]+/\1/g' <<< "$PF_RELEASE")}
+PF_VERSION="${PF_VERSION:-$(cut -d' ' -f2 < "${PF_ROOT}/conf/pf-release")}"
+PF_RELEASE="${PF_RELEASE:-$(< "${PF_ROOT}/conf/pf-release")}"
+PF_RELEASE_VERSION="${PF_RELEASE_VERSION:-$(sed -r 's/.*\b([0-9]+\.[0-9]+)\.[0-9]+/\1/g' <<< "${PF_RELEASE}")}"
 
-# Docker image tag - use CI environment or source from build_id if available
+# Docker image tag for PacketFence containers
 if [ -z "${TAG_OR_BRANCH_NAME:-}" ]; then
     if [ -n "${CI_COMMIT_TAG:-}" ]; then
         export TAG_OR_BRANCH_NAME="${CI_COMMIT_TAG}"
     elif [ -n "${CI_COMMIT_REF_SLUG:-}" ]; then
         export TAG_OR_BRANCH_NAME="${CI_COMMIT_REF_SLUG}"
     elif [ -f "${PF_ROOT}/conf/build_id" ]; then
+        # shellcheck disable=SC1091
         source "${PF_ROOT}/conf/build_id"
         export TAG_OR_BRANCH_NAME
     else
@@ -67,124 +45,79 @@ if [ -z "${TAG_OR_BRANCH_NAME:-}" ]; then
     fi
 fi
 
-echo "=============================================="
-echo "Building USB Bootable ISO"
-echo "=============================================="
-echo "PF_VERSION: ${PF_VERSION}"
-echo "PF_RELEASE: ${PF_RELEASE}"
-echo "PF_RELEASE_VERSION: ${PF_RELEASE_VERSION}"
-echo "TAG_OR_BRANCH_NAME: ${TAG_OR_BRANCH_NAME}"
-echo "ISO_OUT: ${ISO_OUT}"
-echo "=============================================="
+# Resolve absolute paths used as ISO_IN/ISO_OUT for stage 3
+if [[ "${ISO_IN}" != /* ]]; then ISO_IN="${SCRIPT_DIR}/${ISO_IN}"; fi
+if [[ "${ISO_OUT}" != /* ]]; then ISO_OUT="${SCRIPT_DIR}/${ISO_OUT}"; fi
 
-# Cleanup function
-cleanup() {
-    echo "Cleaning up..."
-    rm -f ${SCRIPT_DIR}/preseed.cfg
-    # Keep work directory for debugging if build fails
-}
-trap cleanup EXIT
+# Export so step scripts inherit
+export WORK_DIR ISOFILES_DIR REPO_DIR DOCKER_IMAGES_DIR
+export PF_VERSION PF_RELEASE PF_RELEASE_VERSION TAG_OR_BRANCH_NAME
+export ISO_IN ISO_OUT BUILDER_IMAGE
 
-# Create work directories
-mkdir -p ${WORK_DIR}
-mkdir -p ${ISOFILES_DIR}
-mkdir -p ${REPO_DIR}
-mkdir -p ${DOCKER_IMAGES_DIR}
-
-# Step 1: Download base Debian DVD ISO if not present
-echo "===> Step 1: Checking base Debian DVD ISO"
-if ! [ -f ${SCRIPT_DIR}/${ISO_IN} ]; then
-    echo "Downloading ${ISO_IN}... (this will take several minutes - ~3.8 GB)"
-    wget --progress=dot:giga https://cdimage.debian.org/cdimage/archive/${DEBIAN_VERSION}/amd64/iso-dvd/${ISO_IN} -O ${SCRIPT_DIR}/${ISO_IN}
-    echo "Download complete: $(du -h ${SCRIPT_DIR}/${ISO_IN} | cut -f1)"
-else
-    echo "Base DVD ISO already present: ${ISO_IN} ($(du -h ${SCRIPT_DIR}/${ISO_IN} | cut -f1))"
+if ! command -v docker >/dev/null 2>&1; then
+    echo "ERROR: docker command not found. Install Docker Engine to use this build." >&2
+    exit 1
 fi
 
-# Step 2: Create local APT repository with all packages
-echo "===> Step 2: Creating local APT repository"
-${SCRIPT_DIR}/create-local-repo.sh ${REPO_DIR} ${PF_RELEASE_VERSION}
+# Optional: clean work directory unless SKIP_CLEAN=1
+if [ "${SKIP_CLEAN:-0}" != "1" ]; then
+    echo "===> Cleaning work directory (set SKIP_CLEAN=1 to keep)"
+    if [ -d "${WORK_DIR}" ]; then
+        chmod -R +w "${WORK_DIR}" 2>/dev/null || true
+        rm -rf "${WORK_DIR}"
+    fi
+else
+    echo "===> Keeping existing work directory (SKIP_CLEAN=1)"
+fi
 
-# Step 3: Pre-download Docker images
-echo "===> Step 3: Pre-downloading Docker images"
-${SCRIPT_DIR}/predownload-docker-images.sh ${DOCKER_IMAGES_DIR}
-
-# Step 4: Extract base ISO
-echo "===> Step 4: Extracting base ISO"
-rm -rf ${ISOFILES_DIR}/*
-xorriso -osirrox on -indev ${SCRIPT_DIR}/${ISO_IN} -extract / ${ISOFILES_DIR}
-
-# Step 5: Generate preseed configuration
-echo "===> Step 5: Generating preseed configuration"
-sed -e "s/%%PF_VERSION%%/${PF_RELEASE_VERSION}/g" \
-    -e "s/%%PF_RELEASE%%/${PF_RELEASE}/g" \
-    "${SCRIPT_DIR}/preseed-offline.cfg.tmpl" > "${SCRIPT_DIR}/preseed.cfg"
-
-# Step 6: Inject preseed into initrd
-echo "===> Step 6: Injecting preseed into initrd"
-chmod +w -R "${ISOFILES_DIR}/install.amd/"
-gunzip ${ISOFILES_DIR}/install.amd/initrd.gz
-echo preseed.cfg | cpio -H newc -o -A -F ${ISOFILES_DIR}/install.amd/initrd
-gzip ${ISOFILES_DIR}/install.amd/initrd
-chmod -w -R ${ISOFILES_DIR}/install.amd/
-
-# Step 7: Add local repository to ISO
-echo "===> Step 7: Adding local repository to ISO"
-mkdir -p ${ISOFILES_DIR}/pf-repo
-cp -r ${REPO_DIR}/* ${ISOFILES_DIR}/pf-repo/
-
-# Step 8: Add Docker images to ISO
-echo "===> Step 8: Adding Docker images to ISO"
-mkdir -p ${ISOFILES_DIR}/docker-images
-cp -r ${DOCKER_IMAGES_DIR}/* ${ISOFILES_DIR}/docker-images/
-
-# Step 9: Copy post-installation script
-echo "===> Step 9: Adding post-installation script"
-cp ${SCRIPT_DIR}/postinst-offline.sh ${ISOFILES_DIR}/
-
-# Step 10: Update boot configurations
-echo "===> Step 10: Updating boot configurations"
-chmod a+w ${ISOFILES_DIR}/isolinux/gtk.cfg ${ISOFILES_DIR}/isolinux/drkgtk.cfg ${ISOFILES_DIR}/isolinux/menu.cfg ${ISOFILES_DIR}/boot/grub/grub.cfg || true
-cp ${SCRIPT_DIR}/gtk.cfg ${ISOFILES_DIR}/isolinux/gtk.cfg
-cp ${SCRIPT_DIR}/drkgtk.cfg ${ISOFILES_DIR}/isolinux/drkgtk.cfg
-cp ${SCRIPT_DIR}/menu.cfg ${ISOFILES_DIR}/isolinux/menu.cfg
-cp ${SCRIPT_DIR}/grub.cfg ${ISOFILES_DIR}/boot/grub/grub.cfg
-chmod 0444 ${ISOFILES_DIR}/isolinux/* || true
-
-# Step 11: Update MD5 checksums
-echo "===> Step 11: Updating MD5 checksums"
-cd "${ISOFILES_DIR}"
-chmod +w md5sum.txt
-# Don't follow symlinks (-follow causes filesystem loops)
-# Some files may fail (symlinks, special files) - continue anyway
-find . -type f ! -name md5sum.txt -print0 | xargs -0 md5sum > md5sum.txt 2>&1 || true
-chmod -w md5sum.txt
-cd "${SCRIPT_DIR}"
-
-# Step 12: Build final ISO
-echo "===> Step 12: Building final ISO"
-# Volume ID: max 16 chars for Joliet (PF- prefix + 13 chars)
-VERSION_SHORT="${PF_VERSION##*/}"
-VERSION_SHORT="${VERSION_SHORT:0:13}"
-VOLID="PF-${VERSION_SHORT}"
-xorriso -as mkisofs \
-    -r -J -joliet-long \
-    -b isolinux/isolinux.bin \
-    -c isolinux/boot.cat \
-    -boot-load-size 4 \
-    -boot-info-table \
-    -no-emul-boot \
-    -eltorito-alt-boot \
-    -e boot/grub/efi.img \
-    -no-emul-boot \
-    -isohybrid-gpt-basdat \
-    -isohybrid-apm-hfsplus \
-    -V "${VOLID}" \
-    -o ${ISO_OUT} \
-    ${ISOFILES_DIR}
+mkdir -p "${WORK_DIR}" "${ISOFILES_DIR}" "${REPO_DIR}" "${DOCKER_IMAGES_DIR}"
 
 echo "=============================================="
-echo "USB Bootable ISO created successfully!"
+echo "USB Bootable ISO build"
+echo "=============================================="
+echo "PF_VERSION:           ${PF_VERSION}"
+echo "PF_RELEASE:           ${PF_RELEASE}"
+echo "PF_RELEASE_VERSION:   ${PF_RELEASE_VERSION}"
+echo "TAG_OR_BRANCH_NAME:   ${TAG_OR_BRANCH_NAME}"
+echo "BUILDER_IMAGE:        ${BUILDER_IMAGE}"
+echo "ISO_IN:               ${ISO_IN}"
+echo "ISO_OUT:              ${ISO_OUT}"
+echo "WORK_DIR:             ${WORK_DIR}"
+echo "=============================================="
+
+# Stage 0: Base Debian DVD ISO (host, wget)
+echo ""
+echo "===> Stage 0: Base Debian DVD ISO"
+if ! [ -f "${ISO_IN}" ]; then
+    if ! command -v wget >/dev/null 2>&1; then
+        echo "ERROR: wget not found on host (needed to fetch base DVD)." >&2
+        exit 1
+    fi
+    BASE_NAME=$(basename "${ISO_IN}")
+    echo "Downloading ${BASE_NAME}... (~3.8 GB, several minutes)"
+    wget --progress=dot:giga \
+        "https://cdimage.debian.org/cdimage/archive/${DEBIAN_VERSION}/amd64/iso-dvd/${BASE_NAME}" \
+        -O "${ISO_IN}"
+    echo "Base ISO: $(du -h "${ISO_IN}" | cut -f1)"
+else
+    echo "Base ISO already present: ${ISO_IN} ($(du -h "${ISO_IN}" | cut -f1))"
+fi
+
+# Stage 1: Pre-pull Docker images (host)
+echo ""
+"${SCRIPT_DIR}/step1-pull-docker-images.sh"
+
+# Stage 2: Build offline APT repository (container)
+echo ""
+"${SCRIPT_DIR}/step2-create-local-repo.sh"
+
+# Stage 3: Assemble final ISO (container)
+echo ""
+"${SCRIPT_DIR}/step3-assemble-iso.sh"
+
+echo ""
+echo "=============================================="
+echo "Build complete!"
 echo "Output: ${ISO_OUT}"
-echo "Size: $(du -h ${ISO_OUT} | cut -f1)"
+[ -f "${ISO_OUT}" ] && echo "Size:   $(du -h "${ISO_OUT}" | cut -f1)"
 echo "=============================================="

--- a/ci/usb-bootable-iso/build-usb-bootable-iso.sh
+++ b/ci/usb-bootable-iso/build-usb-bootable-iso.sh
@@ -42,9 +42,9 @@ DOCKER_IMAGES_DIR=${WORK_DIR}/docker-images
 if [ "${SKIP_CLEAN:-0}" != "1" ]; then
     echo "===> Cleaning work directory to avoid stale package conflicts"
     if [ -d "${WORK_DIR}" ]; then
-        chmod -R +w ${WORK_DIR}
+        chmod -R +w "${WORK_DIR}"
     fi
-    rm -rf ${WORK_DIR}
+    rm -rf "${WORK_DIR}"
 else
     echo "===> Skipping work directory cleanup (SKIP_CLEAN=1)"
 fi

--- a/ci/usb-bootable-iso/build-usb-bootable-iso.sh
+++ b/ci/usb-bootable-iso/build-usb-bootable-iso.sh
@@ -105,14 +105,15 @@ chmod 0444 ${ISOFILES_DIR}/isolinux/* || true
 echo "===> Step 11: Updating MD5 checksums"
 cd ${ISOFILES_DIR}
 chmod +w md5sum.txt
-find -follow -type f ! -name md5sum.txt -print0 | xargs -0 md5sum > md5sum.txt || echo "MD5 generation completed with warnings"
+# Don't follow symlinks (-follow causes filesystem loops)
+find . -type f ! -name md5sum.txt -print0 | xargs -0 md5sum > md5sum.txt 2>/dev/null || echo "MD5 generation completed with warnings"
 chmod -w md5sum.txt
 cd ${SCRIPT_DIR}
 
 # Step 12: Build final ISO
 echo "===> Step 12: Building final ISO"
-# ISO 9660 volume ID has a 32 character limit
-# Format: PFusb-${short_name} (6 chars prefix + 26 chars max for name)
+# ISO 9660 volume ID: max 32 chars, Joliet: max 16 chars
+# Format: PF-${short_name} (3 chars prefix + 13 chars max for Joliet compatibility)
 if [[ "${PF_VERSION}" == *"/"* ]]; then
     VERSION_SHORT="${PF_VERSION##*/}"
     echo "Volume ID: extracted '${VERSION_SHORT}' from '${PF_VERSION}'"
@@ -120,9 +121,9 @@ else
     VERSION_SHORT="${PF_VERSION}"
     echo "Volume ID: using '${VERSION_SHORT}' (no slash found)"
 fi
-# Truncate to 26 characters to fit within 32 char limit with "PFusb-" prefix
-VERSION_SHORT="${VERSION_SHORT:0:26}"
-VOLID="PFusb-${VERSION_SHORT}"
+# Truncate to 13 characters to fit within 16 char Joliet limit with "PF-" prefix
+VERSION_SHORT="${VERSION_SHORT:0:13}"
+VOLID="PF-${VERSION_SHORT}"
 echo "Volume ID: final value '${VOLID}' (${#VOLID} chars)"
 xorriso -as mkisofs \
     -r -J -joliet-long \

--- a/ci/usb-bootable-iso/build-usb-bootable-iso.sh
+++ b/ci/usb-bootable-iso/build-usb-bootable-iso.sh
@@ -111,6 +111,19 @@ cd ${SCRIPT_DIR}
 
 # Step 12: Build final ISO
 echo "===> Step 12: Building final ISO"
+# ISO 9660 volume ID has a 32 character limit
+# Format: PFusb-${short_name} (6 chars prefix + 26 chars max for name)
+if [[ "${PF_VERSION}" == *"/"* ]]; then
+    VERSION_SHORT="${PF_VERSION##*/}"
+    echo "Volume ID: extracted '${VERSION_SHORT}' from '${PF_VERSION}'"
+else
+    VERSION_SHORT="${PF_VERSION}"
+    echo "Volume ID: using '${VERSION_SHORT}' (no slash found)"
+fi
+# Truncate to 26 characters to fit within 32 char limit with "PFusb-" prefix
+VERSION_SHORT="${VERSION_SHORT:0:26}"
+VOLID="PFusb-${VERSION_SHORT}"
+echo "Volume ID: final value '${VOLID}' (${#VOLID} chars)"
 xorriso -as mkisofs \
     -r -J -joliet-long \
     -b isolinux/isolinux.bin \
@@ -123,7 +136,7 @@ xorriso -as mkisofs \
     -no-emul-boot \
     -isohybrid-gpt-basdat \
     -isohybrid-apm-hfsplus \
-    -V "PacketFence USB ${PF_VERSION}" \
+    -V "${VOLID}" \
     -o ${ISO_OUT} \
     ${ISOFILES_DIR}
 

--- a/ci/usb-bootable-iso/build-usb-bootable-iso.sh
+++ b/ci/usb-bootable-iso/build-usb-bootable-iso.sh
@@ -93,7 +93,7 @@ cp ${SCRIPT_DIR}/postinst-offline.sh ${ISOFILES_DIR}/
 
 # Step 10: Update boot configurations
 echo "===> Step 10: Updating boot configurations"
-chmod a+w ${ISOFILES_DIR}/isolinux/gtk.cfg ${ISOFILES_DIR}/isolinux/drkgtk.cfg ${ISOFILES_DIR}/boot/grub/grub.cfg || true
+chmod a+w ${ISOFILES_DIR}/isolinux/gtk.cfg ${ISOFILES_DIR}/isolinux/drkgtk.cfg ${ISOFILES_DIR}/isolinux/menu.cfg ${ISOFILES_DIR}/boot/grub/grub.cfg || true
 cp ${SCRIPT_DIR}/gtk.cfg ${ISOFILES_DIR}/isolinux/gtk.cfg
 cp ${SCRIPT_DIR}/drkgtk.cfg ${ISOFILES_DIR}/isolinux/drkgtk.cfg
 cp ${SCRIPT_DIR}/menu.cfg ${ISOFILES_DIR}/isolinux/menu.cfg

--- a/ci/usb-bootable-iso/build-usb-bootable-iso.sh
+++ b/ci/usb-bootable-iso/build-usb-bootable-iso.sh
@@ -74,10 +74,7 @@ fi
 
 # Step 2: Create local APT repository with all packages
 echo "===> Step 2: Creating local APT repository"
-# debootstrap requires root privileges
-sudo ${SCRIPT_DIR}/create-local-repo.sh ${REPO_DIR} ${PF_RELEASE_VERSION}
-# Fix ownership after running as root
-sudo chown -R $(id -u):$(id -g) ${REPO_DIR}
+${SCRIPT_DIR}/create-local-repo.sh ${REPO_DIR} ${PF_RELEASE_VERSION}
 
 # Step 3: Pre-download Docker images
 echo "===> Step 3: Pre-downloading Docker images"

--- a/ci/usb-bootable-iso/build-usb-bootable-iso.sh
+++ b/ci/usb-bootable-iso/build-usb-bootable-iso.sh
@@ -38,8 +38,12 @@ DOCKER_IMAGES_DIR=${WORK_DIR}/docker-images
 
 # Clean work directory to avoid stale package conflicts
 # Set SKIP_CLEAN=1 to skip cleaning (for faster rebuilds when debugging)
+# Make files writable first because extracted ISO files have read-only permissions
 if [ "${SKIP_CLEAN:-0}" != "1" ]; then
     echo "===> Cleaning work directory to avoid stale package conflicts"
+    if [ -d "${WORK_DIR}" ]; then
+        chmod -R +w ${WORK_DIR}
+    fi
     rm -rf ${WORK_DIR}
 else
     echo "===> Skipping work directory cleanup (SKIP_CLEAN=1)"

--- a/ci/usb-bootable-iso/build-usb-bootable-iso.sh
+++ b/ci/usb-bootable-iso/build-usb-bootable-iso.sh
@@ -5,6 +5,27 @@ set -o nounset -o pipefail -o errexit
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 PF_ROOT=$(cd "${SCRIPT_DIR}/../.." && pwd)
 
+# Install required packages if not present
+echo "===> Checking/installing required packages..."
+# Note: docker.io not listed - CI runner has Docker from docker.com repo
+REQUIRED_PKGS="debootstrap xorriso dpkg-dev cpio gnupg"
+MISSING_PKGS=""
+for pkg in ${REQUIRED_PKGS}; do
+    if ! dpkg -s "${pkg}" >/dev/null 2>&1; then
+        MISSING_PKGS="${MISSING_PKGS} ${pkg}"
+    fi
+done
+if [ -n "${MISSING_PKGS}" ]; then
+    echo "Installing missing packages:${MISSING_PKGS}"
+    sudo apt-get update -qq
+    sudo apt-get install -y -qq ${MISSING_PKGS}
+fi
+# Verify docker is available (from any source)
+if ! command -v docker >/dev/null 2>&1; then
+    echo "ERROR: docker command not found. Please install Docker."
+    exit 1
+fi
+
 # Configuration
 ISO_IN=${ISO_IN:-debian-12.6.0-amd64-netinst.iso}
 ISO_OUT=${ISO_OUT:-packetfence-usb-installer.iso}

--- a/ci/usb-bootable-iso/build-usb-bootable-iso.sh
+++ b/ci/usb-bootable-iso/build-usb-bootable-iso.sh
@@ -28,7 +28,6 @@ if ! command -v docker >/dev/null 2>&1; then
 fi
 
 # Configuration
-# DEBIAN_VERSION sourced from ../debian-version.conf
 ISO_IN=${ISO_IN:-debian-${DEBIAN_VERSION}-amd64-DVD-1.iso}
 ISO_OUT=${ISO_OUT:-packetfence-usb-installer.iso}
 WORK_DIR=${SCRIPT_DIR}/work
@@ -117,15 +116,13 @@ xorriso -osirrox on -indev ${SCRIPT_DIR}/${ISO_IN} -extract / ${ISOFILES_DIR}
 
 # Step 5: Generate preseed configuration
 echo "===> Step 5: Generating preseed configuration"
-# Generate as preseed.cfg (standard name) for auto-detection by installer
-cat ${SCRIPT_DIR}/preseed-offline.cfg.tmpl | \
-    sed "s/%%PF_VERSION%%/${PF_RELEASE_VERSION}/g" | \
-    sed "s/%%PF_RELEASE%%/${PF_RELEASE}/g" > ${SCRIPT_DIR}/preseed.cfg
+sed -e "s/%%PF_VERSION%%/${PF_RELEASE_VERSION}/g" \
+    -e "s/%%PF_RELEASE%%/${PF_RELEASE}/g" \
+    "${SCRIPT_DIR}/preseed-offline.cfg.tmpl" > "${SCRIPT_DIR}/preseed.cfg"
 
 # Step 6: Inject preseed into initrd
 echo "===> Step 6: Injecting preseed into initrd"
-# Inject as preseed.cfg (standard name) - installer will auto-detect it
-chmod +w -R ${ISOFILES_DIR}/install.amd/
+chmod +w -R "${ISOFILES_DIR}/install.amd/"
 gunzip ${ISOFILES_DIR}/install.amd/initrd.gz
 echo preseed.cfg | cpio -H newc -o -A -F ${ISOFILES_DIR}/install.amd/initrd
 gzip ${ISOFILES_DIR}/install.amd/initrd
@@ -166,19 +163,10 @@ cd "${SCRIPT_DIR}"
 
 # Step 12: Build final ISO
 echo "===> Step 12: Building final ISO"
-# ISO 9660 volume ID: max 32 chars, Joliet: max 16 chars
-# Format: PF-${short_name} (3 chars prefix + 13 chars max for Joliet compatibility)
-if [[ "${PF_VERSION}" == *"/"* ]]; then
-    VERSION_SHORT="${PF_VERSION##*/}"
-    echo "Volume ID: extracted '${VERSION_SHORT}' from '${PF_VERSION}'"
-else
-    VERSION_SHORT="${PF_VERSION}"
-    echo "Volume ID: using '${VERSION_SHORT}' (no slash found)"
-fi
-# Truncate to 13 characters to fit within 16 char Joliet limit with "PF-" prefix
+# Volume ID: max 16 chars for Joliet (PF- prefix + 13 chars)
+VERSION_SHORT="${PF_VERSION##*/}"
 VERSION_SHORT="${VERSION_SHORT:0:13}"
 VOLID="PF-${VERSION_SHORT}"
-echo "Volume ID: final value '${VOLID}' (${#VOLID} chars)"
 xorriso -as mkisofs \
     -r -J -joliet-long \
     -b isolinux/isolinux.bin \

--- a/ci/usb-bootable-iso/create-local-repo.sh
+++ b/ci/usb-bootable-iso/create-local-repo.sh
@@ -16,76 +16,44 @@ echo "REPO_DIR: ${REPO_DIR}"
 echo "PF_RELEASE_VERSION: ${PF_RELEASE_VERSION}"
 echo "=============================================="
 
+# Use absolute path for REPO_DIR
+REPO_DIR=$(cd "$(dirname "${REPO_DIR}")" && pwd)/$(basename "${REPO_DIR}")
+
 # Create directory structure
 mkdir -p ${REPO_DIR}/pool/main
 mkdir -p ${REPO_DIR}/dists/bookworm/main/binary-amd64
 
-# Create a temporary directory for package download
-TEMP_DIR=$(mktemp -d)
-trap "rm -rf ${TEMP_DIR}" EXIT
+# Create a temporary chroot for clean package resolution
+CHROOT_DIR=$(mktemp -d)
+trap "echo 'Cleaning up chroot...'; rm -rf ${CHROOT_DIR}" EXIT
 
-# Create a minimal sources.list for downloading packages
-cat > ${TEMP_DIR}/sources.list << EOF
+echo "===> Creating minimal chroot for package download"
+debootstrap --variant=minbase --include=apt,gnupg,ca-certificates bookworm ${CHROOT_DIR} http://deb.debian.org/debian
+
+# Configure repositories in chroot
+cat > ${CHROOT_DIR}/etc/apt/sources.list << EOF
 deb http://deb.debian.org/debian bookworm main contrib non-free non-free-firmware
 deb http://deb.debian.org/debian bookworm-updates main contrib non-free non-free-firmware
 deb http://security.debian.org/debian-security bookworm-security main contrib non-free non-free-firmware
-deb http://inverse.ca/downloads/PacketFence/debian/${PF_RELEASE_VERSION} bookworm bookworm
 EOF
 
-# Create apt configuration
-mkdir -p ${TEMP_DIR}/apt/lists/partial
-mkdir -p ${TEMP_DIR}/apt/cache/archives/partial
+# Add PacketFence repository
+mkdir -p ${CHROOT_DIR}/etc/apt/keyrings
+curl -fsSL https://inverse.ca/downloads/GPG_PUBLIC_KEY | gpg --dearmor > ${CHROOT_DIR}/etc/apt/keyrings/packetfence.gpg
+cat > ${CHROOT_DIR}/etc/apt/sources.list.d/packetfence.list << EOF
+deb [signed-by=/etc/apt/keyrings/packetfence.gpg] http://inverse.ca/downloads/PacketFence/debian/${PF_RELEASE_VERSION} bookworm bookworm
+EOF
 
-APT_CONFIG="Dir::Etc::sourcelist=${TEMP_DIR}/sources.list;
-Dir::Etc::sourceparts=-;
-Dir::State::lists=${TEMP_DIR}/apt/lists;
-Dir::Cache=${TEMP_DIR}/apt/cache;
-APT::Get::AllowUnauthenticated=true;
-Acquire::AllowInsecureRepositories=true;"
+# Copy GPG key to repo for later use
+cp ${CHROOT_DIR}/etc/apt/keyrings/packetfence.gpg ${REPO_DIR}/packetfence.gpg
 
-# Add PacketFence GPG key
-echo "===> Adding PacketFence GPG key"
-curl -fsSL https://inverse.ca/downloads/GPG_PUBLIC_KEY | gpg --dearmor > ${TEMP_DIR}/packetfence.gpg
-export APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
-
-# Update package lists
-echo "===> Updating package lists"
-apt-get -o "${APT_CONFIG}" update 2>/dev/null || true
-
-# List of base packages needed for installation
-BASE_PACKAGES="
-    sudo
-    bzip2
-    acpid
-    cryptsetup
-    zlib1g-dev
-    wget
-    curl
-    dkms
-    make
-    nfs-common
-    net-tools
-    build-essential
-    linux-headers-amd64
-    gnupg2
-    apt-transport-https
-    tmux
-    tcpdump
-    lnav
-    apg
-    sysstat
-    bsd-mailx
-    cgroupfs-mount
-    openssh-server
-"
-
-# PacketFence and its major dependencies
-PF_PACKAGES="
+# List of packages to install (will pull all dependencies)
+PACKAGES="
     packetfence
-    mariadb-server
-    redis-server
     docker.io
     containerd
+    mariadb-server
+    redis-server
     freeradius
     freeradius-utils
     freeradius-ldap
@@ -95,55 +63,46 @@ PF_PACKAGES="
     snmp
     snmptrapd
     snmpd
-    libsnmp-dev
-    nodejs
     fingerbank-collector
+    sudo
+    openssh-server
+    curl
+    wget
+    gnupg2
+    ca-certificates
+    apt-transport-https
+    net-tools
+    tcpdump
+    tmux
+    lnav
 "
 
-# Download all packages with dependencies
-echo "===> Downloading packages (this may take a while)..."
-cd ${TEMP_DIR}
+# Update and download all packages with dependencies in chroot
+echo "===> Updating package lists in chroot"
+chroot ${CHROOT_DIR} apt-get update
 
-# Download packages
-apt-get -o "${APT_CONFIG}" download \
-    --print-uris \
-    ${BASE_PACKAGES} ${PF_PACKAGES} 2>/dev/null | \
-    grep "^'" | \
-    cut -d"'" -f2 > ${TEMP_DIR}/package_urls.txt || true
+echo "===> Downloading all packages with dependencies"
+# Use apt-get install with download-only to get ALL dependencies
+chroot ${CHROOT_DIR} apt-get install -y --download-only -o APT::Install-Recommends=0 ${PACKAGES} || true
 
-# Also get dependencies
-apt-get -o "${APT_CONFIG}" install \
-    --download-only \
-    --print-uris \
-    -y \
-    ${BASE_PACKAGES} ${PF_PACKAGES} 2>/dev/null | \
-    grep "^'" | \
-    cut -d"'" -f2 >> ${TEMP_DIR}/package_urls.txt || true
+# Some packages may fail due to pre-depends, try downloading them directly
+echo "===> Downloading any missing packages"
+chroot ${CHROOT_DIR} bash -c "apt-get download ${PACKAGES} 2>/dev/null || true"
 
-# Remove duplicates
-sort -u ${TEMP_DIR}/package_urls.txt > ${TEMP_DIR}/package_urls_unique.txt
-
-# Download packages using wget for better progress
-echo "===> Downloading $(wc -l < ${TEMP_DIR}/package_urls_unique.txt) packages..."
-mkdir -p ${TEMP_DIR}/packages
-cd ${TEMP_DIR}/packages
-
-# Download in parallel using xargs
-cat ${TEMP_DIR}/package_urls_unique.txt | xargs -P 10 -I {} wget -q --show-progress -nc {} 2>/dev/null || true
-
-# Alternative: use apt-get download directly
-echo "===> Using apt-get to download remaining packages..."
-apt-get -o "${APT_CONFIG}" download ${BASE_PACKAGES} ${PF_PACKAGES} 2>/dev/null || true
-
-# Also download dependencies
-for pkg in ${BASE_PACKAGES} ${PF_PACKAGES}; do
-    apt-get -o "${APT_CONFIG}" download $(apt-cache -o "${APT_CONFIG}" depends --recurse --no-recommends --no-suggests --no-conflicts --no-breaks --no-replaces --no-enhances ${pkg} 2>/dev/null | grep "^\w" | sort -u) 2>/dev/null || true
+# Download dependencies recursively using apt-cache
+echo "===> Resolving and downloading all dependencies"
+chroot ${CHROOT_DIR} bash -c '
+PACKAGES="packetfence docker.io containerd mariadb-server redis-server freeradius fingerbank-collector"
+for pkg in $PACKAGES; do
+    deps=$(apt-cache depends --recurse --no-recommends --no-suggests --no-conflicts --no-breaks --no-replaces --no-enhances "$pkg" 2>/dev/null | grep "^\w" | grep -v "^<" | sort -u)
+    apt-get download $deps 2>/dev/null || true
 done
+'
 
 # Move all downloaded packages to repo
 echo "===> Moving packages to repository"
-find ${TEMP_DIR} -name "*.deb" -exec mv {} ${REPO_DIR}/pool/main/ \; 2>/dev/null || true
-# Note: Don't copy from /var/cache/apt/archives as it contains unrelated host packages
+find ${CHROOT_DIR}/var/cache/apt/archives -name "*.deb" -exec cp {} ${REPO_DIR}/pool/main/ \; 2>/dev/null || true
+find ${CHROOT_DIR} -maxdepth 1 -name "*.deb" -exec mv {} ${REPO_DIR}/pool/main/ \; 2>/dev/null || true
 
 # Generate Packages file
 echo "===> Generating Packages index"

--- a/ci/usb-bootable-iso/create-local-repo.sh
+++ b/ci/usb-bootable-iso/create-local-repo.sh
@@ -28,27 +28,27 @@ mkdir -p ${REPO_DIR}/dists/bookworm/main/binary-amd64
 
 # Create a temporary chroot for clean package resolution
 CHROOT_DIR=$(mktemp -d)
-trap "echo 'Cleaning up chroot...'; rm -rf ${CHROOT_DIR}" EXIT
+trap "echo 'Cleaning up chroot...'; sudo rm -rf ${CHROOT_DIR}" EXIT
 
 echo "===> Creating minimal chroot for package download"
-debootstrap --variant=minbase --include=apt,gnupg,ca-certificates bookworm ${CHROOT_DIR} http://deb.debian.org/debian
+sudo debootstrap --variant=minbase --include=apt,gnupg,ca-certificates bookworm ${CHROOT_DIR} http://deb.debian.org/debian
 
-# Configure repositories in chroot
-cat > ${CHROOT_DIR}/etc/apt/sources.list << EOF
+# Configure repositories in chroot (need sudo since debootstrap created files as root)
+sudo tee ${CHROOT_DIR}/etc/apt/sources.list > /dev/null << EOF
 deb http://deb.debian.org/debian bookworm main contrib non-free non-free-firmware
 deb http://deb.debian.org/debian bookworm-updates main contrib non-free non-free-firmware
 deb http://security.debian.org/debian-security bookworm-security main contrib non-free non-free-firmware
 EOF
 
 # Add PacketFence repository
-mkdir -p ${CHROOT_DIR}/etc/apt/keyrings
-curl -fsSL https://inverse.ca/downloads/GPG_PUBLIC_KEY | gpg --dearmor > ${CHROOT_DIR}/etc/apt/keyrings/packetfence.gpg
-cat > ${CHROOT_DIR}/etc/apt/sources.list.d/packetfence.list << EOF
+sudo mkdir -p ${CHROOT_DIR}/etc/apt/keyrings
+curl -fsSL https://inverse.ca/downloads/GPG_PUBLIC_KEY | gpg --dearmor | sudo tee ${CHROOT_DIR}/etc/apt/keyrings/packetfence.gpg > /dev/null
+sudo tee ${CHROOT_DIR}/etc/apt/sources.list.d/packetfence.list > /dev/null << EOF
 deb [signed-by=/etc/apt/keyrings/packetfence.gpg] http://inverse.ca/downloads/PacketFence/debian/${PF_RELEASE_VERSION} bookworm bookworm
 EOF
 
 # Copy GPG key to repo for later use
-cp ${CHROOT_DIR}/etc/apt/keyrings/packetfence.gpg ${REPO_DIR}/packetfence.gpg
+sudo cp ${CHROOT_DIR}/etc/apt/keyrings/packetfence.gpg ${REPO_DIR}/packetfence.gpg
 
 # List of packages to install (will pull all dependencies)
 PACKAGES="
@@ -82,19 +82,19 @@ PACKAGES="
 
 # Update and download all packages with dependencies in chroot
 echo "===> Updating package lists in chroot"
-chroot ${CHROOT_DIR} apt-get update
+sudo chroot ${CHROOT_DIR} apt-get update
 
 echo "===> Downloading all packages with dependencies"
 # Use apt-get install with download-only to get ALL dependencies
-chroot ${CHROOT_DIR} apt-get install -y --download-only -o APT::Install-Recommends=0 ${PACKAGES} || true
+sudo chroot ${CHROOT_DIR} apt-get install -y --download-only -o APT::Install-Recommends=0 ${PACKAGES} || true
 
 # Some packages may fail due to pre-depends, try downloading them directly
 echo "===> Downloading any missing packages"
-chroot ${CHROOT_DIR} bash -c "apt-get download ${PACKAGES} 2>/dev/null || true"
+sudo chroot ${CHROOT_DIR} bash -c "apt-get download ${PACKAGES} 2>/dev/null || true"
 
 # Download dependencies recursively using apt-cache
 echo "===> Resolving and downloading all dependencies"
-chroot ${CHROOT_DIR} bash -c '
+sudo chroot ${CHROOT_DIR} bash -c '
 PACKAGES="packetfence docker.io containerd mariadb-server redis-server freeradius fingerbank-collector"
 for pkg in $PACKAGES; do
     deps=$(apt-cache depends --recurse --no-recommends --no-suggests --no-conflicts --no-breaks --no-replaces --no-enhances "$pkg" 2>/dev/null | grep "^\w" | grep -v "^<" | sort -u)
@@ -104,8 +104,10 @@ done
 
 # Move all downloaded packages to repo
 echo "===> Moving packages to repository"
-find ${CHROOT_DIR}/var/cache/apt/archives -name "*.deb" -exec cp {} ${REPO_DIR}/pool/main/ \; 2>/dev/null || true
-find ${CHROOT_DIR} -maxdepth 1 -name "*.deb" -exec mv {} ${REPO_DIR}/pool/main/ \; 2>/dev/null || true
+sudo find ${CHROOT_DIR}/var/cache/apt/archives -name "*.deb" -exec cp {} ${REPO_DIR}/pool/main/ \; 2>/dev/null || true
+sudo find ${CHROOT_DIR} -maxdepth 1 -name "*.deb" -exec mv {} ${REPO_DIR}/pool/main/ \; 2>/dev/null || true
+# Fix ownership of copied files
+sudo chown -R $(id -u):$(id -g) ${REPO_DIR}
 
 # Generate Packages file
 echo "===> Generating Packages index"

--- a/ci/usb-bootable-iso/create-local-repo.sh
+++ b/ci/usb-bootable-iso/create-local-repo.sh
@@ -143,7 +143,7 @@ done
 # Move all downloaded packages to repo
 echo "===> Moving packages to repository"
 find ${TEMP_DIR} -name "*.deb" -exec mv {} ${REPO_DIR}/pool/main/ \; 2>/dev/null || true
-find /var/cache/apt/archives -name "*.deb" -exec cp {} ${REPO_DIR}/pool/main/ \; 2>/dev/null || true
+# Note: Don't copy from /var/cache/apt/archives as it contains unrelated host packages
 
 # Generate Packages file
 echo "===> Generating Packages index"

--- a/ci/usb-bootable-iso/create-local-repo.sh
+++ b/ci/usb-bootable-iso/create-local-repo.sh
@@ -55,7 +55,7 @@ mkdir -p ${REPO_DIR}/dists/bookworm/main/binary-amd64
 
 # Create a temporary chroot for package download
 CHROOT_DIR=$(mktemp -d)
-trap "echo 'Cleaning up chroot...'; sudo rm -rf ${CHROOT_DIR}" EXIT
+trap 'echo "Cleaning up chroot..."; sudo rm -rf "${CHROOT_DIR}"' EXIT
 
 echo "===> Creating minimal chroot for package download"
 sudo debootstrap --variant=minbase --include=apt,gnupg,ca-certificates bookworm ${CHROOT_DIR} http://deb.debian.org/debian

--- a/ci/usb-bootable-iso/create-local-repo.sh
+++ b/ci/usb-bootable-iso/create-local-repo.sh
@@ -94,6 +94,7 @@ ${SUDO} cp ${CHROOT_DIR}/etc/apt/keyrings/packetfence.gpg ${REPO_DIR}/packetfenc
 
 # Packages to download (not on DVD or need specific versions)
 PACKAGES="
+    dpkg-dev
     packetfence
     packetfence-pfcmd-suid
     packetfence-config

--- a/ci/usb-bootable-iso/create-local-repo.sh
+++ b/ci/usb-bootable-iso/create-local-repo.sh
@@ -149,3 +149,33 @@ echo "Packages: ${PKG_COUNT}"
 echo "Size: ${REPO_SIZE}"
 echo "Location: ${REPO_DIR}"
 echo "=============================================="
+
+# Verify key packages are present
+echo ""
+echo "===> Verifying key packages in repository:"
+KEY_PACKAGES="packetfence packetfence-pfcmd-suid docker.io containerd mariadb-server redis-server freeradius fingerbank-collector"
+MISSING=""
+for pkg in ${KEY_PACKAGES}; do
+    if find ${REPO_DIR}/pool -name "${pkg}_*.deb" | grep -q .; then
+        echo "  [OK] ${pkg}"
+    else
+        echo "  [MISSING] ${pkg}"
+        MISSING="${MISSING} ${pkg}"
+    fi
+done
+
+if [ -n "${MISSING}" ]; then
+    echo ""
+    echo "WARNING: Missing packages:${MISSING}"
+    echo "The offline installation may fail!"
+    exit 1
+fi
+
+echo ""
+echo "===> Package breakdown by source:"
+echo "  PacketFence packages: $(find ${REPO_DIR}/pool -name "packetfence*.deb" -o -name "fingerbank*.deb" | wc -l)"
+echo "  Docker packages: $(find ${REPO_DIR}/pool -name "docker*.deb" -o -name "containerd*.deb" | wc -l)"
+echo "  MariaDB packages: $(find ${REPO_DIR}/pool -name "mariadb*.deb" -o -name "mysql*.deb" -o -name "galera*.deb" | wc -l)"
+echo "  FreeRADIUS packages: $(find ${REPO_DIR}/pool -name "freeradius*.deb" | wc -l)"
+echo "  Other packages: $(find ${REPO_DIR}/pool -name "*.deb" | wc -l) total"
+echo "=============================================="

--- a/ci/usb-bootable-iso/create-local-repo.sh
+++ b/ci/usb-bootable-iso/create-local-repo.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -o nounset -o pipefail -o errexit
 
+# Ensure /usr/sbin is in PATH (debootstrap is installed there)
+export PATH="/usr/sbin:/sbin:${PATH}"
+
 # Arguments
 REPO_DIR=${1:-./repo}
 PF_RELEASE_VERSION=${2:-15.1}

--- a/ci/usb-bootable-iso/create-local-repo.sh
+++ b/ci/usb-bootable-iso/create-local-repo.sh
@@ -56,6 +56,8 @@ sudo cp ${CHROOT_DIR}/etc/apt/keyrings/packetfence.gpg ${REPO_DIR}/packetfence.g
 PACKAGES="
     packetfence
     fingerbank-collector
+    linux-image-amd64
+    linux-headers-amd64
     bind9-dnsutils
     bind9-libs
     bind9-host
@@ -167,7 +169,7 @@ echo "=============================================="
 # Verify key packages are present
 echo ""
 echo "===> Verifying key packages in repository:"
-KEY_PACKAGES="packetfence fingerbank-collector docker-ce docker-ce-cli containerd.io"
+KEY_PACKAGES="packetfence fingerbank-collector docker-ce docker-ce-cli containerd.io linux-image-amd64"
 MISSING=""
 for pkg in ${KEY_PACKAGES}; do
     if find ${REPO_DIR}/pool -name "${pkg}_*.deb" | grep -q .; then

--- a/ci/usb-bootable-iso/create-local-repo.sh
+++ b/ci/usb-bootable-iso/create-local-repo.sh
@@ -55,6 +55,14 @@ sudo cp ${CHROOT_DIR}/etc/apt/keyrings/packetfence.gpg ${REPO_DIR}/packetfence.g
 #   - Other dependencies
 PACKAGES="
     packetfence
+    packetfence-pfcmd-suid
+    packetfence-config
+    packetfence-redis-cache
+    packetfence-perl
+    packetfence-ntlm-wrapper
+    packetfence-golang-daemon
+    packetfence-archive-keyring
+    fingerbank
     fingerbank-collector
     linux-image-amd64
     linux-headers-amd64

--- a/ci/usb-bootable-iso/create-local-repo.sh
+++ b/ci/usb-bootable-iso/create-local-repo.sh
@@ -21,14 +21,19 @@ PF_REPO_TYPE=${PF_REPO_TYPE:-debian-branches}
 
 # Build URL based on repo type
 # gitlab pipelines use: http://inverse.ca/downloads/PacketFence/gitlab/PIPELINE_ID/debian bookworm main
-# branches use: http://inverse.ca/downloads/PacketFence/debian/VERSION bookworm bookworm
+# branches use: http://inverse.ca/downloads/PacketFence/debian-branches/VERSION bookworm bookworm
+# Note: packetfence packages are in debian-branches repo, fingerbank/docker are in debian repo
 if [[ "${PF_REPO_TYPE}" == gitlab/* ]]; then
     PF_REPO_BASE_URL="http://inverse.ca/downloads/PacketFence/${PF_REPO_TYPE}/debian"
     PF_REPO_COMPONENT="main"
 else
-    PF_REPO_BASE_URL="http://inverse.ca/downloads/PacketFence/debian/${PF_RELEASE_VERSION}"
+    # Use the PF_REPO_TYPE in the URL (e.g., debian-branches or debian)
+    PF_REPO_BASE_URL="http://inverse.ca/downloads/PacketFence/${PF_REPO_TYPE}/${PF_RELEASE_VERSION}"
     PF_REPO_COMPONENT="bookworm"
 fi
+
+# URL for dependency packages (fingerbank, docker, freeradius are in debian/VERSION repo)
+PF_DEPS_BASE_URL="http://inverse.ca/downloads/PacketFence/debian/${PF_RELEASE_VERSION}"
 
 echo "=============================================="
 echo "Creating PacketFence Package Repository"
@@ -38,6 +43,7 @@ echo "REPO_DIR: ${REPO_DIR}"
 echo "PF_RELEASE_VERSION: ${PF_RELEASE_VERSION}"
 echo "PF_REPO_TYPE: ${PF_REPO_TYPE}"
 echo "PF_REPO_BASE_URL: ${PF_REPO_BASE_URL}"
+echo "PF_DEPS_BASE_URL: ${PF_DEPS_BASE_URL}"
 echo "=============================================="
 
 # Use absolute path for REPO_DIR
@@ -64,14 +70,15 @@ EOF
 
 echo "Configured PacketFence repo: ${PF_REPO_BASE_URL}"
 
-# For gitlab pipelines, add devel repo for dependencies (fingerbank, packetfence-perl, etc.)
-# The gitlab repo only contains packetfence packages built during CI
-if [[ "${PF_REPO_TYPE}" == gitlab/* ]]; then
-    echo "===> Adding devel repository for dependencies"
+# Add dependencies repo for fingerbank, freeradius, docker packages
+# These are always in debian/VERSION repo, separate from packetfence packages
+# (packetfence packages are in debian-branches/VERSION or gitlab/PIPELINE_ID repos)
+if [[ "${PF_REPO_BASE_URL}" != "${PF_DEPS_BASE_URL}" ]]; then
+    echo "===> Adding dependencies repository (fingerbank, freeradius, etc.)"
     sudo tee ${CHROOT_DIR}/etc/apt/sources.list.d/packetfence_deps.list > /dev/null << EOF
-deb [signed-by=/etc/apt/keyrings/packetfence.gpg] http://inverse.ca/downloads/PacketFence/debian/${PF_RELEASE_VERSION} bookworm bookworm
+deb [signed-by=/etc/apt/keyrings/packetfence.gpg] ${PF_DEPS_BASE_URL} bookworm bookworm
 EOF
-    echo "Configured dependencies repo: http://inverse.ca/downloads/PacketFence/debian/${PF_RELEASE_VERSION}"
+    echo "Configured dependencies repo: ${PF_DEPS_BASE_URL}"
 fi
 
 # Copy GPG key to repo for later use

--- a/ci/usb-bootable-iso/create-local-repo.sh
+++ b/ci/usb-bootable-iso/create-local-repo.sh
@@ -51,6 +51,7 @@ sudo cp ${CHROOT_DIR}/etc/apt/keyrings/packetfence.gpg ${REPO_DIR}/packetfence.g
 #   - PacketFence and fingerbank packages
 #   - Packages that might be missing from DVD-1
 #   - FreeRADIUS packages (specific versions needed)
+#   - Packages from preseed pkgsel/include that may not be on DVD-1
 #   - Other dependencies
 PACKAGES="
     packetfence
@@ -78,6 +79,8 @@ PACKAGES="
     snmp
     vlan
     arping
+    lnav
+    cgroupfs-mount
     fping
     ipset
 "

--- a/ci/usb-bootable-iso/create-local-repo.sh
+++ b/ci/usb-bootable-iso/create-local-repo.sh
@@ -246,11 +246,21 @@ echo "=============================================="
 echo ""
 echo "===> Verifying key packages:"
 KEY_PACKAGES="packetfence fingerbank-collector docker-ce docker-ce-cli containerd.io"
+ALLOW_MISSING_PKGS="${ALLOW_MISSING_PKGS:-}"
+MISSING_PKGS=""
 for pkg in ${KEY_PACKAGES}; do
     if find ${REPO_DIR}/pool -name "${pkg}_*.deb" | grep -q .; then
         echo "  [OK] ${pkg}"
+    elif echo " ${ALLOW_MISSING_PKGS} " | grep -q " ${pkg} "; then
+        echo "  [SKIP] ${pkg} (allowed missing via ALLOW_MISSING_PKGS)"
     else
-        echo "  [MISSING] ${pkg} (may be on DVD or not yet published)"
+        echo "  [MISSING] ${pkg}"
+        MISSING_PKGS="${MISSING_PKGS} ${pkg}"
     fi
 done
 echo "=============================================="
+if [ -n "${MISSING_PKGS}" ]; then
+    echo "ERROR: required packages not in local repo:${MISSING_PKGS}" >&2
+    echo "Set ALLOW_MISSING_PKGS=\"pkg1 pkg2\" to bypass for known-absent packages." >&2
+    exit 1
+fi

--- a/ci/usb-bootable-iso/create-local-repo.sh
+++ b/ci/usb-bootable-iso/create-local-repo.sh
@@ -18,7 +18,15 @@ PF_ROOT=$(cd "${SCRIPT_DIR}/../.." && pwd)
 #   - debian-lastrelease: Last release builds (for maintenance releases)
 #   - gitlab/PIPELINE_ID: Specific CI pipeline builds
 PF_REPO_TYPE=${PF_REPO_TYPE:-debian-branches}
-PF_REPO_BASE_URL="https://inverse.ca/downloads/PacketFence/${PF_REPO_TYPE}/${PF_RELEASE_VERSION}"
+
+# Build URL based on repo type
+# gitlab pipelines use: http://inverse.ca/downloads/PacketFence/gitlab/PIPELINE_ID/debian
+# other types use: http://inverse.ca/downloads/PacketFence/TYPE/VERSION
+if [[ "${PF_REPO_TYPE}" == gitlab/* ]]; then
+    PF_REPO_BASE_URL="http://inverse.ca/downloads/PacketFence/${PF_REPO_TYPE}/debian"
+else
+    PF_REPO_BASE_URL="http://inverse.ca/downloads/PacketFence/${PF_REPO_TYPE}/${PF_RELEASE_VERSION}"
+fi
 
 echo "=============================================="
 echo "Creating PacketFence Package Repository"

--- a/ci/usb-bootable-iso/create-local-repo.sh
+++ b/ci/usb-bootable-iso/create-local-repo.sh
@@ -98,6 +98,7 @@ PACKAGES="
     libcache-bdb-perl
     liblog-fast-perl
     libfile-flock-perl
+    libcjson1
 "
 
 # Add Docker repository for docker-ce packages

--- a/ci/usb-bootable-iso/create-local-repo.sh
+++ b/ci/usb-bootable-iso/create-local-repo.sh
@@ -20,12 +20,14 @@ PF_ROOT=$(cd "${SCRIPT_DIR}/../.." && pwd)
 PF_REPO_TYPE=${PF_REPO_TYPE:-debian-branches}
 
 # Build URL based on repo type
-# gitlab pipelines use: http://inverse.ca/downloads/PacketFence/gitlab/PIPELINE_ID/debian
-# other types use: http://inverse.ca/downloads/PacketFence/TYPE/VERSION
+# gitlab pipelines use: http://inverse.ca/downloads/PacketFence/gitlab/PIPELINE_ID/debian bookworm main
+# other types use: http://inverse.ca/downloads/PacketFence/TYPE/VERSION bookworm bookworm
 if [[ "${PF_REPO_TYPE}" == gitlab/* ]]; then
     PF_REPO_BASE_URL="http://inverse.ca/downloads/PacketFence/${PF_REPO_TYPE}/debian"
+    PF_REPO_COMPONENT="main"
 else
     PF_REPO_BASE_URL="http://inverse.ca/downloads/PacketFence/${PF_REPO_TYPE}/${PF_RELEASE_VERSION}"
+    PF_REPO_COMPONENT="bookworm"
 fi
 
 echo "=============================================="
@@ -57,7 +59,7 @@ echo "===> Configuring PacketFence repository in chroot"
 sudo mkdir -p ${CHROOT_DIR}/etc/apt/keyrings
 curl -fsSL https://inverse.ca/downloads/GPG_PUBLIC_KEY | gpg --dearmor | sudo tee ${CHROOT_DIR}/etc/apt/keyrings/packetfence.gpg > /dev/null
 sudo tee ${CHROOT_DIR}/etc/apt/sources.list.d/packetfence.list > /dev/null << EOF
-deb [signed-by=/etc/apt/keyrings/packetfence.gpg] ${PF_REPO_BASE_URL} bookworm bookworm
+deb [signed-by=/etc/apt/keyrings/packetfence.gpg] ${PF_REPO_BASE_URL} bookworm ${PF_REPO_COMPONENT}
 EOF
 
 echo "Configured PacketFence repo: ${PF_REPO_BASE_URL}"

--- a/ci/usb-bootable-iso/create-local-repo.sh
+++ b/ci/usb-bootable-iso/create-local-repo.sh
@@ -179,7 +179,22 @@ fi
 
 # Update and download remaining packages from repositories
 echo "===> Updating package lists in chroot"
-${SUDO} chroot ${CHROOT_DIR} apt-get update
+# Retry apt-get update on transient network failures.
+apt_update_with_retry() {
+    local attempt=1 max=5 delay=5
+    while [ ${attempt} -le ${max} ]; do
+        if ${SUDO} chroot ${CHROOT_DIR} apt-get update; then
+            return 0
+        fi
+        echo "apt-get update failed (attempt ${attempt}/${max}); retrying in ${delay}s..." >&2
+        sleep ${delay}
+        attempt=$((attempt + 1))
+        delay=$((delay * 2))
+    done
+    echo "ERROR: apt-get update failed after ${max} attempts" >&2
+    return 1
+}
+apt_update_with_retry
 
 echo "===> Downloading PacketFence packages and dependencies from repositories"
 # Download packages and dependencies (skip if already copied locally)

--- a/ci/usb-bootable-iso/create-local-repo.sh
+++ b/ci/usb-bootable-iso/create-local-repo.sh
@@ -64,6 +64,16 @@ EOF
 
 echo "Configured PacketFence repo: ${PF_REPO_BASE_URL}"
 
+# For gitlab pipelines, add devel repo for dependencies (fingerbank, packetfence-perl, etc.)
+# The gitlab repo only contains packetfence packages built during CI
+if [[ "${PF_REPO_TYPE}" == gitlab/* ]]; then
+    echo "===> Adding devel repository for dependencies"
+    sudo tee ${CHROOT_DIR}/etc/apt/sources.list.d/packetfence_deps.list > /dev/null << EOF
+deb [signed-by=/etc/apt/keyrings/packetfence.gpg] http://inverse.ca/downloads/PacketFence/debian/${PF_RELEASE_VERSION} bookworm bookworm
+EOF
+    echo "Configured dependencies repo: http://inverse.ca/downloads/PacketFence/debian/${PF_RELEASE_VERSION}"
+fi
+
 # Copy GPG key to repo for later use
 sudo cp ${CHROOT_DIR}/etc/apt/keyrings/packetfence.gpg ${REPO_DIR}/packetfence.gpg
 

--- a/ci/usb-bootable-iso/create-local-repo.sh
+++ b/ci/usb-bootable-iso/create-local-repo.sh
@@ -127,12 +127,29 @@ EOF
 # Docker packages to download
 DOCKER_PACKAGES="docker-ce docker-ce-cli containerd.io"
 
-# Update and download PacketFence packages
+# Check for locally built PacketFence packages first
+LOCAL_BUILD_DIR="${PF_ROOT}/../debian-packages"
+if [ -d "${LOCAL_BUILD_DIR}" ]; then
+    echo "===> Checking for locally built PacketFence packages in ${LOCAL_BUILD_DIR}"
+    if ls ${LOCAL_BUILD_DIR}/*.deb 1> /dev/null 2>&1; then
+        echo "Found locally built packages, copying to repository..."
+        cp ${LOCAL_BUILD_DIR}/*.deb ${REPO_DIR}/pool/main/ || true
+        echo "Locally built packages copied"
+    fi
+fi
+
+# Also check parent directory for .deb files (CI artifact location)
+if ls ${PF_ROOT}/../*.deb 1> /dev/null 2>&1; then
+    echo "===> Found .deb files in parent directory, copying to repository..."
+    cp ${PF_ROOT}/../*.deb ${REPO_DIR}/pool/main/ || true
+fi
+
+# Update and download remaining packages from repositories
 echo "===> Updating package lists in chroot"
 sudo chroot ${CHROOT_DIR} apt-get update
 
-echo "===> Downloading PacketFence packages and dependencies"
-# Download PacketFence and fingerbank-collector with all dependencies
+echo "===> Downloading PacketFence packages and dependencies from repositories"
+# Download packages and dependencies (skip if already copied locally)
 # Dependencies not on DVD will be downloaded here
 sudo chroot ${CHROOT_DIR} apt-get install -y --download-only ${PACKAGES} || true
 
@@ -144,7 +161,7 @@ echo "===> Downloading packages directly"
 sudo chroot ${CHROOT_DIR} bash -c "apt-get download ${PACKAGES} 2>/dev/null || true"
 
 # Move all downloaded packages to repo
-echo "===> Moving packages to repository"
+echo "===> Moving downloaded packages to repository"
 sudo find ${CHROOT_DIR}/var/cache/apt/archives -name "*.deb" -exec cp {} ${REPO_DIR}/pool/main/ \; 2>/dev/null || true
 sudo find ${CHROOT_DIR} -maxdepth 1 -name "*.deb" -exec mv {} ${REPO_DIR}/pool/main/ \; 2>/dev/null || true
 # Fix ownership of copied files
@@ -212,9 +229,15 @@ done
 
 if [ -n "${MISSING}" ]; then
     echo ""
-    echo "WARNING: Missing packages:${MISSING}"
-    echo "The offline installation may fail!"
-    exit 1
+    echo "WARNING: Missing packages from pf-repo:${MISSING}"
+    echo ""
+    echo "This is expected for development builds where packages are not yet published."
+    echo "The build will continue - missing packages may be:"
+    echo "  - Available on the DVD ISO"
+    echo "  - Installed from Debian repositories during preseed"
+    echo "  - Not critical for basic installation"
+    echo ""
+    # Don't fail - let the build continue
 fi
 
 echo ""

--- a/ci/usb-bootable-iso/create-local-repo.sh
+++ b/ci/usb-bootable-iso/create-local-repo.sh
@@ -21,12 +21,12 @@ PF_REPO_TYPE=${PF_REPO_TYPE:-debian-branches}
 
 # Build URL based on repo type
 # gitlab pipelines use: http://inverse.ca/downloads/PacketFence/gitlab/PIPELINE_ID/debian bookworm main
-# other types use: http://inverse.ca/downloads/PacketFence/TYPE/VERSION bookworm bookworm
+# branches use: http://inverse.ca/downloads/PacketFence/debian/VERSION bookworm bookworm
 if [[ "${PF_REPO_TYPE}" == gitlab/* ]]; then
     PF_REPO_BASE_URL="http://inverse.ca/downloads/PacketFence/${PF_REPO_TYPE}/debian"
     PF_REPO_COMPONENT="main"
 else
-    PF_REPO_BASE_URL="http://inverse.ca/downloads/PacketFence/${PF_REPO_TYPE}/${PF_RELEASE_VERSION}"
+    PF_REPO_BASE_URL="http://inverse.ca/downloads/PacketFence/debian/${PF_RELEASE_VERSION}"
     PF_REPO_COMPONENT="bookworm"
 fi
 

--- a/ci/usb-bootable-iso/create-local-repo.sh
+++ b/ci/usb-bootable-iso/create-local-repo.sh
@@ -103,6 +103,18 @@ PACKAGES="
     libdbd-sqlite3-perl
     sqlite3
     libdata-powerset-perl
+    libcatalyst-perl
+    libcatalyst-modules-perl
+    libaliased-perl
+    libmoosex-types-loadableclass-perl
+    libconfig-general-perl
+    libreadonly-xs-perl
+    libcatalyst-action-rest-perl
+    liblwp-protocol-https-perl
+    liblwp-protocol-connect-perl
+    libjson-perl
+    libsql-translator-perl
+    libfile-touch-perl
 "
 
 # Add Docker repository for docker-ce packages

--- a/ci/usb-bootable-iso/create-local-repo.sh
+++ b/ci/usb-bootable-iso/create-local-repo.sh
@@ -4,6 +4,14 @@ set -o nounset -o pipefail -o errexit
 # Ensure /usr/sbin is in PATH (debootstrap is installed there)
 export PATH="/usr/sbin:/sbin:${PATH}"
 
+# Use sudo only when not already root (e.g., when running on the host).
+# When run inside a container as root, sudo may not be installed.
+if [ "${EUID:-$(id -u)}" -eq 0 ]; then
+    SUDO=""
+else
+    SUDO="sudo"
+fi
+
 # Arguments
 REPO_DIR=${1:-./repo}
 PF_RELEASE_VERSION=${2:-15.1}
@@ -55,16 +63,16 @@ mkdir -p ${REPO_DIR}/dists/bookworm/main/binary-amd64
 
 # Create a temporary chroot for package download
 CHROOT_DIR=$(mktemp -d)
-trap 'echo "Cleaning up chroot..."; sudo rm -rf "${CHROOT_DIR}"' EXIT
+trap 'echo "Cleaning up chroot..."; ${SUDO} rm -rf "${CHROOT_DIR}"' EXIT
 
 echo "===> Creating minimal chroot for package download"
-sudo debootstrap --variant=minbase --include=apt,gnupg,ca-certificates bookworm ${CHROOT_DIR} http://deb.debian.org/debian
+${SUDO} debootstrap --variant=minbase --include=apt,gnupg,ca-certificates bookworm ${CHROOT_DIR} http://deb.debian.org/debian
 
 # Add PacketFence repository only (we'll use DVD for Debian packages)
 echo "===> Configuring PacketFence repository in chroot"
-sudo mkdir -p ${CHROOT_DIR}/etc/apt/keyrings
-curl -fsSL https://inverse.ca/downloads/GPG_PUBLIC_KEY | gpg --dearmor | sudo tee ${CHROOT_DIR}/etc/apt/keyrings/packetfence.gpg > /dev/null
-sudo tee ${CHROOT_DIR}/etc/apt/sources.list.d/packetfence.list > /dev/null << EOF
+${SUDO} mkdir -p ${CHROOT_DIR}/etc/apt/keyrings
+curl -fsSL https://inverse.ca/downloads/GPG_PUBLIC_KEY | gpg --dearmor | ${SUDO} tee ${CHROOT_DIR}/etc/apt/keyrings/packetfence.gpg > /dev/null
+${SUDO} tee ${CHROOT_DIR}/etc/apt/sources.list.d/packetfence.list > /dev/null << EOF
 deb [signed-by=/etc/apt/keyrings/packetfence.gpg] ${PF_REPO_BASE_URL} bookworm ${PF_REPO_COMPONENT}
 EOF
 
@@ -75,14 +83,14 @@ echo "Configured PacketFence repo: ${PF_REPO_BASE_URL}"
 # (packetfence packages are in debian-branches/VERSION or gitlab/PIPELINE_ID repos)
 if [[ "${PF_REPO_BASE_URL}" != "${PF_DEPS_BASE_URL}" ]]; then
     echo "===> Adding dependencies repository (fingerbank, freeradius, etc.)"
-    sudo tee ${CHROOT_DIR}/etc/apt/sources.list.d/packetfence_deps.list > /dev/null << EOF
+    ${SUDO} tee ${CHROOT_DIR}/etc/apt/sources.list.d/packetfence_deps.list > /dev/null << EOF
 deb [signed-by=/etc/apt/keyrings/packetfence.gpg] ${PF_DEPS_BASE_URL} bookworm bookworm
 EOF
     echo "Configured dependencies repo: ${PF_DEPS_BASE_URL}"
 fi
 
 # Copy GPG key to repo for later use
-sudo cp ${CHROOT_DIR}/etc/apt/keyrings/packetfence.gpg ${REPO_DIR}/packetfence.gpg
+${SUDO} cp ${CHROOT_DIR}/etc/apt/keyrings/packetfence.gpg ${REPO_DIR}/packetfence.gpg
 
 # Packages to download (not on DVD or need specific versions)
 PACKAGES="
@@ -144,8 +152,8 @@ PACKAGES="
 
 # Add Docker repository
 echo "===> Adding Docker repository for docker-ce packages"
-curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor | sudo tee ${CHROOT_DIR}/etc/apt/keyrings/docker.gpg > /dev/null
-sudo tee ${CHROOT_DIR}/etc/apt/sources.list.d/docker.list > /dev/null << EOF
+curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor | ${SUDO} tee ${CHROOT_DIR}/etc/apt/keyrings/docker.gpg > /dev/null
+${SUDO} tee ${CHROOT_DIR}/etc/apt/sources.list.d/docker.list > /dev/null << EOF
 deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian bookworm stable
 EOF
 
@@ -171,26 +179,26 @@ fi
 
 # Update and download remaining packages from repositories
 echo "===> Updating package lists in chroot"
-sudo chroot ${CHROOT_DIR} apt-get update
+${SUDO} chroot ${CHROOT_DIR} apt-get update
 
 echo "===> Downloading PacketFence packages and dependencies from repositories"
 # Download packages and dependencies (skip if already copied locally)
 # Dependencies not on DVD will be downloaded here
-sudo chroot ${CHROOT_DIR} apt-get install -y --download-only ${PACKAGES} || true
+${SUDO} chroot ${CHROOT_DIR} apt-get install -y --download-only ${PACKAGES} || true
 
 echo "===> Downloading Docker packages"
-sudo chroot ${CHROOT_DIR} apt-get install -y --download-only ${DOCKER_PACKAGES} || true
+${SUDO} chroot ${CHROOT_DIR} apt-get install -y --download-only ${DOCKER_PACKAGES} || true
 
 # Download the packages directly as well
 echo "===> Downloading packages directly"
-sudo chroot ${CHROOT_DIR} bash -c "apt-get download ${PACKAGES} 2>/dev/null || true"
+${SUDO} chroot ${CHROOT_DIR} bash -c "apt-get download ${PACKAGES} 2>/dev/null || true"
 
 # Move all downloaded packages to repo
 echo "===> Moving downloaded packages to repository"
-sudo find ${CHROOT_DIR}/var/cache/apt/archives -name "*.deb" -exec cp {} ${REPO_DIR}/pool/main/ \; 2>/dev/null || true
-sudo find ${CHROOT_DIR} -maxdepth 1 -name "*.deb" -exec mv {} ${REPO_DIR}/pool/main/ \; 2>/dev/null || true
+${SUDO} find ${CHROOT_DIR}/var/cache/apt/archives -name "*.deb" -exec cp {} ${REPO_DIR}/pool/main/ \; 2>/dev/null || true
+${SUDO} find ${CHROOT_DIR} -maxdepth 1 -name "*.deb" -exec mv {} ${REPO_DIR}/pool/main/ \; 2>/dev/null || true
 # Fix ownership of copied files
-sudo chown -R $(id -u):$(id -g) ${REPO_DIR}
+${SUDO} chown -R $(id -u):$(id -g) ${REPO_DIR}
 
 # Generate Packages file
 echo "===> Generating Packages index"

--- a/ci/usb-bootable-iso/create-local-repo.sh
+++ b/ci/usb-bootable-iso/create-local-repo.sh
@@ -84,14 +84,7 @@ fi
 # Copy GPG key to repo for later use
 sudo cp ${CHROOT_DIR}/etc/apt/keyrings/packetfence.gpg ${REPO_DIR}/packetfence.gpg
 
-# List of PacketFence-specific packages to download
-# Note: DVD already has all standard Debian packages (systemd, mariadb, etc.)
-# We need to download what's NOT on the DVD:
-#   - PacketFence and fingerbank packages
-#   - Packages that might be missing from DVD-1
-#   - FreeRADIUS packages (specific versions needed)
-#   - Packages from preseed pkgsel/include that may not be on DVD-1
-#   - Other dependencies
+# Packages to download (not on DVD or need specific versions)
 PACKAGES="
     packetfence
     packetfence-pfcmd-suid
@@ -146,17 +139,10 @@ PACKAGES="
     libio-socket-ssl-perl
     acl
 "
-# Note: Many perl packages (liblog-fast-perl, libcatalyst-perl, libreadonly-perl, etc.)
-# are virtual packages provided by packetfence-perl and should NOT be listed here.
-# Listing them causes apt-get to fail with "no installation candidate".
-# Exceptions - these ARE real Debian packages needed for offline installation:
-# - liblog-log4perl-perl, libconfig-inifiles-perl: fingerbank has versioned dependencies
-#   (>= 1.43 and >= 2.88) that packetfence-perl's unversioned virtual packages cannot satisfy
-# - liburi-perl, libregexp-ipv6-perl: required by HTTP::Request/LWP bundled in packetfence-perl
-# - libnet-ssleay-perl, libio-socket-ssl-perl: required for SSL/TLS support (XS modules not in packetfence-perl)
-# - acl: required by packetfence preinst script (setfacl command)
+# Note: Most perl packages are virtual (provided by packetfence-perl).
+# Only list real Debian packages needed for versioned deps or XS modules.
 
-# Add Docker repository for docker-ce packages
+# Add Docker repository
 echo "===> Adding Docker repository for docker-ce packages"
 curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor | sudo tee ${CHROOT_DIR}/etc/apt/keyrings/docker.gpg > /dev/null
 sudo tee ${CHROOT_DIR}/etc/apt/sources.list.d/docker.list > /dev/null << EOF
@@ -227,18 +213,14 @@ EOF
 
 # Add checksums to Release file
 cd ${REPO_DIR}/dists/bookworm
-echo "MD5Sum:" >> Release
-for file in main/binary-amd64/Packages main/binary-amd64/Packages.gz; do
-    if [ -f "$file" ]; then
-        echo " $(md5sum $file | cut -d' ' -f1) $(stat -c%s $file) $file" >> Release
-    fi
-done
-
-echo "SHA256:" >> Release
-for file in main/binary-amd64/Packages main/binary-amd64/Packages.gz; do
-    if [ -f "$file" ]; then
-        echo " $(sha256sum $file | cut -d' ' -f1) $(stat -c%s $file) $file" >> Release
-    fi
+FILES="main/binary-amd64/Packages main/binary-amd64/Packages.gz"
+for algo in MD5Sum:md5sum SHA256:sha256sum; do
+    name="${algo%:*}"
+    cmd="${algo#*:}"
+    echo "${name}:" >> Release
+    for file in ${FILES}; do
+        [ -f "$file" ] && echo " $($cmd $file | cut -d' ' -f1) $(stat -c%s $file) $file" >> Release
+    done
 done
 
 # Count packages
@@ -252,34 +234,15 @@ echo "Size: ${REPO_SIZE}"
 echo "Location: ${REPO_DIR}"
 echo "=============================================="
 
-# Verify key packages are present
+# Verify key packages
 echo ""
-echo "===> Verifying key packages in repository:"
-KEY_PACKAGES="packetfence fingerbank-collector docker-ce docker-ce-cli containerd.io linux-image-amd64"
-MISSING=""
+echo "===> Verifying key packages:"
+KEY_PACKAGES="packetfence fingerbank-collector docker-ce docker-ce-cli containerd.io"
 for pkg in ${KEY_PACKAGES}; do
     if find ${REPO_DIR}/pool -name "${pkg}_*.deb" | grep -q .; then
         echo "  [OK] ${pkg}"
     else
-        echo "  [MISSING] ${pkg}"
-        MISSING="${MISSING} ${pkg}"
+        echo "  [MISSING] ${pkg} (may be on DVD or not yet published)"
     fi
 done
-
-if [ -n "${MISSING}" ]; then
-    echo ""
-    echo "WARNING: Missing packages from pf-repo:${MISSING}"
-    echo ""
-    echo "This is expected for development builds where packages are not yet published."
-    echo "The build will continue - missing packages may be:"
-    echo "  - Available on the DVD ISO"
-    echo "  - Installed from Debian repositories during preseed"
-    echo "  - Not critical for basic installation"
-    echo ""
-    # Don't fail - let the build continue
-fi
-
-echo ""
-echo "Note: DVD ISO provides most standard Debian packages."
-echo "      This repo adds PacketFence, Docker, and missing dependencies."
 echo "=============================================="

--- a/ci/usb-bootable-iso/create-local-repo.sh
+++ b/ci/usb-bootable-iso/create-local-repo.sh
@@ -12,12 +12,22 @@ PF_RELEASE_VERSION=${2:-15.1}
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 PF_ROOT=$(cd "${SCRIPT_DIR}/../.." && pwd)
 
+# PacketFence repository URL configuration
+# Available options:
+#   - debian-branches: Branch builds (default, for devel/feature branches)
+#   - debian-lastrelease: Last release builds (for maintenance releases)
+#   - gitlab/PIPELINE_ID: Specific CI pipeline builds
+PF_REPO_TYPE=${PF_REPO_TYPE:-debian-branches}
+PF_REPO_BASE_URL="https://inverse.ca/downloads/PacketFence/${PF_REPO_TYPE}/${PF_RELEASE_VERSION}"
+
 echo "=============================================="
 echo "Creating PacketFence Package Repository"
 echo "(Will be appended to DVD repo on ISO)"
 echo "=============================================="
 echo "REPO_DIR: ${REPO_DIR}"
 echo "PF_RELEASE_VERSION: ${PF_RELEASE_VERSION}"
+echo "PF_REPO_TYPE: ${PF_REPO_TYPE}"
+echo "PF_REPO_BASE_URL: ${PF_REPO_BASE_URL}"
 echo "=============================================="
 
 # Use absolute path for REPO_DIR
@@ -39,8 +49,10 @@ echo "===> Configuring PacketFence repository in chroot"
 sudo mkdir -p ${CHROOT_DIR}/etc/apt/keyrings
 curl -fsSL https://inverse.ca/downloads/GPG_PUBLIC_KEY | gpg --dearmor | sudo tee ${CHROOT_DIR}/etc/apt/keyrings/packetfence.gpg > /dev/null
 sudo tee ${CHROOT_DIR}/etc/apt/sources.list.d/packetfence.list > /dev/null << EOF
-deb [signed-by=/etc/apt/keyrings/packetfence.gpg] http://inverse.ca/downloads/PacketFence/debian/${PF_RELEASE_VERSION} bookworm bookworm
+deb [signed-by=/etc/apt/keyrings/packetfence.gpg] ${PF_REPO_BASE_URL} bookworm bookworm
 EOF
+
+echo "Configured PacketFence repo: ${PF_REPO_BASE_URL}"
 
 # Copy GPG key to repo for later use
 sudo cp ${CHROOT_DIR}/etc/apt/keyrings/packetfence.gpg ${REPO_DIR}/packetfence.gpg

--- a/ci/usb-bootable-iso/create-local-repo.sh
+++ b/ci/usb-bootable-iso/create-local-repo.sh
@@ -142,6 +142,8 @@ PACKAGES="
     libconfig-inifiles-perl
     liburi-perl
     libregexp-ipv6-perl
+    libnet-ssleay-perl
+    libio-socket-ssl-perl
     acl
 "
 # Note: Many perl packages (liblog-fast-perl, libcatalyst-perl, libreadonly-perl, etc.)
@@ -151,6 +153,7 @@ PACKAGES="
 # - liblog-log4perl-perl, libconfig-inifiles-perl: fingerbank has versioned dependencies
 #   (>= 1.43 and >= 2.88) that packetfence-perl's unversioned virtual packages cannot satisfy
 # - liburi-perl, libregexp-ipv6-perl: required by HTTP::Request/LWP bundled in packetfence-perl
+# - libnet-ssleay-perl, libio-socket-ssl-perl: required for SSL/TLS support (XS modules not in packetfence-perl)
 # - acl: required by packetfence preinst script (setfacl command)
 
 # Add Docker repository for docker-ce packages

--- a/ci/usb-bootable-iso/create-local-repo.sh
+++ b/ci/usb-bootable-iso/create-local-repo.sh
@@ -13,7 +13,8 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 PF_ROOT=$(cd "${SCRIPT_DIR}/../.." && pwd)
 
 echo "=============================================="
-echo "Creating Local APT Repository"
+echo "Creating PacketFence Package Repository"
+echo "(Will be appended to DVD repo on ISO)"
 echo "=============================================="
 echo "REPO_DIR: ${REPO_DIR}"
 echo "PF_RELEASE_VERSION: ${PF_RELEASE_VERSION}"
@@ -22,25 +23,19 @@ echo "=============================================="
 # Use absolute path for REPO_DIR
 REPO_DIR=$(cd "$(dirname "${REPO_DIR}")" && pwd)/$(basename "${REPO_DIR}")
 
-# Create directory structure
+# Create directory structure for PacketFence packages
 mkdir -p ${REPO_DIR}/pool/main
 mkdir -p ${REPO_DIR}/dists/bookworm/main/binary-amd64
 
-# Create a temporary chroot for clean package resolution
+# Create a temporary chroot for package download
 CHROOT_DIR=$(mktemp -d)
 trap "echo 'Cleaning up chroot...'; sudo rm -rf ${CHROOT_DIR}" EXIT
 
 echo "===> Creating minimal chroot for package download"
 sudo debootstrap --variant=minbase --include=apt,gnupg,ca-certificates bookworm ${CHROOT_DIR} http://deb.debian.org/debian
 
-# Configure repositories in chroot (need sudo since debootstrap created files as root)
-sudo tee ${CHROOT_DIR}/etc/apt/sources.list > /dev/null << EOF
-deb http://deb.debian.org/debian bookworm main contrib non-free non-free-firmware
-deb http://deb.debian.org/debian bookworm-updates main contrib non-free non-free-firmware
-deb http://security.debian.org/debian-security bookworm-security main contrib non-free non-free-firmware
-EOF
-
-# Add PacketFence repository
+# Add PacketFence repository only (we'll use DVD for Debian packages)
+echo "===> Configuring PacketFence repository in chroot"
 sudo mkdir -p ${CHROOT_DIR}/etc/apt/keyrings
 curl -fsSL https://inverse.ca/downloads/GPG_PUBLIC_KEY | gpg --dearmor | sudo tee ${CHROOT_DIR}/etc/apt/keyrings/packetfence.gpg > /dev/null
 sudo tee ${CHROOT_DIR}/etc/apt/sources.list.d/packetfence.list > /dev/null << EOF
@@ -50,57 +45,26 @@ EOF
 # Copy GPG key to repo for later use
 sudo cp ${CHROOT_DIR}/etc/apt/keyrings/packetfence.gpg ${REPO_DIR}/packetfence.gpg
 
-# List of packages to install (will pull all dependencies)
+# List of PacketFence-specific packages to download
+# Note: DVD already has all standard Debian packages (systemd, docker.io, mariadb, etc.)
+# We only need to download what's NOT on the DVD (mainly PacketFence itself)
 PACKAGES="
     packetfence
-    docker.io
-    containerd
-    mariadb-server
-    redis-server
-    freeradius
-    freeradius-utils
-    freeradius-ldap
-    freeradius-postgresql
-    freeradius-mysql
-    freeradius-krb5
-    snmp
-    snmptrapd
-    snmpd
     fingerbank-collector
-    sudo
-    openssh-server
-    curl
-    wget
-    gnupg2
-    ca-certificates
-    apt-transport-https
-    net-tools
-    tcpdump
-    tmux
-    lnav
 "
 
-# Update and download all packages with dependencies in chroot
+# Update and download PacketFence packages
 echo "===> Updating package lists in chroot"
 sudo chroot ${CHROOT_DIR} apt-get update
 
-echo "===> Downloading all packages with dependencies"
-# Use apt-get install with download-only to get ALL dependencies
-sudo chroot ${CHROOT_DIR} apt-get install -y --download-only -o APT::Install-Recommends=0 ${PACKAGES} || true
+echo "===> Downloading PacketFence packages and dependencies"
+# Download PacketFence and fingerbank-collector with all dependencies
+# Dependencies not on DVD will be downloaded here
+sudo chroot ${CHROOT_DIR} apt-get install -y --download-only ${PACKAGES} || true
 
-# Some packages may fail due to pre-depends, try downloading them directly
-echo "===> Downloading any missing packages"
+# Download the packages directly as well
+echo "===> Downloading packages directly"
 sudo chroot ${CHROOT_DIR} bash -c "apt-get download ${PACKAGES} 2>/dev/null || true"
-
-# Download dependencies recursively using apt-cache
-echo "===> Resolving and downloading all dependencies"
-sudo chroot ${CHROOT_DIR} bash -c '
-PACKAGES="packetfence docker.io containerd mariadb-server redis-server freeradius fingerbank-collector"
-for pkg in $PACKAGES; do
-    deps=$(apt-cache depends --recurse --no-recommends --no-suggests --no-conflicts --no-breaks --no-replaces --no-enhances "$pkg" 2>/dev/null | grep "^\w" | grep -v "^<" | sort -u)
-    apt-get download $deps 2>/dev/null || true
-done
-'
 
 # Move all downloaded packages to repo
 echo "===> Moving packages to repository"
@@ -149,7 +113,7 @@ PKG_COUNT=$(find ${REPO_DIR}/pool -name "*.deb" | wc -l)
 REPO_SIZE=$(du -sh ${REPO_DIR} | cut -f1)
 
 echo "=============================================="
-echo "Local APT Repository created successfully!"
+echo "PacketFence Repository created successfully!"
 echo "Packages: ${PKG_COUNT}"
 echo "Size: ${REPO_SIZE}"
 echo "Location: ${REPO_DIR}"
@@ -158,7 +122,7 @@ echo "=============================================="
 # Verify key packages are present
 echo ""
 echo "===> Verifying key packages in repository:"
-KEY_PACKAGES="packetfence packetfence-pfcmd-suid docker.io containerd mariadb-server redis-server freeradius fingerbank-collector"
+KEY_PACKAGES="packetfence fingerbank-collector"
 MISSING=""
 for pkg in ${KEY_PACKAGES}; do
     if find ${REPO_DIR}/pool -name "${pkg}_*.deb" | grep -q .; then
@@ -177,10 +141,7 @@ if [ -n "${MISSING}" ]; then
 fi
 
 echo ""
-echo "===> Package breakdown by source:"
-echo "  PacketFence packages: $(find ${REPO_DIR}/pool -name "packetfence*.deb" -o -name "fingerbank*.deb" | wc -l)"
-echo "  Docker packages: $(find ${REPO_DIR}/pool -name "docker*.deb" -o -name "containerd*.deb" | wc -l)"
-echo "  MariaDB packages: $(find ${REPO_DIR}/pool -name "mariadb*.deb" -o -name "mysql*.deb" -o -name "galera*.deb" | wc -l)"
-echo "  FreeRADIUS packages: $(find ${REPO_DIR}/pool -name "freeradius*.deb" | wc -l)"
-echo "  Other packages: $(find ${REPO_DIR}/pool -name "*.deb" | wc -l) total"
+echo "Note: DVD ISO provides all standard Debian packages"
+echo "      (systemd, docker, mariadb, freeradius, etc.)"
+echo "      This repo only adds PacketFence-specific packages."
 echo "=============================================="

--- a/ci/usb-bootable-iso/create-local-repo.sh
+++ b/ci/usb-bootable-iso/create-local-repo.sh
@@ -132,28 +132,16 @@ PACKAGES="
     fping
     ipset
     libcache-bdb-perl
-    liblog-fast-perl
-    libfile-flock-perl
     libcjson1
-    liblog-log4perl-perl
     libdbd-sqlite3-perl
     sqlite3
     libdata-powerset-perl
-    libcatalyst-perl
-    libcatalyst-modules-perl
-    libaliased-perl
-    libmoosex-types-loadableclass-perl
-    libconfig-general-perl
-    libreadonly-xs-perl
-    libcatalyst-action-rest-perl
-    liblwp-protocol-https-perl
-    liblwp-protocol-connect-perl
-    libjson-perl
-    libsql-translator-perl
-    libfile-touch-perl
     libglib2.0-0
     libglib2.0-bin
 "
+# Note: Many perl packages (liblog-fast-perl, libcatalyst-perl, libreadonly-perl, etc.)
+# are virtual packages provided by packetfence-perl and should NOT be listed here.
+# Listing them causes apt-get to fail with "no installation candidate".
 
 # Add Docker repository for docker-ce packages
 echo "===> Adding Docker repository for docker-ce packages"

--- a/ci/usb-bootable-iso/create-local-repo.sh
+++ b/ci/usb-bootable-iso/create-local-repo.sh
@@ -46,12 +46,47 @@ EOF
 sudo cp ${CHROOT_DIR}/etc/apt/keyrings/packetfence.gpg ${REPO_DIR}/packetfence.gpg
 
 # List of PacketFence-specific packages to download
-# Note: DVD already has all standard Debian packages (systemd, docker.io, mariadb, etc.)
-# We only need to download what's NOT on the DVD (mainly PacketFence itself)
+# Note: DVD already has all standard Debian packages (systemd, mariadb, etc.)
+# We need to download what's NOT on the DVD:
+#   - PacketFence and fingerbank packages
+#   - Packages that might be missing from DVD-1
+#   - FreeRADIUS packages (specific versions needed)
+#   - Other dependencies
 PACKAGES="
     packetfence
     fingerbank-collector
+    bind9-dnsutils
+    openssh-server
+    freeradius
+    freeradius-ldap
+    freeradius-mysql
+    freeradius-utils
+    freeradius-rest
+    freeradius-redis
+    freeradius-common
+    mariadb-server
+    mariadb-client
+    samba
+    haproxy
+    keepalived
+    monit
+    snmpd
+    snmp
+    vlan
+    arping
+    fping
+    ipset
 "
+
+# Add Docker repository for docker-ce packages
+echo "===> Adding Docker repository for docker-ce packages"
+curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor | sudo tee ${CHROOT_DIR}/etc/apt/keyrings/docker.gpg > /dev/null
+sudo tee ${CHROOT_DIR}/etc/apt/sources.list.d/docker.list > /dev/null << EOF
+deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian bookworm stable
+EOF
+
+# Docker packages to download
+DOCKER_PACKAGES="docker-ce docker-ce-cli containerd.io"
 
 # Update and download PacketFence packages
 echo "===> Updating package lists in chroot"
@@ -61,6 +96,9 @@ echo "===> Downloading PacketFence packages and dependencies"
 # Download PacketFence and fingerbank-collector with all dependencies
 # Dependencies not on DVD will be downloaded here
 sudo chroot ${CHROOT_DIR} apt-get install -y --download-only ${PACKAGES} || true
+
+echo "===> Downloading Docker packages"
+sudo chroot ${CHROOT_DIR} apt-get install -y --download-only ${DOCKER_PACKAGES} || true
 
 # Download the packages directly as well
 echo "===> Downloading packages directly"
@@ -122,7 +160,7 @@ echo "=============================================="
 # Verify key packages are present
 echo ""
 echo "===> Verifying key packages in repository:"
-KEY_PACKAGES="packetfence fingerbank-collector"
+KEY_PACKAGES="packetfence fingerbank-collector docker-ce docker-ce-cli containerd.io"
 MISSING=""
 for pkg in ${KEY_PACKAGES}; do
     if find ${REPO_DIR}/pool -name "${pkg}_*.deb" | grep -q .; then
@@ -141,7 +179,6 @@ if [ -n "${MISSING}" ]; then
 fi
 
 echo ""
-echo "Note: DVD ISO provides all standard Debian packages"
-echo "      (systemd, docker, mariadb, freeradius, etc.)"
-echo "      This repo only adds PacketFence-specific packages."
+echo "Note: DVD ISO provides most standard Debian packages."
+echo "      This repo adds PacketFence, Docker, and missing dependencies."
 echo "=============================================="

--- a/ci/usb-bootable-iso/create-local-repo.sh
+++ b/ci/usb-bootable-iso/create-local-repo.sh
@@ -138,10 +138,20 @@ PACKAGES="
     libdata-powerset-perl
     libglib2.0-0
     libglib2.0-bin
+    liblog-log4perl-perl
+    libconfig-inifiles-perl
+    liburi-perl
+    libregexp-ipv6-perl
+    acl
 "
 # Note: Many perl packages (liblog-fast-perl, libcatalyst-perl, libreadonly-perl, etc.)
 # are virtual packages provided by packetfence-perl and should NOT be listed here.
 # Listing them causes apt-get to fail with "no installation candidate".
+# Exceptions - these ARE real Debian packages needed for offline installation:
+# - liblog-log4perl-perl, libconfig-inifiles-perl: fingerbank has versioned dependencies
+#   (>= 1.43 and >= 2.88) that packetfence-perl's unversioned virtual packages cannot satisfy
+# - liburi-perl, libregexp-ipv6-perl: required by HTTP::Request/LWP bundled in packetfence-perl
+# - acl: required by packetfence preinst script (setfacl command)
 
 # Add Docker repository for docker-ce packages
 echo "===> Adding Docker repository for docker-ce packages"

--- a/ci/usb-bootable-iso/create-local-repo.sh
+++ b/ci/usb-bootable-iso/create-local-repo.sh
@@ -99,6 +99,10 @@ PACKAGES="
     liblog-fast-perl
     libfile-flock-perl
     libcjson1
+    liblog-log4perl-perl
+    libdbd-sqlite3-perl
+    sqlite3
+    libdata-powerset-perl
 "
 
 # Add Docker repository for docker-ce packages

--- a/ci/usb-bootable-iso/create-local-repo.sh
+++ b/ci/usb-bootable-iso/create-local-repo.sh
@@ -69,9 +69,6 @@ PACKAGES="
     bind9-dnsutils
     bind9-libs
     bind9-host
-    openssh-server
-    openssh-client
-    openssh-sftp-server
     freeradius
     freeradius-ldap
     freeradius-mysql

--- a/ci/usb-bootable-iso/create-local-repo.sh
+++ b/ci/usb-bootable-iso/create-local-repo.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+set -o nounset -o pipefail -o errexit
+
+# Arguments
+REPO_DIR=${1:-./repo}
+PF_RELEASE_VERSION=${2:-15.1}
+
+# Get script directory
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PF_ROOT=$(cd "${SCRIPT_DIR}/../.." && pwd)
+
+echo "=============================================="
+echo "Creating Local APT Repository"
+echo "=============================================="
+echo "REPO_DIR: ${REPO_DIR}"
+echo "PF_RELEASE_VERSION: ${PF_RELEASE_VERSION}"
+echo "=============================================="
+
+# Create directory structure
+mkdir -p ${REPO_DIR}/pool/main
+mkdir -p ${REPO_DIR}/dists/bookworm/main/binary-amd64
+
+# Create a temporary directory for package download
+TEMP_DIR=$(mktemp -d)
+trap "rm -rf ${TEMP_DIR}" EXIT
+
+# Create a minimal sources.list for downloading packages
+cat > ${TEMP_DIR}/sources.list << EOF
+deb http://deb.debian.org/debian bookworm main contrib non-free non-free-firmware
+deb http://deb.debian.org/debian bookworm-updates main contrib non-free non-free-firmware
+deb http://security.debian.org/debian-security bookworm-security main contrib non-free non-free-firmware
+deb http://inverse.ca/downloads/PacketFence/debian/${PF_RELEASE_VERSION} bookworm bookworm
+EOF
+
+# Create apt configuration
+mkdir -p ${TEMP_DIR}/apt/lists/partial
+mkdir -p ${TEMP_DIR}/apt/cache/archives/partial
+
+APT_CONFIG="Dir::Etc::sourcelist=${TEMP_DIR}/sources.list;
+Dir::Etc::sourceparts=-;
+Dir::State::lists=${TEMP_DIR}/apt/lists;
+Dir::Cache=${TEMP_DIR}/apt/cache;
+APT::Get::AllowUnauthenticated=true;
+Acquire::AllowInsecureRepositories=true;"
+
+# Add PacketFence GPG key
+echo "===> Adding PacketFence GPG key"
+curl -fsSL https://inverse.ca/downloads/GPG_PUBLIC_KEY | gpg --dearmor > ${TEMP_DIR}/packetfence.gpg
+export APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1
+
+# Update package lists
+echo "===> Updating package lists"
+apt-get -o "${APT_CONFIG}" update 2>/dev/null || true
+
+# List of base packages needed for installation
+BASE_PACKAGES="
+    sudo
+    bzip2
+    acpid
+    cryptsetup
+    zlib1g-dev
+    wget
+    curl
+    dkms
+    make
+    nfs-common
+    net-tools
+    build-essential
+    linux-headers-amd64
+    gnupg2
+    apt-transport-https
+    tmux
+    tcpdump
+    lnav
+    apg
+    sysstat
+    bsd-mailx
+    cgroupfs-mount
+    openssh-server
+"
+
+# PacketFence and its major dependencies
+PF_PACKAGES="
+    packetfence
+    mariadb-server
+    redis-server
+    docker.io
+    containerd
+    freeradius
+    freeradius-utils
+    freeradius-ldap
+    freeradius-postgresql
+    freeradius-mysql
+    freeradius-krb5
+    snmp
+    snmptrapd
+    snmpd
+    libsnmp-dev
+    nodejs
+    fingerbank-collector
+"
+
+# Download all packages with dependencies
+echo "===> Downloading packages (this may take a while)..."
+cd ${TEMP_DIR}
+
+# Download packages
+apt-get -o "${APT_CONFIG}" download \
+    --print-uris \
+    ${BASE_PACKAGES} ${PF_PACKAGES} 2>/dev/null | \
+    grep "^'" | \
+    cut -d"'" -f2 > ${TEMP_DIR}/package_urls.txt || true
+
+# Also get dependencies
+apt-get -o "${APT_CONFIG}" install \
+    --download-only \
+    --print-uris \
+    -y \
+    ${BASE_PACKAGES} ${PF_PACKAGES} 2>/dev/null | \
+    grep "^'" | \
+    cut -d"'" -f2 >> ${TEMP_DIR}/package_urls.txt || true
+
+# Remove duplicates
+sort -u ${TEMP_DIR}/package_urls.txt > ${TEMP_DIR}/package_urls_unique.txt
+
+# Download packages using wget for better progress
+echo "===> Downloading $(wc -l < ${TEMP_DIR}/package_urls_unique.txt) packages..."
+mkdir -p ${TEMP_DIR}/packages
+cd ${TEMP_DIR}/packages
+
+# Download in parallel using xargs
+cat ${TEMP_DIR}/package_urls_unique.txt | xargs -P 10 -I {} wget -q --show-progress -nc {} 2>/dev/null || true
+
+# Alternative: use apt-get download directly
+echo "===> Using apt-get to download remaining packages..."
+apt-get -o "${APT_CONFIG}" download ${BASE_PACKAGES} ${PF_PACKAGES} 2>/dev/null || true
+
+# Also download dependencies
+for pkg in ${BASE_PACKAGES} ${PF_PACKAGES}; do
+    apt-get -o "${APT_CONFIG}" download $(apt-cache -o "${APT_CONFIG}" depends --recurse --no-recommends --no-suggests --no-conflicts --no-breaks --no-replaces --no-enhances ${pkg} 2>/dev/null | grep "^\w" | sort -u) 2>/dev/null || true
+done
+
+# Move all downloaded packages to repo
+echo "===> Moving packages to repository"
+find ${TEMP_DIR} -name "*.deb" -exec mv {} ${REPO_DIR}/pool/main/ \; 2>/dev/null || true
+find /var/cache/apt/archives -name "*.deb" -exec cp {} ${REPO_DIR}/pool/main/ \; 2>/dev/null || true
+
+# Generate Packages file
+echo "===> Generating Packages index"
+cd ${REPO_DIR}
+dpkg-scanpackages pool/main /dev/null > dists/bookworm/main/binary-amd64/Packages
+gzip -k dists/bookworm/main/binary-amd64/Packages
+
+# Create Release file
+echo "===> Generating Release file"
+cat > ${REPO_DIR}/dists/bookworm/Release << EOF
+Origin: PacketFence USB Installer
+Label: PacketFence USB Installer
+Suite: bookworm
+Codename: bookworm
+Version: ${PF_RELEASE_VERSION}
+Architectures: amd64
+Components: main
+Description: PacketFence offline installation repository
+EOF
+
+# Add checksums to Release file
+cd ${REPO_DIR}/dists/bookworm
+echo "MD5Sum:" >> Release
+for file in main/binary-amd64/Packages main/binary-amd64/Packages.gz; do
+    if [ -f "$file" ]; then
+        echo " $(md5sum $file | cut -d' ' -f1) $(stat -c%s $file) $file" >> Release
+    fi
+done
+
+echo "SHA256:" >> Release
+for file in main/binary-amd64/Packages main/binary-amd64/Packages.gz; do
+    if [ -f "$file" ]; then
+        echo " $(sha256sum $file | cut -d' ' -f1) $(stat -c%s $file) $file" >> Release
+    fi
+done
+
+# Count packages
+PKG_COUNT=$(find ${REPO_DIR}/pool -name "*.deb" | wc -l)
+REPO_SIZE=$(du -sh ${REPO_DIR} | cut -f1)
+
+echo "=============================================="
+echo "Local APT Repository created successfully!"
+echo "Packages: ${PKG_COUNT}"
+echo "Size: ${REPO_SIZE}"
+echo "Location: ${REPO_DIR}"
+echo "=============================================="

--- a/ci/usb-bootable-iso/create-local-repo.sh
+++ b/ci/usb-bootable-iso/create-local-repo.sh
@@ -81,6 +81,8 @@ PACKAGES="
     freeradius-common
     mariadb-server
     mariadb-client
+    redis-server
+    redis-tools
     samba
     haproxy
     keepalived
@@ -93,6 +95,9 @@ PACKAGES="
     cgroupfs-mount
     fping
     ipset
+    libcache-bdb-perl
+    liblog-fast-perl
+    libfile-flock-perl
 "
 
 # Add Docker repository for docker-ce packages

--- a/ci/usb-bootable-iso/create-local-repo.sh
+++ b/ci/usb-bootable-iso/create-local-repo.sh
@@ -56,7 +56,11 @@ PACKAGES="
     packetfence
     fingerbank-collector
     bind9-dnsutils
+    bind9-libs
+    bind9-host
     openssh-server
+    openssh-client
+    openssh-sftp-server
     freeradius
     freeradius-ldap
     freeradius-mysql

--- a/ci/usb-bootable-iso/create-local-repo.sh
+++ b/ci/usb-bootable-iso/create-local-repo.sh
@@ -115,6 +115,8 @@ PACKAGES="
     libjson-perl
     libsql-translator-perl
     libfile-touch-perl
+    libglib2.0-0
+    libglib2.0-bin
 "
 
 # Add Docker repository for docker-ce packages

--- a/ci/usb-bootable-iso/drkgtk.cfg
+++ b/ci/usb-bootable-iso/drkgtk.cfg
@@ -3,4 +3,4 @@ label installdark
 	menu label ^Install PacketFence (USB Offline)
 	menu default
 	kernel /install.amd/vmlinuz
-      append vga=788 net.ifnames=0 auto=true priority=medium preseed/file=/preseed-offline.cfg passwd/make-user=false initrd=/install.amd/initrd.gz --- quiet
+	append vga=788 net.ifnames=0 initrd=/install.amd/initrd.gz --- quiet

--- a/ci/usb-bootable-iso/drkgtk.cfg
+++ b/ci/usb-bootable-iso/drkgtk.cfg
@@ -3,5 +3,5 @@ label installdark
 	menu label ^Install PacketFence (USB Offline)
 	menu default
 	kernel /install.amd/vmlinuz
-	append vga=788 net.ifnames=0 initrd=/install.amd/initrd.gz --- quiet
+	append vga=788 net.ifnames=0 auto=true priority=critical initrd=/install.amd/initrd.gz --- quiet
 

--- a/ci/usb-bootable-iso/drkgtk.cfg
+++ b/ci/usb-bootable-iso/drkgtk.cfg
@@ -3,5 +3,4 @@ label installdark
 	menu label ^Install PacketFence (USB Offline)
 	menu default
 	kernel /install.amd/vmlinuz
-	append vga=788 net.ifnames=0 auto=true priority=critical preseed/file=/preseed-offline.cfg passwd/make-user=false initrd=/install.amd/initrd.gz --- quiet
-
+      append vga=788 net.ifnames=0 auto=true priority=medium preseed/file=/preseed-offline.cfg passwd/make-user=false initrd=/install.amd/initrd.gz --- quiet

--- a/ci/usb-bootable-iso/drkgtk.cfg
+++ b/ci/usb-bootable-iso/drkgtk.cfg
@@ -1,0 +1,7 @@
+default installdark
+label installdark
+	menu label ^Install PacketFence (USB Offline)
+	menu default
+	kernel /install.amd/vmlinuz
+	append vga=788 net.ifnames=0 initrd=/install.amd/initrd.gz --- quiet
+

--- a/ci/usb-bootable-iso/drkgtk.cfg
+++ b/ci/usb-bootable-iso/drkgtk.cfg
@@ -3,5 +3,5 @@ label installdark
 	menu label ^Install PacketFence (USB Offline)
 	menu default
 	kernel /install.amd/vmlinuz
-	append vga=788 net.ifnames=0 auto=true priority=critical initrd=/install.amd/initrd.gz --- quiet
+	append vga=788 net.ifnames=0 auto=true priority=critical preseed/file=/preseed-offline.cfg passwd/make-user=false initrd=/install.amd/initrd.gz --- quiet
 

--- a/ci/usb-bootable-iso/grub.cfg
+++ b/ci/usb-bootable-iso/grub.cfg
@@ -26,7 +26,7 @@ play 960 440 1 0 4 440 1
 set theme=/boot/grub/theme/1
 menuentry --hotkey=i 'Install PacketFence (USB Offline)' {
     set background_color=black
-    linux    /install.amd/vmlinuz vga=788 net.ifnames=0 auto=true priority=critical preseed/file=/preseed-offline.cfg passwd/make-user=false --- quiet
+    linux    /install.amd/vmlinuz vga=788 net.ifnames=0 auto=true priority=medium preseed/file=/preseed-offline.cfg passwd/make-user=false --- quiet
     initrd   /install.amd/initrd.gz
 }
 submenu --hotkey=a 'Advanced options ...' {

--- a/ci/usb-bootable-iso/grub.cfg
+++ b/ci/usb-bootable-iso/grub.cfg
@@ -26,7 +26,7 @@ play 960 440 1 0 4 440 1
 set theme=/boot/grub/theme/1
 menuentry --hotkey=i 'Install PacketFence (USB Offline)' {
     set background_color=black
-    linux    /install.amd/vmlinuz vga=788 net.ifnames=0 auto=true priority=critical --- quiet
+    linux    /install.amd/vmlinuz vga=788 net.ifnames=0 auto=true priority=critical preseed/file=/preseed-offline.cfg passwd/make-user=false --- quiet
     initrd   /install.amd/initrd.gz
 }
 submenu --hotkey=a 'Advanced options ...' {

--- a/ci/usb-bootable-iso/grub.cfg
+++ b/ci/usb-bootable-iso/grub.cfg
@@ -26,7 +26,7 @@ play 960 440 1 0 4 440 1
 set theme=/boot/grub/theme/1
 menuentry --hotkey=i 'Install PacketFence (USB Offline)' {
     set background_color=black
-    linux    /install.amd/vmlinuz vga=788 net.ifnames=0 auto=true priority=medium preseed/file=/preseed-offline.cfg passwd/make-user=false --- quiet
+    linux    /install.amd/vmlinuz vga=788 net.ifnames=0 --- quiet
     initrd   /install.amd/initrd.gz
 }
 submenu --hotkey=a 'Advanced options ...' {

--- a/ci/usb-bootable-iso/grub.cfg
+++ b/ci/usb-bootable-iso/grub.cfg
@@ -1,0 +1,58 @@
+if loadfont $prefix/font.pf2 ; then
+  set gfxmode=800x600
+  set gfxpayload=keep
+  insmod efi_gop
+  insmod efi_uga
+  insmod video_bochs
+  insmod video_cirrus
+  insmod gfxterm
+  insmod png
+  terminal_output gfxterm
+fi
+
+if background_image /isolinux/splash.png; then
+  set color_normal=light-gray/black
+  set color_highlight=white/black
+elif background_image /splash.png; then
+  set color_normal=light-gray/black
+  set color_highlight=white/black
+else
+  set menu_color_normal=cyan/blue
+  set menu_color_highlight=white/blue
+fi
+
+insmod play
+play 960 440 1 0 4 440 1
+set theme=/boot/grub/theme/1
+menuentry --hotkey=i 'Install PacketFence (USB Offline)' {
+    set background_color=black
+    linux    /install.amd/vmlinuz vga=788 net.ifnames=0 --- quiet
+    initrd   /install.amd/initrd.gz
+}
+submenu --hotkey=a 'Advanced options ...' {
+    set menu_color_normal=cyan/blue
+    set menu_color_highlight=white/blue
+    set theme=/boot/grub/theme/1-1
+    set gfxpayload=keep
+    menuentry '... Graphical rescue mode' {
+        set background_color=black
+        linux    /install.amd/vmlinuz vga=788 rescue/enable=true --- quiet
+        initrd   /install.amd/gtk/initrd.gz
+    }
+    menuentry --hotkey=r '... Rescue mode' {
+        set background_color=black
+        linux    /install.amd/vmlinuz vga=788 rescue/enable=true --- quiet
+        initrd   /install.amd/initrd.gz
+    }
+    submenu --hotkey=s '... Speech-enabled advanced options ...' {
+        set menu_color_normal=cyan/blue
+        set menu_color_highlight=white/blue
+        set theme=/boot/grub/theme/1-1-1
+        set gfxpayload=keep
+        menuentry --hotkey=r '... Rescue speech mode' {
+            set background_color=black
+            linux    /install.amd/vmlinuz vga=788 rescue/enable=true speakup.synth=soft --- quiet
+            initrd   /install.amd/gtk/initrd.gz
+        }
+    }
+}

--- a/ci/usb-bootable-iso/grub.cfg
+++ b/ci/usb-bootable-iso/grub.cfg
@@ -26,7 +26,7 @@ play 960 440 1 0 4 440 1
 set theme=/boot/grub/theme/1
 menuentry --hotkey=i 'Install PacketFence (USB Offline)' {
     set background_color=black
-    linux    /install.amd/vmlinuz vga=788 net.ifnames=0 --- quiet
+    linux    /install.amd/vmlinuz vga=788 net.ifnames=0 auto=true priority=critical --- quiet
     initrd   /install.amd/initrd.gz
 }
 submenu --hotkey=a 'Advanced options ...' {

--- a/ci/usb-bootable-iso/gtk.cfg
+++ b/ci/usb-bootable-iso/gtk.cfg
@@ -3,5 +3,4 @@ label install
 	menu label ^Install PacketFence (USB Offline)
 	menu default
 	kernel /install.amd/vmlinuz
-	append vga=788 net.ifnames=0 auto=true priority=critical preseed/file=/preseed-offline.cfg passwd/make-user=false initrd=/install.amd/initrd.gz --- quiet
-
+      append vga=788 net.ifnames=0 auto=true priority=medium preseed/file=/preseed-offline.cfg passwd/make-user=false initrd=/install.amd/initrd.gz --- quiet

--- a/ci/usb-bootable-iso/gtk.cfg
+++ b/ci/usb-bootable-iso/gtk.cfg
@@ -3,5 +3,5 @@ label install
 	menu label ^Install PacketFence (USB Offline)
 	menu default
 	kernel /install.amd/vmlinuz
-	append vga=788 net.ifnames=0 auto=true priority=critical initrd=/install.amd/initrd.gz --- quiet
+	append vga=788 net.ifnames=0 auto=true priority=critical preseed/file=/preseed-offline.cfg passwd/make-user=false initrd=/install.amd/initrd.gz --- quiet
 

--- a/ci/usb-bootable-iso/gtk.cfg
+++ b/ci/usb-bootable-iso/gtk.cfg
@@ -3,5 +3,5 @@ label install
 	menu label ^Install PacketFence (USB Offline)
 	menu default
 	kernel /install.amd/vmlinuz
-	append vga=788 net.ifnames=0 initrd=/install.amd/initrd.gz --- quiet
+	append vga=788 net.ifnames=0 auto=true priority=critical initrd=/install.amd/initrd.gz --- quiet
 

--- a/ci/usb-bootable-iso/gtk.cfg
+++ b/ci/usb-bootable-iso/gtk.cfg
@@ -1,0 +1,7 @@
+default install
+label install
+	menu label ^Install PacketFence (USB Offline)
+	menu default
+	kernel /install.amd/vmlinuz
+	append vga=788 net.ifnames=0 initrd=/install.amd/initrd.gz --- quiet
+

--- a/ci/usb-bootable-iso/gtk.cfg
+++ b/ci/usb-bootable-iso/gtk.cfg
@@ -3,4 +3,4 @@ label install
 	menu label ^Install PacketFence (USB Offline)
 	menu default
 	kernel /install.amd/vmlinuz
-      append vga=788 net.ifnames=0 auto=true priority=medium preseed/file=/preseed-offline.cfg passwd/make-user=false initrd=/install.amd/initrd.gz --- quiet
+	append vga=788 net.ifnames=0 initrd=/install.amd/initrd.gz --- quiet

--- a/ci/usb-bootable-iso/menu.cfg
+++ b/ci/usb-bootable-iso/menu.cfg
@@ -1,0 +1,34 @@
+menu hshift 4
+menu width 70
+
+menu title PacketFence USB Offline Installer (BIOS mode)
+include stdmenu.cfg
+include gtk.cfg
+menu begin advanced
+    menu label ^Advanced options
+        menu title Advanced options
+        include stdmenu.cfg
+        label mainmenu
+                menu label ^Back..
+                menu exit
+        include rqtxt.cfg
+menu end
+menu begin dark
+    menu label Accessible ^dark contrast installer menu
+        menu title PacketFence USB Offline Installer (dark contrast)
+        include drkmenu.cfg
+        label mainmenu
+                menu label ^Back..
+                menu exit
+        include drkgtk.cfg
+        menu begin advanced
+            menu label ^Advanced options
+                menu title Advanced options
+                include drkmenu.cfg
+                label mainmenu
+                        menu label ^Back..
+                        menu exit
+                include rqdrk.cfg
+        menu end
+        include x86drkme.cfg
+menu end

--- a/ci/usb-bootable-iso/postinst-offline.sh
+++ b/ci/usb-bootable-iso/postinst-offline.sh
@@ -12,17 +12,8 @@ set -o nounset -o pipefail -o errexit
 PF_VERSION=${1:-15.1}
 
 echo "=============================================="
-echo "PacketFence Offline Post-Installation Script"
-echo "Phase A: Installing dependencies (preseed)"
-echo "=============================================="
+echo "PacketFence Offline Install - Phase A"
 echo "PF_VERSION: ${PF_VERSION}"
-echo "=============================================="
-echo "NOTE: DVD ISO is mounted at /media/cdrom"
-echo "      DVD provides all Debian packages"
-echo "      PF repo at /media/cdrom/pf-repo"
-echo ""
-echo "IMPORTANT: PacketFence will be installed on"
-echo "           first boot (Docker required)"
 echo "=============================================="
 
 # Step 1: Configure local repository from ISO

--- a/ci/usb-bootable-iso/postinst-offline.sh
+++ b/ci/usb-bootable-iso/postinst-offline.sh
@@ -120,22 +120,27 @@ else
     echo "Warning: Docker images not found on ISO at /media/cdrom/docker-images"
 fi
 
-# Step 5b: Copy PacketFence .deb package for installation on first boot
-echo "===> Step 5b: Copying PacketFence .deb package to target filesystem"
+# Step 5b: Copy PacketFence .deb packages for installation on first boot
+echo "===> Step 5b: Copying PacketFence .deb packages to target filesystem"
 
 PF_CACHE_DIR="/var/cache/packetfence-install"
 mkdir -p ${PF_CACHE_DIR}
 
 if [ -d /media/cdrom/pf-repo/pool/main ]; then
-    echo "Copying PacketFence .deb package from ISO to ${PF_CACHE_DIR}..."
-    find /media/cdrom/pf-repo/pool/main -name "packetfence_*.deb" -exec cp {} ${PF_CACHE_DIR}/ \; || {
-        echo "Warning: Failed to copy PacketFence .deb package"
+    echo "Copying PacketFence .deb packages from ISO to ${PF_CACHE_DIR}..."
+    # Copy all PacketFence-related packages (main + pre-depends + depends)
+    find /media/cdrom/pf-repo/pool/main -name "packetfence*.deb" -exec cp {} ${PF_CACHE_DIR}/ \; || {
+        echo "Warning: Failed to copy some PacketFence .deb packages"
     }
-    if ls ${PF_CACHE_DIR}/packetfence_*.deb 1> /dev/null 2>&1; then
-        echo "PacketFence .deb package copied successfully"
+    # Also copy fingerbank packages (pre-depends)
+    find /media/cdrom/pf-repo/pool/main -name "fingerbank*.deb" -exec cp {} ${PF_CACHE_DIR}/ \; || {
+        echo "Warning: Failed to copy fingerbank .deb packages"
+    }
+    if ls ${PF_CACHE_DIR}/*.deb 1> /dev/null 2>&1; then
+        echo "PacketFence packages copied successfully:"
         ls -la ${PF_CACHE_DIR}/
     else
-        echo "ERROR: No PacketFence .deb package found"
+        echo "ERROR: No PacketFence .deb packages found"
     fi
 else
     echo "Warning: PF repo not found on ISO at /media/cdrom/pf-repo/pool/main"
@@ -224,18 +229,22 @@ echo "Removing local ISO repository configuration..."
 rm -f /etc/apt/sources.list.d/packetfence-local.list
 apt-get update 2>/dev/null || true
 
-# Install PacketFence from the copied .deb file
+# Install PacketFence and all related packages from the copied .deb files
 # Now that Docker is running, PacketFence postinst can configure containers
-if [ -f ${PF_CACHE_DIR}/packetfence_*.deb ]; then
-    PF_DEB=$(ls ${PF_CACHE_DIR}/packetfence_*.deb | head -n1)
-    echo "Installing PacketFence from ${PF_DEB}..."
-    DEBIAN_FRONTEND=noninteractive dpkg -i ${PF_DEB} || {
+if ls ${PF_CACHE_DIR}/*.deb 1> /dev/null 2>&1; then
+    echo "Installing PacketFence and related packages from cached .deb files..."
+    echo "Packages to install:"
+    ls ${PF_CACHE_DIR}/*.deb
+
+    # Install all .deb files at once - dpkg will handle the dependency order
+    DEBIAN_FRONTEND=noninteractive dpkg -i ${PF_CACHE_DIR}/*.deb || {
         echo "Warning: PacketFence installation had issues, fixing dependencies..."
         DEBIAN_FRONTEND=noninteractive apt-get install -y -f
-        DEBIAN_FRONTEND=noninteractive dpkg -i ${PF_DEB}
+        DEBIAN_FRONTEND=noninteractive dpkg -i ${PF_CACHE_DIR}/*.deb
     }
+    echo "PacketFence installation completed successfully"
 else
-    echo "ERROR: PacketFence .deb package not found in ${PF_CACHE_DIR}"
+    echo "ERROR: No PacketFence .deb packages found in ${PF_CACHE_DIR}"
     exit 1
 fi
 

--- a/ci/usb-bootable-iso/postinst-offline.sh
+++ b/ci/usb-bootable-iso/postinst-offline.sh
@@ -51,7 +51,7 @@ apt-get update
 echo "===> Step 2: Installing packages from local repository (not on DVD-1)"
 
 # Install packages that are NOT on DVD-1, must come from local pf-repo
-# These are needed by packetfence-* dependency packages
+# These are needed by fingerbank and packetfence-* dependency packages
 DEBIAN_FRONTEND=noninteractive apt-get install -y \
     lnav \
     cgroupfs-mount \
@@ -63,6 +63,18 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y \
     libdbd-sqlite3-perl \
     sqlite3 \
     libdata-powerset-perl \
+    libcatalyst-perl \
+    libcatalyst-modules-perl \
+    libaliased-perl \
+    libmoosex-types-loadableclass-perl \
+    libconfig-general-perl \
+    libreadonly-xs-perl \
+    libcatalyst-action-rest-perl \
+    liblwp-protocol-https-perl \
+    liblwp-protocol-connect-perl \
+    libjson-perl \
+    libsql-translator-perl \
+    libfile-touch-perl \
     || {
     echo "Warning: Some packages failed to install, continuing..."
 }

--- a/ci/usb-bootable-iso/postinst-offline.sh
+++ b/ci/usb-bootable-iso/postinst-offline.sh
@@ -179,6 +179,23 @@ set -o pipefail
 LOG_FILE="/var/log/packetfence-first-boot.log"
 exec > >(tee -a ${LOG_FILE}) 2>&1
 
+# Display installation progress message on login screen
+cat > /etc/issue << 'EOF'
+================================================================================
+  PacketFence Installation In Progress - Please Wait
+================================================================================
+
+  The system is currently installing PacketFence and loading Docker images.
+  This process may take 10-15 minutes.
+
+  Progress can be monitored at: /var/log/packetfence-first-boot.log
+
+  Please wait until installation completes before using the system.
+
+================================================================================
+
+EOF
+
 echo "=============================================="
 echo "PacketFence First Boot - Phase B"
 echo "Starting at: $(date)"
@@ -287,6 +304,43 @@ echo "===> Step 6: Starting services"
 
 systemctl start mariadb || true
 systemctl start redis-server || true
+
+# Update login screen with completion message
+cat > /etc/issue << 'EOF'
+================================================================================
+  PacketFence Installation Complete!
+================================================================================
+
+  PacketFence has been successfully installed and configured.
+
+  Next steps:
+    1. Log in as root
+    2. Run: /usr/local/pf/bin/pfcmd configreload hard
+    3. Access the web interface at https://<this-ip>:1443
+
+  For more information, see: /var/log/packetfence-first-boot.log
+
+================================================================================
+
+EOF
+
+# Also add to MOTD for after login
+cat > /etc/motd << 'EOF'
+================================================================================
+  Welcome to PacketFence!
+================================================================================
+
+  PacketFence has been successfully installed.
+
+  Next steps:
+    1. Run: /usr/local/pf/bin/pfcmd configreload hard
+    2. Access the web interface at https://<this-ip>:1443
+
+  Installation log: /var/log/packetfence-first-boot.log
+  Documentation: https://packetfence.org/doc/
+
+================================================================================
+EOF
 
 # Remove this script and service
 echo "===> Removing first-boot service"

--- a/ci/usb-bootable-iso/postinst-offline.sh
+++ b/ci/usb-bootable-iso/postinst-offline.sh
@@ -218,7 +218,7 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 }
 
 # Verify kernel is still installed
-if [ ! -f /boot/vmlinuz-* ]; then
+if ! ls /boot/vmlinuz-* >/dev/null 2>&1; then
     echo "ERROR: Kernel missing! Reinstalling..."
     DEBIAN_FRONTEND=noninteractive apt-get install -y linux-image-amd64
 fi

--- a/ci/usb-bootable-iso/postinst-offline.sh
+++ b/ci/usb-bootable-iso/postinst-offline.sh
@@ -125,9 +125,6 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     bind9-dnsutils \
     bind9-libs \
     bind9-host \
-    openssh-server \
-    openssh-client \
-    openssh-sftp-server \
     vlan \
     arping \
     fping \

--- a/ci/usb-bootable-iso/postinst-offline.sh
+++ b/ci/usb-bootable-iso/postinst-offline.sh
@@ -50,8 +50,20 @@ apt-get update
 # Step 2: Install packages not available on DVD-1
 echo "===> Step 2: Installing packages from local repository (not on DVD-1)"
 
-# Install lnav and cgroupfs-mount (not on DVD-1, must come from local repo)
-DEBIAN_FRONTEND=noninteractive apt-get install -y lnav cgroupfs-mount || {
+# Install packages that are NOT on DVD-1, must come from local pf-repo
+# These are needed by packetfence-* dependency packages
+DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    lnav \
+    cgroupfs-mount \
+    libcache-bdb-perl \
+    liblog-fast-perl \
+    libfile-flock-perl \
+    libcjson1 \
+    liblog-log4perl-perl \
+    libdbd-sqlite3-perl \
+    sqlite3 \
+    libdata-powerset-perl \
+    || {
     echo "Warning: Some packages failed to install, continuing..."
 }
 

--- a/ci/usb-bootable-iso/postinst-offline.sh
+++ b/ci/usb-bootable-iso/postinst-offline.sh
@@ -177,7 +177,8 @@ set -o pipefail
 # =============================================================================
 
 LOG_FILE="/var/log/packetfence-first-boot.log"
-exec > >(tee -a ${LOG_FILE}) 2>&1
+# Redirect all output to log file only (not to console)
+exec >> ${LOG_FILE} 2>&1
 
 # Function to update installation progress on login screen
 update_progress() {
@@ -430,8 +431,8 @@ Type=oneshot
 ExecStart=/usr/local/bin/packetfence-first-boot.sh
 RemainAfterExit=yes
 TimeoutStartSec=900
-StandardOutput=journal+console
-StandardError=journal+console
+StandardOutput=journal
+StandardError=journal
 
 [Install]
 WantedBy=multi-user.target

--- a/ci/usb-bootable-iso/postinst-offline.sh
+++ b/ci/usb-bootable-iso/postinst-offline.sh
@@ -9,11 +9,11 @@ set -o nounset -o pipefail -o errexit
 # PacketFence installation is deferred to first boot (Phase B).
 # =============================================================================
 
-PF_VERSION=${1:-15.1}
+PF_RELEASE_VERSION=${1:-15.1}
 
 echo "=============================================="
 echo "PacketFence Offline Install - Phase A"
-echo "PF_VERSION: ${PF_VERSION}"
+echo "PF_RELEASE_VERSION: ${PF_RELEASE_VERSION}"
 echo "=============================================="
 
 # Step 1: Configure local repository from ISO
@@ -249,9 +249,9 @@ sed -i 's/#PermitRootLogin.*/PermitRootLogin yes/g' /etc/ssh/sshd_config
 sed -i 's/.*inverse\.ca.*//g' /etc/apt/sources.list
 
 # Configure PacketFence repository for future updates (will be used when network is available)
-# Using debian-branches for now - change to debian/${PF_VERSION} when stable packages are published
+# Using debian-branches for now - change to debian/${PF_RELEASE_VERSION} when stable packages are published
 cat > /etc/apt/sources.list.d/packetfence.list << EOF
-deb [signed-by=/etc/apt/keyrings/packetfence.gpg] https://inverse.ca/downloads/PacketFence/debian-branches/${PF_VERSION} bookworm bookworm
+deb [signed-by=/etc/apt/keyrings/packetfence.gpg] https://inverse.ca/downloads/PacketFence/debian-branches/${PF_RELEASE_VERSION} bookworm bookworm
 EOF
 
 # Step 7: Create first-boot service

--- a/ci/usb-bootable-iso/postinst-offline.sh
+++ b/ci/usb-bootable-iso/postinst-offline.sh
@@ -164,24 +164,41 @@ echo "===> Step 5b: Copying PacketFence .deb packages to target filesystem"
 PF_CACHE_DIR="/var/cache/packetfence-install"
 mkdir -p ${PF_CACHE_DIR}
 
+# Debug: Show what's on the ISO
+echo "Checking ISO contents..."
+echo "Contents of /media/cdrom:"
+ls -la /media/cdrom/ 2>/dev/null || echo "  (cannot list /media/cdrom)"
+echo "Contents of /media/cdrom/pf-repo:"
+ls -la /media/cdrom/pf-repo/ 2>/dev/null || echo "  (cannot list /media/cdrom/pf-repo)"
+echo "Contents of /media/cdrom/pf-repo/pool:"
+ls -la /media/cdrom/pf-repo/pool/ 2>/dev/null || echo "  (cannot list /media/cdrom/pf-repo/pool)"
+echo "Contents of /media/cdrom/pf-repo/pool/main:"
+ls -la /media/cdrom/pf-repo/pool/main/ 2>/dev/null || echo "  (cannot list /media/cdrom/pf-repo/pool/main)"
+
 if [ -d /media/cdrom/pf-repo/pool/main ]; then
     echo "Copying PacketFence .deb packages from ISO to ${PF_CACHE_DIR}..."
-    # Copy all PacketFence-related packages (main + pre-depends + depends)
-    find /media/cdrom/pf-repo/pool/main -name "packetfence*.deb" -exec cp {} ${PF_CACHE_DIR}/ \; || {
-        echo "Warning: Failed to copy some PacketFence .deb packages"
+
+    # Find and show what we're copying
+    echo "PacketFence packages found on ISO:"
+    find /media/cdrom/pf-repo/pool/main -name "packetfence*.deb" -o -name "fingerbank*.deb" 2>/dev/null | head -20
+
+    # Copy all .deb files from the pool (simpler and more reliable)
+    cp /media/cdrom/pf-repo/pool/main/*.deb ${PF_CACHE_DIR}/ 2>/dev/null || {
+        echo "Warning: cp failed, trying find method..."
+        find /media/cdrom/pf-repo/pool/main -name "*.deb" -exec cp {} ${PF_CACHE_DIR}/ \; 2>/dev/null || true
     }
-    # Also copy fingerbank packages (pre-depends)
-    find /media/cdrom/pf-repo/pool/main -name "fingerbank*.deb" -exec cp {} ${PF_CACHE_DIR}/ \; || {
-        echo "Warning: Failed to copy fingerbank .deb packages"
-    }
+
     if ls ${PF_CACHE_DIR}/*.deb 1> /dev/null 2>&1; then
         echo "PacketFence packages copied successfully:"
         ls -la ${PF_CACHE_DIR}/
     else
-        echo "ERROR: No PacketFence .deb packages found"
+        echo "ERROR: No .deb packages found in ${PF_CACHE_DIR} after copy attempt"
+        echo "This will cause first-boot installation to fail!"
     fi
 else
-    echo "Warning: PF repo not found on ISO at /media/cdrom/pf-repo/pool/main"
+    echo "ERROR: PF repo not found on ISO at /media/cdrom/pf-repo/pool/main"
+    echo "Available directories on ISO:"
+    find /media/cdrom -type d 2>/dev/null | head -20
 fi
 
 # Step 6: Configure system
@@ -195,8 +212,9 @@ sed -i 's/#PermitRootLogin.*/PermitRootLogin yes/g' /etc/ssh/sshd_config
 sed -i 's/.*inverse\.ca.*//g' /etc/apt/sources.list
 
 # Configure PacketFence repository for future updates (will be used when network is available)
+# Using debian-branches for now - change to debian/${PF_VERSION} when stable packages are published
 cat > /etc/apt/sources.list.d/packetfence.list << EOF
-deb [signed-by=/etc/apt/keyrings/packetfence.gpg] http://inverse.ca/downloads/PacketFence/debian/${PF_VERSION} bookworm bookworm
+deb [signed-by=/etc/apt/keyrings/packetfence.gpg] https://inverse.ca/downloads/PacketFence/debian-branches/${PF_VERSION} bookworm bookworm
 EOF
 
 # Step 7: Create first-boot service
@@ -205,7 +223,7 @@ echo "===> Step 7: Creating first-boot service"
 # Create the first-boot script (Phase B)
 cat > /usr/local/bin/packetfence-first-boot.sh << 'FIRSTBOOT_EOF'
 #!/bin/bash
-set -o pipefail
+set -o pipefail -o errexit
 
 # =============================================================================
 # PacketFence First Boot Script - Phase B
@@ -215,6 +233,8 @@ set -o pipefail
 # =============================================================================
 
 LOG_FILE="/var/log/packetfence-first-boot.log"
+INSTALL_SUCCESS=0
+
 # Redirect all output to log file only (not to console)
 exec >> ${LOG_FILE} 2>&1
 
@@ -239,6 +259,43 @@ update_progress() {
 
 EOF
 }
+
+# Function to handle script exit (success or failure)
+handle_exit() {
+    local exit_code=$?
+    if [ ${INSTALL_SUCCESS} -eq 0 ] && [ ${exit_code} -ne 0 ]; then
+        echo ""
+        echo "=============================================="
+        echo "ERROR: Script failed with exit code ${exit_code}"
+        echo "Time: $(date)"
+        echo "=============================================="
+        cat > /etc/issue << EOF
+================================================================================
+  PacketFence Installation FAILED
+================================================================================
+
+  The installation encountered an error and could not complete.
+
+  Please check the log file for details:
+    /var/log/packetfence-first-boot.log
+
+  To retry installation:
+    1. Log in as root
+    2. Run: /usr/local/bin/packetfence-first-boot.sh
+
+  Common issues:
+    - Missing .deb packages in /var/cache/packetfence-install
+    - Docker service failed to start
+    - Network issues during package installation
+
+================================================================================
+
+EOF
+    fi
+}
+
+# Set up exit trap to catch all exits (success or failure)
+trap handle_exit EXIT
 
 # Display initial installation progress message on login screen
 update_progress "Initializing" "Starting PacketFence installation..."
@@ -434,6 +491,9 @@ cat > /etc/motd << 'EOF'
 
 ================================================================================
 EOF
+
+# Mark installation as successful (prevents error message in exit trap)
+INSTALL_SUCCESS=1
 
 # Remove this script and service
 echo "===> Removing first-boot service"

--- a/ci/usb-bootable-iso/postinst-offline.sh
+++ b/ci/usb-bootable-iso/postinst-offline.sh
@@ -43,25 +43,34 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y lnav cgroupfs-mount || {
     echo "Warning: Some packages failed to install, continuing..."
 }
 
-# Step 3: Install PacketFence from local repository
-echo "===> Step 3: Installing PacketFence"
+# Step 3: Start Docker (required BEFORE PacketFence installation)
+echo "===> Step 3: Starting Docker service"
 
-# Install PacketFence (this will also install dependencies from local repo)
-DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends packetfence || {
-    echo "Warning: PacketFence installation had issues, attempting to fix..."
-    dpkg --configure -a
-    DEBIAN_FRONTEND=noninteractive apt-get install -y -f
+# Start Docker service - PacketFence postinst needs it running
+systemctl start docker || {
+    echo "Warning: Failed to start Docker, attempting manual start..."
+    dockerd &
+    sleep 5
 }
+
+# Wait for Docker socket to be available
+echo "Waiting for Docker to be ready..."
+for i in {1..30}; do
+    if [ -S /var/run/docker.sock ]; then
+        echo "Docker is ready"
+        break
+    fi
+    sleep 1
+done
+
+if [ ! -S /var/run/docker.sock ]; then
+    echo "ERROR: Docker socket not available after 30 seconds"
+fi
 
 # Step 4: Load pre-downloaded Docker images
 echo "===> Step 4: Loading Docker images"
 
 if [ -d /media/cdrom/docker-images ] && [ -f /media/cdrom/docker-images/load-images.sh ]; then
-    # Start Docker service first
-    systemctl start docker || true
-    sleep 5
-
-    # Load images
     /media/cdrom/docker-images/load-images.sh || {
         echo "Warning: Some Docker images failed to load"
     }
@@ -69,8 +78,19 @@ else
     echo "Warning: Docker images not found on ISO"
 fi
 
-# Step 5: Configure system
-echo "===> Step 5: Configuring system"
+# Step 5: Install PacketFence from local repository
+echo "===> Step 5: Installing PacketFence"
+
+# Install PacketFence (this will also install dependencies from local repo)
+# Docker is now running so postinst scripts can configure containers
+DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends packetfence || {
+    echo "Warning: PacketFence installation had issues, attempting to fix..."
+    dpkg --configure -a
+    DEBIAN_FRONTEND=noninteractive apt-get install -y -f
+}
+
+# Step 6: Configure system
+echo "===> Step 6: Configuring system"
 
 # Allow SSH root login
 sed -i 's/#PermitRootLogin.*/PermitRootLogin yes/g' /etc/ssh/sshd_config
@@ -79,8 +99,8 @@ sed -i 's/#PermitRootLogin.*/PermitRootLogin yes/g' /etc/ssh/sshd_config
 # (they will be added properly when network is available)
 sed -i 's/.*inverse\.ca.*//g' /etc/apt/sources.list
 
-# Step 6: Configure PacketFence repository for future updates
-echo "===> Step 6: Setting up PacketFence repository for future updates"
+# Step 7: Configure PacketFence repository for future updates
+echo "===> Step 7: Setting up PacketFence repository for future updates"
 
 # Add PacketFence GPG key
 curl -fsSL https://inverse.ca/downloads/GPG_PUBLIC_KEY 2>/dev/null | gpg --dearmor -o /etc/apt/keyrings/packetfence.gpg || {
@@ -92,8 +112,8 @@ cat > /etc/apt/sources.list.d/packetfence.list << EOF
 deb [signed-by=/etc/apt/keyrings/packetfence.gpg] http://inverse.ca/downloads/PacketFence/debian/${PF_VERSION} bookworm bookworm
 EOF
 
-# Step 7: Reset MariaDB root password
-echo "===> Step 7: Resetting MariaDB root password"
+# Step 8: Reset MariaDB root password
+echo "===> Step 8: Resetting MariaDB root password"
 
 echo "SET PASSWORD FOR root@'localhost' = PASSWORD('');" > /tmp/reset-root.sql
 mkdir -p /run/mysqld
@@ -101,8 +121,8 @@ chown mysql: /run/mysqld/
 timeout 30 mysqld --skip-networking --init-file /tmp/reset-root.sql --user=mysql > /var/log/reset-root.log 2>&1 || true
 rm -f /tmp/reset-root.sql
 
-# Step 8: Stop services that shouldn't run during installation
-echo "===> Step 8: Stopping services"
+# Step 9: Stop services that shouldn't run during installation
+echo "===> Step 9: Stopping services"
 
 # Stop Docker (will be started on first boot)
 pkill -e docker 2>/dev/null || true
@@ -111,8 +131,8 @@ systemctl stop docker 2>/dev/null || true
 # Stop MariaDB
 systemctl stop mariadb 2>/dev/null || true
 
-# Step 9: Create first-boot marker
-echo "===> Step 9: Creating first-boot configuration"
+# Step 10: Create first-boot marker
+echo "===> Step 10: Creating first-boot configuration"
 
 # Create a first-boot script to finalize setup
 cat > /usr/local/bin/packetfence-first-boot.sh << 'FIRSTBOOT_EOF'

--- a/ci/usb-bootable-iso/postinst-offline.sh
+++ b/ci/usb-bootable-iso/postinst-offline.sh
@@ -42,7 +42,10 @@ apt-get update
 echo "===> Step 2: Installing packages from DVD (needed for first boot)"
 
 # Packages required during first boot when DVD is removed (fingerbank deps, SSL, acl)
+# dpkg-dev is required by Phase B's dpkg-scanpackages call; pull it in explicitly
+# so we don't rely on a transitive dependency from build-essential.
 DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    dpkg-dev \
     liblog-log4perl-perl \
     libconfig-inifiles-perl \
     liburi-perl \

--- a/ci/usb-bootable-iso/postinst-offline.sh
+++ b/ci/usb-bootable-iso/postinst-offline.sh
@@ -99,14 +99,14 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y docker-ce docker-ce-cli contai
 }
 
 # Step 4: Install PacketFence dependencies (but NOT PacketFence itself)
-echo "===> Step 4: Installing PacketFence dependencies"
+echo "===> Step 4: Installing PacketFence dependencies from DVD"
 
 # Ensure kernel is marked to not be auto-removed
 apt-mark hold linux-image-amd64 linux-image-* 2>/dev/null || true
 
-# Install key dependencies that PacketFence needs
+# Install ALL dependencies that PacketFence needs from the DVD
 # PacketFence package itself will be installed on first boot when Docker is running
-# Include linux-image-amd64 to ensure kernel is not removed by dependency resolution
+# These are standard Debian packages that won't be available after DVD is removed
 DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     linux-image-amd64 \
     linux-headers-amd64 \
@@ -127,7 +127,6 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     snmpd \
     snmp \
     monit \
-    fingerbank-collector \
     bind9-dnsutils \
     bind9-libs \
     bind9-host \
@@ -135,6 +134,80 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     arping \
     fping \
     ipset \
+    jq \
+    snmptrapfmt \
+    snmptrapd \
+    snmp-mibs-downloader \
+    conntrack \
+    rsyslog \
+    ipcalc \
+    ipcalc-ng \
+    apache2 \
+    apache2-utils \
+    libapache2-mod-apreq2 \
+    libapache2-mod-perl2 \
+    libapache2-request-perl \
+    libapache-ssllookup-perl \
+    libapache2-mod-systemd \
+    eapoltest \
+    python3-impacket \
+    python-is-python3 \
+    python3.11-venv \
+    krb5-user \
+    sscep \
+    libwww-perl \
+    libtext-csv-xs-perl \
+    libcgi-session-serialize-yaml-perl \
+    libapache-dbi-perl \
+    libdbd-mysql-perl \
+    libnetwork-ipv4addr-perl \
+    iptables-netflow-dkms \
+    liblwp-useragent-determined-perl \
+    libnet-pcap-perl \
+    libsnmp-perl \
+    libnet-telnet-cisco-perl \
+    libnet-cisco-mse-rest-perl \
+    perlmagick \
+    libregexp-common-email-address-perl \
+    libregexp-common-time-perl \
+    libperl-critic-perl \
+    libhtml-template-perl \
+    libtest-perl-critic-perl \
+    libthread-pool-simple-perl \
+    libuniversal-exports-perl \
+    libnet-rawip-perl \
+    libdatetime-format-dateparse-perl \
+    perl-doc \
+    librrds-perl \
+    libnetpacket-perl \
+    libmime-lite-perl \
+    libdata-swap-perl \
+    libposix-atfork-perl \
+    libcrypt-openssl-pkcs12-perl \
+    libnet-dhcp-perl \
+    libnet-interface-perl \
+    libnet-radius-perl \
+    libbsd-resource-perl \
+    libparse-nessus-nbe-perl \
+    libtest-mockdbi-perl \
+    libsoap-lite-perl \
+    libnet-frame-perl \
+    bsdmainutils \
+    libwww-curl-perl \
+    libposix-2008-perl \
+    libdata-messagepack-stream-perl \
+    libnet-nessus-xmlrpc-perl \
+    libnet-nessus-rest-perl \
+    libnet-route-perl \
+    libnet-arp-perl \
+    locales-all \
+    python3-mysqldb \
+    libcrypt-smime-perl \
+    liblasso-perl \
+    libcisco-accesslist-parser-perl \
+    libparse-eyapp-perl \
+    python3-twisted \
+    uuid-runtime \
     || {
     echo "Warning: Some dependencies failed to install, attempting to fix..."
     dpkg --configure -a

--- a/ci/usb-bootable-iso/postinst-offline.sh
+++ b/ci/usb-bootable-iso/postinst-offline.sh
@@ -417,6 +417,8 @@ else
     echo "Warning: Docker images not found at ${DOCKER_CACHE_DIR}"
 fi
 
+update_progress "Step 2/6" "Configuring Docker image tags..."
+
 # Re-tag Docker images to match what PacketFence expects
 # Images may have been downloaded with a different tag (e.g., devel) than what
 # the installed PacketFence package expects (e.g., feature-usb-bootable-iso2)
@@ -495,6 +497,8 @@ if [ -n "${TAG_TO_USE}" ]; then
 else
     echo "No tag available, skipping local registry aliases"
 fi
+
+update_progress "Step 2/6" "Docker images ready"
 
 # Step 3: Install PacketFence
 update_progress "Step 3/6" "Installing PacketFence dependencies..."

--- a/ci/usb-bootable-iso/postinst-offline.sh
+++ b/ci/usb-bootable-iso/postinst-offline.sh
@@ -732,7 +732,13 @@ StandardOutput=journal
 StandardError=journal
 
 [Install]
-WantedBy=multi-user.target
+# Use basic.target instead of multi-user.target to avoid deadlock:
+# first-boot runs postinst -> postinst calls "systemctl isolate packetfence-base.target"
+# packetfence-base.target depends on multi-user.target
+# If first-boot is WantedBy multi-user.target, multi-user.target waits for first-boot to complete -> deadlock
+# Using basic.target, the service is queued early but After=docker.service ensures it waits for Docker.
+# By the time first-boot runs, multi-user.target is already active, breaking the cycle.
+WantedBy=basic.target
 SERVICE_EOF
 
 systemctl enable packetfence-first-boot.service

--- a/ci/usb-bootable-iso/postinst-offline.sh
+++ b/ci/usb-bootable-iso/postinst-offline.sh
@@ -57,6 +57,7 @@ echo "===> Step 2: Installing packages from DVD (needed for first boot)"
 # - liblog-log4perl-perl (>= 1.43): fingerbank requires specific version
 # - libconfig-inifiles-perl (>= 2.88): fingerbank requires specific version
 # - liburi-perl, libregexp-ipv6-perl: needed by HTTP::Request/LWP in packetfence-perl
+# - libnet-ssleay-perl, libio-socket-ssl-perl: SSL/TLS support (XS modules)
 # - acl: needed by packetfence preinst script (setfacl command)
 # - libdbd-sqlite3-perl, sqlite3, libdata-powerset-perl: fingerbank dependencies
 DEBIAN_FRONTEND=noninteractive apt-get install -y \
@@ -64,6 +65,8 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y \
     libconfig-inifiles-perl \
     liburi-perl \
     libregexp-ipv6-perl \
+    libnet-ssleay-perl \
+    libio-socket-ssl-perl \
     acl \
     libdbd-sqlite3-perl \
     sqlite3 \
@@ -554,10 +557,21 @@ APT_EOF
     echo "Local APT repository created successfully"
     echo ""
 
-    # Step 3b: Install all packages using apt-get (proper dependency resolution)
-    echo "===> Step 3b: Installing packages with apt-get..."
+    # Step 3b: Install all dependency packages first (before major applications)
+    echo "===> Step 3b: Installing dependency packages..."
 
-    # Install packetfence-perl first (provides virtual packages)
+    # Get list of all non-packetfence/non-fingerbank packages from the local repo
+    DEP_PKGS=$(ls ${PF_CACHE_DIR}/*.deb 2>/dev/null | xargs -n1 basename | sed 's/_.*$//' | grep -v -E '^(packetfence|fingerbank)' | sort -u || true)
+    if [ -n "$DEP_PKGS" ]; then
+        echo "Installing dependencies: $DEP_PKGS"
+        DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-downgrades $DEP_PKGS || true
+    fi
+    echo ""
+
+    # Step 3c: Install PacketFence ecosystem packages
+    echo "===> Step 3c: Installing PacketFence packages..."
+
+    # Install packetfence-perl (provides virtual packages)
     echo "Installing packetfence-perl..."
     DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-downgrades packetfence-perl || true
 
@@ -576,8 +590,8 @@ APT_EOF
     fi
     echo ""
 
-    # Step 3c: Install main PacketFence package LAST (requires Docker running)
-    echo "===> Step 3c: Installing main PacketFence package..."
+    # Step 3d: Install main PacketFence package LAST (requires Docker running)
+    echo "===> Step 3d: Installing main PacketFence package..."
     DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-downgrades packetfence || {
         echo "Warning: apt-get install packetfence had issues, trying dpkg..."
         PF_MAIN_PKG=$(ls ${PF_CACHE_DIR}/packetfence_*.deb 2>/dev/null | head -n1)

--- a/ci/usb-bootable-iso/postinst-offline.sh
+++ b/ci/usb-bootable-iso/postinst-offline.sh
@@ -43,8 +43,18 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y lnav cgroupfs-mount || {
     echo "Warning: Some packages failed to install, continuing..."
 }
 
-# Step 3: Start Docker (required BEFORE PacketFence installation)
-echo "===> Step 3: Starting Docker service"
+# Step 3: Install Docker packages
+echo "===> Step 3: Installing Docker packages"
+
+# Install Docker packages from local repo (required before starting Docker)
+DEBIAN_FRONTEND=noninteractive apt-get install -y docker-ce docker-ce-cli containerd.io || {
+    echo "Warning: Docker packages installation had issues, attempting to fix..."
+    dpkg --configure -a
+    DEBIAN_FRONTEND=noninteractive apt-get install -y -f
+}
+
+# Step 4: Start Docker service (required BEFORE PacketFence installation)
+echo "===> Step 4: Starting Docker service"
 
 # Start Docker service - PacketFence postinst needs it running
 systemctl start docker || {
@@ -67,8 +77,8 @@ if [ ! -S /var/run/docker.sock ]; then
     echo "ERROR: Docker socket not available after 30 seconds"
 fi
 
-# Step 4: Load pre-downloaded Docker images
-echo "===> Step 4: Loading Docker images"
+# Step 5: Load pre-downloaded Docker images
+echo "===> Step 5: Loading Docker images"
 
 if [ -d /media/cdrom/docker-images ] && [ -f /media/cdrom/docker-images/load-images.sh ]; then
     /media/cdrom/docker-images/load-images.sh || {
@@ -78,8 +88,8 @@ else
     echo "Warning: Docker images not found on ISO"
 fi
 
-# Step 5: Install PacketFence from local repository
-echo "===> Step 5: Installing PacketFence"
+# Step 6: Install PacketFence from local repository
+echo "===> Step 6: Installing PacketFence"
 
 # Install PacketFence (this will also install dependencies from local repo)
 # Docker is now running so postinst scripts can configure containers
@@ -89,8 +99,8 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends packet
     DEBIAN_FRONTEND=noninteractive apt-get install -y -f
 }
 
-# Step 6: Configure system
-echo "===> Step 6: Configuring system"
+# Step 7: Configure system
+echo "===> Step 7: Configuring system"
 
 # Allow SSH root login
 sed -i 's/#PermitRootLogin.*/PermitRootLogin yes/g' /etc/ssh/sshd_config
@@ -99,8 +109,8 @@ sed -i 's/#PermitRootLogin.*/PermitRootLogin yes/g' /etc/ssh/sshd_config
 # (they will be added properly when network is available)
 sed -i 's/.*inverse\.ca.*//g' /etc/apt/sources.list
 
-# Step 7: Configure PacketFence repository for future updates
-echo "===> Step 7: Setting up PacketFence repository for future updates"
+# Step 8: Configure PacketFence repository for future updates
+echo "===> Step 8: Setting up PacketFence repository for future updates"
 
 # Add PacketFence GPG key
 curl -fsSL https://inverse.ca/downloads/GPG_PUBLIC_KEY 2>/dev/null | gpg --dearmor -o /etc/apt/keyrings/packetfence.gpg || {
@@ -112,8 +122,8 @@ cat > /etc/apt/sources.list.d/packetfence.list << EOF
 deb [signed-by=/etc/apt/keyrings/packetfence.gpg] http://inverse.ca/downloads/PacketFence/debian/${PF_VERSION} bookworm bookworm
 EOF
 
-# Step 8: Reset MariaDB root password
-echo "===> Step 8: Resetting MariaDB root password"
+# Step 9: Reset MariaDB root password
+echo "===> Step 9: Resetting MariaDB root password"
 
 echo "SET PASSWORD FOR root@'localhost' = PASSWORD('');" > /tmp/reset-root.sql
 mkdir -p /run/mysqld
@@ -121,8 +131,8 @@ chown mysql: /run/mysqld/
 timeout 30 mysqld --skip-networking --init-file /tmp/reset-root.sql --user=mysql > /var/log/reset-root.log 2>&1 || true
 rm -f /tmp/reset-root.sql
 
-# Step 9: Stop services that shouldn't run during installation
-echo "===> Step 9: Stopping services"
+# Step 10: Stop services that shouldn't run during installation
+echo "===> Step 10: Stopping services"
 
 # Stop Docker (will be started on first boot)
 pkill -e docker 2>/dev/null || true
@@ -131,8 +141,8 @@ systemctl stop docker 2>/dev/null || true
 # Stop MariaDB
 systemctl stop mariadb 2>/dev/null || true
 
-# Step 10: Create first-boot marker
-echo "===> Step 10: Creating first-boot configuration"
+# Step 11: Create first-boot marker
+echo "===> Step 11: Creating first-boot configuration"
 
 # Create a first-boot script to finalize setup
 cat > /usr/local/bin/packetfence-first-boot.sh << 'FIRSTBOOT_EOF'

--- a/ci/usb-bootable-iso/postinst-offline.sh
+++ b/ci/usb-bootable-iso/postinst-offline.sh
@@ -52,29 +52,16 @@ echo "===> Step 2: Installing packages from local repository (not on DVD-1)"
 
 # Install packages that are NOT on DVD-1, must come from local pf-repo
 # These are needed by fingerbank and packetfence-* dependency packages
+# Note: Many perl packages (liblog-fast-perl, libcatalyst-perl, etc.) are virtual
+# packages provided by packetfence-perl - do NOT list them here.
 DEBIAN_FRONTEND=noninteractive apt-get install -y \
     lnav \
     cgroupfs-mount \
     libcache-bdb-perl \
-    liblog-fast-perl \
-    libfile-flock-perl \
     libcjson1 \
-    liblog-log4perl-perl \
     libdbd-sqlite3-perl \
     sqlite3 \
     libdata-powerset-perl \
-    libcatalyst-perl \
-    libcatalyst-modules-perl \
-    libaliased-perl \
-    libmoosex-types-loadableclass-perl \
-    libconfig-general-perl \
-    libreadonly-xs-perl \
-    libcatalyst-action-rest-perl \
-    liblwp-protocol-https-perl \
-    liblwp-protocol-connect-perl \
-    libjson-perl \
-    libsql-translator-perl \
-    libfile-touch-perl \
     libglib2.0-0 \
     libglib2.0-bin \
     || {

--- a/ci/usb-bootable-iso/postinst-offline.sh
+++ b/ci/usb-bootable-iso/postinst-offline.sh
@@ -69,9 +69,14 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y docker-ce docker-ce-cli contai
 # Step 4: Install PacketFence dependencies (but NOT PacketFence itself)
 echo "===> Step 4: Installing PacketFence dependencies"
 
+# Ensure kernel is marked to not be auto-removed
+apt-mark hold linux-image-amd64 linux-image-* 2>/dev/null || true
+
 # Install key dependencies that PacketFence needs
 # PacketFence package itself will be installed on first boot when Docker is running
+# Include linux-image-amd64 to ensure kernel is not removed by dependency resolution
 DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    linux-image-amd64 \
     mariadb-server \
     redis-server \
     freeradius \
@@ -91,6 +96,12 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     dpkg --configure -a
     DEBIAN_FRONTEND=noninteractive apt-get install -y -f
 }
+
+# Verify kernel is still installed
+if [ ! -f /boot/vmlinuz-* ]; then
+    echo "ERROR: Kernel missing! Reinstalling..."
+    DEBIAN_FRONTEND=noninteractive apt-get install -y linux-image-amd64
+fi
 
 # Step 5: Copy Docker images to target filesystem
 echo "===> Step 5: Copying Docker images to target filesystem"

--- a/ci/usb-bootable-iso/postinst-offline.sh
+++ b/ci/usb-bootable-iso/postinst-offline.sh
@@ -455,7 +455,7 @@ else
     echo "PacketFence expects tag (from build_id): ${EXPECTED_TAG}"
 fi
 
-# Re-tag images if needed
+# Re-tag images if needed (for different tags)
 if [ -n "${LOADED_TAG}" ] && [ -n "${EXPECTED_TAG}" ] && [ "${LOADED_TAG}" != "${EXPECTED_TAG}" ]; then
     echo "Tags differ - re-tagging images from '${LOADED_TAG}' to '${EXPECTED_TAG}'..."
     # Get list of images with the loaded tag
@@ -478,6 +478,28 @@ else
     else
         echo "Tags match (${LOADED_TAG}), no re-tagging needed"
     fi
+fi
+
+# Re-tag images for local registry alias (packetfence/<image>:<tag>)
+# PacketFence services expect images at packetfence/<image> not ghcr.io/inverse-inc/packetfence/<image>
+echo "===> Creating local registry aliases for Docker images..."
+TAG_TO_USE="${EXPECTED_TAG:-${LOADED_TAG}}"
+if [ -n "${TAG_TO_USE}" ]; then
+    GHCR_IMAGES=$(docker images --format '{{.Repository}}:{{.Tag}}' | grep "ghcr.io/inverse-inc/packetfence/.*:${TAG_TO_USE}$" || true)
+    if [ -n "${GHCR_IMAGES}" ]; then
+        for img in ${GHCR_IMAGES}; do
+            # Extract image name (e.g., pfconfig from ghcr.io/inverse-inc/packetfence/pfconfig:tag)
+            img_name=$(echo "${img}" | sed "s|ghcr.io/inverse-inc/packetfence/||" | sed "s|:${TAG_TO_USE}$||")
+            local_tag="packetfence/${img_name}:${TAG_TO_USE}"
+            echo "  Creating alias: ${img} -> ${local_tag}"
+            docker tag "${img}" "${local_tag}" || echo "    Warning: Failed to create alias ${local_tag}"
+        done
+        echo "Local registry aliases created successfully"
+    else
+        echo "No ghcr.io images found to alias"
+    fi
+else
+    echo "No tag available, skipping local registry aliases"
 fi
 
 # Step 3: Install PacketFence

--- a/ci/usb-bootable-iso/postinst-offline.sh
+++ b/ci/usb-bootable-iso/postinst-offline.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+set -o nounset -o pipefail -o errexit
+
+PF_VERSION=${1:-15.1}
+
+echo "=============================================="
+echo "PacketFence Offline Post-Installation Script"
+echo "=============================================="
+echo "PF_VERSION: ${PF_VERSION}"
+echo "=============================================="
+
+# Step 1: Configure local repository from ISO
+echo "===> Step 1: Configuring local APT repository from ISO"
+
+# Create directory for local repo
+mkdir -p /etc/apt/keyrings
+
+# Add PacketFence GPG key if available on ISO
+if [ -f /media/cdrom/pf-repo/packetfence.gpg ]; then
+    cp /media/cdrom/pf-repo/packetfence.gpg /etc/apt/keyrings/
+fi
+
+# Configure local repository from ISO
+cat > /etc/apt/sources.list.d/packetfence-local.list << EOF
+deb [trusted=yes] file:///media/cdrom/pf-repo bookworm main
+EOF
+
+# Disable CD-ROM sources
+sed -i '/^deb cdrom:/s/^/#/' /etc/apt/sources.list
+
+# Update package lists
+apt-get update
+
+# Step 2: Install PacketFence from local repository
+echo "===> Step 2: Installing PacketFence"
+
+# Install PacketFence (this will also install dependencies from local repo)
+DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends packetfence || {
+    echo "Warning: PacketFence installation had issues, attempting to fix..."
+    dpkg --configure -a
+    DEBIAN_FRONTEND=noninteractive apt-get install -y -f
+}
+
+# Step 3: Load pre-downloaded Docker images
+echo "===> Step 3: Loading Docker images"
+
+if [ -d /media/cdrom/docker-images ] && [ -f /media/cdrom/docker-images/load-images.sh ]; then
+    # Start Docker service first
+    systemctl start docker || true
+    sleep 5
+
+    # Load images
+    /media/cdrom/docker-images/load-images.sh || {
+        echo "Warning: Some Docker images failed to load"
+    }
+else
+    echo "Warning: Docker images not found on ISO"
+fi
+
+# Step 4: Configure system
+echo "===> Step 4: Configuring system"
+
+# Allow SSH root login
+sed -i 's/#PermitRootLogin.*/PermitRootLogin yes/g' /etc/ssh/sshd_config
+
+# Remove any remaining inverse.ca references from sources.list
+# (they will be added properly when network is available)
+sed -i 's/.*inverse\.ca.*//g' /etc/apt/sources.list
+
+# Step 5: Configure PacketFence repository for future updates
+echo "===> Step 5: Setting up PacketFence repository for future updates"
+
+# Add PacketFence GPG key
+curl -fsSL https://inverse.ca/downloads/GPG_PUBLIC_KEY 2>/dev/null | gpg --dearmor -o /etc/apt/keyrings/packetfence.gpg || {
+    echo "Warning: Could not download GPG key (no network). Repository will be configured on first network access."
+}
+
+# Configure PacketFence repository (will be used when network is available)
+cat > /etc/apt/sources.list.d/packetfence.list << EOF
+deb [signed-by=/etc/apt/keyrings/packetfence.gpg] http://inverse.ca/downloads/PacketFence/debian/${PF_VERSION} bookworm bookworm
+EOF
+
+# Step 6: Reset MariaDB root password
+echo "===> Step 6: Resetting MariaDB root password"
+
+echo "SET PASSWORD FOR root@'localhost' = PASSWORD('');" > /tmp/reset-root.sql
+mkdir -p /run/mysqld
+chown mysql: /run/mysqld/
+timeout 30 mysqld --skip-networking --init-file /tmp/reset-root.sql --user=mysql > /var/log/reset-root.log 2>&1 || true
+rm -f /tmp/reset-root.sql
+
+# Step 7: Stop services that shouldn't run during installation
+echo "===> Step 7: Stopping services"
+
+# Stop Docker (will be started on first boot)
+pkill -e docker 2>/dev/null || true
+systemctl stop docker 2>/dev/null || true
+
+# Stop MariaDB
+systemctl stop mariadb 2>/dev/null || true
+
+# Step 8: Create first-boot marker
+echo "===> Step 8: Creating first-boot configuration"
+
+# Create a first-boot script to finalize setup
+cat > /usr/local/bin/packetfence-first-boot.sh << 'FIRSTBOOT_EOF'
+#!/bin/bash
+# PacketFence first-boot configuration script
+
+# Remove this script after execution
+SCRIPT_PATH=$(readlink -f "$0")
+
+echo "PacketFence first-boot configuration..."
+
+# Start required services
+systemctl start docker
+systemctl start mariadb
+systemctl start redis-server
+
+# Remove the local ISO repository configuration
+rm -f /etc/apt/sources.list.d/packetfence-local.list
+
+# Update package lists (if network available)
+apt-get update 2>/dev/null || true
+
+# Remove this script
+rm -f "$SCRIPT_PATH"
+rm -f /etc/systemd/system/packetfence-first-boot.service
+systemctl daemon-reload
+
+echo "First-boot configuration complete!"
+FIRSTBOOT_EOF
+chmod +x /usr/local/bin/packetfence-first-boot.sh
+
+# Create systemd service for first-boot
+cat > /etc/systemd/system/packetfence-first-boot.service << 'SERVICE_EOF'
+[Unit]
+Description=PacketFence First Boot Configuration
+After=network.target docker.service
+ConditionPathExists=/usr/local/bin/packetfence-first-boot.sh
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/packetfence-first-boot.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target
+SERVICE_EOF
+
+systemctl enable packetfence-first-boot.service
+
+echo "=============================================="
+echo "PacketFence Offline Installation Complete!"
+echo "=============================================="
+echo "The system will reboot. After reboot:"
+echo "1. Log in as root"
+echo "2. Run: /usr/local/pf/bin/pfcmd configreload hard"
+echo "3. Access the web interface at https://<ip>:1443"
+echo "=============================================="

--- a/ci/usb-bootable-iso/postinst-offline.sh
+++ b/ci/usb-bootable-iso/postinst-offline.sh
@@ -635,7 +635,7 @@ ConditionPathExists=/usr/local/bin/packetfence-first-boot.sh
 Type=oneshot
 ExecStart=/usr/local/bin/packetfence-first-boot.sh
 RemainAfterExit=yes
-TimeoutStartSec=900
+TimeoutStartSec=2700
 StandardOutput=journal
 StandardError=journal
 

--- a/ci/usb-bootable-iso/postinst-offline.sh
+++ b/ci/usb-bootable-iso/postinst-offline.sh
@@ -265,32 +265,48 @@ if ls ${PF_CACHE_DIR}/*.deb 1> /dev/null 2>&1; then
     ls ${PF_CACHE_DIR}/*.deb
     echo ""
 
-    # Step 3a: Install Pre-Depends and Depends packages FIRST
+    # Step 3a: Install Pre-Depends packages FIRST (but NOT main packetfence package)
     echo "===> Step 3a: Installing Pre-Depends packages (fingerbank, packetfence-*, etc.)..."
-    PREDEPENDS_PKGS=$(ls ${PF_CACHE_DIR}/fingerbank*.deb ${PF_CACHE_DIR}/packetfence-*.deb 2>/dev/null || true)
-    if [ -n "$PREDEPENDS_PKGS" ]; then
-        DEBIAN_FRONTEND=noninteractive dpkg -i $PREDEPENDS_PKGS || {
-            echo "Warning: Some pre-depends packages had issues, fixing dependencies..."
+    echo "Installing fingerbank packages..."
+    FINGERBANK_PKGS=$(ls ${PF_CACHE_DIR}/fingerbank*.deb 2>/dev/null || true)
+    if [ -n "$FINGERBANK_PKGS" ]; then
+        DEBIAN_FRONTEND=noninteractive dpkg -i $FINGERBANK_PKGS || {
+            echo "Warning: Fingerbank packages had issues, fixing dependencies..."
             DEBIAN_FRONTEND=noninteractive apt-get install -y -f
         }
-        echo "Pre-depends packages installed successfully"
+        echo "Fingerbank packages installed successfully"
     else
-        echo "Warning: No pre-depends packages found"
+        echo "Warning: No fingerbank packages found"
     fi
     echo ""
 
-    # Step 3b: Install main PacketFence package LAST (requires Docker running)
-    echo "===> Step 3b: Installing main PacketFence package..."
+    echo "Installing packetfence dependency packages (packetfence-pfcmd-suid, packetfence-config, etc.)..."
+    # Install packetfence-* packages (hyphen), but NOT packetfence_* (underscore = main package)
+    PFDEP_PKGS=$(ls ${PF_CACHE_DIR}/packetfence-*.deb 2>/dev/null || true)
+    if [ -n "$PFDEP_PKGS" ]; then
+        DEBIAN_FRONTEND=noninteractive dpkg -i $PFDEP_PKGS || {
+            echo "Warning: Some packetfence dependency packages had issues, fixing dependencies..."
+            DEBIAN_FRONTEND=noninteractive apt-get install -y -f
+        }
+        echo "PacketFence dependency packages installed successfully"
+    else
+        echo "Warning: No packetfence dependency packages found"
+    fi
+    echo ""
+
+    # Step 3b: Install main PacketFence package LAST (requires Docker running + all dependencies)
+    echo "===> Step 3b: Installing main PacketFence package (packetfence_*.deb)..."
     if ls ${PF_CACHE_DIR}/packetfence_*.deb 1> /dev/null 2>&1; then
         PF_MAIN=$(ls ${PF_CACHE_DIR}/packetfence_*.deb | head -n1)
+        echo "Installing: ${PF_MAIN}"
         DEBIAN_FRONTEND=noninteractive dpkg -i ${PF_MAIN} || {
-            echo "Warning: PacketFence installation had issues, fixing dependencies..."
+            echo "Warning: PacketFence main package installation had issues, fixing dependencies..."
             DEBIAN_FRONTEND=noninteractive apt-get install -y -f
             DEBIAN_FRONTEND=noninteractive dpkg -i ${PF_MAIN}
         }
         echo "PacketFence main package installed successfully"
     else
-        echo "ERROR: Main PacketFence package not found"
+        echo "ERROR: Main PacketFence package (packetfence_*.deb) not found"
         exit 1
     fi
 

--- a/ci/usb-bootable-iso/postinst-offline.sh
+++ b/ci/usb-bootable-iso/postinst-offline.sh
@@ -35,8 +35,16 @@ sed -i '/^deb cdrom:/d' /etc/apt/sources.list
 # Update package lists
 apt-get update
 
-# Step 2: Install PacketFence from local repository
-echo "===> Step 2: Installing PacketFence"
+# Step 2: Install packages not available on DVD-1
+echo "===> Step 2: Installing packages from local repository (not on DVD-1)"
+
+# Install lnav and cgroupfs-mount (not on DVD-1, must come from local repo)
+DEBIAN_FRONTEND=noninteractive apt-get install -y lnav cgroupfs-mount || {
+    echo "Warning: Some packages failed to install, continuing..."
+}
+
+# Step 3: Install PacketFence from local repository
+echo "===> Step 3: Installing PacketFence"
 
 # Install PacketFence (this will also install dependencies from local repo)
 DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends packetfence || {
@@ -45,8 +53,8 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends packet
     DEBIAN_FRONTEND=noninteractive apt-get install -y -f
 }
 
-# Step 3: Load pre-downloaded Docker images
-echo "===> Step 3: Loading Docker images"
+# Step 4: Load pre-downloaded Docker images
+echo "===> Step 4: Loading Docker images"
 
 if [ -d /media/cdrom/docker-images ] && [ -f /media/cdrom/docker-images/load-images.sh ]; then
     # Start Docker service first
@@ -61,8 +69,8 @@ else
     echo "Warning: Docker images not found on ISO"
 fi
 
-# Step 4: Configure system
-echo "===> Step 4: Configuring system"
+# Step 5: Configure system
+echo "===> Step 5: Configuring system"
 
 # Allow SSH root login
 sed -i 's/#PermitRootLogin.*/PermitRootLogin yes/g' /etc/ssh/sshd_config
@@ -71,8 +79,8 @@ sed -i 's/#PermitRootLogin.*/PermitRootLogin yes/g' /etc/ssh/sshd_config
 # (they will be added properly when network is available)
 sed -i 's/.*inverse\.ca.*//g' /etc/apt/sources.list
 
-# Step 5: Configure PacketFence repository for future updates
-echo "===> Step 5: Setting up PacketFence repository for future updates"
+# Step 6: Configure PacketFence repository for future updates
+echo "===> Step 6: Setting up PacketFence repository for future updates"
 
 # Add PacketFence GPG key
 curl -fsSL https://inverse.ca/downloads/GPG_PUBLIC_KEY 2>/dev/null | gpg --dearmor -o /etc/apt/keyrings/packetfence.gpg || {
@@ -84,8 +92,8 @@ cat > /etc/apt/sources.list.d/packetfence.list << EOF
 deb [signed-by=/etc/apt/keyrings/packetfence.gpg] http://inverse.ca/downloads/PacketFence/debian/${PF_VERSION} bookworm bookworm
 EOF
 
-# Step 6: Reset MariaDB root password
-echo "===> Step 6: Resetting MariaDB root password"
+# Step 7: Reset MariaDB root password
+echo "===> Step 7: Resetting MariaDB root password"
 
 echo "SET PASSWORD FOR root@'localhost' = PASSWORD('');" > /tmp/reset-root.sql
 mkdir -p /run/mysqld
@@ -93,8 +101,8 @@ chown mysql: /run/mysqld/
 timeout 30 mysqld --skip-networking --init-file /tmp/reset-root.sql --user=mysql > /var/log/reset-root.log 2>&1 || true
 rm -f /tmp/reset-root.sql
 
-# Step 7: Stop services that shouldn't run during installation
-echo "===> Step 7: Stopping services"
+# Step 8: Stop services that shouldn't run during installation
+echo "===> Step 8: Stopping services"
 
 # Stop Docker (will be started on first boot)
 pkill -e docker 2>/dev/null || true
@@ -103,8 +111,8 @@ systemctl stop docker 2>/dev/null || true
 # Stop MariaDB
 systemctl stop mariadb 2>/dev/null || true
 
-# Step 8: Create first-boot marker
-echo "===> Step 8: Creating first-boot configuration"
+# Step 9: Create first-boot marker
+echo "===> Step 9: Creating first-boot configuration"
 
 # Create a first-boot script to finalize setup
 cat > /usr/local/bin/packetfence-first-boot.sh << 'FIRSTBOOT_EOF'

--- a/ci/usb-bootable-iso/postinst-offline.sh
+++ b/ci/usb-bootable-iso/postinst-offline.sh
@@ -365,17 +365,29 @@ if ls ${PF_CACHE_DIR}/*.deb 1> /dev/null 2>&1; then
     fi
     echo ""
 
-    # Install fingerbank packages (depends on perl packages provided by packetfence-perl)
-    echo "Installing fingerbank packages..."
-    FINGERBANK_PKGS=$(ls ${PF_CACHE_DIR}/fingerbank*.deb 2>/dev/null || true)
-    if [ -n "$FINGERBANK_PKGS" ]; then
-        DEBIAN_FRONTEND=noninteractive dpkg -i $FINGERBANK_PKGS || {
-            echo "Warning: Fingerbank packages had issues, fixing dependencies..."
+    # Install fingerbank packages in correct order:
+    # 1. fingerbank-collector first (fingerbank depends on it)
+    # 2. fingerbank second (depends on packetfence-perl and fingerbank-collector)
+    echo "Installing fingerbank-collector..."
+    if ls ${PF_CACHE_DIR}/fingerbank-collector_*.deb 1> /dev/null 2>&1; then
+        DEBIAN_FRONTEND=noninteractive dpkg -i ${PF_CACHE_DIR}/fingerbank-collector_*.deb || {
+            echo "Warning: fingerbank-collector had issues, fixing dependencies..."
             DEBIAN_FRONTEND=noninteractive apt-get install -y -f
         }
-        echo "Fingerbank packages installed successfully"
+        echo "fingerbank-collector installed successfully"
     else
-        echo "Warning: No fingerbank packages found"
+        echo "Warning: fingerbank-collector package not found"
+    fi
+
+    echo "Installing fingerbank..."
+    if ls ${PF_CACHE_DIR}/fingerbank_*.deb 1> /dev/null 2>&1; then
+        DEBIAN_FRONTEND=noninteractive dpkg -i ${PF_CACHE_DIR}/fingerbank_*.deb || {
+            echo "Warning: fingerbank had issues, fixing dependencies..."
+            DEBIAN_FRONTEND=noninteractive apt-get install -y -f
+        }
+        echo "fingerbank installed successfully"
+    else
+        echo "Warning: fingerbank package not found"
     fi
     echo ""
 

--- a/ci/usb-bootable-iso/postinst-offline.sh
+++ b/ci/usb-bootable-iso/postinst-offline.sh
@@ -41,16 +41,7 @@ apt-get update
 # Step 2: Install packages from DVD needed for first boot
 echo "===> Step 2: Installing packages from DVD (needed for first boot)"
 
-# Install packages from DVD that are required during first boot when DVD is removed.
-# These are standard Debian packages ON the DVD, but won't be available after reboot.
-#
-# Packages needed by fingerbank (with versioned dependencies):
-# - liblog-log4perl-perl (>= 1.43): fingerbank requires specific version
-# - libconfig-inifiles-perl (>= 2.88): fingerbank requires specific version
-# - liburi-perl, libregexp-ipv6-perl: needed by HTTP::Request/LWP in packetfence-perl
-# - libnet-ssleay-perl, libio-socket-ssl-perl: SSL/TLS support (XS modules)
-# - acl: needed by packetfence preinst script (setfacl command)
-# - libdbd-sqlite3-perl, sqlite3, libdata-powerset-perl: fingerbank dependencies
+# Packages required during first boot when DVD is removed (fingerbank deps, SSL, acl)
 DEBIAN_FRONTEND=noninteractive apt-get install -y \
     liblog-log4perl-perl \
     libconfig-inifiles-perl \
@@ -67,9 +58,8 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y \
 }
 
 # Step 2b: Install packages from pf-repo (not on DVD)
-echo "===> Step 2b: Installing packages from local pf-repo (not on DVD)"
+echo "===> Step 2b: Installing packages from local pf-repo"
 
-# These packages are NOT on the Debian DVD, they come from pf-repo
 DEBIAN_FRONTEND=noninteractive apt-get install -y \
     lnav \
     cgroupfs-mount \
@@ -81,26 +71,20 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y \
     echo "Warning: Some packages failed to install, continuing..."
 }
 
-# Step 3: Install Docker packages
+# Step 3: Install Docker packages (don't start - won't work in chroot)
 echo "===> Step 3: Installing Docker packages"
 
-# Install Docker packages from local repo
-# NOTE: Do NOT attempt to start Docker - it won't work in chroot environment
 DEBIAN_FRONTEND=noninteractive apt-get install -y docker-ce docker-ce-cli containerd.io || {
     echo "Warning: Docker packages installation had issues, attempting to fix..."
     dpkg --configure -a
     DEBIAN_FRONTEND=noninteractive apt-get install -y -f
 }
 
-# Step 4: Install PacketFence dependencies (but NOT PacketFence itself)
+# Step 4: Install PacketFence dependencies (PacketFence itself installed on first boot)
 echo "===> Step 4: Installing PacketFence dependencies from DVD"
 
-# Ensure kernel is marked to not be auto-removed
 apt-mark hold linux-image-amd64 linux-image-* 2>/dev/null || true
 
-# Install ALL dependencies that PacketFence needs from the DVD
-# PacketFence package itself will be installed on first boot when Docker is running
-# These are standard Debian packages that won't be available after DVD is removed
 DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     linux-image-amd64 \
     linux-headers-amd64 \
@@ -237,41 +221,18 @@ echo "===> Step 5b: Copying PacketFence .deb packages to target filesystem"
 PF_CACHE_DIR="/var/cache/packetfence-install"
 mkdir -p ${PF_CACHE_DIR}
 
-# Debug: Show what's on the ISO
-echo "Checking ISO contents..."
-echo "Contents of /media/cdrom:"
-ls -la /media/cdrom/ 2>/dev/null || echo "  (cannot list /media/cdrom)"
-echo "Contents of /media/cdrom/pf-repo:"
-ls -la /media/cdrom/pf-repo/ 2>/dev/null || echo "  (cannot list /media/cdrom/pf-repo)"
-echo "Contents of /media/cdrom/pf-repo/pool:"
-ls -la /media/cdrom/pf-repo/pool/ 2>/dev/null || echo "  (cannot list /media/cdrom/pf-repo/pool)"
-echo "Contents of /media/cdrom/pf-repo/pool/main:"
-ls -la /media/cdrom/pf-repo/pool/main/ 2>/dev/null || echo "  (cannot list /media/cdrom/pf-repo/pool/main)"
-
 if [ -d /media/cdrom/pf-repo/pool/main ]; then
     echo "Copying PacketFence .deb packages from ISO to ${PF_CACHE_DIR}..."
-
-    # Find and show what we're copying
-    echo "PacketFence packages found on ISO:"
-    find /media/cdrom/pf-repo/pool/main -name "packetfence*.deb" -o -name "fingerbank*.deb" 2>/dev/null | head -20
-
-    # Copy all .deb files from the pool (simpler and more reliable)
-    cp /media/cdrom/pf-repo/pool/main/*.deb ${PF_CACHE_DIR}/ 2>/dev/null || {
-        echo "Warning: cp failed, trying find method..."
+    cp /media/cdrom/pf-repo/pool/main/*.deb ${PF_CACHE_DIR}/ 2>/dev/null || \
         find /media/cdrom/pf-repo/pool/main -name "*.deb" -exec cp {} ${PF_CACHE_DIR}/ \; 2>/dev/null || true
-    }
 
     if ls ${PF_CACHE_DIR}/*.deb 1> /dev/null 2>&1; then
-        echo "PacketFence packages copied successfully:"
-        ls -la ${PF_CACHE_DIR}/
+        echo "PacketFence packages copied: $(ls ${PF_CACHE_DIR}/*.deb | wc -l) files"
     else
-        echo "ERROR: No .deb packages found in ${PF_CACHE_DIR} after copy attempt"
-        echo "This will cause first-boot installation to fail!"
+        echo "ERROR: No .deb packages copied - first-boot installation will fail!"
     fi
 else
     echo "ERROR: PF repo not found on ISO at /media/cdrom/pf-repo/pool/main"
-    echo "Available directories on ISO:"
-    find /media/cdrom -type d 2>/dev/null | head -20
 fi
 
 # Step 6: Configure system
@@ -428,7 +389,7 @@ EXPECTED_TAG=""
 
 # Read the tag that was used when images were downloaded
 if [ -f ${DOCKER_CACHE_DIR}/image-tag.txt ]; then
-    LOADED_TAG=$(cat ${DOCKER_CACHE_DIR}/image-tag.txt | tr -d '[:space:]')
+    LOADED_TAG=$(tr -d '[:space:]' < ${DOCKER_CACHE_DIR}/image-tag.txt)
     echo "Loaded images have tag: ${LOADED_TAG}"
 fi
 
@@ -436,66 +397,37 @@ fi
 if [ -f /usr/local/pf/conf/build_id ]; then
     EXPECTED_TAG=$(grep -oP 'TAG_OR_BRANCH_NAME=\K.*' /usr/local/pf/conf/build_id 2>/dev/null | tr -d '[:space:]' || true)
 fi
-# Fallback: extract version from pf-release if build_id doesn't have TAG_OR_BRANCH_NAME
+# Fallback: extract version from pf-release
 if [ -z "${EXPECTED_TAG}" ] && [ -f /usr/local/pf/conf/pf-release ]; then
-    # For releases, use the version number (e.g., 15.1.0)
-    PF_VERSION=$(cat /usr/local/pf/conf/pf-release | awk '{print $2}')
-    if [[ "${PF_VERSION}" == *"/"* ]]; then
-        # Branch name format: feature/branch-name -> feature-branch-name
-        EXPECTED_TAG=$(echo "${PF_VERSION}" | sed 's#/#-#g')
-    else
-        EXPECTED_TAG="${PF_VERSION}"
-    fi
+    PF_VERSION=$(awk '{print $2}' /usr/local/pf/conf/pf-release)
+    EXPECTED_TAG="${PF_VERSION//\//-}"
     echo "PacketFence expects tag (from pf-release): ${EXPECTED_TAG}"
 else
     echo "PacketFence expects tag (from build_id): ${EXPECTED_TAG}"
 fi
 
-# Re-tag images if needed (for different tags)
+# Re-tag images if tags differ
 if [ -n "${LOADED_TAG}" ] && [ -n "${EXPECTED_TAG}" ] && [ "${LOADED_TAG}" != "${EXPECTED_TAG}" ]; then
-    echo "Tags differ - re-tagging images from '${LOADED_TAG}' to '${EXPECTED_TAG}'..."
-    # Get list of images with the loaded tag
+    echo "Re-tagging images from '${LOADED_TAG}' to '${EXPECTED_TAG}'..."
     IMAGES_TO_RETAG=$(docker images --format '{{.Repository}}:{{.Tag}}' | grep ":${LOADED_TAG}$" || true)
-    if [ -n "${IMAGES_TO_RETAG}" ]; then
-        for img in ${IMAGES_TO_RETAG}; do
-            new_tag="${img%:${LOADED_TAG}}:${EXPECTED_TAG}"
-            echo "  Re-tagging: ${img} -> ${new_tag}"
-            docker tag "${img}" "${new_tag}" || echo "    Warning: Failed to re-tag ${img}"
-        done
-        echo "Docker images re-tagged successfully"
-    else
-        echo "No images found with tag '${LOADED_TAG}' to re-tag"
-    fi
-else
-    if [ -z "${LOADED_TAG}" ]; then
-        echo "No image-tag.txt found, skipping re-tag"
-    elif [ -z "${EXPECTED_TAG}" ]; then
-        echo "Could not determine expected tag, skipping re-tag"
-    else
-        echo "Tags match (${LOADED_TAG}), no re-tagging needed"
-    fi
+    for img in ${IMAGES_TO_RETAG}; do
+        new_tag="${img%:${LOADED_TAG}}:${EXPECTED_TAG}"
+        docker tag "${img}" "${new_tag}" 2>/dev/null || true
+    done
+elif [ -n "${LOADED_TAG}" ] && [ "${LOADED_TAG}" == "${EXPECTED_TAG}" ]; then
+    echo "Tags match (${LOADED_TAG}), no re-tagging needed"
 fi
 
-# Re-tag images for local registry alias (packetfence/<image>:<tag>)
-# PacketFence services expect images at packetfence/<image> not ghcr.io/inverse-inc/packetfence/<image>
+# Create local registry aliases (packetfence/<image> from ghcr.io/inverse-inc/packetfence/<image>)
 echo "===> Creating local registry aliases for Docker images..."
 TAG_TO_USE="${EXPECTED_TAG:-${LOADED_TAG}}"
 if [ -n "${TAG_TO_USE}" ]; then
     GHCR_IMAGES=$(docker images --format '{{.Repository}}:{{.Tag}}' | grep "ghcr.io/inverse-inc/packetfence/.*:${TAG_TO_USE}$" || true)
-    if [ -n "${GHCR_IMAGES}" ]; then
-        for img in ${GHCR_IMAGES}; do
-            # Extract image name (e.g., pfconfig from ghcr.io/inverse-inc/packetfence/pfconfig:tag)
-            img_name=$(echo "${img}" | sed "s|ghcr.io/inverse-inc/packetfence/||" | sed "s|:${TAG_TO_USE}$||")
-            local_tag="packetfence/${img_name}:${TAG_TO_USE}"
-            echo "  Creating alias: ${img} -> ${local_tag}"
-            docker tag "${img}" "${local_tag}" || echo "    Warning: Failed to create alias ${local_tag}"
-        done
-        echo "Local registry aliases created successfully"
-    else
-        echo "No ghcr.io images found to alias"
-    fi
-else
-    echo "No tag available, skipping local registry aliases"
+    for img in ${GHCR_IMAGES}; do
+        img_name="${img#ghcr.io/inverse-inc/packetfence/}"
+        img_name="${img_name%:${TAG_TO_USE}}"
+        docker tag "${img}" "packetfence/${img_name}:${TAG_TO_USE}" 2>/dev/null || true
+    done
 fi
 
 update_progress "Step 2/6" "Docker images ready"

--- a/ci/usb-bootable-iso/postinst-offline.sh
+++ b/ci/usb-bootable-iso/postinst-offline.sh
@@ -249,7 +249,7 @@ else
 fi
 
 # Step 3: Install PacketFence
-update_progress "Step 3/6" "Installing PacketFence packages..."
+update_progress "Step 3/6" "Installing PacketFence dependencies..."
 echo "===> Step 3: Installing PacketFence"
 
 # Remove local ISO repository configuration (ISO is no longer mounted)
@@ -263,13 +263,37 @@ if ls ${PF_CACHE_DIR}/*.deb 1> /dev/null 2>&1; then
     echo "Installing PacketFence and related packages from cached .deb files..."
     echo "Packages to install:"
     ls ${PF_CACHE_DIR}/*.deb
+    echo ""
 
-    # Install all .deb files at once - dpkg will handle the dependency order
-    DEBIAN_FRONTEND=noninteractive dpkg -i ${PF_CACHE_DIR}/*.deb || {
-        echo "Warning: PacketFence installation had issues, fixing dependencies..."
-        DEBIAN_FRONTEND=noninteractive apt-get install -y -f
-        DEBIAN_FRONTEND=noninteractive dpkg -i ${PF_CACHE_DIR}/*.deb
-    }
+    # Step 3a: Install Pre-Depends and Depends packages FIRST
+    echo "===> Step 3a: Installing Pre-Depends packages (fingerbank, packetfence-*, etc.)..."
+    PREDEPENDS_PKGS=$(ls ${PF_CACHE_DIR}/fingerbank*.deb ${PF_CACHE_DIR}/packetfence-*.deb 2>/dev/null || true)
+    if [ -n "$PREDEPENDS_PKGS" ]; then
+        DEBIAN_FRONTEND=noninteractive dpkg -i $PREDEPENDS_PKGS || {
+            echo "Warning: Some pre-depends packages had issues, fixing dependencies..."
+            DEBIAN_FRONTEND=noninteractive apt-get install -y -f
+        }
+        echo "Pre-depends packages installed successfully"
+    else
+        echo "Warning: No pre-depends packages found"
+    fi
+    echo ""
+
+    # Step 3b: Install main PacketFence package LAST (requires Docker running)
+    echo "===> Step 3b: Installing main PacketFence package..."
+    if ls ${PF_CACHE_DIR}/packetfence_*.deb 1> /dev/null 2>&1; then
+        PF_MAIN=$(ls ${PF_CACHE_DIR}/packetfence_*.deb | head -n1)
+        DEBIAN_FRONTEND=noninteractive dpkg -i ${PF_MAIN} || {
+            echo "Warning: PacketFence installation had issues, fixing dependencies..."
+            DEBIAN_FRONTEND=noninteractive apt-get install -y -f
+            DEBIAN_FRONTEND=noninteractive dpkg -i ${PF_MAIN}
+        }
+        echo "PacketFence main package installed successfully"
+    else
+        echo "ERROR: Main PacketFence package not found"
+        exit 1
+    fi
+
     echo "PacketFence installation completed successfully"
 else
     echo "ERROR: No PacketFence .deb packages found in ${PF_CACHE_DIR}"

--- a/ci/usb-bootable-iso/postinst-offline.sh
+++ b/ci/usb-bootable-iso/postinst-offline.sh
@@ -349,7 +349,23 @@ if ls ${PF_CACHE_DIR}/*.deb 1> /dev/null 2>&1; then
     echo ""
 
     # Step 3a: Install Pre-Depends packages FIRST (but NOT main packetfence package)
-    echo "===> Step 3a: Installing Pre-Depends packages (fingerbank, packetfence-*, etc.)..."
+    # Order matters: packetfence-perl provides virtual perl packages that fingerbank depends on
+    echo "===> Step 3a: Installing Pre-Depends packages..."
+
+    # Install packetfence-perl FIRST - it provides virtual perl packages needed by fingerbank
+    echo "Installing packetfence-perl (provides perl dependencies)..."
+    if ls ${PF_CACHE_DIR}/packetfence-perl_*.deb 1> /dev/null 2>&1; then
+        DEBIAN_FRONTEND=noninteractive dpkg -i ${PF_CACHE_DIR}/packetfence-perl_*.deb || {
+            echo "Warning: packetfence-perl had issues, fixing dependencies..."
+            DEBIAN_FRONTEND=noninteractive apt-get install -y -f
+        }
+        echo "packetfence-perl installed successfully"
+    else
+        echo "Warning: packetfence-perl package not found"
+    fi
+    echo ""
+
+    # Install fingerbank packages (depends on perl packages provided by packetfence-perl)
     echo "Installing fingerbank packages..."
     FINGERBANK_PKGS=$(ls ${PF_CACHE_DIR}/fingerbank*.deb 2>/dev/null || true)
     if [ -n "$FINGERBANK_PKGS" ]; then
@@ -363,9 +379,9 @@ if ls ${PF_CACHE_DIR}/*.deb 1> /dev/null 2>&1; then
     fi
     echo ""
 
-    echo "Installing packetfence dependency packages (packetfence-pfcmd-suid, packetfence-config, etc.)..."
-    # Install packetfence-* packages (hyphen), but NOT packetfence_* (underscore = main package)
-    PFDEP_PKGS=$(ls ${PF_CACHE_DIR}/packetfence-*.deb 2>/dev/null || true)
+    # Install remaining packetfence-* packages (excluding packetfence-perl already installed)
+    echo "Installing other packetfence dependency packages..."
+    PFDEP_PKGS=$(ls ${PF_CACHE_DIR}/packetfence-*.deb 2>/dev/null | grep -v packetfence-perl_ || true)
     if [ -n "$PFDEP_PKGS" ]; then
         DEBIAN_FRONTEND=noninteractive dpkg -i $PFDEP_PKGS || {
             echo "Warning: Some packetfence dependency packages had issues, fixing dependencies..."

--- a/ci/usb-bootable-iso/postinst-offline.sh
+++ b/ci/usb-bootable-iso/postinst-offline.sh
@@ -482,6 +482,15 @@ RELEASE_EOF
 deb [trusted=yes] file://${LOCAL_REPO} local main
 APT_EOF
 
+    # First boot may run with no Internet. Move the remote PacketFence repo
+    # aside so apt-get update doesn't fail trying to reach inverse.ca; restore
+    # it once the local install completes.
+    PACKETFENCE_LIST_DISABLED=""
+    if [ -f /etc/apt/sources.list.d/packetfence.list ]; then
+        mv /etc/apt/sources.list.d/packetfence.list /etc/apt/sources.list.d/packetfence.list.disabled
+        PACKETFENCE_LIST_DISABLED=1
+    fi
+
     # Update apt cache
     apt-get update
     echo "Local APT repository created successfully"
@@ -533,6 +542,9 @@ APT_EOF
 
     # Cleanup local repo config
     rm -f /etc/apt/sources.list.d/packetfence-local-install.list
+    if [ -n "${PACKETFENCE_LIST_DISABLED}" ]; then
+        mv /etc/apt/sources.list.d/packetfence.list.disabled /etc/apt/sources.list.d/packetfence.list
+    fi
     apt-get update 2>/dev/null || true
 
     echo "PacketFence installation completed successfully"

--- a/ci/usb-bootable-iso/postinst-offline.sh
+++ b/ci/usb-bootable-iso/postinst-offline.sh
@@ -179,15 +179,19 @@ set -o pipefail
 LOG_FILE="/var/log/packetfence-first-boot.log"
 exec > >(tee -a ${LOG_FILE}) 2>&1
 
-# Display installation progress message on login screen
-cat > /etc/issue << 'EOF'
+# Function to update installation progress on login screen
+update_progress() {
+    local step="$1"
+    local message="$2"
+    cat > /etc/issue << EOF
 ================================================================================
   PacketFence Installation In Progress - Please Wait
 ================================================================================
 
-  The system is currently installing PacketFence and loading Docker images.
-  This process may take 10-15 minutes.
+  Current Step: ${step}
+  Status: ${message}
 
+  This process may take 10-15 minutes total.
   Progress can be monitored at: /var/log/packetfence-first-boot.log
 
   Please wait until installation completes before using the system.
@@ -195,6 +199,10 @@ cat > /etc/issue << 'EOF'
 ================================================================================
 
 EOF
+}
+
+# Display initial installation progress message on login screen
+update_progress "Initializing" "Starting PacketFence installation..."
 
 echo "=============================================="
 echo "PacketFence First Boot - Phase B"
@@ -205,6 +213,7 @@ DOCKER_CACHE_DIR="/var/cache/packetfence-docker-images"
 PF_CACHE_DIR="/var/cache/packetfence-install"
 
 # Step 1: Start Docker service
+update_progress "Step 1/6" "Starting Docker service..."
 echo "===> Step 1: Starting Docker service"
 systemctl start docker || {
     echo "ERROR: Failed to start Docker service"
@@ -227,6 +236,7 @@ if [ ! -S /var/run/docker.sock ]; then
 fi
 
 # Step 2: Load Docker images
+update_progress "Step 2/6" "Loading Docker images (this may take several minutes)..."
 echo "===> Step 2: Loading Docker images"
 
 if [ -d ${DOCKER_CACHE_DIR} ] && [ -f ${DOCKER_CACHE_DIR}/load-images.sh ]; then
@@ -239,6 +249,7 @@ else
 fi
 
 # Step 3: Install PacketFence
+update_progress "Step 3/6" "Installing PacketFence packages..."
 echo "===> Step 3: Installing PacketFence"
 
 # Remove local ISO repository configuration (ISO is no longer mounted)
@@ -266,6 +277,7 @@ else
 fi
 
 # Step 4: Reset MariaDB root password
+update_progress "Step 4/6" "Configuring MariaDB database..."
 echo "===> Step 4: Resetting MariaDB root password"
 
 systemctl start mariadb || true
@@ -282,6 +294,7 @@ mysql < /tmp/reset-root.sql 2>/dev/null || {
 rm -f /tmp/reset-root.sql
 
 # Step 5: Cleanup
+update_progress "Step 5/6" "Cleaning up temporary files..."
 echo "===> Step 5: Cleanup"
 
 # Remove Docker image cache
@@ -300,6 +313,7 @@ fi
 apt-get update 2>/dev/null || true
 
 # Step 6: Start services
+update_progress "Step 6/6" "Starting services and finalizing installation..."
 echo "===> Step 6: Starting services"
 
 systemctl start mariadb || true

--- a/ci/usb-bootable-iso/postinst-offline.sh
+++ b/ci/usb-bootable-iso/postinst-offline.sh
@@ -497,78 +497,77 @@ if ls ${PF_CACHE_DIR}/*.deb 1> /dev/null 2>&1; then
     ls ${PF_CACHE_DIR}/*.deb
     echo ""
 
-    # Step 3a: Install Pre-Depends packages FIRST (but NOT main packetfence package)
-    # Order matters: packetfence-perl provides virtual perl packages that fingerbank depends on
-    echo "===> Step 3a: Installing Pre-Depends packages..."
+    # Step 3a: Create local APT repository from cached packages
+    # This allows apt-get to properly resolve dependencies
+    echo "===> Step 3a: Creating local APT repository from cached packages..."
 
-    # Install packetfence-perl FIRST - it provides virtual perl packages needed by fingerbank
-    echo "Installing packetfence-perl (provides perl dependencies)..."
-    if ls ${PF_CACHE_DIR}/packetfence-perl_*.deb 1> /dev/null 2>&1; then
-        DEBIAN_FRONTEND=noninteractive dpkg -i ${PF_CACHE_DIR}/packetfence-perl_*.deb || {
-            echo "Warning: packetfence-perl had issues, fixing dependencies..."
-            DEBIAN_FRONTEND=noninteractive apt-get install -y -f
-        }
-        echo "packetfence-perl installed successfully"
-    else
-        echo "Warning: packetfence-perl package not found"
-    fi
+    LOCAL_REPO="/var/cache/packetfence-repo"
+    mkdir -p ${LOCAL_REPO}/pool
+    cp ${PF_CACHE_DIR}/*.deb ${LOCAL_REPO}/pool/
+
+    # Generate Packages index
+    cd ${LOCAL_REPO}
+    mkdir -p dists/local/main/binary-amd64
+    dpkg-scanpackages pool /dev/null > dists/local/main/binary-amd64/Packages
+    gzip -k dists/local/main/binary-amd64/Packages
+
+    # Create Release file
+    cat > dists/local/Release << RELEASE_EOF
+Origin: PacketFence Local
+Label: PacketFence Local
+Suite: local
+Codename: local
+Architectures: amd64
+Components: main
+Description: PacketFence offline installation local repository
+RELEASE_EOF
+
+    # Configure apt to use the local repository
+    cat > /etc/apt/sources.list.d/packetfence-local-install.list << APT_EOF
+deb [trusted=yes] file://${LOCAL_REPO} local main
+APT_EOF
+
+    # Update apt cache
+    apt-get update
+    echo "Local APT repository created successfully"
     echo ""
 
-    # Install fingerbank packages in correct order:
-    # 1. fingerbank-collector first (fingerbank depends on it)
-    # 2. fingerbank second (depends on packetfence-perl and fingerbank-collector)
+    # Step 3b: Install all packages using apt-get (proper dependency resolution)
+    echo "===> Step 3b: Installing packages with apt-get..."
+
+    # Install packetfence-perl first (provides virtual packages)
+    echo "Installing packetfence-perl..."
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-downgrades packetfence-perl || true
+
+    # Install fingerbank packages
     echo "Installing fingerbank-collector..."
-    if ls ${PF_CACHE_DIR}/fingerbank-collector_*.deb 1> /dev/null 2>&1; then
-        DEBIAN_FRONTEND=noninteractive dpkg -i ${PF_CACHE_DIR}/fingerbank-collector_*.deb || {
-            echo "Warning: fingerbank-collector had issues, fixing dependencies..."
-            DEBIAN_FRONTEND=noninteractive apt-get install -y -f
-        }
-        echo "fingerbank-collector installed successfully"
-    else
-        echo "Warning: fingerbank-collector package not found"
-    fi
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-downgrades fingerbank-collector || true
 
     echo "Installing fingerbank..."
-    if ls ${PF_CACHE_DIR}/fingerbank_*.deb 1> /dev/null 2>&1; then
-        DEBIAN_FRONTEND=noninteractive dpkg -i ${PF_CACHE_DIR}/fingerbank_*.deb || {
-            echo "Warning: fingerbank had issues, fixing dependencies..."
-            DEBIAN_FRONTEND=noninteractive apt-get install -y -f
-        }
-        echo "fingerbank installed successfully"
-    else
-        echo "Warning: fingerbank package not found"
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-downgrades fingerbank || true
+
+    # Install other packetfence-* packages (excluding main packetfence)
+    echo "Installing packetfence dependency packages..."
+    PF_DEP_NAMES=$(ls ${PF_CACHE_DIR}/packetfence-*.deb 2>/dev/null | xargs -n1 basename | sed 's/_.*$//' | grep -v "^packetfence$" | sort -u || true)
+    if [ -n "$PF_DEP_NAMES" ]; then
+        DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-downgrades $PF_DEP_NAMES || true
     fi
     echo ""
 
-    # Install remaining packetfence-* packages (excluding packetfence-perl already installed)
-    echo "Installing other packetfence dependency packages..."
-    PFDEP_PKGS=$(ls ${PF_CACHE_DIR}/packetfence-*.deb 2>/dev/null | grep -v packetfence-perl_ || true)
-    if [ -n "$PFDEP_PKGS" ]; then
-        DEBIAN_FRONTEND=noninteractive dpkg -i $PFDEP_PKGS || {
-            echo "Warning: Some packetfence dependency packages had issues, fixing dependencies..."
-            DEBIAN_FRONTEND=noninteractive apt-get install -y -f
-        }
-        echo "PacketFence dependency packages installed successfully"
-    else
-        echo "Warning: No packetfence dependency packages found"
-    fi
-    echo ""
+    # Step 3c: Install main PacketFence package LAST (requires Docker running)
+    echo "===> Step 3c: Installing main PacketFence package..."
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-downgrades packetfence || {
+        echo "Warning: apt-get install packetfence had issues, trying dpkg..."
+        PF_MAIN_PKG=$(ls ${PF_CACHE_DIR}/packetfence_*.deb 2>/dev/null | head -n1)
+        if [ -n "$PF_MAIN_PKG" ]; then
+            DEBIAN_FRONTEND=noninteractive dpkg --force-depends -i ${PF_MAIN_PKG}
+            DEBIAN_FRONTEND=noninteractive dpkg --configure --force-depends packetfence || true
+        fi
+    }
 
-    # Step 3b: Install main PacketFence package LAST (requires Docker running + all dependencies)
-    echo "===> Step 3b: Installing main PacketFence package (packetfence_*.deb)..."
-    if ls ${PF_CACHE_DIR}/packetfence_*.deb 1> /dev/null 2>&1; then
-        PF_MAIN=$(ls ${PF_CACHE_DIR}/packetfence_*.deb | head -n1)
-        echo "Installing: ${PF_MAIN}"
-        DEBIAN_FRONTEND=noninteractive dpkg -i ${PF_MAIN} || {
-            echo "Warning: PacketFence main package installation had issues, fixing dependencies..."
-            DEBIAN_FRONTEND=noninteractive apt-get install -y -f
-            DEBIAN_FRONTEND=noninteractive dpkg -i ${PF_MAIN}
-        }
-        echo "PacketFence main package installed successfully"
-    else
-        echo "ERROR: Main PacketFence package (packetfence_*.deb) not found"
-        exit 1
-    fi
+    # Cleanup local repo config
+    rm -f /etc/apt/sources.list.d/packetfence-local-install.list
+    apt-get update 2>/dev/null || true
 
     echo "PacketFence installation completed successfully"
 else

--- a/ci/usb-bootable-iso/postinst-offline.sh
+++ b/ci/usb-bootable-iso/postinst-offline.sh
@@ -8,6 +8,10 @@ echo "PacketFence Offline Post-Installation Script"
 echo "=============================================="
 echo "PF_VERSION: ${PF_VERSION}"
 echo "=============================================="
+echo "NOTE: DVD ISO is mounted at /media/cdrom"
+echo "      DVD provides all Debian packages"
+echo "      PF repo at /media/cdrom/pf-repo"
+echo "=============================================="
 
 # Step 1: Configure local repository from ISO
 echo "===> Step 1: Configuring local APT repository from ISO"

--- a/ci/usb-bootable-iso/postinst-offline.sh
+++ b/ci/usb-bootable-iso/postinst-offline.sh
@@ -120,6 +120,27 @@ else
     echo "Warning: Docker images not found on ISO at /media/cdrom/docker-images"
 fi
 
+# Step 5b: Copy PacketFence .deb package for installation on first boot
+echo "===> Step 5b: Copying PacketFence .deb package to target filesystem"
+
+PF_CACHE_DIR="/var/cache/packetfence-install"
+mkdir -p ${PF_CACHE_DIR}
+
+if [ -d /media/cdrom/pf-repo/pool/main ]; then
+    echo "Copying PacketFence .deb package from ISO to ${PF_CACHE_DIR}..."
+    find /media/cdrom/pf-repo/pool/main -name "packetfence_*.deb" -exec cp {} ${PF_CACHE_DIR}/ \; || {
+        echo "Warning: Failed to copy PacketFence .deb package"
+    }
+    if ls ${PF_CACHE_DIR}/packetfence_*.deb 1> /dev/null 2>&1; then
+        echo "PacketFence .deb package copied successfully"
+        ls -la ${PF_CACHE_DIR}/
+    else
+        echo "ERROR: No PacketFence .deb package found"
+    fi
+else
+    echo "Warning: PF repo not found on ISO at /media/cdrom/pf-repo/pool/main"
+fi
+
 # Step 6: Configure system
 echo "===> Step 6: Configuring system"
 
@@ -159,6 +180,7 @@ echo "Starting at: $(date)"
 echo "=============================================="
 
 DOCKER_CACHE_DIR="/var/cache/packetfence-docker-images"
+PF_CACHE_DIR="/var/cache/packetfence-install"
 
 # Step 1: Start Docker service
 echo "===> Step 1: Starting Docker service"
@@ -197,12 +219,25 @@ fi
 # Step 3: Install PacketFence
 echo "===> Step 3: Installing PacketFence"
 
+# Remove local ISO repository configuration (ISO is no longer mounted)
+echo "Removing local ISO repository configuration..."
+rm -f /etc/apt/sources.list.d/packetfence-local.list
+apt-get update 2>/dev/null || true
+
+# Install PacketFence from the copied .deb file
 # Now that Docker is running, PacketFence postinst can configure containers
-DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends packetfence || {
-    echo "Warning: PacketFence installation had issues, attempting to fix..."
-    dpkg --configure -a
-    DEBIAN_FRONTEND=noninteractive apt-get install -y -f
-}
+if [ -f ${PF_CACHE_DIR}/packetfence_*.deb ]; then
+    PF_DEB=$(ls ${PF_CACHE_DIR}/packetfence_*.deb | head -n1)
+    echo "Installing PacketFence from ${PF_DEB}..."
+    DEBIAN_FRONTEND=noninteractive dpkg -i ${PF_DEB} || {
+        echo "Warning: PacketFence installation had issues, fixing dependencies..."
+        DEBIAN_FRONTEND=noninteractive apt-get install -y -f
+        DEBIAN_FRONTEND=noninteractive dpkg -i ${PF_DEB}
+    }
+else
+    echo "ERROR: PacketFence .deb package not found in ${PF_CACHE_DIR}"
+    exit 1
+fi
 
 # Step 4: Reset MariaDB root password
 echo "===> Step 4: Resetting MariaDB root password"
@@ -229,8 +264,11 @@ if [ -d ${DOCKER_CACHE_DIR} ]; then
     rm -rf ${DOCKER_CACHE_DIR}
 fi
 
-# Remove local ISO repository configuration
-rm -f /etc/apt/sources.list.d/packetfence-local.list
+# Remove PacketFence .deb cache
+if [ -d ${PF_CACHE_DIR} ]; then
+    echo "Removing PacketFence installation cache..."
+    rm -rf ${PF_CACHE_DIR}
+fi
 
 # Update package lists (if network available)
 apt-get update 2>/dev/null || true

--- a/ci/usb-bootable-iso/postinst-offline.sh
+++ b/ci/usb-bootable-iso/postinst-offline.sh
@@ -423,6 +423,63 @@ else
     echo "Warning: Docker images not found at ${DOCKER_CACHE_DIR}"
 fi
 
+# Re-tag Docker images to match what PacketFence expects
+# Images may have been downloaded with a different tag (e.g., devel) than what
+# the installed PacketFence package expects (e.g., feature-usb-bootable-iso2)
+echo "===> Checking if Docker images need re-tagging..."
+LOADED_TAG=""
+EXPECTED_TAG=""
+
+# Read the tag that was used when images were downloaded
+if [ -f ${DOCKER_CACHE_DIR}/image-tag.txt ]; then
+    LOADED_TAG=$(cat ${DOCKER_CACHE_DIR}/image-tag.txt | tr -d '[:space:]')
+    echo "Loaded images have tag: ${LOADED_TAG}"
+fi
+
+# Read the tag that PacketFence expects (from build_id or pf-release)
+if [ -f /usr/local/pf/conf/build_id ]; then
+    EXPECTED_TAG=$(grep -oP 'TAG_OR_BRANCH_NAME=\K.*' /usr/local/pf/conf/build_id 2>/dev/null | tr -d '[:space:]' || true)
+fi
+# Fallback: extract version from pf-release if build_id doesn't have TAG_OR_BRANCH_NAME
+if [ -z "${EXPECTED_TAG}" ] && [ -f /usr/local/pf/conf/pf-release ]; then
+    # For releases, use the version number (e.g., 15.1.0)
+    PF_VERSION=$(cat /usr/local/pf/conf/pf-release | awk '{print $2}')
+    if [[ "${PF_VERSION}" == *"/"* ]]; then
+        # Branch name format: feature/branch-name -> feature-branch-name
+        EXPECTED_TAG=$(echo "${PF_VERSION}" | sed 's#/#-#g')
+    else
+        EXPECTED_TAG="${PF_VERSION}"
+    fi
+    echo "PacketFence expects tag (from pf-release): ${EXPECTED_TAG}"
+else
+    echo "PacketFence expects tag (from build_id): ${EXPECTED_TAG}"
+fi
+
+# Re-tag images if needed
+if [ -n "${LOADED_TAG}" ] && [ -n "${EXPECTED_TAG}" ] && [ "${LOADED_TAG}" != "${EXPECTED_TAG}" ]; then
+    echo "Tags differ - re-tagging images from '${LOADED_TAG}' to '${EXPECTED_TAG}'..."
+    # Get list of images with the loaded tag
+    IMAGES_TO_RETAG=$(docker images --format '{{.Repository}}:{{.Tag}}' | grep ":${LOADED_TAG}$" || true)
+    if [ -n "${IMAGES_TO_RETAG}" ]; then
+        for img in ${IMAGES_TO_RETAG}; do
+            new_tag="${img%:${LOADED_TAG}}:${EXPECTED_TAG}"
+            echo "  Re-tagging: ${img} -> ${new_tag}"
+            docker tag "${img}" "${new_tag}" || echo "    Warning: Failed to re-tag ${img}"
+        done
+        echo "Docker images re-tagged successfully"
+    else
+        echo "No images found with tag '${LOADED_TAG}' to re-tag"
+    fi
+else
+    if [ -z "${LOADED_TAG}" ]; then
+        echo "No image-tag.txt found, skipping re-tag"
+    elif [ -z "${EXPECTED_TAG}" ]; then
+        echo "Could not determine expected tag, skipping re-tag"
+    else
+        echo "Tags match (${LOADED_TAG}), no re-tagging needed"
+    fi
+fi
+
 # Step 3: Install PacketFence
 update_progress "Step 3/6" "Installing PacketFence dependencies..."
 echo "===> Step 3: Installing PacketFence"

--- a/ci/usb-bootable-iso/postinst-offline.sh
+++ b/ci/usb-bootable-iso/postinst-offline.sh
@@ -1,16 +1,28 @@
 #!/bin/bash
 set -o nounset -o pipefail -o errexit
 
+# =============================================================================
+# PacketFence Offline Post-Installation Script - Phase A (runs during preseed)
+# =============================================================================
+# IMPORTANT: This script runs in a chroot environment during Debian installer.
+# systemd is NOT running, so Docker/systemctl commands will NOT work here.
+# PacketFence installation is deferred to first boot (Phase B).
+# =============================================================================
+
 PF_VERSION=${1:-15.1}
 
 echo "=============================================="
 echo "PacketFence Offline Post-Installation Script"
+echo "Phase A: Installing dependencies (preseed)"
 echo "=============================================="
 echo "PF_VERSION: ${PF_VERSION}"
 echo "=============================================="
 echo "NOTE: DVD ISO is mounted at /media/cdrom"
 echo "      DVD provides all Debian packages"
 echo "      PF repo at /media/cdrom/pf-repo"
+echo ""
+echo "IMPORTANT: PacketFence will be installed on"
+echo "           first boot (Docker required)"
 echo "=============================================="
 
 # Step 1: Configure local repository from ISO
@@ -46,61 +58,59 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y lnav cgroupfs-mount || {
 # Step 3: Install Docker packages
 echo "===> Step 3: Installing Docker packages"
 
-# Install Docker packages from local repo (required before starting Docker)
+# Install Docker packages from local repo
+# NOTE: Do NOT attempt to start Docker - it won't work in chroot environment
 DEBIAN_FRONTEND=noninteractive apt-get install -y docker-ce docker-ce-cli containerd.io || {
     echo "Warning: Docker packages installation had issues, attempting to fix..."
     dpkg --configure -a
     DEBIAN_FRONTEND=noninteractive apt-get install -y -f
 }
 
-# Step 4: Start Docker service (required BEFORE PacketFence installation)
-echo "===> Step 4: Starting Docker service"
+# Step 4: Install PacketFence dependencies (but NOT PacketFence itself)
+echo "===> Step 4: Installing PacketFence dependencies"
 
-# Start Docker service - PacketFence postinst needs it running
-systemctl start docker || {
-    echo "Warning: Failed to start Docker, attempting manual start..."
-    dockerd &
-    sleep 5
-}
-
-# Wait for Docker socket to be available
-echo "Waiting for Docker to be ready..."
-for i in {1..30}; do
-    if [ -S /var/run/docker.sock ]; then
-        echo "Docker is ready"
-        break
-    fi
-    sleep 1
-done
-
-if [ ! -S /var/run/docker.sock ]; then
-    echo "ERROR: Docker socket not available after 30 seconds"
-fi
-
-# Step 5: Load pre-downloaded Docker images
-echo "===> Step 5: Loading Docker images"
-
-if [ -d /media/cdrom/docker-images ] && [ -f /media/cdrom/docker-images/load-images.sh ]; then
-    /media/cdrom/docker-images/load-images.sh || {
-        echo "Warning: Some Docker images failed to load"
-    }
-else
-    echo "Warning: Docker images not found on ISO"
-fi
-
-# Step 6: Install PacketFence from local repository
-echo "===> Step 6: Installing PacketFence"
-
-# Install PacketFence (this will also install dependencies from local repo)
-# Docker is now running so postinst scripts can configure containers
-DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends packetfence || {
-    echo "Warning: PacketFence installation had issues, attempting to fix..."
+# Install key dependencies that PacketFence needs
+# PacketFence package itself will be installed on first boot when Docker is running
+DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    mariadb-server \
+    redis-server \
+    freeradius \
+    freeradius-ldap \
+    freeradius-mysql \
+    freeradius-utils \
+    freeradius-rest \
+    freeradius-redis \
+    haproxy \
+    keepalived \
+    samba \
+    snmpd \
+    monit \
+    fingerbank-collector \
+    || {
+    echo "Warning: Some dependencies failed to install, attempting to fix..."
     dpkg --configure -a
     DEBIAN_FRONTEND=noninteractive apt-get install -y -f
 }
 
-# Step 7: Configure system
-echo "===> Step 7: Configuring system"
+# Step 5: Copy Docker images to target filesystem
+echo "===> Step 5: Copying Docker images to target filesystem"
+
+DOCKER_CACHE_DIR="/var/cache/packetfence-docker-images"
+mkdir -p ${DOCKER_CACHE_DIR}
+
+if [ -d /media/cdrom/docker-images ]; then
+    echo "Copying Docker images from ISO to ${DOCKER_CACHE_DIR}..."
+    cp -r /media/cdrom/docker-images/* ${DOCKER_CACHE_DIR}/ || {
+        echo "Warning: Failed to copy some Docker images"
+    }
+    echo "Docker images copied successfully"
+    ls -la ${DOCKER_CACHE_DIR}/
+else
+    echo "Warning: Docker images not found on ISO at /media/cdrom/docker-images"
+fi
+
+# Step 6: Configure system
+echo "===> Step 6: Configuring system"
 
 # Allow SSH root login
 sed -i 's/#PermitRootLogin.*/PermitRootLogin yes/g' /etc/ssh/sshd_config
@@ -109,82 +119,153 @@ sed -i 's/#PermitRootLogin.*/PermitRootLogin yes/g' /etc/ssh/sshd_config
 # (they will be added properly when network is available)
 sed -i 's/.*inverse\.ca.*//g' /etc/apt/sources.list
 
-# Step 8: Configure PacketFence repository for future updates
-echo "===> Step 8: Setting up PacketFence repository for future updates"
-
-# Add PacketFence GPG key
-curl -fsSL https://inverse.ca/downloads/GPG_PUBLIC_KEY 2>/dev/null | gpg --dearmor -o /etc/apt/keyrings/packetfence.gpg || {
-    echo "Warning: Could not download GPG key (no network). Repository will be configured on first network access."
-}
-
-# Configure PacketFence repository (will be used when network is available)
+# Configure PacketFence repository for future updates (will be used when network is available)
 cat > /etc/apt/sources.list.d/packetfence.list << EOF
 deb [signed-by=/etc/apt/keyrings/packetfence.gpg] http://inverse.ca/downloads/PacketFence/debian/${PF_VERSION} bookworm bookworm
 EOF
 
-# Step 9: Reset MariaDB root password
-echo "===> Step 9: Resetting MariaDB root password"
+# Step 7: Create first-boot service
+echo "===> Step 7: Creating first-boot service"
 
-echo "SET PASSWORD FOR root@'localhost' = PASSWORD('');" > /tmp/reset-root.sql
-mkdir -p /run/mysqld
-chown mysql: /run/mysqld/
-timeout 30 mysqld --skip-networking --init-file /tmp/reset-root.sql --user=mysql > /var/log/reset-root.log 2>&1 || true
-rm -f /tmp/reset-root.sql
-
-# Step 10: Stop services that shouldn't run during installation
-echo "===> Step 10: Stopping services"
-
-# Stop Docker (will be started on first boot)
-pkill -e docker 2>/dev/null || true
-systemctl stop docker 2>/dev/null || true
-
-# Stop MariaDB
-systemctl stop mariadb 2>/dev/null || true
-
-# Step 11: Create first-boot marker
-echo "===> Step 11: Creating first-boot configuration"
-
-# Create a first-boot script to finalize setup
+# Create the first-boot script (Phase B)
 cat > /usr/local/bin/packetfence-first-boot.sh << 'FIRSTBOOT_EOF'
 #!/bin/bash
-# PacketFence first-boot configuration script
+set -o pipefail
 
-# Remove this script after execution
-SCRIPT_PATH=$(readlink -f "$0")
+# =============================================================================
+# PacketFence First Boot Script - Phase B
+# =============================================================================
+# This script runs on first boot when systemd is active and Docker can run.
+# It completes the PacketFence installation that couldn't happen during preseed.
+# =============================================================================
 
-echo "PacketFence first-boot configuration..."
+LOG_FILE="/var/log/packetfence-first-boot.log"
+exec > >(tee -a ${LOG_FILE}) 2>&1
 
-# Start required services
-systemctl start docker
-systemctl start mariadb
-systemctl start redis-server
+echo "=============================================="
+echo "PacketFence First Boot - Phase B"
+echo "Starting at: $(date)"
+echo "=============================================="
 
-# Remove the local ISO repository configuration
+DOCKER_CACHE_DIR="/var/cache/packetfence-docker-images"
+
+# Step 1: Start Docker service
+echo "===> Step 1: Starting Docker service"
+systemctl start docker || {
+    echo "ERROR: Failed to start Docker service"
+    exit 1
+}
+
+# Wait for Docker socket to be available
+echo "Waiting for Docker to be ready..."
+for i in {1..60}; do
+    if [ -S /var/run/docker.sock ]; then
+        echo "Docker is ready after ${i} seconds"
+        break
+    fi
+    sleep 1
+done
+
+if [ ! -S /var/run/docker.sock ]; then
+    echo "ERROR: Docker socket not available after 60 seconds"
+    exit 1
+fi
+
+# Step 2: Load Docker images
+echo "===> Step 2: Loading Docker images"
+
+if [ -d ${DOCKER_CACHE_DIR} ] && [ -f ${DOCKER_CACHE_DIR}/load-images.sh ]; then
+    chmod +x ${DOCKER_CACHE_DIR}/load-images.sh
+    ${DOCKER_CACHE_DIR}/load-images.sh || {
+        echo "Warning: Some Docker images failed to load"
+    }
+else
+    echo "Warning: Docker images not found at ${DOCKER_CACHE_DIR}"
+fi
+
+# Step 3: Install PacketFence
+echo "===> Step 3: Installing PacketFence"
+
+# Now that Docker is running, PacketFence postinst can configure containers
+DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends packetfence || {
+    echo "Warning: PacketFence installation had issues, attempting to fix..."
+    dpkg --configure -a
+    DEBIAN_FRONTEND=noninteractive apt-get install -y -f
+}
+
+# Step 4: Reset MariaDB root password
+echo "===> Step 4: Resetting MariaDB root password"
+
+systemctl start mariadb || true
+sleep 3
+
+echo "SET PASSWORD FOR root@'localhost' = PASSWORD('');" > /tmp/reset-root.sql
+mysql < /tmp/reset-root.sql 2>/dev/null || {
+    # If mysql client fails, try with mysqld directly
+    systemctl stop mariadb || true
+    mkdir -p /run/mysqld
+    chown mysql: /run/mysqld/
+    timeout 30 mysqld --skip-networking --init-file=/tmp/reset-root.sql --user=mysql > /var/log/reset-root.log 2>&1 || true
+}
+rm -f /tmp/reset-root.sql
+
+# Step 5: Cleanup
+echo "===> Step 5: Cleanup"
+
+# Remove Docker image cache
+if [ -d ${DOCKER_CACHE_DIR} ]; then
+    echo "Removing Docker image cache..."
+    rm -rf ${DOCKER_CACHE_DIR}
+fi
+
+# Remove local ISO repository configuration
 rm -f /etc/apt/sources.list.d/packetfence-local.list
 
 # Update package lists (if network available)
 apt-get update 2>/dev/null || true
 
-# Remove this script
-rm -f "$SCRIPT_PATH"
+# Step 6: Start services
+echo "===> Step 6: Starting services"
+
+systemctl start mariadb || true
+systemctl start redis-server || true
+
+# Remove this script and service
+echo "===> Removing first-boot service"
+SCRIPT_PATH=$(readlink -f "$0")
 rm -f /etc/systemd/system/packetfence-first-boot.service
 systemctl daemon-reload
+rm -f "$SCRIPT_PATH"
 
-echo "First-boot configuration complete!"
+echo "=============================================="
+echo "PacketFence First Boot Complete!"
+echo "Finished at: $(date)"
+echo "=============================================="
+echo ""
+echo "Next steps:"
+echo "1. Log in as root"
+echo "2. Run: /usr/local/pf/bin/pfcmd configreload hard"
+echo "3. Access the web interface at https://<ip>:1443"
+echo "=============================================="
 FIRSTBOOT_EOF
+
 chmod +x /usr/local/bin/packetfence-first-boot.sh
 
 # Create systemd service for first-boot
 cat > /etc/systemd/system/packetfence-first-boot.service << 'SERVICE_EOF'
 [Unit]
-Description=PacketFence First Boot Configuration
-After=network.target docker.service
+Description=PacketFence First Boot - Install PacketFence and Configure Containers
+After=network.target docker.service mariadb.service
+Wants=docker.service
 ConditionPathExists=/usr/local/bin/packetfence-first-boot.sh
 
 [Service]
 Type=oneshot
 ExecStart=/usr/local/bin/packetfence-first-boot.sh
 RemainAfterExit=yes
+TimeoutStartSec=900
+StandardOutput=journal+console
+StandardError=journal+console
 
 [Install]
 WantedBy=multi-user.target
@@ -192,11 +273,25 @@ SERVICE_EOF
 
 systemctl enable packetfence-first-boot.service
 
+# Step 8: Display completion message
 echo "=============================================="
-echo "PacketFence Offline Installation Complete!"
+echo "Phase A Complete - Dependencies Installed"
 echo "=============================================="
-echo "The system will reboot. After reboot:"
-echo "1. Log in as root"
-echo "2. Run: /usr/local/pf/bin/pfcmd configreload hard"
-echo "3. Access the web interface at https://<ip>:1443"
+echo ""
+echo "IMPORTANT: PacketFence will be installed"
+echo "automatically on first boot."
+echo ""
+echo "Please REMOVE the USB/ISO device before"
+echo "the system reboots."
+echo ""
+echo "First boot will take several minutes to:"
+echo "  - Start Docker service"
+echo "  - Load container images"
+echo "  - Install PacketFence"
+echo "  - Configure services"
+echo ""
+echo "After first boot completes:"
+echo "  1. Log in as root"
+echo "  2. Run: /usr/local/pf/bin/pfcmd configreload hard"
+echo "  3. Access: https://<ip>:1443"
 echo "=============================================="

--- a/ci/usb-bootable-iso/postinst-offline.sh
+++ b/ci/usb-bootable-iso/postinst-offline.sh
@@ -101,20 +101,35 @@ apt-mark hold linux-image-amd64 linux-image-* 2>/dev/null || true
 # Include linux-image-amd64 to ensure kernel is not removed by dependency resolution
 DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     linux-image-amd64 \
+    linux-headers-amd64 \
     mariadb-server \
+    mariadb-client \
     redis-server \
+    redis-tools \
     freeradius \
     freeradius-ldap \
     freeradius-mysql \
     freeradius-utils \
     freeradius-rest \
     freeradius-redis \
+    freeradius-common \
     haproxy \
     keepalived \
     samba \
     snmpd \
+    snmp \
     monit \
     fingerbank-collector \
+    bind9-dnsutils \
+    bind9-libs \
+    bind9-host \
+    openssh-server \
+    openssh-client \
+    openssh-sftp-server \
+    vlan \
+    arping \
+    fping \
+    ipset \
     || {
     echo "Warning: Some dependencies failed to install, attempting to fix..."
     dpkg --configure -a

--- a/ci/usb-bootable-iso/postinst-offline.sh
+++ b/ci/usb-bootable-iso/postinst-offline.sh
@@ -191,7 +191,7 @@ update_progress() {
   Current Step: ${step}
   Status: ${message}
 
-  This process may take 10-15 minutes total.
+  Depending on allocated resources, PacketFence installation can take 10-40 minutes.
   Progress can be monitored at: /var/log/packetfence-first-boot.log
 
   Please wait until installation completes before using the system.

--- a/ci/usb-bootable-iso/postinst-offline.sh
+++ b/ci/usb-bootable-iso/postinst-offline.sh
@@ -75,6 +75,8 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y \
     libjson-perl \
     libsql-translator-perl \
     libfile-touch-perl \
+    libglib2.0-0 \
+    libglib2.0-bin \
     || {
     echo "Warning: Some packages failed to install, continuing..."
 }

--- a/ci/usb-bootable-iso/postinst-offline.sh
+++ b/ci/usb-bootable-iso/postinst-offline.sh
@@ -25,8 +25,8 @@ cat > /etc/apt/sources.list.d/packetfence-local.list << EOF
 deb [trusted=yes] file:///media/cdrom/pf-repo bookworm main
 EOF
 
-# Disable CD-ROM sources
-sed -i '/^deb cdrom:/s/^/#/' /etc/apt/sources.list
+# Disable CD-ROM apt source (prevents "Please insert CD" prompts)
+sed -i '/^deb cdrom:/d' /etc/apt/sources.list
 
 # Update package lists
 apt-get update

--- a/ci/usb-bootable-iso/postinst-offline.sh
+++ b/ci/usb-bootable-iso/postinst-offline.sh
@@ -47,21 +47,40 @@ sed -i '/^deb cdrom:/d' /etc/apt/sources.list
 # Update package lists
 apt-get update
 
-# Step 2: Install packages not available on DVD-1
-echo "===> Step 2: Installing packages from local repository (not on DVD-1)"
+# Step 2: Install packages from DVD needed for first boot
+echo "===> Step 2: Installing packages from DVD (needed for first boot)"
 
-# Install packages that are NOT on DVD-1, must come from local pf-repo
-# These are needed by fingerbank and packetfence-* dependency packages
-# Note: Many perl packages (liblog-fast-perl, libcatalyst-perl, etc.) are virtual
-# packages provided by packetfence-perl - do NOT list them here.
+# Install packages from DVD that are required during first boot when DVD is removed.
+# These are standard Debian packages ON the DVD, but won't be available after reboot.
+#
+# Packages needed by fingerbank (with versioned dependencies):
+# - liblog-log4perl-perl (>= 1.43): fingerbank requires specific version
+# - libconfig-inifiles-perl (>= 2.88): fingerbank requires specific version
+# - liburi-perl, libregexp-ipv6-perl: needed by HTTP::Request/LWP in packetfence-perl
+# - acl: needed by packetfence preinst script (setfacl command)
+# - libdbd-sqlite3-perl, sqlite3, libdata-powerset-perl: fingerbank dependencies
+DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    liblog-log4perl-perl \
+    libconfig-inifiles-perl \
+    liburi-perl \
+    libregexp-ipv6-perl \
+    acl \
+    libdbd-sqlite3-perl \
+    sqlite3 \
+    libdata-powerset-perl \
+    || {
+    echo "Warning: Some packages failed to install, continuing..."
+}
+
+# Step 2b: Install packages from pf-repo (not on DVD)
+echo "===> Step 2b: Installing packages from local pf-repo (not on DVD)"
+
+# These packages are NOT on the Debian DVD, they come from pf-repo
 DEBIAN_FRONTEND=noninteractive apt-get install -y \
     lnav \
     cgroupfs-mount \
     libcache-bdb-perl \
     libcjson1 \
-    libdbd-sqlite3-perl \
-    sqlite3 \
-    libdata-powerset-perl \
     libglib2.0-0 \
     libglib2.0-bin \
     || {

--- a/ci/usb-bootable-iso/predownload-docker-images.sh
+++ b/ci/usb-bootable-iso/predownload-docker-images.sh
@@ -1,18 +1,13 @@
 #!/bin/bash
 set -o nounset -o pipefail -o errexit
 
-# Arguments
 DOCKER_IMAGES_DIR=${1:-./docker-images}
-
-# Get script directory
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 PF_ROOT=$(cd "${SCRIPT_DIR}/../.." && pwd)
 
-# Source configuration
-source <(grep 'KNK_REGISTRY_URL' ${PF_ROOT}/config.mk | tr -d ' ')
+# Source registry URL from config
+source <(grep 'KNK_REGISTRY_URL' "${PF_ROOT}/config.mk" | tr -d ' ') 2>/dev/null || true
 KNK_REGISTRY_URL=${KNK_REGISTRY_URL:-ghcr.io/inverse-inc/packetfence}
-
-# Get tag from environment or use devel
 TAG_OR_BRANCH_NAME=${TAG_OR_BRANCH_NAME:-devel}
 
 echo "=============================================="
@@ -23,53 +18,17 @@ echo "KNK_REGISTRY_URL: ${KNK_REGISTRY_URL}"
 echo "TAG_OR_BRANCH_NAME: ${TAG_OR_BRANCH_NAME}"
 echo "=============================================="
 
-# Create output directory
-mkdir -p ${DOCKER_IMAGES_DIR}
+mkdir -p "${DOCKER_IMAGES_DIR}"
 
-# List of Docker images to download
-# Based on containers directory (excluding build-only images)
-CONTAINERS_IMAGES="
-    pfcron
-    pfcmd
-    httpd.aaa
-    pfstats
-    pfconfig
-    haproxy-admin
-    httpd.admin_dispatcher
-    haproxy-portal
-    ntlm-auth-api
-    pfldapexplorer
-    pfdns-connector
-    radiusd-acct
-    radiusd-eduroam
-    radiusd-load-balancer
-    radiusd-cli
-    pfperl-api
-    httpd.portal
-    pfsso
-    api-frontend
-    httpd.dispatcher
-    pfacct
-    radiusd-auth
-    httpd.webservices
-    pfsetacls
-    pfpki
-    pfconnector
-    proxysql
-    pfqueue
+# Docker images to download (containers + extras)
+ALL_IMAGES="
+    pfcron pfcmd httpd.aaa pfstats pfconfig haproxy-admin httpd.admin_dispatcher
+    haproxy-portal ntlm-auth-api pfldapexplorer pfdns-connector radiusd-acct
+    radiusd-eduroam radiusd-load-balancer radiusd-cli pfperl-api httpd.portal
+    pfsso api-frontend httpd.dispatcher pfacct radiusd-auth httpd.webservices
+    pfsetacls pfpki pfconnector proxysql pfqueue fingerbank-db netdata kafka
 "
 
-# Additional images that might be needed
-EXTRA_IMAGES="
-    fingerbank-db
-    netdata
-    kafka
-"
-
-# Combine all images
-ALL_IMAGES="${CONTAINERS_IMAGES} ${EXTRA_IMAGES}"
-
-# Pull all images first, then save together to share layers
 RETRY_LIMIT=3
 FAILED_IMAGES=""
 PULLED_IMAGES=""

--- a/ci/usb-bootable-iso/predownload-docker-images.sh
+++ b/ci/usb-bootable-iso/predownload-docker-images.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+set -o nounset -o pipefail -o errexit
+
+# Arguments
+DOCKER_IMAGES_DIR=${1:-./docker-images}
+
+# Get script directory
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PF_ROOT=$(cd "${SCRIPT_DIR}/../.." && pwd)
+
+# Source configuration
+source <(grep 'KNK_REGISTRY_URL' ${PF_ROOT}/config.mk | tr -d ' ')
+KNK_REGISTRY_URL=${KNK_REGISTRY_URL:-ghcr.io/inverse-inc/packetfence}
+
+# Get tag from environment or use devel
+TAG_OR_BRANCH_NAME=${TAG_OR_BRANCH_NAME:-devel}
+
+echo "=============================================="
+echo "Pre-downloading Docker Images"
+echo "=============================================="
+echo "DOCKER_IMAGES_DIR: ${DOCKER_IMAGES_DIR}"
+echo "KNK_REGISTRY_URL: ${KNK_REGISTRY_URL}"
+echo "TAG_OR_BRANCH_NAME: ${TAG_OR_BRANCH_NAME}"
+echo "=============================================="
+
+# Create output directory
+mkdir -p ${DOCKER_IMAGES_DIR}
+
+# List of Docker images to download
+# Based on containers directory (excluding build-only images)
+CONTAINERS_IMAGES="
+    pfcron
+    pfcmd
+    httpd.aaa
+    pfstats
+    pfconfig
+    haproxy-admin
+    httpd.admin_dispatcher
+    haproxy-portal
+    ntlm-auth-api
+    pfldapexplorer
+    pfdns-connector
+    radiusd-acct
+    radiusd-eduroam
+    radiusd-load-balancer
+    radiusd-cli
+    pfperl-api
+    httpd.portal
+    pfsso
+    api-frontend
+    httpd.dispatcher
+    pfacct
+    radiusd-auth
+    httpd.webservices
+    pfsetacls
+    pfpki
+    pfconnector
+    proxysql
+    pfqueue
+"
+
+# Additional images that might be needed
+EXTRA_IMAGES="
+    fingerbank-db
+    netdata
+    kafka
+"
+
+# Combine all images
+ALL_IMAGES="${CONTAINERS_IMAGES} ${EXTRA_IMAGES}"
+
+# Download and save each image
+RETRY_LIMIT=3
+FAILED_IMAGES=""
+SUCCESS_COUNT=0
+TOTAL_COUNT=0
+
+for img in ${ALL_IMAGES}; do
+    img=$(echo $img | tr -d ' ')
+    [ -z "$img" ] && continue
+
+    TOTAL_COUNT=$((TOTAL_COUNT + 1))
+    FULL_IMAGE="${KNK_REGISTRY_URL}/${img}:${TAG_OR_BRANCH_NAME}"
+    OUTPUT_FILE="${DOCKER_IMAGES_DIR}/${img}.tar.gz"
+
+    echo "===> [$TOTAL_COUNT] Processing: ${img}"
+
+    # Skip if already downloaded
+    if [ -f "${OUTPUT_FILE}" ]; then
+        echo "    Already exists: ${OUTPUT_FILE}"
+        SUCCESS_COUNT=$((SUCCESS_COUNT + 1))
+        continue
+    fi
+
+    # Pull image with retries
+    PULLED=false
+    for attempt in $(seq 1 $RETRY_LIMIT); do
+        echo "    Pulling (attempt ${attempt}/${RETRY_LIMIT})..."
+        if docker pull -q ${FULL_IMAGE} 2>/dev/null; then
+            PULLED=true
+            break
+        else
+            if [ $attempt -lt $RETRY_LIMIT ]; then
+                echo "    Retrying in 3 seconds..."
+                sleep 3
+            fi
+        fi
+    done
+
+    if [ "$PULLED" = false ]; then
+        echo "    FAILED to pull: ${FULL_IMAGE}"
+        FAILED_IMAGES="${FAILED_IMAGES} ${img}"
+        continue
+    fi
+
+    # Save image to tar.gz
+    echo "    Saving to: ${OUTPUT_FILE}"
+    docker save ${FULL_IMAGE} | gzip > ${OUTPUT_FILE}
+
+    if [ -f "${OUTPUT_FILE}" ]; then
+        SIZE=$(du -h ${OUTPUT_FILE} | cut -f1)
+        echo "    Saved: ${SIZE}"
+        SUCCESS_COUNT=$((SUCCESS_COUNT + 1))
+    else
+        echo "    FAILED to save: ${img}"
+        FAILED_IMAGES="${FAILED_IMAGES} ${img}"
+    fi
+done
+
+# Create a loader script to import images on target system
+cat > ${DOCKER_IMAGES_DIR}/load-images.sh << 'LOADER_EOF'
+#!/bin/bash
+set -o nounset -o pipefail -o errexit
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+echo "Loading pre-downloaded Docker images..."
+
+for img_file in ${SCRIPT_DIR}/*.tar.gz; do
+    [ -f "$img_file" ] || continue
+    img_name=$(basename "$img_file" .tar.gz)
+    echo "Loading: ${img_name}"
+    gunzip -c "$img_file" | docker load
+done
+
+echo "All Docker images loaded successfully!"
+LOADER_EOF
+chmod +x ${DOCKER_IMAGES_DIR}/load-images.sh
+
+# Summary
+TOTAL_SIZE=$(du -sh ${DOCKER_IMAGES_DIR} | cut -f1)
+
+echo "=============================================="
+echo "Docker Images Download Complete"
+echo "=============================================="
+echo "Successful: ${SUCCESS_COUNT}/${TOTAL_COUNT}"
+echo "Total Size: ${TOTAL_SIZE}"
+echo "Location: ${DOCKER_IMAGES_DIR}"
+if [ -n "${FAILED_IMAGES}" ]; then
+    echo "FAILED:${FAILED_IMAGES}"
+    echo "=============================================="
+    exit 1
+fi
+echo "=============================================="

--- a/ci/usb-bootable-iso/predownload-docker-images.sh
+++ b/ci/usb-bootable-iso/predownload-docker-images.sh
@@ -69,63 +69,63 @@ EXTRA_IMAGES="
 # Combine all images
 ALL_IMAGES="${CONTAINERS_IMAGES} ${EXTRA_IMAGES}"
 
-# Download and save each image
+# Pull all images first, then save together to share layers
 RETRY_LIMIT=3
 FAILED_IMAGES=""
+PULLED_IMAGES=""
 SUCCESS_COUNT=0
 TOTAL_COUNT=0
+OUTPUT_FILE="${DOCKER_IMAGES_DIR}/all-images.tar.gz"
 
-for img in ${ALL_IMAGES}; do
-    img=$(echo $img | tr -d ' ')
-    [ -z "$img" ] && continue
+# Check if already downloaded
+if [ -f "${OUTPUT_FILE}" ]; then
+    echo "Docker images archive already exists: ${OUTPUT_FILE}"
+    echo "Size: $(du -h ${OUTPUT_FILE} | cut -f1)"
+    echo "Delete it to re-download"
+else
+    # Pull all images
+    for img in ${ALL_IMAGES}; do
+        img=$(echo $img | tr -d ' ')
+        [ -z "$img" ] && continue
 
-    TOTAL_COUNT=$((TOTAL_COUNT + 1))
-    FULL_IMAGE="${KNK_REGISTRY_URL}/${img}:${TAG_OR_BRANCH_NAME}"
-    OUTPUT_FILE="${DOCKER_IMAGES_DIR}/${img}.tar.gz"
+        TOTAL_COUNT=$((TOTAL_COUNT + 1))
+        FULL_IMAGE="${KNK_REGISTRY_URL}/${img}:${TAG_OR_BRANCH_NAME}"
 
-    echo "===> [$TOTAL_COUNT] Processing: ${img}"
+        echo "===> [$TOTAL_COUNT] Pulling: ${img}"
 
-    # Skip if already downloaded
-    if [ -f "${OUTPUT_FILE}" ]; then
-        echo "    Already exists: ${OUTPUT_FILE}"
-        SUCCESS_COUNT=$((SUCCESS_COUNT + 1))
-        continue
-    fi
-
-    # Pull image with retries
-    PULLED=false
-    for attempt in $(seq 1 $RETRY_LIMIT); do
-        echo "    Pulling (attempt ${attempt}/${RETRY_LIMIT})..."
-        if docker pull -q ${FULL_IMAGE} 2>/dev/null; then
-            PULLED=true
-            break
-        else
-            if [ $attempt -lt $RETRY_LIMIT ]; then
-                echo "    Retrying in 3 seconds..."
-                sleep 3
+        # Pull image with retries
+        PULLED=false
+        for attempt in $(seq 1 $RETRY_LIMIT); do
+            echo "    Attempt ${attempt}/${RETRY_LIMIT}..."
+            if docker pull -q ${FULL_IMAGE} 2>/dev/null; then
+                PULLED=true
+                break
+            else
+                if [ $attempt -lt $RETRY_LIMIT ]; then
+                    echo "    Retrying in 3 seconds..."
+                    sleep 3
+                fi
             fi
+        done
+
+        if [ "$PULLED" = false ]; then
+            echo "    FAILED to pull: ${FULL_IMAGE}"
+            FAILED_IMAGES="${FAILED_IMAGES} ${img}"
+        else
+            echo "    Pulled successfully"
+            PULLED_IMAGES="${PULLED_IMAGES} ${FULL_IMAGE}"
+            SUCCESS_COUNT=$((SUCCESS_COUNT + 1))
         fi
     done
 
-    if [ "$PULLED" = false ]; then
-        echo "    FAILED to pull: ${FULL_IMAGE}"
-        FAILED_IMAGES="${FAILED_IMAGES} ${img}"
-        continue
+    # Save ALL images in a single archive (shared layers are deduplicated)
+    if [ -n "${PULLED_IMAGES}" ]; then
+        echo ""
+        echo "===> Saving all images to single archive (layers will be deduplicated)..."
+        docker save ${PULLED_IMAGES} | gzip > ${OUTPUT_FILE}
+        echo "Saved: $(du -h ${OUTPUT_FILE} | cut -f1)"
     fi
-
-    # Save image to tar.gz
-    echo "    Saving to: ${OUTPUT_FILE}"
-    docker save ${FULL_IMAGE} | gzip > ${OUTPUT_FILE}
-
-    if [ -f "${OUTPUT_FILE}" ]; then
-        SIZE=$(du -h ${OUTPUT_FILE} | cut -f1)
-        echo "    Saved: ${SIZE}"
-        SUCCESS_COUNT=$((SUCCESS_COUNT + 1))
-    else
-        echo "    FAILED to save: ${img}"
-        FAILED_IMAGES="${FAILED_IMAGES} ${img}"
-    fi
-done
+fi
 
 # Create a loader script to import images on target system
 cat > ${DOCKER_IMAGES_DIR}/load-images.sh << 'LOADER_EOF'
@@ -136,12 +136,18 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 echo "Loading pre-downloaded Docker images..."
 
-for img_file in ${SCRIPT_DIR}/*.tar.gz; do
-    [ -f "$img_file" ] || continue
-    img_name=$(basename "$img_file" .tar.gz)
-    echo "Loading: ${img_name}"
-    gunzip -c "$img_file" | docker load
-done
+if [ -f "${SCRIPT_DIR}/all-images.tar.gz" ]; then
+    echo "Loading all images from single archive..."
+    gunzip -c "${SCRIPT_DIR}/all-images.tar.gz" | docker load
+else
+    # Fallback: load individual image files
+    for img_file in ${SCRIPT_DIR}/*.tar.gz; do
+        [ -f "$img_file" ] || continue
+        img_name=$(basename "$img_file" .tar.gz)
+        echo "Loading: ${img_name}"
+        gunzip -c "$img_file" | docker load
+    done
+fi
 
 echo "All Docker images loaded successfully!"
 LOADER_EOF

--- a/ci/usb-bootable-iso/predownload-docker-images.sh
+++ b/ci/usb-bootable-iso/predownload-docker-images.sh
@@ -125,6 +125,10 @@ else
         docker save ${PULLED_IMAGES} | gzip > ${OUTPUT_FILE}
         echo "Saved: $(du -h ${OUTPUT_FILE} | cut -f1)"
     fi
+
+    # Save the tag used for these images (needed for re-tagging on target system)
+    echo "${TAG_OR_BRANCH_NAME}" > ${DOCKER_IMAGES_DIR}/image-tag.txt
+    echo "Saved image tag: ${TAG_OR_BRANCH_NAME}"
 fi
 
 # Create a loader script to import images on target system

--- a/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
+++ b/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
@@ -87,7 +87,9 @@ d-i krb5-config/default_realm string
 d-i krb5-config/kerberos_servers string
 
 ### Package selection
+# Pre-select standard utilities and ssh-server, skip the interactive dialog
 tasksel tasksel/first multiselect standard ssh-server
+d-i pkgsel/tasksel/first/seen boolean true
 
 # Individual additional packages to install
 # PF: install linux-headers-amd64 to avoid issue with NetFlow kernel module

--- a/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
+++ b/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
@@ -20,16 +20,19 @@ d-i netcfg/hostname string packetfence
 # Disable that annoying WEP key dialog.
 d-i netcfg/wireless_wep string
 
-### Configure package manager - OFFLINE MODE
-# Keep CD-ROM as package source for base system packages
+### Configure package manager - OFFLINE MODE WITH DVD
+# Keep CD-ROM as PRIMARY package source - DVD has complete Debian packages
 d-i apt-setup/cdrom/set-first boolean true
 d-i apt-setup/cdrom/set-next boolean false
 d-i apt-setup/cdrom/set-failed boolean false
 
-# Disable network mirror - we use local repository on ISO
+# Disable network mirror - we use DVD + local PF repo on ISO
 d-i apt-setup/use_mirror boolean false
 
-### Mirror settings - Use local repository from ISO
+# Do NOT eject CD-ROM - we need it mounted for PacketFence installation
+d-i cdrom-detect/eject boolean false
+
+### Mirror settings - No external mirrors
 d-i mirror/country string manual
 d-i mirror/http/hostname string
 d-i mirror/http/directory string
@@ -91,12 +94,13 @@ tasksel tasksel/first multiselect standard ssh-server
 
 # Individual additional packages to install
 # PF: install linux-headers-amd64 to avoid issue with NetFlow kernel module
+# PF: install systemd packages explicitly for offline installer
 d-i pkgsel/include string sudo bzip2 acpid cryptsetup \
                           zlib1g-dev wget curl dkms make \
                           nfs-common net-tools build-essential \
                           linux-headers-amd64 gnupg2 apt-transport-https \
                           tmux tcpdump lnav apg sysstat bsd-mailx \
-                          cgroupfs-mount
+                          cgroupfs-mount systemd systemd-sysv libnss-systemd
 
 # Whether to upgrade packages after debootstrap.
 # Allowed values: none, safe-upgrade, full-upgrade
@@ -127,17 +131,18 @@ d-i preseed/early_command string sed -i \
   /usr/lib/pre-pkgsel.d/20install-hwpackages
 
 # Late command - run post-installation script for offline setup
+# IMPORTANT: ISO must stay mounted for PacketFence installation
 # This script will:
-# - Configure the local repository from the ISO
-# - Install PacketFence from local packages
-# - Load pre-downloaded Docker images
+# - Configure the local PF repository from the ISO
+# - Install PacketFence from local packages (ISO must be mounted)
+# - Load pre-downloaded Docker images from ISO
 # - Configure the system for first boot
 d-i preseed/late_command string \
   mount --bind /proc /target/proc ; \
   mount --bind /sys /target/sys ; \
   mount --bind /dev /target/dev ; \
   in-target mkdir -p /media/cdrom ; \
-  mount /dev/sr0 /target/media/cdrom || mount /dev/sda1 /target/media/cdrom || true ; \
+  mount --bind /cdrom /target/media/cdrom ; \
   in-target cp -a /media/cdrom/postinst-offline.sh /usr/local/bin/ ; \
   in-target chmod 700 /usr/local/bin/postinst-offline.sh ; \
   in-target /bin/bash /usr/local/bin/postinst-offline.sh %%PF_VERSION%% ; \

--- a/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
+++ b/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
@@ -115,7 +115,7 @@ d-i pkgsel/include string sudo bzip2 acpid cryptsetup \
                           tmux tcpdump apg sysstat bsd-mailx \
                           systemd systemd-sysv libnss-systemd \
                           apparmor klibc-utils linux-base \
-                          bind9-dnsutils openssh-server
+                          bind9-dnsutils
 
 # Whether to upgrade packages after debootstrap.
 # For offline installation, skip upgrade (no network mirrors available)

--- a/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
+++ b/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
@@ -82,12 +82,12 @@ d-i partman-lvm/confirm_nooverwrite boolean true
 # Use atomic partitioning (all files in one partition)
 d-i partman-auto/choose_recipe select atomic
 
-# Let user confirm partitioning choices
-# Do NOT auto-confirm - user should verify before writing
-d-i partman-partitioning/confirm_write_new_label boolean true
-d-i partman/confirm boolean true
-d-i partman/confirm_nooverwrite boolean true
-d-i partman-md/confirm boolean true
+# User must review and confirm partitioning before writing to disk
+# Do NOT preset these - let the installer prompt for confirmation
+# d-i partman-partitioning/confirm_write_new_label boolean true
+# d-i partman/confirm boolean true
+# d-i partman/confirm_nooverwrite boolean true
+# d-i partman-md/confirm boolean true
 
 ### Base system installation
 # Force non-interactive install

--- a/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
+++ b/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
@@ -36,6 +36,12 @@ d-i mirror/http/directory string
 d-i mirror/http/proxy string
 
 ### Account setup
+# Enable root login
+d-i passwd/root-login boolean true
+
+# Do not allow empty root password - installer will prompt for password
+d-i passwd/root-password-empty boolean false
+
 # Skip creation of a normal user account.
 d-i passwd/make-user boolean false
 

--- a/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
+++ b/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
@@ -62,27 +62,29 @@ d-i clock-setup/utc boolean true
 d-i clock-setup/ntp boolean true
 
 ### Partitioning
-# Allow user to choose the disk for installation
-# Do NOT preset partman-auto/disk - let user select
-
-# Use REGULAR partitioning (NO LVM) - simple standard partitions
-d-i partman-auto/method string regular
+# Allow user to choose the disk AND partitioning method
+# Do NOT preset partman-auto/disk - let user select disk
+# Do NOT preset partman-auto/method - let user choose: Guided, Guided LVM, Manual
 
 # Remove existing LVM configuration if present
 d-i partman-lvm/device_remove_lvm boolean true
-d-i partman-lvm/confirm boolean false
 
 # Remove existing software RAID if present
 d-i partman-md/device_remove_md boolean true
 
-# Use atomic partitioning (all files in one partition)
+# Use atomic partitioning recipe when guided is chosen (all files in one partition)
 d-i partman-auto/choose_recipe select atomic
 
-# Automatically confirm partitioning to avoid excessive prompts
+# LVM settings (used only if user chooses LVM)
+d-i partman-auto-lvm/guided_size string max
+d-i partman-lvm/confirm boolean true
+d-i partman-lvm/confirm_nooverwrite boolean true
+
+# Confirm partitioning changes
 d-i partman-partitioning/confirm_write_new_label boolean true
-d-i partman/choose_partition select finish
 d-i partman/confirm boolean true
 d-i partman/confirm_nooverwrite boolean true
+d-i partman-md/confirm boolean true
 
 ### Base system installation
 # Force non-interactive install

--- a/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
+++ b/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
@@ -42,6 +42,10 @@ d-i mirror/http/proxy string
 # Skip creation of a normal user account - only root will be created
 d-i passwd/make-user boolean false
 
+# Explicitly set no username to prevent any user creation prompts
+d-i passwd/username string
+d-i passwd/user-fullname string
+
 # Root password will be set during installation
 d-i passwd/root-login boolean true
 

--- a/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
+++ b/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
@@ -100,13 +100,15 @@ tasksel tasksel/first multiselect standard ssh-server
 # PF: install linux-headers-amd64 to avoid issue with NetFlow kernel module
 # PF: install systemd packages explicitly for offline installer
 # PF: include apparmor and klibc-utils to prevent autoremove errors
+# PF: include bind9-dnsutils for DNS utilities needed by PacketFence
 d-i pkgsel/include string sudo bzip2 acpid cryptsetup \
                           zlib1g-dev wget curl dkms make \
                           nfs-common net-tools build-essential \
                           linux-headers-amd64 gnupg2 apt-transport-https \
                           tmux tcpdump lnav apg sysstat bsd-mailx \
                           cgroupfs-mount systemd systemd-sysv libnss-systemd \
-                          apparmor klibc-utils linux-base
+                          apparmor klibc-utils linux-base \
+                          bind9-dnsutils openssh-server
 
 # Whether to upgrade packages after debootstrap.
 # For offline installation, skip upgrade (no network mirrors available)

--- a/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
+++ b/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
@@ -103,8 +103,11 @@ d-i pkgsel/include string sudo bzip2 acpid cryptsetup \
                           cgroupfs-mount systemd systemd-sysv libnss-systemd
 
 # Whether to upgrade packages after debootstrap.
-# Allowed values: none, safe-upgrade, full-upgrade
-d-i pkgsel/upgrade select full-upgrade
+# For offline installation, skip upgrade (no network mirrors available)
+d-i pkgsel/upgrade select none
+
+# Skip autoremove during installation
+d-i pkgsel/update-policy select none
 
 # Do not participate in popularity contest
 popularity-contest popularity-contest/participate boolean false

--- a/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
+++ b/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
@@ -1,0 +1,147 @@
+#_preseed_V1
+#### Contents of the preconfiguration file (for bookworm) - OFFLINE USB INSTALLER
+### Localization
+# Preseeding only locale sets language, country and locale.
+d-i debian-installer/locale string en_US
+
+# Keyboard selection.
+d-i keyboard-configuration/xkb-keymap select us
+
+### Network configuration
+# netcfg will choose an interface that has link if possible. This makes it
+# skip displaying a list if there is more than one interface.
+d-i netcfg/choose_interface select auto
+
+# Any hostname and domain names assigned from dhcp take precedence over
+# values set here. However, setting the values still prevents the questions
+# from being shown, even if values come from dhcp.
+d-i netcfg/hostname string packetfence
+
+# Disable that annoying WEP key dialog.
+d-i netcfg/wireless_wep string
+
+### Configure package manager - OFFLINE MODE
+# Disable CD-ROM as package source after initial install
+d-i apt-setup/cdrom/set-first boolean false
+d-i apt-setup/cdrom/set-next boolean false
+d-i apt-setup/cdrom/set-failed boolean false
+
+# Disable network mirror - we use local repository on ISO
+d-i apt-setup/use_mirror boolean false
+
+### Mirror settings - Use local repository from ISO
+d-i mirror/country string manual
+d-i mirror/http/hostname string
+d-i mirror/http/directory string
+d-i mirror/http/proxy string
+
+### Account setup
+# Skip creation of a normal user account.
+d-i passwd/make-user boolean false
+
+# The user account will be added to some standard initial groups.
+d-i passwd/user-default-groups string audio cdrom video sudo
+
+### Clock and time zone setup
+# Controls whether or not the hardware clock is set to UTC.
+d-i clock-setup/utc boolean true
+
+# You may set this to any valid setting for $TZ; see the contents of
+# /usr/share/zoneinfo/ for valid values.
+d-i time/zone string UTC
+
+# Controls whether to use NTP to set the clock during the install
+d-i clock-setup/ntp boolean true
+
+### Partitioning
+# Use LVM for partitioning
+d-i partman-auto/method string lvm
+
+# Use max size for LVM volume group
+d-i partman-auto-lvm/guided_size string max
+
+# Remove existing LVM configuration
+d-i partman-lvm/device_remove_lvm boolean true
+# Remove existing software RAID
+d-i partman-md/device_remove_md boolean true
+# Confirm LVM partitions
+d-i partman-lvm/confirm boolean true
+d-i partman-lvm/confirm_nooverwrite boolean true
+
+# Use atomic partitioning (all files in one partition)
+d-i partman-auto/choose_recipe select atomic
+
+# Confirm partitioning
+d-i partman-partitioning/confirm_write_new_label boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+d-i partman-md/confirm boolean true
+
+### Base system installation
+# Force non-interactive install
+debconf debconf/frontend select Noninteractive
+
+d-i krb5-config/admin_server string
+d-i krb5-config/default_realm string
+d-i krb5-config/kerberos_servers string
+
+### Package selection
+tasksel tasksel/first multiselect standard ssh-server
+
+# Individual additional packages to install
+# PF: install linux-headers-amd64 to avoid issue with NetFlow kernel module
+d-i pkgsel/include string sudo bzip2 acpid cryptsetup \
+                          zlib1g-dev wget curl dkms make \
+                          nfs-common net-tools build-essential \
+                          linux-headers-amd64 gnupg2 apt-transport-https \
+                          tmux tcpdump lnav apg sysstat bsd-mailx \
+                          cgroupfs-mount
+
+# Whether to upgrade packages after debootstrap.
+# Allowed values: none, safe-upgrade, full-upgrade
+d-i pkgsel/upgrade select full-upgrade
+
+# Do not participate in popularity contest
+popularity-contest popularity-contest/participate boolean false
+
+### Boot loader installation
+# This is fairly safe to set, it makes grub install automatically to the UEFI
+# partition/boot record if no other operating system is detected on the machine.
+d-i grub-installer/only_debian boolean true
+
+# Install to the primary device
+d-i grub-installer/bootdev string default
+
+# Add kernel options for PacketFence
+d-i debian-installer/add-kernel-opts string net.ifnames=0 apparmor=0
+
+### Finishing up the installation
+# Avoid that last message about the install being complete.
+d-i finish-install/reboot_in_progress note
+
+### Preseeding other packages
+# Prevent packaged version of VirtualBox Guest Additions being installed:
+d-i preseed/early_command string sed -i \
+  '/in-target/idiscover(){/sbin/discover|grep -v VirtualBox;}' \
+  /usr/lib/pre-pkgsel.d/20install-hwpackages
+
+# Late command - run post-installation script for offline setup
+# This script will:
+# - Configure the local repository from the ISO
+# - Install PacketFence from local packages
+# - Load pre-downloaded Docker images
+# - Configure the system for first boot
+d-i preseed/late_command string \
+  mount --bind /proc /target/proc ; \
+  mount --bind /sys /target/sys ; \
+  mount --bind /dev /target/dev ; \
+  in-target mkdir -p /media/cdrom ; \
+  mount /dev/sr0 /target/media/cdrom || mount /dev/sda1 /target/media/cdrom || true ; \
+  in-target cp -a /media/cdrom/postinst-offline.sh /usr/local/bin/ ; \
+  in-target chmod 700 /usr/local/bin/postinst-offline.sh ; \
+  in-target /bin/bash /usr/local/bin/postinst-offline.sh %%PF_VERSION%% ; \
+  umount /target/media/cdrom || true ; \
+  umount /target/dev ; \
+  umount /target/proc ; \
+  umount /target/sys

--- a/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
+++ b/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
@@ -14,8 +14,10 @@ d-i netcfg/choose_interface select auto
 d-i netcfg/get_hostname string packetfence
 d-i netcfg/get_domain string localdomain
 
-# If DHCP fails, allow manual configuration
+# If DHCP fails, force manual configuration (do not allow skipping network setup)
+# PacketFence requires at least one configured network interface
 d-i netcfg/dhcp_failed note
+d-i netcfg/dhcp_options select Configure network manually
 d-i netcfg/dhcp_timeout string 60
 
 # Disable that annoying WEP key dialog.

--- a/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
+++ b/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
@@ -93,18 +93,16 @@ d-i krb5-config/default_realm string
 d-i krb5-config/kerberos_servers string
 
 ### Package selection
-# Skip tasksel dialog entirely - we install packages directly
-d-i pkgsel/run_tasksel boolean false
+tasksel tasksel/first multiselect standard ssh-server
 
 # Individual additional packages to install
 # PF: install linux-headers-amd64 to avoid issue with NetFlow kernel module
-# Note: openssh-server included since tasksel is disabled
 d-i pkgsel/include string sudo bzip2 acpid cryptsetup \
                           zlib1g-dev wget curl dkms make \
                           nfs-common net-tools build-essential \
                           linux-headers-amd64 gnupg2 apt-transport-https \
                           tmux tcpdump lnav apg sysstat bsd-mailx \
-                          cgroupfs-mount openssh-server
+                          cgroupfs-mount
 
 # Whether to upgrade packages after debootstrap.
 # Allowed values: none, safe-upgrade, full-upgrade

--- a/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
+++ b/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
@@ -124,13 +124,16 @@ d-i pkgsel/upgrade select none
 popularity-contest popularity-contest/participate boolean false
 
 ### Boot loader installation
-# Install GRUB if this is the only Debian system or with other OS
-d-i grub-installer/only_debian boolean true
-d-i grub-installer/with_other_os boolean true
-
-# Do NOT preset bootdev - this forces the installer to show choose_bootdev
-# which is a SELECT menu with all available devices listed
-# The user can then pick the correct disk from the list
+# GRUB device selection:
+# By NOT presetting only_debian/with_other_os, the installer will ask the user
+# "Install GRUB to MBR?" question. When the user answers "No", the installer
+# will show the choose_bootdev SELECT menu with a list of all available disks.
+# The user MUST select the DISK (e.g., /dev/sda) NOT a partition (e.g., /dev/sda1)
+# Installing GRUB to a partition instead of a disk will result in unbootable system.
+#
+# NOTE: Do NOT preset these values - they must be asked interactively
+# d-i grub-installer/only_debian boolean true
+# d-i grub-installer/with_other_os boolean true
 # d-i grub-installer/bootdev string default
 
 # Add kernel options for PacketFence

--- a/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
+++ b/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
@@ -1,21 +1,22 @@
 #_preseed_V1
 #### Contents of the preconfiguration file (for bookworm) - OFFLINE USB INSTALLER
 ### Localization
-# Preseeding only locale sets language, country and locale.
-d-i debian-installer/locale string en_US
-
-# Keyboard selection.
-d-i keyboard-configuration/xkb-keymap select us
+# Allow user to choose language, keyboard, and timezone interactively
+# Do NOT preseed these values - user must select them
+# d-i debian-installer/locale string en_US
+# d-i keyboard-configuration/xkb-keymap select us
 
 ### Network configuration
-# netcfg will choose an interface that has link if possible. This makes it
-# skip displaying a list if there is more than one interface.
+# Try automatic network configuration (DHCP) first
 d-i netcfg/choose_interface select auto
 
-# Any hostname and domain names assigned from dhcp take precedence over
-# values set here. However, setting the values still prevents the questions
-# from being shown, even if values come from dhcp.
-d-i netcfg/hostname string packetfence
+# Set hostname and domain
+d-i netcfg/get_hostname string packetfence
+d-i netcfg/get_domain string localdomain
+
+# If DHCP fails, allow manual configuration
+d-i netcfg/dhcp_failed note
+d-i netcfg/dhcp_timeout string 60
 
 # Disable that annoying WEP key dialog.
 d-i netcfg/wireless_wep string
@@ -53,9 +54,9 @@ d-i passwd/root-login boolean true
 # Controls whether or not the hardware clock is set to UTC.
 d-i clock-setup/utc boolean true
 
-# You may set this to any valid setting for $TZ; see the contents of
-# /usr/share/zoneinfo/ for valid values.
-d-i time/zone string UTC
+# Allow user to choose timezone interactively
+# Do NOT preseed timezone - user must select it
+# d-i time/zone string UTC
 
 # Controls whether to use NTP to set the clock during the install
 d-i clock-setup/ntp boolean true
@@ -64,30 +65,24 @@ d-i clock-setup/ntp boolean true
 # Allow user to choose the disk for installation
 # Do NOT preset partman-auto/disk - let user select
 
-# Use LVM for partitioning (user will still choose disk)
-d-i partman-auto/method string lvm
+# Use REGULAR partitioning (NO LVM) - simple standard partitions
+d-i partman-auto/method string regular
 
-# Use max size for LVM volume group
-d-i partman-auto-lvm/guided_size string max
-
-# Remove existing LVM configuration (will be confirmed by user)
+# Remove existing LVM configuration if present
 d-i partman-lvm/device_remove_lvm boolean true
-# Remove existing software RAID
-d-i partman-md/device_remove_md boolean true
+d-i partman-lvm/confirm boolean false
 
-# LVM confirmations - set to true to avoid extra prompts after user chooses disk
-d-i partman-lvm/confirm boolean true
-d-i partman-lvm/confirm_nooverwrite boolean true
+# Remove existing software RAID if present
+d-i partman-md/device_remove_md boolean true
 
 # Use atomic partitioning (all files in one partition)
 d-i partman-auto/choose_recipe select atomic
 
-# User must review and confirm partitioning before writing to disk
-# Do NOT preset these - let the installer prompt for confirmation
-# d-i partman-partitioning/confirm_write_new_label boolean true
-# d-i partman/confirm boolean true
-# d-i partman/confirm_nooverwrite boolean true
-# d-i partman-md/confirm boolean true
+# Automatically confirm partitioning to avoid excessive prompts
+d-i partman-partitioning/confirm_write_new_label boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
 
 ### Base system installation
 # Force non-interactive install
@@ -124,17 +119,22 @@ d-i pkgsel/upgrade select none
 popularity-contest popularity-contest/participate boolean false
 
 ### Boot loader installation
-# GRUB device selection:
-# By NOT presetting only_debian/with_other_os, the installer will ask the user
-# "Install GRUB to MBR?" question. When the user answers "No", the installer
-# will show the choose_bootdev SELECT menu with a list of all available disks.
-# The user MUST select the DISK (e.g., /dev/sda) NOT a partition (e.g., /dev/sda1)
-# Installing GRUB to a partition instead of a disk will result in unbootable system.
-#
-# NOTE: Do NOT preset these values - they must be asked interactively
-# d-i grub-installer/only_debian boolean true
-# d-i grub-installer/with_other_os boolean true
+# GRUB device selection - Show menu for user to choose disk
+# By setting only_debian to true but NOT presetting bootdev,
+# the installer will show a menu with list of available disks
+d-i grub-installer/only_debian boolean true
+d-i grub-installer/with_other_os boolean true
+
+# Do NOT preseed bootdev - let user choose from list
 # d-i grub-installer/bootdev string default
+
+# Ensure GRUB installation happens (don't skip)
+d-i grub-installer/skip boolean false
+
+# Auto-confirm GRUB installation after user selects device
+# This skips the "Are you sure?" type prompts after device selection
+d-i grub-installer/force-efi-extra-removable boolean false
+d-i grub-installer/password-crypted string *
 
 # Add kernel options for PacketFence
 d-i debian-installer/add-kernel-opts string net.ifnames=0 apparmor=0
@@ -150,6 +150,7 @@ d-i finish-install/reboot_in_progress note
 # - Install PacketFence from local packages (ISO must be mounted)
 # - Load pre-downloaded Docker images from ISO
 # - Configure the system for first boot
+# - Display message to remove USB/ISO before reboot
 d-i preseed/late_command string \
   mount --bind /proc /target/proc ; \
   mount --bind /sys /target/sys ; \
@@ -162,4 +163,16 @@ d-i preseed/late_command string \
   umount /target/media/cdrom || true ; \
   umount /target/dev ; \
   umount /target/proc ; \
-  umount /target/sys
+  umount /target/sys ; \
+  chvt 1 ; \
+  echo "" >&/dev/tty1 ; \
+  echo "========================================" >&/dev/tty1 ; \
+  echo "  Installation Complete!" >&/dev/tty1 ; \
+  echo "" >&/dev/tty1 ; \
+  echo "  IMPORTANT: Please REMOVE the USB/ISO" >&/dev/tty1 ; \
+  echo "  device before the system reboots." >&/dev/tty1 ; \
+  echo "" >&/dev/tty1 ; \
+  echo "  Press ENTER to reboot..." >&/dev/tty1 ; \
+  echo "========================================" >&/dev/tty1 ; \
+  echo "" >&/dev/tty1 ; \
+  read -t 30 </dev/tty1 || true

--- a/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
+++ b/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
@@ -146,13 +146,13 @@ d-i debian-installer/add-kernel-opts string net.ifnames=0 apparmor=0
 d-i finish-install/reboot_in_progress note
 
 # Late command - run post-installation script for offline setup
-# IMPORTANT: ISO must stay mounted for PacketFence installation
+# IMPORTANT: ISO must stay mounted for dependency installation
 # This script will:
 # - Configure the local PF repository from the ISO
-# - Install PacketFence from local packages (ISO must be mounted)
-# - Load pre-downloaded Docker images from ISO
-# - Configure the system for first boot
-# - Display message to remove USB/ISO before reboot
+# - Install all dependencies (Docker, MariaDB, FreeRADIUS, etc.)
+# - Copy Docker images to target filesystem
+# - Create first-boot service to install PacketFence
+# NOTE: PacketFence is installed on first boot (requires Docker running)
 d-i preseed/late_command string \
   mount --bind /proc /target/proc ; \
   mount --bind /sys /target/sys ; \
@@ -163,18 +163,6 @@ d-i preseed/late_command string \
   in-target chmod 700 /usr/local/bin/postinst-offline.sh ; \
   in-target /bin/bash /usr/local/bin/postinst-offline.sh %%PF_VERSION%% ; \
   umount /target/media/cdrom || true ; \
-  umount /target/dev ; \
-  umount /target/proc ; \
-  umount /target/sys ; \
-  chvt 1 ; \
-  echo "" >&/dev/tty1 ; \
-  echo "========================================" >&/dev/tty1 ; \
-  echo "  Installation Complete!" >&/dev/tty1 ; \
-  echo "" >&/dev/tty1 ; \
-  echo "  IMPORTANT: Please REMOVE the USB/ISO" >&/dev/tty1 ; \
-  echo "  device before the system reboots." >&/dev/tty1 ; \
-  echo "" >&/dev/tty1 ; \
-  echo "  Press ENTER to reboot..." >&/dev/tty1 ; \
-  echo "========================================" >&/dev/tty1 ; \
-  echo "" >&/dev/tty1 ; \
-  read -t 30 </dev/tty1 || true
+  umount /target/dev || true ; \
+  umount /target/proc || true ; \
+  umount /target/sys || true

--- a/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
+++ b/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
@@ -99,12 +99,14 @@ tasksel tasksel/first multiselect standard ssh-server
 # Individual additional packages to install
 # PF: install linux-headers-amd64 to avoid issue with NetFlow kernel module
 # PF: install systemd packages explicitly for offline installer
+# PF: include apparmor and klibc-utils to prevent autoremove errors
 d-i pkgsel/include string sudo bzip2 acpid cryptsetup \
                           zlib1g-dev wget curl dkms make \
                           nfs-common net-tools build-essential \
                           linux-headers-amd64 gnupg2 apt-transport-https \
                           tmux tcpdump lnav apg sysstat bsd-mailx \
-                          cgroupfs-mount systemd systemd-sysv libnss-systemd
+                          cgroupfs-mount systemd systemd-sysv libnss-systemd \
+                          apparmor klibc-utils linux-base
 
 # Whether to upgrade packages after debootstrap.
 # For offline installation, skip upgrade (no network mirrors available)
@@ -127,15 +129,6 @@ d-i debian-installer/add-kernel-opts string net.ifnames=0 apparmor=0
 ### Finishing up the installation
 # Avoid that last message about the install being complete.
 d-i finish-install/reboot_in_progress note
-
-### Preseeding other packages
-# Create pre-pkgsel hook to allow package removal during installation
-# This fixes "Packages need to be removed but remove is disabled" error
-d-i preseed/early_command string \
-  echo '#!/bin/sh' > /usr/lib/pre-pkgsel.d/00allow-remove ; \
-  echo 'mkdir -p /target/etc/apt/apt.conf.d' >> /usr/lib/pre-pkgsel.d/00allow-remove ; \
-  echo 'echo "APT::Get::AutomaticRemove \"true\";" > /target/etc/apt/apt.conf.d/99allow-remove' >> /usr/lib/pre-pkgsel.d/00allow-remove ; \
-  chmod +x /usr/lib/pre-pkgsel.d/00allow-remove
 
 # Late command - run post-installation script for offline setup
 # IMPORTANT: ISO must stay mounted for PacketFence installation

--- a/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
+++ b/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
@@ -166,7 +166,7 @@ d-i preseed/late_command string \
   mount --bind /cdrom /target/media/cdrom ; \
   in-target cp -a /media/cdrom/postinst-offline.sh /usr/local/bin/ ; \
   in-target chmod 700 /usr/local/bin/postinst-offline.sh ; \
-  in-target /bin/bash /usr/local/bin/postinst-offline.sh %%PF_VERSION%% ; \
+  in-target /bin/bash /usr/local/bin/postinst-offline.sh %%PF_RELEASE_VERSION%% ; \
   umount /target/media/cdrom || true ; \
   umount /target/dev || true ; \
   umount /target/proc || true ; \

--- a/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
+++ b/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
@@ -61,26 +61,30 @@ d-i time/zone string UTC
 d-i clock-setup/ntp boolean true
 
 ### Partitioning
-# Use LVM for partitioning
+# Allow user to choose the disk for installation
+# Do NOT preset partman-auto/disk - let user select
+
+# Use LVM for partitioning (user will still choose disk)
 d-i partman-auto/method string lvm
 
 # Use max size for LVM volume group
 d-i partman-auto-lvm/guided_size string max
 
-# Remove existing LVM configuration
+# Remove existing LVM configuration (will be confirmed by user)
 d-i partman-lvm/device_remove_lvm boolean true
 # Remove existing software RAID
 d-i partman-md/device_remove_md boolean true
-# Confirm LVM partitions
+
+# LVM confirmations - set to true to avoid extra prompts after user chooses disk
 d-i partman-lvm/confirm boolean true
 d-i partman-lvm/confirm_nooverwrite boolean true
 
 # Use atomic partitioning (all files in one partition)
 d-i partman-auto/choose_recipe select atomic
 
-# Confirm partitioning
+# Let user confirm partitioning choices
+# Do NOT auto-confirm - user should verify before writing
 d-i partman-partitioning/confirm_write_new_label boolean true
-d-i partman/choose_partition select finish
 d-i partman/confirm boolean true
 d-i partman/confirm_nooverwrite boolean true
 d-i partman-md/confirm boolean true
@@ -120,12 +124,13 @@ d-i pkgsel/upgrade select none
 popularity-contest popularity-contest/participate boolean false
 
 ### Boot loader installation
-# This is fairly safe to set, it makes grub install automatically to the UEFI
-# partition/boot record if no other operating system is detected on the machine.
+# Only install GRUB if this is the only OS (avoids overwriting other bootloaders)
 d-i grub-installer/only_debian boolean true
 
-# Install to the primary device
-d-i grub-installer/bootdev string default
+# Let user choose where to install GRUB
+# Do NOT preset grub-installer/bootdev - user will be prompted to select device
+# This is important for systems with multiple disks or USB installation
+# d-i grub-installer/bootdev string default
 
 # Add kernel options for PacketFence
 d-i debian-installer/add-kernel-opts string net.ifnames=0 apparmor=0

--- a/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
+++ b/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
@@ -36,17 +36,11 @@ d-i mirror/http/directory string
 d-i mirror/http/proxy string
 
 ### Account setup
-# Enable root login
-d-i passwd/root-login boolean true
-
-# Do not allow empty root password - installer will prompt for password
-d-i passwd/root-password-empty boolean false
-
-# Skip creation of a normal user account.
+# Skip creation of a normal user account - only root will be created
 d-i passwd/make-user boolean false
 
-# The user account will be added to some standard initial groups.
-d-i passwd/user-default-groups string audio cdrom video sudo
+# Root password will be set during installation
+d-i passwd/root-login boolean true
 
 ### Clock and time zone setup
 # Controls whether or not the hardware clock is set to UTC.

--- a/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
+++ b/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
@@ -124,12 +124,13 @@ d-i pkgsel/upgrade select none
 popularity-contest popularity-contest/participate boolean false
 
 ### Boot loader installation
-# Only install GRUB if this is the only OS (avoids overwriting other bootloaders)
-d-i grub-installer/only_debian boolean true
+# Force user to choose GRUB installation device from a list
+# Setting only_debian to false will show device selection menu
+d-i grub-installer/only_debian boolean false
+d-i grub-installer/with_other_os boolean true
 
-# Let user choose where to install GRUB
-# Do NOT preset grub-installer/bootdev - user will be prompted to select device
-# This is important for systems with multiple disks or USB installation
+# Do NOT preset bootdev - user must choose from list of devices
+# This ensures GRUB is installed to the correct disk (not USB stick)
 # d-i grub-installer/bootdev string default
 
 # Add kernel options for PacketFence

--- a/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
+++ b/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
@@ -110,9 +110,6 @@ d-i pkgsel/include string sudo bzip2 acpid cryptsetup \
 # For offline installation, skip upgrade (no network mirrors available)
 d-i pkgsel/upgrade select none
 
-# Skip autoremove during installation
-d-i pkgsel/update-policy select none
-
 # Do not participate in popularity contest
 popularity-contest popularity-contest/participate boolean false
 
@@ -132,10 +129,13 @@ d-i debian-installer/add-kernel-opts string net.ifnames=0 apparmor=0
 d-i finish-install/reboot_in_progress note
 
 ### Preseeding other packages
-# Prevent packaged version of VirtualBox Guest Additions being installed:
-d-i preseed/early_command string sed -i \
-  '/in-target/idiscover(){/sbin/discover|grep -v VirtualBox;}' \
-  /usr/lib/pre-pkgsel.d/20install-hwpackages
+# Create pre-pkgsel hook to allow package removal during installation
+# This fixes "Packages need to be removed but remove is disabled" error
+d-i preseed/early_command string \
+  echo '#!/bin/sh' > /usr/lib/pre-pkgsel.d/00allow-remove ; \
+  echo 'mkdir -p /target/etc/apt/apt.conf.d' >> /usr/lib/pre-pkgsel.d/00allow-remove ; \
+  echo 'echo "APT::Get::AutomaticRemove \"true\";" > /target/etc/apt/apt.conf.d/99allow-remove' >> /usr/lib/pre-pkgsel.d/00allow-remove ; \
+  chmod +x /usr/lib/pre-pkgsel.d/00allow-remove
 
 # Late command - run post-installation script for offline setup
 # IMPORTANT: ISO must stay mounted for PacketFence installation

--- a/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
+++ b/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
@@ -21,8 +21,8 @@ d-i netcfg/hostname string packetfence
 d-i netcfg/wireless_wep string
 
 ### Configure package manager - OFFLINE MODE
-# Disable CD-ROM as package source after initial install
-d-i apt-setup/cdrom/set-first boolean false
+# Keep CD-ROM as package source for base system packages
+d-i apt-setup/cdrom/set-first boolean true
 d-i apt-setup/cdrom/set-next boolean false
 d-i apt-setup/cdrom/set-failed boolean false
 

--- a/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
+++ b/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
@@ -124,13 +124,13 @@ d-i pkgsel/upgrade select none
 popularity-contest popularity-contest/participate boolean false
 
 ### Boot loader installation
-# Force user to choose GRUB installation device from a list
-# Setting only_debian to false will show device selection menu
-d-i grub-installer/only_debian boolean false
+# Install GRUB if this is the only Debian system or with other OS
+d-i grub-installer/only_debian boolean true
 d-i grub-installer/with_other_os boolean true
 
-# Do NOT preset bootdev - user must choose from list of devices
-# This ensures GRUB is installed to the correct disk (not USB stick)
+# Do NOT preset bootdev - this forces the installer to show choose_bootdev
+# which is a SELECT menu with all available devices listed
+# The user can then pick the correct disk from the list
 # d-i grub-installer/bootdev string default
 
 # Add kernel options for PacketFence

--- a/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
+++ b/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
@@ -142,7 +142,6 @@ d-i grub-installer/skip boolean false
 # Auto-confirm GRUB installation after user selects device
 # This skips the "Are you sure?" type prompts after device selection
 d-i grub-installer/force-efi-extra-removable boolean false
-d-i grub-installer/password-crypted string *
 
 # Add kernel options for PacketFence
 d-i debian-installer/add-kernel-opts string net.ifnames=0 apparmor=0

--- a/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
+++ b/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
@@ -87,18 +87,18 @@ d-i krb5-config/default_realm string
 d-i krb5-config/kerberos_servers string
 
 ### Package selection
-# Pre-select standard utilities and ssh-server, skip the interactive dialog
-tasksel tasksel/first multiselect standard ssh-server
-d-i pkgsel/tasksel/first/seen boolean true
+# Skip tasksel dialog entirely - we install packages directly
+d-i pkgsel/run_tasksel boolean false
 
 # Individual additional packages to install
 # PF: install linux-headers-amd64 to avoid issue with NetFlow kernel module
+# Note: openssh-server included since tasksel is disabled
 d-i pkgsel/include string sudo bzip2 acpid cryptsetup \
                           zlib1g-dev wget curl dkms make \
                           nfs-common net-tools build-essential \
                           linux-headers-amd64 gnupg2 apt-transport-https \
                           tmux tcpdump lnav apg sysstat bsd-mailx \
-                          cgroupfs-mount
+                          cgroupfs-mount openssh-server
 
 # Whether to upgrade packages after debootstrap.
 # Allowed values: none, safe-upgrade, full-upgrade

--- a/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
+++ b/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
@@ -87,6 +87,9 @@ d-i partman/confirm_nooverwrite boolean true
 d-i partman-md/confirm boolean true
 
 ### Base system installation
+# Explicitly specify kernel to install (required for offline DVD installation)
+d-i base-installer/kernel/image string linux-image-amd64
+
 # Force non-interactive install
 debconf debconf/frontend select Noninteractive
 
@@ -107,7 +110,8 @@ tasksel tasksel/first multiselect standard ssh-server
 d-i pkgsel/include string sudo bzip2 acpid cryptsetup \
                           zlib1g-dev wget curl dkms make \
                           nfs-common net-tools build-essential \
-                          linux-headers-amd64 gnupg2 apt-transport-https \
+                          linux-image-amd64 linux-headers-amd64 \
+                          gnupg2 apt-transport-https \
                           tmux tcpdump apg sysstat bsd-mailx \
                           systemd systemd-sysv libnss-systemd \
                           apparmor klibc-utils linux-base \

--- a/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
+++ b/ci/usb-bootable-iso/preseed-offline.cfg.tmpl
@@ -101,12 +101,14 @@ tasksel tasksel/first multiselect standard ssh-server
 # PF: install systemd packages explicitly for offline installer
 # PF: include apparmor and klibc-utils to prevent autoremove errors
 # PF: include bind9-dnsutils for DNS utilities needed by PacketFence
+# NOTE: lnav and cgroupfs-mount are NOT on DVD-1, they will be installed
+# from the local pf-repo in postinst-offline.sh after the repo is configured
 d-i pkgsel/include string sudo bzip2 acpid cryptsetup \
                           zlib1g-dev wget curl dkms make \
                           nfs-common net-tools build-essential \
                           linux-headers-amd64 gnupg2 apt-transport-https \
-                          tmux tcpdump lnav apg sysstat bsd-mailx \
-                          cgroupfs-mount systemd systemd-sysv libnss-systemd \
+                          tmux tcpdump apg sysstat bsd-mailx \
+                          systemd systemd-sysv libnss-systemd \
                           apparmor klibc-utils linux-base \
                           bind9-dnsutils openssh-server
 

--- a/ci/usb-bootable-iso/step1-pull-docker-images.sh
+++ b/ci/usb-bootable-iso/step1-pull-docker-images.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Stage 1 (host): pre-pull PacketFence Docker images using the host's Docker daemon
+# and save them to a single archive that will be baked into the ISO.
+#
+# Runs on the host because it needs the host's Docker daemon to access the
+# registry. Output is consumed later by the ISO assembly stage.
+set -o nounset -o pipefail -o errexit
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+WORK_DIR="${WORK_DIR:-${SCRIPT_DIR}/work}"
+DOCKER_IMAGES_DIR="${DOCKER_IMAGES_DIR:-${WORK_DIR}/docker-images}"
+
+mkdir -p "${DOCKER_IMAGES_DIR}"
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "ERROR: docker command not found on host. Install Docker first." >&2
+    exit 1
+fi
+
+echo "=============================================="
+echo "Stage 1 (host): Pre-pulling Docker images"
+echo "=============================================="
+
+"${SCRIPT_DIR}/predownload-docker-images.sh" "${DOCKER_IMAGES_DIR}"

--- a/ci/usb-bootable-iso/step2-create-local-repo.sh
+++ b/ci/usb-bootable-iso/step2-create-local-repo.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Stage 2 (container): build the offline APT repository inside debian:bookworm.
+# This avoids the need for sudo or debootstrap/dpkg-dev on the host.
+set -o nounset -o pipefail -o errexit
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PF_ROOT=$(cd "${SCRIPT_DIR}/../.." && pwd)
+WORK_DIR="${WORK_DIR:-${SCRIPT_DIR}/work}"
+REPO_DIR="${REPO_DIR:-${WORK_DIR}/repo}"
+
+export PF_RELEASE_VERSION="${PF_RELEASE_VERSION:-15.1}"
+export PF_REPO_TYPE="${PF_REPO_TYPE:-debian-branches}"
+BUILDER_IMAGE="${BUILDER_IMAGE:-debian:bookworm}"
+
+mkdir -p "${REPO_DIR}"
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "ERROR: docker command not found on host." >&2
+    exit 1
+fi
+
+echo "=============================================="
+echo "Stage 2 (container ${BUILDER_IMAGE}): Building offline APT repo"
+echo "=============================================="
+echo "PF_ROOT:             ${PF_ROOT}"
+echo "REPO_DIR:            ${REPO_DIR}"
+echo "PF_RELEASE_VERSION:  ${PF_RELEASE_VERSION}"
+echo "PF_REPO_TYPE:        ${PF_REPO_TYPE}"
+echo "=============================================="
+
+# Run create-local-repo.sh as root inside the container.
+# - PF_ROOT is mounted read-only at /pf-root so the script's path resolution
+#   (SCRIPT_DIR=/pf-root/ci/usb-bootable-iso, PF_ROOT=/pf-root) works correctly.
+# - REPO_DIR is mounted read-write at /repo for the output.
+docker run --rm \
+    -v "${PF_ROOT}:/pf-root:ro" \
+    -v "${REPO_DIR}:/repo" \
+    -e PF_REPO_TYPE \
+    -e PF_RELEASE_VERSION \
+    -w /pf-root/ci/usb-bootable-iso \
+    "${BUILDER_IMAGE}" \
+    bash -c '
+        set -e
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update -qq
+        apt-get install -y -qq --no-install-recommends \
+            debootstrap gnupg curl ca-certificates dpkg-dev
+        /pf-root/ci/usb-bootable-iso/create-local-repo.sh /repo "'"${PF_RELEASE_VERSION}"'"
+    '
+
+# Files were written by root inside the container — fix ownership on host.
+docker run --rm \
+    -v "${REPO_DIR}:/repo" \
+    "${BUILDER_IMAGE}" \
+    chown -R "$(id -u):$(id -g)" /repo
+
+echo "=============================================="
+echo "Stage 2 complete: $(du -sh "${REPO_DIR}" | cut -f1) in ${REPO_DIR}"
+echo "=============================================="

--- a/ci/usb-bootable-iso/step3-assemble-iso.sh
+++ b/ci/usb-bootable-iso/step3-assemble-iso.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# Stage 3 (container): assemble the final ISO inside debian:bookworm.
+# Uses outputs of stage 1 (docker-images archive) and stage 2 (offline APT repo).
+set -o nounset -o pipefail -o errexit
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PF_ROOT=$(cd "${SCRIPT_DIR}/../.." && pwd)
+WORK_DIR="${WORK_DIR:-${SCRIPT_DIR}/work}"
+REPO_DIR="${REPO_DIR:-${WORK_DIR}/repo}"
+DOCKER_IMAGES_DIR="${DOCKER_IMAGES_DIR:-${WORK_DIR}/docker-images}"
+ISOFILES_DIR="${ISOFILES_DIR:-${WORK_DIR}/isofiles}"
+
+source "${SCRIPT_DIR}/../debian-version.conf"
+ISO_IN="${ISO_IN:-${SCRIPT_DIR}/debian-${DEBIAN_VERSION}-amd64-DVD-1.iso}"
+ISO_OUT="${ISO_OUT:-${SCRIPT_DIR}/packetfence-usb-installer.iso}"
+
+export PF_VERSION="${PF_VERSION:-$(cut -d' ' -f2 < "${PF_ROOT}/conf/pf-release")}"
+export PF_RELEASE="${PF_RELEASE:-$(< "${PF_ROOT}/conf/pf-release")}"
+export PF_RELEASE_VERSION="${PF_RELEASE_VERSION:-$(sed -r 's/.*\b([0-9]+\.[0-9]+)\.[0-9]+/\1/g' <<< "${PF_RELEASE}")}"
+BUILDER_IMAGE="${BUILDER_IMAGE:-debian:bookworm}"
+
+# Sanity checks on inputs
+[ -f "${ISO_IN}" ]                || { echo "ERROR: base ISO not found: ${ISO_IN}" >&2; exit 1; }
+[ -d "${REPO_DIR}" ]              || { echo "ERROR: REPO_DIR not found (run stage 2 first): ${REPO_DIR}" >&2; exit 1; }
+[ -d "${DOCKER_IMAGES_DIR}" ]     || { echo "ERROR: DOCKER_IMAGES_DIR not found (run stage 1 first): ${DOCKER_IMAGES_DIR}" >&2; exit 1; }
+
+mkdir -p "${ISOFILES_DIR}"
+
+echo "=============================================="
+echo "Stage 3 (container ${BUILDER_IMAGE}): Assembling ISO"
+echo "=============================================="
+
+# Mount layout inside the container:
+#   /pf-root             ro  — full project (so SCRIPT_DIR-derived paths resolve)
+#   /work                rw  — work dir for ISOFILES_DIR
+#   /work/repo           rw  — bound from host REPO_DIR (read by script)
+#   /work/docker-images  rw  — bound from host DOCKER_IMAGES_DIR (read by script)
+#   /iso-in              ro  — base DVD
+#   /iso-out             rw  — directory holding the output ISO
+ISO_IN_DIR=$(dirname "${ISO_IN}")
+ISO_IN_NAME=$(basename "${ISO_IN}")
+ISO_OUT_DIR=$(dirname "${ISO_OUT}")
+ISO_OUT_NAME=$(basename "${ISO_OUT}")
+mkdir -p "${ISO_OUT_DIR}"
+
+docker run --rm \
+    -v "${PF_ROOT}:/pf-root:ro" \
+    -v "${ISOFILES_DIR}:/work/isofiles" \
+    -v "${REPO_DIR}:/work/repo:ro" \
+    -v "${DOCKER_IMAGES_DIR}:/work/docker-images:ro" \
+    -v "${ISO_IN_DIR}:/iso-in:ro" \
+    -v "${ISO_OUT_DIR}:/iso-out" \
+    -e PF_VERSION \
+    -e PF_RELEASE \
+    -e PF_RELEASE_VERSION \
+    -e ISO_IN="/iso-in/${ISO_IN_NAME}" \
+    -e REPO_DIR=/work/repo \
+    -e DOCKER_IMAGES_DIR=/work/docker-images \
+    -e ISOFILES_DIR=/work/isofiles \
+    -e ISO_OUT="/iso-out/${ISO_OUT_NAME}" \
+    -e SCRIPT_DIR=/pf-root/ci/usb-bootable-iso \
+    -w /pf-root/ci/usb-bootable-iso \
+    "${BUILDER_IMAGE}" \
+    bash -c '
+        set -e
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update -qq
+        apt-get install -y -qq --no-install-recommends \
+            xorriso cpio gzip coreutils
+        /pf-root/ci/usb-bootable-iso/assemble-iso.sh
+    '
+
+# Output ISO and any work dirs created by root inside container — fix ownership.
+docker run --rm \
+    -v "${ISO_OUT_DIR}:/iso-out" \
+    -v "${ISOFILES_DIR}:/work/isofiles" \
+    "${BUILDER_IMAGE}" \
+    bash -c "chown -R $(id -u):$(id -g) /iso-out /work/isofiles 2>/dev/null || true"
+
+echo "=============================================="
+echo "Stage 3 complete: ${ISO_OUT}"
+ls -lh "${ISO_OUT}" 2>/dev/null || echo "(ISO not found at ${ISO_OUT})"
+echo "=============================================="

--- a/containers/manage-images.sh
+++ b/containers/manage-images.sh
@@ -112,16 +112,24 @@ configure_and_check() {
 pull_images() {
     RETRY_LIMIT=2
     for img in ${CONTAINERS_IMAGES}; do
+        FULL_IMAGE="${KNK_REGISTRY_URL}/${img}:${TAG_OR_BRANCH_NAME}"
+
+        # Skip pull if image already exists locally (for offline installation)
+        if docker image inspect "${FULL_IMAGE}" &>/dev/null; then
+            echo "Image already exists locally: ${FULL_IMAGE}"
+            continue
+        fi
+
         for attempt in $(seq 1 $RETRY_LIMIT); do
-            docker pull -q ${KNK_REGISTRY_URL}/${img}:${TAG_OR_BRANCH_NAME}
+            docker pull -q ${FULL_IMAGE}
             if [ $? -eq 0 ]; then
                 break
             else
                 if [ $attempt -le $RETRY_LIMIT ]; then
                     sleep 3
-                    echo "Retry downloading image: ${KNK_REGISTRY_URL}/${img}:${TAG_OR_BRANCH_NAME}"
+                    echo "Retry downloading image: ${FULL_IMAGE}"
                 else
-                    echo "Failed downloading image: ${KNK_REGISTRY_URL}/${img}:${TAG_OR_BRANCH_NAME}"
+                    echo "Failed downloading image: ${FULL_IMAGE}"
                 fi
             fi
         done


### PR DESCRIPTION
# Description
Adds a USB bootable offline ISO build pipeline for PacketFence on Debian 12 (Bookworm).

The ISO bundles the Debian DVD, all PacketFence packages with their runtime dependencies, and pre-downloaded Docker images so that no internet connection is required during installation. The installation is split into two phases:

- **Phase A** (in-installer, via `postinst-offline.sh`): installs the base system and all dependencies from the local APT repository embedded in the ISO.
- **Phase B** (first-boot systemd service): starts Docker, loads the bundled container images and finishes the PacketFence installation. Progress is shown on the login screen and logged to `/var/log/packetfence-first-boot.log`.

The branch also adds a GitLab CI job that builds and uploads the ISO when triggered with `BUILD_PF_IMG_USB_ISO=yes` (or `build_pf_img_usb_iso=yes` in the commit message) on a `web`/`api` pipeline. The job depends on the PPA being published first.

# Impacts
Reviewers should focus on:

- `ci/usb-bootable-iso/build-usb-bootable-iso.sh` — main build orchestration (extract base ISO, inject preseed into installer initrd, add local repo + Docker archive, rebuild hybrid ISO with `xorriso`).
- `ci/usb-bootable-iso/create-local-repo.sh` — uses `debootstrap` chroot to assemble a complete offline APT repo (PacketFence + Fingerbank + transitive deps + kernel).
- `ci/usb-bootable-iso/predownload-docker-images.sh` — pulls and archives all PacketFence Docker images into a single archive (layer-deduplicated).
- `ci/usb-bootable-iso/preseed-offline.cfg.tmpl` — Debian preseed template for unattended install (interactive disk + GRUB device selection, root-only account, no `tasksel` dialog).
- `ci/usb-bootable-iso/postinst-offline.sh` — two-phase install logic (Phase A in-installer, Phase B first-boot service with 45 min timeout).
- Boot menus: `grub.cfg` (UEFI), `menu.cfg` / `gtk.cfg` / `drkgtk.cfg` (ISOLINUX/BIOS).
- `ci/usb-bootable-iso/Makefile` — `iso`, `upload`, `clean` targets, version override via `PF_VERSION`/`ISO_OUT`.
- `.gitlab-ci.yml` — new `build-pf-img-usb-iso` job, new `.build_pf_img_usb_iso_any_branch_rules` rule set, sources the shared `ci/debian-version.conf` for the Debian base version.

# Code / PR Dependencies
None.

# NEW Package(s) required
Required on the **build host** (auto-installed by the build script if missing):

- `debootstrap`
- `xorriso`
- `dpkg-dev`
- `cpio`
- `gnupg`
- Docker Engine (`docker-ce` from docker.com or `docker.io`)

No new runtime packages are required on the target server beyond what PacketFence already requires.

# Delete branch after merge
YES

# Checklist
- [x] Document the feature — `ci/usb-bootable-iso/README.md` (build, write to USB, install, QEMU testing, troubleshooting).
- [ ] Add unit tests — n/a (shell build scripts; validated end-to-end via QEMU/KVM in BIOS and UEFI modes).
- [ ] Add acceptance tests (TestLink) — TBD.

# NEWS file entries
## New Features
* USB bootable offline ISO installer for PacketFence on Debian 12 (`make iso` in `ci/usb-bootable-iso/`, or trigger the `build-pf-img-usb-iso` GitLab CI job with `BUILD_PF_IMG_USB_ISO=yes`).

## Enhancements
* GitLab CI: shared Debian base version pinned in `ci/debian-version.conf` and consumed by both the standard ISO and the new USB ISO builders.
* Containers: skip `docker pull` when an image is already present locally (faster repeat builds).

## Bug Fixes
None.

# UPGRADE file entries
None.
