### PR TITLE
Add Kerio Control firewall SSO

### DIFF
--- a/NEWS.asciidoc
+++ b/NEWS.asciidoc
@@ -27,6 +27,8 @@ For a list of compatibility related changes see the <<PacketFence_Upgrade_Guide.
 
 === New Features
 
+  - Kerio Control firewall SSO — native per-user SSO via the Kerio Control Administration API (ActiveHosts.login/logout)
+
 === Enhancements
 
 === Bug Fixes

--- a/docs/installation/firewall/kerio.asciidoc
+++ b/docs/installation/firewall/kerio.asciidoc
@@ -1,0 +1,62 @@
+// to display images directly on GitHub
+ifdef::env-github[]
+:encoding: UTF-8
+:lang: en
+:doctype: book
+:toc: left
+:imagesdir: ../../images
+endif::[]
+
+////
+
+    This file is part of the PacketFence project.
+
+    See PacketFence_Installation_Guide.asciidoc
+    for authors, copyright and license information.
+
+////
+
+
+==== Kerio Control
+
+The Kerio Control module performs Single-Sign-On against a Kerio Control
+firewall using its JSON-RPC Administration API. PacketFence binds the
+authenticated username to the device's entry in Kerio's *Active Hosts* table,
+which lets Kerio apply per-user policies and logging.
+
+[options="compact"]
+* *Protocol*: JSON-RPC 2.0 over HTTPS at `/admin/api/jsonrpc/`
+* *Authentication*: A Kerio Control administrator account (`Session.login`)
+* *Operations*: `ActiveHosts.login` (start) and `ActiveHosts.logout` (stop),
+  resolved to the host via `ActiveHosts.get`
+
+[IMPORTANT]
+====
+Kerio can only bind a user to a device that already appears in *Active Hosts*.
+Kerio must therefore be the gateway (in the traffic path) for the user networks.
+If the device is not listed in Kerio's Active Hosts, the SSO has nothing to
+attach to.
+====
+
+When Kerio is mapped to multiple directories, it identifies users as
+`user@domain`. Use the *Username format* / *Default realm* options so PacketFence
+sends the username in the form Kerio expects.
+
+==== SSO Configuration in PacketFence
+
+Go to *'Configuration' -> 'Integration' -> 'Firewall SSO' -> 'Add Firewall' ->
+'Kerio'*.
+
+[options="compact"]
+* *Hostname or IP Address*: IP of your Kerio Control firewall
+* *Username* and *Password*: a Kerio Control administrator account
+* *Port of the service*: 4081 (Kerio Administration API)
+* *Roles*: Add the roles that you want to do SSO with
+
+[NOTE]
+====
+PacketFence learns the device IP from RADIUS accounting. Ensure accounting is
+sent to PacketFence and that *'Configuration' -> 'System Configuration' ->
+'Advanced' -> 'Update the iplog using the accounting'* is enabled so the correct
+IP is sent to Kerio.
+====

--- a/docs/installation/firewall_sso_integration.asciidoc
+++ b/docs/installation/firewall_sso_integration.asciidoc
@@ -60,6 +60,10 @@ include::firewall/jsonrpc.asciidoc[]
 
 include::firewall/junipersrx.asciidoc[]
 
+=== Kerio Control
+
+include::firewall/kerio.asciidoc[]
+
 === Palo Alto
 
 include::firewall/paloalto.asciidoc[]

--- a/go/firewallsso/factory.go
+++ b/go/firewallsso/factory.go
@@ -39,6 +39,7 @@ func NewFactory(ctx context.Context) Factory {
 		"FamilyZone":       newFirewallSSO[FamilyZone],
 		"CiscoIsePic":      newFirewallSSO[CiscoIsePic],
 		"ContentKeeper":    newFirewallSSO[ContentKeeper],
+		"Kerio":            newFirewallSSO[Kerio],
 	}
 	return f
 }

--- a/go/firewallsso/kerio.go
+++ b/go/firewallsso/kerio.go
@@ -1,0 +1,279 @@
+package firewallsso
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/inverse-inc/go-utils/log"
+	"github.com/inverse-inc/packetfence/go/config/pfcrypt"
+)
+
+// Kerio Control firewall SSO.
+//
+// Kerio Control exposes a JSON-RPC Administration API (default port 4081) at
+// /admin/api/jsonrpc/. SSO is performed by binding a username to an existing
+// "active host" entry:
+//   - Session.login           -> obtain an X-Token (+ session cookie)
+//   - ActiveHosts.get         -> resolve the device IP to its active-host id
+//   - ActiveHosts.login       -> bind {hostId, userName}
+//   - ActiveHosts.logout      -> clear the binding for {ids}
+//   - Session.logout          -> drop the admin session
+//
+// The device must already be present in Kerio's Active Hosts (Kerio must be the
+// gateway/in-path for the user network) for the bind to attach.
+type Kerio struct {
+	FirewallSSO
+	Username string              `json:"username"`
+	Password pfcrypt.CryptString `json:"password"`
+	Port     string              `json:"port"`
+}
+
+// Firewall specific init: default the API port to 4081 if unset.
+func (fw *Kerio) initChild(ctx context.Context) error {
+	if fw.Port == "" {
+		log.LoggerWContext(ctx).Debug("Setting default Kerio API port 4081 as it isn't defined")
+		fw.Port = "4081"
+	}
+	return nil
+}
+
+// --- minimal JSON-RPC session client -------------------------------------
+
+type kerioError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+type kerioResponse struct {
+	Result json.RawMessage `json:"result"`
+	Error  *kerioError     `json:"error"`
+}
+
+type kerioHost struct {
+	ID json.Number `json:"id"`
+	IP string      `json:"ip"`
+}
+
+type kerioHostList struct {
+	List       []kerioHost `json:"list"`
+	TotalItems int         `json:"totalItems"`
+}
+
+// kerioSession holds the state for a single Start/Stop operation.
+type kerioSession struct {
+	client *http.Client
+	url    string
+	user   string
+	pass   string
+	token  string
+	cookie string
+	id     int
+}
+
+func (fw *Kerio) newSession(ctx context.Context) *kerioSession {
+	dst := fw.getDst(ctx, "tcp", fw.PfconfigHashNS, fw.Port)
+	return &kerioSession{
+		client: fw.getHttpClient(ctx),
+		url:    "https://" + dst + "/admin/api/jsonrpc/",
+		user:   fw.Username,
+		pass:   fw.Password.String(),
+	}
+}
+
+// raw performs a single JSON-RPC POST. When auth is true the X-Token and
+// session cookie are attached.
+func (s *kerioSession) raw(ctx context.Context, method string, params interface{}, auth bool) (json.RawMessage, *kerioError, error) {
+	s.id++
+	reqBody, err := json.Marshal(map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      s.id,
+		"method":  method,
+		"params":  params,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := http.NewRequest("POST", s.url, bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if auth {
+		req.Header.Set("X-Token", s.token)
+		if s.cookie != "" {
+			req.Header.Set("Cookie", s.cookie)
+		}
+	}
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer resp.Body.Close()
+
+	if sc := resp.Header.Get("Set-Cookie"); sc != "" {
+		s.cookie = strings.SplitN(sc, ";", 2)[0]
+	}
+
+	var out kerioResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, nil, err
+	}
+	return out.Result, out.Error, nil
+}
+
+// login authenticates and stores the session token.
+func (s *kerioSession) login(ctx context.Context) error {
+	s.cookie = ""
+	params := map[string]interface{}{
+		"userName": s.user,
+		"password": s.pass,
+		"application": map[string]string{
+			"name":    "PacketFence",
+			"vendor":  "PacketFence",
+			"version": "1.0",
+		},
+	}
+	res, apiErr, err := s.raw(ctx, "Session.login", params, false)
+	if err != nil {
+		return err
+	}
+	if apiErr != nil {
+		return fmt.Errorf("Kerio Session.login failed: %s", apiErr.Message)
+	}
+	var r struct {
+		Token string `json:"token"`
+	}
+	if err := json.Unmarshal(res, &r); err != nil {
+		return err
+	}
+	if r.Token == "" {
+		return fmt.Errorf("Kerio Session.login returned no token")
+	}
+	s.token = r.Token
+	return nil
+}
+
+// call logs in lazily and retries once if the session expired (-32001).
+func (s *kerioSession) call(ctx context.Context, method string, params interface{}) (json.RawMessage, error) {
+	if s.token == "" {
+		if err := s.login(ctx); err != nil {
+			return nil, err
+		}
+	}
+	res, apiErr, err := s.raw(ctx, method, params, true)
+	if err != nil {
+		return nil, err
+	}
+	if apiErr != nil {
+		if apiErr.Code == -32001 { // session expired, relogin once
+			if err := s.login(ctx); err != nil {
+				return nil, err
+			}
+			res, apiErr, err = s.raw(ctx, method, params, true)
+			if err != nil {
+				return nil, err
+			}
+			if apiErr != nil {
+				return nil, fmt.Errorf("Kerio %s failed: %s", method, apiErr.Message)
+			}
+			return res, nil
+		}
+		return nil, fmt.Errorf("Kerio %s failed: %s", method, apiErr.Message)
+	}
+	return res, nil
+}
+
+// logout drops the admin session (best effort).
+func (s *kerioSession) logout(ctx context.Context) {
+	if s.token == "" {
+		return
+	}
+	s.raw(ctx, "Session.logout", map[string]interface{}{}, true)
+}
+
+// hostIDByIP resolves an IP to its Kerio active-host id, or "" if not present.
+func (s *kerioSession) hostIDByIP(ctx context.Context, ip string) (json.Number, error) {
+	query := map[string]interface{}{
+		"fields":     []string{},
+		"conditions": []interface{}{},
+		"combining":  "Or",
+		"start":      0,
+		"limit":      100000,
+		"orderBy":    []interface{}{},
+	}
+	res, err := s.call(ctx, "ActiveHosts.get", map[string]interface{}{"query": query, "refresh": true})
+	if err != nil {
+		return "", err
+	}
+	var hl kerioHostList
+	if err := json.Unmarshal(res, &hl); err != nil {
+		return "", err
+	}
+	for _, h := range hl.List {
+		if h.IP == ip {
+			return h.ID, nil
+		}
+	}
+	return "", nil
+}
+
+// --- FirewallSSO interface ------------------------------------------------
+
+// Send an SSO start: resolve the host then bind the username to it.
+func (fw *Kerio) Start(ctx context.Context, info map[string]string, timeout int) (bool, error) {
+	s := fw.newSession(ctx)
+	defer s.logout(ctx)
+
+	hostID, err := s.hostIDByIP(ctx, info["ip"])
+	if err != nil {
+		log.LoggerWContext(ctx).Error(fmt.Sprintf("Couldn't query Kerio active hosts: %s", err))
+		return false, err
+	}
+	if hostID == "" {
+		err := fmt.Errorf("no Kerio active host for IP %s (is Kerio the gateway for this network?)", info["ip"])
+		log.LoggerWContext(ctx).Warn(err.Error())
+		return false, err
+	}
+
+	// Clear any stale binding first, then bind the user (mirrors a re-login).
+	s.call(ctx, "ActiveHosts.logout", map[string]interface{}{"ids": []json.Number{hostID}})
+
+	_, err = s.call(ctx, "ActiveHosts.login", map[string]interface{}{
+		"hostId":   hostID,
+		"userName": info["username"],
+	})
+	if err != nil {
+		log.LoggerWContext(ctx).Error(fmt.Sprintf("Couldn't SSO to Kerio: %s", err))
+		return false, err
+	}
+	return true, nil
+}
+
+// Send an SSO stop: clear the binding for the device's active host.
+func (fw *Kerio) Stop(ctx context.Context, info map[string]string) (bool, error) {
+	s := fw.newSession(ctx)
+	defer s.logout(ctx)
+
+	hostID, err := s.hostIDByIP(ctx, info["ip"])
+	if err != nil {
+		log.LoggerWContext(ctx).Error(fmt.Sprintf("Couldn't query Kerio active hosts: %s", err))
+		return false, err
+	}
+	if hostID == "" {
+		// Nothing bound for this IP, treat as success.
+		return true, nil
+	}
+
+	_, err = s.call(ctx, "ActiveHosts.logout", map[string]interface{}{"ids": []json.Number{hostID}})
+	if err != nil {
+		log.LoggerWContext(ctx).Error(fmt.Sprintf("Couldn't SSO stop to Kerio: %s", err))
+		return false, err
+	}
+	return true, nil
+}

--- a/go/firewallsso/kerio_test.go
+++ b/go/firewallsso/kerio_test.go
@@ -1,0 +1,50 @@
+package firewallsso
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestKerioDefaultPort(t *testing.T) {
+	fw := &Kerio{}
+	if err := fw.initChild(ctx); err != nil {
+		t.Fatalf("initChild returned an error: %s", err)
+	}
+	if fw.Port != "4081" {
+		t.Errorf("Expected default Kerio port 4081, got %q", fw.Port)
+	}
+}
+
+func TestKerioKeepsConfiguredPort(t *testing.T) {
+	fw := &Kerio{Port: "4444"}
+	if err := fw.initChild(ctx); err != nil {
+		t.Fatalf("initChild returned an error: %s", err)
+	}
+	if fw.Port != "4444" {
+		t.Errorf("Expected configured port 4444 to be kept, got %q", fw.Port)
+	}
+}
+
+// The host id comes back as a JSON number and must be re-encoded as a bare
+// number (not a quoted string) in ActiveHosts.login / .logout params.
+func TestKerioHostIdEncoding(t *testing.T) {
+	var hl kerioHostList
+	if err := json.Unmarshal([]byte(`{"list":[{"id":42,"ip":"1.2.3.4"}],"totalItems":1}`), &hl); err != nil {
+		t.Fatalf("could not decode host list: %s", err)
+	}
+	if len(hl.List) != 1 || hl.List[0].IP != "1.2.3.4" {
+		t.Fatalf("unexpected decode: %+v", hl)
+	}
+
+	body, err := json.Marshal(map[string]interface{}{
+		"hostId":   hl.List[0].ID,
+		"userName": "lzammit@example.local",
+	})
+	if err != nil {
+		t.Fatalf("could not encode login params: %s", err)
+	}
+	expected := `{"hostId":42,"userName":"lzammit@example.local"}`
+	if string(body) != expected {
+		t.Errorf("Unexpected login params.\n got: %s\nwant: %s", body, expected)
+	}
+}

--- a/html/pfappserver/lib/pfappserver/Form/Config/Firewall_SSO/Kerio.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Firewall_SSO/Kerio.pm
@@ -1,0 +1,77 @@
+package pfappserver::Form::Config::Firewall_SSO::Kerio;
+
+=head1 NAME
+
+pfappserver::Form::Config::Firewall_SSO::Kerio - Web form for a Kerio Control device
+
+=head1 DESCRIPTION
+
+Form definition to create or update a Kerio Control device.
+
+=cut
+
+use HTML::FormHandler::Moose;
+extends 'pfappserver::Form::Config::Firewall_SSO';
+with 'pfappserver::Base::Form::Role::Help';
+
+use pf::config;
+use pf::util;
+use File::Find qw(find);
+
+has_field 'username' =>
+  (
+   type => 'Text',
+   label => 'Username',
+   required => 1,
+   messages => { required => 'Please specify the administrator username for the Kerio Control API' },
+   tags => { after_element => \&help,
+             help => 'A Kerio Control administrator account used to call the Administration API.' },
+  );
+has_field 'password' =>
+  (
+   type => 'ObfuscatedText',
+   label => 'Password',
+   required => 1,
+   messages => { required => 'You must specify the password' },
+  );
+has_field '+port' =>
+  (
+   default => 4081,
+  );
+has_field 'type' =>
+  (
+   type => 'Hidden',
+   default => 'Kerio',
+  );
+
+has_block definition =>
+  (
+   render_list => [ qw(id type username password port categories networks cache_updates cache_timeout username_format default_realm act_on_accounting_stop sso_on_access_reevaluation sso_on_accounting sso_on_dhcp sso_on_role_change) ],
+  );
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2026 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+__PACKAGE__->meta->make_immutable unless $ENV{"PF_SKIP_MAKE_IMMUTABLE"};
+
+1;

--- a/html/pfappserver/root/src/views/Configuration/firewalls/_components/FormTypeKerio.vue
+++ b/html/pfappserver/root/src/views/Configuration/firewalls/_components/FormTypeKerio.vue
@@ -1,0 +1,152 @@
+<template>
+  <base-form
+    :form="form"
+    :isLoading="isLoading"
+    :meta="meta"
+    :schema="schema"
+  >
+    <form-group-identifier :column-label="$i18n.t('Hostname or IP Address')"
+                           :disabled="!isNew && !isClone"
+                           namespace="id"
+    />
+
+    <form-group-username :column-label="$i18n.t('Username')"
+                         namespace="username"
+    />
+
+    <form-group-password :column-label="$i18n.t('Password')"
+                         namespace="password"
+    />
+
+    <form-group-port :column-label="$i18n.t('Port of the service')"
+                     :text="$i18n.t('Kerio Control Administration API port (default 4081).')"
+                     namespace="port"
+    />
+
+    <form-group-categories :column-label="$i18n.t('Roles')"
+                           :text="$i18n.t('Nodes with the selected roles will be affected.')"
+                           namespace="categories"
+    />
+
+    <form-group-networks :column-label="$i18n.t('Networks on which to do SSO')"
+                         :text="$i18n.t('Comma delimited list of networks on which the SSO applies.\nFormat : 192.168.0.0/24')"
+                         namespace="networks"
+    />
+
+    <form-group-cache-updates :column-label="$i18n.t('Cache updates')"
+                              :text="$i18n.t(`Enable this to debounce updates to the Firewall.\nBy default, PacketFence will send a SSO on every DHCP request for every device. Enabling this enables 'sleep' periods during which the update is not sent if the informations stay the same.`)"
+                              disabled-value="disabled"
+                              enabled-value="enabled"
+                              namespace="cache_updates"
+    />
+
+    <form-group-cache-timeout :column-label="$i18n.t('Cache timeout')"
+                              :text="$i18n.t(`Adjust the 'Cache timeout' to half the expiration delay in your firewall.\nYour DHCP renewal interval should match this value.`)"
+                              namespace="cache_timeout"
+    />
+
+    <form-group-username-format :column-label="$i18n.t('Username format')"
+                                :text="$i18n.t('Defines how to format the username that is sent to your firewall. $username represents the username and $realm represents the realm of your user if applicable. $pf_username represents the unstripped username as it is stored in the PacketFence database. If left empty, it will use the username as stored in PacketFence (value of $pf_username).')"
+                                namespace="username_format"
+    />
+
+    <form-group-default-realm :column-label="$i18n.t('Default realm')"
+                              :text="$i18n.t('The default realm to be used while formatting the username when no realm can be extracted from the username.')"
+                              namespace="default_realm"
+    />
+
+    <form-group-use-connector :column-label="$i18n.t('Use Connector')"
+                              :text="$i18n.t('Use the available PacketFence connectors to connect to this authentication source. By default, a local connector is hosted on this server. Using remote connectors is only supported on a standalone instance at the moment.')"
+                              disabled-value="0"
+                              enabled-value="1"
+                              namespace="use_connector"
+    />
+
+    <form-group-sso-on-access-reevaluation namespace="sso_on_access_reevaluation"
+                                           :column-label="$i18n.t('SSO on access reevaluation')"
+                                           :text="$i18n.t('Trigger Single-Sign-On (Firewall SSO) on access reevaluation.')"
+                                           disabled-value="0"
+                                           enabled-value="1"
+    />
+
+    <form-group-sso-on-role-change namespace="sso_on_role_change"
+                                   :column-label="$i18n.t('SSO on role change')"
+                                   :text="$i18n.t('Trigger Single-Sign-On (Firewall SSO) when a device role changes. Note: This only triggers during autoregistration. Warning: If the VLAN changes when the role changes, an incorrect SSO update may occur until PacketFence receives a DHCP packet that updates the IP of the device and triggers a new SSO request.')"
+                                   disabled-value="0"
+                                   enabled-value="1"
+    />
+
+    <form-group-sso-on-accounting namespace="sso_on_accounting"
+                                  :column-label="$i18n.t('SSO on accounting')"
+                                  :text="$i18n.t('Trigger Single-Sign-On (Firewall SSO) on accounting start/interim/stop.')"
+                                  disabled-value="0"
+                                  enabled-value="1"
+    />
+    
+    <form-group-act-on-accounting-stop namespace="act_on_accounting_stop"
+                                       :column-label="$i18n.t('SSO on accounting stop')"
+                                       :text="$i18n.t('Trigger Single-Sign-On (Firewall SSO) on accounting stop.')"
+                                       disabled-value="0"
+                                       enabled-value="1"
+    />
+
+    <form-group-sso-on-dhcp namespace="sso_on_dhcp"
+                            :column-label="$i18n.t('SSO on DHCP')"
+                            :text="$i18n.t('Trigger Single-Sign-On (Firewall SSO) on dhcp.')"
+                            disabled-value="0"
+                            enabled-value="1"
+    />
+  </base-form>
+</template>
+<script>
+import {BaseForm} from '@/components/new/'
+import {
+  FormGroupActOnAccountingStop,
+  FormGroupCacheTimeout,
+  FormGroupCacheUpdates,
+  FormGroupCategories,
+  FormGroupDefaultRealm,
+  FormGroupIdentifier,
+  FormGroupNetworks,
+  FormGroupPassword,
+  FormGroupPort,
+  FormGroupUseConnector,
+  FormGroupUsername,
+  FormGroupUsernameFormat,
+  FormGroupSsoOnAccessReevaluation,
+  FormGroupSsoOnRoleChange,
+  FormGroupSsoOnAccounting,
+  FormGroupSsoOnDhcp,
+} from './'
+import {useForm as setup, useFormProps as props} from '../_composables/useForm'
+
+const components = {
+  BaseForm,
+
+  FormGroupActOnAccountingStop,
+  FormGroupCacheTimeout,
+  FormGroupCacheUpdates,
+  FormGroupCategories,
+  FormGroupDefaultRealm,
+  FormGroupIdentifier,
+  FormGroupNetworks,
+  FormGroupPassword,
+  FormGroupPort,
+  FormGroupUseConnector,
+  FormGroupUsername,
+  FormGroupUsernameFormat,
+  FormGroupSsoOnAccessReevaluation,
+  FormGroupSsoOnRoleChange,
+  FormGroupSsoOnAccounting,
+  FormGroupSsoOnDhcp,
+}
+
+// @vue/component
+export default {
+  name: 'form-type-kerio',
+  inheritAttrs: false,
+  components,
+  props,
+  setup
+}
+</script>

--- a/html/pfappserver/root/src/views/Configuration/firewalls/_components/TheForm.vue
+++ b/html/pfappserver/root/src/views/Configuration/firewalls/_components/TheForm.vue
@@ -26,6 +26,7 @@ import FormTypeFamilyZone from './FormTypeFamilyZone'
 import FormTypeFortiGate from './FormTypeFortiGate'
 import FormTypeIboss from './FormTypeIboss'
 import FormTypeJsonRpc from './FormTypeJsonRpc'
+import FormTypeKerio from './FormTypeKerio'
 import FormTypeJuniperSrx from './FormTypeJuniperSrx'
 import FormTypeLightSpeedRocket from './FormTypeLightSpeedRocket'
 import FormTypePaloAlto from './FormTypePaloAlto'
@@ -43,6 +44,7 @@ const components = {
   FormTypeFortiGate,
   FormTypeIboss,
   FormTypeJsonRpc,
+  FormTypeKerio,
   FormTypeJuniperSrx,
   FormTypeLightSpeedRocket,
   FormTypePaloAlto,
@@ -84,6 +86,8 @@ export const setup = (props) => {
         return FormTypeIboss // break
       case 'JSONRPC':
         return FormTypeJsonRpc // break
+      case 'Kerio':
+        return FormTypeKerio // break
       case 'JuniperSRX':
         return FormTypeJuniperSrx // break
       case 'LightSpeedRocket':

--- a/html/pfappserver/root/src/views/Configuration/firewalls/config.js
+++ b/html/pfappserver/root/src/views/Configuration/firewalls/config.js
@@ -10,6 +10,7 @@ export const types = {
   Iboss:            i18n.t('Iboss'),
   JSONRPC:          i18n.t('JSONRPC'),
   JuniperSRX:       i18n.t('JuniperSRX'),
+  Kerio:            i18n.t('Kerio'),
   LightSpeedRocket: i18n.t('LightSpeedRocket'),
   PaloAlto:         i18n.t('PaloAlto'),
   SmoothWall:       i18n.t('SmoothWall'),

--- a/lib/pf/constants/firewallsso.pm
+++ b/lib/pf/constants/firewallsso.pm
@@ -37,6 +37,7 @@ Readonly::Scalar our $FIREWALL_TYPES => [
     "PaloAlto",
     "WatchGuard",
     "JSONRPC",
+    "Kerio",
     "LightSpeedRocket",
     "SmoothWall",
     "FamilyZone",


### PR DESCRIPTION
# Description
Adds native Single-Sign-On (SSO) support for Kerio Control firewalls. PacketFence binds the authenticated user to the device's entry in Kerio's Active Hosts table via the Kerio Control Administration API: Session.login, then ActiveHosts.get/login/logout over JSON-RPC on port 4081 (with relogin on session-expired -32001). This lets Kerio apply per-user policy and logging driven by PacketFence authentication. Kerio Control was not previously a supported firewall SSO target.

# Impacts
New, self-contained firewall SSO type — no impact on existing firewalls. Reviewer focus:
- go/firewallsso/kerio.go (Start/Stop, session login, IP->hostId resolution)
- factory registration + pf::constants::firewallsso
- admin form (Form/Config/Firewall_SSO/Kerio.pm), Vue type + FormTypeKerio.vue + TheForm.vue
Requirements/behaviour: Kerio must be the gateway so the device appears in Kerio Active Hosts (otherwise there's nothing to bind); the device IP is learned from RADIUS accounting (enable "Update the iplog using the accounting"); multi-directory Kerio expects user@domain, handled via the existing Username format / Default realm options.

# Delete branch after merge
YES

# Checklist
- [yes] Document the feature
- [n/a] Add OpenAPI specification (generated from the FormHandler form; happy to regenerate if you'd like it committed)
- [yes] Add unit tests
- [n/a] Add acceptance tests (TestLink)

# NEWS file entries
## New Features
* Kerio Control firewall SSO — native per-user SSO via the Kerio Control Administration API (ActiveHosts.login/logout)