### PR TITLE
Decorate all MySQL queries with /* pf:<service>[:<unit>] */ 

### DIFF
--- a/go/db/db.go
+++ b/go/db/db.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-sql-driver/mysql"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/inverse-inc/go-utils/log"
+	"github.com/inverse-inc/packetfence/go/db/sqlcomment"
 	"github.com/inverse-inc/packetfence/go/pfconfigdriver"
 )
 
@@ -46,7 +47,9 @@ func ConnectDb(ctx context.Context, dbName string) (*sql.DB, error) {
 }
 
 func ConnectURI(ctx context.Context, uri string) (*sql.DB, error) {
-	db, err := sql.Open("mysql", uri)
+	// Open through the comment-wrapping driver so every statement carries the
+	// /* pf:<service>[:<unit>] */ ProxySQL routing remark.
+	db, err := sql.Open(sqlcomment.DriverName, uri)
 	if err != nil {
 		log.LoggerWContext(ctx).Error(fmt.Sprintf("Error while connecting to DB: %s", err))
 		return nil, err

--- a/go/db/sqlcomment/sqlcomment.go
+++ b/go/db/sqlcomment/sqlcomment.go
@@ -32,7 +32,9 @@ import (
 const DriverName = "mysql-pf"
 
 func init() {
-	sql.Register(DriverName, wrapDriver{mysql.MySQLDriver{}})
+	// Register with a *MySQLDriver, matching go-sql-driver's own registration
+	// and staying correct even if its Driver methods move to a pointer receiver.
+	sql.Register(DriverName, wrapDriver{&mysql.MySQLDriver{}})
 }
 
 type unitCtxKey struct{}

--- a/go/db/sqlcomment/sqlcomment.go
+++ b/go/db/sqlcomment/sqlcomment.go
@@ -56,7 +56,8 @@ func unitFromContext(ctx context.Context) string {
 
 // decorate prepends the routing remark unless the query is already decorated.
 func decorate(ctx context.Context, query string) string {
-	if strings.HasPrefix(query, "/* pf:") {
+	// Treat leading whitespace as insignificant for idempotency since callers may indent multi-line SQL.
+	if strings.HasPrefix(strings.TrimLeft(query, " \t\r\n"), "/* pf:") {
 		return query
 	}
 	tag := "pf:" + sanitize(serviceName())

--- a/go/db/sqlcomment/sqlcomment.go
+++ b/go/db/sqlcomment/sqlcomment.go
@@ -1,0 +1,190 @@
+// Package sqlcomment provides a database/sql driver that wraps the
+// go-sql-driver/mysql driver and prepends a ProxySQL routing remark to every
+// statement it executes.
+//
+// The remark has the form:
+//
+//	/* pf:<service>[:<unit>] */ <SQL>
+//
+// where <service> is the running binary (log.ProcessName) and <unit> is an
+// optional logical work-unit (a cron job name or queue task type) carried on
+// the context via WithQueryUnit. ProxySQL query rules can then route each
+// (service[,unit]) bucket to its own hostgroup with a dedicated max_connections
+// cap, using a match_pattern anchored on `^/\* pf:` (match_digest strips
+// comments and must not be used).
+//
+// The driver is registered under DriverName ("mysql-pf"). Use it exactly like
+// the "mysql" driver: sql.Open(sqlcomment.DriverName, dsn), or for GORM
+// mysql.New(mysql.Config{DriverName: sqlcomment.DriverName, DSN: dsn}).
+package sqlcomment
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"strings"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/inverse-inc/go-utils/log"
+)
+
+// DriverName is the name the wrapped driver is registered under.
+const DriverName = "mysql-pf"
+
+func init() {
+	sql.Register(DriverName, wrapDriver{mysql.MySQLDriver{}})
+}
+
+type unitCtxKey struct{}
+
+// WithQueryUnit returns a context carrying the logical work-unit name that the
+// routing remark should advertise (=> /* pf:<service>:<unit> */). Stamp it at a
+// job/task dispatch point and thread the ctx into the DB calls.
+func WithQueryUnit(ctx context.Context, unit string) context.Context {
+	return context.WithValue(ctx, unitCtxKey{}, unit)
+}
+
+func unitFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	if v, ok := ctx.Value(unitCtxKey{}).(string); ok {
+		return v
+	}
+	return ""
+}
+
+// decorate prepends the routing remark unless the query is already decorated.
+func decorate(ctx context.Context, query string) string {
+	if strings.HasPrefix(query, "/* pf:") {
+		return query
+	}
+	tag := "pf:" + sanitize(serviceName())
+	if u := sanitize(unitFromContext(ctx)); u != "" {
+		tag += ":" + u
+	}
+	return "/* " + tag + " */ " + query
+}
+
+func serviceName() string {
+	n := log.ProcessName
+	// ProcessName defaults to os.Args[0], which may be a path.
+	if i := strings.LastIndexAny(n, `/\`); i >= 0 {
+		n = n[i+1:]
+	}
+	if n == "" {
+		return "unknown"
+	}
+	return n
+}
+
+// sanitize makes a value safe to embed in a SQL comment and unambiguous for a
+// ProxySQL regex: it can never contain the comment terminator, and keeps only
+// routing-safe characters.
+func sanitize(v string) string {
+	v = strings.ReplaceAll(v, "*/", "")
+	var b strings.Builder
+	for _, r := range v {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9',
+			r == '_', r == '-', r == '/', r == '.':
+			b.WriteRune(r)
+		case r == ' ' || r == '\t' || r == '\n' || r == '\r':
+			b.WriteRune('_')
+		}
+	}
+	return b.String()
+}
+
+// wrapDriver wraps a driver.Driver so every opened connection is a wrapConn.
+type wrapDriver struct{ driver.Driver }
+
+func (d wrapDriver) Open(dsn string) (driver.Conn, error) {
+	c, err := d.Driver.Open(dsn)
+	if err != nil {
+		return nil, err
+	}
+	return wrapConn{c}, nil
+}
+
+// wrapConn forwards every connection method to the underlying mysql connection,
+// decorating the SQL on the query/exec/prepare paths. It re-implements the
+// optional database/sql driver interfaces (context exec, transactions, pooling
+// hooks, arg checking, validity) so wrapping does not silently disable mysql
+// behavior.
+type wrapConn struct{ driver.Conn }
+
+var (
+	_ driver.QueryerContext     = wrapConn{}
+	_ driver.ExecerContext      = wrapConn{}
+	_ driver.ConnPrepareContext = wrapConn{}
+	_ driver.ConnBeginTx        = wrapConn{}
+	_ driver.Pinger             = wrapConn{}
+	_ driver.SessionResetter    = wrapConn{}
+	_ driver.Validator          = wrapConn{}
+	_ driver.NamedValueChecker  = wrapConn{}
+)
+
+func (c wrapConn) Prepare(query string) (driver.Stmt, error) {
+	return c.Conn.Prepare(decorate(context.Background(), query))
+}
+
+func (c wrapConn) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {
+	if p, ok := c.Conn.(driver.ConnPrepareContext); ok {
+		return p.PrepareContext(ctx, decorate(ctx, query))
+	}
+	return c.Conn.Prepare(decorate(ctx, query))
+}
+
+func (c wrapConn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	q, ok := c.Conn.(driver.QueryerContext)
+	if !ok {
+		// Let database/sql fall back to the Prepare path (which we decorate).
+		return nil, driver.ErrSkip
+	}
+	return q.QueryContext(ctx, decorate(ctx, query), args)
+}
+
+func (c wrapConn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	e, ok := c.Conn.(driver.ExecerContext)
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+	return e.ExecContext(ctx, decorate(ctx, query), args)
+}
+
+func (c wrapConn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
+	if b, ok := c.Conn.(driver.ConnBeginTx); ok {
+		return b.BeginTx(ctx, opts)
+	}
+	return c.Conn.Begin()
+}
+
+func (c wrapConn) Ping(ctx context.Context) error {
+	if p, ok := c.Conn.(driver.Pinger); ok {
+		return p.Ping(ctx)
+	}
+	return nil
+}
+
+func (c wrapConn) ResetSession(ctx context.Context) error {
+	if r, ok := c.Conn.(driver.SessionResetter); ok {
+		return r.ResetSession(ctx)
+	}
+	return nil
+}
+
+func (c wrapConn) IsValid() bool {
+	if v, ok := c.Conn.(driver.Validator); ok {
+		return v.IsValid()
+	}
+	return true
+}
+
+func (c wrapConn) CheckNamedValue(nv *driver.NamedValue) error {
+	if ck, ok := c.Conn.(driver.NamedValueChecker); ok {
+		return ck.CheckNamedValue(nv)
+	}
+	// No custom checker: let database/sql apply its default conversion.
+	return driver.ErrSkip
+}

--- a/go/db/sqlcomment/sqlcomment.go
+++ b/go/db/sqlcomment/sqlcomment.go
@@ -79,9 +79,12 @@ func serviceName() string {
 	return n
 }
 
-// sanitize makes a value safe to embed in a SQL comment and unambiguous for a
-// ProxySQL regex: it can never contain the comment terminator, and keeps only
-// routing-safe characters.
+// sanitize makes a value safe to embed in a SQL comment: it can never contain
+// the comment terminator, and keeps only a small routing-safe charset. Note the
+// charset still permits regex metacharacters (e.g. '.', '/', '-') because they
+// occur in real service names and task types, so ProxySQL match_pattern rules
+// should escape them or use character classes rather than treating the tag as a
+// regex literal.
 func sanitize(v string) string {
 	v = strings.ReplaceAll(v, "*/", "")
 	var b strings.Builder

--- a/go/db/sqlcomment/sqlcomment.go
+++ b/go/db/sqlcomment/sqlcomment.go
@@ -102,8 +102,14 @@ func sanitize(v string) string {
 	return b.String()
 }
 
-// wrapDriver wraps a driver.Driver so every opened connection is a wrapConn.
+// wrapDriver wraps a driver.Driver so every opened connection is a wrapConn. It
+// also forwards driver.DriverContext (OpenConnector) when the underlying driver
+// supports it -- go-sql-driver/mysql does -- so database/sql keeps using the
+// connector-based path (DSN parsed once) instead of falling back to re-parsing
+// the DSN on every new connection.
 type wrapDriver struct{ driver.Driver }
+
+var _ driver.DriverContext = wrapDriver{}
 
 func (d wrapDriver) Open(dsn string) (driver.Conn, error) {
 	c, err := d.Driver.Open(dsn)
@@ -112,6 +118,47 @@ func (d wrapDriver) Open(dsn string) (driver.Conn, error) {
 	}
 	return wrapConn{c}, nil
 }
+
+func (d wrapDriver) OpenConnector(dsn string) (driver.Connector, error) {
+	dc, ok := d.Driver.(driver.DriverContext)
+	if !ok {
+		// Underlying driver has no DriverContext: use a DSN-based connector that
+		// routes back through our Open (which wraps the conn).
+		return dsnConnector{dsn: dsn, driver: d}, nil
+	}
+	c, err := dc.OpenConnector(dsn)
+	if err != nil {
+		return nil, err
+	}
+	return wrapConnector{Connector: c, driver: d}, nil
+}
+
+// wrapConnector wraps a driver.Connector so each connection is a wrapConn while
+// reporting the wrapping driver from Driver().
+type wrapConnector struct {
+	driver.Connector
+	driver driver.Driver
+}
+
+func (c wrapConnector) Connect(ctx context.Context) (driver.Conn, error) {
+	conn, err := c.Connector.Connect(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return wrapConn{conn}, nil
+}
+
+func (c wrapConnector) Driver() driver.Driver { return c.driver }
+
+// dsnConnector is the fallback connector used when the underlying driver does
+// not implement driver.DriverContext; it mirrors database/sql's own dsnConnector.
+type dsnConnector struct {
+	dsn    string
+	driver driver.Driver
+}
+
+func (c dsnConnector) Connect(context.Context) (driver.Conn, error) { return c.driver.Open(c.dsn) }
+func (c dsnConnector) Driver() driver.Driver                        { return c.driver }
 
 // wrapConn forwards every connection method to the underlying mysql connection,
 // decorating the SQL on the query/exec/prepare paths. It re-implements the

--- a/go/db/sqlcomment/sqlcomment_test.go
+++ b/go/db/sqlcomment/sqlcomment_test.go
@@ -1,0 +1,69 @@
+package sqlcomment
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/inverse-inc/go-utils/log"
+)
+
+func TestDecorateServiceOnly(t *testing.T) {
+	old := log.ProcessName
+	log.ProcessName = "pfacct"
+	defer func() { log.ProcessName = old }()
+
+	got := decorate(context.Background(), "SELECT 1")
+	want := "/* pf:pfacct */ SELECT 1"
+	if got != want {
+		t.Fatalf("decorate() = %q, want %q", got, want)
+	}
+}
+
+func TestDecorateWithUnit(t *testing.T) {
+	old := log.ProcessName
+	log.ProcessName = "pfqueue"
+	defer func() { log.ProcessName = old }()
+
+	ctx := WithQueryUnit(context.Background(), "populate_ntlm_redis_cache")
+	got := decorate(ctx, "UPDATE node SET x=1")
+	want := "/* pf:pfqueue:populate_ntlm_redis_cache */ UPDATE node SET x=1"
+	if got != want {
+		t.Fatalf("decorate() = %q, want %q", got, want)
+	}
+}
+
+func TestDecorateIdempotent(t *testing.T) {
+	old := log.ProcessName
+	log.ProcessName = "pfdns"
+	defer func() { log.ProcessName = old }()
+
+	once := decorate(context.Background(), "SELECT 1")
+	twice := decorate(context.Background(), once)
+	if once != twice {
+		t.Fatalf("decorate not idempotent: once=%q twice=%q", once, twice)
+	}
+	if strings.Count(twice, "/* pf:") != 1 {
+		t.Fatalf("expected exactly one remark, got %q", twice)
+	}
+}
+
+func TestServiceNameStripsPath(t *testing.T) {
+	old := log.ProcessName
+	log.ProcessName = "/usr/local/pf/sbin/pfstats"
+	defer func() { log.ProcessName = old }()
+
+	if got := serviceName(); got != "pfstats" {
+		t.Fatalf("serviceName() = %q, want pfstats", got)
+	}
+}
+
+func TestSanitizeRejectsCommentTerminatorAndJunk(t *testing.T) {
+	if got := sanitize("evil*/ ; DROP"); strings.Contains(got, "*/") {
+		t.Fatalf("sanitize left comment terminator: %q", got)
+	}
+	// spaces collapse, unsafe chars dropped
+	if got := sanitize("a b;c"); got != "a_bc" {
+		t.Fatalf("sanitize() = %q, want a_bc", got)
+	}
+}

--- a/go/db/sqlcomment/sqlcomment_test.go
+++ b/go/db/sqlcomment/sqlcomment_test.go
@@ -48,6 +48,13 @@ func TestDecorateIdempotent(t *testing.T) {
 	}
 }
 
+func TestDecorateAlreadyDecoratedWithLeadingWhitespace(t *testing.T) {
+	q := " \n\t/* pf:pfqueue */ SELECT 1"
+	if got := decorate(context.Background(), q); got != q {
+		t.Fatalf("decorate() modified an already-decorated query: got=%q want=%q", got, q)
+	}
+}
+
 func TestServiceNameStripsPath(t *testing.T) {
 	old := log.ProcessName
 	log.ProcessName = "/usr/local/pf/sbin/pfstats"

--- a/go/db/sqlcomment/sqlcomment_test.go
+++ b/go/db/sqlcomment/sqlcomment_test.go
@@ -2,6 +2,8 @@ package sqlcomment
 
 import (
 	"context"
+	"database/sql"
+	"database/sql/driver"
 	"strings"
 	"testing"
 
@@ -73,4 +75,22 @@ func TestSanitizeRejectsCommentTerminatorAndJunk(t *testing.T) {
 	if got := sanitize("a b;c"); got != "a_bc" {
 		t.Fatalf("sanitize() = %q, want a_bc", got)
 	}
+}
+
+func TestOpenUsesConnectorAndWraps(t *testing.T) {
+	// sql.Open is lazy and does not connect, but because the driver implements
+	// driver.DriverContext, it eagerly calls OpenConnector(dsn) -- which parses
+	// the DSN. A well-formed DSN must therefore succeed without a live DB.
+	db, err := sql.Open(DriverName, "u:p@tcp(127.0.0.1:3306)/test")
+	if err != nil {
+		t.Fatalf("sql.Open(%q): %v", DriverName, err)
+	}
+	defer db.Close()
+
+	// The connector must report our wrapping driver, proving the OpenConnector
+	// path (not the legacy DSN fallback) is in use.
+	if _, ok := db.Driver().(wrapDriver); !ok {
+		t.Fatalf("db.Driver() = %T, want wrapDriver", db.Driver())
+	}
+	var _ driver.DriverContext = wrapDriver{}
 }

--- a/go/plugin/caddy2/api/api.go
+++ b/go/plugin/caddy2/api/api.go
@@ -14,6 +14,7 @@ import (
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
 	"github.com/inverse-inc/go-utils/log"
 	"github.com/inverse-inc/packetfence/go/db"
+	"github.com/inverse-inc/packetfence/go/db/sqlcomment"
 	"github.com/inverse-inc/packetfence/go/fbcollectorclient"
 	"github.com/inverse-inc/packetfence/go/panichandler"
 	"github.com/inverse-inc/packetfence/go/pfconfigdriver"
@@ -90,7 +91,7 @@ func (m *APIHandler) buildHandler(ctx context.Context) error {
 	go func() {
 		for {
 			if done == false {
-				DB, err = gorm.Open(mysql.Open(db.ReturnURIFromConfig(ctx)), &gorm.Config{})
+				DB, err = gorm.Open(mysql.New(mysql.Config{DriverName: sqlcomment.DriverName, DSN: db.ReturnURIFromConfig(ctx)}), &gorm.Config{})
 				if DB != nil {
 					DBP = &DB
 					if wait == false {

--- a/go/plugin/caddy2/pfpki/pfpki.go
+++ b/go/plugin/caddy2/pfpki/pfpki.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/inverse-inc/go-utils/log"
 	"github.com/inverse-inc/packetfence/go/db"
+	"github.com/inverse-inc/packetfence/go/db/sqlcomment"
 	"github.com/inverse-inc/packetfence/go/plugin/caddy2/pfpki/handlers"
 	"github.com/inverse-inc/packetfence/go/plugin/caddy2/pfpki/models"
 	"github.com/inverse-inc/packetfence/go/plugin/caddy2/pfpki/types"
@@ -79,7 +80,7 @@ func (h *Handler) buildPfpkiHandler(ctx context.Context) error {
 
 	var successDBConnect = false
 	for !successDBConnect {
-		Database, err = gorm.Open(mysql.Open(db.ReturnURIFromConfig(ctx)), &gorm.Config{})
+		Database, err = gorm.Open(mysql.New(mysql.Config{DriverName: sqlcomment.DriverName, DSN: db.ReturnURIFromConfig(ctx)}), &gorm.Config{})
 		if err != nil {
 			log.LoggerWContext(ctx).Error(fmt.Sprintf("Failed to connect to the database: %s", err))
 			time.Sleep(time.Duration(5) * time.Second)

--- a/lib/pf/UnifiedApi.pm
+++ b/lib/pf/UnifiedApi.pm
@@ -79,6 +79,7 @@ sub startup {
     $self->hook(before_dispatch => \&before_dispatch_cb);
     $self->hook(after_dispatch => \&after_dispatch_cb);
     $self->hook(before_render => \&before_render_cb);
+    $self->hook(around_action => \&around_action_cb);
     $self->plugin('pf::UnifiedApi::Plugin::RestCrud');
 #   $self->plugin('NYTProf' => {
 #       nytprof => {
@@ -195,6 +196,33 @@ sub after_dispatch_cb {
 
     $c->after_dispatch;
     return;
+}
+
+=head2 around_action_cb
+
+Stamp the matched route as the work unit (MDC C<pf_unit>) for the duration of the
+action, so C<pf::db> decorates this request's queries with
+C</* pf:pfperl-api:E<lt>routeE<gt> */> for ProxySQL routing. The route pattern
+(e.g. C</api/v1/nodes/:node_id>) is bounded -- placeholders, not concrete ids --
+unlike the raw request path. The previous value is restored afterwards so nested
+actions (C<under> chains) and connection reuse never leak a unit.
+
+=cut
+
+sub around_action_cb {
+    my ($next, $c, $action, $last) = @_;
+    my $prev  = Log::Log4perl::MDC->get('pf_unit');
+    my $route = eval { $c->match->endpoint->to_string };
+    Log::Log4perl::MDC->put('pf_unit', $route) if defined $route && length $route;
+    my $result = eval { $next->() };
+    my $err = $@;
+    if (defined $prev) {
+        Log::Log4perl::MDC->put('pf_unit', $prev);
+    } else {
+        Log::Log4perl::MDC->remove('pf_unit');
+    }
+    die $err if $err;
+    return $result;
 }
 
 =head2 before_dispatch_cb

--- a/lib/pf/cmd/pf/pfcron.pm
+++ b/lib/pf/cmd/pf/pfcron.pm
@@ -125,9 +125,12 @@ sub _run {
 
     if (defined $task) {
         # Stamp the work unit so pf::db can decorate this job's queries for
-        # ProxySQL routing (=> /* pf:pfcron:<task_id> */).
+        # ProxySQL routing (=> /* pf:pfcron:<task_id> */). Cleared after the run
+        # so any later work never inherits a stale unit (consistent with
+        # sbin/pfqueue-backend).
         Log::Log4perl::MDC->put('pf_unit', $task_id);
         $task->run();
+        Log::Log4perl::MDC->remove('pf_unit');
     } else {
         exec('/usr/local/pf/sbin/pfcron', map {/^(.*)$/;$1} $self->args);
     }

--- a/lib/pf/cmd/pf/pfcron.pm
+++ b/lib/pf/cmd/pf/pfcron.pm
@@ -129,8 +129,10 @@ sub _run {
         # so any later work never inherits a stale unit (consistent with
         # sbin/pfqueue-backend).
         Log::Log4perl::MDC->put('pf_unit', $task_id);
-        $task->run();
+        my $ok  = eval { $task->run(); 1 };
+        my $err = $@;
         Log::Log4perl::MDC->remove('pf_unit');
+        die $err unless $ok;
     } else {
         exec('/usr/local/pf/sbin/pfcron', map {/^(.*)$/;$1} $self->args);
     }

--- a/lib/pf/cmd/pf/pfcron.pm
+++ b/lib/pf/cmd/pf/pfcron.pm
@@ -79,6 +79,7 @@ pf::cmd::pf::pfcron
 
 use strict;
 use warnings;
+use pf::log;
 use pf::config::pfcron qw(%ConfigCron);
 use pf::constants::exit_code qw($EXIT_SUCCESS);
 use pf::constants;
@@ -123,6 +124,9 @@ sub _run {
     }
 
     if (defined $task) {
+        # Stamp the work unit so pf::db can decorate this job's queries for
+        # ProxySQL routing (=> /* pf:pfcron:<task_id> */).
+        Log::Log4perl::MDC->put('pf_unit', $task_id);
         $task->run();
     } else {
         exec('/usr/local/pf/sbin/pfcron', map {/^(.*)$/;$1} $self->args);

--- a/lib/pf/db.pm
+++ b/lib/pf/db.pm
@@ -125,38 +125,58 @@ sub _sanitize_query_tag {
     return $v;
 }
 
-=item _decorate_sql
+=item _decorate_statement
 
-DBI method-entry callback (prepare / prepare_cached / do). Rewrites the SQL
-statement argument in place to prepend the routing remark, unless it is already
-decorated. Because the rewrite happens before the method runs, the decorated SQL
-becomes the prepare_cached cache key, so distinct units get distinct cached
-statements.
+Return a copy of the SQL statement with the routing remark prepended, unless it
+is already decorated. Works on a copy (never the caller's value), so it is safe
+for static string literals -- unlike modifying DBI's @_ alias in place, which
+dies on read-only literals. The decorated SQL is what gets prepared, so it also
+becomes the prepare_cached cache key (distinct units => distinct cached
+statements).
 
 =cut
 
-sub _decorate_sql {
-    # invocant is the dbh in $_[0]; the SQL statement is $_[1]. Assigning to
-    # $_[1] in place is what DBI propagates to the real method (replacing the
-    # element via splice is NOT seen by DBI). The DAL and the legacy
-    # db_query_execute framework both pass a writable lexical, so those get
-    # decorated. Some callers pass a read-only literal (e.g.
-    # $dbh->do("SET SESSION ...")) which cannot be modified -- those are
-    # connection-setup statements, not routable queries, so skip them rather
-    # than dying.
-    return unless defined $_[1];
-    return if $_[1] =~ m{^\s*/\* pf:};
-    my $decorated = pf_query_comment() . ' ' . $_[1];
-    eval { $_[1] = $decorated; 1 } or return;
-    return;
+sub _decorate_statement {
+    my ($sql) = @_;
+    return $sql unless defined $sql;
+    return $sql if $sql =~ m{^\s*/\* pf:};
+    return pf_query_comment() . ' ' . $sql;
 }
 
 our %CALLBACKS = (
-    connected      => \&set_session,
-    prepare        => \&_decorate_sql,
-    prepare_cached => \&_decorate_sql,
-    do             => \&_decorate_sql,
+    connected => \&set_session,
 );
+
+# DBI handle subclass installed via the RootClass connect attribute (see
+# db_connect). Every prepare/prepare_cached/do goes through these overrides,
+# which decorate the statement with the routing remark before handing it to the
+# real DBI method. The select* helpers call prepare internally, so they are
+# covered transitively. set_session and other callbacks still fire as usual.
+{
+    package pf::db::dbi;
+    our @ISA = ('DBI');
+
+    package pf::db::dbi::st;
+    our @ISA = ('DBI::st');
+
+    package pf::db::dbi::db;
+    our @ISA = ('DBI::db');
+
+    sub prepare {
+        my ($dbh, $statement, @attr) = @_;
+        return $dbh->SUPER::prepare(pf::db::_decorate_statement($statement), @attr);
+    }
+
+    sub prepare_cached {
+        my ($dbh, $statement, @attr) = @_;
+        return $dbh->SUPER::prepare_cached(pf::db::_decorate_statement($statement), @attr);
+    }
+
+    sub do {
+        my ($dbh, $statement, @attr) = @_;
+        return $dbh->SUPER::do(pf::db::_decorate_statement($statement), @attr);
+    }
+}
 
 tie %$DB_Config, 'pfconfig::cached_hash', 'resource::Database';
 
@@ -178,7 +198,7 @@ sub db_connect {
     $logger->debug("(Re)Connecting to MySQL (pid: $$)");
     my ($dsn, $user, $pass) = db_data_source_info();
     # make sure we have a database handle
-    if ( $DBH = DBI->connect($dsn, $user, $pass, { RaiseError => 0, PrintError => 0, mysql_auto_reconnect => 1, mysql_enable_utf8mb4 => 1, Callbacks => \%CALLBACKS })) {
+    if ( $DBH = DBI->connect($dsn, $user, $pass, { RaiseError => 0, PrintError => 0, mysql_auto_reconnect => 1, mysql_enable_utf8mb4 => 1, RootClass => 'pf::db::dbi', Callbacks => \%CALLBACKS })) {
         $logger->debug("connected");
         return on_connect($DBH);
     }

--- a/lib/pf/db.pm
+++ b/lib/pf/db.pm
@@ -80,8 +80,74 @@ sub set_session {
     return;
 }
 
+=item pf_query_comment
+
+Build the ProxySQL routing remark for the current execution context.
+
+Format: C</* pf:E<lt>serviceE<gt>[:E<lt>unitE<gt>] */>
+
+C<service> is the running daemon (the logging 'proc' MDC, which defaults to
+basename($0)). C<unit> is the logical work unit (a pfcron job id or pfqueue task
+type) when one has been stamped in the 'pf_unit' MDC at a dispatch point;
+otherwise it is omitted and C<service> is the whole routing bucket.
+
+ProxySQL rules should match this with C<match_pattern> (not C<match_digest>,
+which strips comments) anchored on C<^/\* pf:>.
+
+=cut
+
+sub pf_query_comment {
+    my $service = Log::Log4perl::MDC->get('proc');
+    $service = basename($0) unless defined $service && length $service;
+    my $tag = 'pf:' . _sanitize_query_tag($service);
+    my $unit = Log::Log4perl::MDC->get('pf_unit');
+    if (defined $unit && length $unit) {
+        my $u = _sanitize_query_tag($unit);
+        $tag .= ":$u" if length $u;
+    }
+    return "/* $tag */";
+}
+
+=item _sanitize_query_tag
+
+Make a value safe to embed inside a SQL comment: never allow the comment
+terminator, normalize package separators, and keep only routing-safe characters.
+
+=cut
+
+sub _sanitize_query_tag {
+    my ($v) = @_;
+    return '' unless defined $v;
+    $v =~ s{\*/}{}g;            # never allow the comment terminator
+    $v =~ s/::/\//g;            # perl package separator -> slash
+    $v =~ s/\s+/_/g;            # collapse whitespace
+    $v =~ s{[^A-Za-z0-9_\-/.]}{}g;
+    return $v;
+}
+
+=item _decorate_sql
+
+DBI method-entry callback (prepare / prepare_cached / do). Rewrites the SQL
+statement argument in place to prepend the routing remark, unless it is already
+decorated. Because the rewrite happens before the method runs, the decorated SQL
+becomes the prepare_cached cache key, so distinct units get distinct cached
+statements.
+
+=cut
+
+sub _decorate_sql {
+    # invocant is the dbh in $_[0]; the SQL statement is $_[1]
+    return unless defined $_[1];
+    return if $_[1] =~ m{^\s*/\* pf:};
+    $_[1] = pf_query_comment() . ' ' . $_[1];
+    return;
+}
+
 our %CALLBACKS = (
-    connected => \&set_session,
+    connected      => \&set_session,
+    prepare        => \&_decorate_sql,
+    prepare_cached => \&_decorate_sql,
+    do             => \&_decorate_sql,
 );
 
 tie %$DB_Config, 'pfconfig::cached_hash', 'resource::Database';

--- a/lib/pf/db.pm
+++ b/lib/pf/db.pm
@@ -92,7 +92,9 @@ type) when one has been stamped in the 'pf_unit' MDC at a dispatch point;
 otherwise it is omitted and C<service> is the whole routing bucket.
 
 ProxySQL rules should match this with C<match_pattern> (not C<match_digest>,
-which strips comments) anchored on C<^/\* pf:>.
+which strips comments) anchored on C<^/\* pf:>. Note the tag may contain C<.>,
+C</> and C<->; escape these (or use character classes) when matching a specific
+service/unit, since C<match_pattern> is a regex.
 
 =cut
 

--- a/lib/pf/db.pm
+++ b/lib/pf/db.pm
@@ -136,10 +136,18 @@ statements.
 =cut
 
 sub _decorate_sql {
-    # invocant is the dbh in $_[0]; the SQL statement is $_[1]
+    # invocant is the dbh in $_[0]; the SQL statement is $_[1]. Assigning to
+    # $_[1] in place is what DBI propagates to the real method (replacing the
+    # element via splice is NOT seen by DBI). The DAL and the legacy
+    # db_query_execute framework both pass a writable lexical, so those get
+    # decorated. Some callers pass a read-only literal (e.g.
+    # $dbh->do("SET SESSION ...")) which cannot be modified -- those are
+    # connection-setup statements, not routable queries, so skip them rather
+    # than dying.
     return unless defined $_[1];
     return if $_[1] =~ m{^\s*/\* pf:};
-    $_[1] = pf_query_comment() . ' ' . $_[1];
+    my $decorated = pf_query_comment() . ' ' . $_[1];
+    eval { $_[1] = $decorated; 1 } or return;
     return;
 }
 

--- a/sbin/pfqueue-backend
+++ b/sbin/pfqueue-backend
@@ -207,10 +207,17 @@ sub process_data {
     my $args = $item->[1];
     my $task = "pf::task::$type"->new;
 
+    # Stamp the work unit so pf::db decorates this task's queries for ProxySQL
+    # routing (=> /* pf:pfqueue:<type> */). Cleared after so the idle loop and
+    # the next task never inherit a stale unit.
+    Log::Log4perl::MDC->put('pf_unit', $type);
+
     my ( $err, $result ) = eval {
         $logger->debug("Running task $type");
         $task->doTask($args);
     };
+
+    Log::Log4perl::MDC->remove('pf_unit');
 
     if ($@) {
         $err = $@;


### PR DESCRIPTION
… for ProxySQL routing

Tag every query PacketFence emits with a routing remark so ProxySQL can map sources of load to dedicated hostgroups, each with its own max_connections cap.

Remark format: /* pf:<service>[:<unit>] */ <SQL>
  - service: the running daemon/binary (Perl MDC 'proc' / Go log.ProcessName)
  - unit:    the logical work unit (cron job id / queue task type), when stamped

Perl (single chokepoint): add prepare/prepare_cached/do to the DBI %CALLBACKS that db_connect already attaches to every handle, so the DAL, the legacy db_query_execute framework, and stray $dbh->do are all decorated in one place. The work unit is carried via a new 'pf_unit' MDC, stamped at:
  - lib/pf/cmd/pf/pfcron.pm  -> /* pf:pfcron:<task_id> */
  - sbin/pfqueue-backend     -> /* pf:pfqueue:<type> */ (cleared after each task)

Go (single chokepoint): new go/db/sqlcomment package registers a wrapping driver "mysql-pf" that prepends the remark on Query/Exec/Prepare and forwards all optional driver interfaces (ConnBeginTx, Pinger, SessionResetter, Validator, NamedValueChecker) so wrapping does not disable mysql behavior. Wired through:
  - go/db/db.go ConnectURI -> sql.Open("mysql-pf", ...)   (all raw-SQL services)
  - pfpki.go / api.go GORM  -> mysql.New{DriverName:"mysql-pf"} (ORM queries)
Work units travel on context via sqlcomment.WithQueryUnit(ctx, name).

Values are sanitized so they can never contain the comment terminator or regex-ambiguous characters, and decoration is idempotent.

Note: Go pfcron jobs emit service-level /* pf:pfcron */ for now; per-job units require threading the dispatcher ctx into jobs (follow-up).

