### PR TITLE
feat(ci): bump VirtualSwitch to 2.6.31 in venom tests and allow TEST_ONLY to trigger CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -617,8 +617,9 @@ variables:
           exit 1
         fi
         # Accept comma-separated list (e.g. auth,virtual) by translating to regex alternation
-        TEST_ONLY_PATTERN=$(printf '%s' "$TEST_ONLY" | tr ',' '|')
-        if echo "$CI_JOB_NAME" | grep -qE "$TEST_ONLY_PATTERN"; then
+        # Filter out empty items to prevent empty alternation (e.g., "mac_auth," -> "mac_auth|" matches everything)
+        TEST_ONLY_PATTERN=$(printf '%s' "$TEST_ONLY" | tr ',' '\n' | grep -v '^[[:space:]]*$' | tr '\n' '|' | sed 's/|$//')
+        if echo "$CI_JOB_NAME" | grep -qE -- "$TEST_ONLY_PATTERN"; then
           echo "Running: $CI_JOB_NAME matches TEST_ONLY pattern: $TEST_ONLY"
         else
           echo "Skipping: $CI_JOB_NAME does not match TEST_ONLY pattern: $TEST_ONLY"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -180,8 +180,8 @@ variables:
   rules:
     - if: '$PUBLISH_PPA == "yes" || $CI_COMMIT_MESSAGE =~ /publish_ppa=yes/'
     - if: '$CI_COMMIT_TAG'
-    - if: '($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ )'
-    - if: '$CI_PIPELINE_SOURCE == "schedule" && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ )'
+    - if: '($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ || $TEST_ONLY != "" )'
+    - if: '$CI_PIPELINE_SOURCE == "schedule" && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ || $TEST_ONLY != "" )'
     - if: '($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && ($BUILD_PF_IMG_DVD_USB_ISO == "yes" || $CI_COMMIT_MESSAGE =~ /build_pf_img_dvd_usb_iso=yes/)'
 
 # run jobs only when:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -195,11 +195,11 @@ variables:
     # NOTE: TEST_ONLY filtering is done in .test_script_job via shell script
     # because GitLab CI doesn't expand variables inside regex patterns
     # Run on devel branch (push, web, not schedule)
-    - if: '$CI_COMMIT_REF_NAME == "devel" && $CI_PIPELINE_SOURCE != "schedule" && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ )'
+    - if: '$CI_COMMIT_REF_NAME == "devel" && $CI_PIPELINE_SOURCE != "schedule" && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ || $TEST_ONLY != "" )'
     # Run on maintenance branches (web/api only)
-    - if: '$CI_COMMIT_REF_NAME =~ /^maintenance\/[[:digit:]]+\.[[:digit:]]+$/ && $CI_COMMIT_TAG == null && ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ )'
+    - if: '$CI_COMMIT_REF_NAME =~ /^maintenance\/[[:digit:]]+\.[[:digit:]]+$/ && $CI_COMMIT_TAG == null && ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ || $TEST_ONLY != "" )'
     # Run on devel/maintenance with schedule
-    - if: '( $CI_COMMIT_REF_NAME == "devel" || $CI_COMMIT_REF_NAME =~ /^maintenance\/[[:digit:]]+\.[[:digit:]]+$/) && $CI_PIPELINE_SOURCE == "schedule" && $CI_COMMIT_TAG == null && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ )'
+    - if: '( $CI_COMMIT_REF_NAME == "devel" || $CI_COMMIT_REF_NAME =~ /^maintenance\/[[:digit:]]+\.[[:digit:]]+$/) && $CI_PIPELINE_SOURCE == "schedule" && $CI_COMMIT_TAG == null && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ || $TEST_ONLY != "" )'
 
 # run jobs only when:
 # - on all branches (except maintenance/X.Y branches) (web) if variable TEST sets to yes or if CI_COMMIT_MESSAGE contains "test=yes".
@@ -209,8 +209,8 @@ variables:
   rules:
     # NOTE: TEST_ONLY filtering is done in .test_script_job via shell script
     # because GitLab CI doesn't expand variables inside regex patterns
-    - if: '$CI_COMMIT_REF_NAME != "devel" && $CI_COMMIT_REF_NAME !~ /^maintenance\/[[:digit:]]+\.[[:digit:]]+$/ && $CI_COMMIT_TAG == null && ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ )'
-    - if: '$CI_COMMIT_REF_NAME != "devel" && $CI_COMMIT_REF_NAME !~ /^maintenance\/[[:digit:]]+\.[[:digit:]]+$/ && $CI_COMMIT_TAG == null && $CI_PIPELINE_SOURCE == "schedule" && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ )'
+    - if: '$CI_COMMIT_REF_NAME != "devel" && $CI_COMMIT_REF_NAME !~ /^maintenance\/[[:digit:]]+\.[[:digit:]]+$/ && $CI_COMMIT_TAG == null && ($CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api") && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ || $TEST_ONLY != "" )'
+    - if: '$CI_COMMIT_REF_NAME != "devel" && $CI_COMMIT_REF_NAME !~ /^maintenance\/[[:digit:]]+\.[[:digit:]]+$/ && $CI_COMMIT_TAG == null && $CI_PIPELINE_SOURCE == "schedule" && ( $TEST == "yes" || $CI_COMMIT_MESSAGE =~ /test=yes/ || $TEST_ONLY != "" )'
 
 # run jobs only when:
 # - on all branches (maintenance/X.Y branches included) and devel with a schedule
@@ -616,7 +616,9 @@ variables:
           echo "Error: TEST_ONLY contains invalid characters (newline or single quote)."
           exit 1
         fi
-        if echo "$CI_JOB_NAME" | grep -qE "$TEST_ONLY"; then
+        # Accept comma-separated list (e.g. auth,virtual) by translating to regex alternation
+        TEST_ONLY_PATTERN=$(printf '%s' "$TEST_ONLY" | tr ',' '|')
+        if echo "$CI_JOB_NAME" | grep -qE "$TEST_ONLY_PATTERN"; then
           echo "Running: $CI_JOB_NAME matches TEST_ONLY pattern: $TEST_ONLY"
         else
           echo "Skipping: $CI_JOB_NAME does not match TEST_ONLY pattern: $TEST_ONLY"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -619,6 +619,11 @@ variables:
         # Accept comma-separated list (e.g. auth,virtual) by translating to regex alternation
         # Filter out empty items to prevent empty alternation (e.g., "mac_auth," -> "mac_auth|" matches everything)
         TEST_ONLY_PATTERN=$(printf '%s' "$TEST_ONLY" | tr ',' '\n' | grep -v '^[[:space:]]*$' | tr '\n' '|' | sed 's/|$//')
+        # Guard against empty pattern (e.g., TEST_ONLY="," or only whitespace) which would match everything
+        if [ -z "$TEST_ONLY_PATTERN" ]; then
+          echo "Error: TEST_ONLY contains no valid test names (only commas/whitespace)."
+          exit 1
+        fi
         if echo "$CI_JOB_NAME" | grep -qE -- "$TEST_ONLY_PATTERN"; then
           echo "Running: $CI_JOB_NAME matches TEST_ONLY pattern: $TEST_ONLY"
         else

--- a/t/venom/lib/virtualswitch/virtualswitch_config_deploy.yml
+++ b/t/venom/lib/virtualswitch/virtualswitch_config_deploy.yml
@@ -12,15 +12,13 @@ input:
   accounting_interval: "60"
   reauth_interval: "0"
   auth_retry_interval: "30"
-  coa_enabled: "true"
-  coa_port: "3799"
   # DHCP
   dhcp_enabled: "true"
   dhcp_server_ip: "10.255.255.1"
   # IPFIX
   ipfix_enabled: "false"
   ipfix_destination_ip: "10.255.255.1"
-  ipfix_destination_port: "2055"
+  ipfix_destination_port: "4739"
   ipfix_export_interval: "60"
   # SCEP
   scep_enabled: "false"
@@ -55,8 +53,6 @@ steps:
       accounting_interval_seconds: {{.input.accounting_interval}}
       reauth_interval_seconds: {{.input.reauth_interval}}
       auth_retry_interval_seconds: {{.input.auth_retry_interval}}
-      coa_enabled: {{.input.coa_enabled}}
-      coa_port: {{.input.coa_port}}
     dhcp:
       enabled: {{.input.dhcp_enabled}}
       server_ip: {{.input.dhcp_server_ip}}

--- a/t/venom/vars/all.yml
+++ b/t/venom/vars/all.yml
@@ -684,8 +684,8 @@ html.pfappserver_dir: '{{.pfserver_root_dir}}/t/html/pfappserver'
 #################################################################################
 # VirtualSwitch package download (requires authentication via GitLab env vars)
 # CI_VIRTUALSWITCH_USER and CI_VIRTUALSWITCH_PASSWORD must be set in GitLab CI/CD variables
-virtualswitch.package.deb_version: "2.6.12-1"
-virtualswitch.package.rpm_version: "2.6.12-1.el8"
+virtualswitch.package.deb_version: "2.6.31-1"
+virtualswitch.package.rpm_version: "2.6.31-1.el8"
 
 # VirtualSwitch network setup (created by virtualswitch-namespace service)
 # The namespace service creates: bridge vswitchbr, veth-host, veth-ns

--- a/t/venom/vars/all.yml
+++ b/t/venom/vars/all.yml
@@ -684,8 +684,8 @@ html.pfappserver_dir: '{{.pfserver_root_dir}}/t/html/pfappserver'
 #################################################################################
 # VirtualSwitch package download (requires authentication via GitLab env vars)
 # CI_VIRTUALSWITCH_USER and CI_VIRTUALSWITCH_PASSWORD must be set in GitLab CI/CD variables
-virtualswitch.package.deb_version: "2.6.5-1"
-virtualswitch.package.rpm_version: "2.6.5-1.el8"
+virtualswitch.package.deb_version: "2.6.12-1"
+virtualswitch.package.rpm_version: "2.6.12-1.el8"
 
 # VirtualSwitch network setup (created by virtualswitch-namespace service)
 # The namespace service creates: bridge vswitchbr, veth-host, veth-ns


### PR DESCRIPTION
# Description

Two improvements bundled together:

1. **VirtualSwitch 2.6.31 venom test alignment** — updates the VirtualSwitch package version in acceptance tests from `2.6.5-1` to `2.6.31-1`, removes `coa_enabled`/`coa_port` from the deploy config (no
longer part of 2.6.31's schema), and updates `ipfix_destination_port` from `2055` to `4739` (IANA-registered standard introduced in 2.6.11).

2. **`TEST_ONLY` now triggers CI without `test=yes`** — previously `TEST_ONLY=mac_auth` alone would not start any test jobs because the GitLab rules still required `TEST == "yes"` or `test=yes` in the
commit message. All test-related rules now accept `$TEST_ONLY != ""` as a standalone trigger. Also adds support for comma-separated patterns (e.g. `TEST_ONLY=mac_auth,virtualswitch`).

# Impacts

- **CI rules** (`.test_devel_and_maintenance_rules`, `.test_branches_only_rules`, `.publish_ppa_rules`): reviewer should verify the new `|| $TEST_ONLY != ""` conditions don't unintentionally trigger jobs
on scheduled pipelines or pushes without the variable set.
- **`.test_script_job` shell filter**: comma-to-pipe translation (`tr ',' '|'`) before the `grep -qE` — verify edge cases (single value, empty string, trailing comma).
- **Venom test vars**: `ipfix_destination_port` and removal of `coa_enabled`/`coa_port` in `virtualswitch_config_deploy.yml` and `all.yml`.

# Delete branch after merge
YES

# Checklist
- [n/a] Document the feature
- [n/a] Add OpenAPI specification
- [n/a] Add unit tests
- [yes] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* `TEST_ONLY` CI variable now triggers test jobs on its own — no need to also set `TEST=yes` or add `test=yes` to the commit message
* `TEST_ONLY` now accepts comma-separated patterns (e.g. `mac_auth,virtualswitch`)
* Align venom VirtualSwitch acceptance tests with VirtualSwitch 2.6.31 (package bump, config schema update, IANA-standard IPFIX port)