### PR TITLE
Reject empty or unparseable CA cert on save

### DIFF
--- a/html/pfappserver/root/src/views/Configuration/sslCertificates/schema.js
+++ b/html/pfappserver/root/src/views/Configuration/sslCertificates/schema.js
@@ -5,7 +5,9 @@ const schemaIntermediateCertificateAuthority = yup.string().nullable().required(
 
 const schemaIntermediateCertificateAuthorities = yup.array().of(schemaIntermediateCertificateAuthority)
 
-export const schema = () => {
+export const schema = (props = {}) => {
+  const { id } = props || {}
+  const isRadius = id === 'radius'
   return yup.object({
     lets_encrypt: yup.boolean(),
     common_name: yup.string()
@@ -27,7 +29,10 @@ export const schema = () => {
         otherwise: yup.string().nullable(),
       }),
     intermediate_cas: schemaIntermediateCertificateAuthorities.meta({ invalidFeedback: i18n.t('Intermediate CA certificates contain one or more errors.') }),
-    subject_alt_name: yup.array().of(yup.string())
+    subject_alt_name: yup.array().of(yup.string()),
+    ca: isRadius
+      ? yup.string().nullable().required(i18n.t('Certification Authority certificate(s) required.'))
+      : yup.string().nullable(),
   })
 }
 

--- a/lib/pf/UnifiedApi/Controller/Config/Certificates.pm
+++ b/lib/pf/UnifiedApi/Controller/Config/Certificates.pm
@@ -208,16 +208,6 @@ sub objects_from_payload {
             }
         }
 
-        if($data->{ca}) {
-            my @texts = split_pem($data->{ca});
-            my @x509s;
-            for my $t (@texts) {
-                my $x509 = pf::ssl::x509_from_string($t) or die "Failed to parse CA certificate\n";
-                push @x509s, $x509;
-            }
-            push @cas, @x509s;
-            $ca = \@x509s;
-        }
     };
     if($@) {
         my $msg = $@;
@@ -225,6 +215,40 @@ sub objects_from_payload {
         $self->log->error($msg);
         $self->render_error("500", $msg);
         return (undef);
+    }
+
+    my $ca_required = exists pf::ssl::certs_map()->{$self->stash->{certificate_id}}{ca_file};
+    my $ca_payload  = $data->{ca};
+    my $ca_present  = defined($ca_payload) && $ca_payload =~ /\S/;
+
+    if ($ca_required && !$ca_present) {
+        my $msg = "A Certification Authority certificate is required.";
+        $self->log->error($msg);
+        $self->render_error(422, $msg);
+        return (undef);
+    }
+
+    if ($ca_present) {
+        my @texts = split_pem($ca_payload);
+        if ($ca_required && !@texts) {
+            my $msg = "A Certification Authority certificate is required.";
+            $self->log->error($msg);
+            $self->render_error(422, $msg);
+            return (undef);
+        }
+        my @x509s;
+        for my $t (@texts) {
+            my $x509 = pf::ssl::x509_from_string($t);
+            unless ($x509) {
+                my $msg = "Failed to parse Certification Authority certificate.";
+                $self->log->error($msg);
+                $self->render_error(422, $msg);
+                return (undef);
+            }
+            push @x509s, $x509;
+        }
+        push @cas, @x509s;
+        $ca = \@x509s;
     }
 
     return ($cert, \@intermediate_cas, \@cas, $ca, $key);

--- a/t/unittest/UnifiedApi/Controller/Config/Certificates.t
+++ b/t/unittest/UnifiedApi/Controller/Config/Certificates.t
@@ -56,7 +56,7 @@ my ($fh, $filename) = Utils::tempfileForConfigStore("pf::ConfigStore::Pf");
 
 #insert known data
 #run tests
-use Test::More tests => 34;
+use Test::More tests => 43;
 use Test::Mojo;
 use Test::NoWarnings;
 
@@ -346,6 +346,21 @@ $t->put_ok("/api/v1/config/certificate/radius?check_chain=true" => json => { cer
 # Provide cert from another CA with the new CA
 $t->put_ok("/api/v1/config/certificate/radius" => json => { certificate => $new_radius_cert, private_key => $new_radius_key, ca => $new_radius_ca_cert })
   ->status_is(200);
+
+# Empty CA payload should be rejected
+$t->put_ok("/api/v1/config/certificate/radius" => json => { certificate => $new_radius_cert, private_key => $new_radius_key, ca => "" })
+  ->status_is(422)
+  ->json_is('/message', "A Certification Authority certificate is required.");
+
+# Missing CA key should be rejected
+$t->put_ok("/api/v1/config/certificate/radius" => json => { certificate => $new_radius_cert, private_key => $new_radius_key })
+  ->status_is(422)
+  ->json_is('/message', "A Certification Authority certificate is required.");
+
+# Unparseable CA payload should be rejected
+$t->put_ok("/api/v1/config/certificate/radius" => json => { certificate => $new_radius_cert, private_key => $new_radius_key, ca => "-----BEGIN CERTIFICATE-----\nnot a cert\n-----END CERTIFICATE-----\n" })
+  ->status_is(422)
+  ->json_is('/message', "Failed to parse Certification Authority certificate.");
 
 # test CSR with missing information
 $t->post_ok("/api/v1/config/certificate/radius/generate_csr" => json => {})


### PR DESCRIPTION
# Description
The /api/v1/config/certificate/{id} endpoint accepted an empty or unreadable Certification Authority payload for the radius certificate, which silently broke RADIUS EAP. Validate before installing: when the certs_map entry declares a ca_file, require a non-empty payload and fail with 422 if any PEM block does not parse as a valid x509 cert.


# Impacts
RADIUS Ca Cert

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Bug Fixes
* Prevent RADIUS Ca certificate to be removed 
