### PR TITLE
fix(radiusd): remove unused SoH module symlink

### DIFF
--- a/raddb/mods-enabled/soh
+++ b/raddb/mods-enabled/soh
@@ -1,1 +1,0 @@
-../mods-available/soh


### PR DESCRIPTION
# Description
(REQUIRED)
Drops the dead `raddb/mods-enabled/soh` symlink — vendored leftover from the stock FreeRADIUS 3 config copy. No enabled PacketFence virtual server invokes the `soh` module, so it was parsed at startup but never called. `raddb/mods-available/soh` stays in place.

# Impacts
(REQUIRED)
- None at runtime. Reviewer: confirm no enabled site (`packetfence`, `-tunnel`, `-cli`, `eduroam`, `-cluster`) references `soh`.

# Delete branch after merge
(REQUIRED)
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ ] Document the feature — n/a
- [ ] Add OpenAPI specification — n/a
- [ ] Add unit tests — n/a
- [ ] Add acceptance tests (TestLink) — n/a

# NEWS file entries
## Bug Fixes
* Removed unused SoH FreeRADIUS module symlink from `raddb/mods-enabled`
