### PR TITLE
fix(dvd-usb-iso): pin pf-repo to Debian snapshot matching DVD release

### DIFF
--- a/ci/debian-version.conf
+++ b/ci/debian-version.conf
@@ -1,8 +1,2 @@
-# Shared Debian version configuration for ISO builders
-# Used by: cd-iso and dvd-usb-iso
-#
-# When updating, verify both ISOs exist at:
-#   https://cdimage.debian.org/cdimage/archive/${DEBIAN_VERSION}/amd64/iso-cd/
-#   https://cdimage.debian.org/cdimage/archive/${DEBIAN_VERSION}/amd64/iso-dvd/
-
-DEBIAN_VERSION=12.12.0
+DEBIAN_VERSION=12.14.0
+DEBIAN_SNAPSHOT_DATE=20260516T235959Z

--- a/ci/dvd-usb-iso/create-local-repo.sh
+++ b/ci/dvd-usb-iso/create-local-repo.sh
@@ -20,6 +20,16 @@ PF_RELEASE_VERSION=${2:-15.1}
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 PF_ROOT=$(cd "${SCRIPT_DIR}/../.." && pwd)
 
+source "${SCRIPT_DIR}/../debian-version.conf"
+
+if [ -n "${DEBIAN_SNAPSHOT_DATE:-}" ]; then
+    DEBIAN_MIRROR="https://snapshot.debian.org/archive/debian/${DEBIAN_SNAPSHOT_DATE}"
+    echo "Using Debian snapshot mirror: ${DEBIAN_MIRROR}"
+else
+    DEBIAN_MIRROR="http://deb.debian.org/debian"
+    echo "WARNING: DEBIAN_SNAPSHOT_DATE not set, using current mirror (may cause version conflicts)"
+fi
+
 # PacketFence repository URL configuration
 # Available options:
 #   - debian-branches: Branch builds (default, for devel/feature branches)
@@ -66,7 +76,19 @@ CHROOT_DIR=$(mktemp -d)
 trap 'echo "Cleaning up chroot..."; ${SUDO} rm -rf "${CHROOT_DIR}"' EXIT
 
 echo "===> Creating minimal chroot for package download"
-${SUDO} debootstrap --variant=minbase --include=apt,gnupg,ca-certificates bookworm ${CHROOT_DIR} http://deb.debian.org/debian
+${SUDO} debootstrap --variant=minbase --include=apt,gnupg,ca-certificates bookworm ${CHROOT_DIR} ${DEBIAN_MIRROR}
+
+if [ -n "${DEBIAN_SNAPSHOT_DATE:-}" ]; then
+    ${SUDO} tee ${CHROOT_DIR}/etc/apt/sources.list > /dev/null << EOF
+deb [check-valid-until=no] ${DEBIAN_MIRROR} bookworm main
+deb [check-valid-until=no] ${DEBIAN_MIRROR} bookworm-updates main
+deb [check-valid-until=no] https://snapshot.debian.org/archive/debian-security/${DEBIAN_SNAPSHOT_DATE} bookworm-security main
+EOF
+    ${SUDO} tee ${CHROOT_DIR}/etc/apt/apt.conf.d/99snapshot > /dev/null << 'EOF'
+Acquire::Check-Valid-Until "false";
+Acquire::Retries "3";
+EOF
+fi
 
 # Add PacketFence repository only (we'll use DVD for Debian packages)
 echo "===> Configuring PacketFence repository in chroot"


### PR DESCRIPTION
# Description
Pin the DVD-USB ISO offline repo to a Debian snapshot matching the DVD release
date, so `pf-repo` package versions match the DVD.

Without pinning, `debootstrap` pulls current Debian packages and the local
`pf-repo` ends up newer than the DVD. `apt` then picks the newer version and
the installer fails on strict version deps (e.g. `openssh-server` u7 on DVD
needs `openssh-client (= u7)`, but `pf-repo` provides u10).

# Impacts
- `ci/dvd-usb-iso/` build pipeline
- Reviewer: confirm `make dvd-usb-iso` succeeds and a VM install completes
  past "Select and install software".

# Delete branch after merge
YES

# Checklist
- [n/a] Document the feature
- [n/a] Add OpenAPI specification
- [n/a] Add unit tests
- [ ] Add acceptance tests (TestLink) — manual VM install validation

# NEWS file entries
## Bug Fixes
* DVD-USB ISO installer failing at "Select and install software" due to
  package version mismatch between the DVD and the bundled offline `pf-repo`
