### PR TITLE
Fix/pfdhcp duplicated

### DIFF
--- a/go/cmd/pfdhcp/api.go
+++ b/go/cmd/pfdhcp/api.go
@@ -362,13 +362,9 @@ func decodeOptions(ctx context.Context, b string, db *sql.DB) (map[dhcp.OptionCo
 func extractMembers(v Network) ([]Node, []string, int) {
 	var Members []Node
 	var Macs []string
-	id, err := GlobalTransactionLock.Lock()
-	if err != nil {
-		log.LoggerWContext(context.Background()).Error("Failed to acquire transaction lock in extractMembers: " + err.Error())
-		return Members, Macs, 0
-	}
+	// hwcache.Items() returns a snapshot under the cache's own mutex; no
+	// outer lock needed.
 	members := v.dhcpHandler.hwcache.Items()
-	GlobalTransactionLock.Unlock(id)
 	var Count int
 	Count = 0
 	for i, item := range members {

--- a/go/cmd/pfdhcp/config.go
+++ b/go/cmd/pfdhcp/config.go
@@ -263,8 +263,20 @@ func (d *Interfaces) readConfig(ctx context.Context, MyDB *sql.DB) {
 
 							hwcache.OnEvicted(func(nic string, pool interface{}) {
 								go func() {
+									idx := uint64(pool.(int))
+									_, currentMac, err := DHCPScope.available.GetMACIndex(idx)
+									if err != nil {
+										return
+									}
+									// Only release the slot if the pool still has it
+									// bound to the evicted MAC. Skip when it has been
+									// reassigned (e.g. FakeMac cool-down, static
+									// binding, or another MAC took over).
+									if currentMac != nic {
+										return
+									}
 									log.LoggerWContext(ctx).Info(nic + " " + dhcp.IPAdd(DHCPScope.start, pool.(int)).String() + " Added back in the pool " + DHCPScope.role + " on index " + strconv.Itoa(pool.(int)))
-									DHCPScope.available.FreeIPIndex(uint64(pool.(int)))
+									DHCPScope.available.FreeIPIndex(idx)
 								}()
 							})
 
@@ -343,8 +355,20 @@ func (d *Interfaces) readConfig(ctx context.Context, MyDB *sql.DB) {
 
 						hwcache.OnEvicted(func(nic string, pool interface{}) {
 							go func() {
+								idx := uint64(pool.(int))
+								_, currentMac, err := DHCPScope.available.GetMACIndex(idx)
+								if err != nil {
+									return
+								}
+								// Only release the slot if the pool still has it
+								// bound to the evicted MAC. Skip when it has been
+								// reassigned (e.g. FakeMac cool-down, static
+								// binding, or another MAC took over).
+								if currentMac != nic {
+									return
+								}
 								log.LoggerWContext(ctx).Info(nic + " " + dhcp.IPAdd(DHCPScope.start, pool.(int)).String() + " Added back in the pool " + DHCPScope.role + " on index " + strconv.Itoa(pool.(int)))
-								DHCPScope.available.FreeIPIndex(uint64(pool.(int)))
+								DHCPScope.available.FreeIPIndex(idx)
 							}()
 						})
 

--- a/go/cmd/pfdhcp/main.go
+++ b/go/cmd/pfdhcp/main.go
@@ -31,7 +31,6 @@ import (
 	"github.com/inverse-inc/go-utils/log"
 	"github.com/inverse-inc/go-utils/sharedutils"
 	"github.com/inverse-inc/packetfence/go/pfconfigdriver"
-	"github.com/inverse-inc/packetfence/go/timedlock"
 	statsd "gopkg.in/alexcesaro/statsd.v2"
 )
 
@@ -67,7 +66,6 @@ var (
 	GlobalMacCache                *cache.Cache
 	GlobalFilterCache             *cache.Cache
 	GlobalTransactionCache        *cache.Cache
-	GlobalTransactionLock         *timedlock.RWLock
 	RequestGlobalTransactionCache *cache.Cache
 
 	// VIP management
@@ -93,7 +91,6 @@ func initializeCaches() {
 	GlobalIPCache = cache.New(ipCacheDuration, ipCacheCleanupInterval)
 	GlobalMacCache = cache.New(ipCacheDuration, ipCacheCleanupInterval)
 	GlobalTransactionCache = cache.New(ipCacheDuration, ipCacheCleanupInterval)
-	GlobalTransactionLock = timedlock.NewRWLock()
 	RequestGlobalTransactionCache = cache.New(ipCacheDuration, ipCacheCleanupInterval)
 	GlobalFilterCache = cache.New(2*time.Minute, 4*time.Minute)
 }
@@ -240,9 +237,10 @@ func (I *Interface) ServeDHCP(ctx context.Context, p dhcp.Packet, msgType dhcp.M
 		return answer
 	}
 
-	// Lock transaction to prevent duplicates
+	// Lock transaction to prevent duplicates. Dedup drops are a normal
+	// consequence of relay/client retransmissions, so log them at Debug.
 	if !I.lockTransaction(ctx, answer.MAC, msgType) {
-		log.LoggerWContext(ctx).Info(fmt.Sprintf(
+		log.LoggerWContext(ctx).Debug(fmt.Sprintf(
 			"Ignored DHCP request: MAC=%s giaddr=%s ciaddr=%s msgType=%s (transaction lock)",
 			answer.MAC.String(), p.GIAddr().String(), p.CIAddr().String(), msgType.String()))
 		return answer
@@ -432,20 +430,14 @@ func (I *Interface) handleRequest(ctx context.Context, p dhcp.Packet, handler DH
 					// Requested IP is equal to what we have in the cache ?
 
 					if dhcp.IPAdd(handler.start, index.(int)).Equal(reqIP) {
-						id, err := GlobalTransactionLock.Lock()
-						if err != nil {
-							log.LoggerWContext(ctx).Error("Failed to acquire transaction lock: " + err.Error())
-							Reply = false
-							return answer
-						}
-						if _, found = RequestGlobalTransactionCache.Get(cacheKey); found {
+						// Per-transaction dedup. cache.Add atomically inserts only
+						// if no entry exists (or the existing one has expired), so
+						// duplicate REQUESTs with the same xID inside 1s are dropped.
+						if err := RequestGlobalTransactionCache.Add(cacheKey, 1, time.Duration(1)*time.Second); err != nil {
 							log.LoggerWContext(ctx).Debug("Not answering to REQUEST. Already processed" + " mac=" + clientMac)
-							GlobalTransactionLock.Unlock(id)
 							Reply = false
 							return answer
 						}
-						RequestGlobalTransactionCache.Set(cacheKey, 1, time.Duration(1)*time.Second)
-						GlobalTransactionLock.Unlock(id)
 						Reply = true
 						Index = index.(int) // So remove the ip from the cache
 					} else {
@@ -787,21 +779,16 @@ reply:
 	return answer
 }
 
-// lockTransaction locks the transaction for a specific MAC address and message type
+// lockTransaction marks a (MAC, msgType) as in-progress so that retransmissions
+// arriving within the next second are silently deduped. Returns false if the
+// key is already present in the cache. cache.Add is atomic under the cache's
+// internal mutex, so no external locking is required.
 func (I *Interface) lockTransaction(ctx context.Context, mac net.HardwareAddr, msgType dhcp.MessageType) bool {
 	cacheKey := mac.String() + " " + msgType.String()
-	id, err := GlobalTransactionLock.Lock()
-	if err != nil {
-		log.LoggerWContext(ctx).Error("Failed to acquire transaction lock: " + err.Error())
-		return false
-	}
-	if _, found := GlobalTransactionCache.Get(cacheKey); found {
+	if err := GlobalTransactionCache.Add(cacheKey, 3, time.Duration(1)*time.Second); err != nil {
 		log.LoggerWContext(ctx).Debug("Not answering to packet. Already in progress")
-		GlobalTransactionLock.Unlock(id)
 		return false
 	}
-	GlobalTransactionCache.Set(cacheKey, 3, time.Duration(1)*time.Second)
-	GlobalTransactionLock.Unlock(id)
 	return true
 }
 

--- a/go/cmd/pfdhcp/main.go
+++ b/go/cmd/pfdhcp/main.go
@@ -294,7 +294,9 @@ func (I *Interface) handleDecline(ctx context.Context, p dhcp.Packet, handler DH
 					handler.hwcache.Delete(answer.MAC.String())
 					// Assign the fakemac to reserve the ip
 					handler.available.FreeIPIndex(uint64(leaseNum))
-					handler.available.ReserveIPIndex(uint64(leaseNum), FakeMac)
+					if _, err := handler.available.ReserveIPIndex(uint64(leaseNum), FakeMac); err != nil {
+						log.LoggerWContext(ctx).Warn("handleDecline: cannot reserve declined IP " + reqIP.String() + " as FakeMac: " + err.Error() + " mac=" + clientMac)
+					}
 					// Put it back into the available IPs in 30 seconds
 					go func(leaseNum int, reqIP net.IP) {
 						// Use a timer that can be interrupted by context cancellation
@@ -350,7 +352,9 @@ func (I *Interface) handleRelease(ctx context.Context, p dhcp.Packet, handler DH
 					handler.hwcache.Delete(answer.MAC.String())
 					// Assign the fakemac to reserve the ip
 					handler.available.FreeIPIndex(uint64(leaseNum))
-					handler.available.ReserveIPIndex(uint64(leaseNum), FakeMac)
+					if _, err := handler.available.ReserveIPIndex(uint64(leaseNum), FakeMac); err != nil {
+						log.LoggerWContext(ctx).Warn("handleRelease: cannot reserve released IP " + reqIP.String() + " as FakeMac: " + err.Error() + " mac=" + clientMac)
+					}
 					// Put it back into the available IPs in 30 seconds
 					go func(leaseNum int, reqIP net.IP) {
 						// Use a timer that can be interrupted by context cancellation
@@ -492,6 +496,19 @@ func (I *Interface) handleRequest(ctx context.Context, p dhcp.Packet, handler DH
 				answer.D = dhcp.ReplyPacket(p, dhcp.NAK, setOptionServerIdentifier(srvIP, handler.ip).To4(), nil, 0, nil)
 				return answer
 			}
+			// Re-assert the pool reservation before ACKing. If the pool says this
+			// index is held by a *different* MAC, our hwcache and the pool have
+			// diverged and we must NOT ACK an IP we don't actually own in the pool.
+			if _, err := handler.available.ReserveIPIndex(uint64(Index), answer.MAC.String()); err != nil {
+				_, currentMac, _ := handler.available.GetMACIndex(uint64(Index))
+				if currentMac != FreeMac && currentMac != answer.MAC.String() {
+					log.LoggerWContext(ctx).Warn("handleRequest: pool/cache divergence — " + reqIP.String() + " is held in pool by " + currentMac + ", not " + answer.MAC.String() + "; sending NAK mac=" + clientMac)
+					handler.hwcache.Delete(answer.MAC.String())
+					answer.D = dhcp.ReplyPacket(p, dhcp.NAK, setOptionServerIdentifier(srvIP, handler.ip).To4(), nil, 0, nil)
+					return answer
+				}
+			}
+
 			answer.D = dhcp.ReplyPacket(p, dhcp.ACK, setOptionServerIdentifier(srvIP, handler.ip).To4(), reqIP, leaseDuration,
 				GlobalOptions.SelectOrderOrAll(options[dhcp.OptionParameterRequestList]))
 			var cacheDuration time.Duration
@@ -511,7 +528,6 @@ func (I *Interface) handleRequest(ctx context.Context, p dhcp.Packet, handler DH
 			log.LoggerWContext(ctx).Info("DHCPACK on " + reqIP.String() + " to " + clientMac + " (" + clientHostname + ")" + " mac=" + clientMac)
 
 			handler.hwcache.Set(answer.MAC.String(), Index, cacheDuration)
-			handler.available.ReserveIPIndex(uint64(Index), answer.MAC.String())
 
 		} else {
 			log.LoggerWContext(ctx).Info("DHCPNAK on " + reqIP.String() + " to " + clientMac + " mac=" + clientMac)
@@ -658,14 +674,24 @@ retry:
 			// Found in the arp cache or able to ping it
 			ipaddr := dhcp.IPAdd(handler.start, free)
 			log.LoggerWContext(ctx).Info(answer.MAC.String() + " Ip " + ipaddr.String() + " already in use, trying next" + " mac=" + clientMac)
-			// Added back in the pool since it's not the dhcp server who gave it
-			handler.hwcache.Delete(answer.MAC.String())
 
 			firstTry = false
 
 			log.LoggerWContext(ctx).Info("Temporarily declaring " + ipaddr.String() + " as unusable" + " mac=" + clientMac)
-			// Reserve with a fake mac
-			handler.available.ReserveIPIndex(uint64(free), FakeMac)
+			// Swap the pool reservation from the requesting MAC to FakeMac so the
+			// 10-minute cool-down actually keeps the IP out of rotation. We must
+			// free then re-reserve because GetFreeIPIndex already bound the slot
+			// to answer.MAC. The hwcache eviction below is now safe because the
+			// OnEvicted callback (config.go) checks that pool.mac[index] still
+			// matches the evicted MAC before freeing.
+			if err := handler.available.FreeIPIndex(uint64(free)); err != nil {
+				log.LoggerWContext(ctx).Warn("handleDiscover: cannot free pingable IP " + ipaddr.String() + ": " + err.Error() + " mac=" + clientMac)
+			}
+			if _, err := handler.available.ReserveIPIndex(uint64(free), FakeMac); err != nil {
+				log.LoggerWContext(ctx).Warn("handleDiscover: cannot reserve pingable IP " + ipaddr.String() + " as FakeMac: " + err.Error() + " mac=" + clientMac)
+			}
+			// Added back in the pool since it's not the dhcp server who gave it
+			handler.hwcache.Delete(answer.MAC.String())
 			// Put it back into the available IPs in 10 minutes
 			go func(free int, ipaddr net.IP) {
 				// Use a timer that can be interrupted by context cancellation

--- a/go/cmd/pfdhcp/main.go
+++ b/go/cmd/pfdhcp/main.go
@@ -716,7 +716,7 @@ retry:
 		handler.hwcache.Set(answer.MAC.String(), free, time.Duration(5)*time.Second)
 		handler.xid.Replace(sharedutils.ByteToString(p.XId()), 1, time.Duration(5)*time.Second)
 	} else {
-		log.LoggerWContext(ctx).Info(answer.MAC.String() + " Nak No space left in the pool " + " mac=" + clientMac)
+		log.LoggerWContext(ctx).Info(answer.MAC.String() + " No space left in the pool, not offering (RFC 2131: silent on DISCOVER)" + " mac=" + clientMac)
 		return answer
 	}
 

--- a/go/cmd/pfdhcp/main.go
+++ b/go/cmd/pfdhcp/main.go
@@ -943,10 +943,22 @@ func initStatsD(ctx context.Context) {
 	}
 }
 
-// initializeWorkerPool creates a worker pool for processing DHCP requests
+// initializeWorkerPool creates a worker pool for processing DHCP requests.
+// Sizes are tunable at runtime via PFDHCP_WORKERS and PFDHCP_QUEUE — the
+// defaults below are increased from the historical 100/100 because the
+// kernel UDP receive buffer is normally the first bottleneck under burst,
+// and once it is enlarged the userspace queue + worker count have to keep
+// up to actually drain it.
 func initializeWorkerPool(db *sql.DB) chan job {
-	maxQueueSize := 100
-	maxWorkers := 100
+	maxWorkers := sharedutils.EnvOrDefaultInt("PFDHCP_WORKERS", 300)
+	if maxWorkers < 1 {
+		maxWorkers = 1
+	}
+	maxQueueSize := sharedutils.EnvOrDefaultInt("PFDHCP_QUEUE", 1000)
+	if maxQueueSize < 1 {
+		maxQueueSize = 1
+	}
+	log.LoggerWContext(ctx).Info(fmt.Sprintf("pfdhcp worker pool: workers=%d queue=%d", maxWorkers, maxQueueSize))
 
 	// Create job channel
 	jobs := make(chan job, maxQueueSize)

--- a/go/cmd/pfdhcp/serverif.go
+++ b/go/cmd/pfdhcp/serverif.go
@@ -7,8 +7,38 @@ import (
 	"os"
 	"syscall"
 
+	"github.com/inverse-inc/go-utils/sharedutils"
 	"golang.org/x/net/ipv4"
 )
+
+// dhcpRcvBufBytes returns the SO_RCVBUF size to apply to every DHCP socket.
+// Default is 8 MiB. Override with PFDHCP_RCVBUF (bytes). Set to 0 to keep
+// the kernel default. Effective size is also clamped by net.core.rmem_max
+// unless SO_RCVBUFFORCE succeeds (requires CAP_NET_ADMIN).
+func dhcpRcvBufBytes() int {
+	return sharedutils.EnvOrDefaultInt("PFDHCP_RCVBUF", 8*1024*1024)
+}
+
+// tuneReceiveBuffer attempts to enlarge the UDP receive buffer. It tries
+// SO_RCVBUFFORCE first (bypasses rmem_max with CAP_NET_ADMIN), then falls
+// back to SO_RCVBUF. Failures are logged but never fatal — the socket can
+// still serve traffic at the kernel default size.
+func tuneReceiveBuffer(s int, label string) {
+	size := dhcpRcvBufBytes()
+	if size <= 0 {
+		return
+	}
+	if err := syscall.SetsockoptInt(s, syscall.SOL_SOCKET, syscall.SO_RCVBUFFORCE, size); err != nil {
+		if err2 := syscall.SetsockoptInt(s, syscall.SOL_SOCKET, syscall.SO_RCVBUF, size); err2 != nil {
+			log.Printf("pfdhcp: %s: failed to set SO_RCVBUF=%d: %s (force: %s)", label, size, err2, err)
+			return
+		}
+	}
+	actual, gerr := syscall.GetsockoptInt(s, syscall.SOL_SOCKET, syscall.SO_RCVBUF)
+	if gerr == nil && actual < size {
+		log.Printf("pfdhcp: %s: SO_RCVBUF requested %d but kernel set %d (raise net.core.rmem_max)", label, size, actual)
+	}
+}
 
 type serveIfConn struct {
 	ifIndex int
@@ -84,6 +114,7 @@ func broadcastOpen(bindAddr net.IP, port int, ifname string) (*ipv4.PacketConn, 
 	if err = syscall.SetsockoptString(s, syscall.SOL_SOCKET, syscall.SO_BINDTODEVICE, ifname); err != nil {
 		log.Fatal(err)
 	}
+	tuneReceiveBuffer(s, "broadcast "+ifname)
 
 	lsa := syscall.SockaddrInet4{Port: port}
 	copy(lsa.Addr[:], bindAddr.To4())
@@ -135,6 +166,7 @@ func UnicastOpen(interfaceNet *Interface) (*ipv4.PacketConn, error) {
 			log.Fatal(err)
 		}
 	}
+	tuneReceiveBuffer(s, "unicast "+interfaceNet.Name)
 	lsa := syscall.SockaddrInet4{Port: interfaceNet.listenPort}
 	copy(lsa.Addr[:], interfaceNet.Ipv4.To4())
 

--- a/go/cmd/pfdhcp/utils.go
+++ b/go/cmd/pfdhcp/utils.go
@@ -98,8 +98,14 @@ func initiaLease(ctx context.Context, dhcpHandler *DHCPHandler, ConfNet pfconfig
 
 			// Calculate the position for the roaring bitmap
 			position := uint32(binary.BigEndian.Uint32(ip4)) - uint32(binary.BigEndian.Uint32(dhcpHandler.start.To4()))
-			// Remove the position in the roaming bitmap
-			dhcpHandler.available.ReserveIPIndex(uint64(position), mac)
+			// Reserve the IP in the pool. If it's already held by another MAC (stale
+			// overlapping ip4log rows for the same IP), skip the cache writes so we
+			// don't end up with two hwcache entries pointing at the same pool slot.
+			// The losing MAC will re-DISCOVER and get a fresh free IP from the pool.
+			if _, err := dhcpHandler.available.ReserveIPIndex(uint64(position), mac); err != nil {
+				log.LoggerWContext(ctx).Warn(fmt.Sprintf("initiaLease: skipping stale lease for mac=%s ip=%s: %s", mac, ipstr, err.Error()))
+				continue
+			}
 			// Add the mac in the cache
 			dhcpHandler.hwcache.Set(mac, int(position), leaseDuration)
 			GlobalIPCache.Set(ipstr, mac, leaseDuration)
@@ -414,7 +420,9 @@ func ExcludeIP(dhcpHandler *DHCPHandler, ipRange string) []net.IP {
 			// Calculate the position for the dhcp pool
 			position := uint32(binary.BigEndian.Uint32(excludeIP4)) - uint32(binary.BigEndian.Uint32(dhcpHandler.start.To4()))
 
-			dhcpHandler.available.ReserveIPIndex(uint64(position), FakeMac)
+			if _, err := dhcpHandler.available.ReserveIPIndex(uint64(position), FakeMac); err != nil {
+				log.LoggerWContext(ctx).Warn(fmt.Sprintf("ExcludeIP: cannot reserve ip=%s as excluded: %s", excludeIP.String(), err.Error()))
+			}
 		}
 	}
 	return excludeIPs
@@ -442,8 +450,11 @@ func AssignIP(dhcpHandler *DHCPHandler, ipRange string) (map[string]uint32, []ne
 					continue
 				}
 				position := uint32(binary.BigEndian.Uint32(parsedIP4)) - uint32(binary.BigEndian.Uint32(dhcpHandler.start.To4()))
-				// Remove the position in the roaming bitmap
-				dhcpHandler.available.ReserveIPIndex(uint64(position), result[1])
+				// Reserve the static binding in the pool
+				if _, err := dhcpHandler.available.ReserveIPIndex(uint64(position), result[1]); err != nil {
+					log.LoggerWContext(ctx).Warn(fmt.Sprintf("AssignIP: cannot reserve static binding mac=%s ip=%s: %s", result[1], parsedIP.String(), err.Error()))
+					continue
+				}
 				couple[result[1]] = position
 				iplist = append(iplist, parsedIP)
 			}

--- a/go/dhcp/pool/memory.go
+++ b/go/dhcp/pool/memory.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"errors"
 	"math/rand"
-	"sort"
 	"strconv"
 	"sync"
 	"time"
@@ -192,23 +191,26 @@ func (dp *Memory) GetFreeIPIndex(mac string) (uint64, string, error) {
 	var available uint64
 
 	if dp.DHCPPool.algorithm == OldestReleased {
-		type kv struct {
-			Key   uint64
-			Value int64
-		}
-
-		var ss []kv
+		// Pick the free index with the oldest `released` timestamp. The
+		// `released` map holds an entry for every index (initialized at pool
+		// creation, refreshed on FreeIPIndex) and is NOT cleared on reserve,
+		// so it must be filtered by `free` before picking — otherwise we
+		// would hand out an IP that is currently reserved and silently
+		// overwrite its MAC binding.
+		var oldestSet bool
+		var oldestTime int64
 		for k, v := range dp.DHCPPool.released {
-			ss = append(ss, kv{k, v})
+			if _, isFree := dp.DHCPPool.free[k]; !isFree {
+				continue
+			}
+			if !oldestSet || v < oldestTime {
+				available = k
+				oldestTime = v
+				oldestSet = true
+			}
 		}
-
-		sort.Slice(ss, func(i, j int) bool {
-			return ss[i].Value < ss[j].Value
-		})
-
-		for _, kv := range ss {
-			available = kv.Key
-			break
+		if !oldestSet {
+			return 0, FreeMac, errors.New("DHCP pool is full")
 		}
 	} else {
 		index := rand.Intn(len(dp.DHCPPool.free))

--- a/go/dhcp/pool/pool_test.go
+++ b/go/dhcp/pool/pool_test.go
@@ -249,6 +249,63 @@ func TestCapacity(t *testing.T) {
 	}
 }
 
+// TestGetFreeIPIndexOldestReleased exercises the OldestReleased algorithm and
+// ensures it never returns an index that is still reserved by another MAC.
+// Previously the algorithm iterated `released` directly without filtering by
+// `free`, which could pick an already-reserved index and silently overwrite
+// its MAC binding.
+func TestGetFreeIPIndexOldestReleased(t *testing.T) {
+	cap := uint64(10)
+	dp, err := Create(ctx, "memory", cap, "PoolTestOldest", OldestReleased, StatsdClient, MySQLdatabase)
+	if err != nil {
+		t.Fatal("Got an error creating the pool", err)
+	}
+
+	macA := "00:11:22:33:44:01"
+	macB := "00:11:22:33:44:02"
+
+	// Reserve every index for macA.
+	for i := uint64(0); i < cap; i++ {
+		if _, err := dp.ReserveIPIndex(i, macA); err != nil {
+			t.Fatalf("ReserveIPIndex(%d) failed: %s", i, err)
+		}
+	}
+
+	// Free one index — that's the only legitimate candidate for the next
+	// GetFreeIPIndex call regardless of how stale `released` looks.
+	if err := dp.FreeIPIndex(5); err != nil {
+		t.Fatalf("FreeIPIndex(5) failed: %s", err)
+	}
+
+	idx, _, err := dp.GetFreeIPIndex(macB)
+	if err != nil {
+		t.Fatalf("GetFreeIPIndex failed: %s", err)
+	}
+	if idx != 5 {
+		t.Fatalf("OldestReleased returned reserved index %d; expected 5 (the only free index)", idx)
+	}
+	if _, returnedMac, _ := dp.GetMACIndex(idx); returnedMac != macB {
+		t.Fatalf("Expected pool.mac[%d]=%s, got %s", idx, macB, returnedMac)
+	}
+
+	// macA must still own every other index — the algorithm must not have
+	// silently re-bound a reserved slot to macB.
+	for i := uint64(0); i < cap; i++ {
+		if i == 5 {
+			continue
+		}
+		_, m, _ := dp.GetMACIndex(i)
+		if m != macA {
+			t.Fatalf("Index %d expected to still be held by %s, got %s", i, macA, m)
+		}
+	}
+
+	// Pool should now be full.
+	if _, _, err := dp.GetFreeIPIndex(macB); err == nil {
+		t.Error("Expected pool-is-full error, got nil")
+	}
+}
+
 func IncrementMAC(mac net.HardwareAddr) net.HardwareAddr {
 	inc := make(net.HardwareAddr, len(mac))
 	copy(inc, mac)


### PR DESCRIPTION
# Description
Fixes the duplicated ip address provided from the pfdhcp pool

# Impacts
pfdhcp

# Issue
Fixes address duplication in the pfdhcp pool

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
## Bug Fixes
* Fixes address duplication in the pfdhcp pool
