### PR TITLE
fix(pfconnector): bind DNS tunnels on 0.0.0.0 and make k8s port patching idempotent

### DIFF
--- a/go/chisel/server/server_handler.go
+++ b/go/chisel/server/server_handler.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -315,44 +316,71 @@ func (s *Server) handleWebsocket(w http.ResponseWriter, req *http.Request) {
 	}
 
 	if client := pfk8s.NewAdminClientFromEnv(); client != nil {
-		patchPortsAdd := []pfk8s.PatchPorts{}
-		patchPortsDel := []pfk8s.PatchPorts{}
-
 		services, err := client.GetService("pfconnector")
 		if err != nil {
-			l.Printf("Error getting pfconnector service: %v", err)
-			// If we can't get the service, we can't patch it, so we just return
-		}
+			// If we can't read the service we can't safely diff its ports, so skip
+			// patching entirely rather than blindly adding (and duplicating) ports.
+			l.Printf("Error getting pfconnector service, skipping port patching: %v", err)
+		} else {
+			patchPortsAdd := []pfk8s.PatchPorts{}
+			delIndexes := []int{}
+			seenNames := map[string]bool{}
 
-		for _, remote := range additionalRemotes {
-			port, _ := strconv.ParseUint(remote.LocalPort, 10, 16)
-			for index, port := range services.Spec.Ports {
-				if port.Name == "port-"+strings.ToLower(remote.LocalProto)+"-"+remote.LocalPort {
-					// If the port already exists, we need to remove it first
+			for _, remote := range additionalRemotes {
+				port, _ := strconv.ParseUint(remote.LocalPort, 10, 16)
+				portName := "port-" + strings.ToLower(remote.LocalProto) + "-" + remote.LocalPort
 
-					patchPortsDel = append(patchPortsDel, pfk8s.PatchPorts{
-						Op:   "remove",
-						Path: "/spec/ports/" + strconv.Itoa(index),
-					})
+				// Skip duplicate remote definitions so we never add the same port
+				// name twice in a single patch.
+				if seenNames[portName] {
+					continue
 				}
+				seenNames[portName] = true
+
+				// Collect every existing port carrying this name so they get removed
+				// first. There may be more than one if a previous run left stale
+				// duplicates behind.
+				for index, svcPort := range services.Spec.Ports {
+					if svcPort.Name == portName {
+						delIndexes = append(delIndexes, index)
+					}
+				}
+
+				patchPortsAdd = append(patchPortsAdd, pfk8s.PatchPorts{
+					Op:   "add",
+					Path: "/spec/ports/-",
+					Value: pfk8s.PatchPortAdd{
+						Port:       int(port),
+						TargetPort: int(port),
+						Protocol:   strings.ToUpper(remote.LocalProto),
+						Name:       portName,
+					},
+				})
 			}
 
-			patchPortsAdd = append(patchPortsAdd, pfk8s.PatchPorts{
-				Op:   "add",
-				Path: "/spec/ports/-",
-				Value: pfk8s.PatchPortAdd{
-					Port:       int(port),
-					TargetPort: int(port),
-					Protocol:   strings.ToUpper(remote.LocalProto),
-					Name:       "port-" + strings.ToLower(remote.LocalProto) + "-" + remote.LocalPort,
-				},
-			})
-		}
-		if err := client.PatchPorts(patchPortsDel); err != nil {
-			l.Printf("Error deleting ports: %v", err)
-		}
-		if err := client.PatchPorts(patchPortsAdd); err != nil {
-			l.Printf("Error adding ports: %v", err)
+			// A JSON Patch applies its operations sequentially, so removing a lower
+			// index first shifts every following element down and makes the later
+			// indexes point at the wrong port (or out of range). Applying the
+			// removals from highest index to lowest keeps every recorded index valid.
+			sort.Sort(sort.Reverse(sort.IntSlice(delIndexes)))
+
+			// Send removals and adds as a single atomic patch, removals first. This
+			// guarantees we never re-add a name that still exists, which is what
+			// produced the k8s "Duplicate value" 422s when a connector reconnected.
+			patch := make([]pfk8s.PatchPorts, 0, len(delIndexes)+len(patchPortsAdd))
+			for _, index := range delIndexes {
+				patch = append(patch, pfk8s.PatchPorts{
+					Op:   "remove",
+					Path: "/spec/ports/" + strconv.Itoa(index),
+				})
+			}
+			patch = append(patch, patchPortsAdd...)
+
+			if len(patch) > 0 {
+				if err := client.PatchPorts(patch); err != nil {
+					l.Printf("Error patching ports: %v", err)
+				}
+			}
 		}
 	}
 

--- a/lib/pfconfig/namespaces/resource/pfconnector_static_connections.pm
+++ b/lib/pfconfig/namespaces/resource/pfconnector_static_connections.pm
@@ -35,8 +35,6 @@ sub init {
       $self->{cache}->get_cache('config::DnsConnectors');
     $self->{_domain_config} =
       $self->{cache}->get_cache('config::Domain');
-    $self->{_pf_config} =
-      $self->{cache}->get_cache('config::Pf');
 }
 
 sub find_connector {
@@ -58,7 +56,6 @@ sub find_connector {
 sub build {
     my ($self) = @_;
     my %hash;
-    my $dns_host = $self->{_pf_config}{'services_host'}{'pfdns_connector_service_host'} // '100.64.0.1';
 
     while ( my ( $id, $data ) =
         each %{ $self->{_authentication_config}{authentication_config_hash} } )
@@ -80,9 +77,13 @@ sub build {
         my $port = $data->{'pfconnector_port'};
         next unless defined $port;
         my $connector = $self->find_connector( $data->{ip} );
-        my $r         = "${dns_host}:${port}:$data->{ip}:$data->{port}/udp";
+        # No local bind host: bind 0.0.0.0 so the pfconnector server listens on
+        # all interfaces (matches the RADIUS/NTLM branches). In k8s the front-end
+        # IP is provided by the pfconnector Service, and binding a specific
+        # Service/cluster IP on the pod fails with "cannot assign requested address".
+        my $r         = "${port}:$data->{ip}:$data->{port}/udp";
         push @{ $hash{$connector} }, $r;
-        $r         = "${dns_host}:${port}:$data->{ip}:$data->{port}";
+        $r         = "${port}:$data->{ip}:$data->{port}";
         push @{ $hash{$connector} }, $r;
     }
     for my $id ( keys %{ $self->{_domain_config} } ) {


### PR DESCRIPTION
# Description
The DNS branch of resource::pfconnector_static_connections prepended pfdns_connector_service_host as the local bind host, unlike the RADIUS/NTLM branches. In k8s that value is the pfconnector Service ClusterIP, which the pod cannot bind, so the tunnel proxy failed with 'bind: cannot assign requested address'. Drop the prefix so DNS tunnels bind 0.0.0.0 and let the Service provide the front-end IP.

Also fix the Service port patching in the chisel server: remove-by-index ops are now sorted descending and sent together with the adds in a single atomic patch, so reconnects no longer fail with k8s 'Duplicate value' 422s (removing a lower index first shifted later indexes out of range, leaving stale ports that the add then collided with).

# Impacts
pfcloud


# Delete branch after merge
YES


# Checklist
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Bug Fixes
* Fixed dynamic bind for pfconnector for dns requests

