### PR TITLE
Require AUP and AUP Template in choice portal module

### DIFF
--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/Choice.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/Choice.pm
@@ -19,6 +19,8 @@ has 'custom_fields' => (is => 'rw', isa => 'ArrayRef[Str]', default => sub {[]})
 
 has 'with_aup' => (is => 'rw', default => sub {1});
 
+has 'aup_template' => (is => 'rw', default => sub {'aup_text.html'});
+
 with 'captiveportal::Role::MultiSource';
 
 use pf::log;
@@ -59,6 +61,7 @@ sub BUILD {
             source_id => $source->id,
             custom_fields => $self->custom_fields,
             with_aup => $self->with_aup,
+            aup_template => $self->aup_template,
         ));
     }
 }

--- a/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/Choice.pm
+++ b/html/captive-portal/lib/captiveportal/PacketFence/DynamicRouting/Module/Authentication/Choice.pm
@@ -17,6 +17,8 @@ has 'source' => (is => 'rw', isa => 'pf::Authentication::Source');
 
 has 'custom_fields' => (is => 'rw', isa => 'ArrayRef[Str]', default => sub {[]});
 
+has 'with_aup' => (is => 'rw', default => sub {1});
+
 with 'captiveportal::Role::MultiSource';
 
 use pf::log;
@@ -56,6 +58,7 @@ sub BUILD {
             parent => $self,
             source_id => $source->id,
             custom_fields => $self->custom_fields,
+            with_aup => $self->with_aup,
         ));
     }
 }

--- a/html/pfappserver/lib/pfappserver/Form/Config/PortalModule/Authentication/Choice.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/PortalModule/Authentication/Choice.pm
@@ -30,22 +30,32 @@ has_field 'with_aup' =>
              help => 'Require the user to accept the AUP' },
   );
 
+has_field 'aup_template' =>
+  (
+   type => 'Text',
+   label => 'AUP template',
+   required => 1,
+   tags => { after_element => \&help,
+             help => 'The template to use for the AUP' },
+  );
+
 ## Definition
 
 sub child_definition {
     my ($self) = @_;
-    return ($self->source_fields, qw(custom_fields template with_aup));
+    return ($self->source_fields, qw(custom_fields template with_aup aup_template));
 }
 
 =head2 BUILD
 
-set the default value for the with_aup field from the module attribute
+set the default value for the with_aup and aup_template fields from the module attributes
 
 =cut
 
 sub BUILD {
     my ($self) = @_;
     $self->field('with_aup')->default($self->for_module->meta->find_attribute_by_name('with_aup')->default->());
+    $self->field('aup_template')->default($self->for_module->meta->find_attribute_by_name('aup_template')->default->());
 }
 
 =over

--- a/html/pfappserver/lib/pfappserver/Form/Config/PortalModule/Authentication/Choice.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/PortalModule/Authentication/Choice.pm
@@ -20,11 +20,32 @@ with 'pfappserver::Base::Form::Role::WithCustomFields';
 use captiveportal::DynamicRouting::Module::Authentication::Choice;
 sub for_module {'captiveportal::PacketFence::DynamicRouting::Module::Authentication::Choice'}
 
+has_field 'with_aup' =>
+  (
+   type => 'Checkbox',
+   label => 'Require AUP',
+   checkbox_value => 1,
+   input_without_param => 0,
+   tags => { after_element => \&help,
+             help => 'Require the user to accept the AUP' },
+  );
+
 ## Definition
 
 sub child_definition {
     my ($self) = @_;
-    return ($self->source_fields, qw(custom_fields template));
+    return ($self->source_fields, qw(custom_fields template with_aup));
+}
+
+=head2 BUILD
+
+set the default value for the with_aup field from the module attribute
+
+=cut
+
+sub BUILD {
+    my ($self) = @_;
+    $self->field('with_aup')->default($self->for_module->meta->find_attribute_by_name('with_aup')->default->());
 }
 
 =over

--- a/html/pfappserver/root/src/views/Configuration/portalModules/_components/FormTypeAuthenticationChoice.vue
+++ b/html/pfappserver/root/src/views/Configuration/portalModules/_components/FormTypeAuthenticationChoice.vue
@@ -29,6 +29,11 @@
       :text="$i18n.t('Require the user to accept the AUP')"
     />
 
+    <form-group-aup-template namespace="aup_template"
+      :column-label="$i18n.t('AUP template')"
+      :text="$i18n.t('The template to use for the Acceptable Use Policy')"
+    />
+
     <form-group-template namespace="template"
       :column-label="$i18n.t('Template')"
     />
@@ -77,7 +82,8 @@ import {
   FormGroupMultiSourceObjectClasses,
   FormGroupMultiSourceTypes,
   FormGroupTemplate,
-  FormGroupWithAup
+  FormGroupWithAup,
+  FormGroupAupTemplate
 } from './'
 
 const components = {
@@ -94,7 +100,8 @@ const components = {
   FormGroupMultiSourceObjectClasses,
   FormGroupMultiSourceTypes,
   FormGroupTemplate,
-  FormGroupWithAup
+  FormGroupWithAup,
+  FormGroupAupTemplate
 }
 
 import { useForm as setup, useFormProps as props } from '../_composables/useForm'

--- a/html/pfappserver/root/src/views/Configuration/portalModules/_components/FormTypeAuthenticationChoice.vue
+++ b/html/pfappserver/root/src/views/Configuration/portalModules/_components/FormTypeAuthenticationChoice.vue
@@ -24,6 +24,11 @@
       :text="$i18n.t('These fields will be saved through the registration process')"
     />
 
+    <form-group-with-aup namespace="with_aup"
+      :column-label="$i18n.t('Require AUP')"
+      :text="$i18n.t('Require the user to accept the AUP')"
+    />
+
     <form-group-template namespace="template"
       :column-label="$i18n.t('Template')"
     />
@@ -71,7 +76,8 @@ import {
   FormGroupMultiSourceAuthClasses,
   FormGroupMultiSourceObjectClasses,
   FormGroupMultiSourceTypes,
-  FormGroupTemplate
+  FormGroupTemplate,
+  FormGroupWithAup
 } from './'
 
 const components = {
@@ -87,7 +93,8 @@ const components = {
   FormGroupMultiSourceAuthClasses,
   FormGroupMultiSourceObjectClasses,
   FormGroupMultiSourceTypes,
-  FormGroupTemplate
+  FormGroupTemplate,
+  FormGroupWithAup
 }
 
 import { useForm as setup, useFormProps as props } from '../_composables/useForm'


### PR DESCRIPTION
# Description
With the default portal module when a choice module use Sources by Class (dynamic source selection) then there is no way to enable or disable the AUP since there is no toggle and by default it´s enabled in the code.
This PR added the "Require AUP" and "AUP Template" in the choice module.

# Impacts
Portal modules

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* Require AUP and AUP Template option in choice portal module