### PR TITLE
fix(azuread): resolve group membership by email when username absent

### DIFF
--- a/lib/pf/Authentication/Source/AzureADSource.pm
+++ b/lib/pf/Authentication/Source/AzureADSource.pm
@@ -228,7 +228,19 @@ sub get_cached_memberOf {
 
 sub match_in_subclass {
     my ($self, $params, $rule, $own_conditions, $matching_conditions) = @_;
-    $params->{memberOf} = [ $self->get_cached_memberOf($params->{username}, $params) ];
+    # Some flows (e.g. sponsor validation) only provide the identity under
+    # 'email' rather than 'username'. Mirror the LDAP source behavior and fall
+    # back to the email so the Graph memberOf lookup can resolve the user
+    # (Graph accepts the userPrincipalName / email as the {id} key).
+    my $username = $params->{username};
+    $username = $params->{email} unless (defined($username) && length($username));
+    if (defined($username) && length($username)) {
+        $params->{memberOf} = [ $self->get_cached_memberOf($username, $params) ];
+    }
+    else {
+        get_logger->warn("No username or email provided while matching in AzureAD source ".$self->id."; skipping group (memberOf) lookup.");
+        $params->{memberOf} = [];
+    }
     my $match = $rule->match;
     # If match any we just want the first
     my @conditions;
@@ -240,7 +252,7 @@ sub match_in_subclass {
         @conditions = grep { $self->match_condition($_, $params) } @$own_conditions;
     }
     push @$matching_conditions, @conditions;
-    return ($params->{'username'}, undef);
+    return ($username, undef);
 }
 
 


### PR DESCRIPTION
The sponsor validation flow (Sponsor.pm) calls pf::authentication::match with the sponsor identity under the 'email' key rather than 'username'. LDAPSource already falls back to 'email' in this case, but AzureADSource read only $params->{username}, so the Graph memberOf lookup fired with an empty identity -> GET /v1.0/users//memberOf -> 404 Not Found plus uninitialized-value warnings, and the sponsor could never be matched.

match_in_subclass now resolves the identity as username // email (Graph accepts the userPrincipalName/email as the {id} key) and returns that resolved identity so the rule is treated as matched. get_memberOf also short-circuits defensively when called with no identity.

