### PR TITLE
Fix CoA timeouts when deauth is tunneled via pfconnector

### DIFF
--- a/lib/pf/Switch.pm
+++ b/lib/pf/Switch.pm
@@ -4188,8 +4188,16 @@ sub radius_deauth_connection_info {
         useConnector => $using_connector,
         nas_ip => $send_disconnect_to,
         secret => $self->{'_radiusSecret'},
-        LocalAddr => $self->deauth_source_ip($send_disconnect_to, $using_connector),
     };
+
+    # When tunneling via pfconnector, the actual UDP peer is a local connector
+    # endpoint (loopback/docker bridge) on a different interface than the route
+    # to the real NAS IP. Binding LocalAddr to the route-to-NAS interface causes
+    # the connected-UDP kernel filter to drop the connector's reply. Let the
+    # kernel pick the source IP for the connector route instead.
+    unless ($using_connector) {
+        $connection_info->{LocalAddr} = $self->deauth_source_ip($send_disconnect_to, $using_connector);
+    }
 
     return $connection_info;
 }


### PR DESCRIPTION
# Description
deauth_source_ip resolves LocalAddr from the route to the real NAS IP, but perform_dynauth then rewrites the UDP peer to a local connector endpoint (loopback/docker bridge) on a different interface. With a connected UDP socket the kernel then drops the connector's reply, so CoA-Request times out at radius.pm line 178 even though the switch sent the ACK. Omit LocalAddr on the pfconnector path and let the kernel pick the source IP for the connector route; the direct path (needed for cluster source-IP selection) is unchanged.

# Impacts
CoA with the pfconnector

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Bug Fixes
* CoA can use the wrong source ip address when the pfconnector is in the loop.
