### PR TITLE
Fix non-deterministic radius filter merge with reply: prefix

### DIFF
--- a/lib/pf/access_filter/radius.pm
+++ b/lib/pf/access_filter/radius.pm
@@ -86,19 +86,33 @@ sub handleAnswerInRule {
             return ($radius_reply, $status);
         }
 
-        foreach my $key (keys %$radius_reply_ref) {
-            if (exists($radius_reply->{$key})) {
-                my $type = reftype($radius_reply->{$key});
-                if (defined($type) && $type eq 'ARRAY') {
-                    my @attribute;
-                    push(@attribute,@{$radius_reply_ref->{$key}});
-                    push(@attribute,@{$radius_reply->{$key}});
-                    $radius_reply_ref->{$key} = \@attribute;
-                    delete $radius_reply->{$key};
-                }
+        # Normalize the optional 'reply:' section prefix and merge filter
+        # answers into the existing reply. Without this, an answer such as
+        # 'reply:Cisco-AVPair = ...' lands under a different hash key than
+        # the bare 'Cisco-AVPair' set by returnRadiusAccessAccept, and both
+        # cross the rlm_rest boundary as duplicate keys targeting the same
+        # attribute -- producing non-deterministic results on the wire.
+        for my $key (keys %$radius_reply) {
+            (my $target = $key) =~ s/^reply://;
+            if ($target =~ /:/) {
+                # other section (control:, request:, session-state:, ...);
+                # leave as-is so it doesn't collide with reply attributes.
+                $radius_reply_ref->{$key} = delete $radius_reply->{$key};
+                next;
             }
+            my @incoming = (reftype($radius_reply->{$key}) // '') eq 'ARRAY'
+                           ? @{$radius_reply->{$key}}
+                           : ($radius_reply->{$key});
+            if (exists $radius_reply_ref->{$target}) {
+                my @existing = (reftype($radius_reply_ref->{$target}) // '') eq 'ARRAY'
+                               ? @{$radius_reply_ref->{$target}}
+                               : ($radius_reply_ref->{$target});
+                $radius_reply_ref->{$target} = [@existing, @incoming];
+            } else {
+                $radius_reply_ref->{$target} = (@incoming > 1) ? \@incoming : $incoming[0];
+            }
+            delete $radius_reply->{$key};
         }
-        $radius_reply_ref = {%$radius_reply_ref, %$radius_reply} if (keys %$radius_reply);
         return ($radius_reply_ref, $status);
     }
 

--- a/t/unittest/access_filter/radius.t
+++ b/t/unittest/access_filter/radius.t
@@ -79,7 +79,7 @@ BEGIN {
 }
 
 use pf::access_filter::radius;
-use Test::More tests => 2 + (scalar @tests * 1);
+use Test::More tests => 3 + (scalar @tests * 1);
 use Test::NoWarnings;
 
 {
@@ -102,13 +102,42 @@ use Test::NoWarnings;
     is_deeply(
         $reply,
         {
-            'Reply-Message'      => 'Request processed by PacketFence',
-            'reply:Cisco-AVPair' => [
+            'Reply-Message' => 'Request processed by PacketFence',
+            'Cisco-AVPair' => [
                 'url-redirect-acl=Pre-Auth',
                 'url-redirect=http://1.2.3.4/Cisco::WLC/sidbob'
             ]
         },
-        "Test filter"
+        "Test filter strips reply: prefix when merging into empty reply"
+    );
+}
+
+{
+    # Regression: filter answer with 'reply:' prefix must merge with the
+    # bare 'Cisco-AVPair' arrayref set by returnRadiusAccessAccept, not
+    # produce a parallel 'reply:Cisco-AVPair' key.
+    my $filter = pf::access_filter::radius->new;
+    $pf::access_filter::radius::LOOKUP{session_id} = sub { "bob" };
+    my $args = {mac => "00:99:88:77:66:55"};
+    my $rule = $filter->test('TestScope', $args);
+    my $existing = {
+        'Cisco-AVPair' => [ 'ip:inacl#101=permit ip any any', 'ip:inacl#102=permit ip any any' ],
+        'Tunnel-Type' => 13,
+    };
+    my ($reply, $status) = $filter->handleAnswerInRule($rule, $args, $existing);
+    is_deeply(
+        $reply,
+        {
+            'Reply-Message' => 'Request processed by PacketFence',
+            'Tunnel-Type'   => 13,
+            'Cisco-AVPair'  => [
+                'ip:inacl#101=permit ip any any',
+                'ip:inacl#102=permit ip any any',
+                'url-redirect-acl=Pre-Auth',
+                'url-redirect=http://1.2.3.4/Cisco::WLC/sidbob',
+            ],
+        },
+        "Test filter merges reply:Cisco-AVPair into existing Cisco-AVPair arrayref"
     );
 }
 


### PR DESCRIPTION
# Description
A radius filter answer such as 'reply:Cisco-AVPair = ...' was stored under a different hash key than the bare 'Cisco-AVPair' set by returnRadiusAccessAccept, so handleAnswerInRule never merged them. Both keys then crossed the rlm_rest boundary as duplicates targeting the same RADIUS attribute, producing a non-deterministic Access-Accept: the filter answer randomly disappeared (or displaced an existing Cisco-AVPair slot) depending on hash iteration order.

Normalize the leading 'reply:' prefix and combine values into a single arrayref. Other section prefixes (control:, request:, session-state:) are left untouched so they don't collide with reply attributes.

# Impacts
RADIUS authorize workflow

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
(REQUIRED, but may be optional...)

## Bug Fixes
* If a radius filter return a Cisco-AVPair and the switch module returns another Cisco-AVPair then the 2 hashes are not correctly merged.

