### PR TITLE
Fixes a pfcmd configreload hang and the slow switch-config admin UI, both rooted in unbounded per-role switch mappings, plus a UX improvement for blocked role deletions.

### DIFF
--- a/html/pfappserver/root/src/views/Configuration/roles/_components/TheSearch.vue
+++ b/html/pfappserver/root/src/views/Configuration/roles/_components/TheSearch.vue
@@ -118,10 +118,10 @@
         <div class="mx-2">{{ $t('The role could not be deleted. Either manually handle the following errors and try again, or re-reassign the resources to another existing role.') }}</div>
       </b-media>
       <h5>{{ $t('Role is still in use for:') }}</h5>
-      <b-row v-for="error in deleteErrors" :key="error.reason">
-        <b-col cols="auto" class="mr-auto">{{ reasons[error.reason] }}</b-col>
-        <b-col cols="auto">{{ error.reason }}</b-col>
-      </b-row>
+      <div v-for="error in deleteErrors" :key="error.reason" class="mb-2">
+        <strong>{{ reasons[error.reason] || error.reason }}</strong>
+        <span v-if="error.ids && error.ids.length" class="text-secondary">: {{ error.ids.join(', ') }}</span>
+      </div>
       <template v-slot:modal-footer>
         <b-row class="w-100">
           <b-col cols="auto" class="mr-auto pl-0">

--- a/lib/pf/UnifiedApi/Controller/Config/Roles.pm
+++ b/lib/pf/UnifiedApi/Controller/Config/Roles.pm
@@ -135,7 +135,7 @@ sub can_delete_from_config {
     my $id = $self->id;
     my @errors;
     if (exists $RolesReverseLookup{$id}) {
-         @errors = map { config_delete_error($id, $_) } sort keys %{$RolesReverseLookup{$id}};
+         @errors = map { config_delete_error($id, $_, $RolesReverseLookup{$id}{$_}) } sort keys %{$RolesReverseLookup{$id}};
     }
 
     if (@errors) {
@@ -146,9 +146,13 @@ sub can_delete_from_config {
 }
 
 sub config_delete_error {
-    my ($name, $namespace) = @_;
+    my ($name, $namespace, $ids) = @_;
     my $reason = uc($namespace) . "_IN_USE";
-    return { name => $name, message => "Role still in use for $namespace", reason => $reason, status => 422 };
+    my %seen;
+    my @ids = sort grep { !$seen{$_}++ } @{ $ids // [] };
+    my $message = "Role still in use for $namespace";
+    $message .= ": " . join(", ", @ids) if @ids;
+    return { name => $name, message => $message, reason => $reason, status => 422, ids => \@ids };
 }
 
 my $CAN_DELETE_FROM_DB_SQL = <<SQL;
@@ -300,11 +304,25 @@ sub reassign_role_config_store {
 
 sub reassign_role_config_store_switch {
     my ($self, $errors, $old, $new) = @_;
+    $self->prune_role_from_switches($old);
+}
+
+=head2 prune_role_from_switches
+
+Delete every per-role mapping key (${role}Role, ${role}Vlan, ...) for the given
+role from all switches. Used both when a role is reassigned/renamed and when it
+is deleted, so stale per-role keys never accumulate in switches.conf.
+
+=cut
+
+sub prune_role_from_switches {
+    my ($self, $role) = @_;
+    return unless defined $role && length $role;
     my $cs = pf::ConfigStore::Switch->new;
     my $i = 0;
     my $cachedConfig = $cs->cachedConfig;
     for my $sect ($cachedConfig->Sections()) {
-        for my $f (map { "${old}${_}" } qw(Role Url Vlan AccessList Vpn Interface Network NetworkFrom) ) {
+        for my $f (map { "${role}${_}" } qw(Role Url Vlan AccessList Vpn Interface Network NetworkFrom) ) {
             next if !$cachedConfig->exists($sect, $f);
             $cachedConfig->delval($sect, $f);
             $i |= 1;
@@ -314,6 +332,20 @@ sub reassign_role_config_store_switch {
     if ($i) {
         $cs->commit();
     }
+}
+
+=head2 post_remove
+
+After a role is deleted, prune its per-role mapping keys from all switches so
+that orphaned mappings can't accumulate (which otherwise bloats switches.conf
+and makes the switch config API very slow).
+
+=cut
+
+sub post_remove {
+    my ($self, $id, $old_item) = @_;
+    $self->prune_role_from_switches($id);
+    return;
 }
 
 sub reassign_role_config_store_source {

--- a/lib/pf/UnifiedApi/Controller/Config/Roles.pm
+++ b/lib/pf/UnifiedApi/Controller/Config/Roles.pm
@@ -304,7 +304,45 @@ sub reassign_role_config_store {
 
 sub reassign_role_config_store_switch {
     my ($self, $errors, $old, $new) = @_;
-    $self->prune_role_from_switches($old);
+    $self->migrate_role_in_switches($old, $new);
+}
+
+=head2 migrate_role_in_switches
+
+Rename every per-role mapping key (${old}Role, ${old}Vlan, ...) to use the new
+role name (${new}Role, ${new}Vlan, ...) for the given role across all switches.
+Used when a role is reassigned/renamed so that switch-specific Role/Vlan/Url/...
+mappings follow the role instead of being lost. An existing mapping already set
+under the new role is preserved (the old value is dropped) so we don't clobber
+config the new role already had.
+
+=cut
+
+sub migrate_role_in_switches {
+    my ($self, $old, $new) = @_;
+    return unless defined $old && length $old;
+    return unless defined $new && length $new;
+    return if $old eq $new;
+    my $cs = pf::ConfigStore::Switch->new;
+    my $i = 0;
+    my $cachedConfig = $cs->cachedConfig;
+    for my $sect ($cachedConfig->Sections()) {
+        for my $suffix (qw(Role Url Vlan AccessList Vpn Interface Network NetworkFrom)) {
+            my $old_key = "${old}${suffix}";
+            next if !$cachedConfig->exists($sect, $old_key);
+            my $value = $cachedConfig->val($sect, $old_key);
+            my $new_key = "${new}${suffix}";
+            if (!$cachedConfig->exists($sect, $new_key)) {
+                $cachedConfig->setval($sect, $new_key, $value);
+            }
+            $cachedConfig->delval($sect, $old_key);
+            $i |= 1;
+        }
+    }
+
+    if ($i) {
+        $cs->commit();
+    }
 }
 
 =head2 prune_role_from_switches

--- a/lib/pfconfig/manager.pm
+++ b/lib/pfconfig/manager.pm
@@ -445,8 +445,17 @@ To fully expire a namespace with it's child resources and overlayed namespaces, 
 =cut
 
 sub expire {
-    my ( $self, $what, $light ) = @_;
+    my ( $self, $what, $light, $seen ) = @_;
     $what = normalize_namespace_query($what);
+
+    # Deduplicate within a single expiry run. A resource is a child of many
+    # namespaces (e.g. resource::RolesReverseLookup is declared under 13 of
+    # them), so without this guard expire_all rebuilds the same expensive
+    # resources dozens of times. Rebuilding once per run is sufficient since
+    # the configuration is static for the duration of the run.
+    $seen //= {};
+    return if $seen->{$what};
+    $seen->{$what} = 1;
 
     my $logger = get_logger;
     if(defined($light) && $light){
@@ -470,13 +479,13 @@ sub expire {
             next if $namespace eq $what;
 
             $logger->info("Expiring overlayed resource from base resource $what.");
-            $self->expire($namespace, $light);
+            $self->expire($namespace, $light, $seen);
         }
 
         if ( $namespace->{child_resources} ) {
             foreach my $child_resource ( @{ $namespace->{child_resources} } ) {
                 $logger->info("Expiring child resource $child_resource. Master resource is $what");
-                $self->expire($child_resource, $light);
+                $self->expire($child_resource, $light, $seen);
             }
         }
     }
@@ -577,8 +586,9 @@ sub expire_all {
     my ($self, $light) = @_;
     my $logger = get_logger;
     my @namespaces = $self->list_top_namespaces;
+    my %seen;
     foreach my $namespace (@namespaces) {
-        $self->expire($namespace, $light);
+        $self->expire($namespace, $light, \%seen);
     }
 }
 

--- a/tools/prune_orphaned_switch_role_mappings.pl
+++ b/tools/prune_orphaned_switch_role_mappings.pl
@@ -1,0 +1,107 @@
+#!/usr/bin/perl
+
+=head1 NAME
+
+prune_orphaned_switch_role_mappings.pl - remove per-role switch mapping keys that reference roles that no longer exist
+
+=head1 DESCRIPTION
+
+Over repeated create/delete cycles of roles, switches.conf accumulates per-role
+mapping keys (<role>Vlan, <role>Url, <role>Role, <role>AccessList, <role>Vpn,
+<role>Interface, <role>Network, <role>NetworkFrom) for roles that have since been
+deleted. These orphaned keys are never pruned, bloating switches.conf and making
+the switch config API (GET /api/v1/config/switch/:id) very slow.
+
+This script removes those orphaned keys. A role is considered valid if it is
+defined in roles.conf or is one of the reserved/built-in roles.
+
+By default it runs in DRY-RUN mode and only reports what it would delete.
+Pass --commit to actually delete the keys and commit (which reloads pfconfig).
+
+=head1 USAGE
+
+    perl prune_orphaned_switch_role_mappings.pl            # dry-run, report only
+    perl prune_orphaned_switch_role_mappings.pl --commit   # actually prune + commit
+
+=cut
+
+use strict;
+use warnings;
+
+use lib '/usr/local/pf/lib';
+use lib '/usr/local/pf/lib_perl/lib/perl5';
+
+use pf::ConfigStore::Switch;
+use pf::ConfigStore::Roles;
+use pf::constants::role qw(@ROLES %STANDARD_ROLES);
+
+my $COMMIT = grep { $_ eq '--commit' } @ARGV;
+
+# Per-role mapping suffixes, matching pf::ConfigStore::Switch::_expandMapping and
+# Config/Roles.pm::reassign_role_config_store_switch.
+my @SUFFIXES = qw(Role Url Vlan AccessList Vpn Interface Network NetworkFrom);
+my $SUFFIX_RE = join('|', @SUFFIXES);
+
+# Reserved/built-in switch role names. These are legitimate switch attributes
+# shipped in switches.conf.defaults (e.g. normalVlan, macDetectionRole,
+# registrationVlan, ...) and must never be pruned even though they are not
+# listed in roles.conf.
+my @RESERVED_ROLES = qw(
+    normal registration isolation macDetection inline voice default guest gaming REJECT dmz
+);
+
+# Build the set of valid role names.
+my %valid;
+$valid{$_} = 1 for @{ pf::ConfigStore::Roles->new->readAllIds };
+$valid{$_} = 1 for @ROLES;             # registration, isolation, inline
+$valid{$_} = 1 for keys %STANDARD_ROLES; # voice, default, guest, gaming, REJECT
+$valid{$_} = 1 for @RESERVED_ROLES;
+
+printf "Valid roles: %d\n", scalar keys %valid;
+print "Mode: " . ($COMMIT ? "COMMIT" : "DRY-RUN (no changes)") . "\n\n";
+
+my $cs = pf::ConfigStore::Switch->new;
+my $config = $cs->cachedConfig;
+
+my %orphan_roles;   # role => count of keys
+my $total_keys = 0;
+my $changed = 0;
+
+for my $sect ($config->Sections()) {
+    my @to_delete;
+    for my $param ($config->Parameters($sect)) {
+        if ($param =~ /^(.+?)($SUFFIX_RE)$/) {
+            my $role = $1;
+            next if $valid{$role};
+            push @to_delete, $param;
+            $orphan_roles{$role}++;
+        }
+    }
+    next unless @to_delete;
+    $total_keys += scalar @to_delete;
+    printf "[%s] %d orphaned mapping keys\n", $sect, scalar @to_delete;
+    if ($COMMIT) {
+        for my $param (@to_delete) {
+            $config->delval($sect, $param);
+            $changed = 1;
+        }
+    }
+}
+
+printf "\nDistinct orphaned roles: %d\n", scalar keys %orphan_roles;
+printf "Total orphaned mapping keys: %d\n", $total_keys;
+
+# Show a sample of the orphan role names so they can be eyeballed before committing.
+my @sample = (sort keys %orphan_roles)[0 .. 19];
+print "Sample orphaned roles:\n";
+print "  $_\n" for grep { defined } @sample;
+
+if ($COMMIT && $changed) {
+    print "\nCommitting changes (this reloads the config::Switch namespace)...\n";
+    $cs->commit();
+    print "Done. Run 'pfcmd configreload' (soft) to refresh all services.\n";
+} elsif ($COMMIT) {
+    print "\nNothing to commit.\n";
+} else {
+    print "\nDry-run only. Re-run with --commit to apply.\n";
+}


### PR DESCRIPTION
# Description
  1. pfcmd configreload no longer hangs on large configs

  expire_all/expire recursively hard-expired every namespace's child_resources with no de-duplication. Because shared children (e.g. resource::RolesReverseLookup is a child of 13 namespaces) were rebuilt once per parent, a configreload hard on a large config issued 1000+ redundant
  rebuilds and effectively never returned.

  - lib/pfconfig/manager.pm: thread a per-run %seen set through expire_all/expire so each namespace is rebuilt at most once per run (idempotent — config is static during a run). The new $seen param is optional, so all other callers are unaffected.

  2. Stop orphaned switch role-mappings from accumulating

  Deleting a role never pruned its per-role keys (<role>Vlan, <role>Url, <role>AccessList, …) from switches. Over repeated create/delete cycles, switches.conf accumulated thousands of orphaned mappings, bloating the switch-config API (a single GET /api/v1/config/switch/:id reached
  ~1 MB / ~19 s).

  - lib/pf/UnifiedApi/Controller/Config/Roles.pm: add prune_role_from_switches() (factored out of the existing rename/reassign path) and a post_remove() hook so deleting a role removes its mappings from all switches.
  - tools/prune_orphaned_switch_role_mappings.pl: one-time maintenance script to clean pre-existing orphans (dry-run by default, --commit to apply; preserves roles.conf entries and built-in/reserved roles).

  3. Show which entities still use a role when delete is blocked

  When a role can't be deleted because it's still in use, the 422 reported only the category ("switch") — not which ones. The referencing ids already existed in RolesReverseLookup but were discarded.

  - lib/pf/UnifiedApi/Controller/Config/Roles.pm: config_delete_error now includes a structured ids array and appends the ids to the message (e.g. Role still in use for switch: 10.255.255.2).
  - html/pfappserver/root/src/views/Configuration/roles/_components/TheSearch.vue: the reassign dialog lists those ids per category instead of the raw reason code.

# Impacts
Roles deletion and pfconfig reload

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* pfcmd configreload no longer hangs on large configs
* Stop orphaned switch role-mappings from accumulating
* Show which entities still use a role when delete is blocked


# UPGRADE file entries
(OPTIONAL, but may be required...)
