### PR TITLE
Record node computername directly from the DHCP server

### DIFF
--- a/go/cmd/pfdhcp/main.go
+++ b/go/cmd/pfdhcp/main.go
@@ -208,7 +208,7 @@ func (I *Interface) ServeDHCP(ctx context.Context, p dhcp.Packet, msgType dhcp.M
 
 	// ctx = log.AddToLogContext(ctx, "mac", answer.MAC.String())
 	clientMac := answer.MAC.String()
-	clientHostname := string(options[dhcp.OptionHostName])
+	clientHostname := sanitizeHostname(string(options[dhcp.OptionHostName]))
 	prettyType := "DHCP" + strings.ToUpper(msgType.String())
 
 	// Get the appropriate handler and network scope
@@ -247,6 +247,21 @@ func (I *Interface) ServeDHCP(ctx context.Context, p dhcp.Packet, msgType dhcp.M
 	}
 
 	log.LoggerWContext(ctx).Debug(clientMac + " " + msgType.String() + " xID " + sharedutils.ByteToString(p.XId()))
+
+	// PacketFence is the DHCP server for this network (a handler/network was
+	// found above). Record the client host name (option 12) on the node right
+	// away from the packet we're answering, rather than relying on the
+	// asynchronous Fingerbank collector to aggregate it later. The Perl DHCP
+	// processor defers computername to us for the networks we serve
+	// (pf_is_dhcp), so this is the authoritative writer for those networks.
+	if clientHostname != "" {
+		switch msgType {
+		case dhcp.Discover, dhcp.Request, dhcp.Inform:
+			if err := MysqlUpdateComputername(ctx, clientMac, clientHostname, db); err != nil {
+				log.LoggerWContext(ctx).Warn("Unable to update computername for " + clientMac + ": " + err.Error())
+			}
+		}
+	}
 
 	// Process request based on message type
 	switch msgType {

--- a/go/cmd/pfdhcp/main.go
+++ b/go/cmd/pfdhcp/main.go
@@ -30,6 +30,7 @@ import (
 	dhcp "github.com/inverse-inc/dhcp4"
 	"github.com/inverse-inc/go-utils/log"
 	"github.com/inverse-inc/go-utils/sharedutils"
+	"github.com/inverse-inc/packetfence/go/jsonrpc2"
 	"github.com/inverse-inc/packetfence/go/pfconfigdriver"
 	statsd "gopkg.in/alexcesaro/statsd.v2"
 )
@@ -84,6 +85,10 @@ var (
 
 	// Connection pool
 	dbConnPool *sql.DB
+
+	// JSON-RPC2 client to the PacketFence AAA API, used to trigger security
+	// events (e.g. hostname_change) back into PacketFence.
+	AAAClient *jsonrpc2.Client
 )
 
 // initializeCaches sets up all the cache systems with consistent timeouts
@@ -139,6 +144,9 @@ func main() {
 
 	// Initialize StatsD client
 	go initStatsD(ctx)
+
+	// Client to the AAA API for triggering security events (hostname_change)
+	AAAClient = jsonrpc2.NewAAAClientFromConfig(ctx)
 
 	// Initialize DHCP configuration
 	DHCPConfig = newDHCPConfig()
@@ -257,9 +265,7 @@ func (I *Interface) ServeDHCP(ctx context.Context, p dhcp.Packet, msgType dhcp.M
 	if clientHostname != "" {
 		switch msgType {
 		case dhcp.Discover, dhcp.Request, dhcp.Inform:
-			if err := MysqlUpdateComputername(ctx, clientMac, clientHostname, db); err != nil {
-				log.LoggerWContext(ctx).Warn("Unable to update computername for " + clientMac + ": " + err.Error())
-			}
+			recordComputername(ctx, clientMac, clientHostname, db)
 		}
 	}
 

--- a/go/cmd/pfdhcp/utils.go
+++ b/go/cmd/pfdhcp/utils.go
@@ -609,6 +609,53 @@ func sanitizeHostname(h string) string {
 	return strings.TrimSpace(strings.TrimRight(h, "\x00"))
 }
 
+// recordComputername persists the DHCP option-12 host name as the node's
+// computername and, when network.hostname_change_detection is enabled, raises
+// the internal::hostname_change security event if the host name changed from a
+// previously-stored non-empty value (possible MAC spoofing). This mirrors the
+// Perl pf::api::detect_computername_change, which PacketFence's DHCP processor
+// no longer runs for networks pfdhcp serves (it defers computername to us).
+func recordComputername(ctx context.Context, mac string, hostname string, db *sql.DB) {
+	if hostname == "" {
+		return
+	}
+
+	// Only pay for the extra read + detection when the feature is enabled
+	// (disabled by default); otherwise just persist the value cheaply.
+	netConf := pfconfigdriver.GetType[pfconfigdriver.PfConfNetwork](ctx)
+	if sharedutils.IsEnabled(netConf.HostnameChangeDetection) {
+		old := mysqlGetComputername(ctx, mac, db)
+		if old != "" && old != hostname {
+			log.LoggerWContext(ctx).Warn("Computername change detected (" + old + " -> " + hostname + ") for " + mac + ". Possible MAC spoofing.")
+			if AAAClient != nil {
+				if err := AAAClient.Notify(ctx, "trigger_security_event", []interface{}{"type", "internal", "mac", mac, "tid", "hostname_change"}); err != nil {
+					log.LoggerWContext(ctx).Error("Unable to trigger hostname_change security event for " + mac + ": " + err.Error())
+				}
+			}
+		}
+	}
+
+	if err := MysqlUpdateComputername(ctx, mac, hostname, db); err != nil {
+		log.LoggerWContext(ctx).Warn("Unable to update computername for " + mac + ": " + err.Error())
+	}
+}
+
+// mysqlGetComputername returns the node's currently stored computername, or ""
+// if the node does not exist or has none.
+func mysqlGetComputername(ctx context.Context, mac string, db *sql.DB) string {
+	dbCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	var computername sql.NullString
+	err := db.QueryRowContext(dbCtx, "SELECT computername FROM node WHERE mac = ?", mac).Scan(&computername)
+	if err != nil {
+		if err != sql.ErrNoRows {
+			log.LoggerWContext(ctx).Error("Unable to read computername for " + mac + ": " + err.Error())
+		}
+		return ""
+	}
+	return computername.String
+}
+
 // MysqlUpdateComputername records the DHCP option-12 host name as the node's
 // computername. PacketFence (this DHCP server) has the host name directly in
 // the packet it answers, so writing it here makes the machine name land

--- a/go/cmd/pfdhcp/utils.go
+++ b/go/cmd/pfdhcp/utils.go
@@ -602,6 +602,31 @@ func MysqlUpdateIP4Log(ctx context.Context, mac string, ip string, duration time
 	return err
 }
 
+// sanitizeHostname cleans a DHCP option-12 (host name) value for storage and
+// logging: some clients pad it with trailing NUL bytes or surrounding
+// whitespace.
+func sanitizeHostname(h string) string {
+	return strings.TrimSpace(strings.TrimRight(h, "\x00"))
+}
+
+// MysqlUpdateComputername records the DHCP option-12 host name as the node's
+// computername. PacketFence (this DHCP server) has the host name directly in
+// the packet it answers, so writing it here makes the machine name land
+// immediately, instead of waiting for the asynchronous Fingerbank collector to
+// aggregate it and a later re-process to persist it. The WHERE clause makes
+// this a no-op when the value is unchanged or the node row does not exist yet.
+func MysqlUpdateComputername(ctx context.Context, mac string, hostname string, db *sql.DB) error {
+	if hostname == "" {
+		return nil
+	}
+	dbCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	_, err := db.ExecContext(dbCtx,
+		"UPDATE node SET computername = ? WHERE mac = ? AND (computername IS NULL OR computername != ?)",
+		hostname, mac, hostname)
+	return err
+}
+
 func stringInSlice(a string, list []string) bool {
 	for _, b := range list {
 		if b == a {

--- a/go/pfconfigdriver/structs.go
+++ b/go/pfconfigdriver/structs.go
@@ -615,6 +615,14 @@ type PfConfDns struct {
 	RecordDNS      string `json:"record_dns_in_sql"`
 }
 
+type PfConfNetwork struct {
+	StructConfig
+	PfconfigMethod          string `val:"hash_element"`
+	PfconfigNS              string `val:"config::Pf"`
+	PfconfigHashNS          string `val:"network"`
+	HostnameChangeDetection string `json:"hostname_change_detection"`
+}
+
 type PfConfParking struct {
 	StructConfig
 	PfconfigMethod          string `val:"hash_element"`

--- a/lib/pf/api.pm
+++ b/lib/pf/api.pm
@@ -1207,8 +1207,8 @@ sub fingerbank_lookup : Public :AllowedAsAction(mac, $mac) {
 =cut
 
 sub fingerbank_process : Public {
-    my ( $class, $mac ) = @_;
-    pf::fingerbank::process($mac);
+    my ( $class, $mac, $overrides ) = @_;
+    pf::fingerbank::process($mac, undef, $overrides);
 }
 
 =head2 fingerbank_update_component

--- a/lib/pf/dhcp/processor.pm
+++ b/lib/pf/dhcp/processor.pm
@@ -274,7 +274,20 @@ sub processFingerbank {
                       . ($fingerbank_args->{dhcp6_enterprise} // '');
         my $cached = $fingerbank_signature_cache->get($mac);
         if (!defined($cached) || $cached ne $signature) {
-            $self->apiClient->notify('fingerbank_process', $mac);
+            # Forward the attributes we parsed straight from this DHCP packet so
+            # pf::fingerbank::process can record them (notably the option-12
+            # hostname as computername) without depending on the Fingerbank
+            # collector having already aggregated them for this endpoint. The
+            # collector ingests asynchronously, so re-deriving these from it
+            # races its own ingestion -- which is why a freshly-seen device's
+            # machine name only showed up after a later re-process. Keys here use
+            # the namespace pf::fingerbank expects (hostname, dhcp_fingerprint,
+            # dhcp_vendor).
+            my %parsed_attributes;
+            $parsed_attributes{hostname}         = $fingerbank_args->{computername}     if defined($fingerbank_args->{computername})     && length($fingerbank_args->{computername});
+            $parsed_attributes{dhcp_fingerprint} = $fingerbank_args->{dhcp_fingerprint} if defined($fingerbank_args->{dhcp_fingerprint}) && length($fingerbank_args->{dhcp_fingerprint});
+            $parsed_attributes{dhcp_vendor}      = $fingerbank_args->{dhcp_vendor}      if defined($fingerbank_args->{dhcp_vendor})      && length($fingerbank_args->{dhcp_vendor});
+            $self->apiClient->notify('fingerbank_process', $mac, \%parsed_attributes);
             $fingerbank_signature_cache->set($mac, $signature, $FINGERBANK_SIGNATURE_TTL);
         }
     }

--- a/lib/pf/dhcp/processor_v4.pm
+++ b/lib/pf/dhcp/processor_v4.pm
@@ -268,9 +268,21 @@ sub process_packet {
         $tmp{'dhcp_vendor'} = defined($dhcp->{'options'}{'60'}) ? $dhcp->{'options'}{'60'} : '';
         $tmp{'last_dhcp'} = mysql_date();
         if (defined($dhcp->{'options'}{'12'})) {
-            $tmp{'computername'} = $dhcp->{'options'}{'12'};
-            if(isenabled($Config{network}{hostname_change_detection})){
-                $self->apiClient->notify('detect_computername_change', $dhcp->{'chaddr'}, $tmp{'computername'});
+            # When PacketFence is the DHCP server for this network (pfdhcp), it
+            # records the computername itself, synchronously, from the packet it
+            # answers -- so it lands immediately instead of waiting on the
+            # asynchronous Fingerbank collector. Only the listener/collector
+            # path owns the computername for networks PF does not serve. We skip
+            # here only when we can affirmatively determine PF is the DHCP server
+            # (a known client IP that falls in a served network); otherwise we
+            # still record it to avoid losing the hostname.
+            my $req_ip = ($dhcp->{'yiaddr'} ne "0.0.0.0") ? $dhcp->{'yiaddr'} : $dhcp->{'options'}{'50'};
+            my $pf_serves_dhcp = (defined($req_ip) && $self->pf_is_dhcp($req_ip)) ? 1 : 0;
+            unless ($pf_serves_dhcp) {
+                $tmp{'computername'} = $dhcp->{'options'}{'12'};
+                if(isenabled($Config{network}{hostname_change_detection})){
+                    $self->apiClient->notify('detect_computername_change', $dhcp->{'chaddr'}, $tmp{'computername'});
+                }
             }
         }
 

--- a/lib/pf/fingerbank.pm
+++ b/lib/pf/fingerbank.pm
@@ -87,7 +87,7 @@ my $api_client;
 
 sub process {
     my $timer = pf::StatsD::Timer->new();
-    my ( $mac, $force ) = @_;
+    my ( $mac, $force, $overrides ) = @_;
     my $logger = pf::log::get_logger;
 
     unless(fingerbank::Config::is_api_key_configured()) {
@@ -116,6 +116,33 @@ sub process {
     }
 
     $query_args->{mac} = $mac;
+
+    # Overlay attributes parsed directly from the live DHCP packet (passed in by
+    # pf::dhcp::processor) over what the collector returned. The collector
+    # aggregates endpoint data asynchronously and may not yet hold the option-12
+    # hostname (or the latest fingerprint) that PF already parsed, so prefer the
+    # in-hand values when recording the result below.
+    if (ref($overrides) eq 'HASH') {
+        for my $attr (keys %$overrides) {
+            my $val = $overrides->{$attr};
+            next unless defined($val) && length($val);
+            $query_args->{$attr} = $val;
+        }
+
+        # Persist the freshly-parsed hostname right away, independent of whether
+        # the Fingerbank query below runs (it can be skipped by the freshness
+        # guard or fail upstream). This guarantees the machine name lands on the
+        # first DHCP packet that carries it rather than waiting for a later
+        # collector-backed re-process.
+        my $hostname = $overrides->{hostname};
+        if (defined($hostname) && length($hostname)
+                && (!defined($node_before->{computername}) || $node_before->{computername} ne $hostname)) {
+            pf::dal::node->update_items(
+                -set   => { computername => $hostname },
+                -where => { mac => $mac },
+            );
+        }
+    }
 
     if(!$force && $query_args->{last_updated}->epoch <= $process_timestamp->epoch) {
         $logger->debug("No recent data found for $mac, will not trigger device profiling. Was last updated at $query_args->{last_updated} and last process timestamp is $process_timestamp");


### PR DESCRIPTION
# Description
The node computername was only ever written via the Fingerbank collector round-trip: pf::fingerbank::process queries the collector (GET /endpoint_data/<mac>) and record_result maps the collector's hostname to computername. The collector ingests DHCP asynchronously, so for a freshly-seen MAC it has the fingerprint (device_class shows up) but not yet the option-12 hostname, which record_result then skips. The machine name therefore only appeared after a later re-process (e.g. the second DHCP cycle following autoreg).

Fix it with an ownership split by network:

- pfdhcp (the Go DHCP server) is now the authoritative, immediate writer of computername for the networks it serves. It already holds the client hostname and a DB handle, so MysqlUpdateComputername records it (idempotently) on Discover/Request/Inform, from whichever packet carries option 12.
- The Perl listener/collector path defers to pfdhcp for served networks (gated on !pf_is_dhcp) and keeps ownership for networks PF does not serve.
- processFingerbank now forwards the attributes it already parsed (hostname/dhcp_fingerprint/dhcp_vendor) to fingerbank_process instead of discarding them, and pf::fingerbank::process overlays these in-hand values (and writes the hostname directly) so unmanaged-network records no longer depend on collector timing.

Caveat: network.hostname_change_detection (default disabled) is managed in pfdhcp for networks managed by the pfdhcp.

# Impacts
Updates of Computer name 


# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* Update computer name via pfdhcp if it manages this network
