### PR TITLE
Bump fingerbank package to 4.3.4 to ship collector.port type fix

### DIFF
--- a/addons/perl-client/debian/changelog
+++ b/addons/perl-client/debian/changelog
@@ -1,3 +1,9 @@
+fingerbank (4.3.4) unstable; urgency=medium
+
+  * Fix collector.port field type from numeric to text to allow the env variable default
+
+ -- Inverse inc. <info@inverse.ca>  Mon, 15 Jun 2026 11:12:12 +0200
+
 fingerbank (4.3.3) unstable; urgency=medium
 
   * Use env variables for the configuration

--- a/addons/perl-client/lib/fingerbank/Constant.pm
+++ b/addons/perl-client/lib/fingerbank/Constant.pm
@@ -48,7 +48,7 @@ BEGIN {
 
 =cut
 
-Readonly::Scalar our $VERSION     => "4.3.3";
+Readonly::Scalar our $VERSION     => "4.3.4";
 Readonly::Scalar our $FALSE       => 0;
 Readonly::Scalar our $TRUE        => 1;
 Readonly::Scalar our $YES         => 'yes';

--- a/addons/perl-client/rpm/fingerbank.spec
+++ b/addons/perl-client/rpm/fingerbank.spec
@@ -1,6 +1,6 @@
 %global     fb_prefix %{_prefix}/local/%{name}
 Name:       fingerbank
-Version:    4.3.3
+Version:    4.3.4
 Release:    1%{?dist}
 BuildArch:  noarch
 Summary:    An exhaustive device profiling tool
@@ -118,6 +118,8 @@ rm -rf %{buildroot}
 
 
 %changelog
+* Mon Jun 15 2026 Inverse Inc. <info@inverse.ca> - 4.3.4-1
+- Fix collector.port field type from numeric to text to allow the env variable default
 * Tue Apr 15 2025 Inverse Inc. <info@inverse.ca> - 4.3.3-1
 - USe environment variables for the configuration
 * Tue Aug 23 2022 Inverse Inc. <info@inverse.ca> - 4.3.2-1


### PR DESCRIPTION
# Description
The collector.port type was changed from numeric to text in 1e89fcc57f but the fingerbank package version stayed at 4.3.3, so apt/yum skip the upgrade and the corrected fingerbank.conf.doc never reaches /usr/local/fingerbank/conf. Bump the version so the fix is deployed.

# Impacts
Fingerbank

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* Updated fingerbank perl version
