### PR TITLE
fix(vagrant): version branch boxes by pipeline ID with `-ci-` prefix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1460,7 +1460,7 @@ build_pf_img_vagrant_branch_debian_bookworm:
     - .build_pf_img_vagrant_job
   script:
     - export PF_MINOR_RELEASE="$(perl -ne 'print $1 if (m/.*?(\d+\.\d+)/)' conf/pf-release)"
-    - export BOX_VERSION="${PF_MINOR_RELEASE}.${CI_PIPELINE_ID}"
+    - export BOX_VERSION="${PF_MINOR_RELEASE}-ci-${CI_PIPELINE_ID}"
     - export BOX_NAME="pfdeb12branch"
     - export BOX_DESC="PacketFence ${PF_MINOR_RELEASE} - ${CI_COMMIT_REF_SLUG} - ${BOX_VERSION}"
     - export CI_PAGES_URL="http://inverse.ca/downloads/PacketFence/gitlab/${CI_PIPELINE_ID}"
@@ -1530,7 +1530,7 @@ build_pf_img_vagrant_ad_branch_debian_bullseye:
     - .build_pf_img_vagrant_job
   script:
     - export PF_MINOR_RELEASE="$(perl -ne 'print $1 if (m/.*?(\d+\.\d+)/)' conf/pf-release)"
-    - export BOX_VERSION="${PF_MINOR_RELEASE}.${CI_PIPELINE_ID}"
+    - export BOX_VERSION="${PF_MINOR_RELEASE}-ci-${CI_PIPELINE_ID}"
     - export BOX_NAME="pfad11branch"
     - export BOX_DESC="PacketFence AD ${PF_MINOR_RELEASE} - ${CI_COMMIT_REF_SLUG} - ${BOX_VERSION}"
     - export CI_PAGES_URL="http://inverse.ca/downloads/PacketFence/gitlab/${CI_PIPELINE_ID}"
@@ -1595,7 +1595,7 @@ build_pf_img_vagrant_node_branch_debian_bullseye:
     - .build_pf_img_vagrant_job
   script:
     - export PF_MINOR_RELEASE="$(perl -ne 'print $1 if (m/.*?(\d+\.\d+)/)' conf/pf-release)"
-    - export BOX_VERSION="${PF_MINOR_RELEASE}.${CI_PIPELINE_ID}"
+    - export BOX_VERSION="${PF_MINOR_RELEASE}-ci-${CI_PIPELINE_ID}"
     - export BOX_NAME="pfnode11branch"
     - export BOX_DESC="PacketFence node+wireless ${PF_MINOR_RELEASE} - ${CI_COMMIT_REF_SLUG} - ${BOX_VERSION}"
     - timeout ${PIPELINE_TIMEOUT_SCRIPT} make -e -C ${VAGRANT_IMG_DIR}
@@ -1688,7 +1688,7 @@ build_pf_img_vagrant_branch_el8:
     - .build_pf_img_vagrant_job
   script:
     - export PF_MINOR_RELEASE="$(perl -ne 'print $1 if (m/.*?(\d+\.\d+)/)' conf/pf-release)"
-    - export BOX_VERSION="${PF_MINOR_RELEASE}.${CI_PIPELINE_ID}"
+    - export BOX_VERSION="${PF_MINOR_RELEASE}-ci-${CI_PIPELINE_ID}"
     - export BOX_NAME="pfel8branch"
     - export BOX_DESC="PacketFence ${PF_MINOR_RELEASE} - ${CI_COMMIT_REF_SLUG} - ${BOX_VERSION}"
     - export CI_PAGES_URL="http://inverse.ca/downloads/PacketFence/gitlab/${CI_PIPELINE_ID}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1453,13 +1453,14 @@ build_pf_img_vagrant_maintenance_debian_bookworm:
     - if: '$CI_COMMIT_REF_NAME =~ /^maintenance\/[[:digit:]]+\.[[:digit:]]+$/ && $CI_COMMIT_TAG == null && ($CI_PIPELINE_SOURCE == "schedule" || $CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api")'
 
 # Feature branches: packages come from the pipeline PPA (publish_ppa); all
-# feature branches share the same Linode prefix, the build version distinguishes them.
+# feature branches share the same Linode prefix, the pipeline ID (BOX_VERSION)
+# distinguishes builds and lets a user pin a specific pipeline's box.
 build_pf_img_vagrant_branch_debian_bookworm:
   extends:
     - .build_pf_img_vagrant_job
   script:
     - export PF_MINOR_RELEASE="$(perl -ne 'print $1 if (m/.*?(\d+\.\d+)/)' conf/pf-release)"
-    - export BOX_VERSION="${PF_MINOR_RELEASE}.$(date -u +%Y%m%d%H%M%S)"
+    - export BOX_VERSION="${PF_MINOR_RELEASE}.${CI_PIPELINE_ID}"
     - export BOX_NAME="pfdeb12branch"
     - export BOX_DESC="PacketFence ${PF_MINOR_RELEASE} - ${CI_COMMIT_REF_SLUG} - ${BOX_VERSION}"
     - export CI_PAGES_URL="http://inverse.ca/downloads/PacketFence/gitlab/${CI_PIPELINE_ID}"
@@ -1529,7 +1530,7 @@ build_pf_img_vagrant_ad_branch_debian_bullseye:
     - .build_pf_img_vagrant_job
   script:
     - export PF_MINOR_RELEASE="$(perl -ne 'print $1 if (m/.*?(\d+\.\d+)/)' conf/pf-release)"
-    - export BOX_VERSION="${PF_MINOR_RELEASE}.$(date -u +%Y%m%d%H%M%S)"
+    - export BOX_VERSION="${PF_MINOR_RELEASE}.${CI_PIPELINE_ID}"
     - export BOX_NAME="pfad11branch"
     - export BOX_DESC="PacketFence AD ${PF_MINOR_RELEASE} - ${CI_COMMIT_REF_SLUG} - ${BOX_VERSION}"
     - export CI_PAGES_URL="http://inverse.ca/downloads/PacketFence/gitlab/${CI_PIPELINE_ID}"
@@ -1594,7 +1595,7 @@ build_pf_img_vagrant_node_branch_debian_bullseye:
     - .build_pf_img_vagrant_job
   script:
     - export PF_MINOR_RELEASE="$(perl -ne 'print $1 if (m/.*?(\d+\.\d+)/)' conf/pf-release)"
-    - export BOX_VERSION="${PF_MINOR_RELEASE}.$(date -u +%Y%m%d%H%M%S)"
+    - export BOX_VERSION="${PF_MINOR_RELEASE}.${CI_PIPELINE_ID}"
     - export BOX_NAME="pfnode11branch"
     - export BOX_DESC="PacketFence node+wireless ${PF_MINOR_RELEASE} - ${CI_COMMIT_REF_SLUG} - ${BOX_VERSION}"
     - timeout ${PIPELINE_TIMEOUT_SCRIPT} make -e -C ${VAGRANT_IMG_DIR}
@@ -1680,13 +1681,14 @@ build_pf_img_vagrant_maintenance_el8:
     - if: '$CI_COMMIT_REF_NAME =~ /^maintenance\/[[:digit:]]+\.[[:digit:]]+$/ && $CI_COMMIT_TAG == null && ($CI_PIPELINE_SOURCE == "schedule" || $CI_PIPELINE_SOURCE == "web" || $CI_PIPELINE_SOURCE == "api")'
 
 # EL 8 feature branches: packages come from the pipeline PPA (publish_ppa); all
-# feature branches share the same Linode prefix, the build version distinguishes them.
+# feature branches share the same Linode prefix, the pipeline ID (BOX_VERSION)
+# distinguishes builds and lets a user pin a specific pipeline's box.
 build_pf_img_vagrant_branch_el8:
   extends:
     - .build_pf_img_vagrant_job
   script:
     - export PF_MINOR_RELEASE="$(perl -ne 'print $1 if (m/.*?(\d+\.\d+)/)' conf/pf-release)"
-    - export BOX_VERSION="${PF_MINOR_RELEASE}.$(date -u +%Y%m%d%H%M%S)"
+    - export BOX_VERSION="${PF_MINOR_RELEASE}.${CI_PIPELINE_ID}"
     - export BOX_NAME="pfel8branch"
     - export BOX_DESC="PacketFence ${PF_MINOR_RELEASE} - ${CI_COMMIT_REF_SLUG} - ${BOX_VERSION}"
     - export CI_PAGES_URL="http://inverse.ca/downloads/PacketFence/gitlab/${CI_PIPELINE_ID}"

--- a/addons/vagrant/inventory/hosts
+++ b/addons/vagrant/inventory/hosts
@@ -17,24 +17,27 @@ all:
     nodes:
       hosts:
         node01:
-          box: inverse-inc/pfnode11dev
-          box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfnode11dev/metadata.json
+          box: inverse-inc/pfnode11branch
+          box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfnode11branch/metadata.json
+          box_version: '15.2-ci-2636370262'
           mgmt_ip: "{{ users_vars[dict_name]['vms']['node01']['ip'] }}"
           mgmt_netmask: "{{ users_vars[dict_name]['vms']['node01']['netmask'] }}"
           ansible_host: "{{ mgmt_ip }}"
           # only used when run outside Vagrant
           ansible_python_interpreter: '/usr/bin/python3'
         node02:
-          box: inverse-inc/pfnode11dev
-          box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfnode11dev/metadata.json
+          box: inverse-inc/pfnode11branch
+          box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfnode11branch/metadata.json
+          box_version: '15.2-ci-2636370262'
           mgmt_ip: "{{ users_vars[dict_name]['vms']['node02']['ip'] }}"
           mgmt_netmask: "{{ users_vars[dict_name]['vms']['node02']['netmask'] }}"
           ansible_host: "{{ mgmt_ip }}"
           # only used when run outside Vagrant
           ansible_python_interpreter: '/usr/bin/python3'
         node03:
-          box: inverse-inc/pfnode11dev
-          box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfnode11dev/metadata.json
+          box: inverse-inc/pfnode11branch
+          box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfnode11branch/metadata.json
+          box_version: '15.2-ci-2636370262'
           mgmt_ip: "{{ users_vars[dict_name]['vms']['node03']['ip'] }}"
           mgmt_netmask: "{{ users_vars[dict_name]['vms']['node03']['netmask'] }}"
           ansible_host: "{{ mgmt_ip }}"

--- a/addons/vagrant/inventory/hosts
+++ b/addons/vagrant/inventory/hosts
@@ -17,27 +17,24 @@ all:
     nodes:
       hosts:
         node01:
-          box: inverse-inc/pfnode11branch
-          box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfnode11branch/metadata.json
-          box_version: '15.2-ci-2636370262'
+          box: inverse-inc/pfnode11dev
+          box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfnode11dev/metadata.json
           mgmt_ip: "{{ users_vars[dict_name]['vms']['node01']['ip'] }}"
           mgmt_netmask: "{{ users_vars[dict_name]['vms']['node01']['netmask'] }}"
           ansible_host: "{{ mgmt_ip }}"
           # only used when run outside Vagrant
           ansible_python_interpreter: '/usr/bin/python3'
         node02:
-          box: inverse-inc/pfnode11branch
-          box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfnode11branch/metadata.json
-          box_version: '15.2-ci-2636370262'
+          box: inverse-inc/pfnode11dev
+          box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfnode11dev/metadata.json
           mgmt_ip: "{{ users_vars[dict_name]['vms']['node02']['ip'] }}"
           mgmt_netmask: "{{ users_vars[dict_name]['vms']['node02']['netmask'] }}"
           ansible_host: "{{ mgmt_ip }}"
           # only used when run outside Vagrant
           ansible_python_interpreter: '/usr/bin/python3'
         node03:
-          box: inverse-inc/pfnode11branch
-          box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfnode11branch/metadata.json
-          box_version: '15.2-ci-2636370262'
+          box: inverse-inc/pfnode11dev
+          box_url: https://packetfence-vagrant-box.us-ord-1.linodeobjects.com/pfnode11dev/metadata.json
           mgmt_ip: "{{ users_vars[dict_name]['vms']['node03']['ip'] }}"
           mgmt_netmask: "{{ users_vars[dict_name]['vms']['node03']['netmask'] }}"
           ansible_host: "{{ mgmt_ip }}"


### PR DESCRIPTION
# Description
(REQUIRED)
Version feature-branch Vagrant boxes by **pipeline ID** instead of a build date,
and tag them with a `-ci-` prefix so they are unmistakable from the
date-versioned devel/maintenance boxes.

Branch boxes now resolve as `15.2-ci-<pipeline_id>.box` (e.g. `15.2-ci-2636370262.box`)
instead of `15.2.<YYYYMMDDHHMMSS>.box`. All feature branches still share one
Linode prefix; the pipeline-ID version distinguishes builds and lets a user
pin a specific pipeline's box.

# Impacts
(REQUIRED)
- `.gitlab-ci.yml` — the four branch box build jobs (`debian_bookworm`,
  `ad_branch`, `node_branch`, `el8`) now export
  `BOX_VERSION="${PF_MINOR_RELEASE}-ci-${CI_PIPELINE_ID}"`.
- Box version is a valid `Gem::Version` (verified): the `-ci-` form is a
  prerelease, harmless here because branch boxes are always pinned exactly.

# Code / PR Dependencies
(OPTIONAL. REMOVE IF NOT NEEDED)
N/A

# Delete branch after merge
(REQUIRED)
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ ] Document the feature — n/a (CI/build-only)
- [ ] Add OpenAPI specification — n/a
- [ ] Add unit tests — n/a
- [ ] Add acceptance tests (TestLink) — n/a

# NEWS file entries
## Enhancements
* Feature-branch Vagrant boxes are versioned by pipeline ID and tagged `-ci-`
  (`15.2-ci-<pipeline_id>`), so a specific branch build can be pinned and is
  never confused with date-versioned devel/maintenance boxes.