### PR TITLE
feat(keepalived): allow per-zone virtual_router_id in cluster.conf

### DIFF
--- a/NEWS.asciidoc
+++ b/NEWS.asciidoc
@@ -33,6 +33,8 @@ For a list of compatibility related changes see the <<PacketFence_Upgrade_Guide.
 
 === Enhancements
 
+  - Per-zone VRRP router id: in a multi-zone (layer 3) cluster, the keepalived `virtual_router_id` can now be set per zone in the zone's CLUSTER section of cluster.conf, instead of sharing the single `active_active` value across all zones
+
 === Bug Fixes
 
 === Security Fixes

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1648,7 +1648,7 @@ EOT
 [active_active.virtual_router_id]
 type=text
 description=<<EOT
-The virtual router id for keepalive. Leave untouched unless you have another keepalive cluster in this network. Must be between 1 and 255.
+The virtual router id for keepalive. Leave untouched unless you have another keepalive cluster in this network. Must be between 1 and 255. In a multi-zone (layer 3) cluster, this can be overridden per zone by setting virtual_router_id in the zone's CLUSTER section of cluster.conf.
 EOT
 
 [active_active.vrrp_unicast]

--- a/docs/cluster/layer_3_clusters.asciidoc
+++ b/docs/cluster/layer_3_clusters.asciidoc
@@ -130,6 +130,11 @@ Notes on the configuration:
    management IP on which the zone should be joined.
  * Given the zones aren't in the same layer 2 network, the same virtual IP
    cannot be used between zones.
+ * By default all zones share the `virtual_router_id` defined in the
+   `active_active` section of `pf.conf`. If zones share a layer 2 network with
+   another keepalived cluster, a distinct VRRP router id can be set per zone by
+   adding `virtual_router_id=<1-255>` to the zone's "CLUSTER" section (for
+   example under `[DC2 CLUSTER]`).
  * Always declare a "CLUSTER" definition even though a zone has
    only a single server.
  * The network equipment should point RADIUS authentication and accounting to
@@ -292,6 +297,11 @@ Notes on the configuration:
    management IP on which the zone should be joined.
  * Given the zones aren't in the same layer 2 network, the same virtual IP
    cannot be used between zones.
+ * By default all zones share the `virtual_router_id` defined in the
+   `active_active` section of `pf.conf`. If zones share a layer 2 network with
+   another keepalived cluster, a distinct VRRP router id can be set per zone by
+   adding `virtual_router_id=<1-255>` to the zone's "CLUSTER" section (for
+   example under `[DC2 CLUSTER]`).
  * Always declare a "CLUSTER" definition even though a zone has
    only a single server.
  * The network equipment should point RADIUS authentication and accounting to

--- a/lib/pf/services/manager/keepalived.pm
+++ b/lib/pf/services/manager/keepalived.pm
@@ -104,6 +104,10 @@ $routes
 EOT
 
     if ( $pf::cluster::cluster_enabled ) {
+        # Allow the virtual_router_id to be overridden per cluster (DC zone) through the
+        # CLUSTER section of cluster.conf. This lets zones in separate regions use distinct
+        # VRRP router ids. Falls back to the global active_active setting when unset.
+        my $virtual_router_id = $ConfigCluster{$CLUSTER}{'virtual_router_id'} || $Config{'active_active'}{'virtual_router_id'};
         my @ints = uniq(@listen_ints,@dhcplistener_ints, (map { $_->{'Tint'} } @portal_ints, @radius_ints));
         foreach my $interface ( @ints ) {
             my $cfg = $Config{"interface $interface"};
@@ -123,7 +127,7 @@ EOT
             }
             $tags{'vrrp'} .= <<"EOT";
 vrrp_instance $cfg->{'ip'} {
-  virtual_router_id $Config{'active_active'}{'virtual_router_id'}
+  virtual_router_id $virtual_router_id
   advert_int 5
   priority $priority
   state MASTER


### PR DESCRIPTION
# Description
In a multi-zone (layer 3) cluster, all zones shared the single active_active.virtual_router_id, so every server emitted the same VRRP router id even when zones sit in different regions. Read the router id from the zone's CLUSTER section of cluster.conf when set, falling back to the global active_active value otherwise.

# Impacts
- keepalived config

# Delete branch after merge
YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [x] Document the feature
- [ ] Add OpenAPI specification - n/a
- [ ] Add unit tests - n/a
- [ ] Add acceptance tests (TestLink) - n/a

# NEWS file entries

## New Features
* Per-zone VRRP router id: in a multi-zone (layer 3) cluster, the keepalived `virtual_router_id` can now be set per zone in the zone's CLUSTER section of cluster.conf, instead of sharing the single `active_active` value across all zones

