### PR TITLE
fingerbank: refresh collector auth header at request time

### DIFF
--- a/lib/pf/fingerbank.pm
+++ b/lib/pf/fingerbank.pm
@@ -154,6 +154,25 @@ sub process {
     }
 }
 
+=head2 _refresh_collector_auth
+
+Set the current Fingerbank API key as the C<Authorization> header on a collector request.
+
+The built request is cached (see L</endpoint_attributes> and L</update_collector_endpoint_data>)
+in the Redis-backed C<fingerbank> CHI namespace with no expiration, so the auth header baked in
+by C<fingerbank::Collector::build_request> would otherwise become stale when the API key is
+rotated, causing C<401 Unauthorized> from the collector until the cache is manually flushed.
+Refreshing the header at request time keeps it in sync with C<fingerbank.conf> (which
+C<fingerbank::Config> reloads on file mtime change).
+
+=cut
+
+sub _refresh_collector_auth {
+    my ($req) = @_;
+    $req->header(Authorization => "Token ".fingerbank::Config::get_config('upstream', 'api_key'));
+    return $req;
+}
+
 =head2 endpoint_attributes
 
 Given a MAC address, collect all the latest known data profiling attributes.
@@ -174,6 +193,7 @@ sub endpoint_attributes {
     my $req = cache()->compute("pf::fingerbank::endpoint_attributes::request::$mac", sub {
         $collector->build_request("GET", "/endpoint_data/$mac");
     });
+    _refresh_collector_auth($req);
 
     my $res = $collector_ua->request($req);
     if ($res->is_success) {
@@ -232,6 +252,7 @@ sub update_collector_endpoint_data {
     my $req = cache()->compute("pf::fingerbank::update_collector_endpoint_data::request::$mac", sub {
         $collector->build_request("PATCH", "/endpoint_data/$mac");
     });
+    _refresh_collector_auth($req);
     $req->content(encode_json($data));
 
     my $res = $collector_ua->request($req);


### PR DESCRIPTION
The collector request built by fingerbank::Collector::build_request bakes the 'Authorization: Token <api_key>' header into the HTTP::Request, and pf::fingerbank caches that request object in the Redis-backed 'fingerbank' CHI namespace with no expiration (keyed per-MAC). When the Fingerbank API key is rotated, the cached request keeps sending the old token, so the collector returns 401 Unauthorized until the cache is manually flushed -- a service restart does not help because the cache is persistent.

Set the Authorization header from the current config on each request instead of relying on the cached value. fingerbank::Config reloads fingerbank.conf on file mtime change, so this picks up key rotations immediately with no cache flush required.

Affects endpoint_attributes() and update_collector_endpoint_data().

# Description
(REQUIRED)
Describe what the new code is used for.
ie: Allow PacketFence to trigger the coffee machine on wireless EAP 802.1X connection to brew a fresh espresso.

# Impacts
(REQUIRED)
Describe what to reviewer should look at. Will also help for testing purposes.
ie: - RADIUS authorize workflow

# Code / PR Dependencies
(OPTIONAL. REMOVE IF NOT NEEDED)
List the PRs or other factors on which this PR depends

# NEW Package(s) required
(OPTIONAL. REMOVE IF NOT NEEDED)
Which new package(s) (all supported distributions) are required for this PR to work.

# Issue
(OPTIONAL. REMOVE IF NOT NEEDED)
The following syntax 'fixes #ISSUE_NUMBER' will automatically closes a Github issue on pull-request merge time.
Modify the ISSUE_NUMBER in order to reflect the Github issue that need to be closed
fixes #ISSUE_NUMBER

# Delete branch after merge
(REQUIRED)
YES | NO

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
(REQUIRED, but may be optional...)
## New Features
* Feature 1
* Feature 2

## Enhancements
* Enhancement 1
* Enhancement 2

## Bug Fixes
If an issue exists on Github, please refer to it (name) along with it's number...
* Issue with Zammitbug in sandwich context (#42)
* Issue with Zammitbug in dinde context (#43)

# UPGRADE file entries
(OPTIONAL, but may be required...)
