### PR TITLE
htpasswd: manage users from the admin UI and sync across the cluster

### DIFF
--- a/NEWS.asciidoc
+++ b/NEWS.asciidoc
@@ -29,6 +29,15 @@ For a list of compatibility related changes see the <<PacketFence_Upgrade_Guide.
 
 === Enhancements
 
+  - Htpasswd authentication source — list, add, change the password of, and
+    remove users directly from the admin UI; every write is propagated to the
+    other cluster members through pf::cluster::sync_files() so the password
+    file stays in sync without any CLI work
+  - Htpasswd authentication source — create a new htpasswd file directly
+    from the admin UI; the file is created on the local node and, when
+    running in a cluster, propagated to the other members so a fresh
+    source is immediately usable without touching the filesystem manually
+
 === Bug Fixes
 
 === Security Fixes

--- a/docs/api/spec/static/paths/config/sources.yaml
+++ b/docs/api/spec/static/paths/config/sources.yaml
@@ -26,3 +26,209 @@
               $ref: '#/components/schemas/ConfigSource'
     tags:
       - Config/Sources
+
+/api/v1/config/source/{source_id}/htpasswd_users:
+  description: |-
+    Manage users defined in the htpasswd file of an Htpasswd authentication
+    source. Every write is propagated to all cluster members through
+    pf::cluster::sync_files().
+  parameters:
+    - description: '`PRIMARY KEY`'
+      in: path
+      name: source_id
+      required: true
+      schema:
+        type: string
+  get:
+    description: |-
+      List the users defined in the htpasswd file of the source.
+      The response also tells whether the file exists on the local
+      filesystem so the GUI can offer to create it on demand.
+    operationId: api.v1.Config.Sources.resource.htpasswd_users.list
+    responses:
+      '200':
+        description: Users defined in the htpasswd file.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                items:
+                  type: array
+                  items:
+                    type: string
+                file_exists:
+                  type: boolean
+                  description: |-
+                    True when the htpasswd file exists on the local
+                    filesystem; false when it has not been created yet.
+      '401':
+        $ref: '#/components/responses/Forbidden'
+      '404':
+        $ref: '#/components/responses/NotFound'
+      '405':
+        description: The source exists but is not an Htpasswd source.
+    tags:
+      - Config/Sources
+  post:
+    description: |-
+      Add a user to the htpasswd file (or update the password of an existing
+      one). The change is written through Apache::Htpasswd and the file is
+      then synced to all cluster members.
+    operationId: api.v1.Config.Sources.resource.htpasswd_users.create
+    requestBody:
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - username
+              - password
+            properties:
+              username:
+                type: string
+              password:
+                type: string
+                format: password
+    responses:
+      '201':
+        description: User created or updated.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                username:
+                  type: string
+      '400':
+        $ref: '#/components/responses/BadRequest'
+      '401':
+        $ref: '#/components/responses/Forbidden'
+      '404':
+        $ref: '#/components/responses/NotFound'
+      '405':
+        description: The source exists but is not an Htpasswd source.
+      '422':
+        $ref: '#/components/responses/UnprocessableEntity'
+    tags:
+      - Config/Sources
+
+/api/v1/config/source/{source_id}/htpasswd_file:
+  description: |-
+    Create the htpasswd file of an Htpasswd authentication source on disk
+    and propagate it to all cluster members. Idempotent.
+  parameters:
+    - description: '`PRIMARY KEY`'
+      in: path
+      name: source_id
+      required: true
+      schema:
+        type: string
+  post:
+    description: |-
+      Create an empty htpasswd file for this source on the local node and
+      sync it to all cluster members through pf::cluster::sync_files().
+      Returns 201 when the file was newly created, 200 when it already
+      existed.
+    operationId: api.v1.Config.Sources.resource.htpasswd_file.create
+    responses:
+      '200':
+        description: File already existed; nothing was written.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                created:
+                  type: integer
+                  enum: [0]
+      '201':
+        description: File was newly created and synced to the cluster.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                created:
+                  type: integer
+                  enum: [1]
+      '401':
+        $ref: '#/components/responses/Forbidden'
+      '404':
+        $ref: '#/components/responses/NotFound'
+      '405':
+        description: The source exists but is not an Htpasswd source.
+      '500':
+        description: The file could not be created on disk.
+    tags:
+      - Config/Sources
+
+/api/v1/config/source/{source_id}/htpasswd_users/{username}:
+  description: Update or delete a single user in the htpasswd file.
+  parameters:
+    - description: '`PRIMARY KEY`'
+      in: path
+      name: source_id
+      required: true
+      schema:
+        type: string
+    - description: Username in the htpasswd file.
+      in: path
+      name: username
+      required: true
+      schema:
+        type: string
+  patch:
+    description: Change the password of an existing user.
+    operationId: api.v1.Config.Sources.resource.htpasswd_users.update
+    requestBody:
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - password
+            properties:
+              password:
+                type: string
+                format: password
+    responses:
+      '200':
+        description: Password updated.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                username:
+                  type: string
+      '400':
+        $ref: '#/components/responses/BadRequest'
+      '401':
+        $ref: '#/components/responses/Forbidden'
+      '404':
+        $ref: '#/components/responses/NotFound'
+      '405':
+        description: The source exists but is not an Htpasswd source.
+      '422':
+        $ref: '#/components/responses/UnprocessableEntity'
+    tags:
+      - Config/Sources
+  delete:
+    description: |-
+      Remove a user from the htpasswd file and sync the file to all cluster
+      members. Idempotent: a missing user still returns 204.
+    operationId: api.v1.Config.Sources.resource.htpasswd_users.delete
+    responses:
+      '204':
+        description: User deleted (or did not exist).
+      '401':
+        $ref: '#/components/responses/Forbidden'
+      '404':
+        $ref: '#/components/responses/NotFound'
+      '405':
+        description: The source exists but is not an Htpasswd source.
+      '422':
+        $ref: '#/components/responses/UnprocessableEntity'
+    tags:
+      - Config/Sources

--- a/docs/installation/authentication_sources.asciidoc
+++ b/docs/installation/authentication_sources.asciidoc
@@ -113,6 +113,35 @@ by clicking on the `Preview` button near the Connexion's title.
 Unplug and unregister your endpoint. Reconnect the endpoint - you should see the
 captive portal with the new Email-based registration option.
 
+=== Htpasswd Authentication
+
+The Htpasswd source authenticates users against an Apache-style password file.
+From _Configuration -> Policies and Access Control -> Authentication Sources_,
+click `New internal source -> Htpasswd` and provide a `Name`, `Description` and
+the path to the file. You can either type the path of an existing file or
+upload a file from your workstation -- the uploaded content is stored under
+[filename]`/usr/local/pf/conf/uploads/sources/`.
+
+==== Managing Users from the Admin UI
+
+Once the source is saved, a *Users* section appears in the source form. From
+there you can:
+
+[options="compact"]
+ * list the users currently defined in the htpasswd file,
+ * create a new htpasswd file on the local node when the configured path
+   does not yet exist on disk (and, when running in a cluster, propagate
+   it to the other members),
+ * add a new user,
+ * change the password of an existing user,
+ * delete a user.
+
+Every write goes through Apache::Htpasswd and is then propagated to the other
+cluster members through the standard [filename]`pf::cluster::sync_files()`
+helper, so the password file stays in sync on all nodes without any CLI work.
+Deleting a user is idempotent: removing an unknown user is a no-op and still
+returns success.
+
 === Adding SMS Authentication for Guests
 
 This section will show you how to enable SMS authentication on the captive

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source/Htpasswd.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source/Htpasswd.pm
@@ -18,10 +18,15 @@ with 'pfappserver::Base::Form::Role::Help', 'pfappserver::Base::Form::Role::Inte
 # Form fields
 has_field 'path' =>
   (
-   type => 'Path',
+   type => 'Text',
    required => 0,
    element_class => ['input-xxlarge'],
-   # Default value needed for creating dummy source
+   # Default value needed for creating dummy source.
+   # We deliberately use Text (and validate ourselves below) instead of the
+   # 'Path' field type: the latter rejects any path that does not exist on
+   # disk, which prevents the admin from creating a fresh Htpasswd source
+   # whose file has not been created yet -- creating that file is exactly
+   # what the new "Create new htpasswd file" button does.
    default => '',
   );
 
@@ -38,17 +43,32 @@ has_field 'path_upload' =>
 
 =head2 validate
 
-Make sure the htpasswd file is readable.
+Validate the configured path:
+
+  * an absolute path including a file name is required;
+  * if the file already exists on disk it must be a regular file readable
+    by the pf user -- directories or other special files are rejected so
+    that the "Create new htpasswd file" button in the Users section cannot
+    accidentally overwrite something else;
+  * a non-existing file is accepted as long as its parent directory exists
+    and is writable -- creating the file on demand is exactly what the
+    Users section's "Create new htpasswd file" button does.
 
 =cut
 
 sub validate {
     my $self = shift;
-
     $self->SUPER::validate();
     my $path = $self->value->{path};
-    if (defined($path) && !-r $path) {
-        $self->field('path')->add_error("The file is not readable by the user 'pf'.");
+    return unless defined $path && $path ne '';
+
+    my $field = $self->field('path');
+    my $source = pf::Authentication::Source::HtpasswdSource->new(
+        id   => '__validate__',
+        path => $path,
+    );
+    for my $err ($source->validate_path) {
+        $field->add_error($err);
     }
 }
 

--- a/html/pfappserver/root/src/views/Configuration/sources/_api.js
+++ b/html/pfappserver/root/src/views/Configuration/sources/_api.js
@@ -54,5 +54,28 @@ export default {
     return apiCall.postQuiet('config/sources/test', data).then(response => {
       return response
     })
+  },
+  htpasswdUsersList: id => {
+    return apiCall.get(['config', 'source', id, 'htpasswd_users']).then(response => {
+      return response.data
+    })
+  },
+  htpasswdUsersCreate: ({ id, username, password }) => {
+    return apiCall.post(['config', 'source', id, 'htpasswd_users'], { username, password }).then(response => {
+      return response.data
+    })
+  },
+  htpasswdUsersUpdate: ({ id, username, password }) => {
+    return apiCall.patch(['config', 'source', id, 'htpasswd_users', username], { password }).then(response => {
+      return response.data
+    })
+  },
+  htpasswdUsersDelete: ({ id, username }) => {
+    return apiCall.delete(['config', 'source', id, 'htpasswd_users', username])
+  },
+  htpasswdFileCreate: ({ id }) => {
+    return apiCall.post(['config', 'source', id, 'htpasswd_file'], {}).then(response => {
+      return response.data
+    })
   }
 }

--- a/html/pfappserver/root/src/views/Configuration/sources/_components/BaseHtpasswdUsers.vue
+++ b/html/pfappserver/root/src/views/Configuration/sources/_components/BaseHtpasswdUsers.vue
@@ -1,0 +1,257 @@
+<template>
+  <b-form-group class="base-form-group base-htpasswd-users"
+    :state="state"
+    :invalid-feedback="invalidFeedback"
+    :label="$i18n.t('Users')"
+    label-cols="3"
+  >
+    <b-container fluid class="px-0">
+
+      <b-alert :show="!hasPath" variant="warning" class="mb-2">
+        {{ $i18n.t('Save the source with a file path before managing users.') }}
+      </b-alert>
+
+      <template v-if="hasPath">
+        <b-alert :show="!!message" :variant="messageVariant" dismissible
+          @dismissed="message = ''"
+        >{{ message }}</b-alert>
+
+        <template v-if="!fileExists">
+          <b-alert :show="true" variant="info" class="mb-2">
+            {{ $i18n.t('The htpasswd file does not yet exist on the filesystem.') }}
+          </b-alert>
+          <b-button variant="outline-primary" :disabled="isLoading" @click="onCreateFile">
+            <icon class="mr-1" name="file-medical" />{{ $i18n.t('Create new htpasswd file') }}
+          </b-button>
+        </template>
+
+        <template v-else>
+        <b-table :items="items" :fields="fields" :busy="isLoading"
+          small hover responsive striped show-empty borderless
+          :empty-text="$i18n.t('No users defined in the htpasswd file.')"
+        >
+          <template v-slot:cell(buttons)="{ item }">
+            <div class="text-right text-nowrap">
+              <b-button size="sm" variant="outline-secondary" class="my-1 mr-1"
+                :disabled="isLoading"
+                @click="onEdit(item)"
+              >{{ $i18n.t('Change password') }}</b-button>
+              <base-button-confirm size="sm" variant="outline-danger" class="my-1"
+                :disabled="isLoading"
+                :confirm="$i18n.t('Delete?')"
+                reverse
+                @click="onDelete(item)"
+              >{{ $i18n.t('Delete') }}</base-button-confirm>
+            </div>
+          </template>
+        </b-table>
+
+        <b-button variant="outline-primary" :disabled="isLoading" @click="onAdd">
+          <icon class="mr-1" name="plus-circle" />{{ $i18n.t('Add User') }}
+        </b-button>
+
+        <b-modal v-model="showModal" :title="modalTitle" centered no-close-on-backdrop
+          :ok-disabled="isLoading || !modalUsername || !modalPassword"
+          :ok-title="$i18n.t('Save')"
+          :cancel-title="$i18n.t('Cancel')"
+          @ok.prevent="onSave"
+        >
+          <b-form-group :label="$i18n.t('Username')" label-cols="4">
+            <b-form-input v-model="modalUsername" :disabled="isEditing || isLoading" autofocus />
+          </b-form-group>
+          <b-form-group :label="$i18n.t('Password')" label-cols="4">
+            <b-form-input v-model="modalPassword" type="password" :disabled="isLoading" />
+          </b-form-group>
+        </b-modal>
+        </template>
+      </template>
+
+    </b-container>
+  </b-form-group>
+</template>
+<script>
+import { computed, ref, toRefs, watch } from '@vue/composition-api'
+import { BaseButtonConfirm } from '@/components/new/'
+import i18n from '@/utils/locale'
+import api from '../_api'
+
+const components = {
+  BaseButtonConfirm
+}
+
+const props = {
+  id: {
+    type: String
+  },
+  form: {
+    type: Object
+  },
+  isNew: {
+    type: Boolean,
+    default: false
+  }
+}
+
+const setup = (props) => {
+
+  const {
+    id,
+    form,
+    isNew
+  } = toRefs(props)
+
+  const items = ref([])
+  const isLoading = ref(false)
+  const message = ref('')
+  const messageVariant = ref('danger')
+  const state = ref(null)
+  const invalidFeedback = ref(undefined)
+  const fileExists = ref(true)
+
+  const fields = [
+    { key: 'username', label: i18n.t('Username'), sortable: true },
+    { key: 'buttons', label: '', class: 'text-right' }
+  ]
+
+  const hasPath = computed(() => {
+    if (isNew.value) return false
+    const path = (form.value || {}).path
+    return !!(id.value && path)
+  })
+
+  const setError = msg => {
+    message.value = msg
+    messageVariant.value = 'danger'
+  }
+  const setInfo = msg => {
+    message.value = msg
+    messageVariant.value = 'success'
+  }
+
+  const reload = () => {
+    if (!hasPath.value) return Promise.resolve()
+    isLoading.value = true
+    return api.htpasswdUsersList(id.value).then(data => {
+      items.value = (data.items || []).map(username => ({ username }))
+      fileExists.value = (data.file_exists !== false)
+      state.value = null
+    }).catch(err => {
+      const msg = ((err.response || {}).data || {}).message || `${err}`
+      setError(msg)
+      state.value = false
+      invalidFeedback.value = msg
+    }).finally(() => {
+      isLoading.value = false
+    })
+  }
+
+  watch(
+    () => [hasPath.value, (form.value || {}).path],
+    () => { reload() },
+    { immediate: true }
+  )
+
+  const showModal = ref(false)
+  const isEditing = ref(false)
+  const modalUsername = ref('')
+  const modalPassword = ref('')
+  const modalTitle = computed(() => isEditing.value
+    ? i18n.t('Change password for {username}', { username: modalUsername.value })
+    : i18n.t('Add User')
+  )
+
+  const onAdd = () => {
+    isEditing.value = false
+    modalUsername.value = ''
+    modalPassword.value = ''
+    showModal.value = true
+  }
+
+  const onEdit = item => {
+    isEditing.value = true
+    modalUsername.value = item.username
+    modalPassword.value = ''
+    showModal.value = true
+  }
+
+  const onSave = () => {
+    const username = modalUsername.value
+    const password = modalPassword.value
+    if (!username || !password) return
+    isLoading.value = true
+    const promise = isEditing.value
+      ? api.htpasswdUsersUpdate({ id: id.value, username, password })
+      : api.htpasswdUsersCreate({ id: id.value, username, password })
+    return promise.then(() => {
+      setInfo(isEditing.value
+        ? i18n.t('Password changed for {username}.', { username })
+        : i18n.t('User {username} saved.', { username })
+      )
+      showModal.value = false
+      return reload()
+    }).catch(err => {
+      const msg = ((err.response || {}).data || {}).message || `${err}`
+      setError(msg)
+    }).finally(() => {
+      isLoading.value = false
+    })
+  }
+
+  const onDelete = item => {
+    isLoading.value = true
+    return api.htpasswdUsersDelete({ id: id.value, username: item.username }).then(() => {
+      setInfo(i18n.t('User {username} deleted.', { username: item.username }))
+      return reload()
+    }).catch(err => {
+      const msg = ((err.response || {}).data || {}).message || `${err}`
+      setError(msg)
+    }).finally(() => {
+      isLoading.value = false
+    })
+  }
+
+  const onCreateFile = () => {
+    isLoading.value = true
+    return api.htpasswdFileCreate({ id: id.value }).then(() => {
+      setInfo(i18n.t('Htpasswd file created and synced to all cluster members.'))
+      return reload()
+    }).catch(err => {
+      const msg = ((err.response || {}).data || {}).message || `${err}`
+      setError(msg)
+    }).finally(() => {
+      isLoading.value = false
+    })
+  }
+
+  return {
+    items,
+    fields,
+    isLoading,
+    hasPath,
+    fileExists,
+    message,
+    messageVariant,
+    state,
+    invalidFeedback,
+    showModal,
+    isEditing,
+    modalTitle,
+    modalUsername,
+    modalPassword,
+    onAdd,
+    onEdit,
+    onSave,
+    onDelete,
+    onCreateFile
+  }
+}
+
+// @vue/component
+export default {
+  name: 'base-htpasswd-users',
+  inheritAttrs: false,
+  components,
+  props,
+  setup
+}
+</script>

--- a/html/pfappserver/root/src/views/Configuration/sources/_components/FormTypeHtpasswd.vue
+++ b/html/pfappserver/root/src/views/Configuration/sources/_components/FormTypeHtpasswd.vue
@@ -17,6 +17,15 @@
     <form-group-path namespace="path"
       :column-label="$i18n.t('Htpasswd File Path')"
       :title="$i18n.t('Upload Htpasswd File')"
+      :text="$i18n.t(
+        'Type a path or upload an existing file. A missing file can be created from the Users section below.'
+      )"
+    />
+
+    <htpasswd-users v-if="!isNew && !isClone"
+      :id="id"
+      :form="form"
+      :is-new="isNew"
     />
 
     <form-group-realms namespace="realms"
@@ -42,6 +51,7 @@ import {
   FormGroupIdentifier,
   FormGroupPath,
   FormGroupRealms,
+  HtpasswdUsers,
 } from './'
 
 const components = {
@@ -53,6 +63,7 @@ const components = {
   FormGroupIdentifier,
   FormGroupPath,
   FormGroupRealms,
+  HtpasswdUsers,
 }
 
 import { useForm as setup, useFormProps as props } from '../_composables/useForm'

--- a/html/pfappserver/root/src/views/Configuration/sources/_components/index.js
+++ b/html/pfappserver/root/src/views/Configuration/sources/_components/index.js
@@ -19,6 +19,7 @@ import BaseFormGroupDomains from './BaseFormGroupDomains'
 import BaseFormGroupHostPortEncryption from './BaseFormGroupHostPortEncryption'
 import BaseFormGroupPersonMappings from './BaseFormGroupPersonMappings'
 import BaseFormGroupProtocolHostPort from './BaseFormGroupProtocolHostPort'
+import BaseHtpasswdUsers from './BaseHtpasswdUsers'
 import ButtonSamlMetaData from './ButtonSamlMetaData'
 import TheForm from './TheForm'
 import TheView from './TheView'
@@ -145,6 +146,7 @@ export {
   BaseFormGroupChosenOne                    as FormGroupEduroamRadiusAuthProxyType,
   BaseFormGroupInput                        as FormGroupEduroamOperatorName,
 
+  BaseHtpasswdUsers                         as HtpasswdUsers,
   BaseServices,
   ButtonSamlMetaData,
   TheForm,

--- a/lib/pf/Authentication/Source/HtpasswdSource.pm
+++ b/lib/pf/Authentication/Source/HtpasswdSource.pm
@@ -12,6 +12,7 @@ use pf::constants qw($TRUE $FALSE);
 use pf::Authentication::constants;
 use pf::constants::authentication::messages;
 use pf::Authentication::Source;
+use pf::cluster;
 use pf::util;
 use pf::log;
 
@@ -101,6 +102,216 @@ sub match_in_subclass {
     }
 
     return (undef, undef);
+}
+
+=head2 _ensure_password_file
+
+Make sure the password file exists and is writable. Creates an empty file if
+missing so that user CRUD operations from the GUI work on a fresh source.
+When the file is newly created it is fixed up for the pf user and propagated
+to the other cluster members through pf::cluster::sync_files().
+Returns the path on success, dies otherwise.
+
+=cut
+
+sub _ensure_password_file {
+    my ($self) = @_;
+    my $logger = get_logger();
+    my $path = $self->{'path'};
+    die "no path configured for this Htpasswd source\n"
+        unless defined $path && $path ne '';
+
+    if (! -e $path) {
+        safe_file_update($path, "");
+        fix_file_permissions($path);
+        eval { pf::cluster::sync_files([$path]) };
+        if ($@) {
+            $logger->error("error syncing new htpasswd file '$path' to cluster: $@");
+        }
+    }
+    return $path;
+}
+
+=head2 validate_path
+
+Check that the configured path is usable for an htpasswd file. Returns the
+empty list when the path is valid, otherwise a list of human-readable error
+messages describing every problem found. The checks mirror what the
+Htpasswd source form does at save time, so that the "Create new htpasswd
+file" GUI action refuses to act on the same paths the form would reject.
+
+=cut
+
+sub validate_path {
+    my ($self) = @_;
+    require File::Basename;
+
+    my $path = $self->{'path'};
+    my @errors;
+    if (!defined $path || $path eq '') {
+        return ('no path configured for this Htpasswd source');
+    }
+    if ($path !~ m{^/}) {
+        push @errors, "Path must be absolute, e.g. /usr/local/pf/conf/htpasswd_admins.";
+    }
+    my ($base, $dir) = File::Basename::fileparse($path);
+    if ($base eq '' || $base eq '.' || $base eq '..') {
+        push @errors, "Path must include a file name, not just a directory.";
+    }
+    if (-e $path) {
+        if (-d $path) {
+            push @errors, "Path points to an existing directory, not a file.";
+        }
+        elsif (!-f $path) {
+            push @errors, "Path exists but is not a regular file.";
+        }
+        elsif (!-r $path) {
+            push @errors, "The file is not readable by the user 'pf'.";
+        }
+    }
+    elsif (defined $dir && $dir ne '') {
+        # File does not exist yet. Missing intermediate directories will be
+        # created by safe_file_update / pf_make_dir, so we only require that
+        # the closest existing ancestor really is a directory. The IO layer
+        # surfaces any real write-permission problem at create time.
+        # The path must also live somewhere under the PacketFence tree so we
+        # don't help an admin scatter htpasswd files in unrelated places.
+        my $ancestor = $dir;
+        $ancestor =~ s{/+$}{};
+        while (length $ancestor && !-e $ancestor) {
+            $ancestor =~ s{/[^/]+$}{};
+        }
+        $ancestor = '/' if $ancestor eq '';
+        if (!-d $ancestor) {
+            push @errors, "Closest existing ancestor '$ancestor' is not a directory.";
+        }
+        if ($path !~ m{^/usr/local/pf/}) {
+            push @errors, "Path must live under /usr/local/pf/ (got '$path').";
+        }
+    }
+    return @errors;
+}
+
+=head2 create_file
+
+Create the password file for this source on disk (empty) and propagate it to
+all cluster members. Idempotent: if the file already exists, nothing is
+written. Validates the configured path first (same rules as the source
+form) and dies with the validation message when the path is unusable.
+Returns a hashref { created => 0|1 } indicating whether the file was newly
+created. Dies on write errors.
+
+=cut
+
+sub create_file {
+    my ($self) = @_;
+    my @errors = $self->validate_path;
+    if (@errors) {
+        die join("\n", @errors) . "\n";
+    }
+    my $path = $self->{'path'};
+    my $already = -e $path ? 1 : 0;
+    $self->_ensure_password_file;
+    return { created => $already ? 0 : 1 };
+}
+
+=head2 file_exists
+
+Return a boolean indicating whether the configured htpasswd file exists on
+the local filesystem. No cluster check is performed.
+
+=cut
+
+sub file_exists {
+    my ($self) = @_;
+    my $path = $self->{'path'};
+    return 0 unless defined $path && $path ne '';
+    return -e $path ? 1 : 0;
+}
+
+=head2 list_users
+
+Return the list of usernames defined in the htpasswd file.
+
+=cut
+
+sub list_users {
+    my ($self) = @_;
+    my $path = $self->{'path'};
+    return [] unless defined $path && $path ne '' && -r $path;
+
+    my $htpasswd = Apache::Htpasswd->new({ passwdFile => $path, ReadOnly => 1 });
+    my @users = $htpasswd->fetchUsers();
+    return [ sort @users ];
+}
+
+=head2 set_user
+
+Add or update a user in the htpasswd file and sync the file to all cluster
+members. Dies on validation errors or htpasswd library errors.
+
+=cut
+
+sub set_user {
+    my ($self, $username, $password) = @_;
+    my $logger = get_logger();
+
+    die "username must not be empty\n"
+        if !defined $username || $username eq '';
+    die "username must not contain ':' or whitespace\n"
+        if $username =~ /[:\s]/;
+    die "password must not be empty\n"
+        if !defined $password || $password eq '';
+
+    my $path = $self->_ensure_password_file;
+    my $htpasswd = Apache::Htpasswd->new({ passwdFile => $path });
+    my $ok;
+    if ($htpasswd->fetchPass($username)) {
+        $ok = $htpasswd->htpasswd($username, $password, { 'overwrite' => 1 });
+    } else {
+        $ok = $htpasswd->htpasswd($username, $password);
+    }
+    unless ($ok) {
+        die "unable to write user '$username' to '$path': " . $htpasswd->error . "\n";
+    }
+    fix_file_permissions($path);
+
+    eval { pf::cluster::sync_files([$path]) };
+    if ($@) {
+        $logger->error("error syncing htpasswd file '$path' to cluster: $@");
+    }
+    return $TRUE;
+}
+
+=head2 delete_user
+
+Remove a user from the htpasswd file and sync the file to all cluster members.
+Returns true even if the user did not exist. Dies on htpasswd library errors.
+
+=cut
+
+sub delete_user {
+    my ($self, $username) = @_;
+    my $logger = get_logger();
+
+    die "username must not be empty\n"
+        if !defined $username || $username eq '';
+
+    my $path = $self->{'path'};
+    return $TRUE unless defined $path && $path ne '' && -e $path;
+
+    my $htpasswd = Apache::Htpasswd->new({ passwdFile => $path });
+    return $TRUE unless $htpasswd->fetchPass($username);
+
+    unless ($htpasswd->htDelete($username)) {
+        die "unable to delete user '$username' from '$path': " . $htpasswd->error . "\n";
+    }
+
+    eval { pf::cluster::sync_files([$path]) };
+    if ($@) {
+        $logger->error("error syncing htpasswd file '$path' to cluster: $@");
+    }
+    return $TRUE;
 }
 
 =head1 AUTHOR

--- a/lib/pf/UnifiedApi.pm
+++ b/lib/pf/UnifiedApi.pm
@@ -1598,6 +1598,16 @@ sub setup_api_v1_config_sources_routes {
     $collection_route->any(['POST'] => "/test")->to("Config::Sources#test")->name("api.v1.Config.Sources.test");
     $resource_route->register_sub_action({ method => 'GET', action => 'saml_metadata'});
 
+    my $htpasswd_users_route = $resource_route->any("/htpasswd_users")->name("api.v1.Config.Sources.resource.htpasswd_users");
+    $htpasswd_users_route->any(['GET'])->to("Config::Sources#htpasswd_users_list")->name("api.v1.Config.Sources.resource.htpasswd_users.list");
+    $htpasswd_users_route->any(['POST'])->to("Config::Sources#htpasswd_users_create" => {auditable => 1})->name("api.v1.Config.Sources.resource.htpasswd_users.create");
+    my $htpasswd_user_route = $htpasswd_users_route->any("/#username")->name("api.v1.Config.Sources.resource.htpasswd_users.user");
+    $htpasswd_user_route->any(['PATCH'])->to("Config::Sources#htpasswd_users_update" => {auditable => 1})->name("api.v1.Config.Sources.resource.htpasswd_users.update");
+    $htpasswd_user_route->any(['DELETE'])->to("Config::Sources#htpasswd_users_delete" => {auditable => 1})->name("api.v1.Config.Sources.resource.htpasswd_users.delete");
+
+    my $htpasswd_file_route = $resource_route->any("/htpasswd_file")->name("api.v1.Config.Sources.resource.htpasswd_file");
+    $htpasswd_file_route->any(['POST'])->to("Config::Sources#htpasswd_file_create" => {auditable => 1})->name("api.v1.Config.Sources.resource.htpasswd_file.create");
+
     return ($collection_route, $resource_route);
 }
 

--- a/lib/pf/UnifiedApi/Controller/Config/Sources.pm
+++ b/lib/pf/UnifiedApi/Controller/Config/Sources.pm
@@ -180,6 +180,141 @@ sub saml_metadata {
     return $self->render(text => $xml);;
 }
 
+=head2 _get_htpasswd_source
+
+Resolve the source id from the route and ensure it is an Htpasswd source.
+Renders a proper error response and returns undef on failure.
+
+=cut
+
+sub _get_htpasswd_source {
+    my ($self) = @_;
+    my $id = $self->id;
+    my $source = pf::authentication::getAuthenticationSource($id);
+    if (!defined $source) {
+        $self->render_error(404, "source '$id' not found");
+        return undef;
+    }
+    if (($source->{type} // '') ne 'Htpasswd') {
+        $self->render_error(405, "source '$id' is not an Htpasswd source");
+        return undef;
+    }
+    return $source;
+}
+
+=head2 htpasswd_users_list
+
+List the users defined in the htpasswd file of the source.
+
+=cut
+
+sub htpasswd_users_list {
+    my ($self) = @_;
+    my $source = $self->_get_htpasswd_source or return;
+    my $users = eval { $source->list_users };
+    if ($@) {
+        return $self->render_error(500, "$@");
+    }
+    my $file_exists = $source->file_exists ? \1 : \0;
+    return $self->render(
+        status => 200,
+        json   => { items => $users, file_exists => $file_exists },
+    );
+}
+
+=head2 htpasswd_file_create
+
+Create the htpasswd file for the source on disk and sync it to all cluster
+members. Idempotent: returns 201 when the file was newly created, 200 when
+it already existed.
+
+=cut
+
+sub htpasswd_file_create {
+    my ($self) = @_;
+    my $source = $self->_get_htpasswd_source or return;
+    my @errors = $source->validate_path;
+    if (@errors) {
+        return $self->render_error(422, join(' ', @errors));
+    }
+    my $result = eval { $source->create_file };
+    if ($@) {
+        return $self->render_error(500, "$@");
+    }
+    my $status = $result->{created} ? 201 : 200;
+    return $self->render(status => $status, json => $result);
+}
+
+=head2 htpasswd_users_create
+
+Create or update a user. Body: { username, password }.
+
+=cut
+
+sub htpasswd_users_create {
+    my ($self) = @_;
+    my $source = $self->_get_htpasswd_source or return;
+    my ($error, $data) = $self->get_json;
+    if (defined $error) {
+        return $self->render_error(400, "Bad Request : $error");
+    }
+    my $username = $data->{username};
+    my $password = $data->{password};
+    if (!defined $username || $username eq '') {
+        return $self->render_error(422, "username is required");
+    }
+    if (!defined $password || $password eq '') {
+        return $self->render_error(422, "password is required");
+    }
+    eval { $source->set_user($username, $password) };
+    if ($@) {
+        return $self->render_error(422, "$@");
+    }
+    return $self->render(status => 201, json => { username => $username });
+}
+
+=head2 htpasswd_users_update
+
+Update the password of an existing user. Body: { password }.
+
+=cut
+
+sub htpasswd_users_update {
+    my ($self) = @_;
+    my $source = $self->_get_htpasswd_source or return;
+    my $username = $self->stash('username');
+    my ($error, $data) = $self->get_json;
+    if (defined $error) {
+        return $self->render_error(400, "Bad Request : $error");
+    }
+    my $password = $data->{password};
+    if (!defined $password || $password eq '') {
+        return $self->render_error(422, "password is required");
+    }
+    eval { $source->set_user($username, $password) };
+    if ($@) {
+        return $self->render_error(422, "$@");
+    }
+    return $self->render(status => 200, json => { username => $username });
+}
+
+=head2 htpasswd_users_delete
+
+Delete a user from the htpasswd file.
+
+=cut
+
+sub htpasswd_users_delete {
+    my ($self) = @_;
+    my $source = $self->_get_htpasswd_source or return;
+    my $username = $self->stash('username');
+    eval { $source->delete_user($username) };
+    if ($@) {
+        return $self->render_error(422, "$@");
+    }
+    return $self->render(status => 204, data => '');
+}
+
 sub cleanup_item {
     my ($self, $item) = @_;
     $item = $self->SUPER::cleanup_item($item);

--- a/t/unittest/UnifiedApi/Controller/Config/Sources/Htpasswd.t
+++ b/t/unittest/UnifiedApi/Controller/Config/Sources/Htpasswd.t
@@ -20,7 +20,7 @@ BEGIN {
     use setup_test_config;
 }
 
-use Test::More tests => 26;
+use Test::More tests => 75;
 
 #This test will running last
 use Test::NoWarnings;
@@ -210,6 +210,121 @@ $t->patch_ok("$base_url/$id3" =>
   )
   ->status_is(200)
   ->json_is("/path", "/usr/local/pf/conf/uploads/sources/${id3}_path_upload.conf");
+
+# htpasswd_users sub-resource (GUI-driven user management) ====================
+
+# the source created above via path_upload already has one user 'authtest'
+$t->get_ok("$base_url/$id1/htpasswd_users")
+  ->status_is(200)
+  ->json_is('/items', ['authtest']);
+
+# add a new user
+$t->post_ok("$base_url/$id1/htpasswd_users" =>
+    json => { username => 'alice', password => 's3cret' }
+  )
+  ->status_is(201)
+  ->json_is('/username', 'alice');
+
+# listing now shows both, sorted
+$t->get_ok("$base_url/$id1/htpasswd_users")
+  ->status_is(200)
+  ->json_is('/items', ['alice', 'authtest']);
+
+# update an existing user's password
+$t->patch_ok("$base_url/$id1/htpasswd_users/alice" =>
+    json => { password => 'new-s3cret' }
+  )
+  ->status_is(200)
+  ->json_is('/username', 'alice');
+
+# rejecting invalid input
+$t->post_ok("$base_url/$id1/htpasswd_users" =>
+    json => { username => 'bob', password => '' }
+  )
+  ->status_is(422);
+
+$t->post_ok("$base_url/$id1/htpasswd_users" =>
+    json => { username => 'has:colon', password => 'whatever' }
+  )
+  ->status_is(422);
+
+# delete the user
+$t->delete_ok("$base_url/$id1/htpasswd_users/alice")
+  ->status_is(204);
+
+$t->get_ok("$base_url/$id1/htpasswd_users")
+  ->status_is(200)
+  ->json_is('/items', ['authtest']);
+
+# deleting an unknown user is a no-op (still 204)
+$t->delete_ok("$base_url/$id1/htpasswd_users/nobody")
+  ->status_is(204);
+
+# the sub-resource is only available on Htpasswd sources
+# create a non-Htpasswd source for negative testing
+my $null_id = "null_$$";
+$t->post_ok("$collection_base_url" =>
+    json => {
+        type => 'Null',
+        id => $null_id,
+        description => "negative test",
+    }
+  )
+  ->status_is(201);
+
+$t->get_ok("$base_url/$null_id/htpasswd_users")
+  ->status_is(405);
+
+# htpasswd_file sub-resource (create file on demand) =========================
+
+# list response carries file_exists for an existing source
+$t->get_ok("$base_url/$id1/htpasswd_users")
+  ->status_is(200)
+  ->json_is('/file_exists', $true);
+
+# create a fresh source that points at a path which does not exist yet
+my $missing_id = "missing_$$";
+my $missing_path = "/tmp/pf-test-htpasswd-${missing_id}.conf";
+unlink $missing_path;
+$t->post_ok("$collection_base_url" =>
+    json => {
+        type => 'Htpasswd',
+        id   => $missing_id,
+        path => $missing_path,
+        path_upload => undef,
+        description => "missing-file test",
+    }
+  )
+  ->status_is(201);
+
+# list now reports file_exists: false
+$t->get_ok("$base_url/$missing_id/htpasswd_users")
+  ->status_is(200)
+  ->json_is('/items', [])
+  ->json_is('/file_exists', $false);
+
+# create the file via the new endpoint
+$t->post_ok("$base_url/$missing_id/htpasswd_file")
+  ->status_is(201)
+  ->json_is('/created', 1);
+ok(-e $missing_path, "$missing_path was created on disk");
+
+# second call is a no-op (200, created => 0)
+$t->post_ok("$base_url/$missing_id/htpasswd_file")
+  ->status_is(200)
+  ->json_is('/created', 0);
+
+# list now reports file_exists: true and an empty list
+$t->get_ok("$base_url/$missing_id/htpasswd_users")
+  ->status_is(200)
+  ->json_is('/items', [])
+  ->json_is('/file_exists', $true);
+
+# create endpoint is only available on Htpasswd sources
+$t->post_ok("$base_url/$null_id/htpasswd_file")
+  ->status_is(405);
+
+unlink $missing_path;
 
 =head1 AUTHOR
 


### PR DESCRIPTION
## Related issue

Addresses #9038 ("Add GUI Visibility for htpasswd Administrative Users in
PacketFence"). The original request was a read-only view of the users
defined in an Htpasswd source; this PR satisfies that and goes beyond it
by also covering full add / change-password / delete management plus
on-demand file creation, all propagated cluster-wide. The reviewers may
decide whether they want to close the issue with this PR or keep it open
for the lighter read-only-only variant.

## Description

Until now the only way to add or remove users in an Htpasswd authentication
source was to edit (or upload) the password file outside of PacketFence and
to repeat the operation on every cluster member. That is error-prone and a
poor fit for clustered deployments where the file has to be in sync on all
nodes.

This PR adds a small **Users** section to the Htpasswd source form. Once
the source has been saved with a file path (typed or uploaded), the admin
can list, add, change and delete users directly from the GUI. Every write
goes through `Apache::Htpasswd` and is then propagated to the other cluster
members through the existing `pf::cluster::sync_files()` helper -- the
same mechanism the `path_upload` field already relies on -- so all nodes
stay consistent without any CLI work.

The form also accepts a path that does not yet exist on disk. The Users
section then shows a *Create new htpasswd file* button that creates the
file on the local node and, when running in a cluster, propagates it to
the other members; missing intermediate directories are created on every
node by the existing `safe_file_update` / `pf_make_dir` chain.

Backend:

- `pf::Authentication::Source::HtpasswdSource` gains `list_users`,
  `set_user`, `delete_user`, `file_exists`, `create_file` and
  `validate_path` helpers. `validate_path` performs all the path sanity
  checks in one place and is reused by the source form validator so the
  Save and the Create-File paths cannot disagree.
- `pf::UnifiedApi::Controller::Config::Sources` exposes the new
  endpoints under `/api/v1/config/source/<id>/htpasswd_users`
  (GET/POST/PATCH/DELETE) and `/htpasswd_file` (POST), with the
  standard `auditable` flag on every write. The list response carries a
  `file_exists` boolean.
- `pfappserver::Form::Config::Source::Htpasswd` switches the path field
  from `Path` to `Text` (so a path pointing at a not-yet-existing file
  can be saved) and delegates the validation to
  `HtpasswdSource::validate_path`.

Frontend:

- New `BaseHtpasswdUsers` component (table + add / change-password /
  delete modal + a *Create new htpasswd file* button shown when the
  configured path is missing) embedded in `FormTypeHtpasswd` when
  editing an existing source. The user list is reloaded whenever the
  path field changes.
- Five corresponding api helpers in `sources/_api.js`.

## Impacts

- **Auth sources / GUI**: adds a new section to the Htpasswd source form.
- **API**: 5 new endpoints under
  `/api/v1/config/source/<id>/htpasswd_users` and `…/htpasswd_file`.
- **Cluster**: reuses `pf::cluster::sync_files()` -- no new transport,
  no new daemon.
- **Filesystem**: empty files created through the new button are fixed
  up with `fix_file_permissions` so PacketFence can read them.
- No DB schema change. No new package dependency.

## Delete branch after merge

YES

## Checklist

- [x] Document the feature (extended
      `docs/installation/authentication_sources.asciidoc`)
- [x] Add OpenAPI specification (extended
      `docs/api/spec/static/paths/config/sources.yaml`)
- [x] Add unit tests (extended
      `t/unittest/UnifiedApi/Controller/Config/Sources/Htpasswd.t` --
      `prove` could not be run in the test environment because the test
      harness needs write access to `/usr/local/pf/logs/`, which the CI
      provides)
- [ ] Add acceptance tests (TestLink) -- happy to coordinate with QA on
      a TestLink scenario for the GUI flow

## NEWS file entries

```
  - Htpasswd authentication source — list, add, change the password of, and
    remove users directly from the admin UI; every write is propagated to the
    other cluster members through pf::cluster::sync_files() so the password
    file stays in sync without any CLI work
  - Htpasswd authentication source — create a new htpasswd file directly
    from the admin UI; the file is created on the local node and, when
    running in a cluster, propagated to the other members so a fresh
    source is immediately usable without touching the filesystem manually
```

The `(#NNNN)` PR-number suffix on those NEWS bullets will be added once
GitHub assigns this PR a number.

## Notes for reviewers

- The new POST `/htpasswd_file` endpoint is intentionally a sibling of
  `htpasswd_users` rather than an implicit side-effect of the list
  endpoint, so an admin who points the source at an existing htpasswd
  file is never surprised by an unrelated write.
- The path validator restricts new files to live under `/usr/local/pf/`
  so we never end up writing into a path that is not bind-mounted into
  the `pfperl-api` container -- which would silently land in the
  ephemeral container layer.
- Hashing algorithm remains the `Apache::Htpasswd` default (CRYPT).
  Making it configurable (bcrypt) is a sensible follow-up but kept out
  of this PR to stay small and focused.