### PR TITLE
Fix/pfconnector accounting route by code

### DIFF
--- a/go/chisel/share/radius_proxy/proxy.go
+++ b/go/chisel/share/radius_proxy/proxy.go
@@ -27,12 +27,14 @@ type Proxy struct {
 	attributes_keys []string
 	secret          []byte
 	sessionTimeout  time.Duration
-	backends        *Backends
+	authBackends    *Backends
+	acctBackends    *Backends
 	*cio.Logger
 }
 
 type ProxyConfig struct {
-	Addrs          []string
+	AuthAddrs      []string
+	AcctAddrs      []string
 	Secret         []byte
 	SessionTimeout time.Duration
 	Logger         *cio.Logger
@@ -41,7 +43,8 @@ type ProxyConfig struct {
 func NewProxy(config *ProxyConfig) *Proxy {
 	radiusProxy := &Proxy{
 		sessionTimeout: config.SessionTimeout,
-		backends:       NewBackends(config.SessionTimeout, config.Addrs...),
+		authBackends:   NewBackends(config.SessionTimeout, config.AuthAddrs...),
+		acctBackends:   NewBackends(config.SessionTimeout, config.AcctAddrs...),
 		secret:         []byte(config.Secret),
 		Logger:         config.Logger,
 	}
@@ -49,8 +52,23 @@ func NewProxy(config *ProxyConfig) *Proxy {
 	return radiusProxy
 }
 
+// backendsForPacket selects the backend pool based on the RADIUS packet code.
+// Accounting-Request packets are routed to the accounting pool (pfacct); every
+// other packet (Access-Request, Status-Server, ...) goes to the authentication
+// pool (radiusd-auth). Without this split an accounting packet could be hashed
+// onto a radiusd-auth backend, which listens on the auth port and silently
+// discards accounting.
+func (rp *Proxy) backendsForPacket(p *radius.Packet) *Backends {
+	if p.Code == radius.CodeAccountingRequest {
+		return rp.acctBackends
+	}
+
+	return rp.authBackends
+}
+
 func (rp *Proxy) Cleanup(stop chan struct{}) {
-	rp.backends.sessions.Cleanup(5*time.Second, stop)
+	go rp.authBackends.sessions.Cleanup(5*time.Second, stop)
+	rp.acctBackends.sessions.Cleanup(5*time.Second, stop)
 }
 
 func (rp *Proxy) addProxyState(p *radius.Packet) bool {
@@ -59,20 +77,29 @@ func (rp *Proxy) addProxyState(p *radius.Packet) bool {
 		return false
 	}
 
+	backends := rp.backendsForPacket(p)
 	id, _ := uuid.NewUUID()
 	value := id.String()
 	rfc2865.ProxyState_SetString(p, value)
-	be := rp.backends.pickBackend(p)
-	rp.backends.sessions.Add(value, rp.sessionTimeout, be)
+	be := backends.pickBackend(p)
+	backends.sessions.Add(value, rp.sessionTimeout, be)
 	return true
 }
 
-func (rp *Proxy) AddBackend(addr string) {
-	rp.backends.Add(addr)
+func (rp *Proxy) AddAuthBackend(addr string) {
+	rp.authBackends.Add(addr)
 }
 
-func (rp *Proxy) DeleteBackend(addr string) {
-	rp.backends.Delete(addr)
+func (rp *Proxy) DeleteAuthBackend(addr string) {
+	rp.authBackends.Delete(addr)
+}
+
+func (rp *Proxy) AddAcctBackend(addr string) {
+	rp.acctBackends.Add(addr)
+}
+
+func (rp *Proxy) DeleteAcctBackend(addr string) {
+	rp.acctBackends.Delete(addr)
 }
 
 func (rp *Proxy) ProxyPacket(payload []byte, connectorID string) ([]byte, string, error) {
@@ -125,12 +152,12 @@ func (rp *Proxy) ProxyPacket(payload []byte, connectorID string) ([]byte, string
 		return nil, "", err
 	}
 
-	be := rp.backends.getBackend(packet)
+	be := rp.backendsForPacket(packet).getBackend(packet)
 	if be == nil {
 		return nil, "", errors.New("No backend available")
 	}
 
-	rp.Debugf("Proxy to %s for connector %s", be.addr, connectorID)
+	rp.Debugf("Proxy %s to %s for connector %s", packet.Code, be.addr, connectorID)
 	rp.IfDebugHandle(func(l *cio.Logger) {
 		l.Printf("Payload Proxied")
 		LogPacket(l, packet)

--- a/go/chisel/share/radius_proxy/proxy.go
+++ b/go/chisel/share/radius_proxy/proxy.go
@@ -68,7 +68,7 @@ func (rp *Proxy) backendsForPacket(p *radius.Packet) *Backends {
 
 func (rp *Proxy) Cleanup(stop chan struct{}) {
 	go rp.authBackends.sessions.Cleanup(5*time.Second, stop)
-	rp.acctBackends.sessions.Cleanup(5*time.Second, stop)
+	go rp.acctBackends.sessions.Cleanup(5*time.Second, stop)
 }
 
 func (rp *Proxy) addProxyState(p *radius.Packet) bool {

--- a/go/chisel/share/radius_proxy/proxy_test.go
+++ b/go/chisel/share/radius_proxy/proxy_test.go
@@ -1,0 +1,65 @@
+package radius_proxy
+
+import (
+	"testing"
+	"time"
+
+	"layeh.com/radius"
+)
+
+const (
+	testAuthAddr = "10.0.0.1:1812"
+	testAcctAddr = "10.0.0.2:1813"
+)
+
+func newTestProxy() *Proxy {
+	return NewProxy(&ProxyConfig{
+		AuthAddrs:      []string{testAuthAddr},
+		AcctAddrs:      []string{testAcctAddr},
+		Secret:         []byte("testing123"),
+		SessionTimeout: time.Second,
+	})
+}
+
+// Accounting-Request must land on the accounting pool (pfacct) and everything
+// else on the authentication pool (radiusd-auth). Collapsing the two pools, or
+// routing accounting through the auth pool, sends Accounting-Request to the
+// auth port where it is silently discarded.
+func TestBackendsForPacketRoutesByCode(t *testing.T) {
+	rp := newTestProxy()
+
+	tests := []struct {
+		name string
+		code radius.Code
+		want *Backends
+	}{
+		{"accounting -> acct pool", radius.CodeAccountingRequest, rp.acctBackends},
+		{"access -> auth pool", radius.CodeAccessRequest, rp.authBackends},
+		{"status-server -> auth pool", radius.CodeStatusServer, rp.authBackends},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := radius.New(tc.code, []byte("testing123"))
+			if got := rp.backendsForPacket(p); got != tc.want {
+				t.Fatalf("backendsForPacket(%s) routed to the wrong pool", tc.code)
+			}
+		})
+	}
+}
+
+// The backend actually selected for a packet must come from the pool that
+// matches its code.
+func TestProxyPicksBackendFromCorrectPool(t *testing.T) {
+	rp := newTestProxy()
+
+	acct := radius.New(radius.CodeAccountingRequest, []byte("testing123"))
+	if be := rp.backendsForPacket(acct).pickBackend(acct); be == nil || be.addr != testAcctAddr {
+		t.Fatalf("accounting packet picked %v, want %s", be, testAcctAddr)
+	}
+
+	access := radius.New(radius.CodeAccessRequest, []byte("testing123"))
+	if be := rp.backendsForPacket(access).pickBackend(access); be == nil || be.addr != testAuthAddr {
+		t.Fatalf("access packet picked %v, want %s", be, testAuthAddr)
+	}
+}

--- a/go/chisel/share/radius_proxy/tunnel_radius.go
+++ b/go/chisel/share/radius_proxy/tunnel_radius.go
@@ -21,7 +21,12 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-const defaultRadiusAuthK8Filter = "app=radiusd-auth"
+const (
+	defaultRadiusAuthK8Filter = "app=radiusd-auth"
+	defaultRadiusAcctK8Filter = "app=pfacct"
+	defaultRadiusAuthPort     = 1812
+	defaultRadiusAcctPort     = 1813
+)
 
 func isPodReady(pod *v1.Pod) bool {
 	if pod.DeletionTimestamp != nil {
@@ -37,10 +42,10 @@ func isPodReady(pod *v1.Pod) bool {
 	return false
 }
 
-func getPodHostPort(pod *v1.Pod) string {
+func getPodHostPort(pod *v1.Pod, defaultPort int) string {
 	port, err := getPodPort(pod)
 	if err != nil {
-		return pod.Status.PodIP + ":1812"
+		return fmt.Sprintf("%s:%d", pod.Status.PodIP, defaultPort)
 	}
 
 	return fmt.Sprintf("%s:%d", pod.Status.PodIP, port)
@@ -81,12 +86,14 @@ func clientSetFromEnv() (*kubernetes.Clientset, error) {
 	)
 }
 
-func getRadiusAuthFilter() string {
-	if filter := os.Getenv("K8S_RADIUS_AUTH_FILTER"); filter != "" {
+// getRadiusFilter returns the pod label selector from envVar, or defaultFilter
+// when it is unset. Used identically for the auth and accounting backend pools.
+func getRadiusFilter(envVar, defaultFilter string) string {
+	if filter := os.Getenv(envVar); filter != "" {
 		return filter
 	}
 
-	return defaultRadiusAuthK8Filter
+	return defaultFilter
 }
 
 func NewRadiusProxyFromKubernetes(l *cio.Logger, radiusSecret string) (*Proxy, chan struct{}, error) {
@@ -100,30 +107,61 @@ func NewRadiusProxyFromKubernetes(l *cio.Logger, radiusSecret string) (*Proxy, c
 		return nil, nil, err
 	}
 
-	filter := getRadiusAuthFilter()
-
 	namespace := string(data)
-	pods, err := clientset.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: filter})
+	authFilter := getRadiusFilter("K8S_RADIUS_AUTH_FILTER", defaultRadiusAuthK8Filter)
+	acctFilter := getRadiusFilter("K8S_RADIUS_ACCT_FILTER", defaultRadiusAcctK8Filter)
+
+	authServers, err := listPodHostPorts(clientset, namespace, authFilter, defaultRadiusAuthPort, l)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	servers := []string{}
-	for _, p := range pods.Items {
-		addr := getPodHostPort(&p)
-		l.Infof("Adding address %s", addr)
-		servers = append(servers, addr)
+	acctServers, err := listPodHostPorts(clientset, namespace, acctFilter, defaultRadiusAcctPort, l)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	radiusProxy := NewProxy(
 		&ProxyConfig{
 			Secret:         []byte(radiusSecret),
-			Addrs:          servers,
+			AuthAddrs:      authServers,
+			AcctAddrs:      acctServers,
 			SessionTimeout: 20 * time.Second,
 			Logger:         l,
 		},
 	)
 
+	stop := make(chan struct{})
+	// Auth packets (Access-Request, ...) are load-balanced across radiusd-auth
+	// pods; accounting packets are load-balanced across pfacct pods. Routing is
+	// done by RADIUS packet code in Proxy.backendsForPacket.
+	startPodInformer(clientset, namespace, authFilter, defaultRadiusAuthPort, l, radiusProxy.AddAuthBackend, radiusProxy.DeleteAuthBackend, stop)
+	startPodInformer(clientset, namespace, acctFilter, defaultRadiusAcctPort, l, radiusProxy.AddAcctBackend, radiusProxy.DeleteAcctBackend, stop)
+
+	return radiusProxy, stop, nil
+}
+
+// listPodHostPorts returns the host:port of every pod matching filter, using
+// defaultPort when the pod does not advertise a container port.
+func listPodHostPorts(clientset *kubernetes.Clientset, namespace, filter string, defaultPort int, l *cio.Logger) ([]string, error) {
+	pods, err := clientset.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: filter})
+	if err != nil {
+		return nil, err
+	}
+
+	servers := []string{}
+	for _, p := range pods.Items {
+		addr := getPodHostPort(&p, defaultPort)
+		l.Infof("Adding address %s", addr)
+		servers = append(servers, addr)
+	}
+
+	return servers, nil
+}
+
+// startPodInformer watches pods matching filter and keeps a backend pool in
+// sync via the add/del callbacks. The controller stops when stop is closed.
+func startPodInformer(clientset *kubernetes.Clientset, namespace, filter string, defaultPort int, l *cio.Logger, add, del func(string), stop chan struct{}) {
 	watchlist := cache.NewFilteredListWatchFromClient(
 		clientset.CoreV1().RESTClient(),
 		string(v1.ResourcePods),
@@ -141,39 +179,37 @@ func NewRadiusProxyFromKubernetes(l *cio.Logger, radiusSecret string) (*Proxy, c
 			AddFunc: func(obj interface{}) {
 				pod := obj.(*v1.Pod)
 				if isPodReady(pod) {
-					address := getPodHostPort(pod)
+					address := getPodHostPort(pod, defaultPort)
 					l.Infof("Adding %s", address)
-					radiusProxy.AddBackend(address)
+					add(address)
 					return
 				}
 			},
 			DeleteFunc: func(obj interface{}) {
 				pod := obj.(*v1.Pod)
-				address := getPodHostPort(pod)
+				address := getPodHostPort(pod, defaultPort)
 				l.Infof("Removing %s", address)
-				radiusProxy.DeleteBackend(address)
+				del(address)
 			},
 			UpdateFunc: func(oldObj, newObj interface{}) {
 				pod := newObj.(*v1.Pod)
 				if isPodReady(pod) {
-					address := getPodHostPort(pod)
+					address := getPodHostPort(pod, defaultPort)
 					l.Infof("Adding %s", address)
-					radiusProxy.AddBackend(address)
+					add(address)
 					return
 				}
 
 				if pod.DeletionTimestamp != nil {
-					address := getPodHostPort(pod)
+					address := getPodHostPort(pod, defaultPort)
 					l.Infof("%s is terminating removing", address)
-					radiusProxy.DeleteBackend(address)
+					del(address)
 				}
 			},
 		},
 	)
-	stop := make(chan struct{})
-	go controller.Run(stop)
 
-	return radiusProxy, stop, nil
+	go controller.Run(stop)
 }
 
 func TLSClientConfigFromEnv() rest.TLSClientConfig {

--- a/go/chisel/share/radius_proxy/tunnel_radius.go
+++ b/go/chisel/share/radius_proxy/tunnel_radius.go
@@ -186,7 +186,22 @@ func startPodInformer(clientset *kubernetes.Clientset, namespace, filter string,
 				}
 			},
 			DeleteFunc: func(obj interface{}) {
-				pod := obj.(*v1.Pod)
+				pod, ok := obj.(*v1.Pod)
+				if !ok {
+					// On a missed delete the informer delivers a
+					// DeletedFinalStateUnknown tombstone instead of the
+					// object; unwrap it to recover the last-known pod.
+					tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+					if !ok {
+						l.Infof("DeleteFunc got unexpected object type %T, ignoring", obj)
+						return
+					}
+					pod, ok = tombstone.Obj.(*v1.Pod)
+					if !ok {
+						l.Infof("DeleteFunc tombstone contained unexpected object type %T, ignoring", tombstone.Obj)
+						return
+					}
+				}
 				address := getPodHostPort(pod, defaultPort)
 				l.Infof("Removing %s", address)
 				del(address)


### PR DESCRIPTION
# Description
The cloud-NAC pfconnector RADIUS proxy built a single backend pool from radiusd-auth pods (podIP:1812) and selected a backend by hashing User-Name+Calling-Station-ID, never inspecting the RADIUS packet code. As a result Accounting-Request packets arriving on the 1813->pfacct tunnel were proxied to radiusd-auth on the auth port (a type=auth listener), which silently discards accounting. Authentication worked; accounting never reached pfacct and pfacct logged nothing.

Split the proxy into two pools and route by packet code:
- Access-Request (and other non-accounting codes) -> radiusd-auth pool (1812), discovered via K8S_RADIUS_AUTH_FILTER (default app=radiusd-auth).
- Accounting-Request -> pfacct pool (1813), discovered via K8S_RADIUS_ACCT_FILTER (default app=pfacct).

Pool discovery and the pod informer were factored into shared helpers (listPodHostPorts, startPodInformer) and a single getRadiusFilter helper so auth and accounting are handled identically. Session affinity and cleanup now operate per pool.

Adds proxy_test.go covering packet-code routing.

# Impacts
- RADIUS accounting in the cloud

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Bug
* Forward the accounting to pfacct and not radiusd-auth in the cloud.
