### PR TITLE
fix(vagrant): ship el8 boxes unregistered so RHEL repos stay reachable

### DIFF
--- a/addons/vagrant/inventory/hosts
+++ b/addons/vagrant/inventory/hosts
@@ -17,24 +17,24 @@ all:
     nodes:
       hosts:
         node01:
-          box: inverse-inc/pfnode11dev
-          box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfnode11dev/metadata.json
+          box: inverse-inc/pfnode11branch
+          box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfnode11branch/metadata.json
           mgmt_ip: "{{ users_vars[dict_name]['vms']['node01']['ip'] }}"
           mgmt_netmask: "{{ users_vars[dict_name]['vms']['node01']['netmask'] }}"
           ansible_host: "{{ mgmt_ip }}"
           # only used when run outside Vagrant
           ansible_python_interpreter: '/usr/bin/python3'
         node02:
-          box: inverse-inc/pfnode11dev
-          box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfnode11dev/metadata.json
+          box: inverse-inc/pfnode11branch
+          box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfnode11branch/metadata.json
           mgmt_ip: "{{ users_vars[dict_name]['vms']['node02']['ip'] }}"
           mgmt_netmask: "{{ users_vars[dict_name]['vms']['node02']['netmask'] }}"
           ansible_host: "{{ mgmt_ip }}"
           # only used when run outside Vagrant
           ansible_python_interpreter: '/usr/bin/python3'
         node03:
-          box: inverse-inc/pfnode11dev
-          box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfnode11dev/metadata.json
+          box: inverse-inc/pfnode11branch
+          box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfnode11branch/metadata.json
           mgmt_ip: "{{ users_vars[dict_name]['vms']['node03']['ip'] }}"
           mgmt_netmask: "{{ users_vars[dict_name]['vms']['node03']['netmask'] }}"
           ansible_host: "{{ mgmt_ip }}"
@@ -44,8 +44,8 @@ all:
     wireless:
       hosts:
         wireless01:
-          box: inverse-inc/pfnode11dev
-          box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfnode11dev/metadata.json
+          box: inverse-inc/pfnode11branch
+          box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfnode11branch/metadata.json
           mgmt_ip: "{{ users_vars[dict_name]['vms']['wireless01']['ip'] }}"
           mgmt_netmask: "{{ users_vars[dict_name]['vms']['wireless01']['netmask'] }}"
           ansible_host: "{{ mgmt_ip }}"
@@ -78,8 +78,8 @@ all:
           cpus: 1
           memory: 512
         ad:
-          box: inverse-inc/pfad11dev
-          box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfad11dev/metadata.json
+          box: inverse-inc/pfad11branch
+          box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfad11branch/metadata.json
           mgmt_ip: "{{ users_vars[dict_name]['vms']['ad']['ip'] }}"
           mgmt_netmask: "{{ users_vars[dict_name]['vms']['ad']['netmask'] }}"
           ansible_host:  "{{ mgmt_ip }}"
@@ -112,8 +112,8 @@ all:
         clusters:
           hosts:
             pf1el8dev:
-              box: inverse-inc/pfel8dev
-              box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfel8dev/metadata.json
+              box: inverse-inc/pfel8branch
+              box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfel8branch/metadata.json
               mgmt_ip: "{{ users_vars[dict_name]['vms']['pf1el8dev']['ip'] }}"
               mgmt_netmask: "{{ users_vars[dict_name]['vms']['pf1el8dev']['netmask'] }}"
               ansible_host: "{{ mgmt_ip }}"
@@ -122,8 +122,8 @@ all:
               memory: 16384
               disk_size: 130
             pf2el8dev:
-              box: inverse-inc/pfel8dev
-              box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfel8dev/metadata.json
+              box: inverse-inc/pfel8branch
+              box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfel8branch/metadata.json
               mgmt_ip: "{{ users_vars[dict_name]['vms']['pf2el8dev']['ip'] }}"
               mgmt_netmask: "{{ users_vars[dict_name]['vms']['pf2el8dev']['netmask'] }}"
               ansible_host: "{{ mgmt_ip }}"
@@ -132,8 +132,8 @@ all:
               memory: 16384
               disk_size: 130
             pf3el8dev:
-              box: inverse-inc/pfel8dev
-              box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfel8dev/metadata.json
+              box: inverse-inc/pfel8branch
+              box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfel8branch/metadata.json
               mgmt_ip: "{{ users_vars[dict_name]['vms']['pf3el8dev']['ip'] }}"
               mgmt_netmask: "{{ users_vars[dict_name]['vms']['pf3el8dev']['netmask'] }}"
               ansible_host: "{{ mgmt_ip }}"
@@ -142,8 +142,8 @@ all:
               memory: 16384
               disk_size: 130
             pf1deb12dev:
-              box: inverse-inc/pfdeb12dev
-              box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfdeb12dev/metadata.json
+              box: inverse-inc/pfdeb12branch
+              box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfdeb12branch/metadata.json
               mgmt_ip: "{{ users_vars[dict_name]['vms']['pf1deb12dev']['ip'] }}"
               mgmt_netmask: "{{ users_vars[dict_name]['vms']['pf1deb12dev']['netmask'] }}"
               ansible_host: "{{ mgmt_ip }}"
@@ -152,8 +152,8 @@ all:
               memory: 16384
               disk_size: 130
             pf2deb12dev:
-              box: inverse-inc/pfdeb12dev
-              box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfdeb12dev/metadata.json
+              box: inverse-inc/pfdeb12branch
+              box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfdeb12branch/metadata.json
               mgmt_ip: "{{ users_vars[dict_name]['vms']['pf2deb12dev']['ip'] }}"
               mgmt_netmask: "{{ users_vars[dict_name]['vms']['pf2deb12dev']['netmask'] }}"
               ansible_host: "{{ mgmt_ip }}"
@@ -162,8 +162,8 @@ all:
               memory: 16384
               disk_size: 130
             pf3deb12dev:
-              box: inverse-inc/pfdeb12dev
-              box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfdeb12dev/metadata.json
+              box: inverse-inc/pfdeb12branch
+              box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfdeb12branch/metadata.json
               mgmt_ip: "{{ users_vars[dict_name]['vms']['pf3deb12dev']['ip'] }}"
               mgmt_netmask: "{{ users_vars[dict_name]['vms']['pf3deb12dev']['netmask'] }}"
               ansible_host: "{{ mgmt_ip }}"
@@ -235,8 +235,8 @@ all:
         standalones:
           hosts:
             pfel8dev:
-              box: inverse-inc/pfel8dev
-              box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfel8dev/metadata.json
+              box: inverse-inc/pfel8branch
+              box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfel8branch/metadata.json
               mgmt_ip: "{{ users_vars[dict_name]['vms']['pfel8dev']['ip'] }}"
               mgmt_netmask: "{{ users_vars[dict_name]['vms']['pfel8dev']['netmask'] }}"
               ansible_host: "{{ mgmt_ip }}"
@@ -245,8 +245,8 @@ all:
               memory: 16384
               disk_size: 130
             pfdeb12dev:
-              box: inverse-inc/pfdeb12dev
-              box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfdeb12dev/metadata.json
+              box: inverse-inc/pfdeb12branch
+              box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfdeb12branch/metadata.json
               mgmt_ip: "{{ users_vars[dict_name]['vms']['pfdeb12dev']['ip'] }}"
               mgmt_netmask: "{{ users_vars[dict_name]['vms']['pfdeb12dev']['netmask'] }}"
               ansible_host: "{{ mgmt_ip }}"

--- a/addons/vagrant/inventory/hosts
+++ b/addons/vagrant/inventory/hosts
@@ -17,24 +17,24 @@ all:
     nodes:
       hosts:
         node01:
-          box: inverse-inc/pfnode11branch
-          box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfnode11branch/metadata.json
+          box: inverse-inc/pfnode11dev
+          box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfnode11dev/metadata.json
           mgmt_ip: "{{ users_vars[dict_name]['vms']['node01']['ip'] }}"
           mgmt_netmask: "{{ users_vars[dict_name]['vms']['node01']['netmask'] }}"
           ansible_host: "{{ mgmt_ip }}"
           # only used when run outside Vagrant
           ansible_python_interpreter: '/usr/bin/python3'
         node02:
-          box: inverse-inc/pfnode11branch
-          box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfnode11branch/metadata.json
+          box: inverse-inc/pfnode11dev
+          box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfnode11dev/metadata.json
           mgmt_ip: "{{ users_vars[dict_name]['vms']['node02']['ip'] }}"
           mgmt_netmask: "{{ users_vars[dict_name]['vms']['node02']['netmask'] }}"
           ansible_host: "{{ mgmt_ip }}"
           # only used when run outside Vagrant
           ansible_python_interpreter: '/usr/bin/python3'
         node03:
-          box: inverse-inc/pfnode11branch
-          box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfnode11branch/metadata.json
+          box: inverse-inc/pfnode11dev
+          box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfnode11dev/metadata.json
           mgmt_ip: "{{ users_vars[dict_name]['vms']['node03']['ip'] }}"
           mgmt_netmask: "{{ users_vars[dict_name]['vms']['node03']['netmask'] }}"
           ansible_host: "{{ mgmt_ip }}"
@@ -44,8 +44,8 @@ all:
     wireless:
       hosts:
         wireless01:
-          box: inverse-inc/pfnode11branch
-          box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfnode11branch/metadata.json
+          box: inverse-inc/pfnode11dev
+          box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfnode11dev/metadata.json
           mgmt_ip: "{{ users_vars[dict_name]['vms']['wireless01']['ip'] }}"
           mgmt_netmask: "{{ users_vars[dict_name]['vms']['wireless01']['netmask'] }}"
           ansible_host: "{{ mgmt_ip }}"
@@ -78,8 +78,8 @@ all:
           cpus: 1
           memory: 512
         ad:
-          box: inverse-inc/pfad11branch
-          box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfad11branch/metadata.json
+          box: inverse-inc/pfad11dev
+          box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfad11dev/metadata.json
           mgmt_ip: "{{ users_vars[dict_name]['vms']['ad']['ip'] }}"
           mgmt_netmask: "{{ users_vars[dict_name]['vms']['ad']['netmask'] }}"
           ansible_host:  "{{ mgmt_ip }}"
@@ -112,8 +112,8 @@ all:
         clusters:
           hosts:
             pf1el8dev:
-              box: inverse-inc/pfel8branch
-              box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfel8branch/metadata.json
+              box: inverse-inc/pfel8dev
+              box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfel8dev/metadata.json
               mgmt_ip: "{{ users_vars[dict_name]['vms']['pf1el8dev']['ip'] }}"
               mgmt_netmask: "{{ users_vars[dict_name]['vms']['pf1el8dev']['netmask'] }}"
               ansible_host: "{{ mgmt_ip }}"
@@ -122,8 +122,8 @@ all:
               memory: 16384
               disk_size: 130
             pf2el8dev:
-              box: inverse-inc/pfel8branch
-              box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfel8branch/metadata.json
+              box: inverse-inc/pfel8dev
+              box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfel8dev/metadata.json
               mgmt_ip: "{{ users_vars[dict_name]['vms']['pf2el8dev']['ip'] }}"
               mgmt_netmask: "{{ users_vars[dict_name]['vms']['pf2el8dev']['netmask'] }}"
               ansible_host: "{{ mgmt_ip }}"
@@ -132,8 +132,8 @@ all:
               memory: 16384
               disk_size: 130
             pf3el8dev:
-              box: inverse-inc/pfel8branch
-              box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfel8branch/metadata.json
+              box: inverse-inc/pfel8dev
+              box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfel8dev/metadata.json
               mgmt_ip: "{{ users_vars[dict_name]['vms']['pf3el8dev']['ip'] }}"
               mgmt_netmask: "{{ users_vars[dict_name]['vms']['pf3el8dev']['netmask'] }}"
               ansible_host: "{{ mgmt_ip }}"
@@ -142,8 +142,8 @@ all:
               memory: 16384
               disk_size: 130
             pf1deb12dev:
-              box: inverse-inc/pfdeb12branch
-              box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfdeb12branch/metadata.json
+              box: inverse-inc/pfdeb12dev
+              box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfdeb12dev/metadata.json
               mgmt_ip: "{{ users_vars[dict_name]['vms']['pf1deb12dev']['ip'] }}"
               mgmt_netmask: "{{ users_vars[dict_name]['vms']['pf1deb12dev']['netmask'] }}"
               ansible_host: "{{ mgmt_ip }}"
@@ -152,8 +152,8 @@ all:
               memory: 16384
               disk_size: 130
             pf2deb12dev:
-              box: inverse-inc/pfdeb12branch
-              box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfdeb12branch/metadata.json
+              box: inverse-inc/pfdeb12dev
+              box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfdeb12dev/metadata.json
               mgmt_ip: "{{ users_vars[dict_name]['vms']['pf2deb12dev']['ip'] }}"
               mgmt_netmask: "{{ users_vars[dict_name]['vms']['pf2deb12dev']['netmask'] }}"
               ansible_host: "{{ mgmt_ip }}"
@@ -162,8 +162,8 @@ all:
               memory: 16384
               disk_size: 130
             pf3deb12dev:
-              box: inverse-inc/pfdeb12branch
-              box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfdeb12branch/metadata.json
+              box: inverse-inc/pfdeb12dev
+              box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfdeb12dev/metadata.json
               mgmt_ip: "{{ users_vars[dict_name]['vms']['pf3deb12dev']['ip'] }}"
               mgmt_netmask: "{{ users_vars[dict_name]['vms']['pf3deb12dev']['netmask'] }}"
               ansible_host: "{{ mgmt_ip }}"
@@ -235,8 +235,8 @@ all:
         standalones:
           hosts:
             pfel8dev:
-              box: inverse-inc/pfel8branch
-              box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfel8branch/metadata.json
+              box: inverse-inc/pfel8dev
+              box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfel8dev/metadata.json
               mgmt_ip: "{{ users_vars[dict_name]['vms']['pfel8dev']['ip'] }}"
               mgmt_netmask: "{{ users_vars[dict_name]['vms']['pfel8dev']['netmask'] }}"
               ansible_host: "{{ mgmt_ip }}"
@@ -245,8 +245,8 @@ all:
               memory: 16384
               disk_size: 130
             pfdeb12dev:
-              box: inverse-inc/pfdeb12branch
-              box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfdeb12branch/metadata.json
+              box: inverse-inc/pfdeb12dev
+              box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfdeb12dev/metadata.json
               mgmt_ip: "{{ users_vars[dict_name]['vms']['pfdeb12dev']['ip'] }}"
               mgmt_netmask: "{{ users_vars[dict_name]['vms']['pfdeb12dev']['netmask'] }}"
               ansible_host: "{{ mgmt_ip }}"

--- a/addons/vagrant/playbooks/tasks/register_rhel_subscription_tasks.yml
+++ b/addons/vagrant/playbooks/tasks/register_rhel_subscription_tasks.yml
@@ -18,11 +18,6 @@
   retries: 3
   delay: 10
   until: reg_rhel_sub_register_password is successful
-  
-- name: Check if RHEL is already registered
-  ansible.builtin.stat:
-    path: /etc/pki/consumer/cert.pem
-  register: reg_rhel_sub_consumer_cert
 
 - name: Register RHEL subscription
   community.general.redhat_subscription:
@@ -33,10 +28,4 @@
   register: reg_rhel_sub_register_el
   retries: 3
   delay: 10
-  until: >-
-    reg_rhel_sub_register_el is successful
-    or 'already registered' in (reg_rhel_sub_register_el.msg | default(''))
-  failed_when:
-    - reg_rhel_sub_register_el is failed
-    - "'already registered' not in (reg_rhel_sub_register_el.msg | default(''))"
-  when: not reg_rhel_sub_consumer_cert.stat.exists
+  until: reg_rhel_sub_register_el is successful

--- a/ci/packer/vagrant_img/build.pkr.hcl
+++ b/ci/packer/vagrant_img/build.pkr.hcl
@@ -70,6 +70,19 @@ build {
     script = "${var.pfroot_dir}/addons/dev-helpers/debian/install-pf-dependencies.sh"
   }
 
+  # Ship the box unregistered: the build-time RHEL subscription goes stale once
+  # this build's consumer is reaped, leaving published boxes unable to reach
+  # entitled repos. Runtime provisioning re-registers per dev/CI.
+  provisioner "shell" {
+    only = ["qemu.el-8"]
+    execute_command = "echo 'vagrant' | sudo -S -E bash '{{.Path}}'"
+    inline = [
+      "set -eux",
+      "subscription-manager unregister || true",
+      "subscription-manager clean || true",
+    ]
+  }
+
   # Local .box output picked up by upload-to-linode.sh (Linode Object Storage
   # replaced Vagrant Cloud for distribution).
   post-processors {
@@ -210,6 +223,19 @@ build {
     galaxy_file = "${var.provisioner_dir}/requirements.yml"
     galaxy_force_install = false
     use_proxy = false
+  }
+
+  # Ship the box unregistered: the build-time RHEL subscription goes stale once
+  # this build's consumer is reaped, leaving published boxes unable to reach
+  # entitled repos. Runtime provisioning re-registers per dev/CI.
+  provisioner "shell" {
+    only = ["qemu.el-8"]
+    execute_command = "echo 'vagrant' | sudo -S -E bash '{{.Path}}'"
+    inline = [
+      "set -eux",
+      "subscription-manager unregister || true",
+      "subscription-manager clean || true",
+    ]
   }
 
   # Local .box output picked up by upload-to-linode.sh (Linode Object Storage


### PR DESCRIPTION
# Description
Ship el8 Vagrant boxes unregistered so their RHEL repositories stay reachable after publication.

#9095 introduced build-time RHEL subscription registration (baking a consumer cert into the box) plus a runtime gate that skipped re-registration whenever that cert was present. The baked entitlement goes stale once the build consumer is reaped, so a published/rebuilt box can no longer reach `rhel-8-for-x86_64-appstream-rpms`.

This PR:
- Unregisters and cleans `subscription-manager` at the end of both el8 packer builds so the box ships clean.
- Drops the runtime "already registered" gate so provisioning always registers fresh per dev/CI (matches `maintenance/15.1`).

# Impacts
(REQUIRED)
- el8 vagrant box builds (`ci/packer/vagrant_img/build.pkr.hcl`, `qemu.el-8`):
  verify the unregister/clean step runs at the end of both build blocks.
- Runtime RHEL registration
  (`addons/vagrant/playbooks/tasks/register_rhel_subscription_tasks.yml`): confirm provisioning a freshly built el8 box registers cleanly and can reach the AppStream repos.

# Code / PR Dependencies
(OPTIONAL. REMOVE IF NOT NEEDED)
Reverts/supersedes the registration behavior added in #9095.

# Delete branch after merge
(REQUIRED)
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ ] Document the feature — n/a
- [ ] Add OpenAPI specification — n/a
- [ ] Add unit tests — n/a
- [ ] Add acceptance tests (TestLink) — n/a

# NEWS file entries
(REQUIRED, but may be optional...)
## Bug Fixes
* el8 Vagrant boxes shipped with a stale RHEL entitlement, leaving rebuilt boxes unable to reach `rhel-8-for-x86_64-appstream-rpms`; boxes now ship unregistered and register fresh at provisioning time

# UPGRADE file entries
(OPTIONAL, but may be required...)
n/a
