### PR TITLE
fix(security): replace shell command execution with safe_pf_run

### DIFF
--- a/addons/AD/migrate.pl
+++ b/addons/AD/migrate.pl
@@ -29,17 +29,29 @@ BEGIN {
 }
 
 use pf::util;
+use pf::util::dns;
 use pf::domain;
 use pf::ConfigStore::Domain;
 
-my $REALM = pf_run('grep default_realm /etc/krb5.conf | awk \'{print $3}\'');
-chomp($REALM);
-my $WORKGROUP = pf_run('grep workgroup /etc/samba/smb.conf | awk \'{print $3}\'');
-chomp($WORKGROUP);
-my $SERVER = pf_run('grep admin_server /etc/krb5.conf | head -1 | awk \'{print $3}\'');
-chomp($SERVER);
-my $NAMESERVER = pf_run('grep nameserver /etc/resolv.conf | head -1 | awk \'{print $2}\'');
-chomp($NAMESERVER);
+# Return the value of the first "<key> = <value>" line in $file, or '' if none.
+# Replaces the old `grep <key> <file> | awk '{print $3}'` shell pipelines.
+sub _first_config_value {
+    my ($file, $key) = @_;
+    open(my $fh, '<', $file) or return '';
+    while (my $line = <$fh>) {
+        if ($line =~ /^\s*\Q$key\E\s*=\s*(\S+)/) {
+            close($fh);
+            return $1;
+        }
+    }
+    close($fh);
+    return '';
+}
+
+my $REALM      = _first_config_value('/etc/krb5.conf',      'default_realm');
+my $WORKGROUP  = _first_config_value('/etc/samba/smb.conf', 'workgroup');
+my $SERVER     = _first_config_value('/etc/krb5.conf',      'admin_server');
+my $NAMESERVER = eval { pf::util::dns::get_resolv_dns_servers()->[0] } // '';
 
 print "CAUTION: This account needs to have the rights to bind a new server on the domain. \n";
 print "What is the username to bind this server on the domain : ";
@@ -76,7 +88,7 @@ print "Are these settings fine ? This is your last chance before the domain bind
 my $confirm = <STDIN>;
 chomp($confirm);
 if($confirm eq 'y'){
-  pf_run('cp /etc/krb5.conf /etc/krb5.conf.pf_backup');
+  safe_pf_run('cp /etc/krb5.conf /etc/krb5.conf.pf_backup');
   pf::domain::regenerate_configuration();
   my $output = pf::domain::join_domain($WORKGROUP, $config);
   # we remove the password after the configuration

--- a/addons/AD/migrate.pl
+++ b/addons/AD/migrate.pl
@@ -88,7 +88,7 @@ print "Are these settings fine ? This is your last chance before the domain bind
 my $confirm = <STDIN>;
 chomp($confirm);
 if($confirm eq 'y'){
-  safe_pf_run('cp /etc/krb5.conf /etc/krb5.conf.pf_backup');
+  safe_pf_run('cp', '/etc/krb5.conf', '/etc/krb5.conf.pf_backup');
   pf::domain::regenerate_configuration();
   my $output = pf::domain::join_domain($WORKGROUP, $config);
   # we remove the password after the configuration
@@ -98,7 +98,7 @@ else{
   print "Please re-run the script again or configure the domain directly through the admin UI in 'Configuration->Domain' \n";
 }
 
-pf_run("chown pf:pf $domain_config_file");
+safe_pf_run("chown", "pf:pf", $domain_config_file);
 
 =head1 AUTHOR
 

--- a/addons/upgrade/to-13.1-move-ntlm-auth-to-rest.pl
+++ b/addons/upgrade/to-13.1-move-ntlm-auth-to-rest.pl
@@ -36,7 +36,7 @@ my $updated = 0;
 my $ntlm_auth_host = "100.64.0.1";
 my $ntlm_auth_port = 4999;
 
-my $tmp = pf_run("date +%Y%m%d_%H%M%S");
+my $tmp = safe_pf_run("date +%Y%m%d_%H%M%S");
 $tmp =~ s/^\s+|\s+$//g;
 
 my $domain_bk="/usr/local/pf/conf/domain.conf_".$tmp."_bk";

--- a/addons/upgrade/to-13.1-move-ntlm-auth-to-rest.pl
+++ b/addons/upgrade/to-13.1-move-ntlm-auth-to-rest.pl
@@ -36,13 +36,13 @@ my $updated = 0;
 my $ntlm_auth_host = "100.64.0.1";
 my $ntlm_auth_port = 4999;
 
-my $tmp = safe_pf_run("date +%Y%m%d_%H%M%S");
+my $tmp = safe_pf_run("date", "+%Y%m%d_%H%M%S");
 $tmp =~ s/^\s+|\s+$//g;
 
 my $domain_bk="/usr/local/pf/conf/domain.conf_".$tmp."_bk";
 my $realm_bk="/usr/local/pf/conf/realm.conf_".$tmp."_bk";
-pf_run("cp -R /usr/local/pf/conf/domain.conf $domain_bk");
-pf_run("cp -R /usr/local/pf/conf/realm.conf $realm_bk");
+safe_pf_run("cp", "-R", "/usr/local/pf/conf/domain.conf", $domain_bk);
+safe_pf_run("cp", "-R", "/usr/local/pf/conf/realm.conf", $realm_bk);
 
 for my $section (grep {/^\S+$/} $ini->Sections()) {
     print("Updating config for section: $section\n");
@@ -200,9 +200,9 @@ if ($updated) {
 }
 
 print("Stopping winbindd\n");
-pf_run("sudo systemctl stop packetfence-winbindd 2>/dev/null");
+safe_pf_run(qw(sudo systemctl stop packetfence-winbindd), { redirect_stderr_to_stdout => 1 });
 sleep(3);
-pf_run("sudo systemctl disable packetfence-winbindd 2>/dev/null");
+safe_pf_run(qw(sudo systemctl disable packetfence-winbindd), { redirect_stderr_to_stdout => 1 });
 print("/chroots/* directories will be removed at the next reboot.\n");
 print("Domain config backup is available here $domain_bk\n");
 print("Realm  config backup is available here $realm_bk\n");
@@ -213,10 +213,10 @@ print("Realm  config backup is available here $realm_bk\n");
 
 sub tdbdump_get_value {
     my ($tdb_file, $key) = @_;
-    my $cmd = "/usr/bin/tdbdump $tdb_file -k $key";
 
-    my $result = qx($cmd);
-    my $exit_code = $? >> 8;
+    my $status;
+    my $result = safe_pf_run("/usr/bin/tdbdump", $tdb_file, "-k", $key, { status_ref => \$status });
+    my $exit_code = (defined $status ? $status : -1) >> 8;
 
     return $exit_code, $result;
 }

--- a/bin/cluster/sync
+++ b/bin/cluster/sync
@@ -54,6 +54,7 @@ use pf::file_paths qw(
 );
 use pf::constants::cluster qw(@FILES_TO_SYNC);
 use pf::cluster;
+use pf::util qw(safe_pf_run);
 use fingerbank::FilePath;
 use Pod::Usage;
 
@@ -146,7 +147,7 @@ if($master_server){
             open(my $fh, '>', $file);
             print $fh $result;
             close($fh);
-            `chown pf:pf $file`;
+            safe_pf_run("chown", "pf:pf", $file);
         };
         if($@){
             get_logger->error("Failed to sync file : $file . $@");

--- a/bin/pfcmd_vlan
+++ b/bin/pfcmd_vlan
@@ -424,7 +424,7 @@ if ($reevaluateAccess) {
                     print ", " . ( $$oui_info[0] || 'unknown' );
                 }
                 if ($showPF) {
-                    my @pfcmd = pf_run("$bin_dir/pfcmd node view $mac");
+                    my @pfcmd = safe_pf_run("$bin_dir/pfcmd", "node", "view", $mac);
                     @pfcmd = split( /[|]/, $pfcmd[1] );
                     print ", $pfcmd[7]" unless ( $pfcmd[7] eq '' );
                     print ", $pfcmd[1]" unless ( $pfcmd[1] eq '' );
@@ -521,7 +521,7 @@ if ($reevaluateAccess) {
                     print ", " . ( $$oui_info[0] || 'unknown' );
                 }
                 if ($showPF) {
-                    my @pfcmd = pf_run("$bin_dir/pfcmd node view $currentMac");
+                    my @pfcmd = safe_pf_run("$bin_dir/pfcmd", "node", "view", $currentMac);
                     @pfcmd = split( /[|]/, $pfcmd[1] );
                     print ", $pfcmd[8]" unless ( $pfcmd[8] eq '' );
                     print ", $pfcmd[1]" unless ( $pfcmd[1] eq '' );

--- a/lib/pf/Switch/Xirrus.pm
+++ b/lib/pf/Switch/Xirrus.pm
@@ -35,6 +35,7 @@ use warnings;
 
 use POSIX;
 use Try::Tiny;
+use Digest::MD5 qw(md5_hex);
 
 use pf::config qw(
     $MAC
@@ -416,9 +417,7 @@ sub getAcceptForm {
     my $challenge = $portalSession->param("ecwp-original-param-challenge");
     my $newchal  = pack "H32", $challenge;
 
-    my @ib = unpack("C*", "\0" . $mac . $newchal);
-    my $encstr = join("", map {sprintf('\%3.3o', $_)} @ib);
-    my ($passvar) = split(/ /, `printf '$encstr' | md5sum`);
+    my $passvar = md5_hex("\0" . $mac . $newchal);
 
     $mac =~ s/:/-/g;
 

--- a/lib/pf/UnifiedApi/Controller/SystemServices.pm
+++ b/lib/pf/UnifiedApi/Controller/SystemServices.pm
@@ -36,7 +36,7 @@ sub status {
     my $pid = safe_pf_run(qw(sudo systemctl show -p MainPID), $self->param("system_service_id"));
     $pid //= '';
     chomp $pid;
-    $pid = (split(/=/, $pid))[1];
+    $pid = (split(/=/, $pid, 2))[1] // '';
     return $self->render(json => {message => ($pid ? "Service is running" : "Service is not running"), pid => $pid+0}, status => ($pid ? 200 : 500));
 }
 

--- a/lib/pf/UnifiedApi/Controller/SystemServices.pm
+++ b/lib/pf/UnifiedApi/Controller/SystemServices.pm
@@ -24,22 +24,17 @@ sub resource {
     return 1;
 }
 
-sub quoted_system_service_id {
-    my ($id) = @_;
-    ($id) =~ s/'/'"'"'/g;
-    return "'$id'"
-}
-
 sub systemctl {
     my ($command, $service) = @_;
-    my $cmd = "sudo systemctl $command ".quoted_system_service_id($service);
-    return system($cmd);
+    my $status_ref;
+    safe_pf_run(qw(sudo systemctl), $command, $service, {status_ref => \$status_ref});
+    return $status_ref;
 }
 
 sub status {
     my ($self) = @_;
-    my $service = quoted_system_service_id($self->param("system_service_id"));
-    my $pid = `sudo systemctl show -p MainPID $service`;
+    my $pid = safe_pf_run(qw(sudo systemctl show -p MainPID), $self->param("system_service_id"));
+    $pid //= '';
     chomp $pid;
     $pid = (split(/=/, $pid))[1];
     return $self->render(json => {message => ($pid ? "Service is running" : "Service is not running"), pid => $pid+0}, status => ($pid ? 200 : 500));

--- a/lib/pf/domain.pm
+++ b/lib/pf/domain.pm
@@ -33,21 +33,6 @@ our $template = Template->new($TT_OPTIONS);
 
 our $ADD_COMPUTERS_BIN = '/usr/local/pf/bin/impacket-addcomputer';
 
-=head2 run
-
-Executes a command and returns the results as the domain interfaces expect it
-
-=cut
-
-sub run {
-    my ($cmd) = @_;
-    local $?;
-    my $result = `$cmd`;
-    my $code = $? >> 8;
-
-    return ($code, $result);
-}
-
 =head2 add_computer
 
 Executes the command in the OS to test the domain join

--- a/lib/pf/ipset_cache.pm
+++ b/lib/pf/ipset_cache.pm
@@ -20,6 +20,7 @@ use Moo;
 use CHI;
 use pf::log;
 use pf::util qw(safe_pf_run);
+use File::Temp qw(tempfile);
 
 our $logger = get_logger();
 
@@ -84,15 +85,17 @@ sub _add_pairs_to_ipset {
     my $setname = $self->setname;
     my $binary = $self->ipset_binary;
     my $data = join("\n", (map { "add $setname " . _format_pair($_) } @$pairs), "");
-    my $pid = open(my $ipset, "| LANG=C sudo $binary -! restore 2>&1");
-    unless (defined $pid) {
-        $logger->error("Cannot start ipset ");
+    my ($fh, $tmpfile) = tempfile();
+    print $fh $data;
+    close($fh);
+    my $status;
+    safe_pf_run("sudo", $binary, "-!", "restore",
+        { stdin => $tmpfile, redirect_stderr_to_stdout => 1, status_ref => \$status });
+    unlink $tmpfile;
+    unless (defined $status && $status == 0) {
+        $logger->error("Cannot run ipset restore");
         return undef;
     }
-    $logger->trace("ipset process pid : $pid");
-    print $ipset $data;
-    close($ipset);
-    waitpid($pid, 0);
     return 1;
 }
 

--- a/lib/pf/iptables.pm
+++ b/lib/pf/iptables.pm
@@ -33,6 +33,7 @@ use Try::Tiny;
 use Switch;
 use Symbol qw(gensym);
 use File::Path qw(make_path);
+use File::Temp qw(tempfile);
 use IPC::Open3 qw(open3);
 use File::Basename;
 use Scalar::Util 'reftype';
@@ -1904,10 +1905,14 @@ sub inline_mangle_rules {
         }
 
         if (@ops) {
-            my $cmd = "LANG=C sudo ipset restore 2>&1";
-            open(IPSET, "| $cmd") || die "$cmd failed: $!\n";
-            print IPSET join("\n", @ops);
-            close IPSET;
+            my ($fh, $tmpfile) = tempfile();
+            print $fh join("\n", @ops);
+            close($fh);
+            my $status;
+            safe_pf_run(qw(sudo ipset restore),
+                { stdin => $tmpfile, redirect_stderr_to_stdout => 1, status_ref => \$status });
+            unlink $tmpfile;
+            die "ipset restore failed\n" unless (defined $status && $status == 0);
         }
         $logger->info("Mangle rules are done.");
     } else {

--- a/lib/pf/services/manager.pm
+++ b/lib/pf/services/manager.pm
@@ -420,7 +420,9 @@ sub isAlive {
     my $logger = get_logger();
     my $target = $self->systemdTarget;
     my $res;
-    safe_pf_run(qw(sudo systemctl -q is-active), $target, { status_ref => \$res });
+    # is-active exits non-zero (3) for inactive/failed services, which is a
+    # normal state and must not be logged as a command failure on this hot path.
+    safe_pf_run(qw(sudo systemctl -q is-active), $target, { status_ref => \$res, accepted_exit_status => [1, 2, 3, 4] });
     my $alive = (defined $res && $res == 0) ? 1 : 0;
     $logger->debug("sudo systemctl -q is-active $target returned code " . ($res // -1));
     return $alive;

--- a/lib/pf/services/manager.pm
+++ b/lib/pf/services/manager.pm
@@ -264,9 +264,7 @@ sub pid {
     my ($self) = @_;
     my $logger = get_logger();
     my $name = $self->{name};
-    my $pid = safe_pf_run(qw(sudo systemctl show -p MainPID), "packetfence-$name");
-    chomp $pid;
-    $pid = (split(/=/, $pid))[1];
+    my $pid = $self->systemctlShowProperty('MainPID', "packetfence-$name");
     if (defined $pid) {
         $logger->debug("sudo systemctl packetfence-$name returned $pid");
     } else {
@@ -454,9 +452,7 @@ Return true if systemd consider the service as enabled
 sub isEnabled {
     my ($self) = @_;
     my $name   = $self->name;
-    my $state  = safe_pf_run(qw(sudo systemctl show -p UnitFileState), "packetfence-$name");
-    chomp $state;
-    $state = ( split( /=/, $state ) )[1];
+    my $state  = $self->systemctlShowProperty('UnitFileState', "packetfence-$name");
     if ( defined $state and $state eq "enabled" ) {
         return $TRUE;
     }
@@ -488,9 +484,7 @@ sub _unitFileExists {
     # Use 'systemctl show' instead of 'systemctl cat' because
     # 'systemctl cat' fails inside Docker containers while
     # 'systemctl show' works via the D-Bus socket.
-    my $output = safe_pf_run(qw(sudo systemctl show -p LoadState), $target, { redirect_stderr_to_stdout => 1 });
-    chomp $output;
-    my $load_state = (split(/=/, $output))[1];
+    my $load_state = $self->systemctlShowProperty('LoadState', $target, { redirect_stderr_to_stdout => 1 });
     return defined $load_state && $load_state ne 'not-found';
 }
 
@@ -566,6 +560,24 @@ restart the service
 sub restart {
     my ($self) = @_;
     return $self->restartService();
+}
+
+=head2 systemctlShowProperty
+
+Run C<systemctl show -p PROPERTY NAME> and return the value of the property
+(the part after the C<=>), with any trailing newline removed. Returns undef
+if the command produced no output. An optional hashref of options is passed
+through to C<safe_pf_run>.
+
+=cut
+
+sub systemctlShowProperty {
+    my ($self, $prop, $name, $options) = @_;
+    my @extra = defined $options ? ($options) : ();
+    my $value = safe_pf_run(qw(sudo systemctl show -p), $prop, $name, @extra);
+    return undef unless defined $value;
+    chomp $value;
+    return (split(/=/, $value, 2))[1];
 }
 
 =head1 AUTHOR

--- a/lib/pf/services/manager.pm
+++ b/lib/pf/services/manager.pm
@@ -264,7 +264,7 @@ sub pid {
     my ($self) = @_;
     my $logger = get_logger();
     my $name = $self->{name};
-    my $pid = `sudo systemctl show -p MainPID packetfence-$name`;
+    my $pid = safe_pf_run(qw(sudo systemctl show -p MainPID), "packetfence-$name");
     chomp $pid;
     $pid = (split(/=/, $pid))[1];
     if (defined $pid) {
@@ -321,7 +321,9 @@ sub stopService {
     }
     my $pid    = $self->pid;
     $logger->info("Stopping $name with pid $pid");
-    `sudo systemctl stop packetfence-$name`;
+    my $stop_status;
+    safe_pf_run(qw(sudo systemctl stop), "packetfence-$name", { status_ref => \$stop_status });
+    local $? = $stop_status // -1;
     if ( $? == -1 ) {
         $logger->error("failed to execute: $!\n");
     }
@@ -417,9 +419,10 @@ sub isAlive {
     my ($self) = @_;
     my $logger = get_logger();
     my $target = $self->systemdTarget;
-    my $res = system("sudo systemctl -q is-active $target");
-    my $alive = $res == 0 ? 1 : 0;
-    $logger->debug("sudo systemctl -q is-active $target returned code $res");
+    my $res;
+    safe_pf_run(qw(sudo systemctl -q is-active), $target, { status_ref => \$res });
+    my $alive = (defined $res && $res == 0) ? 1 : 0;
+    $logger->debug("sudo systemctl -q is-active $target returned code " . ($res // -1));
     return $alive;
 }
 
@@ -449,7 +452,7 @@ Return true if systemd consider the service as enabled
 sub isEnabled {
     my ($self) = @_;
     my $name   = $self->name;
-    my $state  = `sudo systemctl show -p UnitFileState packetfence-$name`;
+    my $state  = safe_pf_run(qw(sudo systemctl show -p UnitFileState), "packetfence-$name");
     chomp $state;
     $state = ( split( /=/, $state ) )[1];
     if ( defined $state and $state eq "enabled" ) {
@@ -483,7 +486,7 @@ sub _unitFileExists {
     # Use 'systemctl show' instead of 'systemctl cat' because
     # 'systemctl cat' fails inside Docker containers while
     # 'systemctl show' works via the D-Bus socket.
-    my $output = `sudo systemctl show -p LoadState $target 2>/dev/null`;
+    my $output = safe_pf_run(qw(sudo systemctl show -p LoadState), $target, { redirect_stderr_to_stdout => 1 });
     chomp $output;
     my $load_state = (split(/=/, $output))[1];
     return defined $load_state && $load_state ne 'not-found';
@@ -497,7 +500,9 @@ Enable the service in systemd.
 
 sub sysdEnable {
     my $self = shift;
-    return system( "sudo systemctl enable " . $self->systemdTarget) == 0;
+    my $status;
+    safe_pf_run(qw(sudo systemctl enable), $self->systemdTarget, { status_ref => \$status });
+    return defined($status) && $status == 0;
 }
 
 =head2 sysdDisable
@@ -511,7 +516,9 @@ sub sysdDisable {
     my $target = $self->systemdTarget;
     # Check if the unit file exists before trying to disable it
     return $TRUE unless $self->_unitFileExists($target);
-    return system( "sudo systemctl disable " . $target) == 0;
+    my $status;
+    safe_pf_run(qw(sudo systemctl disable), $target, { status_ref => \$status });
+    return defined($status) && $status == 0;
 }
 
 =head2 _build_restart_launcher

--- a/lib/pf/services/manager/fingerbank_collector.pm
+++ b/lib/pf/services/manager/fingerbank_collector.pm
@@ -22,6 +22,7 @@ use pf::file_paths qw(
     $server_key
 );
 use pf::constants;
+use pf::util;
 
 extends 'pf::services::manager';
 
@@ -35,8 +36,8 @@ sub isManaged {
 sub generateConfig {
     # Perform HTTPS setup
 
-    system("systemctl set-environment COLLECTOR_HTTP_CERT=$server_cert");
-    system("systemctl set-environment COLLECTOR_HTTP_KEY=$server_key");
+    safe_pf_run("systemctl", "set-environment", "COLLECTOR_HTTP_CERT=$server_cert");
+    safe_pf_run("systemctl", "set-environment", "COLLECTOR_HTTP_KEY=$server_key");
 
     return $TRUE;
 }

--- a/lib/pf/services/manager/pf.pm
+++ b/lib/pf/services/manager/pf.pm
@@ -152,9 +152,7 @@ sub print_status {
 sub sub_pid {
     my ($self, $service) = @_;
     my $logger = get_logger();
-    my $pid = safe_pf_run(qw(sudo systemctl show -p MainPID), $service);
-    chomp $pid;
-    $pid = (split(/=/, $pid))[1];
+    my $pid = $self->systemctlShowProperty('MainPID', $service);
     if (defined $pid) {
         $logger->debug("sudo systemctl $service returned $pid");
     } else {

--- a/lib/pf/services/manager/pf.pm
+++ b/lib/pf/services/manager/pf.pm
@@ -21,6 +21,7 @@ use Moo;
 use pf::constants qw($TRUE $FALSE);
 use pf::log;
 use pf::util::console;
+use pf::util;
 use pf::cluster;
 extends 'pf::services::manager';
 
@@ -95,7 +96,10 @@ sub print_status {
                     $isManaged = $FALSE;
                 }
             }
-            my $active = `systemctl is-active $service`;
+            # is-active exits non-zero for inactive/failed/activating states
+            # but still prints the state word, so accept those exit codes to
+            # preserve the output (and avoid uninitialized-value warnings).
+            my $active = safe_pf_run(qw(systemctl is-active), $service, { accepted_exit_status => [1, 2, 3, 4] }) // '';
             chomp $active;
             $service .= (" " x (50 - length($service)));
             if ($active eq 'reloading') {
@@ -148,7 +152,7 @@ sub print_status {
 sub sub_pid {
     my ($self, $service) = @_;
     my $logger = get_logger();
-    my $pid = `sudo systemctl show -p MainPID $service`;
+    my $pid = safe_pf_run(qw(sudo systemctl show -p MainPID), $service);
     chomp $pid;
     $pid = (split(/=/, $pid))[1];
     if (defined $pid) {

--- a/lib/pf/services/manager/tracking.pm
+++ b/lib/pf/services/manager/tracking.pm
@@ -75,9 +75,7 @@ sub pid {
     my ($self) = @_;
     my $logger = get_logger();
     my $name = $self->{name};
-    my $state = safe_pf_run(qw(sudo systemctl show -p ActiveState), "packetfence-$name.path");
-    chomp $state;
-    $state = (split(/=/, $state))[1];
+    my $state = $self->systemctlShowProperty('ActiveState', "packetfence-$name.path") // '';
     if ($state ne "inactive") {
         $logger->debug("sudo systemctl packetfence-$name returned $state");
         return $TRUE;

--- a/lib/pf/services/manager/tracking.pm
+++ b/lib/pf/services/manager/tracking.pm
@@ -16,6 +16,7 @@ use strict;
 use warnings;
 use Moo;
 use pf::log;
+use pf::util;
 use pf::constants qw($TRUE $FALSE);
 
 extends 'pf::services::manager';
@@ -74,7 +75,7 @@ sub pid {
     my ($self) = @_;
     my $logger = get_logger();
     my $name = $self->{name};
-    my $state = `sudo systemctl show -p ActiveState packetfence-$name.path`;
+    my $state = safe_pf_run(qw(sudo systemctl show -p ActiveState), "packetfence-$name.path");
     chomp $state;
     $state = (split(/=/, $state))[1];
     if ($state ne "inactive") {

--- a/lib/pf/ssl.pm
+++ b/lib/pf/ssl.pm
@@ -17,6 +17,7 @@ use warnings;
 
 use File::Temp qw(tempfile);
 use pf::constants qw($TRUE $FALSE);
+use Digest::MD5 qw(md5_hex);
 use File::Slurp qw(read_file write_file);
 use LWP::UserAgent;
 use pf::util;
@@ -133,7 +134,7 @@ Get the modulus MD5 of an RSA key
 
 sub rsa_modulus_md5 {
     my ($rsa) = @_;
-    return openssl_modulus_md5("rsa", $rsa->get_private_key_string());
+    return modulus_md5("rsa", $rsa->get_private_key_string());
 }
 
 =head2 x509_modulus_md5
@@ -144,26 +145,48 @@ Get the modulus MD5 of an x509 certificate
 
 sub x509_modulus_md5 {
     my ($x509) = @_;
-    return openssl_modulus_md5("x509", $x509->as_string());
+    return modulus_md5("x509", $x509->as_string());
 }
 
-=head2 openssl_modulus_md5
+=head2 modulus_md5
 
-Get the modulus MD5 through OpenSSL
+Get the modulus MD5 of an RSA key ("rsa") or x509 certificate ("x509").
+
+This computes the same value as the OpenSSL pipeline:
+
+    openssl $type -noout -modulus | openssl md5
+
+i.e. the MD5 of the C<Modulus=E<lt>UPPERCASE-HEXE<gt>\n> line that
+C<openssl -modulus> prints, but does so in pure Perl without shelling out.
 
 =cut
 
-sub openssl_modulus_md5 {
+sub modulus_md5 {
     my ($type, $data) = @_;
-    my $result = `echo "$data" | openssl $type -noout -modulus | openssl md5 | awk '{ print \$2 }'`;
-    chomp($result);
-    if($? != 0) {
-        get_logger->error("Unable to get modulus: $result");
+
+    my $modulus = eval {
+        if ($type eq "rsa") {
+            my $rsa = rsa_from_string($data);
+            my ($n) = $rsa->get_key_parameters();
+            $n->to_hex;
+        }
+        elsif ($type eq "x509") {
+            my $x509 = x509_from_string($data);
+            defined($x509) ? $x509->modulus() : undef;
+        }
+        else {
+            die "unsupported modulus type '$type'\n";
+        }
+    };
+
+    if ($@ || !defined($modulus) || $modulus eq "") {
+        get_logger->error("Unable to get modulus: " . ($@ || "no modulus could be extracted"));
         return undef;
     }
-    else {
-        return $result;
-    }
+
+    # openssl prints the modulus as "Modulus=<UPPERCASE-HEX>" followed by a
+    # newline, and that exact byte sequence is what gets hashed.
+    return md5_hex("Modulus=" . $modulus . "\n");
 }
 
 =head2 validate_cert_key_match

--- a/lib/pf/ssl.pm
+++ b/lib/pf/ssl.pm
@@ -384,18 +384,33 @@ sub verify_chain {
     my ($cert, $intermediates) = @_;
     my $cert_str = $cert->as_string();
 
-    my (undef, $tmpinter) = tempfile();
     my $bundle = "";
     foreach my $inter (@$intermediates) {
         $bundle .= $inter->as_string();
     }
     $bundle .= "\n$cert_str\n";
-    write_file($tmpinter, $bundle);
 
-    my $result = `/bin/bash -c "echo '$cert_str' | openssl verify -verbose -CAfile <(cat $OS_CA_CERT_FILE $tmpinter)"`;
-    unlink $tmpinter;
+    # Trusted material for the verification: the system CA bundle followed by
+    # the provided intermediates and certificate (matches the previous
+    # "cat $OS_CA_CERT_FILE $tmpinter" behavior).
+    my $ca_content = (-r $OS_CA_CERT_FILE) ? read_file($OS_CA_CERT_FILE) : "";
+    my (undef, $cafile) = tempfile();
+    write_file($cafile, $ca_content . $bundle);
 
-    if($? != 0) {
+    # The certificate being verified, passed as a file argument rather than
+    # through a shell pipe.
+    my (undef, $certfile) = tempfile();
+    write_file($certfile, $cert_str);
+
+    my $status;
+    my $result = safe_pf_run(
+        "openssl", "verify", "-verbose", "-CAfile", $cafile, $certfile,
+        { redirect_stderr_to_stdout => 1, status_ref => \$status },
+    );
+    unlink $cafile;
+    unlink $certfile;
+
+    if (!defined($status) || $status != 0) {
         get_logger->error("Chain verification failed");
         return ($FALSE, $result);
     }

--- a/lib/pf/util.pm
+++ b/lib/pf/util.pm
@@ -493,7 +493,9 @@ sub getlocalmac {
     return (-1) if ( !$dev );
     my $chi = pf::CHI->new(namespace => 'local_mac');
     my $mac = $chi->compute($dev, sub {
-        foreach (`LC_ALL=C /sbin/ifconfig -a $dev`) {
+        # Force a neutral locale; LC_ALL overrides LANG (which safe_pf_run sets).
+        local $ENV{LC_ALL} = 'C';
+        foreach (safe_pf_run("/sbin/ifconfig", "-a", $dev)) {
             if (/ether\s+(\w\w:\w\w:\w\w:\w\w:\w\w:\w\w)/i) {
                 # cache the value
                 return clean_mac($1);

--- a/lib/pf/util.pm
+++ b/lib/pf/util.pm
@@ -1054,8 +1054,20 @@ sub safe_pf_run {
     local $!;
     local $ENV{LANG} = 'C';
     my $status_ref = $options->{status_ref};
+
+    # Block SIGCHLD across the fork/wait. pfconfig/pfqueue/pfqueue-backend/pffilter/
+    # pfdhcplistener install a $SIG{CHLD} reaper (waitpid(-1, WNOHANG); local $?).
+    # We drain the child's pipes to EOF before waiting, so the child has already
+    # exited by then -- without this block, that reaper collects it first and our
+    # waitpid returns -1 (a false failure). Other child deaths during the window
+    # are simply queued and delivered to the daemon's handler when we restore.
+    my $sigchld_set     = POSIX::SigSet->new(POSIX::SIGCHLD());
+    my $old_sigset      = POSIX::SigSet->new();
+    my $sigchld_blocked = POSIX::sigprocmask(POSIX::SIG_BLOCK(), $sigchld_set, $old_sigset);
+
     my $pid = eval {open3($chld_in, $chld_out, $chld_err, $bin, @args)};
     if ($@) {
+        POSIX::sigprocmask(POSIX::SIG_SETMASK(), $old_sigset) if $sigchld_blocked;
         if (defined $status_ref) {
             $$status_ref = -1;
         }
@@ -1097,6 +1109,7 @@ sub safe_pf_run {
 
     waitpid($pid, 0);
     my $status = $?;
+    POSIX::sigprocmask(POSIX::SIG_SETMASK(), $old_sigset) if $sigchld_blocked;
     if (defined $status_ref) {
         $$status_ref = $status;
     }

--- a/lib/pf/util.pm
+++ b/lib/pf/util.pm
@@ -495,7 +495,8 @@ sub getlocalmac {
     my $mac = $chi->compute($dev, sub {
         # Force a neutral locale; LC_ALL overrides LANG (which safe_pf_run sets).
         local $ENV{LC_ALL} = 'C';
-        foreach (safe_pf_run("/sbin/ifconfig", "-a", $dev)) {
+        # Merge stderr to avoid separate pipe that could fill if ifconfig writes warnings
+        foreach (safe_pf_run("/sbin/ifconfig", "-a", $dev, { redirect_stderr_to_stdout => 1 })) {
             if (/ether\s+(\w\w:\w\w:\w\w:\w\w:\w\w:\w\w)/i) {
                 # cache the value
                 return clean_mac($1);
@@ -1071,12 +1072,9 @@ sub safe_pf_run {
         return undef; # scalar context
     }
 
-    waitpid($pid, 0);
-    my $status = $?;
-    if (defined $status_ref) {
-        $$status_ref = $status;
-    }
-
+    # CRITICAL: Drain stdout and stderr BEFORE waitpid to prevent deadlock.
+    # If the child writes enough data to fill the pipe buffer (~64KB), it will
+    # block waiting for us to read. If we waitpid first, we deadlock.
     my $out;
     if (!$stdout) {
         $out = do {
@@ -1084,6 +1082,23 @@ sub safe_pf_run {
             my $o = <$chld_out>;
             $o
         };
+    }
+
+    # Drain stderr as well (previously undrained, causing potential deadlock).
+    # Only read if stderr wasn't redirected to stdout or a file.
+    my $err;
+    if (!$redirect_stderr_to_stdout && !$stdout && $chld_err != \*STDERR) {
+        $err = do {
+            local $/ = undef;
+            my $e = <$chld_err>;
+            $e
+        };
+    }
+
+    waitpid($pid, 0);
+    my $status = $?;
+    if (defined $status_ref) {
+        $$status_ref = $status;
     }
 
     chdir $switch_back_wd if defined($switch_back_wd);
@@ -1103,8 +1118,16 @@ sub safe_pf_run {
         $loggable_command =~ s/$options->{log_strip}/*obfuscated-information*/g;
     }
 
+    # Prepare stderr for logging if available
+    my $stderr_msg = '';
+    if (defined($err) && length($err) > 0) {
+        # Truncate very long stderr to avoid log spam
+        my $stderr_display = length($err) > 500 ? substr($err, 0, 500) . '...[truncated]' : $err;
+        $stderr_msg = " stderr: $stderr_display";
+    }
+
     if ($status == -1) {
-        $logger->warn("Problem trying to run command: $loggable_command called from $caller. OS Error: $exception");
+        $logger->warn("Problem trying to run command: $loggable_command called from $caller. OS Error: $exception$stderr_msg");
         return;
     }
 
@@ -1113,9 +1136,9 @@ sub safe_pf_run {
         my $with_core = ($status & 128) ? 'with' : 'without';
         $logger->warn(
             "Problem trying to run command: $loggable_command called from $caller. "
-            . "Child died with signal $signal $with_core coredump."
+            . "Child died with signal $signal $with_core coredump.$stderr_msg"
         );
-        return 
+        return
     }
     my $exit_status = $status >> 8;
     # user specified that this error code is ok
@@ -1129,7 +1152,7 @@ sub safe_pf_run {
 
     $logger->warn(
         "Problem trying to run command: $loggable_command called from $caller. "
-        . "Child exited with non-zero value $exit_status"
+        . "Child exited with non-zero value $exit_status$stderr_msg"
     );
 
     return 

--- a/lib/pfconfig/git_storage.pm
+++ b/lib/pfconfig/git_storage.pm
@@ -167,7 +167,7 @@ sub delete_file {
         }
 
         my $status;
-        safe_pf_run("git", "rm", $file,
+        safe_pf_run("git", "rm", "--", $file,
             { working_directory => $proto->git_directory, status_ref => \$status });
         if(defined($status) && $status == 0) {
             safe_pf_run("git", "commit", "--allow-empty", "-m", "delete $file",

--- a/lib/pfconfig/git_storage.pm
+++ b/lib/pfconfig/git_storage.pm
@@ -210,7 +210,7 @@ sub pull {
     
     my $status;
     safe_pf_run("git", "pull",
-        { working_directory => $proto->git_directory, status_ref => \$status });
+        { working_directory => $proto->git_directory, status_ref => \$status, redirect_stderr_to_stdout => 1 });
     if(!defined($status) || $status != 0) {
         return (0, "Unable to pull repository.");
     }
@@ -229,7 +229,7 @@ sub push {
 
     my $status;
     safe_pf_run("git", "push",
-        { working_directory => $proto->git_directory, status_ref => \$status });
+        { working_directory => $proto->git_directory, status_ref => \$status, redirect_stderr_to_stdout => 1 });
     if(!defined($status) || $status != 0) {
         return (0, "Unable to push repository. Please retry the change.");
     }
@@ -260,7 +260,7 @@ sub update {
 
         my $status;
         safe_pf_run("git", "pull",
-            { working_directory => $proto->git_directory, status_ref => \$status });
+            { working_directory => $proto->git_directory, status_ref => \$status, redirect_stderr_to_stdout => 1 });
         if(!defined($status) || $status != 0) {
             $last_error = "Unable to pull repository";
             sleep 3;

--- a/lib/pfconfig/git_storage.pm
+++ b/lib/pfconfig/git_storage.pm
@@ -16,7 +16,7 @@ use strict;
 use warnings;
 
 use pfconfig::config;
-use pf::util qw(isenabled);
+use pf::util qw(isenabled safe_pf_run);
 use pf::log;
 use File::Basename;
 use List::MoreUtils qw(firstval);
@@ -94,22 +94,28 @@ sub commit_file {
         }
 
         my $basedir = dirname($dst);
-        system("mkdir -p $basedir");
-        if($? != 0) {
+        my $status;
+        safe_pf_run("mkdir", "-p", $basedir, { status_ref => \$status });
+        if(!defined($status) || $status != 0) {
             $last_error = "Unable to create directory for file $dst";
             sleep 3;
             next;
         }
 
-        system("cp -a $src $dst");
-        if($? != 0) {
+        safe_pf_run("cp", "-a", $src, $dst, { status_ref => \$status });
+        if(!defined($status) || $status != 0) {
             $last_error = "Unable to copy $src into git repository $dst";
             sleep 3;
             next;
         }
 
-        system("cd ".$proto->git_directory." && git add -f $unprefixed_dst && git commit --allow-empty -m 'update $unprefixed_dst'");
-        if($? != 0) {
+        safe_pf_run("git", "add", "-f", $unprefixed_dst,
+            { working_directory => $proto->git_directory, status_ref => \$status });
+        if(defined($status) && $status == 0) {
+            safe_pf_run("git", "commit", "--allow-empty", "-m", "update $unprefixed_dst",
+                { working_directory => $proto->git_directory, status_ref => \$status });
+        }
+        if(!defined($status) || $status != 0) {
             $last_error = "Unable to commit to repository. Please retry the change.";
             sleep 3;
             next;
@@ -160,8 +166,14 @@ sub delete_file {
             next;
         }
 
-        system("cd ".$proto->git_directory." && git rm $file && git commit --allow-empty -m 'delete $file'");
-        if($? != 0) {
+        my $status;
+        safe_pf_run("git", "rm", $file,
+            { working_directory => $proto->git_directory, status_ref => \$status });
+        if(defined($status) && $status == 0) {
+            safe_pf_run("git", "commit", "--allow-empty", "-m", "delete $file",
+                { working_directory => $proto->git_directory, status_ref => \$status });
+        }
+        if(!defined($status) || $status != 0) {
             $last_error = "Unable to commit to repository. Please retry the change.";
             sleep 3;
             next;
@@ -196,8 +208,10 @@ Pulls the git repository
 sub pull {
     my ($proto) = @_;
     
-    system("cd ".$proto->git_directory." && git pull");
-    if($? != 0) {
+    my $status;
+    safe_pf_run("git", "pull",
+        { working_directory => $proto->git_directory, status_ref => \$status });
+    if(!defined($status) || $status != 0) {
         return (0, "Unable to pull repository.");
     }
 
@@ -213,8 +227,10 @@ Pushes the git repository
 sub push {
     my ($proto) = @_;
 
-    system("cd ".$proto->git_directory." && git push");
-    if($? != 0) {
+    my $status;
+    safe_pf_run("git", "push",
+        { working_directory => $proto->git_directory, status_ref => \$status });
+    if(!defined($status) || $status != 0) {
         return (0, "Unable to push repository. Please retry the change.");
     }
 
@@ -242,24 +258,34 @@ sub update {
             return 0;
         }
 
-        system("cd ".$proto->git_directory." && git pull");
-        if($? != 0) {
+        my $status;
+        safe_pf_run("git", "pull",
+            { working_directory => $proto->git_directory, status_ref => \$status });
+        if(!defined($status) || $status != 0) {
             $last_error = "Unable to pull repository";
             sleep 3;
             next;
         }
-        system("cp -a ".$proto->git_directory."/conf/* ".$proto->conf_directory."/");
-        if($? != 0) {
-            $last_error = "Unable to copy conf/ repository files";
-            sleep 3;
-            next;
+
+        # Expand the glob in Perl (no shell) before passing each source to cp.
+        my @conf_files = glob($proto->git_directory . "/conf/*");
+        if(@conf_files) {
+            safe_pf_run("cp", "-a", @conf_files, $proto->conf_directory . "/", { status_ref => \$status });
+            if(!defined($status) || $status != 0) {
+                $last_error = "Unable to copy conf/ repository files";
+                sleep 3;
+                next;
+            }
         }
 
-        system("cp -a ".$proto->git_directory."/fingerbank/conf/* ".$proto->fingerbank_conf_directory."/");
-        if($? != 0) {
-            $last_error = "Unable to copy fingerbank/conf/ repository files";
-            sleep 3;
-            next;
+        my @fb_conf_files = glob($proto->git_directory . "/fingerbank/conf/*");
+        if(@fb_conf_files) {
+            safe_pf_run("cp", "-a", @fb_conf_files, $proto->fingerbank_conf_directory . "/", { status_ref => \$status });
+            if(!defined($status) || $status != 0) {
+                $last_error = "Unable to copy fingerbank/conf/ repository files";
+                sleep 3;
+                next;
+            }
         }
 
         $last_error = undef;

--- a/lib/pfconfig/git_storage.pm
+++ b/lib/pfconfig/git_storage.pm
@@ -109,7 +109,7 @@ sub commit_file {
             next;
         }
 
-        safe_pf_run("git", "add", "-f", $unprefixed_dst,
+        safe_pf_run("git", "add", "-f", "--", $unprefixed_dst,
             { working_directory => $proto->git_directory, status_ref => \$status });
         if(defined($status) && $status == 0) {
             safe_pf_run("git", "commit", "--allow-empty", "-m", "update $unprefixed_dst",

--- a/lib/pfconfig/namespaces/config/Pf.pm
+++ b/lib/pfconfig/namespaces/config/Pf.pm
@@ -217,7 +217,9 @@ sub set_timezone {
         my $msg = "WARNING: The timezone is being changed from $lt to $tz on the system. It is advised to reboot the server so that all services start with the correct timezone.\n";
         print STDERR $msg;
         get_logger->warn($msg);
-        system("sudo timedatectl set-timezone $tz") && die "Unable to set timezone on the system \n";
+        my $status;
+        safe_pf_run(qw(sudo timedatectl set-timezone), $tz, { status_ref => \$status });
+        die "Unable to set timezone on the system \n" unless (defined($status) && $status == 0);
     }
 }
 

--- a/sbin/pf-mariadb
+++ b/sbin/pf-mariadb
@@ -106,16 +106,16 @@ Launch MySQL/MariaDB with a specific set of arguments
 sub launch_mysql {
     my ($exec, @args) = @_;
     $exec //= 1;
-    
-    my $args = join(' ', @args);
+
+    @args = grep { defined && length } @args;
     # Must not lookup in /sbin for mysqld, but in /usr/sbin
     $ENV{PATH} = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:/root/bin:/bin";
-    my $cmd = "mysqld_safe --defaults-file=/usr/local/pf/var/conf/mariadb.conf $args";
-    print "Starting MySQL with command: $cmd \n";
+    my @cmd = ("mysqld_safe", "--defaults-file=/usr/local/pf/var/conf/mariadb.conf", @args);
+    print "Starting MySQL with command: @cmd \n";
     if($exec) {
-        exec($cmd);
+        exec(@cmd);
     } else {
-        `$cmd`;
+        safe_pf_run(@cmd);
     }
 }
 

--- a/sbin/pf-mariadb
+++ b/sbin/pf-mariadb
@@ -115,7 +115,10 @@ sub launch_mysql {
     if($exec) {
         exec(@cmd);
     } else {
-        safe_pf_run(@cmd);
+        # mysqld_safe stays in the foreground; merge stderr into stdout so the
+        # child's output shares a single pipe that safe_pf_run drains, rather
+        # than leaving stderr undrained where it could fill and deadlock.
+        safe_pf_run(@cmd, { redirect_stderr_to_stdout => 1 });
     }
 }
 

--- a/sbin/pfdhcplistener
+++ b/sbin/pfdhcplistener
@@ -28,7 +28,7 @@ use File::Basename qw(basename);
 use Getopt::Std;
 use Net::Pcap 0.16;
 use Pod::Usage;
-use POSIX qw(:signal_h pause :sys_wait_h SIG_BLOCK SIG_SETMASK);
+use POSIX qw(:signal_h pause :sys_wait_h SIG_BLOCK SIG_UNBLOCK SIG_SETMASK);
 use Fcntl qw(:flock);
 use Try::Tiny;
 use pf::util::dhcp;
@@ -458,6 +458,9 @@ sub runtask {
     }
     elsif ($pid == 0) {
         $SIG{CHLD} = 'DEFAULT';
+        # The parent forked us inside its SIGCHLD-blocked window; unblock so the
+        # child starts with a clean signal mask matching its DEFAULT disposition.
+        sigprocmask(SIG_UNBLOCK, POSIX::SigSet->new(POSIX::SIGCHLD()));
         $IS_CHILD = 1;
         Log::Log4perl::MDC->put('tid', $$);
         setup_global($task);

--- a/sbin/pfdhcplistener
+++ b/sbin/pfdhcplistener
@@ -28,7 +28,7 @@ use File::Basename qw(basename);
 use Getopt::Std;
 use Net::Pcap 0.16;
 use Pod::Usage;
-use POSIX qw(:signal_h pause :sys_wait_h SIG_BLOCK SIG_UNBLOCK);
+use POSIX qw(:signal_h pause :sys_wait_h SIG_BLOCK SIG_SETMASK);
 use Fcntl qw(:flock);
 use Try::Tiny;
 use pf::util::dhcp;
@@ -435,12 +435,13 @@ run all runtasks
 
 sub runtasks {
     my $mask = POSIX::SigSet->new(POSIX::SIGCHLD());
-    sigprocmask(SIG_BLOCK, $mask);
+    my $oldmask = POSIX::SigSet->new();
+    sigprocmask(SIG_BLOCK, $mask, $oldmask);
     while (@REGISTERED_TASKS) {
         my $task = shift @REGISTERED_TASKS;
         runtask($task);
     }
-    sigprocmask(SIG_UNBLOCK, $mask);
+    sigprocmask(SIG_SETMASK, $oldmask);
 }
 
 =head2 runtask

--- a/sbin/pffilter
+++ b/sbin/pffilter
@@ -29,7 +29,7 @@ BEGIN {
 
 use Getopt::Std;
 use File::Basename qw(basename);
-use POSIX qw(:signal_h pause :sys_wait_h SIG_BLOCK SIG_UNBLOCK);
+use POSIX qw(:signal_h pause :sys_wait_h SIG_BLOCK SIG_SETMASK);
 use pf::AtFork;
 use Pod::Usage;
 use Fcntl qw(:flock);
@@ -239,12 +239,13 @@ run all runtasks
 
 sub runtasks {
     my $mask = POSIX::SigSet->new(POSIX::SIGCHLD());
-    sigprocmask(SIG_BLOCK, $mask);
+    my $oldmask = POSIX::SigSet->new();
+    sigprocmask(SIG_BLOCK, $mask, $oldmask);
     while (@REGISTERED_TASKS) {
         my $task = shift @REGISTERED_TASKS;
         runtask($task);
     }
-    sigprocmask(SIG_UNBLOCK, $mask);
+    sigprocmask(SIG_SETMASK, $oldmask);
 }
 
 =head2 runtask

--- a/sbin/pffilter
+++ b/sbin/pffilter
@@ -29,7 +29,7 @@ BEGIN {
 
 use Getopt::Std;
 use File::Basename qw(basename);
-use POSIX qw(:signal_h pause :sys_wait_h SIG_BLOCK SIG_SETMASK);
+use POSIX qw(:signal_h pause :sys_wait_h SIG_BLOCK SIG_UNBLOCK SIG_SETMASK);
 use pf::AtFork;
 use Pod::Usage;
 use Fcntl qw(:flock);
@@ -263,6 +263,9 @@ sub runtask {
     }
     elsif ($pid == 0) {
         $SIG{CHLD} = 'DEFAULT';
+        # The parent forked us inside its SIGCHLD-blocked window; unblock so the
+        # child starts with a clean signal mask matching its DEFAULT disposition.
+        sigprocmask(SIG_UNBLOCK, POSIX::SigSet->new(POSIX::SIGCHLD()));
         $IS_CHILD = 1;
         Log::Log4perl::MDC->put('tid', $$);
         _runtask($task);

--- a/sbin/pfqueue
+++ b/sbin/pfqueue
@@ -246,12 +246,13 @@ run all run_tasks
 
 sub run_tasks {
     my $mask = POSIX::SigSet->new(POSIX::SIGCHLD());
-    sigprocmask(SIG_BLOCK, $mask);
+    my $oldmask = POSIX::SigSet->new();
+    sigprocmask(SIG_BLOCK, $mask, $oldmask);
     while (@REGISTERED_TASKS) {
         my $task = shift @REGISTERED_TASKS;
         run_task($task);
     }
-    sigprocmask(SIG_UNBLOCK, $mask);
+    sigprocmask(SIG_SETMASK, $oldmask);
 }
 
 =head2 run_task

--- a/t/unittest/safe_pf_run.t
+++ b/t/unittest/safe_pf_run.t
@@ -1,0 +1,320 @@
+#!/usr/bin/perl
+
+=head1 NAME
+
+safe_pf_run
+
+=cut
+
+=head1 DESCRIPTION
+
+unit test for pf::util::safe_pf_run
+
+safe_pf_run runs a command via IPC::Open3 with the binary and arguments passed
+as a list (never through a shell), so these tests focus on:
+
+* the return-value contract in scalar / list / void context
+* that no shell interpretation (globbing, metacharacters, word splitting)
+  happens on the arguments
+* the option hash: status_ref, accepted_exit_status, stdin, stdout,
+  stdout_append, redirect_stderr_to_stdout, working_directory, log_strip
+* that large output on stdout (and on a merged stdout+stderr) is fully drained
+  and does not deadlock waitpid
+
+=cut
+
+use strict;
+use warnings;
+#
+BEGIN {
+    #include test libs
+    use lib qw(/usr/local/pf/t);
+    #Module for overriding configuration paths
+    use setup_test_config;
+}
+
+use Test::More tests => 33;
+use Test::NoWarnings;
+
+use File::Temp qw(tempfile tempdir);
+use File::Slurp qw(read_file write_file);
+use Cwd qw(getcwd abs_path);
+use POSIX qw(WNOHANG);
+
+use pf::util qw(safe_pf_run);
+
+# The child process used throughout is the running perl interpreter. It is
+# always present and lets us produce deterministic output / exit codes without
+# depending on the behaviour of external utilities.
+my $PERL = $^X;
+
+# Run a coderef under an alarm so a regression that reintroduces a pipe-buffer
+# deadlock fails fast instead of hanging the whole suite. Returns the eval
+# error ('' on success).
+sub run_with_timeout {
+    my ($seconds, $code) = @_;
+    my $err = '';
+    eval {
+        local $SIG{ALRM} = sub { die "timeout\n" };
+        alarm($seconds);
+        $code->();
+        alarm(0);
+        1;
+    } or $err = $@;
+    alarm(0);
+    return $err;
+}
+
+# --- return value contract -------------------------------------------------
+
+is(
+    safe_pf_run($PERL, '-e', 'print "hello"'),
+    "hello",
+    "scalar context returns the captured stdout"
+);
+
+is(
+    safe_pf_run($PERL, '-e', 'print "line\n"'),
+    "line\n",
+    "scalar context preserves a trailing newline"
+);
+
+is_deeply(
+    [ safe_pf_run($PERL, '-e', 'print "a\nb\nc\n"') ],
+    [ "a\n", "b\n", "c\n" ],
+    "list context returns one element per line (newlines retained)"
+);
+
+# --- no shell: arguments are passed verbatim -------------------------------
+
+is(
+    safe_pf_run($PERL, '-e', 'print $ARGV[0]', 'foo; echo INJECTED `whoami` $(id)'),
+    'foo; echo INJECTED `whoami` $(id)',
+    "shell metacharacters in an argument are passed literally (no shell)"
+);
+
+is(
+    safe_pf_run($PERL, '-e', 'print $ARGV[0]', '*'),
+    '*',
+    "a '*' argument is not glob-expanded (no shell)"
+);
+
+is(
+    safe_pf_run($PERL, '-e', 'print scalar(@ARGV)', 'one two three', 'four'),
+    '2',
+    "an argument containing spaces is a single argv element (no word splitting)"
+);
+
+is(
+    safe_pf_run($PERL, '-e', 'print join("|", @ARGV)', 'a b', 'c'),
+    'a b|c',
+    "argument values are delivered to the child unchanged"
+);
+
+# --- status_ref ------------------------------------------------------------
+
+{
+    my $status;
+    safe_pf_run($PERL, '-e', 'exit 0', { status_ref => \$status });
+    is($status, 0, "status_ref is 0 on success");
+}
+
+{
+    my $status;
+    safe_pf_run($PERL, '-e', 'exit 3', { status_ref => \$status });
+    is($status >> 8, 3, "status_ref carries the raw wait status (exit code 3)");
+}
+
+# --- failure handling ------------------------------------------------------
+
+is(
+    safe_pf_run($PERL, '-e', 'exit 1'),
+    undef,
+    "a non-zero exit returns undef in scalar context"
+);
+
+# --- accepted_exit_status --------------------------------------------------
+
+is(
+    safe_pf_run($PERL, '-e', 'print "data"; exit 3', { accepted_exit_status => [3] }),
+    "data",
+    "accepted_exit_status treats the listed code as success and returns output"
+);
+
+is(
+    safe_pf_run($PERL, '-e', 'exit 5', { accepted_exit_status => [3] }),
+    undef,
+    "an exit code not in accepted_exit_status still fails"
+);
+
+# --- stdin -----------------------------------------------------------------
+
+{
+    my (undef, $infile) = tempfile();
+    write_file($infile, "hello\n");
+    is(
+        safe_pf_run($PERL, '-e', 'local $/; print uc <STDIN>', { stdin => $infile }),
+        "HELLO\n",
+        "stdin feeds the file contents to the command"
+    );
+    unlink $infile;
+}
+
+# --- stdout to file --------------------------------------------------------
+
+{
+    my (undef, $outfile) = tempfile();
+    my $ret = safe_pf_run($PERL, '-e', 'print "tofile"', { stdout => $outfile });
+    is($ret, undef, "with stdout redirected to a file the scalar return is undef");
+    is(read_file($outfile), "tofile", "stdout is written to the file");
+    unlink $outfile;
+}
+
+# --- stdout_append ---------------------------------------------------------
+
+{
+    my (undef, $appendfile) = tempfile();
+    safe_pf_run($PERL, '-e', 'print "AA"', { stdout => $appendfile });
+    safe_pf_run($PERL, '-e', 'print "BB"', { stdout => $appendfile, stdout_append => 1 });
+    is(read_file($appendfile), "AABB", "stdout_append appends instead of truncating");
+    unlink $appendfile;
+}
+
+# --- redirect_stderr_to_stdout ---------------------------------------------
+
+{
+    my $merged = safe_pf_run(
+        $PERL, '-e', 'print STDOUT "OUT"; print STDERR "ERR"',
+        { redirect_stderr_to_stdout => 1 },
+    );
+    ok(
+        defined($merged) && $merged =~ /OUT/ && $merged =~ /ERR/,
+        "redirect_stderr_to_stdout captures both streams"
+    );
+}
+
+is(
+    safe_pf_run($PERL, '-e', 'print STDOUT "OUT"; print STDERR "ERR"'),
+    "OUT",
+    "without redirect, only stdout is returned (stderr is drained, not returned)"
+);
+
+# --- working_directory -----------------------------------------------------
+
+{
+    my $orig = getcwd();
+    my $dir  = tempdir(CLEANUP => 1);
+    my $child_cwd = safe_pf_run(
+        $PERL, '-MCwd', '-e', 'print Cwd::abs_path(q{.})',
+        { working_directory => $dir },
+    );
+    is($child_cwd, abs_path($dir), "the command runs in working_directory");
+    is(getcwd(), $orig, "the caller's cwd is restored after the command");
+}
+
+# --- environment -----------------------------------------------------------
+
+is(
+    safe_pf_run($PERL, '-e', 'print $ENV{LANG} // "no-lang"'),
+    "C",
+    "LANG is forced to C for the child"
+);
+
+# --- log_strip -------------------------------------------------------------
+
+is(
+    safe_pf_run($PERL, '-e', 'print "topsecret"', { log_strip => "secret" }),
+    "topsecret",
+    "log_strip redacts only log output, not the returned value"
+);
+
+# --- failure to launch -----------------------------------------------------
+
+{
+    my $status;
+    my $ret = safe_pf_run("/no/such/binary_xyz", "arg", { status_ref => \$status });
+    is($ret, undef, "a command that cannot be launched returns undef");
+    is($status, -1, "status_ref is set to -1 when the command cannot be launched");
+}
+
+# --- large output must not deadlock (regression) ---------------------------
+# The child writes far more than a pipe buffer (~64KB). safe_pf_run must drain
+# stdout before waitpid, otherwise the child blocks on a full pipe and we hang.
+
+{
+    my $big;
+    my $size = 1024 * 256; # 256KB
+    my $err = run_with_timeout(30, sub {
+        $big = safe_pf_run($PERL, '-e', "print q{x} x $size");
+    });
+    is($err, '', "large stdout does not deadlock");
+    is(length($big // ''), $size, "large stdout is fully captured");
+}
+
+{
+    my $merged;
+    my $half = 1024 * 200; # 200KB on each stream
+    my $err = run_with_timeout(30, sub {
+        $merged = safe_pf_run(
+            $PERL, '-e', "print STDOUT q{o} x $half; print STDERR q{e} x $half",
+            { redirect_stderr_to_stdout => 1 },
+        );
+    });
+    is($err, '', "large merged stdout+stderr does not deadlock");
+    is(length($merged // ''), $half * 2, "large merged output is fully captured");
+}
+
+# --- competing SIGCHLD reaper (regression) ---------------------------------
+# The long-running daemons (pfconfig, pfqueue, pfqueue-backend, pffilter,
+# pfdhcplistener) install a $SIG{CHLD} handler that reaps any terminated child
+# with waitpid(-1, WNOHANG) and discards its status. Because safe_pf_run drains
+# the child's pipes to EOF before waiting, the child has already exited by the
+# time it waits -- so unless safe_pf_run blocks SIGCHLD across the fork/wait,
+# the daemon's reaper collects the child first and safe_pf_run's own waitpid
+# returns -1: a false failure for a command that actually succeeded.
+
+{
+    local $SIG{CHLD} = sub { 1 while waitpid(-1, WNOHANG) > 0 };
+
+    my $status;
+    my $out = safe_pf_run($PERL, '-e', 'print "ok"; exit 0', { status_ref => \$status });
+    is($out, "ok", "output is returned despite a competing SIGCHLD reaper");
+    is($status, 0, "status_ref is 0 despite a competing SIGCHLD reaper");
+
+    is_deeply(
+        [ safe_pf_run($PERL, '-e', 'print "a\nb\n"') ],
+        [ "a\n", "b\n" ],
+        "list context still works with a competing SIGCHLD reaper",
+    );
+
+    my $fstatus;
+    safe_pf_run($PERL, '-e', 'exit 4', { status_ref => \$fstatus });
+    is($fstatus >> 8, 4, "a genuine non-zero exit is still reported with a competing reaper");
+}
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2026 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut

--- a/t/unittest/security_events.t
+++ b/t/unittest/security_events.t
@@ -21,24 +21,30 @@ BEGIN {
     use setup_test_config;
 }
 
-use Test::More tests => 33;
+use Test::More tests => 21;
 use Test2::Tools::Compare qw(bag item end);
 use_ok('pf::security_event');
 
 # Will be able to match a security_event with multiple triggers by only passing the trigger info
 my @security_events = $pf::security_event::SECURITY_EVENT_FILTER_ENGINE->match_all({device_id => 2});
-is(@security_events, 1);
-is($security_events[0], "1100009");
+Test2::Tools::Compare::is(
+    \@security_events,
+    ['1100009'],
+);
 
 # Will be able to match a security_event with multiple data that will all trigger it
 @security_events = $pf::security_event::SECURITY_EVENT_FILTER_ENGINE->match_all({device_id => 2, dhcp_fingerprint_id => 3});
-is(@security_events, 1);
-is($security_events[0], "1100009");
+Test2::Tools::Compare::is(
+    \@security_events,
+    ['1100009'],
+);
 
 # Will be able to match a security_event with multiple data when only a part will match
 @security_events = $pf::security_event::SECURITY_EVENT_FILTER_ENGINE->match_all({device_id => 2, dhcp_fingerprint_id => "dinde"});
-is(@security_events, 1);
-is($security_events[0], "1100009");
+Test2::Tools::Compare::is(
+    \@security_events,
+    ['1100009'],
+);
 
 # Will be able to match multiple security_events on the same trigger
 @security_events = $pf::security_event::SECURITY_EVENT_FILTER_ENGINE->match_all({last_detect_id => 1});
@@ -64,26 +70,38 @@ Test2::Tools::Compare::is(
 
 # Will be able to match a mac trigger that uses a regex
 @security_events = $pf::security_event::SECURITY_EVENT_FILTER_ENGINE->match_all({mac => "12:34:56:78:90:12"});
-is(@security_events, 1);
-is($security_events[0], "1100009");
+Test2::Tools::Compare::is(
+    \@security_events,
+    ['1100009'],
+);
 
 # Will not be able to match on a disabled security_event
 @security_events = $pf::security_event::SECURITY_EVENT_FILTER_ENGINE->match_all({last_detect_id => -1});
-is(@security_events, 0);
+Test2::Tools::Compare::is(
+    \@security_events,
+    [],
+);
 
 # Can match a combined trigger
 @security_events = $pf::security_event::SECURITY_EVENT_FILTER_ENGINE->match_all({last_detect_id => 10, mac => "21:34:56:78:90:12"});
-is(@security_events, 1);
-is($security_events[0], "1100011");
+Test2::Tools::Compare::is(
+    \@security_events,
+    ['1100011'],
+);
 
 # Can't match a part of a combined trigger
 @security_events = $pf::security_event::SECURITY_EVENT_FILTER_ENGINE->match_all({last_detect_id => 9, mac => "21:34:56:78:90:12"});
-is(@security_events, 0);
+Test2::Tools::Compare::is(
+    \@security_events,
+    [],
+);
 
 # Test a security_event using DHCPv6 fingerprint
 @security_events = $pf::security_event::SECURITY_EVENT_FILTER_ENGINE->match_all({dhcp6_fingerprint_id => 2});
-is(@security_events, 1);
-is($security_events[0], "1100012");
+Test2::Tools::Compare::is(
+    \@security_events,
+    ['1100012'],
+);
 
 # Test a security_event using DHCPv6 fingerprint that shouldn't match
 @security_events = $pf::security_event::SECURITY_EVENT_FILTER_ENGINE->match_all({dhcp6_fingerprint_id => 3});
@@ -91,36 +109,53 @@ is(@security_events, 0);
 
 # Test a security_event using DHCPv6 enterprise
 @security_events = $pf::security_event::SECURITY_EVENT_FILTER_ENGINE->match_all({dhcp6_enterprise_id => 2});
-is(@security_events, 1);
-is($security_events[0], "1100012");
+Test2::Tools::Compare::is(
+    \@security_events,
+    ['1100012'],
+);
 
 # Test a security_event using DHCPv6 enteprise that shouldn't match
 @security_events = $pf::security_event::SECURITY_EVENT_FILTER_ENGINE->match_all({dhcp6_enterprise_id => 1});
-is(@security_events, 0);
+Test2::Tools::Compare::is(
+    \@security_events,
+    [],
+);
 
 # Test a security_event using role
 @security_events = $pf::security_event::SECURITY_EVENT_FILTER_ENGINE->match_all({role => "default"});
-is(@security_events, 1);
-is($security_events[0], "1100014");
+Test2::Tools::Compare::is(
+    \@security_events,
+    ['1100014'],
+);
 
 # Test a security_event using VLAN
 @security_events = $pf::security_event::SECURITY_EVENT_FILTER_ENGINE->match_all({last_vlan => "100"});
-is(@security_events, 1);
-is($security_events[0], "1100019");
+Test2::Tools::Compare::is(
+    \@security_events,
+    ['1100019'],
+);
 
 # Test a security_event using network
 @security_events = $pf::security_event::SECURITY_EVENT_FILTER_ENGINE->match_all({last_ip => "172.30.0.1"});
-is(@security_events, 1);
-is($security_events[0], "1100020");
+Test2::Tools::Compare::is(
+    \@security_events,
+    ['1100020'],
+);
 
 # Test a security_event using network and device_is_not
 @security_events = $pf::security_event::SECURITY_EVENT_FILTER_ENGINE->match_all({last_ip => "172.31.0.1", device_id => 1});
-is(@security_events, 1);
-is($security_events[0], "1100021");
+Test2::Tools::Compare::is(
+    \@security_events,
+    ['1100021'],
+);
 
 # Test a security_event using network and device_is_not
 @security_events = $pf::security_event::SECURITY_EVENT_FILTER_ENGINE->match_all({last_ip => "172.31.0.1", device_id => 33453});
-is(@security_events, 0);
+#is(@security_events, 0);
+Test2::Tools::Compare::is(
+    \@security_events,
+    [],
+);
 
 @security_events = $pf::security_event::SECURITY_EVENT_FILTER_ENGINE->match_all(
     {
@@ -128,8 +163,10 @@ is(@security_events, 0);
         last_switch      => '172.16.8.30'
     }
 );
-is(@security_events, 1);
-is($security_events[0], "1100018");
+Test2::Tools::Compare::is(
+    \@security_events,
+    ['1100018'],
+);
 
 #This test will running last
 use Test::NoWarnings;

--- a/t/unittest/ssl.t
+++ b/t/unittest/ssl.t
@@ -22,7 +22,7 @@ BEGIN {
     use setup_test_config;
 }
 
-use Test::More tests => 20;
+use Test::More tests => 23;
 use Test::NoWarnings;
 
 use pf::constants qw($TRUE $FALSE);
@@ -150,6 +150,14 @@ my $x509 = pf::ssl::x509_from_string($ss_test_cert);
 is(ref($x509), "Crypt::OpenSSL::X509", "x509_from_string returns a Crypt::OpenSSL::X509");
 
 is($x509->subject, "C=MX, ST=Cucaracha, L=Villa de los Tacos, O=Zammitocorpo, CN=pf.zammitocorpo.mx", "certificate has the right subject");
+
+# Reference value computed with the OpenSSL CLI pipeline this code replaces:
+#   openssl x509 -noout -modulus | openssl md5
+# (the cert and key match, so both modulus MD5s are identical)
+my $expected_modulus_md5 = "205ee9d2d1c13e5e7b12ae59e00ff974";
+is(pf::ssl::x509_modulus_md5($x509), $expected_modulus_md5, "x509_modulus_md5 matches the OpenSSL CLI value");
+is(pf::ssl::rsa_modulus_md5($rsa), $expected_modulus_md5, "rsa_modulus_md5 matches the OpenSSL CLI value");
+isnt(pf::ssl::rsa_modulus_md5($rsa_bad_cert), $expected_modulus_md5, "non-matching key yields a different modulus MD5");
 
 is(pf::ssl::validate_cert_key_match($x509, $rsa), $TRUE, "Cert/key that are matching should match");
 


### PR DESCRIPTION
## Summary

Replaces shell-interpolated command execution (`pf_run`, backticks, `qx`, `system`, piped `open`) with `safe_pf_run`, which runs commands via `open3` with an explicit argument list — no shell, so no command-injection or glob/word-splitting surprises. Also rewrites a couple of shell pipelines in pure Perl where that was cleaner than spawning a process at all.

## Changes

- **Command execution hardening** — convert call sites across the codebase to `safe_pf_run(BIN, @ARGS, \%opts)`:
  - `addons/AD/migrate.pl`, `addons/upgrade/to-13.1-move-ntlm-auth-to-rest.pl`, `bin/cluster/sync`, `bin/pfcmd_vlan`
  - `lib/pf/services/manager.pm` and managers (`pf`, `tracking`, `fingerbank_collector`) — `systemctl` start/stop/enable/disable/show/is-active
  - `lib/pf/ipset_cache.pm`, `lib/pf/iptables.pm` — feed `ipset restore` from a temp file via `stdin` instead of a shell pipe
  - `lib/pfconfig/git_storage.pm` — git pull/push/add/commit/rm and conf copies (globs expanded in Perl, `working_directory` instead of `cd &&`)
  - `lib/pfconfig/namespaces/config/Pf.pm` — `timedatectl set-timezone`
  - `sbin/pf-mariadb` — `mysqld_safe` launched with an argument list
- **Pure-Perl rewrites (no subprocess):**
  - `lib/pf/Switch/Xirrus.pm` — `Digest::MD5::md5_hex` instead of `printf … | md5sum`
  - `lib/pf/domain.pm` — parse AD config in Perl instead of shelling out
  - `lib/pf/ssl.pm` — `verify_chain`/`modulus_md5` without `/bin/bash -c` process substitution; tests in `t/unittest/ssl.t`
- **Robustness fixes** (latest commit):
  - `git_storage` pull/push and `pf-mariadb` `mysqld_safe`: merge stderr into stdout so `safe_pf_run` drains the child's output rather than leaving stderr undrained, which could fill the pipe buffer and hang `waitpid`.
  - `services::manager::isAlive`: accept exit codes 1–4 from `systemctl is-active` so inactive/failed services on this hot path aren't logged as command failures (matches `print_status`).

## Test plan

- `t/unittest/ssl.t` covers the rewritten chain verification.
- Manual verification of service start/stop/status, ipset/iptables rule loading, and pfconfig git sync recommended before merge.

