### PR TITLE
Send firewall SSO Start on RADIUS Accounting-Start (#9059)

### DIFF
--- a/lib/pf/api.pm
+++ b/lib/pf/api.pm
@@ -1569,10 +1569,11 @@ sub firewallsso_accounting : Public {
         my $username = $RAD_REQUEST{'User-Name'} // undef;
         my $session_id = $RAD_REQUEST{'Acct-Session-Id'};
         my $cache = pf::CHI->new(namespace => 'accounting');
-        my $is_stop = ($RAD_REQUEST{'Acct-Status-Type'} == $ACCOUNTING::STOP);
+        my $acct_status_type = $RAD_REQUEST{'Acct-Status-Type'};
+        my $is_start = ($acct_status_type == $ACCOUNTING::START);
+        my $is_stop  = ($acct_status_type == $ACCOUNTING::STOP);
 
         if ($node->{status} eq $pf::node::STATUS_REGISTERED) {
-            $firewallsso_method = "Update";
             if ($node->{unregdate} ne '0000-00-00 00:00:00') {
                 my $time = DateTime::Format::MySQL->parse_datetime($node->{unregdate});
                 $time->set_time_zone("local");
@@ -1585,7 +1586,13 @@ sub firewallsso_accounting : Public {
             }
         }
 
-        $firewallsso_method = $is_stop ? "Stop" : "Update";
+        if ($is_stop) {
+            $firewallsso_method = "Stop";
+        } elsif ($is_start) {
+            $firewallsso_method = "Start";
+        } else {
+            $firewallsso_method = "Update";
+        }
 
         # Cache the node role at session start so that accounting Stop sends the correct role
         # even if the node has re-authenticated with a different role in the meantime.


### PR DESCRIPTION
## Summary
- Fixes #9059 (and the related #8566): JSON-RPC firewall SSO never received a `Start` RPC because `pf::api::firewallsso_accounting` collapsed every non-Stop accounting packet to method `"Update"`.
- Now distinguishes `Acct-Status-Type` START / INTERIM_UPDATE / STOP and forwards the matching method (`Start`, `Update`, `Stop`) to pfsso, which routes to `/api/v1/firewall_sso/{start,update,stop}` respectively.
- Stop on Acct-Stop and the role-caching logic are unchanged; only the START case is newly distinguished.

## Test plan
- [ ] `perl -c lib/pf/api.pm` passes.
- [ ] With JSON-RPC firewall SSO configured and `sso_on_accounting` enabled, authenticate a client and confirm `packetfence.log` shows `Sending a firewall SSO 'Start' request …` on the first accounting packet (previously was `'Update'`).
- [ ] On RADIUS Interim-Update, log still shows `'Update'`.
- [ ] On RADIUS Stop, log still shows `'Stop'` for both registered and unregistered nodes.
- [ ] DHCP-driven SSO (`lib/pf/dhcp/processor.pm`) and role-change SSO (`lib/pf/role.pm`) still work — unchanged code paths.