### PR TITLE
build(radiusd): pin FreeRADIUS 4:3.2.11+git 

### DIFF
--- a/containers/radiusd/Dockerfile
+++ b/containers/radiusd/Dockerfile
@@ -4,7 +4,7 @@ FROM ${KNK_REGISTRY_URL}/pfdebian:${IMAGE_TAG}
 
 RUN apt-get -qq update \
     && apt-get clean \
-    && apt-get -qq install -y freeradius=4:3.2.8+git freeradius-common=4:3.2.8+git freeradius-config=4:3.2.8+git freeradius-ldap=4:3.2.8+git freeradius-mysql=4:3.2.8+git freeradius-redis=4:3.2.8+git freeradius-rest=4:3.2.8+git freeradius-utils=4:3.2.8+git \
+    && apt-get -qq install -y freeradius=4:3.2.11+git freeradius-common=4:3.2.11+git freeradius-config=4:3.2.11+git freeradius-ldap=4:3.2.11+git freeradius-mysql=4:3.2.11+git freeradius-redis=4:3.2.11+git freeradius-rest=4:3.2.11+git freeradius-utils=4:3.2.11+git \
     && apt-get clean
 
 WORKDIR /usr/local/pf/


### PR DESCRIPTION
4:3.2.8+git is no longer published in the pool, so the devel radiusd image build fails (E: Version '4:3.2.8+git' for 'freeradius' was not found). Pin the exact published version 4:3.2.11+git.

Make Jeremy happy again

