### PR TITLE
fix(mariadb): mask mariadb.socket so it can't hold :3306

### DIFF
--- a/debian/packetfence.preinst
+++ b/debian/packetfence.preinst
@@ -80,9 +80,10 @@ case "$1" in
         groupmod -g 2025 pf
         usermod -aG pf mysql
 
-        # prevent conflicting mariadb service from starting
-        /bin/systemctl mask mariadb
+        # mask the socket too; masking mariadb.service alone leaves :3306 bound
+        /bin/systemctl mask mariadb mariadb.socket
         /bin/systemctl stop mariadb
+        /bin/systemctl stop mariadb.socket || true
         # journald
         /usr/bin/install -d -g systemd-journal /var/log/journal
         /bin/setfacl -R -nm g:adm:rx,d:g:adm:rx /var/log/journal
@@ -119,12 +120,13 @@ case "$1" in
         stop_service_if_exists pfappserver
         /usr/sbin/update-rc.d -f pfappserver remove
         set -e
+        # mask before isolate: isolate starts packetfence-mariadb, which needs :3306
+        /bin/systemctl mask mariadb mariadb.socket
+        /bin/systemctl stop mariadb
+        /bin/systemctl stop mariadb.socket || true
         # only packetfence-config, packetfence-redis-cache and packetfence-mariadb
         # services are running after the following command:
         /bin/systemctl isolate packetfence-base.target
-        # prevent conflicting mariadb service from starting
-        /bin/systemctl mask mariadb
-        /bin/systemctl stop mariadb
 
         #Change the uid/gid
         set +e


### PR DESCRIPTION
## What
`debian/packetfence.preinst` now masks and stops `mariadb.socket` alongside `mariadb.service`, on both the install and upgrade paths. In the upgrade path this is done **before** `systemctl isolate packetfence-base.target` — that isolate starts `packetfence-mariadb` (`WantedBy=`), so if the socket were still bound to `:3306` at that point mariadbd would hit `EADDRINUSE` and could exhaust its `StartLimit` before the socket is stopped.

## Why
The preinst masked `mariadb.service` but not Debian's `mariadb.socket`. Masking the service only stops socket-activation from launching it — the socket unit still binds `[::]:3306`. That collides with PacketFence's own `mariadbd` (bind-address = management IP), so after a restart mariadbd can't rebind (`errno 98: Address already in use`) and `packetfence-mariadb` crash-loops with the DB down.

It surfaced as the **configurator venom suite** failing at `restart_mariadb_service` (504), cascading into 500/401 on the later steps once the DB never came back.

## Root cause detail
- `systemctl list-sockets` → `[::]:3306  mariadb.socket  mariadb.service`
- `ss -ltnp 'sport = :3306'` → held by `systemd` (pid 1), i.e. the socket unit, not a mariadb process.
- Boot-timing race: whoever binds 3306 first wins. Freshly-provisioned CI runners running the full configurator flow let the socket win; warm boxes (mariadb already up since boot) don't — hence the flakiness / "only on the runner".

## Change
```sh
# mask the socket too; masking mariadb.service alone leaves :3306 bound
/bin/systemctl mask mariadb mariadb.socket
/bin/systemctl stop mariadb
/bin/systemctl stop mariadb.socket || true
```

## Testing
- `sh -n` (dash) syntax check passes.
- Reproduced live on `pfdeb12dev`: `mariadb.socket` holding `[::]:3306`, mariadbd aborting on bind. `systemctl mask --now mariadb.socket` frees it and `packetfence-mariadb` comes up.
- Configurator suite passes on a box without the socket contending.

## Risk / scope
Debian packaging only; no code paths changed. PacketFence never uses Debian's `mariadb.service`/`mariadb.socket` (it runs `packetfence-mariadb`), so masking the socket is safe. Existing installs pick it up on next upgrade; already-running boxes can apply `systemctl mask --now mariadb.socket`.