### PR TITLE
fix(backup): reapply DB triggers on import and carry them in the exportable backup

### DIFF
--- a/addons/full-import/export.sh
+++ b/addons/full-import/export.sh
@@ -55,8 +55,17 @@ if echo "$last_db_dump" | grep '\.sql.gz$' >/dev/null; then
     mariadb_args="$mariadb_args -p$mariadb_root_pass"
   fi
 
+  db_name=$(/usr/local/pf/bin/get_pf_conf database db)
+  db_name=${db_name:-pf}
+
   echo "Database dump uses mysqldump. Exporting the grants from the database. Enter the MariaDB root password if prompted to"
   mysql $mariadb_args --skip-column-names -A -e"SELECT CONCAT('SHOW GRANTS FOR ''',user,'''@''',host,''';') FROM mysql.user WHERE user<>'' AND user<>'PUBLIC'" | mysql $mariadb_args --skip-column-names -A | sed 's/$/;/g' > grants.sql
+
+  # pf-user dump omits triggers (no TRIGGER privilege); dump them as root.
+  # Routines are skipped: the base pf dump already carries them.
+  echo "Exporting the triggers from the database"
+  mysqldump $mariadb_args --single-transaction --no-create-info --no-data --skip-add-drop-table \
+    --triggers "$db_name" > triggers.sql
 fi
 
 main_splitter

--- a/addons/full-import/export.sh
+++ b/addons/full-import/export.sh
@@ -66,6 +66,24 @@ if echo "$last_db_dump" | grep '\.sql.gz$' >/dev/null; then
   echo "Exporting the triggers from the database"
   mysqldump $mariadb_args --single-transaction --no-create-info --no-data --skip-add-drop-table \
     --triggers "$db_name" > triggers.sql
+
+  # The nightly dump omits large history tables via --ignore-table, but triggers
+  # write to them (e.g. the locationlog trigger inserts into locationlog_history),
+  # so export their structure only to recreate the empty tables on import.
+  # Keep this list in sync with the --ignore-table list in backup-and-maintenance.sh;
+  # only tables that exist are dumped, so obsolete names (pre-10.3) are ignored.
+  excluded_tables="locationlog_history iplog_archive"
+  existing_excluded=""
+  for t in $excluded_tables; do
+    if [ -n "$(mysql $mariadb_args -N -B -e "SHOW TABLES LIKE '$t'" "$db_name" 2>/dev/null)" ]; then
+      existing_excluded="$existing_excluded $t"
+    fi
+  done
+  if [ -n "$existing_excluded" ]; then
+    echo "Exporting the structure of the tables excluded from the dump:$existing_excluded"
+    mysqldump $mariadb_args --no-data --skip-triggers --skip-add-drop-table \
+      "$db_name" $existing_excluded > excluded_tables_schema.sql
+  fi
 fi
 
 main_splitter

--- a/addons/full-import/import.sh
+++ b/addons/full-import/import.sh
@@ -166,7 +166,15 @@ finalize_import() {
     configreload
 
     main_splitter
-    echo "Completed import of the database and the configuration! Complete any necessary adjustments and restart PacketFence"
+    if [ "$do_full_import" -eq 1 ]; then
+        echo "Completed import of the database and the configuration! Complete any necessary adjustments and restart PacketFence"
+    elif [ "$do_db_import" -eq 1 ]; then
+        echo "Completed import of the database! Complete any necessary adjustments and restart PacketFence"
+    elif [ "$do_config_import" -eq 1 ]; then
+        echo "Completed import of the configuration! Complete any necessary adjustments and restart PacketFence"
+    else
+        echo "Completed import! Complete any necessary adjustments and restart PacketFence"
+    fi
 
     # Done with everything, time to cleanup!
     systemctl cat monit > /dev/null 2>&1 && systemctl enable monit

--- a/addons/full-import/import.sh
+++ b/addons/full-import/import.sh
@@ -79,7 +79,7 @@ import_db() {
     if echo "$db_dump" | grep '\.sql$' >/dev/null; then
         echo "The database dump uses mysqldump"
         #TODO /tmp/grants.sql should be included in the export
-        import_mysqldump grants.sql $db_dump usr/local/pf/conf/pf.conf $do_db_restore
+        import_mysqldump grants.sql $db_dump usr/local/pf/conf/pf.conf
     elif echo "$db_dump" | grep '\.xbstream$' >/dev/null; then
         echo "The database uses mariabackup"
         # permit to remove mariabackup if everything goes well
@@ -96,7 +96,10 @@ import_db() {
         exit 1
     fi
 
-    if [ "$do_db_restore" -eq 0 ] ; then
+    if [ "$do_restore_as_is" -eq 1 ]; then
+        main_splitter
+        echo "--restore-as-is: same version, skipping database upgrade"
+    else
         handle_devel_upgrade `egrep -o '[0-9]+\.[0-9]+\.[0-9]+$' /usr/local/pf/conf/pf-release | egrep -o '^[0-9]+\.[0-9]+'`
 
         #TODO: check the version of the export, we want to support only 10.3.0 and above
@@ -105,9 +108,6 @@ import_db() {
         main_splitter
         db_name=`get_db_name usr/local/pf/conf/pf.conf`
         upgrade_database $db_name
-    else
-        main_splitter
-        echo "Only database restoration has been selected. No upgrade on database will be done"
     fi
 }
 
@@ -122,10 +122,14 @@ import_config() {
     restore_profile_templates
 
     main_splitter
-    upgrade_imported_configuration
+    if [ "$do_restore_as_is" -eq 1 ]; then
+        echo "--restore-as-is: same version, skipping configuration upgrade"
+    else
+        upgrade_imported_configuration
+    fi
 
     main_splitter
-    if [ "$do_adjust_config" -eq 1 ]; then
+    if [ "$do_adjust_db_conf" -eq 1 ]; then
         echo "Performing adjustments on the configuration"
         adjust_configuration
     else
@@ -139,42 +143,31 @@ import_config() {
 
 
 finalize_import() {
-    if [ "$do_db_restore" -eq 0 ] ; then
-        main_splitter
-        echo "Finalizing import"
+    main_splitter
+    echo "Finalizing import"
 
-        sub_splitter
-        echo "Applying fixpermissions"
-        /usr/local/pf/bin/pfcmd fixpermissions
+    sub_splitter
+    echo "Applying fixpermissions"
+    /usr/local/pf/bin/pfcmd fixpermissions
 
-        sub_splitter
-        echo "Restarting packetfence-redis-cache"
-        systemctl restart packetfence-redis-cache
+    sub_splitter
+    echo "Restarting packetfence-redis-cache"
+    systemctl restart packetfence-redis-cache
 
-        sub_splitter
-        echo "Restarting packetfence-config"
-        systemctl restart packetfence-config
+    sub_splitter
+    echo "Restarting packetfence-config"
+    systemctl restart packetfence-config
 
-        sub_splitter
-        echo "Reloading configuration"
-        configreload
+    sub_splitter
+    echo "Reloading configuration"
+    configreload
 
-        main_splitter
-        echo "Completed import of the database and the configuration! Complete any necessary adjustments and restart PacketFence"
+    main_splitter
+    echo "Completed import of the database and the configuration! Complete any necessary adjustments and restart PacketFence"
 
-        # Done with everything, time to cleanup!
-        systemctl cat monit > /dev/null 2>&1 && systemctl enable monit
-    else
-        main_splitter
-        echo "Finalizing db restoration"
+    # Done with everything, time to cleanup!
+    systemctl cat monit > /dev/null 2>&1 && systemctl enable monit
 
-        sub_splitter
-        echo "Restarting service packetfence-httpd.admin_dispatcher"
-        systemctl restart packetfence-httpd.admin_dispatcher
-        echo "Restarting packetfence-haproxy-admin service"
-        systemctl start packetfence-haproxy-admin
-        echo "Completed import of the database! Complete any necessary adjustments and restart PacketFence"
-    fi
     popd > /dev/null
 }
 
@@ -188,9 +181,9 @@ Options:
  -f,--file                  Import a PacketFence export (mandatory)
  -h,--help                  Display this help
  --db                       Import only database from PacketFence export
- --db-restore               Restore only database from PacketFence export without upgrade process
  --conf                     Import only configuration from PacketFence export
- --skip-adjust-conf         Don't run adjustments on configuration (only use it if you know what you are doing)
+ --skip-adjust-db-conf      Config import only: keep the backup's DB host/port instead of forcing localhost
+ --restore-as-is            Reapply the backup exactly: same version (no upgrade), keep its DB host/port, no prompts
 
 EOF
 }
@@ -200,16 +193,16 @@ EOF
 #############################################################################
 do_full_import=1
 do_db_import=0
-do_db_restore=0
 do_config_import=0
-do_adjust_config=1
+do_adjust_db_conf=1
+do_restore_as_is=0
 mariabackup_installed=false
 EXPORT_FILE=${EXPORT_FILE:-}
 
 # Parse option
 # TEMP=$(getopt -o f:h --long file:,help,db,conf \
     #      -n "$0" -- "$@") || (echo "getopt failed." && exit 1)
-TEMP=$(getopt -o f:h --long file:,help,db,db-restore,conf,skip-adjust-conf \
+TEMP=$(getopt -o f:h --long file:,help,db,conf,skip-adjust-db-conf,restore-as-is \
      -n "$0" -- "$@") || (echo "getopt failed." && exit 1)
 
 # Note the quotes around `$TEMP': they are essential!
@@ -226,16 +219,16 @@ while true ; do
             help ; exit 0 ; shift
             ;;
         --db)
-            do_db_restore=0 ; do_db_import=1 ; do_full_import=0 ; shift
-            ;;
-        --db-restore)
-            do_db_restore=1 ; do_db_import=1 ; do_full_import=0 ; shift
+            do_db_import=1 ; do_full_import=0 ; shift
             ;;
         --conf)
             do_config_import=1 ; do_full_import=0 ; shift
             ;;
-        --skip-adjust-conf)
-            do_adjust_config=0 ; shift
+        --skip-adjust-db-conf)
+            do_adjust_db_conf=0 ; shift
+            ;;
+        --restore-as-is)
+            do_restore_as_is=1 ; shift
             ;;
         --)
             shift ; break
@@ -255,6 +248,12 @@ fi
 if [ ! -f "$EXPORT_FILE" ]; then
     echo "$EXPORT_FILE is not a regular file"
     exit 1
+fi
+
+# --restore-as-is reapplies the backup verbatim, so it also keeps the backup's
+# DB host/port (skips adjust_configuration) like --skip-adjust-db-conf does.
+if [ "$do_restore_as_is" -eq 1 ]; then
+    do_adjust_db_conf=0
 fi
 
 #############################################################################

--- a/addons/full-import/import.sh
+++ b/addons/full-import/import.sh
@@ -119,6 +119,13 @@ import_config() {
     handle_network_change
 
     main_splitter
+    if [ "$do_restore_as_is" -eq 1 ]; then
+        echo "--restore-as-is: leaving cluster.conf untouched"
+    else
+        handle_cluster_conf_change
+    fi
+
+    main_splitter
     restore_profile_templates
 
     main_splitter

--- a/addons/full-import/import.sh
+++ b/addons/full-import/import.sh
@@ -119,11 +119,7 @@ import_config() {
     handle_network_change
 
     main_splitter
-    if [ "$do_restore_as_is" -eq 1 ]; then
-        echo "--restore-as-is: leaving cluster.conf untouched"
-    else
-        handle_cluster_conf_change
-    fi
+    handle_cluster_conf_restore `pwd`
 
     main_splitter
     restore_profile_templates
@@ -191,6 +187,7 @@ Options:
  --conf                     Import only configuration from PacketFence export
  --skip-adjust-db-conf      Config import only: keep the backup's DB host/port instead of forcing localhost
  --restore-as-is            Reapply the backup exactly: same version (no upgrade), keep its DB host/port, no prompts
+ --update-cluster-conf      Restore the export's cluster.conf and adjust it for this server (default: keep cluster.conf empty)
 
 EOF
 }
@@ -203,13 +200,14 @@ do_db_import=0
 do_config_import=0
 do_adjust_db_conf=1
 do_restore_as_is=0
+do_update_cluster_conf=0
 mariabackup_installed=false
 EXPORT_FILE=${EXPORT_FILE:-}
 
 # Parse option
 # TEMP=$(getopt -o f:h --long file:,help,db,conf \
     #      -n "$0" -- "$@") || (echo "getopt failed." && exit 1)
-TEMP=$(getopt -o f:h --long file:,help,db,conf,skip-adjust-db-conf,restore-as-is \
+TEMP=$(getopt -o f:h --long file:,help,db,conf,skip-adjust-db-conf,restore-as-is,update-cluster-conf \
      -n "$0" -- "$@") || (echo "getopt failed." && exit 1)
 
 # Note the quotes around `$TEMP': they are essential!
@@ -236,6 +234,9 @@ while true ; do
             ;;
         --restore-as-is)
             do_restore_as_is=1 ; shift
+            ;;
+        --update-cluster-conf)
+            do_update_cluster_conf=1 ; shift
             ;;
         --)
             shift ; break

--- a/addons/functions/configuration.functions
+++ b/addons/functions/configuration.functions
@@ -27,6 +27,10 @@ function restore_config_files() {
   dump_dir="$1"
   files=`get_config_files`
   for f in $files; do
+    # cluster.conf is not restored here; handle_cluster_conf_restore decides its fate.
+    if [ "$f" = "$CLUSTER_CONF_PATH" ]; then
+      continue
+    fi
     echo "Restoring $f"
     mkdir -p `dirname $f`
     check_code $?
@@ -286,6 +290,52 @@ function cluster_set_interface_ip() {
 function cluster_set_management_ip() {
   local section="$1" ip="$2"
   perl -MConfig::IniFiles -I/usr/local/pf/lib_perl/lib/perl5/ -e "\$c = Config::IniFiles->new( -file => '$CLUSTER_CONF_PATH'); if (\$c->SectionExists('$section')) { \$c->setval('$section', 'management_ip', '$ip'); \$c->RewriteConfig; }"
+}
+
+# Reset the live cluster.conf to an empty (standalone) configuration.
+function reset_cluster_conf() {
+  if [ -f "${CLUSTER_CONF_PATH}.example" ]; then
+    cp -a "${CLUSTER_CONF_PATH}.example" "$CLUSTER_CONF_PATH"
+  else
+    printf '[CLUSTER]\nmanagement_ip=\n' > "$CLUSTER_CONF_PATH"
+  fi
+  chown pf: "$CLUSTER_CONF_PATH"
+}
+
+# Decide what to do with cluster.conf on import (it is skipped by restore_config_files):
+#   --restore-as-is       : keep this server's current cluster.conf untouched
+#   --update-cluster-conf : restore the export's cluster.conf and adjust it for this server
+#   default               : keep the export's copy for reference, reset the live one to empty
+function handle_cluster_conf_restore() {
+  local dump_dir="$1"
+  local src="$dump_dir/usr/local/pf/conf/cluster.conf"
+
+  if [ "${do_restore_as_is:-0}" -eq 1 ]; then
+    echo "--restore-as-is: keeping this server's current cluster.conf unchanged"
+    return 0
+  fi
+
+  if [ "${do_update_cluster_conf:-0}" -eq 1 ]; then
+    if [ -f "$src" ]; then
+      echo "Restoring cluster.conf from the export and adjusting it for this server"
+      cp -a "$src" "$CLUSTER_CONF_PATH"
+      chown pf: "$CLUSTER_CONF_PATH"
+      handle_cluster_conf_change
+    else
+      echo "WARN: no cluster.conf found in the export; leaving the current one in place"
+    fi
+    return 0
+  fi
+
+  # Default: do not adopt the export's cluster configuration. Keep it for
+  # reference and leave this server standalone with an empty cluster.conf.
+  if [ -f "$src" ]; then
+    echo "Saving the export's cluster.conf as ${CLUSTER_CONF_PATH}.imported for reference"
+    cp -a "$src" "${CLUSTER_CONF_PATH}.imported"
+    chown pf: "${CLUSTER_CONF_PATH}.imported"
+  fi
+  echo "Resetting cluster.conf to a standalone (empty) configuration"
+  reset_cluster_conf
 }
 
 # Adjust the restored cluster.conf for this server, mirroring the pf.conf handling.

--- a/addons/functions/configuration.functions
+++ b/addons/functions/configuration.functions
@@ -1,6 +1,11 @@
 #!/bin/bash
 
 export PF_CONF_PATH="/usr/local/pf/conf/pf.conf"
+export CLUSTER_CONF_PATH="/usr/local/pf/conf/cluster.conf"
+
+# Interface renames applied to pf.conf during handle_network_change; reused to
+# adjust the local node's sections in cluster.conf (old_name -> new_name).
+declare -A PF_IFACE_RENAMES
 
 function ipcalc_wrapper() {
   if is_deb_based; then
@@ -102,6 +107,8 @@ function rewrite_pf_ip_address() {
 function rename_interface() {
   perl -MConfig::IniFiles -I/usr/local/pf/lib_perl/lib/perl5/ -e "\$c = Config::IniFiles->new( -file => '$PF_CONF_PATH') ; \$c->RenameSection('interface $1', 'interface $2') ; \$c->RewriteConfig"
   echo "Renamed $1 to $2 in pf.conf"
+  # Remember the rename so cluster.conf's node/VIP sections can be updated too.
+  PF_IFACE_RENAMES["$1"]="$2"
 }
 
 function delete_interface() {
@@ -251,6 +258,80 @@ function delete_pf_database_port() {
 
 function is_cluster() {
   [ `perl -I/usr/local/pf/lib_perl/lib/perl5/ -I/usr/local/pf/lib -Mpf::config::cluster -e 'print $cluster_enabled'` -eq 1 ]
+}
+
+# A restored cluster.conf describes a real cluster only when CLUSTER/management_ip
+# is set (same test pf::config::cluster uses for $cluster_enabled).
+function cluster_conf_is_active() {
+  [ -f "$CLUSTER_CONF_PATH" ] || return 1
+  local mgmt_ip
+  mgmt_ip=$(perl -MConfig::IniFiles -I/usr/local/pf/lib_perl/lib/perl5/ -e "\$c = Config::IniFiles->new( -file => '$CLUSTER_CONF_PATH'); \$v = \$c->val('CLUSTER', 'management_ip'); print defined(\$v) ? \$v : ''")
+  [ -n "$mgmt_ip" ]
+}
+
+function cluster_conf_has_host() {
+  perl -MConfig::IniFiles -I/usr/local/pf/lib_perl/lib/perl5/ -e "\$c = Config::IniFiles->new( -file => '$CLUSTER_CONF_PATH'); exit(\$c->SectionExists('$1') ? 0 : 1)"
+}
+
+function cluster_rename_interface_section() {
+  local prefix="$1" old="$2" new="$3"
+  perl -MConfig::IniFiles -I/usr/local/pf/lib_perl/lib/perl5/ -e "\$c = Config::IniFiles->new( -file => '$CLUSTER_CONF_PATH'); if (\$c->SectionExists('$prefix interface $old')) { \$c->RenameSection('$prefix interface $old', '$prefix interface $new'); \$c->RewriteConfig; }"
+}
+
+function cluster_set_interface_ip() {
+  local prefix="$1" ifn="$2" ip="$3"
+  perl -MConfig::IniFiles -I/usr/local/pf/lib_perl/lib/perl5/ -e "\$c = Config::IniFiles->new( -file => '$CLUSTER_CONF_PATH'); if (\$c->SectionExists('$prefix interface $ifn')) { \$c->setval('$prefix interface $ifn', 'ip', '$ip'); \$c->RewriteConfig; }"
+}
+
+function cluster_set_management_ip() {
+  local section="$1" ip="$2"
+  perl -MConfig::IniFiles -I/usr/local/pf/lib_perl/lib/perl5/ -e "\$c = Config::IniFiles->new( -file => '$CLUSTER_CONF_PATH'); if (\$c->SectionExists('$section')) { \$c->setval('$section', 'management_ip', '$ip'); \$c->RewriteConfig; }"
+}
+
+# Adjust the restored cluster.conf for this server, mirroring the pf.conf handling.
+# Only the local node ([<hostname>] and its interfaces) is adjusted from the
+# already-corrected pf.conf; VIP interface renames are propagated cluster-wide,
+# but VIP IPs and peer-node sections cannot be derived here and are left as-is.
+function handle_cluster_conf_change() {
+  echo "Checking cluster.conf for any necessary node configuration changes"
+  if ! cluster_conf_is_active; then
+    echo "cluster.conf has no cluster management IP; nothing to adjust (standalone configuration)"
+    return 0
+  fi
+
+  local host=`hostname`
+  echo "Detected a cluster configuration; adjusting local node '$host' in cluster.conf"
+
+  if ! cluster_conf_has_host "$host"; then
+    echo "WARN: cluster.conf has no [$host] section. The backup likely comes from a different node or cluster."
+    echo "WARN: Review $CLUSTER_CONF_PATH manually before enabling clustering."
+    return 0
+  fi
+
+  # Interface renames resolved while adjusting pf.conf apply cluster-wide, so
+  # update both the local node's sections and the CLUSTER (VIP) sections.
+  if [ "${#PF_IFACE_RENAMES[@]}" -gt 0 ]; then
+    for old in "${!PF_IFACE_RENAMES[@]}"; do
+      new="${PF_IFACE_RENAMES[$old]}"
+      echo "Renaming interface $old to $new in cluster.conf ([$host] and [CLUSTER])"
+      cluster_rename_interface_section "$host" "$old" "$new"
+      cluster_rename_interface_section "CLUSTER" "$old" "$new"
+    done
+  fi
+
+  # Sync the local node's interface IPs and management IP from the corrected pf.conf.
+  for interface in `list_pf_interfaces`; do
+    local pf_ip=`get_pf_ip_address $interface`
+    [ -z "$pf_ip" ] && continue
+    cluster_set_interface_ip "$host" "$interface" "$pf_ip"
+    if get_pf_interface_type "$interface" | grep -q management; then
+      echo "Setting management_ip of [$host] to $pf_ip in cluster.conf"
+      cluster_set_management_ip "$host" "$pf_ip"
+    fi
+  done
+
+  echo "NOTE: Virtual IPs in [CLUSTER ...] and peer-node sections were left unchanged."
+  echo "NOTE: Verify $CLUSTER_CONF_PATH: peer nodes' IPs cannot be derived from this server."
 }
 
 function get_pf_version_in_export() {

--- a/addons/functions/configuration.functions
+++ b/addons/functions/configuration.functions
@@ -143,6 +143,11 @@ function handle_network_change() {
       handle_interface_exists $interface
       check_code $?
     else
+      # --restore-as-is: don't prompt to remap/delete; leave the interface untouched.
+      if [ "${do_restore_as_is:-0}" = 1 ]; then
+        echo "--restore-as-is: leaving $interface untouched in pf.conf"
+        continue
+      fi
       stop_it=""
       while [ -z "$stop_it" ]; do
         sub_splitter

--- a/addons/functions/database.functions
+++ b/addons/functions/database.functions
@@ -48,7 +48,7 @@ function import_mysqldump() {
   mysql ${mariadb_args} -e "drop database if exists $db_name; create database $db_name"
 
   sub_splitter
-  # We reimport the schema so that we have the functions and triggers if the dump doesn't contain the triggers
+  # Detect a trigger-less dump (a pf-user mysqldump omits triggers); reapplied after import below.
   if ! egrep "CREATE.*TRIGGER.*(AFTER|BEFORE)" $dump_file > /dev/null; then
     echo "Dump file was made without triggers and procedures"
 
@@ -66,14 +66,28 @@ function import_mysqldump() {
     sed -i 's/DELETE IGNORE FROM `action`;//g' $dump_file
     sed -i 's/DELETE IGNORE FROM `activation`;//g' $dump_file
 
+    dump_without_triggers=1
   else
     echo "Dump file includes triggers and procedures"
+    dump_without_triggers=0
   fi
 
   sub_splitter
   echo "Importing $dump_file into $db_name"
   mysql ${mariadb_args} $db_name < $dump_file
   check_code $?
+
+  # A pf-user mysqldump omits triggers; reapply only the triggers (not tables/seed
+  # data, which would clobber the restored rows) from the matching schema.
+  if [ "$dump_without_triggers" = 1 ]; then
+    sub_splitter
+    schema_version=`echo "$pf_version_in_export" | egrep -o '^[0-9]+\.[0-9]+'`
+    schema_file="/usr/local/pf/db/pf-schema-$schema_version.sql"
+    [ -f "$schema_file" ] || schema_file="/usr/local/pf/db/pf-schema-X.Y.sql"
+    echo "Reapplying triggers from $schema_file"
+    awk '/^DELIMITER \//{b=$0 ORS;f=1;t=0;next} f&&/^DELIMITER ;/{b=b $0 ORS;if(t)printf "%s",b;f=0;next} f{b=b $0 ORS;if(/CREATE TRIGGER/)t=1}' "$schema_file" | mysql ${mariadb_args} $db_name
+    check_code $?
+  fi
 
   sub_splitter
   echo "Importing grants"

--- a/addons/functions/database.functions
+++ b/addons/functions/database.functions
@@ -78,6 +78,15 @@ function import_mysqldump() {
   mysql ${mariadb_args} $db_name < $dump_file
   check_code $?
 
+  # Recreate the empty structure of tables excluded from the dump (--ignore-table)
+  # so triggers that write to them (e.g. locationlog -> locationlog_history) work.
+  if [ -f excluded_tables_schema.sql ]; then
+    sub_splitter
+    echo "Restoring structure of tables excluded from the dump"
+    sed 's/CREATE TABLE /CREATE TABLE IF NOT EXISTS /g' excluded_tables_schema.sql | mysql ${mariadb_args} $db_name
+    check_code $?
+  fi
+
   # pf dump omits triggers: reapply from triggers.sql (new exports) or the matching schema
   # (old exports). Idempotent, so it is safe before upgrade_database patches changed triggers.
   if [ "$dump_without_triggers" = 1 ]; then

--- a/addons/functions/database.functions
+++ b/addons/functions/database.functions
@@ -80,11 +80,24 @@ function import_mysqldump() {
 
   # Recreate the empty structure of tables excluded from the dump (--ignore-table)
   # so triggers that write to them (e.g. locationlog -> locationlog_history) work.
+  # New exports carry excluded_tables_schema.sql; older ones don't, so fall back
+  # to the matching schema (same pattern as the trigger reapply below).
+  sub_splitter
   if [ -f excluded_tables_schema.sql ]; then
-    sub_splitter
-    echo "Restoring structure of tables excluded from the dump"
+    echo "Restoring structure of tables excluded from the dump (from export)"
     sed 's/CREATE TABLE /CREATE TABLE IF NOT EXISTS /g' excluded_tables_schema.sql | mysql ${mariadb_args} $db_name
     check_code $?
+  else
+    schema_version=`echo "$pf_version_in_export" | egrep -o '^[0-9]+\.[0-9]+'`
+    schema_file="/usr/local/pf/db/pf-schema-$schema_version.sql"
+    [ -f "$schema_file" ] || schema_file="/usr/local/pf/db/pf-schema-X.Y.sql"
+    echo "excluded_tables_schema.sql not in export, recreating excluded tables from $schema_file"
+    # Keep this list in sync with the --ignore-table list in backup-and-maintenance.sh.
+    for t in locationlog_history iplog_archive; do
+      awk -v t="$t" 'BEGIN{p=0} $0 ~ "^CREATE TABLE (IF NOT EXISTS )?`?" t "`?[ (]" {p=1} p{print} p&&/;[[:space:]]*$/{p=0}' "$schema_file" \
+        | sed 's/CREATE TABLE /CREATE TABLE IF NOT EXISTS /g' | mysql ${mariadb_args} $db_name
+      check_code $?
+    done
   fi
 
   # pf dump omits triggers: reapply from triggers.sql (new exports) or the matching schema

--- a/addons/functions/database.functions
+++ b/addons/functions/database.functions
@@ -32,7 +32,8 @@ function import_mysqldump() {
 
   mariadb_args="--defaults-file=`pwd`/setup_mycnf --socket=/var/lib/mysql/mysql.sock"
   # we need a grant dump generated via: mysql ${MYSQL_CONN} --skip-column-names -A -e"SELECT CONCAT('SHOW GRANTS FOR ''',user,'''@''',host,''';') FROM mysql.user WHERE user<>''" | mysql ${MYSQL_CONN} --skip-column-names -A | sed 's/$/;/g' > grants.sql
-  if ! test_db_connection_no_creds; then
+  # --restore-as-is: never prompt; rely on socket auth (fails later with a clear error if unavailable).
+  if ! test_db_connection_no_creds && [ "${do_restore_as_is:-0}" != 1 ]; then
     echo -n "Please enter the root password for MariaDB:"
     read -s mariadb_root_pass
     echo
@@ -77,16 +78,22 @@ function import_mysqldump() {
   mysql ${mariadb_args} $db_name < $dump_file
   check_code $?
 
-  # A pf-user mysqldump omits triggers; reapply only the triggers (not tables/seed
-  # data, which would clobber the restored rows) from the matching schema.
+  # pf dump omits triggers: reapply from triggers.sql (new exports) or the matching schema
+  # (old exports). Idempotent, so it is safe before upgrade_database patches changed triggers.
   if [ "$dump_without_triggers" = 1 ]; then
     sub_splitter
-    schema_version=`echo "$pf_version_in_export" | egrep -o '^[0-9]+\.[0-9]+'`
-    schema_file="/usr/local/pf/db/pf-schema-$schema_version.sql"
-    [ -f "$schema_file" ] || schema_file="/usr/local/pf/db/pf-schema-X.Y.sql"
-    echo "Reapplying triggers from $schema_file"
-    awk '/^DELIMITER \//{b=$0 ORS;f=1;t=0;next} f&&/^DELIMITER ;/{b=b $0 ORS;if(t)printf "%s",b;f=0;next} f{b=b $0 ORS;if(/CREATE TRIGGER/)t=1}' "$schema_file" | mysql ${mariadb_args} $db_name
-    check_code $?
+    if [ -f triggers.sql ]; then
+      echo "Applying triggers from export (triggers.sql)"
+      mysql ${mariadb_args} $db_name < triggers.sql
+      check_code $?
+    else
+      schema_version=`echo "$pf_version_in_export" | egrep -o '^[0-9]+\.[0-9]+'`
+      schema_file="/usr/local/pf/db/pf-schema-$schema_version.sql"
+      [ -f "$schema_file" ] || schema_file="/usr/local/pf/db/pf-schema-X.Y.sql"
+      echo "triggers.sql not found in export, reapplying triggers from $schema_file"
+      awk '/^DELIMITER \//{b=$0 ORS;f=1;t=0;next} f&&/^DELIMITER ;/{b=b $0 ORS;if(t)printf "%s",b;f=0;next} f{b=b $0 ORS;if(/CREATE TRIGGER/)t=1}' "$schema_file" | mysql ${mariadb_args} $db_name
+      check_code $?
+    fi
   fi
 
   sub_splitter
@@ -138,9 +145,14 @@ function import_mariabackup() {
   check_code $?
 
   sub_splitter
-  echo "Performing upgrade of MariaDB. Enter the MariaDB root password if prompted to"
-  echo "NOTE: The root password you must enter is the one of the server of which you're reimporting the data, not this server's MariaDB root password"
-  mysql_upgrade -p
+  # --restore-as-is: same version, no MariaDB engine upgrade.
+  if [ "${do_restore_as_is:-0}" = 1 ]; then
+    echo "--restore-as-is: same version, skipping MariaDB upgrade"
+  else
+    echo "Performing upgrade of MariaDB. Enter the MariaDB root password if prompted to"
+    echo "NOTE: The root password you must enter is the one of the server of which you're reimporting the data, not this server's MariaDB root password"
+    mysql_upgrade -p
+  fi
 
   popd
 }

--- a/addons/functions/database.functions
+++ b/addons/functions/database.functions
@@ -51,7 +51,7 @@ function import_mysqldump() {
   sub_splitter
   # Detect a trigger-less dump (a pf-user mysqldump omits triggers); reapplied after import below.
   if ! egrep "CREATE.*TRIGGER.*(AFTER|BEFORE)" $dump_file > /dev/null; then
-    echo "Dump file was made without triggers and procedures"
+    echo "Dump file was made without triggers"
 
     sub_splitter
     echo "Replacing CREATE TABLE and DROP TABLE statements"

--- a/addons/functions/database.functions
+++ b/addons/functions/database.functions
@@ -69,7 +69,7 @@ function import_mysqldump() {
 
     dump_without_triggers=1
   else
-    echo "Dump file includes triggers and procedures"
+    echo "Dump file includes triggers"
     dump_without_triggers=0
   fi
 

--- a/addons/functions/helpers.functions
+++ b/addons/functions/helpers.functions
@@ -18,6 +18,11 @@ function check_code() {
 
 function prompt() {
   msg="$1"
+  # --restore-as-is: don't ask, keep things as they are (answer "no").
+  if [ "${do_restore_as_is:-0}" = 1 ]; then
+    echo "$msg (y/n): n [--restore-as-is]"
+    return 1
+  fi
   answer=""
   while [ "$answer" != "y" ] && [ "$answer" != "n" ]; do
     echo -n "$msg (y/n): "

--- a/docs/installation/export_import_mechanism.asciidoc
+++ b/docs/installation/export_import_mechanism.asciidoc
@@ -157,6 +157,23 @@ If any issues are experienced during import, run it again.
 
 If all goes well, restart services using <<PacketFence_Upgrade_Guide.asciidoc#_restart_packetfence_services,following instructions>>.
 
+===== Import options
+
+Without any option, `import.sh` performs a full import (database and configuration)
+and upgrades them to the running version when the export comes from an older one.
+
+`-f, --file <archive>`:: Path to the export archive to import (mandatory).
+`--db`:: Import only the database.
+`--conf`:: Import only the configuration.
+`--restore-as-is`:: Restore the export exactly as it was backed up. Intended for
+restoring onto the *same* PacketFence version: no database, MariaDB or
+configuration upgrade is performed, the backup's database host and port are kept,
+and no question is asked (fully non-interactive).
+`--skip-adjust-db-conf`:: On a configuration import, keep the backup's database
+host and port instead of rewriting them to `localhost`. Useful on a cross-version
+import that must preserve a non-local database host. (`--restore-as-is` already
+implies this.)
+
 ===== Additional steps to build or rebuild a cluster
 
 To build or rebuild a cluster, follow instructions in <<PacketFence_Clustering_Guide.asciidoc#_cluster_setup,Cluster setup section>>.

--- a/docs/installation/export_import_mechanism.asciidoc
+++ b/docs/installation/export_import_mechanism.asciidoc
@@ -48,28 +48,51 @@ installations.
    at end of import process.
 [options="compact"]
 * The import process will not join server to Active Directory domains automatically. Rejoin server manually.
-* The import process will only restore the files that can be edited via the admin interface which include:
-** Standard configuration files in [filename]`/usr/local/pf/conf/*.conf`
+* The import process restores the configuration files tracked by PacketFence
+(the [filename]`@pf::file_paths::stored_config_files` list), which include:
+** Standard configuration files in [filename]`/usr/local/pf/conf/*.conf`,
+including [filename]`log.conf`, [filename]`pfconfig.conf` and
+[filename]`cluster.conf`
+** A few non-`.conf` data files stored alongside the configuration:
+[filename]`oui.txt`, [filename]`allowed_device_oui.txt`,
+[filename]`allowed_device_types.txt` and
+[filename]`fingerbank-collector.env.defaults`
+** The [filename]`vlan_filters.conf.defaults` and
+[filename]`radius_filters.conf.defaults` default files
+** Files referenced from the configuration that live outside the standard set,
+discovered automatically at export time (for example
+[filename]`/usr/local/pf/conf/iptables-custom.conf.inc` and
+[filename]`/usr/local/pf/conf/ip6tables-custom.conf.inc`)
 ** Connection profiles HTML templates in
 [filename]`/usr/local/pf/html/captive-portal/profile-templates/`
 ** Standard certificates
 *** [filename]`/usr/local/pf/conf/ssl/*`
 *** [filename]`/usr/local/pf/raddb/certs/*`
+** [filename]`/usr/local/pf/conf/cluster.conf` (adjusted for the local node, see below)
+
+NOTE: Because the [filename]`*.conf.defaults` files above are restored as-is,
+importing an older export can overwrite the default files shipped with the
+running version. Review them after a cross-version import.
+
 [options="compact"]
 * Here is a short list of the configuration files that will not be restored. Changes to these files need to be migrated manually. This list is not meant to be complete:
 ** [filename]`/usr/local/pf/conf/radiusd/*`
-** [filename]`/usr/local/pf/conf/log.conf`
 ** [filename]`/usr/local/pf/conf/log.conf.d/*`
-** [filename]`/usr/local/pf/conf/iptables.conf.tt` (but
-[filename]`/usr/local/pf/conf/iptables-custom.conf.inc` and
-[filename]`/usr/local/pf/conf/ip6tables-custom.conf.inc` are restored)
-** [filename]`/usr/local/pf/conf/cluster.conf`
+** [filename]`/usr/local/pf/conf/iptables.conf.tt`
 
 
-WARNING: The import process will never replace a virtual IP address in
-configurations. If the export has been done on a cluster, ensure there are no
-references to
-virtual IP address of this cluster after import has been completed.
+* When the export comes from a cluster, [filename]`cluster.conf` is restored and
+adjusted for the server running the import: the local node's section
+([filename]`[<hostname>]`) has its interface IPs and management IP rewritten to
+match the values applied to [filename]`pf.conf`, and any interface rename is
+propagated to the `CLUSTER` (virtual IP) sections. This adjustment is skipped
+with `--restore-as-is`, which restores [filename]`cluster.conf` verbatim.
+
+WARNING: The import process only adjusts the local node in [filename]`cluster.conf`.
+It never rewrites virtual IP addresses, and peer-node sections cannot be derived
+from a single server. After the import, verify the `CLUSTER` sections and the
+other nodes' sections in [filename]`/usr/local/pf/conf/cluster.conf`, and ensure
+there are no stale references to the previous cluster's virtual IP addresses.
 
 === Export on current installation
 
@@ -169,6 +192,13 @@ and upgrades them to the running version when the export comes from an older one
 restoring onto the *same* PacketFence version: no database, MariaDB or
 configuration upgrade is performed, the backup's database host and port are kept,
 and no question is asked (fully non-interactive).
+
+NOTE: With `--restore-as-is`, files are restored verbatim and no node-specific
+adjustment is applied. For example, [filename]`cluster.conf` is copied as-is
+without rewriting the local node's interfaces or IP addresses (the same holds for
+other configuration files that a normal import would adjust). Use this option
+only when restoring onto a host whose identity matches the backup; otherwise run
+a normal import so these files are adjusted for this server.
 `--skip-adjust-db-conf`:: On a configuration import, keep the backup's database
 host and port instead of rewriting them to `localhost`. Useful on a cross-version
 import that must preserve a non-local database host. (`--restore-as-is` already
@@ -179,7 +209,9 @@ implies this.)
 To build or rebuild a cluster, follow instructions in <<PacketFence_Clustering_Guide.asciidoc#_cluster_setup,Cluster setup section>>.
 
 If the previous installation was a cluster, some steps may not be necessary
-to do.  The export archive will contain the previous
-[filename]`cluster.conf` file.
+to do.  The export archive contains the previous [filename]`cluster.conf`
+file, which is restored and adjusted for the local node during the import (see
+the assumptions and limitations above). Review the `CLUSTER` and peer-node
+sections before starting the cluster.
 
 WARNING: if Mariabackup was installed before running the import, it's possible that it needs to be reinstalled.

--- a/docs/installation/export_import_mechanism.asciidoc
+++ b/docs/installation/export_import_mechanism.asciidoc
@@ -51,8 +51,8 @@ installations.
 * The import process restores the configuration files tracked by PacketFence
 (the [filename]`@pf::file_paths::stored_config_files` list), which include:
 ** Standard configuration files in [filename]`/usr/local/pf/conf/*.conf`,
-including [filename]`log.conf`, [filename]`pfconfig.conf` and
-[filename]`cluster.conf`
+including [filename]`log.conf` and [filename]`pfconfig.conf`
+(but *not* [filename]`cluster.conf`, see below)
 ** A few non-`.conf` data files stored alongside the configuration:
 [filename]`oui.txt`, [filename]`allowed_device_oui.txt`,
 [filename]`allowed_device_types.txt` and
@@ -68,7 +68,6 @@ discovered automatically at export time (for example
 ** Standard certificates
 *** [filename]`/usr/local/pf/conf/ssl/*`
 *** [filename]`/usr/local/pf/raddb/certs/*`
-** [filename]`/usr/local/pf/conf/cluster.conf` (adjusted for the local node, see below)
 
 NOTE: Because the [filename]`*.conf.defaults` files above are restored as-is,
 importing an older export can overwrite the default files shipped with the
@@ -81,18 +80,24 @@ running version. Review them after a cross-version import.
 ** [filename]`/usr/local/pf/conf/iptables.conf.tt`
 
 
-* When the export comes from a cluster, [filename]`cluster.conf` is restored and
-adjusted for the server running the import: the local node's section
-([filename]`[<hostname>]`) has its interface IPs and management IP rewritten to
-match the values applied to [filename]`pf.conf`, and any interface rename is
-propagated to the `CLUSTER` (virtual IP) sections. This adjustment is skipped
-with `--restore-as-is`, which restores [filename]`cluster.conf` verbatim.
+* [filename]`cluster.conf` is *not* restored by default. The imported server is
+left standalone with an empty [filename]`cluster.conf`, and the export's copy is
+kept as [filename]`/usr/local/pf/conf/cluster.conf.imported` for reference. This
+matches the recommendation to import onto a standalone server. Two options change
+this behaviour:
+** `--update-cluster-conf` restores the export's [filename]`cluster.conf` and
+adjusts it for this server: the local node's section ([filename]`[<hostname>]`)
+has its interface IPs and management IP rewritten to match the values applied to
+[filename]`pf.conf`, and any interface rename is propagated to the `CLUSTER`
+(virtual IP) sections.
+** `--restore-as-is` leaves this server's *current* [filename]`cluster.conf`
+untouched (it is neither reset nor overwritten from the export).
 
-WARNING: The import process only adjusts the local node in [filename]`cluster.conf`.
-It never rewrites virtual IP addresses, and peer-node sections cannot be derived
-from a single server. After the import, verify the `CLUSTER` sections and the
-other nodes' sections in [filename]`/usr/local/pf/conf/cluster.conf`, and ensure
-there are no stale references to the previous cluster's virtual IP addresses.
+WARNING: With `--update-cluster-conf`, only the local node is adjusted. Virtual
+IP addresses are never rewritten, and peer-node sections cannot be derived from a
+single server. After the import, verify the `CLUSTER` sections and the other
+nodes' sections in [filename]`/usr/local/pf/conf/cluster.conf`, and ensure there
+are no stale references to the previous cluster's virtual IP addresses.
 
 === Export on current installation
 
@@ -191,14 +196,14 @@ and upgrades them to the running version when the export comes from an older one
 `--restore-as-is`:: Restore the export exactly as it was backed up. Intended for
 restoring onto the *same* PacketFence version: no database, MariaDB or
 configuration upgrade is performed, the backup's database host and port are kept,
-and no question is asked (fully non-interactive).
-
-NOTE: With `--restore-as-is`, files are restored verbatim and no node-specific
-adjustment is applied. For example, [filename]`cluster.conf` is copied as-is
-without rewriting the local node's interfaces or IP addresses (the same holds for
-other configuration files that a normal import would adjust). Use this option
-only when restoring onto a host whose identity matches the backup; otherwise run
-a normal import so these files are adjusted for this server.
+and no question is asked (fully non-interactive). This server's current
+[filename]`cluster.conf` is kept untouched (it is not reset nor overwritten from
+the export).
+`--update-cluster-conf`:: Restore the export's [filename]`cluster.conf` and adjust
+it for this server (see the assumptions and limitations above). Without this
+option, [filename]`cluster.conf` is not imported: the server is left standalone
+with an empty [filename]`cluster.conf` and the export's copy is kept as
+[filename]`cluster.conf.imported`. Ignored when `--restore-as-is` is used.
 `--skip-adjust-db-conf`:: On a configuration import, keep the backup's database
 host and port instead of rewriting them to `localhost`. Useful on a cross-version
 import that must preserve a non-local database host. (`--restore-as-is` already
@@ -209,9 +214,10 @@ implies this.)
 To build or rebuild a cluster, follow instructions in <<PacketFence_Clustering_Guide.asciidoc#_cluster_setup,Cluster setup section>>.
 
 If the previous installation was a cluster, some steps may not be necessary
-to do.  The export archive contains the previous [filename]`cluster.conf`
-file, which is restored and adjusted for the local node during the import (see
-the assumptions and limitations above). Review the `CLUSTER` and peer-node
-sections before starting the cluster.
+to do.  By default the import leaves the server standalone and keeps the export's
+[filename]`cluster.conf` as [filename]`cluster.conf.imported` for reference. To
+reuse the previous cluster configuration, run the import with
+`--update-cluster-conf`, then review the `CLUSTER` and peer-node sections before
+starting the cluster (see the assumptions and limitations above).
 
 WARNING: if Mariabackup was installed before running the import, it's possible that it needs to be reinstalled.

--- a/t/venom/test_suites/backup_db_and_restore/00_backup_db_and_restore.yml
+++ b/t/venom/test_suites/backup_db_and_restore/00_backup_db_and_restore.yml
@@ -19,3 +19,11 @@ testcases:
         "Content-Type": "application/json"
       assertions:
         - result.statuscode ShouldEqual 201
+
+# Seed a marker in a restored config location so later tests can prove the config is restored.
+- name: create_config_restore_marker
+  steps:
+  - type: exec
+    script: echo 'venom-config-restore-marker' > {{.backup_db_and_restore.conf_marker}}
+    assertions:
+      - result.code ShouldEqual 0

--- a/t/venom/test_suites/backup_db_and_restore/05_backup_db_and_restore.yml
+++ b/t/venom/test_suites/backup_db_and_restore/05_backup_db_and_restore.yml
@@ -22,13 +22,15 @@ testcases:
       echo "$list"
       echo "$list" | grep -q '^grants.sql$'
       echo "$list" | grep -q '^triggers.sql$'
+      echo "$list" | grep -q '^excluded_tables_schema.sql$'
       db=$(echo "$list" | grep -E '^packetfence-db-dump-.*\.sql\.gz$' | head -n 1)
       [ -n "$db" ]
       tmp=$(mktemp -d)
-      tar -xzf "$tgz" -C "$tmp" "$db" triggers.sql
+      tar -xzf "$tgz" -C "$tmp" "$db" triggers.sql excluded_tables_schema.sql
       zcat "$tmp/$db" | grep -q 'CREATE TABLE'              # schema
       zcat "$tmp/$db" | grep -q 'INSERT INTO'               # data
       grep -qiE 'CREATE .*TRIGGER' "$tmp/triggers.sql"      # triggers
+      grep -q 'locationlog_history' "$tmp/excluded_tables_schema.sql"  # excluded table structure
       rm -rf "$tmp"
     assertions:
       - result.code ShouldEqual 0

--- a/t/venom/test_suites/backup_db_and_restore/05_backup_db_and_restore.yml
+++ b/t/venom/test_suites/backup_db_and_restore/05_backup_db_and_restore.yml
@@ -9,6 +9,30 @@ testcases:
   - type: exec
     script: /usr/local/pf/addons/exportable-backup.sh
 
+# The export must be self-contained: schema + data (db dump), triggers/routines
+# and grants are each packaged into the archive alongside each other.
+- name: export_archive_contains_all_objects
+  steps:
+  - type: exec
+    script: |
+      tgz=$(find {{.backup_db_and_restore.backup_dir}} -name "packetfence-exportable-backup-*.tgz" -newermt "-10 minute" | head -n 1)
+      [ -n "$tgz" ] || { echo "no exportable backup archive found"; exit 1; }
+      echo "archive=$tgz"
+      list=$(tar -tzf "$tgz")
+      echo "$list"
+      echo "$list" | grep -q '^grants.sql$'
+      echo "$list" | grep -q '^triggers.sql$'
+      db=$(echo "$list" | grep -E '^packetfence-db-dump-.*\.sql\.gz$' | head -n 1)
+      [ -n "$db" ]
+      tmp=$(mktemp -d)
+      tar -xzf "$tgz" -C "$tmp" "$db" triggers.sql
+      zcat "$tmp/$db" | grep -q 'CREATE TABLE'              # schema
+      zcat "$tmp/$db" | grep -q 'INSERT INTO'               # data
+      grep -qiE 'CREATE .*TRIGGER' "$tmp/triggers.sql"      # triggers
+      rm -rf "$tmp"
+    assertions:
+      - result.code ShouldEqual 0
+
 - name: delete_user_in_db
   steps:
   - type: http

--- a/t/venom/test_suites/backup_db_and_restore/10_backup_db_and_restore.yml
+++ b/t/venom/test_suites/backup_db_and_restore/10_backup_db_and_restore.yml
@@ -10,7 +10,7 @@ testcases:
 - name: import_previous_exportation
   steps:
   - type: exec
-    script: '/usr/local/pf/addons/full-import/import.sh --db-restore -f {{.get_backup_name.result.systemout}}'
+    script: '/usr/local/pf/addons/full-import/import.sh --db --restore-as-is -f {{.get_backup_name.result.systemout}}'
 
 - name: sleep_for_iptables_to_restart
   steps:

--- a/t/venom/test_suites/backup_db_and_restore/10_backup_db_and_restore.yml
+++ b/t/venom/test_suites/backup_db_and_restore/10_backup_db_and_restore.yml
@@ -12,7 +12,11 @@ testcases:
   - type: exec
     script: '/usr/local/pf/addons/full-import/import.sh --db --restore-as-is -f {{.get_backup_name.result.systemout}}'
 
-- name: sleep_for_iptables_to_restart
+# import.sh isolates packetfence-base; restart PacketFence like an operator would
+# so the webadmin API is reachable for the following testcases.
+- name: restart_packetfence
   steps:
+  - type: pfcmd_run_command
+    command: 'service pf start'
   - type: exec
-    script: sleep 10
+    script: sleep 30

--- a/t/venom/test_suites/backup_db_and_restore/15_backup_db_and_restore.yml
+++ b/t/venom/test_suites/backup_db_and_restore/15_backup_db_and_restore.yml
@@ -23,7 +23,7 @@ testcases:
   steps:
   - type: exec
     script: |
-      [ -n "$(mysql -N pf -e "SHOW TABLES LIKE 'locationlog_history';")" ] || { echo "locationlog_history missing"; exit 1; }
+      [ "$(mysql -N pf -e "SELECT COUNT(*) FROM information_schema.TABLES WHERE TABLE_SCHEMA='pf' AND TABLE_NAME='locationlog_history';")" = 1 ] || { echo "locationlog_history missing"; exit 1; }
       c=$(mysql -N pf -e "SELECT COUNT(*) FROM locationlog_history;")
       echo "locationlog_history_rows=$c"
       [ "$c" -eq 0 ]

--- a/t/venom/test_suites/backup_db_and_restore/15_backup_db_and_restore.yml
+++ b/t/venom/test_suites/backup_db_and_restore/15_backup_db_and_restore.yml
@@ -1,5 +1,35 @@
 name: Verify DB triggers and routines survived the restore
 testcases:
+# Every table defined in the reference schema must exist after the restore.
+- name: all_schema_tables_are_present
+  steps:
+  - type: exec
+    script: |
+      ver=$(egrep -o '[0-9]+\.[0-9]+\.[0-9]+' /usr/local/pf/conf/pf-release | egrep -o '^[0-9]+\.[0-9]+')
+      schema=/usr/local/pf/db/pf-schema-$ver.sql
+      [ -f "$schema" ] || schema=/usr/local/pf/db/pf-schema-X.Y.sql
+      missing=""
+      for t in $(grep -oE '^CREATE TABLE (IF NOT EXISTS )?`?[a-zA-Z0-9_]+`?' "$schema" | sed -E 's/^CREATE TABLE (IF NOT EXISTS )?//; s/`//g'); do
+        [ -n "$(mysql -N pf -e "SHOW TABLES LIKE '$t';")" ] || missing="$missing $t"
+      done
+      echo "schema=$schema missing_tables:$missing"
+      [ -z "$missing" ]
+    assertions:
+      - result.code ShouldEqual 0
+
+# locationlog_history is excluded from the dump; the import must recreate it
+# empty (so the locationlog trigger that writes to it works).
+- name: excluded_table_present_and_empty
+  steps:
+  - type: exec
+    script: |
+      [ -n "$(mysql -N pf -e "SHOW TABLES LIKE 'locationlog_history';")" ] || { echo "locationlog_history missing"; exit 1; }
+      c=$(mysql -N pf -e "SELECT COUNT(*) FROM locationlog_history;")
+      echo "locationlog_history_rows=$c"
+      [ "$c" -eq 0 ]
+    assertions:
+      - result.code ShouldEqual 0
+
 # Query as root: SHOW TRIGGERS / information_schema is privilege-filtered for the pf user.
 - name: password_delete_trigger_is_present
   steps:

--- a/t/venom/test_suites/backup_db_and_restore/15_backup_db_and_restore.yml
+++ b/t/venom/test_suites/backup_db_and_restore/15_backup_db_and_restore.yml
@@ -1,0 +1,38 @@
+name: Verify DB triggers survived the restore
+testcases:
+# Query as root: SHOW TRIGGERS / information_schema is privilege-filtered for the pf user.
+- name: password_delete_trigger_is_present
+  steps:
+  - type: exec
+    script: mysql -N pf -e "SELECT COUNT(*) FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA='pf' AND TRIGGER_NAME='password_delete_trigger';"
+    assertions:
+      - result.systemout ShouldEqual 1
+
+- name: all_schema_triggers_are_present
+  steps:
+  - type: exec
+    script: |
+      ver=$(egrep -o '[0-9]+\.[0-9]+\.[0-9]+' /usr/local/pf/conf/pf-release | egrep -o '^[0-9]+\.[0-9]+')
+      schema=/usr/local/pf/db/pf-schema-$ver.sql
+      [ -f "$schema" ] || schema=/usr/local/pf/db/pf-schema-X.Y.sql
+      expected=$(grep -cE '^CREATE TRIGGER ' "$schema")
+      actual=$(mysql -N pf -e "SELECT COUNT(*) FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA='pf';")
+      echo "schema=$schema expected=$expected actual=$actual"
+      [ "$expected" -gt 0 ] && [ "$expected" -eq "$actual" ]
+    assertions:
+      - result.code ShouldEqual 0
+
+- name: deleting_a_person_removes_its_password
+  steps:
+  - type: exec
+    script: |
+      mysql pf -e "DELETE FROM password WHERE pid='venom_trigger_check'; DELETE FROM person WHERE pid='venom_trigger_check';"
+      mysql pf -e "INSERT INTO person(pid) VALUES('venom_trigger_check');"
+      mysql pf -e "INSERT INTO password(pid,password,expiration) VALUES('venom_trigger_check','x','2031-12-01 00:00:00');"
+      mysql pf -e "DELETE FROM person WHERE pid='venom_trigger_check';"
+      left=$(mysql -N pf -e "SELECT COUNT(*) FROM password WHERE pid='venom_trigger_check';")
+      mysql pf -e "DELETE FROM password WHERE pid='venom_trigger_check';"
+      echo "password_rows_after_person_delete=$left"
+      [ "$left" -eq 0 ]
+    assertions:
+      - result.code ShouldEqual 0

--- a/t/venom/test_suites/backup_db_and_restore/15_backup_db_and_restore.yml
+++ b/t/venom/test_suites/backup_db_and_restore/15_backup_db_and_restore.yml
@@ -1,4 +1,4 @@
-name: Verify DB triggers survived the restore
+name: Verify DB triggers and routines survived the restore
 testcases:
 # Query as root: SHOW TRIGGERS / information_schema is privilege-filtered for the pf user.
 - name: password_delete_trigger_is_present
@@ -19,6 +19,16 @@ testcases:
       actual=$(mysql -N pf -e "SELECT COUNT(*) FROM information_schema.TRIGGERS WHERE TRIGGER_SCHEMA='pf';")
       echo "schema=$schema expected=$expected actual=$actual"
       [ "$expected" -gt 0 ] && [ "$expected" -eq "$actual" ]
+    assertions:
+      - result.code ShouldEqual 0
+
+- name: all_db_routines_are_present
+  steps:
+  - type: exec
+    script: |
+      actual=$(mysql -N pf -e "SELECT COUNT(*) FROM information_schema.ROUTINES WHERE ROUTINE_SCHEMA='pf' AND ROUTINE_NAME IN ('acct_start','acct_stop','acct_update','FREERADIUS_DECODE','ROUND_TO_HOUR','ROUND_TO_MONTH');")
+      echo "routines_present=$actual"
+      [ "$actual" -eq 6 ]
     assertions:
       - result.code ShouldEqual 0
 

--- a/t/venom/test_suites/backup_db_and_restore/15_backup_db_and_restore.yml
+++ b/t/venom/test_suites/backup_db_and_restore/15_backup_db_and_restore.yml
@@ -10,7 +10,7 @@ testcases:
       [ -f "$schema" ] || schema=/usr/local/pf/db/pf-schema-X.Y.sql
       missing=""
       for t in $(grep -oE '^CREATE TABLE (IF NOT EXISTS )?`?[a-zA-Z0-9_]+`?' "$schema" | sed -E 's/^CREATE TABLE (IF NOT EXISTS )?//; s/`//g'); do
-        [ -n "$(mysql -N pf -e "SHOW TABLES LIKE '$t';")" ] || missing="$missing $t"
+        [ "$(mysql -N pf -e "SELECT COUNT(*) FROM information_schema.TABLES WHERE TABLE_SCHEMA='pf' AND TABLE_NAME='$t';")" = 1 ] || missing="$missing $t"
       done
       echo "schema=$schema missing_tables:$missing"
       [ -z "$missing" ]

--- a/t/venom/test_suites/backup_db_and_restore/25_backup_db_and_restore.yml
+++ b/t/venom/test_suites/backup_db_and_restore/25_backup_db_and_restore.yml
@@ -1,0 +1,41 @@
+name: Restore configuration only with --conf --restore-as-is
+testcases:
+- name: get_backup_name
+  steps:
+  - type: exec
+    script: 'find {{.backup_db_and_restore.backup_dir}} -name "packetfence-exportable-backup-*.tgz" -newermt "-30 minute" | head -n 1'
+    assertions:
+      - result.systemout ShouldNotBeEmpty
+
+# Remove the marker so a successful restore has to bring it back from the backup.
+- name: remove_config_marker
+  steps:
+  - type: exec
+    script: rm -f {{.backup_db_and_restore.conf_marker}}
+    assertions:
+      - result.code ShouldEqual 0
+
+- name: import_conf_restore_as_is
+  steps:
+  - type: exec
+    script: '/usr/local/pf/addons/full-import/import.sh --conf --restore-as-is -f {{.get_backup_name.result.systemout}}'
+    assertions:
+      - result.code ShouldEqual 0
+      - result.systemout ShouldContainSubstring skipping configuration upgrade
+
+# Config restored: the marker file is back with its original content.
+- name: config_marker_restored
+  steps:
+  - type: exec
+    script: cat {{.backup_db_and_restore.conf_marker}}
+    assertions:
+      - result.code ShouldEqual 0
+      - result.systemout ShouldContainSubstring venom-config-restore-marker
+
+# A configuration-only import must not touch the database: the restored user is still there.
+- name: db_left_untouched
+  steps:
+  - type: exec
+    script: mysql -N pf -e "SELECT COUNT(*) FROM person WHERE pid='{{.backup_db_and_restore.user}}';"
+    assertions:
+      - result.systemout ShouldEqual 1

--- a/t/venom/test_suites/backup_db_and_restore/25_backup_db_and_restore.yml
+++ b/t/venom/test_suites/backup_db_and_restore/25_backup_db_and_restore.yml
@@ -39,3 +39,12 @@ testcases:
     script: mysql -N pf -e "SELECT COUNT(*) FROM person WHERE pid='{{.backup_db_and_restore.user}}';"
     assertions:
       - result.systemout ShouldEqual 1
+
+# import.sh isolates packetfence-base; restart PacketFence like an operator would
+# so the webadmin API is reachable for the following testsuite.
+- name: restart_packetfence
+  steps:
+  - type: pfcmd_run_command
+    command: 'service pf start'
+  - type: exec
+    script: sleep 30

--- a/t/venom/test_suites/backup_db_and_restore/30_backup_db_and_restore.yml
+++ b/t/venom/test_suites/backup_db_and_restore/30_backup_db_and_restore.yml
@@ -1,0 +1,67 @@
+name: Full restore with --restore-as-is
+testcases:
+- name: get_login_token
+  steps:
+  - type: get_login_token
+    retry: 5
+    delay: 1
+
+# Wipe both the DB user and the config marker so a full restore has to bring both back.
+- name: delete_user_in_db
+  steps:
+  - type: http
+    method: DELETE
+    url: '{{.pfserver_webadmin_url}}/api/v1/user/{{.backup_db_and_restore.user}}'
+    ignore_verify_ssl: true
+    headers:
+      "Authorization": "{{.get_login_token.result.token}}"
+      "Content-Type": "application/json"
+    assertions:
+      - result.statuscode ShouldEqual 200
+
+- name: remove_config_marker
+  steps:
+  - type: exec
+    script: rm -f {{.backup_db_and_restore.conf_marker}}
+    assertions:
+      - result.code ShouldEqual 0
+
+- name: get_backup_name
+  steps:
+  - type: exec
+    script: 'find {{.backup_db_and_restore.backup_dir}} -name "packetfence-exportable-backup-*.tgz" -newermt "-30 minute" | head -n 1'
+    assertions:
+      - result.systemout ShouldNotBeEmpty
+
+- name: import_full_restore_as_is
+  steps:
+  - type: exec
+    script: '/usr/local/pf/addons/full-import/import.sh --restore-as-is -f {{.get_backup_name.result.systemout}}'
+    assertions:
+      - result.code ShouldEqual 0
+      - result.systemout ShouldContainSubstring skipping database upgrade
+      - result.systemout ShouldContainSubstring skipping configuration upgrade
+
+- name: sleep_for_services_to_restart
+  steps:
+  - type: exec
+    script: sleep 10
+
+# Database restored: the user is back.
+- name: user_restored_in_db
+  steps:
+  - type: exec
+    script: mysql -N pf -e "SELECT COUNT(*) FROM person WHERE pid='{{.backup_db_and_restore.user}}';"
+    assertions:
+      - result.systemout ShouldEqual 1
+    retry: 5
+    delay: 2
+
+# Configuration restored: the marker file is back with its original content.
+- name: config_marker_restored
+  steps:
+  - type: exec
+    script: cat {{.backup_db_and_restore.conf_marker}}
+    assertions:
+      - result.code ShouldEqual 0
+      - result.systemout ShouldContainSubstring venom-config-restore-marker

--- a/t/venom/test_suites/backup_db_and_restore/30_backup_db_and_restore.yml
+++ b/t/venom/test_suites/backup_db_and_restore/30_backup_db_and_restore.yml
@@ -42,10 +42,14 @@ testcases:
       - result.systemout ShouldContainSubstring skipping database upgrade
       - result.systemout ShouldContainSubstring skipping configuration upgrade
 
-- name: sleep_for_services_to_restart
+# import.sh isolates packetfence-base; restart PacketFence like an operator would
+# so the DB is up here and the webadmin API is reachable for the teardown.
+- name: restart_packetfence
   steps:
+  - type: pfcmd_run_command
+    command: 'service pf start'
   - type: exec
-    script: sleep 10
+    script: sleep 30
 
 # Database restored: the user is back.
 - name: user_restored_in_db

--- a/t/venom/test_suites/backup_db_and_restore/TESTSUITE.md
+++ b/t/venom/test_suites/backup_db_and_restore/TESTSUITE.md
@@ -6,10 +6,11 @@ MariaDB running and available using UNIX socket
 ## Scenario steps
 1. Create user in DB using API and seed a config marker file
 2. Backup files and DB with exportable-backup script, and check the archive
-   carries the schema, data, grants and triggers
+   carries the schema, data, grants, triggers and the excluded tables' structure
 3. Delete user in DB using API
-4. Restore the database only with `--db --restore-as-is` and check the DB
-   triggers and routines survived the restore
+4. Restore the database only with `--db --restore-as-is` and check that all
+   schema tables are present (including the excluded, now-empty
+   locationlog_history) and the DB triggers and routines survived the restore
 5. Check that the user created at first step is still here using API
 6. Restore the configuration only with `--conf --restore-as-is` and check the
    config marker is restored while the database is left untouched

--- a/t/venom/test_suites/backup_db_and_restore/TESTSUITE.md
+++ b/t/venom/test_suites/backup_db_and_restore/TESTSUITE.md
@@ -4,13 +4,19 @@
 MariaDB running and available using UNIX socket
 
 ## Scenario steps
-1. Create user in DB using API
-2. Backup files and DB with exportable-backup script
+1. Create user in DB using API and seed a config marker file
+2. Backup files and DB with exportable-backup script, and check the archive
+   carries the schema, data, grants and triggers
 3. Delete user in DB using API
-4. Import only db from backup
-5. Check that user created at first step is still here using API: validate
-   that application is running after DB restore
+4. Restore the database only with `--db --restore-as-is` and check the DB
+   triggers and routines survived the restore
+5. Check that the user created at first step is still here using API
+6. Restore the configuration only with `--conf --restore-as-is` and check the
+   config marker is restored while the database is left untouched
+7. Full restore with `--restore-as-is` and check both the user (database) and
+   the config marker (configuration) are restored
 
 ## Teardown steps
 1. Remove all backup files
-2. Remove user created
+2. Remove the config marker
+3. Remove user created

--- a/t/venom/test_suites/backup_db_and_restore/teardown/00_teardown.yml
+++ b/t/venom/test_suites/backup_db_and_restore/teardown/00_teardown.yml
@@ -9,6 +9,11 @@ testcases:
     - type: exec
       script: 'find {{.backup_db_and_restore.backup_dir}} -name "packetfence-*" -delete'
 
+- name: delete_config_marker
+  steps:
+    - type: exec
+      script: rm -f {{.backup_db_and_restore.conf_marker}}
+
 - name: delete_user_in_db
   steps:
   - type: http

--- a/t/venom/vars/all.yml
+++ b/t/venom/vars/all.yml
@@ -190,6 +190,8 @@ wireless_dot1x_eap_peap.profiles.wireless.unreg_on_acct_stop: enabled
 # Create user for db
 backup_db_and_restore.user: adminvenom
 backup_db_and_restore.backup_dir: /root/backup
+# Non-functional marker file used to prove configuration is restored from the backup
+backup_db_and_restore.conf_marker: /usr/local/pf/html/captive-portal/profile-templates/venom_restore_marker.txt
 
 ################################################################################
 ## mac auth test suites specific variables


### PR DESCRIPTION
# Description
(REQUIRED)

Restoring a PacketFence DB silently dropped all triggers, so the restored
instance stopped cleaning up related rows — most visibly, deleting a user no
longer removed its `password` row (re-creating the user then failed with `409
Conflict`), and the `ip4log`/`ip6log`/`locationlog` history triggers were lost.

Root cause: `mysqldump` runs as the `pf` user, which lacks the `TRIGGER`
privilege, so the dump has no triggers. On import the DB is dropped, recreated
and reloaded from that trigger-less dump, and the triggers were never reapplied.

Fix:
- **Reapply triggers on import.** `import_mysqldump` reapplies triggers when the
  dump has none — from `triggers.sql` in the export, falling back to the matching
  `pf-schema-<version>.sql`. Idempotent, and runs before `upgrade_database`.
- **Self-contained export.** `export.sh` (already root) also dumps `triggers.sql`
  (triggers only). Routines already ride in the base dump; there are no DB events.
- **Replace `--db-restore` with `--restore-as-is`.** A composable non-interactive
  modifier (with `--db`/`--conf`/full) that skips upgrades and keeps the backup's
  values.

# Impacts
(REQUIRED)
- `export.sh` emits `triggers.sql` alongside `grants.sql`.
- `database.functions` (`import_mysqldump`) reapplies triggers when the dump lacks
  them.
- `import.sh` drops `--db-restore`, adds `--restore-as-is`.

# Backport
(REQUIRED)
Bug was masked by cross-version upgrades but real for same-version restore, a
standard workflow since `exportable-backup` (14.1). Affected: **14.1 → 15.1**.
Backport to at least **maintenance/15.1**.

# Delete branch after merge
(REQUIRED)
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [x] Document the feature — n/a (documented in the script's `--help`)
- [x] Add unit tests — n/a (shell backup/import path)
- [x] Add acceptance tests — venom `backup_db_and_restore` checks the export
  carries triggers and that triggers/routines survive the restore, and covers the
  `--restore-as-is` db/conf/full restores, each restarting PacketFence
  (`pfcmd service pf start`) so the API is reachable after.

# NEWS file entries
(REQUIRED, but may be optional...)
## Bug Fixes
* Database import/restore no longer drops triggers, fixing orphaned `password`
  rows after a user is deleted on restored databases
## Enhancements
* The exportable backup now includes the database triggers so a restore is
  self-contained; `import.sh` gains `--restore-as-is` for non-interactive imports

# UPGRADE file entries
(OPTIONAL, but may be required...)
Databases restored with older code may be missing triggers. Re-import with the
fixed code, or reapply from `/usr/local/pf/db/pf-schema-<version>.sql` as root.
