### PR TITLE
fix(configurator): set admin password when schema seeds no default (#9118)

### DIFF
--- a/html/pfappserver/root/src/views/Configurator/packetfence/_components/FormAdministrator.vue
+++ b/html/pfappserver/root/src/views/Configurator/packetfence/_components/FormAdministrator.vue
@@ -98,20 +98,27 @@ export const setup = (props, context) => {
     let savePromise = new Promise((resolve, reject) => {
       const { pid, password } = form.value
       form.value.valid_from = "1970-01-01 00:00:00"
-      if (userExists.value) {
-        $store.dispatch('$_users/updatePassword', Object.assign({ quiet: true }, { pid, password })).then(resolve, reject)
-      } else {
-        $store.dispatch('$_users/getUser', { pid: 'admin', quiet: true }).then(() => {
-          // User exists
-          userExists.value = true
+      // admin no longer has a default password row in the schema (#9118): create it (POST) with
+      // the ALL access level the seed row used to grant when absent, update it (PATCH) otherwise
+      const createPassword = () => $store.dispatch('$_users/createPassword', Object.assign({ quiet: true }, {
+        pid,
+        password,
+        access_level: 'ALL',
+        valid_from: '1970-01-01',
+        expiration: '2038-01-01'
+      })).then(resolve, reject)
+      // re-fetch: the database is configured earlier in this same step, so the mount lookup may have failed
+      $store.dispatch('$_users/getUser', { pid: 'admin', quiet: true }).then(_form => {
+        userExists.value = true
+        if (_form.has_password) {
           $store.dispatch('$_users/updatePassword', Object.assign({ quiet: true }, { pid, password })).then(resolve, reject)
-        }).catch(() => {
-          // User doesn't exist
-          $store.dispatch('$_users/createUser', form.value).then(() => {
-            $store.dispatch('$_users/createPassword', Object.assign({ quiet: true }, form.value)).then(resolve, reject)
-          }).catch(reject)
-        })
-      }
+        } else {
+          createPassword()
+        }
+      }).catch(() => {
+        // User doesn't exist
+        $store.dispatch('$_users/createUser', form.value).then(createPassword).catch(reject)
+      })
     })
     return savePromise
       .then(() => state.value.administrator = form.value)

--- a/html/pfappserver/root/src/views/Configurator/packetfence/_components/FormAdministrator.vue
+++ b/html/pfappserver/root/src/views/Configurator/packetfence/_components/FormAdministrator.vue
@@ -106,6 +106,7 @@ export const setup = (props, context) => {
         access_level: 'ALL',
         valid_from: '1970-01-01 00:00:00',
         expiration: '2038-01-01 00:00:00'
+      })).then(resolve, reject)
       // re-fetch: the database is configured earlier in this same step, so the mount lookup may have failed
       $store.dispatch('$_users/getUser', { pid: 'admin', quiet: true }).then(_form => {
         userExists.value = true

--- a/html/pfappserver/root/src/views/Configurator/packetfence/_components/FormAdministrator.vue
+++ b/html/pfappserver/root/src/views/Configurator/packetfence/_components/FormAdministrator.vue
@@ -104,9 +104,8 @@ export const setup = (props, context) => {
         pid,
         password,
         access_level: 'ALL',
-        valid_from: '1970-01-01',
-        expiration: '2038-01-01'
-      })).then(resolve, reject)
+        valid_from: '1970-01-01 00:00:00',
+        expiration: '2038-01-01 00:00:00'
       // re-fetch: the database is configured earlier in this same step, so the mount lookup may have failed
       $store.dispatch('$_users/getUser', { pid: 'admin', quiet: true }).then(_form => {
         userExists.value = true

--- a/t/venom/test_suites/configurator/20_run_configurator_step2.yml
+++ b/t/venom/test_suites/configurator/20_run_configurator_step2.yml
@@ -199,8 +199,8 @@ testcases:
         "password": "{{.configurator.admin.password}}",
         "pid": "admin",
         "access_level": "ALL",
-        "valid_from": "1970-01-01",
-        "expiration": "2038-01-01"
+        "valid_from": "1970-01-01 00:00:00",
+        "expiration": "2038-01-01 00:00:00"
       }
     headers:
       "Content-Type": "application/json"

--- a/t/venom/test_suites/configurator/20_run_configurator_step2.yml
+++ b/t/venom/test_suites/configurator/20_run_configurator_step2.yml
@@ -205,4 +205,4 @@ testcases:
     headers:
       "Content-Type": "application/json"
     assertions:
-      - result.statuscode ShouldEqual 200
+      - result.statuscode ShouldEqual 201

--- a/t/venom/test_suites/configurator/20_run_configurator_step2.yml
+++ b/t/venom/test_suites/configurator/20_run_configurator_step2.yml
@@ -187,16 +187,20 @@ testcases:
     assertions:
       - result.statuscode ShouldEqual 200
 
+# admin no longer has a default password row in the schema, so create it (POST) instead of updating (PATCH)
 - name: set_admin_account_password
   steps:
   - type: http
-    method: PATCH
+    method: POST
     url: '{{.pfserver_webadmin_url}}/api/v1/configurator/user/admin/password'
     ignore_verify_ssl: true
     body: >-
       {
         "password": "{{.configurator.admin.password}}",
-        "pid": "admin"
+        "pid": "admin",
+        "access_level": "ALL",
+        "valid_from": "1970-01-01",
+        "expiration": "2038-01-01"
       }
     headers:
       "Content-Type": "application/json"


### PR DESCRIPTION
# Description
Fixes admin password setup after #9118 removed the seeded `admin` password row.
The `person` row for `admin` still exists but has no `password` row, so both the
venom test and the configurator wizard were updating (PATCH) a row that didn't
exist and failing with 404. They now create it (POST) with the `ALL` access level
the seed row used to grant.

# Impacts
- Configurator "Configure PacketFence" step (`FormAdministrator.vue`): admin password
  create/update flow — branch on `has_password`, POST when absent, PATCH when present.
- Venom `configurator` test suite: `set_admin_account_password` now POSTs and expects 201.

# Issue
follows #9118

# Delete branch after merge
YES

# Checklist
- [n/a] Document the feature
- [n/a] Add OpenAPI specification
- [n/a] Add unit tests
- [yes] Add acceptance tests (TestLink) — covered by existing venom configurator suite

# NEWS file entries
## Bug Fixes
* Configurator wizard and venom test failed to set the admin password after the default
  password row was removed from the schema (#9118)