### PR TITLE
Fingerbank: save general settings via bulk_update endpoint

### DIFF
--- a/html/pfappserver/lib/pfappserver/Form/Config/FingerbankSetting.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/FingerbankSetting.pm
@@ -21,7 +21,7 @@ use pf::error qw(is_error);
 tie our %Doc_Config, 'pfconfig::cached_hash', 'config::FingerbankDoc';
 tie our %Defaults, 'pfconfig::cached_hash', 'config::FingerbankSettingsDefaults';
 
-has 'section' => ( is => 'ro' );
+has 'section' => ( is => 'rw' );
 
 my %FIELD_VALIDATORS = (
     'upstream.api_key' => sub {

--- a/html/pfappserver/root/src/views/Configuration/_composables/useViewResource.js
+++ b/html/pfappserver/root/src/views/Configuration/_composables/useViewResource.js
@@ -86,8 +86,9 @@ export const useViewResource = (resource, props, context) => {
   const onReset = () => init().then(() => isModified.value = false)
 
   const onSave = () => {
-    isModified.value = true
-    save()
+    save().then(() => {
+      isModified.value = true
+    }).catch(() => { /* errors surfaced via session.apiErrors + notifications */ })
   }
 
   watch(props, () => init(), { deep: true, immediate: true })

--- a/html/pfappserver/root/src/views/Configuration/fingerbank/generalSettings/_api.js
+++ b/html/pfappserver/root/src/views/Configuration/fingerbank/generalSettings/_api.js
@@ -17,6 +17,12 @@ export default {
       return response.data
     })
   },
+  fingerbankBulkUpdateGeneralSettings: (items, options = {}) => {
+    const patch = options.quiet ? 'patchQuiet' : 'patch'
+    return apiCall[patch](['config', 'fingerbank_settings', 'bulk_update'], { items }).then(response => {
+      return response.data
+    })
+  },
   fingerbankCollectorFlags: token => {
     return apiCall.get('fingerbank-collector/flags', { headers: { Authorization: `Token ${token}` } }).then(response => {
       return response.data

--- a/html/pfappserver/root/src/views/Configuration/fingerbank/generalSettings/_store.js
+++ b/html/pfappserver/root/src/views/Configuration/fingerbank/generalSettings/_store.js
@@ -77,12 +77,14 @@ export const actions = {
   },
   setGeneralSettings: ({ commit, dispatch }, data) => {
     commit('GENERAL_SETTINGS_REQUEST')
-    let promises = []
-    Object.keys(data).forEach(id => {
-      let refactored = { ...data[id], ...{ id } }
-      promises.push(api.fingerbankUpdateGeneralSetting(id, refactored))
-    })
-    return Promise.all(promises).then(response => {
+    const items = Object.keys(data).map(id => ({ ...data[id], id }))
+    return api.fingerbankBulkUpdateGeneralSettings(items).then(response => {
+      const failed = ((response && response.items) || []).find(item => item.status >= 300)
+      if (failed) {
+        const err = new Error(failed.message || `Failed to update '${failed.id}'`)
+        err.response = { data: { message: failed.message, errors: response.items } }
+        throw err
+      }
       commit('GENERAL_SETTINGS_REPLACED', data)
       return response
     }).catch(err => {

--- a/html/pfappserver/root/src/views/Configuration/fingerbank/generalSettings/_store.js
+++ b/html/pfappserver/root/src/views/Configuration/fingerbank/generalSettings/_store.js
@@ -79,20 +79,36 @@ export const actions = {
     commit('GENERAL_SETTINGS_REQUEST')
     const items = Object.keys(data).map(id => ({ ...data[id], id }))
     return api.fingerbankBulkUpdateGeneralSettings(items).then(response => {
-      const failed = ((response && response.items) || []).find(item => item.status >= 300)
-      if (failed) {
-        const err = new Error(failed.message || `Failed to update '${failed.id}'`)
-        err.response = { data: { message: failed.message, errors: response.items } }
+      const failedItems = ((response && response.items) || []).filter(item => item.status >= 300)
+      if (failedItems.length) {
+        const apiErrors = {}
+        failedItems.forEach(item => {
+          (item.errors || []).forEach(e => {
+            const key = `${item.id}.${e.field}`
+            apiErrors[key] = e.message
+            dispatch('notification/danger', { message: `${key}: ${e.message}` }, { root: true })
+          })
+          if (!item.errors || !item.errors.length) {
+            const message = item.message || `Failed to update '${item.id}'`
+            dispatch('notification/danger', { message }, { root: true })
+          }
+        })
+        if (Object.keys(apiErrors).length) {
+          commit('session/API_ERRORS', apiErrors, { root: true })
+        }
+        const summary = failedItems.map(i => i.message || `Failed to update '${i.id}'`).join('; ')
+        commit('GENERAL_SETTINGS_ERROR', { data: { message: summary } })
+        const err = new Error(summary)
+        err.response = { status: failedItems[0].status, data: { message: summary, errors: failedItems.flatMap(i => (i.errors || []).map(e => ({ ...e, field: `${i.id}.${e.field}` }))) } }
         throw err
       }
       commit('GENERAL_SETTINGS_REPLACED', data)
+      commit('ACCOUNT_INFO_RESET')
+      dispatch('getAccountInfo').catch(() => {})
       return response
     }).catch(err => {
       commit('GENERAL_SETTINGS_ERROR', err.response)
       throw err
-    }).finally(() => {
-      commit('ACCOUNT_INFO_RESET')
-      dispatch('getAccountInfo').catch(() => {})
     })
   }
 }


### PR DESCRIPTION
# Description
Replace the per-section PATCH loop with a single PATCH to
/api/v1/config/fingerbank_settings/bulk_update so all sections
(upstream, collector, query, proxy) are persisted in one request.
Surface per-item failures from the bulk response as a rejected promise
so form validation errors still bubble to the UI.

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)
