### PR TITLE
fix/sereal-safe

### DIFF
--- a/lib/pf/Sereal.pm
+++ b/lib/pf/Sereal.pm
@@ -15,14 +15,44 @@ pf::Sereal
 use strict;
 use warnings;
 use Sereal::Encoder;
-use Sereal::Decoder;
+use Sereal::Decoder qw(sereal_decode_with_object);
+use Scalar::Util qw(reftype);
 use base qw(Exporter);
 
-our @EXPORT_OK = qw($ENCODER $DECODER $ENCODER_FREEZER);
+our @EXPORT_OK = qw($ENCODER $DECODER $ENCODER_FREEZER $DECODER_SAFE %ALLOWED_THAW sereal_decode_safe);
 
 our $ENCODER = Sereal::Encoder->new();
 our $ENCODER_FREEZER = Sereal::Encoder->new({ freeze_callbacks => 1});
 our $DECODER = Sereal::Decoder->new;
+
+=head2 $DECODER_SAFE
+
+A restricted decoder used to deserialize data coming from a less-trusted
+boundary (network sockets, the queue, the database).
+
+It is created with C<no_thaw_objects> so it B<never> invokes an object's
+C<THAW> method on its own. Instead, each frozen object is returned as a
+C<Sereal::Decoder::THAW_args> placeholder (a blessed array ref whose leading
+elements are the C<FREEZE> arguments and whose last element is the target
+class name). L</sereal_decode_safe> walks the decoded structure and only
+reconstructs the classes explicitly listed in L</%ALLOWED_THAW>, turning an
+otherwise arbitrary C<< $class->THAW(...) >> gadget into an allow-listed
+operation.
+
+=cut
+
+our $DECODER_SAFE = Sereal::Decoder->new({ no_thaw_objects => 1 });
+
+=head2 %ALLOWED_THAW
+
+The set of class names L</sereal_decode_safe> is willing to run C<THAW> on.
+Anything not listed here throws instead of being deserialized into an object.
+
+=cut
+
+our %ALLOWED_THAW = (
+    'pf::config::crypt::object' => 1,
+);
 
 =head2 CLONE
 
@@ -34,6 +64,57 @@ sub CLONE {
     $ENCODER = Sereal::Encoder->new;
     $DECODER = Sereal::Decoder->new;
     $ENCODER_FREEZER = Sereal::Encoder->new({ freeze_callbacks => 1});
+    $DECODER_SAFE = Sereal::Decoder->new({ no_thaw_objects => 1 });
+}
+
+=head2 sereal_decode_safe($blob)
+
+Decode a Sereal C<$blob> using L</$DECODER_SAFE> and reconstruct any frozen
+objects, but only for the classes listed in L</%ALLOWED_THAW>. Encountering a
+frozen object of any other class is fatal. Returns the decoded structure.
+
+=cut
+
+sub sereal_decode_safe {
+    my ($blob) = @_;
+    my $data;
+    sereal_decode_with_object($DECODER_SAFE, $blob, $data);
+    return _thaw_allowlisted($data, {});
+}
+
+# Recursively walk a structure decoded with $DECODER_SAFE, replacing every
+# Sereal::Decoder::THAW_args placeholder with the real object -- but only when
+# its target class is allow-listed. We descend into the guts of blessed
+# objects too, because allow-listed frozen values (e.g. encrypted config
+# fields) legitimately appear nested inside blessed config objects such as
+# authentication sources.
+sub _thaw_allowlisted {
+    my ($node, $seen) = @_;
+    return $node unless ref $node;
+    return $node if $seen->{$node}++;    # guard against cycles
+
+    if (ref($node) eq 'Sereal::Decoder::THAW_args') {
+        my @args   = @$node;
+        my $target = pop @args;
+        unless ($ALLOWED_THAW{$target}) {
+            die "pf::Sereal: refusing to THAW disallowed class '$target'\n";
+        }
+        # Thaw inner objects first (matches Sereal's LIFO thaw ordering).
+        $_ = _thaw_allowlisted($_, $seen) for @args;
+        return $target->THAW("Sereal", @args);
+    }
+
+    my $reftype = reftype($node);
+    if ($reftype eq 'ARRAY') {
+        $_ = _thaw_allowlisted($_, $seen) for @$node;
+    }
+    elsif ($reftype eq 'HASH') {
+        $_ = _thaw_allowlisted($_, $seen) for values %$node;
+    }
+    elsif ($reftype eq 'SCALAR' || $reftype eq 'REF') {
+        $$node = _thaw_allowlisted($$node, $seen);
+    }
+    return $node;
 }
 
 =head1 AUTHOR

--- a/lib/pf/Sereal/CHISerializer.pm
+++ b/lib/pf/Sereal/CHISerializer.pm
@@ -1,0 +1,84 @@
+package pf::Sereal::CHISerializer;
+
+=head1 NAME
+
+pf::Sereal::CHISerializer - CHI value serializer backed by pf::Sereal
+
+=cut
+
+=head1 DESCRIPTION
+
+pf::Sereal::CHISerializer
+
+A drop-in CHI serializer (an object exposing C<serialize>/C<deserialize>) that
+encodes with the freeze-aware encoder and, crucially, decodes through
+L<pf::Sereal/sereal_decode_safe> so a CHI backend will only ever run C<THAW>
+on the classes listed in C<%pf::Sereal::ALLOWED_THAW>.
+
+It exists because L<Data::Serializer::Sereal> insists on a bare
+C<Sereal::Decoder> instance and calls C<THAW> unconditionally, which leaves no
+seam to restrict which classes get deserialized.
+
+=cut
+
+use strict;
+use warnings;
+use Sereal::Encoder qw(sereal_encode_with_object);
+use pf::Sereal qw($ENCODER_FREEZER sereal_decode_safe);
+
+sub new {
+    my ($proto) = @_;
+    my $class = ref($proto) || $proto;
+    return bless({}, $class);
+}
+
+=head2 serialize($value)
+
+Encode a value the same way the rest of pfconfig does (freeze callbacks on).
+
+=cut
+
+sub serialize {
+    my ($self, $value) = @_;
+    return sereal_encode_with_object($ENCODER_FREEZER, $value);
+}
+
+=head2 deserialize($blob)
+
+Decode using the restricted decoder, reconstructing only allow-listed classes.
+
+=cut
+
+sub deserialize {
+    my ($self, $blob) = @_;
+    return sereal_decode_safe($blob);
+}
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2026 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;

--- a/lib/pf/pfqueue/consumer/redis.pm
+++ b/lib/pf/pfqueue/consumer/redis.pm
@@ -16,10 +16,9 @@ use strict;
 use warnings;
 use pf::Redis;
 use Time::HiRes qw(usleep);
-use Sereal::Decoder qw(sereal_decode_with_object);
 use pf::dal;
 use pf::log;
-use pf::Sereal qw($DECODER);
+use pf::Sereal qw(sereal_decode_safe);
 use Moo;
 use pf::util::pfqueue qw(task_counter_id);
 use pf::constants::pfqueue qw(
@@ -122,7 +121,7 @@ sub process_next_job {
         local $@;
         eval {
             local $@;
-            sereal_decode_with_object($DECODER, $data, my $item);
+            my $item = sereal_decode_safe($data);
             if (ref($item) ne 'ARRAY') {
                 die "Invalid object stored in queue";
             }

--- a/lib/pfconfig/backend/memory.pm
+++ b/lib/pfconfig/backend/memory.pm
@@ -20,7 +20,7 @@ use warnings;
 use base 'pfconfig::backend';
 use CHI;
 use pfconfig::empty_string;
-use pf::Sereal qw($DECODER $ENCODER_FREEZER);
+use pf::Sereal::CHISerializer;
 
 my $empty_string = pfconfig::empty_string->new;
 
@@ -35,10 +35,7 @@ sub init {
     $self->{cache} = CHI->new(
         driver       => 'Memory',
         datastore    => {},
-        'serializer' => {
-            serializer => 'Sereal',
-            options    => { encoder => $ENCODER_FREEZER, decoder => $DECODER }
-        }
+        'serializer' => pf::Sereal::CHISerializer->new,
     );
 }
 

--- a/lib/pfconfig/backend/mysql.pm
+++ b/lib/pfconfig/backend/mysql.pm
@@ -15,12 +15,11 @@ pfconfig::backend::mysql
 use strict;
 use warnings;
 use Sereal::Encoder qw(sereal_encode_with_object);
-use Sereal::Decoder qw(sereal_decode_with_object);
 use DBI;
 use pfconfig::config;
 use Try::Tiny;
 use pf::log;
-use pf::Sereal qw($DECODER $ENCODER_FREEZER);
+use pf::Sereal qw($ENCODER_FREEZER sereal_decode_safe);
 use pf::config::crypt::object;
 use pf::config::crypt::object::freeze;
 
@@ -213,7 +212,7 @@ sub get {
     }
     my $element;
     while ( my $row = $statement->fetchrow_hashref() ) {
-        $element = sereal_decode_with_object($DECODER, $row->{value});
+        $element = sereal_decode_safe($row->{value});
     }
     return $element;
 }

--- a/lib/pfconfig/cached.pm
+++ b/lib/pfconfig/cached.pm
@@ -35,9 +35,8 @@ use JSON::MaybeXS;
 use pf::log;
 use pfconfig::util qw($undef_element normalize_namespace_query);
 use pfconfig::constants;
-use Sereal::Decoder qw(sereal_decode_with_object);
 use Time::HiRes qw(stat time);
-use pf::Sereal qw($DECODER);
+use pf::Sereal qw(sereal_decode_safe);
 use pfconfig::config;
 use pf::config::crypt::object;
 use pf::config::crypt::string;
@@ -231,7 +230,7 @@ sub _get_from_socket {
     # it returns it as a sereal hash
     my $result;
     if ( $response ne "undef\n" ) {
-        eval { $result = sereal_decode_with_object($DECODER, $response); };
+        eval { $result = sereal_decode_safe($response); };
         if ($@) {
             print STDERR $@;
             print STDERR "$what $response";

--- a/lib/pfconfig/util.pm
+++ b/lib/pfconfig/util.pm
@@ -24,8 +24,7 @@ use pfconfig::undef_element;
 use pf::log;
 use pfconfig::constants;
 use IO::Socket::UNIX;
-use pf::Sereal qw($DECODER);
-use Sereal::Decoder qw(sereal_decode_with_object);
+use pf::Sereal qw(sereal_decode_safe);
 use Readonly;
 use JSON::MaybeXS qw(encode_json);
 use pfconfig::config;
@@ -81,7 +80,7 @@ sub fetch_decode_socket {
     die "cannot connect to the server $!n" unless $socket;
 
     my $response = fetch_socket($socket, $payload);
-    return sereal_decode_with_object($DECODER, $response);
+    return sereal_decode_safe($response);
 }
 
 sub socket_expire {

--- a/t/unittest/Sereal.t
+++ b/t/unittest/Sereal.t
@@ -1,0 +1,162 @@
+#!/usr/bin/perl
+
+=head1 NAME
+
+Sereal
+
+=head1 DESCRIPTION
+
+unit test for pf::Sereal, in particular the restricted decoder
+(sereal_decode_safe) which only reconstructs allow-listed THAW classes.
+
+=cut
+
+use strict;
+use warnings;
+
+BEGIN {
+    #include test libs
+    use lib qw(/usr/local/pf/t);
+    #Adds lib and lib_perl to @INC (does not start pfconfig)
+    use test_paths;
+}
+
+use Test::More;
+use CHI;
+use Sereal::Encoder qw(sereal_encode_with_object);
+use pf::Sereal qw($ENCODER_FREEZER %ALLOWED_THAW sereal_decode_safe);
+use pf::Sereal::CHISerializer;
+
+# A class we explicitly allow to be thawed
+{
+    package t::Good;
+    sub new   { my ($c, $v) = @_; bless \$v, $c }
+    sub FREEZE { my $s = shift; return $$s }
+    sub THAW   { my ($c, $ser, $data) = @_; return bless \$data, "t::Good::Reified" }
+}
+
+# A class that must never be thawed through the safe decoder
+our $EVIL_THAW_RAN = 0;
+{
+    package t::Evil;
+    sub new    { my ($c, $v) = @_; bless \$v, $c }
+    sub FREEZE { my $s = shift; return $$s }
+    sub THAW   { $main::EVIL_THAW_RAN = 1; die "EVIL THAW RAN!" }
+}
+
+# A plain blessed object with no FREEZE/THAW hook
+{
+    package t::Plain;
+    sub new { bless { n => 5 }, shift }
+}
+
+$ALLOWED_THAW{'t::Good'} = 1;
+
+# --- default allow-list -----------------------------------------------------
+ok($ALLOWED_THAW{'pf::config::crypt::object'},
+    "pf::config::crypt::object is allow-listed by default");
+
+# --- plain data round-trips -------------------------------------------------
+{
+    my $in  = { a => [1, 2, 3], b => "str", c => { d => undef } };
+    my $out = sereal_decode_safe(sereal_encode_with_object($ENCODER_FREEZER, $in));
+    is_deeply($out, $in, "plain data round-trips through sereal_decode_safe");
+}
+
+# --- ordinary blessed object passes through untouched -----------------------
+{
+    my $out = sereal_decode_safe(
+        sereal_encode_with_object($ENCODER_FREEZER, { o => t::Plain->new }));
+    is(ref($out->{o}), "t::Plain", "non-FREEZE blessed object passes through");
+    is($out->{o}{n}, 5, "  ... with its contents intact");
+}
+
+# --- allow-listed object is reconstructed, including when nested ------------
+{
+    my $in = {
+        top  => t::Good->new("token"),
+        list => [1, { deep => t::Good->new("z") }],
+    };
+    my $out = sereal_decode_safe(sereal_encode_with_object($ENCODER_FREEZER, $in));
+    is(ref($out->{top}), "t::Good::Reified", "allow-listed object reconstructed");
+    is(${ $out->{top} }, "token", "  ... with the right value");
+    is(${ $out->{list}[1]{deep} }, "z", "nested allow-listed object reconstructed");
+    is($out->{list}[0], 1, "sibling plain data preserved");
+}
+
+# --- allow-listed object nested inside a *blessed* object -------------------
+# This mirrors real config: an encrypted value lives inside a blessed
+# authentication source object. The walk must descend into blessed containers.
+{
+    my $source = t::Plain->new;
+    $source->{password} = t::Good->new("hunter2");
+    my $out = sereal_decode_safe(
+        sereal_encode_with_object($ENCODER_FREEZER, { src => $source }));
+    is(ref($out->{src}), "t::Plain", "blessed container stays blessed");
+    is(ref($out->{src}{password}), "t::Good::Reified",
+        "allow-listed object nested in blessed object is reconstructed");
+    is(${ $out->{src}{password} }, "hunter2", "  ... with the right value");
+}
+
+# --- disallowed object is refused and its THAW never runs -------------------
+{
+    local $EVIL_THAW_RAN = 0;
+    my $blob = sereal_encode_with_object($ENCODER_FREEZER, { bad => t::Evil->new("pwn") });
+    my $ok = eval { sereal_decode_safe($blob); 1 };
+    ok(!$ok, "disallowed class makes sereal_decode_safe die");
+    like($@, qr/refusing to THAW disallowed class 't::Evil'/,
+        "  ... with the expected error message");
+    is($EVIL_THAW_RAN, 0, "disallowed class THAW was never invoked");
+}
+
+# --- CHISerializer enforces the same rules through a real CHI cache ---------
+{
+    my $cache = CHI->new(
+        driver     => "Memory",
+        datastore  => {},
+        serializer => pf::Sereal::CHISerializer->new,
+    );
+
+    $cache->set("good", { admin => t::Good->new("secret"), meta => [1, 2] });
+    my $v = $cache->get("good");
+    is(ref($v->{admin}), "t::Good::Reified", "CHISerializer reconstructs allow-listed object on get");
+    is(${ $v->{admin} }, "secret", "  ... with the right value");
+    is_deeply($v->{meta}, [1, 2], "  ... and preserves sibling data");
+
+    local $EVIL_THAW_RAN = 0;
+    $cache->set("bad", { x => t::Evil->new("pwn") });
+    my $ok = eval { $cache->get("bad"); 1 };
+    ok(!$ok, "CHISerializer refuses disallowed class on get");
+    is($EVIL_THAW_RAN, 0, "  ... without invoking its THAW");
+}
+
+done_testing();
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2026 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;


### PR DESCRIPTION
# Description
Deserializing Sereal data invokes ClassName->THAW on whatever frozen
objects the stream contains, which is an arbitrary-method-call gadget on
attacker-influenced input. Add a restricted decode path and route the
less-trusted boundaries (pfconfig socket, pfqueue, DB, L2 cache) through it.

- pf::Sereal: add $DECODER_SAFE (no_thaw_objects), %ALLOWED_THAW and
  sereal_decode_safe(), which decodes then walks the structure and only
  reconstructs allow-listed classes (currently pf::config::crypt::object),
  dying on anything else. Walk descends into blessed containers so encrypted
  values nested in blessed config objects still thaw.
- pf::Sereal::CHISerializer: custom CHI serializer so the Memory backend
  decodes through the restricted path (Data::Serializer::Sereal cannot).
- Wire util.pm, cached.pm, pfqueue consumer, mysql + memory backends.
- Add t/unittest/Sereal.t.

# Delete branch after merge
YES
