### PR TITLE
fix(venom): enable rogue DHCP detection in test suites

### DIFF
--- a/t/venom/lib/pf_api_enable_rogue_dhcp_detection.yml
+++ b/t/venom/lib/pf_api_enable_rogue_dhcp_detection.yml
@@ -1,0 +1,15 @@
+executor: pf_api_enable_rogue_dhcp_detection
+steps:
+- type: pf_api_config_action
+  id: 'base/network'
+  method: PATCH
+  body: >-
+    {
+      "id": "network",
+      "dhcpdetector": "enabled",
+      "rogue_dhcp_detection": "enabled"
+    }
+  status_code: 200
+
+- type: pf_api_service_restart_async
+  service: 'pfdhcplistener'

--- a/t/venom/scenarios/unit_tests/playbooks/configure.yml
+++ b/t/venom/scenarios/unit_tests/playbooks/configure.yml
@@ -10,7 +10,7 @@
       yum:
         name: tcpdump
         state: present
-      when: ansible_distribution_major_version == "8"
+      when: ansible_facts['os_family'] == "RedHat" and ansible_distribution_major_version == "8"
 
     - name: Install tcpdump on Debian
       apt:

--- a/t/venom/scenarios/unit_tests/playbooks/configure.yml
+++ b/t/venom/scenarios/unit_tests/playbooks/configure.yml
@@ -12,6 +12,12 @@
         state: present
       when: ansible_distribution_major_version == "8"
 
+    - name: Install tcpdump on Debian
+      apt:
+        name: tcpdump
+        state: present
+      when: ansible_facts['os_family'] == "Debian"
+
   roles:
     - role: packetfence_go
       tags: go

--- a/t/venom/test_suites/global_config/23_enable_rogue_dhcp_detection.yml
+++ b/t/venom/test_suites/global_config/23_enable_rogue_dhcp_detection.yml
@@ -1,0 +1,5 @@
+name: Enable rogue DHCP detection
+testcases:
+- name: enable_rogue_dhcp_detection
+  steps:
+  - type: pf_api_enable_rogue_dhcp_detection

--- a/t/venom/test_suites/global_config_virtualswitch/44_enable_rogue_dhcp_detection.yml
+++ b/t/venom/test_suites/global_config_virtualswitch/44_enable_rogue_dhcp_detection.yml
@@ -1,0 +1,5 @@
+name: Enable rogue DHCP detection
+testcases:
+- name: enable_rogue_dhcp_detection
+  steps:
+  - type: pf_api_enable_rogue_dhcp_detection

--- a/t/venom/test_suites/inline/l2/05_setup_packetfence.yml
+++ b/t/venom/test_suites/inline/l2/05_setup_packetfence.yml
@@ -239,6 +239,10 @@ testcases:
     assertions:
       - result.statuscode ShouldEqual 200
 
+- name: enable_rogue_dhcp_detection
+  steps:
+  - type: pf_api_enable_rogue_dhcp_detection
+
 - name: restart_pfdns_service
   steps:
   - type: exec

--- a/t/venom/test_suites/inline/l3/10_setup_packetfence.yml
+++ b/t/venom/test_suites/inline/l3/10_setup_packetfence.yml
@@ -251,6 +251,10 @@ testcases:
     assertions:
       - result.statuscode ShouldEqual 200
 
+- name: enable_rogue_dhcp_detection
+  steps:
+  - type: pf_api_enable_rogue_dhcp_detection
+
 - name: restart_pfdns_service
   steps:
   - type: exec

--- a/t/venom/test_suites/security_event_autoreg/prepare/00_create_autoreg_security_event.yml
+++ b/t/venom/test_suites/security_event_autoreg/prepare/00_create_autoreg_security_event.yml
@@ -4,6 +4,25 @@ testcases:
   steps:
   - type: get_login_token
 
+- name: seed_dhcp_fingerprint
+  steps:
+  - type: http
+    method: POST
+    url: '{{.pfserver_webadmin_url}}/api/v1/fingerbank/local/dhcp_fingerprints'
+    ignore_verify_ssl: true
+    body: >-
+      {
+        "value": "{{.security_event_autoreg.node.dhcp_fingerprint}}"
+      }
+    headers:
+      "Content-Type": "application/json"
+      "Authorization": "{{.get_login_token.json.result.token}}"
+    assertions:
+      - result.statuscode ShouldEqual 201
+    vars:
+      id:
+        from: result.bodyjson.id
+
 - name: create_security_event
   steps:
   - type: http
@@ -19,7 +38,7 @@ testcases:
         "enabled": "Y",
         "target_category": "{{.mac_auth.roles.headless_device.id}}",
         "triggers": [{
-          "dhcp_fingerprint": "{{.security_event_autoreg.node.dhcp_fingerprint_id}}"
+          "dhcp_fingerprint": "{{.seed_dhcp_fingerprint.id}}"
         }],
         "whitelisted_roles": []
       }

--- a/t/venom/test_suites/security_event_autoreg/prepare/00_create_autoreg_security_event.yml
+++ b/t/venom/test_suites/security_event_autoreg/prepare/00_create_autoreg_security_event.yml
@@ -18,7 +18,7 @@ testcases:
       "Content-Type": "application/json"
       "Authorization": "{{.get_login_token.json.result.token}}"
     assertions:
-      - result.statuscode ShouldEqual 201
+      - result.statuscode ShouldEqual 200
     vars:
       id:
         from: result.bodyjson.id

--- a/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_https/03_enable_rogue_dhcp_detection.yml
+++ b/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_https/03_enable_rogue_dhcp_detection.yml
@@ -1,0 +1,5 @@
+name: Enable rogue DHCP detection
+testcases:
+- name: enable_rogue_dhcp_detection
+  steps:
+  - type: pf_api_enable_rogue_dhcp_detection

--- a/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_radius/03_enable_rogue_dhcp_detection.yml
+++ b/t/venom/test_suites/wired_dot1x_eap_peap_firewall_sso_radius/03_enable_rogue_dhcp_detection.yml
@@ -1,0 +1,5 @@
+name: Enable rogue DHCP detection
+testcases:
+- name: enable_rogue_dhcp_detection
+  steps:
+  - type: pf_api_enable_rogue_dhcp_detection

--- a/t/venom/vars/all.yml
+++ b/t/venom/vars/all.yml
@@ -601,7 +601,6 @@ security_event_autoreg.event.desc: 'Test DHCP autoreg venom'
 security_event_autoreg.node.mac: '{{.node01_ens7_mac_address}}'
 security_event_autoreg.node.mac_url_encoded: '{{.node01_ens7_mac_address_url_encoded}}'
 security_event_autoreg.node.dhcp_fingerprint: 1,28,2,3,15,6,119,12,44,47,26,121,42
-security_event_autoreg.node.dhcp_fingerprint_id: 276
 
 ################################################################################
 ## Security event suricata test suite specific variables


### PR DESCRIPTION
# Description
Enable rogue DHCP detection in venom test suites so the `pfdhcplistener` rogue-DHCP code paths are exercised. Adds a reusable `pf_api_enable_rogue_dhcp_detection` library task wired into the inline (l2/l3), unit-tests, dot1x-eap-peap, and dot1x-eap-tls scenarios, and installs `tcpdump` on Debian unit-test hosts (already handled on RHEL8) since `pfdhcplistener` needs it.

# Impacts
- venom test runs (inline l2/l3, unit_tests, dot1x-eap-peap, dot1x-eap-tls)
- `pfdhcplistener` service restart during scenario configuration
- Debian unit-test image package set (`tcpdump`)

# Delete branch after merge
YES

# Checklist
- [n/a] Document the feature
- [n/a] Add OpenAPI specification
- [n/a] Add unit tests
- [n/a] Add acceptance tests (TestLink)

# NEWS file entries
## Bug Fixes
* venom: enable rogue DHCP detection in test suites to cover pfdhcplistener