### PR TITLE
fix(ci): bound log collection so it can't skip VM destroy

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -681,6 +681,20 @@ lint_ci_yaml:
       .gitlab-ci.yml
   allow_failure: false
 
+# Guards that a hung log collection can't skip VM destruction during cleanup.
+test_clean_environment:
+  extends:
+    - .check_job
+  needs:
+    - job: run_pipeline_if_necessary
+      optional: true
+  image: ${PFBUILD_DEB_IMG}:${PFBUILD_DEFAULT_DEV_TAG}
+  rules:
+    - when: always
+  script:
+    - ${TESTCIDIR}/clean-test-environment.test.sh
+  allow_failure: false
+
 ########################################
 # BUILD_IMG_CONTAINER JOBS (kaniko / pfdebian / pfdebian_related / radiusd / radiusd_related)
 ########################################

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,6 +30,9 @@ variables:
   # synced with Pipeline timeout in GitLab UI
   PIPELINE_TIMEOUT_SCRIPT: 160m
   PIPELINE_TIMEOUT_CLEANUP: 10m
+  # sub-budgets of PIPELINE_TIMEOUT_CLEANUP; sum must stay below it
+  PIPELINE_TIMEOUT_TEARDOWN: 6m
+  PIPELINE_TIMEOUT_CLEAN: 3m
   BUILD_PFAPPSERVER_VUE: "yes"
   PFBUILD_RHEL_IMG: ghcr.io/inverse-inc/packetfence/pfbuild-centos-8
   PFBUILD_DEB_IMG: ghcr.io/inverse-inc/packetfence/pfbuild-debian-bookworm

--- a/ci/lib/test/clean-test-environment.sh
+++ b/ci/lib/test/clean-test-environment.sh
@@ -54,13 +54,22 @@ configure_and_check() {
     fi
 }
 
+# best-effort and bounded so a hung log fetch can't starve the destroy below
 teardown() {
-    MAKE_TARGET=teardown make -e -C ${TEST_DIR} ${CI_JOB_NAME}
+    timeout "${PIPELINE_TIMEOUT_TEARDOWN:-6m}" \
+        env MAKE_TARGET=teardown make -e -C ${TEST_DIR} ${CI_JOB_NAME} \
+        || echo "WARN: log collection timed out or failed, continuing to VM destroy"
+}
+
+# VM destroy, bounded and independent from log collection; its exit code decides cleanup success
+clean() {
+    timeout "${PIPELINE_TIMEOUT_CLEAN:-3m}" \
+        env MAKE_TARGET=clean make -e -C ${TEST_DIR} ${CI_JOB_NAME}
 }
 
 teardown_clean() {
     teardown
-    MAKE_TARGET=clean make -e -C ${TEST_DIR} ${CI_JOB_NAME}
+    clean
 }
 
 log_section "Configure and check"

--- a/ci/lib/test/clean-test-environment.test.sh
+++ b/ci/lib/test/clean-test-environment.test.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Regression test for clean-test-environment.sh: a hung/slow log collection
+# (teardown) must not prevent VM destruction (clean), even when the outer
+# PIPELINE_TIMEOUT_CLEANUP fires.
+#
+# Usage: clean-test-environment.test.sh [path-to-clean-test-environment.sh]
+set -o nounset -o pipefail
+
+SCRIPT_DIR=$(readlink -e "$(dirname "${BASH_SOURCE[0]}")")
+TARGET="${1:-${SCRIPT_DIR}/clean-test-environment.sh}"
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+export DESTROY_MARKER="$WORK/destroyed"
+
+# Fake make on PATH: teardown hangs longer than the outer timeout, clean
+# records that VM destruction ran.
+mkdir -p "$WORK/bin"
+cat > "$WORK/bin/make" <<'EOF'
+#!/bin/bash
+if [ "${MAKE_TARGET:-}" = "teardown" ]; then
+    exec sleep "${FAKE_TEARDOWN_SLEEP:-6}"
+elif [ "${MAKE_TARGET:-}" = "clean" ]; then
+    : > "$DESTROY_MARKER"
+fi
+EOF
+chmod +x "$WORK/bin/make"
+
+# Outer timeout mirrors .gitlab-ci.yml's PIPELINE_TIMEOUT_CLEANUP wrapper.
+# teardown budget (1s) < hung log fetch (6s) < outer budget (4s): the fix must
+# kill log collection early and still reach VM destroy.
+timeout 4s \
+    env PATH="$WORK/bin:$PATH" \
+        PIPELINE_TIMEOUT_TEARDOWN=1s \
+        PIPELINE_TIMEOUT_CLEAN=2s \
+        JOB_STATUS=1 \
+        CI_JOB_NAME=unit_tests_deb12 \
+        KEEP_VMS=no \
+        CI_PIPELINE_SOURCE=push \
+        bash "$TARGET" >/dev/null 2>&1 || true
+
+if [ -f "$DESTROY_MARKER" ]; then
+    echo "PASS: VM destroy ran despite log collection timing out"
+    exit 0
+fi
+echo "FAIL: VM destroy did not run after log collection timed out"
+exit 1

--- a/ci/lib/test/clean-test-environment.test.sh
+++ b/ci/lib/test/clean-test-environment.test.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # Regression test for clean-test-environment.sh: a hung/slow log collection
-# (teardown) must not prevent VM destruction (clean), even when the outer
-# PIPELINE_TIMEOUT_CLEANUP fires.
+# (teardown) must not prevent VM destruction (clean). Without an internal
+# teardown bound, a hung fetch would run past the outer PIPELINE_TIMEOUT_CLEANUP
+# and abort the job before clean; the fix keeps cleanup under that budget.
 #
 # Usage: clean-test-environment.test.sh [path-to-clean-test-environment.sh]
 set -o nounset -o pipefail
@@ -28,8 +29,9 @@ EOF
 chmod +x "$WORK/bin/make"
 
 # Outer timeout mirrors .gitlab-ci.yml's PIPELINE_TIMEOUT_CLEANUP wrapper.
-# teardown budget (1s) < hung log fetch (6s) < outer budget (4s): the fix must
-# kill log collection early and still reach VM destroy.
+# Without the internal bound the hung 6s fetch would exceed the 4s outer budget
+# and abort before VM destroy. Bounding teardown (1s) + clean (2s) keeps cleanup
+# under the outer budget, so it never fires and destroy still runs.
 timeout 4s \
     env PATH="$WORK/bin:$PATH" \
         PIPELINE_TIMEOUT_TEARDOWN=1s \


### PR DESCRIPTION
# Description
(REQUIRED)
Splits CI cleanup into two bounded steps: `teardown` (log collection) is now best-effort under `PIPELINE_TIMEOUT_TEARDOWN`, and `clean` (VM destroy) runs independently under `PIPELINE_TIMEOUT_CLEAN`. Previously a hung log fetch could eat the whole cleanup window and leave test VMs alive, leaking runner resources. VM destroy now always runs and its exit code decides cleanup success. Adds a `clean-test-environment.test.sh` unit test plus a `test_clean_environment` CI job to guard the behavior.

# Impacts
(REQUIRED)
- CI cleanup stage. Reviewer: confirm the two new sub-budgets stay under `PIPELINE_TIMEOUT_CLEANUP` (10m), and that a timed-out `teardown` still reaches `clean`.

# Delete branch after merge
(REQUIRED)
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ ] Document the feature — n/a
- [ ] Add OpenAPI specification — n/a
- [x] Add unit tests — yes (`clean-test-environment.test.sh`)
- [ ] Add acceptance tests (TestLink) — n/a

# NEWS file entries
## Bug Fixes
* CI cleanup: bound log collection so a hang can't skip VM destroy and leak test VMs