### PR TITLE
Escape user input in LDAP filters to prevent injection

### DIFF
--- a/lib/pf/Authentication/Source/ADSource.pm
+++ b/lib/pf/Authentication/Source/ADSource.pm
@@ -12,6 +12,7 @@ use pf::Authentication::constants;
 use pf::constants::authentication::messages;
 use pf::Authentication::Source::LDAPSource;
 use pf::constants;
+use Net::LDAP::Util qw(escape_filter_value);
 
 use Moose;
 extends 'pf::Authentication::Source::LDAPSource';
@@ -52,9 +53,10 @@ sub findAtttributeFrom {
         return ($FALSE, "Error communicating with the LDAP server");
     }
 
+    my $escaped_from_value = escape_filter_value($from_value);
     my $result = $connection->search(
-        base => $self->{basedn}, 
-        filter => "($from_attribute=$from_value)", 
+        base => $self->{basedn},
+        filter => "($from_attribute=$escaped_from_value)",
         attrs => [$to_attribute],
     );
 

--- a/lib/pf/Authentication/Source/LDAPSource.pm
+++ b/lib/pf/Authentication/Source/LDAPSource.pm
@@ -670,7 +670,8 @@ sub ldap_filter_for_conditions {
   if ($params->{'username'}) {
       $expression = $self->_makefilter($params->{'username'});
   } elsif ($params->{'email'}) {
-      $expression = '(|(' . $self->{'email_attribute'} . '=' . $params->{'email'} . ')(proxyAddresses=smtp:' . $params->{'email'} . ')(mailLocalAddress=' . $params->{'email'} . ')(mailAlternateAddress=' . $params->{'email'} . '))';
+      my $email = escape_filter_value($params->{'email'});
+      $expression = '(|(' . $self->{'email_attribute'} . '=' . $email . ')(proxyAddresses=smtp:' . $email . ')(mailLocalAddress=' . $email . ')(mailAlternateAddress=' . $email . '))';
   }
 
   if ($expression) {
@@ -743,9 +744,10 @@ sub search_attributes_in_subclass {
       return $FALSE;
     }
 
+    my $escaped = escape_filter_value($username);
     my $searchresult = $connection->search(
                   base => $self->{'basedn'},
-                  filter => "($self->{'usernameattribute'}=$username)"
+                  filter => "($self->{'usernameattribute'}=$escaped)"
     );
     if ($searchresult->is_error()) {
       $logger->error("Unable to locate user '$username'");


### PR DESCRIPTION
# Description
Escape user input in LDAP filters to prevent injection

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
## Bug Fixes
* Escape user input in LDAP filters to prevent injection
