### PR TITLE
fix(debian): install .dockerignore into /usr/local/pf, not filesystem root

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -160,7 +160,10 @@ install: build
 	make MYSQL_SUFFIX=server src/mariadb_udf/pf_udf.so
 	install -D -m0755 src/mariadb_udf/pf_udf.so $(CURDIR)/debian/packetfence/$$(/usr/bin/mariadb-config --plugindir)/pf_udf.so
 	#dockerignore
-	install -m0755 .dockerignore $(CURDIR)/debian/packetfence/.dockerignore
+	# Must land in the container build context root (/usr/local/pf), not the
+	# filesystem root, otherwise `docker build .` tars logs/ and var/ (see the
+	# "write too long" errors when building local containers).
+	install -D -m0644 .dockerignore $(CURDIR)/debian/packetfence$(PREFIX)/$(NAME)/.dockerignore
 	#PacketFence pfcmd suid
 	install -d -m0755 $(CURDIR)/debian/packetfence-pfcmd-suid$(PREFIX)/$(NAME)/bin
 	gcc src/pfcmd.c -o $(CURDIR)/debian/packetfence-pfcmd-suid$(PREFIX)/$(NAME)/bin/pfcmd


### PR DESCRIPTION
# Description
The Debian packaging installed .dockerignore to
debian/packetfence/.dockerignore, which maps to /.dockerignore on the host instead of the container build-context root /usr/local/pf/.dockerignore.

As a result `docker build .` (e.g. addons/dev-helpers/build-local-container.sh) had no ignore file in its context and tarred the whole logs/ and var/ trees, producing "archive/tar: write too long" errors on live-growing files and sending gigabytes of needless build context.

Install it under $(PREFIX)/$(NAME) so it lands at /usr/local/pf/.dockerignore, matching the RPM spec. Also drop the spurious executable bit (0755 -> 0644).

# Impacts
addons/dev-helpers/build-local-container.sh doesn't send useless file in docker build context

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Bug Fixes
* .dockerignore was installed in / instead of /usr/local/pf so addons/dev-helpers/build-local-container.sh tar all.
