### PR TITLE
pfqueue: hash pfdhcplistener_external by client MAC (4 workers)

### DIFF
--- a/conf/pfqueue.conf.defaults
+++ b/conf/pfqueue.conf.defaults
@@ -70,15 +70,21 @@ workers=1
 #
 # pfdhcplistener_external queue configuration
 #
+# Hashed by client DHCP MAC: each MAC is pinned to one of `workers`
+# dedicated workers, so per-client packet ordering is preserved while
+# different clients can be processed in parallel. Weight is unused for
+# hashed queues (pfconfig forces weight=0 internally).
+#
 [queue pfdhcplistener_external]
 #
-# The weight of queue among shared workers
+# The number of dedicated workers for queue (one Redis list per worker:
+# pfdhcplistener_external_000 .. pfdhcplistener_external_NNN-1)
 #
-weight=4
+workers=4
 #
-# The number of dedicated workers for queue
+# Fan packets out into per-worker lists keyed by hash of the submission id
 #
-workers=1
+hashed=enabled
 
 #
 # pfdetect queue configuration

--- a/lib/pf/api/queue_cluster.pm
+++ b/lib/pf/api/queue_cluster.pm
@@ -15,7 +15,9 @@ pf::api::queue_cluster
 use strict;
 use warnings;
 use pf::cluster qw($cluster_enabled);
+use pf::config::pfqueue qw(%ConfigPfqueue);
 use pf::log;
+use pf::util qw(isenabled);
 use Moo;
 use List::Util qw(shuffle);
 use CHI;
@@ -123,6 +125,45 @@ sub local_notify {
     my ($self, $method, @args) = @_;
     get_logger->debug("sending $method locally");
     $self->local_client->submit($self->queue, api => [$method, @args]);
+    return;
+}
+
+=head2 notify_hashed
+
+Submit an api call keyed by $hash_key. When the target queue is configured
+with hashed=enabled the call is routed to the worker bucket selected by
+jhash($hash_key) % workers, preserving per-key ordering across packets.
+Hashed submissions are always processed on the local node (random
+cluster-wide routing would break the per-key ordering guarantee). When the
+target queue is not hashed, falls back to the regular notify() path so
+callers can use the same API regardless of queue configuration.
+
+=cut
+
+sub notify_hashed {
+    my ($self, $hash_key, $method, @args) = @_;
+    my $queue_conf = $ConfigPfqueue{queue_config}{$self->queue};
+    if ($queue_conf && isenabled($queue_conf->{hashed})) {
+        $self->local_notify_hashed($hash_key, $method, @args);
+    } else {
+        $self->notify($method, @args);
+    }
+    return;
+}
+
+=head2 local_notify_hashed
+
+Send a hashed submission to the local redis service. Selects the worker
+bucket via submit_hashed() using the queue's configured workers count.
+
+=cut
+
+sub local_notify_hashed {
+    my ($self, $hash_key, $method, @args) = @_;
+    my $queue = $self->queue;
+    my $workers = $ConfigPfqueue{queue_config}{$queue}{workers};
+    get_logger->debug("sending $method locally (hashed key=$hash_key, workers=$workers)");
+    $self->local_client->submit_hashed($workers, $hash_key, $queue, api => [$method, @args]);
     return;
 }
 

--- a/lib/pf/dhcp/processor.pm
+++ b/lib/pf/dhcp/processor.pm
@@ -27,6 +27,7 @@ use pf::config qw(
     %connection_type_to_str
     $INLINE
     %ConfigFirewallSSO
+    %ConfigScan
 );
 use pf::config::util;
 use pf::constants qw($TRUE);
@@ -190,7 +191,12 @@ sub processIPTasks {
     # Conformity scan
     # 2017.03.20 - dwuelfrath@inverse.ca - There is currently no ipv6 support for conformity scan. Remove the condition once "resolved"
     unless ( $iptasks_arguments{'ipversion'} eq $IPV6 ) {
-        $self->apiClient->notify('trigger_scan', %iptasks_arguments );
+        # Mirror the early-return in pf::api::trigger_scan: skip the
+        # enqueue when no scan engines exist so we don't ship a task the
+        # general-queue worker would immediately drop.
+        if (scalar keys %ConfigScan) {
+            $self->apiClient->notify('trigger_scan', %iptasks_arguments );
+        }
     }
 
     # Parking security_event

--- a/lib/pf/dhcp/processor.pm
+++ b/lib/pf/dhcp/processor.pm
@@ -96,7 +96,7 @@ my @local_dhcp_servers_ip;
 # cadence DHCP clients renew on — so the firewall session stays alive without
 # enqueueing an Update on every renewal packet.
 my $sso_refresh_hash = {};
-my $sso_refresh_cache = CHI->new( driver => 'Memory', datastore => $sso_refresh_hash );
+my $sso_refresh_cache = CHI->new( driver => 'RawMemory', datastore => $sso_refresh_hash );
 
 # Tracks the last (dhcp_fingerprint|dhcp_vendor|computername) signature
 # observed per MAC, so fingerbank_process is only enqueued when the device's
@@ -106,7 +106,7 @@ my $sso_refresh_cache = CHI->new( driver => 'Memory', datastore => $sso_refresh_
 # expires_in (24h) — long enough to suppress renewal storms, short enough
 # that updated Fingerbank signatures get re-applied within a day.
 my $fingerbank_signature_hash = {};
-my $fingerbank_signature_cache = CHI->new( driver => 'Memory', datastore => $fingerbank_signature_hash );
+my $fingerbank_signature_cache = CHI->new( driver => 'RawMemory', datastore => $fingerbank_signature_hash );
 Readonly::Scalar my $FINGERBANK_SIGNATURE_TTL => 86400;
 
 

--- a/lib/pf/dhcp/processor.pm
+++ b/lib/pf/dhcp/processor.pm
@@ -16,6 +16,7 @@ use strict;
 use warnings;
 
 # External libs
+use CHI;
 use Readonly;
 
 # Internal libs
@@ -72,6 +73,15 @@ Readonly::Hash my %IPTASKS_ARGUMENTS_MAP => (
 # Local DHCP servers local cache
 my @local_dhcp_servers_mac;
 my @local_dhcp_servers_ip;
+
+# Tracks when each (mac, ip, lease_length) last queued a firewallsso 'Update'.
+# Process-local; with the hashed pfdhcplistener_external queue each MAC is
+# pinned to one worker, so a per-process cache covers all packets for a given
+# client. Entries are set with TTL = lease_length / 2 — the same half-lease
+# cadence DHCP clients renew on — so the firewall session stays alive without
+# enqueueing an Update on every renewal packet.
+my $sso_refresh_hash = {};
+my $sso_refresh_cache = CHI->new( driver => 'Memory', datastore => $sso_refresh_hash );
 
 
 =head2 _get_local_dhcp_servers
@@ -137,11 +147,23 @@ sub processIPTasks {
 
     # Firewall SSO
     if (any { pf::util::isenabled($_->{'sso_on_dhcp'}) } values %ConfigFirewallSSO ) {
-        if ( $iptasks_arguments{'oldip'} && $iptasks_arguments{'oldip'} ne $iptasks_arguments{'ip'} ) {
-            $self->apiClient->notify( 'firewallsso', (method => 'Stop', mac => $iptasks_arguments{'mac'}, ip => $iptasks_arguments{'oldip'}, timeout => undef, source => $DHCP) );
-            $self->apiClient->notify( 'firewallsso', (method => 'Start', mac => $iptasks_arguments{'mac'}, ip => $iptasks_arguments{'ip'}, timeout => $iptasks_arguments{'lease_length'} || $DEFAULT_LEASE_LENGTH, source => $DHCP) );
+        my $sso_mac     = $iptasks_arguments{'mac'};
+        my $sso_ip      = $iptasks_arguments{'ip'};
+        my $sso_timeout = $iptasks_arguments{'lease_length'} || $DEFAULT_LEASE_LENGTH;
+        if ( $iptasks_arguments{'oldip'} && $iptasks_arguments{'oldip'} ne $sso_ip ) {
+            $self->apiClient->notify( 'firewallsso', (method => 'Stop', mac => $sso_mac, ip => $iptasks_arguments{'oldip'}, timeout => undef, source => $DHCP) );
+            $self->apiClient->notify( 'firewallsso', (method => 'Start', mac => $sso_mac, ip => $sso_ip, timeout => $sso_timeout, source => $DHCP) );
+            # Force the refresh on the new IP so the next packet skips Update.
+            $sso_refresh_cache->remove("$sso_mac|$sso_ip|$sso_timeout");
         }
-        $self->apiClient->notify( 'firewallsso', (method => 'Update', mac => $iptasks_arguments{'mac'}, ip => $iptasks_arguments{'ip'}, timeout => $iptasks_arguments{'lease_length'} || $DEFAULT_LEASE_LENGTH, source => $DHCP) );
+        # Refresh the firewall session timeout at most once per half-lease.
+        # Without this gate every DHCP renewal packet (one per client per
+        # half-lease) queued a redundant general-queue task.
+        my $sso_refresh_key = "$sso_mac|$sso_ip|$sso_timeout";
+        unless ($sso_refresh_cache->get($sso_refresh_key)) {
+            $self->apiClient->notify( 'firewallsso', (method => 'Update', mac => $sso_mac, ip => $sso_ip, timeout => $sso_timeout, source => $DHCP) );
+            $sso_refresh_cache->set($sso_refresh_key, 1, int($sso_timeout / 2));
+        }
     }
 
     # Inline enforcement

--- a/lib/pf/dhcp/processor.pm
+++ b/lib/pf/dhcp/processor.pm
@@ -98,11 +98,12 @@ my @local_dhcp_servers_ip;
 my $sso_refresh_hash = {};
 my $sso_refresh_cache = CHI->new( driver => 'RawMemory', datastore => $sso_refresh_hash );
 
-# Tracks the last (dhcp_fingerprint|dhcp_vendor|computername) signature
-# observed per MAC, so fingerbank_process is only enqueued when the device's
-# DHCP fingerprint actually changes. Fingerbank classification is a pure
-# function of those three fields, so re-running it on identical input wastes
-# a general-queue task per DHCP renewal. TTL mirrors the [storage fingerbank]
+# Tracks the last DHCP signature observed per MAC (the IPv4 and DHCPv6
+# fingerprint/vendor fields plus computername), so fingerbank_process is only
+# enqueued when the device's DHCP fingerprint actually changes. Fingerbank
+# classification is a pure function of those fields, so re-running it on
+# identical input wastes a general-queue task per DHCP renewal. TTL mirrors
+# the [storage fingerbank]
 # expires_in (24h) — long enough to suppress renewal storms, short enough
 # that updated Fingerbank signatures get re-applied within a day.
 my $fingerbank_signature_hash = {};
@@ -179,8 +180,10 @@ sub processIPTasks {
         if ( $iptasks_arguments{'oldip'} && $iptasks_arguments{'oldip'} ne $sso_ip ) {
             $self->apiClient->notify( 'firewallsso', (method => 'Stop', mac => $sso_mac, ip => $iptasks_arguments{'oldip'}, timeout => undef, source => $DHCP) );
             $self->apiClient->notify( 'firewallsso', (method => 'Start', mac => $sso_mac, ip => $sso_ip, timeout => $sso_timeout, source => $DHCP) );
-            # Force the refresh on the new IP so the next packet skips Update.
-            $sso_refresh_cache->remove("$sso_mac|$sso_ip|$sso_timeout");
+            # Start already established the session for the new IP with this
+            # timeout, so arm the cache to skip the redundant Update below (and
+            # subsequent renewals) until the next half-lease.
+            $sso_refresh_cache->set("$sso_mac|$sso_ip|$sso_timeout", 1, int($sso_timeout / 2));
         }
         # Refresh the firewall session timeout at most once per half-lease.
         # Without this gate every DHCP renewal packet (one per client per
@@ -258,12 +261,17 @@ sub processFingerbank {
     my $dhcp_filter_rule = $self->filterEngine->filter('Fingerbank', $fingerbank_args);
     unless ( (keys %$dhcp_filter_rule) > 0 ) {
         # Suppress fingerbank_process when the device's DHCP signature is
-        # unchanged. Classification depends only on these three fields, so
-        # re-running on every renewal packet just wastes a general-queue task.
+        # unchanged. Classification depends only on these fields, so re-running
+        # on every renewal packet just wastes a general-queue task. The
+        # signature must cover every field mapped into fingerbank_args that
+        # influences classification, including the DHCPv6-derived ones, or a
+        # change in only the DHCPv6 fingerprint/enterprise would be suppressed.
         my $mac = $fingerbank_args->{mac};
         my $signature = ($fingerbank_args->{dhcp_fingerprint} // '') . '|'
                       . ($fingerbank_args->{dhcp_vendor} // '') . '|'
-                      . ($fingerbank_args->{computername} // '');
+                      . ($fingerbank_args->{computername} // '') . '|'
+                      . ($fingerbank_args->{dhcp6_fingerprint} // '') . '|'
+                      . ($fingerbank_args->{dhcp6_enterprise} // '');
         my $cached = $fingerbank_signature_cache->get($mac);
         if (!defined($cached) || $cached ne $signature) {
             $self->apiClient->notify('fingerbank_process', $mac);

--- a/lib/pf/dhcp/processor.pm
+++ b/lib/pf/dhcp/processor.pm
@@ -83,6 +83,17 @@ my @local_dhcp_servers_ip;
 my $sso_refresh_hash = {};
 my $sso_refresh_cache = CHI->new( driver => 'Memory', datastore => $sso_refresh_hash );
 
+# Tracks the last (dhcp_fingerprint|dhcp_vendor|computername) signature
+# observed per MAC, so fingerbank_process is only enqueued when the device's
+# DHCP fingerprint actually changes. Fingerbank classification is a pure
+# function of those three fields, so re-running it on identical input wastes
+# a general-queue task per DHCP renewal. TTL mirrors the [storage fingerbank]
+# expires_in (24h) — long enough to suppress renewal storms, short enough
+# that updated Fingerbank signatures get re-applied within a day.
+my $fingerbank_signature_hash = {};
+my $fingerbank_signature_cache = CHI->new( driver => 'Memory', datastore => $fingerbank_signature_hash );
+Readonly::Scalar my $FINGERBANK_SIGNATURE_TTL => 86400;
+
 
 =head2 _get_local_dhcp_servers
 
@@ -226,7 +237,18 @@ sub processFingerbank {
     # If there is a match, we override Fingerbank call
     my $dhcp_filter_rule = $self->filterEngine->filter('Fingerbank', $fingerbank_args);
     unless ( (keys %$dhcp_filter_rule) > 0 ) {
-        $self->apiClient->notify('fingerbank_process', $fingerbank_args->{mac});
+        # Suppress fingerbank_process when the device's DHCP signature is
+        # unchanged. Classification depends only on these three fields, so
+        # re-running on every renewal packet just wastes a general-queue task.
+        my $mac = $fingerbank_args->{mac};
+        my $signature = ($fingerbank_args->{dhcp_fingerprint} // '') . '|'
+                      . ($fingerbank_args->{dhcp_vendor} // '') . '|'
+                      . ($fingerbank_args->{computername} // '');
+        my $cached = $fingerbank_signature_cache->get($mac);
+        if (!defined($cached) || $cached ne $signature) {
+            $self->apiClient->notify('fingerbank_process', $mac);
+            $fingerbank_signature_cache->set($mac, $signature, $FINGERBANK_SIGNATURE_TTL);
+        }
     }
 }
 

--- a/lib/pf/dhcp/processor.pm
+++ b/lib/pf/dhcp/processor.pm
@@ -43,7 +43,21 @@ use Moose;
 
 tie our %NetworkConfig, 'pfconfig::cached_hash', "resource::network_config";
 
-has 'apiClient'    => (is => 'ro', default => sub { pf::client::getClient });
+# pf::api::can_fork runs the api method in-process (and forks for :Fork
+# methods like trigger_scan). pf::client::getClient would default to
+# pf::api::jsonrpcclient inside the modern Go-driven pfqueue worker
+# (sbin/pfqueue-backend doesn't setClient), so each notify() turns into an
+# HTTPS POST to webservices — 5-7 round-trips per DHCP packet. Loading the
+# class lazily avoids a compile-time circular dep with pf::api (pf::api
+# loads this module, and pf::api::can_fork is already loaded by pf::task::api
+# before any DHCP task runs).
+has 'apiClient'    => (
+    is      => 'ro',
+    default => sub {
+        require pf::api::can_fork;
+        pf::api::can_fork->new;
+    },
+);
 has 'filterEngine' => (is => 'rw', default => sub { pf::access_filter::dhcp->new });
 
 

--- a/sbin/pfdhcplistener
+++ b/sbin/pfdhcplistener
@@ -361,7 +361,7 @@ sub process_pkt {
                 #  - there is no cache entry (packet wasn't seen in the last $rate_limiting seconds)
                 if(!defined($rate_limit_key) || $rate_limiting == 0 || !$rate_limit_cache->get($rate_limit_key)) {
                     my $apiclient = api_client();
-                    $apiclient->notify('process_dhcpv4', %args);
+                    $apiclient->notify_hashed($dhcp_mac, 'process_dhcpv4', %args);
                     if(defined($rate_limit_key) && $rate_limiting != 0) {
                         $rate_limit_cache->set($rate_limit_key, 1, $rate_limiting);
                     }
@@ -378,7 +378,7 @@ sub process_pkt {
                 # TODO: Rate-limiting for IPv6 just as for IPv4
 
                 my $apiclient = api_client();
-                $apiclient->notify('process_dhcpv6', MIME::Base64::encode($l4->{data}));
+                $apiclient->notify_hashed($args{src_mac}, 'process_dhcpv6', MIME::Base64::encode($l4->{data}));
             }
 
             # Non IPv4 nor IPv6 packet


### PR DESCRIPTION
# Description
  
  Reduces the per-packet work done by the external DHCP listener path (pfdhcplistener_external), which previously enqueued several redundant
  general-queue tasks for every DHCP packet — including the half-lease renewal packets every client sends. Under load (relayed DHCP through
  pfdhcplistener_external) this was the dominant source of pfqueue churn and webservices round-trips.

  The branch makes the listener horizontally scalable and suppresses work whose input hasn't changed:

  * Parallelize the queue — pfdhcplistener_external goes from a single worker to workers=4 hashed=enabled, hashed by client MAC so all
  packets for a given device pin to one worker (a prerequisite for the process-local caches below to be correct).
  * firewallsso — instead of queuing a firewallsso Update on every packet whenever any firewall has sso_on_dhcp enabled, gate it behind a
  process-local CHI cache keyed by (mac, ip, lease_length) with TTL = lease_length / 2. The session stays alive at the half-lease renewal
  cadence without a task per packet. IP changes still do Stop + Start and re-arm the cache for the new IP.
  * fingerbank — skip fingerbank_process when the device's DHCP signature (IPv4 + DHCPv6 fingerprint/vendor fields + computername) is
  unchanged. Classification is a pure function of those fields; the signature is cached per MAC (24h TTL, mirroring [storage fingerbank]).
  Filter-engine rules still run on every packet so their side effects are preserved.
  * trigger_scan — short-circuit when no scan engines are configured, avoiding a queued task that does nothing.
  * apiClient — pin the DHCP processor's apiClient to pf::api::can_fork so its notifies run in-process. Under the modern pfqueue-backend
  worker (which, unlike legacy sbin/pfqueue, never calls setClient), pf::client::getClient was defaulting to jsonrpcclient, turning each
  notify into an HTTPS POST to localhost webservices — 5–7 round-trips per DHCP packet.

# Impacts

  Reviewers should look at:
  * DHCP processing flow (lib/pf/dhcp/processor.pm) — processIPTasks, processFingerbank, and the apiClient attribute default.
  * pfqueue worker model — the pfdhcplistener_external queue now runs 4 hashed workers; the firewallsso/fingerbank caches are process-local
  and only correct because of MAC-based hashing (each MAC pinned to one worker). Verify the hashing config.
  * Firewall SSO behavior — confirm sessions stay alive across renewals and that IP-change does Stop/Start without a redundant Update on the
  same packet.
  * Fingerbank classification — confirm a change in only the DHCPv6 fingerprint/enterprise still triggers re-classification (was previously
  suppressed).
  * can_fork client — confirm :Fork methods (e.g. trigger_scan) still fork as before, and that running notifies in-process under
  pfqueue-backend has no unintended side effects.

# Code / PR Dependencies

  N/A

# NEW Package(s) required

  None.

# Issue

  N/A

# Delete branch after merge

  YES

# Checklist

  - [ ] Document the feature — n/a (internal performance optimization, no user-facing feature)
  - [ ] Add OpenAPI specification — n/a
  - [ ] Add unit tests — no
  - [ ] Add acceptance tests (TestLink) — no

## NEWS file entries

  Enhancements

  * Parallelized the pfdhcplistener_external pfqueue task (4 workers, hashed by client MAC) to remove the single-worker bottleneck on
  relayed DHCP
  * Reduced redundant general-queue tasks per DHCP packet: firewallsso Update is now gated to once per half-lease, fingerbank classification
  is skipped when the DHCP signature is unchanged, and trigger_scan short-circuits when no scan engines are configured
  * DHCP processor api calls now run in-process under pfqueue-backend instead of issuing HTTPS round-trips to webservices

## Bug Fixes

  * firewallsso no longer queued a redundant Update on the same packet as an IP-change Stop/Start
  * fingerbank classification was incorrectly suppressed when only the DHCPv6 fingerprint/enterprise number changed