### PR TITLE
Self-heal missing locationlog_history in 15.0->15.1 upgrade (#9069)

### DIFF
--- a/db/upgrade-15.0-15.1.sql
+++ b/db/upgrade-15.0-15.1.sql
@@ -194,6 +194,35 @@ CALL AddColumnUnlessExists('locationlog', 'switch_id',
     'VARCHAR(255) DEFAULT NULL AFTER `switch_mac`');
 
 \! echo "Updating locationlog_history";
+CREATE TABLE IF NOT EXISTS `locationlog_history` (
+  `id` BIGINT NOT NULL PRIMARY KEY AUTO_INCREMENT,
+  `mac` varchar(17) default NULL,
+  `switch` varchar(17) NOT NULL default '',
+  `port` varchar(20) NOT NULL default '',
+  `vlan` varchar(50) default NULL,
+  `role` varchar(255) default NULL,
+  `connection_type` varchar(50) NOT NULL default '',
+  `connection_sub_type` varchar(50) default NULL,
+  `dot1x_username` varchar(255) NOT NULL default '',
+  `ssid` varchar(32) NOT NULL default '',
+  `start_time` datetime NOT NULL default '0000-00-00 00:00:00',
+  `end_time` datetime NOT NULL default '0000-00-00 00:00:00',
+  `switch_ip` varchar(17) DEFAULT NULL,
+  `switch_ip_int` int(10) unsigned AS (INET_ATON(`switch_ip`)) STORED,
+  `switch_mac` varchar(17) DEFAULT NULL,
+  `stripped_user_name` varchar (255) DEFAULT NULL,
+  `realm`  varchar (255) DEFAULT NULL,
+  `session_id` VARCHAR(255) DEFAULT NULL,
+  `ifDesc` VARCHAR(255) DEFAULT NULL,
+  `voip` enum('no','yes') NOT NULL DEFAULT 'no',
+  KEY `locationlog_view_mac` (`mac`, `end_time`),
+  KEY `locationlog_end_time` ( `end_time`),
+  KEY `locationlog_view_switchport` (`switch`,`port`,`end_time`,`vlan`),
+  KEY `locationlog_ssid` (`ssid`),
+  KEY `locationlog_session_id_end_time` (`session_id`, `end_time`),
+  KEY `locationlog_switch_ip_int` (`switch_ip_int`)
+) ENGINE=InnoDB DEFAULT CHARACTER SET = 'utf8mb4' COLLATE = 'utf8mb4_general_ci';
+
 CALL AddColumnUnlessExists('locationlog_history', 'switch_id',
     'VARCHAR(255) DEFAULT NULL AFTER `switch_mac`');
 


### PR DESCRIPTION
# Description
Make the `15.0 -> 15.1` database upgrade self-healing when the
`locationlog_history` table is missing on the target DB. The script now
issues a `CREATE TABLE IF NOT EXISTS locationlog_history` (matching the
15.0 baseline schema) immediately before the `switch_id` column is added
and the `locationlog_insert_in_history_after_insert` trigger is
recreated. Healthy installations are unaffected; broken installations
no longer abort with `ERROR 1146 (42S02): Table 'pf.locationlog_history'
doesn't exist`.

# Impacts
- `db/upgrade-15.0-15.1.sql`
- Re-run safety of the 15.0 -> 15.1 upgrade path
- The `locationlog_insert_in_history_after_insert` trigger (depends on
  the table being present)

# Issue
fixes #9069

# Delete branch after merge
YES

# NEWS file entries
## Bug Fixes
* Database upgrade from 15.0 to 15.1 fails when `locationlog_history`
  is missing (#9069)