### PR TITLE
fix(kafka): make multi-node cluster reachable for PF-listener clients

### DIFF
--- a/bin/kafka-init.pl
+++ b/bin/kafka-init.pl
@@ -17,6 +17,7 @@ use lib qw(/usr/local/pf/lib_perl/lib/perl5);
 use pf::file_paths qw($kafka_config_file);
 use pf::IniFiles;
 use pf::cluster qw($cluster_enabled @cluster_hosts %ConfigCluster);
+use pfconfig::manager;
 use Crypt::OpenSSL::Random;
 use MIME::Base64;
 use Data::UUID;
@@ -110,7 +111,13 @@ sub get_cluster_member_for_kafka {
 
 sub make_member {
     my ($host, $ip, $node_id) = @_;
-    my $advertised_listeners = qq{INTERNAL://${ip}:29092,EXTERNAL://${ip}:9092,PF://containers-gateway.internal:9095,PFCONNECTOR://127.0.0.1:9096};
+    # In a cluster, every broker must advertise a unique, cross-node routable
+    # address for the PF listener. Using containers-gateway.internal here makes
+    # all brokers advertise the same hostname, which resolves to each node's own
+    # local broker -- so clients can never reach a partition leader / group
+    # coordinator that lives on another node (Not Leader / Not Coordinator
+    # errors). Advertise the node's management IP, like INTERNAL/EXTERNAL do.
+    my $advertised_listeners = qq{INTERNAL://${ip}:29092,EXTERNAL://${ip}:9092,PF://${ip}:9095,PFCONNECTOR://127.0.0.1:9096};
     return {
         host => $host,
         node_id => $node_id,
@@ -134,7 +141,14 @@ sub set_or_create {
     }
 }
 
-$ini->RewriteConfig() if $changed;
+if ($changed) {
+    $ini->RewriteConfig();
+    # We edited kafka.conf directly on disk, so the pfconfig cache for this
+    # namespace is now stale. Expire it so that downstream consumers
+    # (e.g. `pfcmd service kafka generateconfig` building var/conf/kafka.env)
+    # read the values we just wrote instead of the previous cached ones.
+    pfconfig::manager->new->expire("config::Kafka");
+}
 
 =head1 AUTHOR
 

--- a/go/cmd/pfkafka/main.go
+++ b/go/cmd/pfkafka/main.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"time"
@@ -54,11 +56,21 @@ func main() {
 		}
 	}()
 
+	ctx := context.Background()
 	for {
-		m, err := r.ReadMessage(context.Background())
+		m, err := r.ReadMessage(ctx)
 		if err != nil {
-			fmt.Printf("Error: %s", err)
-			break
+			// The reader was closed or the context was cancelled: nothing left to do.
+			if errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) {
+				fmt.Fprintf(os.Stderr, "reader stopped: %s\n", err)
+				break
+			}
+			// Transient errors (leader election, coordinator move, metadata
+			// refresh, broker reconnects) are expected: kafka-go recovers on
+			// the next read, so log and keep going instead of exiting.
+			fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+			time.Sleep(time.Second)
+			continue
 		}
 		//fmt.Printf("message at offset-partition %d-%d: %s = %s\n", m.Offset, m.Partition, string(m.Key), string(m.Value))
 		fmt.Printf("%s\n", string(m.Value))

--- a/lib/pf/iptables.pm
+++ b/lib/pf/iptables.pm
@@ -1424,6 +1424,7 @@ sub iptables_kafka_rules {
                 util_safe_push( "-i $tint -p tcp -m tcp -s $ip --dport 29092 -j ACCEPT", $chains->{'filter'}{'INPUT'} );
                 util_safe_push( "-i $tint -p tcp -m tcp -s $ip --dport 9092 -j ACCEPT", $chains->{'filter'}{'INPUT'} );
                 util_safe_push( "-i $tint -p tcp -m tcp -s $ip --dport 9093 -j ACCEPT", $chains->{'filter'}{'INPUT'} );
+                util_safe_push( "-i $tint -p tcp -m tcp -s $ip --dport 9095 -j ACCEPT", $chains->{'filter'}{'INPUT'} );
             }
         } else {
             $logger->warn("Service $service_name: No ConfigKafka iptables cluster_ips is available.");


### PR DESCRIPTION
# Description
In a clustered setup, every broker advertised its PF listener (9095) as containers-gateway.internal, which resolves to each node's own local Docker gateway. Clients (pfkafka, PF services) could therefore never reach a partition leader or group coordinator living on another node, surfacing 'Not Leader For Partition' / 'Not Coordinator For Group' errors.

- kafka-init.pl: advertise the PF listener on the node's management IP (PF://${ip}:9095), like INTERNAL/EXTERNAL already do, so each broker exposes a unique cross-node routable address. Also expire the config::Kafka pfconfig cache after rewriting kafka.conf so downstream generateconfig reads the fresh values instead of the stale cache.
- iptables.pm: open port 9095 for cluster member IPs in iptables_kafka_rules (was missing), restricted to cluster_ips only.
- pfkafka: log and retry transient fetch errors instead of exiting on the first one, so the troubleshooting tool survives leader/coordinator moves.


# Impacts
Kafka cluster

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Bug Fixes
* Fixed kafka cluster communication
