### PR TITLE
fix(pfacct): stop dropping accounting under load (UDP buffer + backpressure)

### DIFF
--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1959,6 +1959,24 @@ description=<<EOT
 If rate limiting on pfacct is enabled,  the Time to Live value in minutes represent the time of the accounting cache
 EOT
 
+[radius_configuration.pfacct_socket_recv_buffer]
+type=numeric
+description=<<EOT
+Size in bytes of the UDP receive buffer (SO_RCVBUF) requested by pfacct on its accounting socket. Larger values absorb bursts from busy switches and avoid kernel packet drops (visible as "receive buffer errors" in netstat -su). The kernel caps the effective value at net.core.rmem_max. Zero leaves the OS default in place.
+EOT
+
+[radius_configuration.pfacct_aaa_notify_workers]
+type=numeric
+description=<<EOT
+The number of workers forwarding accounting notifications to httpd.aaa. If zero it will be twice the number of CPUs.
+EOT
+
+[radius_configuration.pfacct_aaa_notify_queue_size]
+type=numeric
+description=<<EOT
+The size of the queue for each AAA notification worker.
+EOT
+
 [dns_configuration.record_dns_in_sql]
 type=toggle
 options=enabled|disabled

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -1475,6 +1475,22 @@ pfacct_rate_limit=disabled
 #
 # If rate limiting on pfacct is enabled,  the Time to Live value in minutes represent the time of the accounting cache
 pfacct_rate_limit_cache_ttl=5
+# radius_configuration.pfacct_socket_recv_buffer
+#
+# Size in bytes of the UDP receive buffer (SO_RCVBUF) requested by pfacct on its
+# accounting socket. Larger values absorb bursts from busy switches and avoid
+# kernel packet drops ("receive buffer errors" in netstat -su). The kernel caps
+# the effective value at net.core.rmem_max. Zero leaves the OS default in place.
+pfacct_socket_recv_buffer=16777216
+# radius_configuration.pfacct_aaa_notify_workers
+#
+# The number of workers forwarding accounting notifications to httpd.aaa.
+# If zero it will be twice the number of CPUs.
+pfacct_aaa_notify_workers=0
+# radius_configuration.pfacct_aaa_notify_queue_size
+#
+# The size of the queue for each AAA notification worker.
+pfacct_aaa_notify_queue_size=1000
 
 [dns_configuration]
 #

--- a/debian/packetfence.sysctl
+++ b/debian/packetfence.sysctl
@@ -1,0 +1,20 @@
+# Managed by PacketFence - UDP receive buffer tuning
+#
+# High-volume RADIUS accounting (pfacct) on a busy switch (thousands of devices)
+# can burst far more UDP datagrams than the stock 208KB socket buffer holds; the
+# kernel then drops the excess ("receive buffer errors" in `netstat -su`), which
+# leaves nodes stuck showing offline until pfacct is restarted. These settings
+# raise the ceiling and defaults for pfacct and the other UDP listeners (pfdns,
+# pfdhcp). pfacct additionally requests its own buffer via SO_RCVBUF
+# (radius_configuration.pfacct_socket_recv_buffer), capped by rmem_max below.
+#
+# Apply immediately with: sysctl --system
+
+# Maximum SO_RCVBUF a socket may request (pfacct requests up to this value).
+net.core.rmem_max = 33554432
+
+# Default receive buffer for sockets that do not set their own.
+net.core.rmem_default = 1048576
+
+# Backlog of packets queued between the NIC and the socket layer.
+net.core.netdev_max_backlog = 250000

--- a/debian/rules
+++ b/debian/rules
@@ -140,6 +140,8 @@ install: build
 	install -d -m0755 $(CURDIR)/debian/packetfence/etc/modules-load.d
 	install -m0644 $(CURDIR)/debian/packetfence.modprobe $(CURDIR)/debian/packetfence/etc/modprobe.d/packetfence.conf
 	install -m0644 $(CURDIR)/debian/packetfence.modules-load $(CURDIR)/debian/packetfence/etc/modules-load.d/packetfence.conf
+	install -d -m0755 $(CURDIR)/debian/packetfence/etc/sysctl.d
+	install -m0644 $(CURDIR)/debian/packetfence.sysctl $(CURDIR)/debian/packetfence/etc/sysctl.d/99-packetfence-udp.conf
 
 	# copy the rsyslog systemd drop in and journald
 	install -d -m0755 $(CURDIR)/debian/packetfence/etc/systemd/system/rsyslog.service.d/

--- a/go/cmd/pfacct/nodeSession.go
+++ b/go/cmd/pfacct/nodeSession.go
@@ -1,9 +1,21 @@
 package main
 
 import (
-	cache "github.com/fdurand/go-cache"
 	"strconv"
+	"time"
+
+	cache "github.com/fdurand/go-cache"
 )
+
+// nodeSession entries are normally removed when the accounting Stop arrives.
+// A missed or dropped Stop (common under load) would otherwise leave the entry
+// in the cache forever, leaking memory. nodeSessionExpiration bounds how long
+// an idle entry survives and nodeSessionCleanupInterval drives the janitor that
+// evicts expired entries. The expiration is refreshed on every access (see
+// getNodeSessionFromCache), so it behaves as an idle timeout: active sessions
+// never expire, abandoned ones are reclaimed.
+const nodeSessionExpiration = 12 * time.Hour
+const nodeSessionCleanupInterval = 15 * time.Minute
 
 type nodeSession struct {
 	timeBalance      int64
@@ -22,7 +34,11 @@ func (h *PfAcct) setNodeSessionCache(sessionId uint64, ns *nodeSession) {
 func (h *PfAcct) getNodeSessionFromCache(sessionId uint64) *nodeSession {
 	nodeId := formatNodeId(sessionId)
 	if i, found := h.NodeSessionCache.Get(nodeId); found {
-		return i.(*nodeSession)
+		ns := i.(*nodeSession)
+		// Refresh the idle timeout so long-lived, still-active sessions are
+		// never evicted mid-session.
+		h.NodeSessionCache.Set(nodeId, ns, cache.DefaultExpiration)
+		return ns
 	}
 
 	return nil

--- a/go/cmd/pfacct/pfacct.go
+++ b/go/cmd/pfacct/pfacct.go
@@ -99,7 +99,7 @@ func NewPfAcct(logLevel string) *PfAcct {
 		AAANotifyQueueSize:  DefaultAAANotifyQueueSize,
 	}
 	pfAcct.SwitchInfoCache = cache.New(5*time.Minute, 10*time.Minute)
-	pfAcct.NodeSessionCache = cache.New(cache.NoExpiration, cache.NoExpiration)
+	pfAcct.NodeSessionCache = cache.New(nodeSessionExpiration, nodeSessionCleanupInterval)
 	pfAcct.AcctSessionCache = cache.New(5*time.Minute, 10*time.Minute)
 
 	pfAcct.LoggerCtx = ctx

--- a/go/cmd/pfacct/pfacct.go
+++ b/go/cmd/pfacct/pfacct.go
@@ -27,6 +27,7 @@ import (
 
 const DefaultTimeDuration = 5 * time.Minute
 const DefaultRadiusWorkQueueSize = 1000
+const DefaultAAANotifyQueueSize = 1000
 
 type radiusRequest struct {
 	w          radius.ResponseWriter
@@ -58,7 +59,8 @@ type PfAcct struct {
 	StatsdOption            statsd.Option
 	StatsdClient            *statsd.Client
 	radiusRequests          []chan<- radiusRequest
-	overflows               []atomic.Int64
+	aaaNotifyQueues         []chan<- aaaNotifyJob
+	aaaNotifyDropped        atomic.Int64
 	localSecret             string
 	StatsdOnce              tryableonce.TryableOnce
 	isProxied               bool
@@ -67,6 +69,9 @@ type PfAcct struct {
 	ProcessBandwidthAcct    bool
 	RadiusWorkers           int
 	RadiusWorkQueueSize     int
+	SocketRecvBuffer        int
+	AAANotifyWorkers        int
+	AAANotifyQueueSize      int
 }
 
 func NewPfAcct(logLevel string) *PfAcct {
@@ -91,6 +96,7 @@ func NewPfAcct(logLevel string) *PfAcct {
 		Db:                  Database,
 		TimeDuration:        DefaultTimeDuration,
 		RadiusWorkQueueSize: DefaultRadiusWorkQueueSize,
+		AAANotifyQueueSize:  DefaultAAANotifyQueueSize,
 	}
 	pfAcct.SwitchInfoCache = cache.New(5*time.Minute, 10*time.Minute)
 	pfAcct.NodeSessionCache = cache.New(cache.NoExpiration, cache.NoExpiration)
@@ -101,11 +107,12 @@ func NewPfAcct(logLevel string) *PfAcct {
 
 	pfAcct.SetupConfig(ctx)
 	pfAcct.radiusRequests = makeRadiusRequests(pfAcct, pfAcct.RadiusWorkers, pfAcct.RadiusWorkQueueSize)
-	pfAcct.overflows = make([]atomic.Int64, pfAcct.RadiusWorkers, pfAcct.RadiusWorkers)
 	pfAcct.AAAClient = jsonrpc2.NewAAAClientFromConfig(ctx)
+	pfAcct.aaaNotifyQueues = makeAAANotifiers(pfAcct, pfAcct.AAANotifyWorkers, pfAcct.AAANotifyQueueSize)
 	//pfAcct.Dispatcher = NewDispatcher(16, 128)
 
 	pfAcct.runPing()
+	pfAcct.reportAAADrops()
 	return pfAcct
 }
 
@@ -122,6 +129,51 @@ func makeRadiusRequests(h *PfAcct, requestFanOut, backlog int) []chan<- radiusRe
 	}
 
 	return requests
+}
+
+// aaaNotifyJob carries a pre-serialized radius_accounting notification to the
+// dedicated AAA notifier pool.
+type aaaNotifyJob struct {
+	ctx  context.Context
+	attr map[string]interface{}
+}
+
+// makeAAANotifiers builds a MAC-sharded pool of workers that forward
+// radius_accounting notifications to httpd.aaa. Decoupling this (potentially
+// remote and slow) call from the accounting workers keeps the node
+// online/offline DB updates current even when httpd.aaa is overloaded, while
+// sharding by MAC preserves per-device ordering of the notifications.
+func makeAAANotifiers(h *PfAcct, workers, backlog int) []chan<- aaaNotifyJob {
+	queues := make([]chan<- aaaNotifyJob, workers)
+	for i := 0; i < workers; i++ {
+		c := make(chan aaaNotifyJob, backlog)
+		queues[i] = c
+		go func(c <-chan aaaNotifyJob) {
+			for job := range c {
+				if err := h.AAAClient.Notify(job.ctx, "radius_accounting", job.attr); err != nil {
+					logError(job.ctx, err.Error())
+				}
+			}
+		}(c)
+	}
+
+	return queues
+}
+
+// reportAAADrops periodically logs how many radius_accounting notifications
+// were dropped because the notifier queues were saturated. Drops here do not
+// affect node online/offline status (written synchronously by the accounting
+// workers); they only mean some accounting side effects (ip4log, locationlog,
+// triggers) were skipped while httpd.aaa could not keep up.
+func (pfAcct *PfAcct) reportAAADrops() {
+	go func() {
+		for {
+			time.Sleep(60 * time.Second)
+			if dropped := pfAcct.aaaNotifyDropped.Swap(0); dropped > 0 {
+				logWarn(pfAcct.LoggerCtx, fmt.Sprintf("Dropped %d radius_accounting notifications in the last 60s because the AAA notify queue was full (httpd.aaa may be overloaded); node online/offline status is unaffected", dropped))
+			}
+		}
+	}()
 }
 
 func (pfAcct *PfAcct) SetupConfig(ctx context.Context) {
@@ -197,6 +249,32 @@ func (pfAcct *PfAcct) SetupConfig(ctx context.Context) {
 	} else {
 		pfAcct.RadiusWorkQueueSize = int(i)
 	}
+
+	// Size (in bytes) of the UDP socket receive buffer requested via SO_RCVBUF.
+	// The kernel caps the effective value at net.core.rmem_max. Zero leaves the
+	// OS default (net.core.rmem_default) in place.
+	if i, err := strconv.ParseInt(RadiusConfiguration.PfacctSocketRecvBuffer, 10, 64); err != nil {
+		logWarn(ctx, fmt.Sprintf("Invalid number '%s' pfacct_socket_recv_buffer, leaving the OS default UDP receive buffer in place", RadiusConfiguration.PfacctSocketRecvBuffer))
+	} else {
+		pfAcct.SocketRecvBuffer = int(i)
+	}
+
+	if i, err := strconv.ParseInt(RadiusConfiguration.PfacctAAANotifyWorkers, 10, 64); err != nil {
+		logWarn(ctx, fmt.Sprintf("Invalid number '%s' pfacct_aaa_notify_workers defaulting to '%d'", RadiusConfiguration.PfacctAAANotifyWorkers, pfAcct.AAANotifyWorkers))
+	} else {
+		pfAcct.AAANotifyWorkers = int(i)
+	}
+
+	// If set to zero use twice the number of CPUs for the AAA notifier pool
+	pfAcct.AAANotifyWorkers = cmp.Or(pfAcct.AAANotifyWorkers, 2*numOfCpus)
+
+	if i, err := strconv.ParseInt(RadiusConfiguration.PfacctAAANotifyQueueSize, 10, 64); err != nil {
+		logWarn(ctx, fmt.Sprintf("Invalid number '%s' pfacct_aaa_notify_queue_size defaulting to '%d'", RadiusConfiguration.PfacctAAANotifyQueueSize, pfAcct.AAANotifyQueueSize))
+	} else {
+		pfAcct.AAANotifyQueueSize = int(i)
+	}
+
+	pfAcct.AAANotifyQueueSize = cmp.Or(pfAcct.AAANotifyQueueSize, DefaultAAANotifyQueueSize)
 
 	localSecret := pfconfigdriver.LocalSecret{}
 	pfconfigdriver.FetchDecodeSocket(ctx, &localSecret)

--- a/go/cmd/pfacct/radius.go
+++ b/go/cmd/pfacct/radius.go
@@ -103,6 +103,13 @@ func (h *PfAcct) HandleAccounting(w radius.ResponseWriter, r *radius.Request) {
 		return
 	}
 
+	// Acknowledge the switch immediately, before queuing the request for
+	// processing. This way a slow or backpressured worker queue can never
+	// delay the response and trigger accounting retransmits from the switch.
+	outPacket := r.Response(radius.CodeAccountingResponse)
+	rfc2865.ReplyMessage_SetString(outPacket, "Accounting OK")
+	w.Write(h.AddProxyState(outPacket, r))
+
 	rr := radiusRequest{
 		r:          r,
 		status:     status,
@@ -111,26 +118,17 @@ func (h *PfAcct) HandleAccounting(w radius.ResponseWriter, r *radius.Request) {
 	}
 
 	h.sendRadiusRequestToQueue(rr)
-	outPacket := r.Response(radius.CodeAccountingResponse)
-	rfc2865.ReplyMessage_SetString(outPacket, "Accounting OK")
-	w.Write(h.AddProxyState(outPacket, r))
-	// h.handleAccountingRequest(w, r, switchInfo, mac)
-	// h.Dispatcher.SubmitJob(Work(func() { h.handleAccountingRequest(r, switchInfo) }))
 }
 
 func (h *PfAcct) sendRadiusRequestToQueue(rr radiusRequest) {
 	queueIndex := djb2Hash(rr.mac[:]) % uint64(len(h.radiusRequests))
-	select {
-	case h.radiusRequests[queueIndex] <- rr:
-	default:
-		go func() {
-			h.overflows[queueIndex].Add(1)
-			h.radiusRequests[queueIndex] <- rr
-			h.overflows[queueIndex].Add(-1)
-		}()
-	}
-
-	h.SendGauge(fmt.Sprintf("pfacct.radiusRequests[%d]", queueIndex), len(h.radiusRequests[queueIndex])+int(h.overflows[queueIndex].Load()))
+	// Blocking send: this applies natural backpressure when a worker falls
+	// behind instead of spawning an unbounded number of goroutines (which grew
+	// memory without limit and reordered a MAC's packets under load). The
+	// switch was already acknowledged in HandleAccounting, so blocking here
+	// cannot cause accounting retransmits.
+	h.radiusRequests[queueIndex] <- rr
+	h.SendGauge(fmt.Sprintf("pfacct.radiusRequests[%d]", queueIndex), len(h.radiusRequests[queueIndex]))
 }
 
 func (h *PfAcct) handleAccountingRequest(rr radiusRequest) {
@@ -322,10 +320,10 @@ func (h *PfAcct) accountingUniqueSessionId(r *radius.Request) uint64 {
 }
 
 func (h *PfAcct) sendRadiusAccounting(rr radiusRequest, switchInfo *SwitchInfo) {
-	h.sendRadiusAccountingCall(rr.r)
+	h.sendRadiusAccountingCall(rr.r, rr.mac)
 }
 
-func (h *PfAcct) sendRadiusAccountingCall(r *radius.Request) {
+func (h *PfAcct) sendRadiusAccountingCall(r *radius.Request, m mac.Mac) {
 	ctx := r.Context()
 	attr := packetToMap(ctx, r.Packet)
 	attr["PF_HEADERS"] = map[string]string{
@@ -340,15 +338,28 @@ func (h *PfAcct) sendRadiusAccountingCall(r *radius.Request) {
 
 	status := rfc2866.AcctStatusType_Get(r.Packet)
 
-	if h.RateLimit && h.rateLimit(attr, status) {
-		if err := h.AAAClient.Notify(ctx, "radius_accounting", attr); err != nil {
-			logError(ctx, err.Error())
-		}
-	} else if !h.RateLimit {
-		if err := h.AAAClient.Notify(ctx, "radius_accounting", attr); err != nil {
-			logError(ctx, err.Error())
-		}
+	// h.rateLimit has side effects (it updates the rate-limit caches) and must
+	// only be evaluated when rate limiting is enabled; short-circuit ordering
+	// preserves that.
+	if !h.RateLimit || h.rateLimit(attr, status) {
+		h.enqueueAAANotify(ctx, m, attr)
 	}
+}
+
+// enqueueAAANotify hands a radius_accounting notification to the MAC-sharded
+// notifier pool without blocking the accounting worker. If the target queue is
+// saturated the notification is dropped and counted (see reportAAADrops)
+// rather than stalling the worker, since node online/offline status has already
+// been written to the DB by the time we get here.
+func (h *PfAcct) enqueueAAANotify(ctx context.Context, m mac.Mac, attr map[string]interface{}) {
+	queueIndex := djb2Hash(m[:]) % uint64(len(h.aaaNotifyQueues))
+	select {
+	case h.aaaNotifyQueues[queueIndex] <- aaaNotifyJob{ctx: ctx, attr: attr}:
+	default:
+		h.aaaNotifyDropped.Add(1)
+	}
+
+	h.SendGauge(fmt.Sprintf("pfacct.aaaNotify[%d]", queueIndex), len(h.aaaNotifyQueues[queueIndex]))
 }
 
 func (h *PfAcct) rateLimit(attr map[string]interface{}, status rfc2866.AcctStatusType) bool {
@@ -463,6 +474,17 @@ func (h *PfAcct) radiusListen(w *sync.WaitGroup) *radius.PacketServer {
 		pc, err := net.ListenUDP("udp4", addr)
 		if err != nil {
 			panic(err)
+		}
+		// Grow the UDP socket receive buffer so bursts from busy switches
+		// (thousands of devices) are absorbed instead of being dropped by the
+		// kernel ("receive buffer errors" in netstat -su). The kernel silently
+		// caps the effective size at net.core.rmem_max.
+		if h.SocketRecvBuffer > 0 {
+			if err := pc.SetReadBuffer(h.SocketRecvBuffer); err != nil {
+				logWarn(ctx, fmt.Sprintf("Unable to set UDP read buffer to %d bytes on %s: %s", h.SocketRecvBuffer, addr.String(), err.Error()))
+			} else {
+				logInfo(ctx, fmt.Sprintf("Requested UDP read buffer of %d bytes on %s (kernel caps at net.core.rmem_max)", h.SocketRecvBuffer, addr.String()))
+			}
 		}
 		intRADIUS = append(intRADIUS, pc)
 	}

--- a/go/pfconfigdriver/structs.go
+++ b/go/pfconfigdriver/structs.go
@@ -718,6 +718,9 @@ type PfConfRadiusConfiguration struct {
 	PfacctWorkQueueSize                string   `json:"pfacct_work_queue_size"`
 	PfacctRateLimit                    string   `json:"pfacct_rate_limit"`
 	PfacctRateLimitCacheTtl            string   `json:"pfacct_rate_limit_cache_ttl"`
+	PfacctSocketRecvBuffer             string   `json:"pfacct_socket_recv_buffer"`
+	PfacctAAANotifyWorkers             string   `json:"pfacct_aaa_notify_workers"`
+	PfacctAAANotifyQueueSize           string   `json:"pfacct_aaa_notify_queue_size"`
 }
 
 type PfQueueConfig struct {

--- a/packetfence.sysctl
+++ b/packetfence.sysctl
@@ -1,0 +1,20 @@
+# Managed by PacketFence - UDP receive buffer tuning
+#
+# High-volume RADIUS accounting (pfacct) on a busy switch (thousands of devices)
+# can burst far more UDP datagrams than the stock 208KB socket buffer holds; the
+# kernel then drops the excess ("receive buffer errors" in `netstat -su`), which
+# leaves nodes stuck showing offline until pfacct is restarted. These settings
+# raise the ceiling and defaults for pfacct and the other UDP listeners (pfdns,
+# pfdhcp). pfacct additionally requests its own buffer via SO_RCVBUF
+# (radius_configuration.pfacct_socket_recv_buffer), capped by rmem_max below.
+#
+# Apply immediately with: sysctl --system
+
+# Maximum SO_RCVBUF a socket may request (pfacct requests up to this value).
+net.core.rmem_max = 33554432
+
+# Default receive buffer for sockets that do not set their own.
+net.core.rmem_default = 1048576
+
+# Backlog of packets queued between the NIC and the socket layer.
+net.core.netdev_max_backlog = 250000

--- a/rpm/packetfence.spec
+++ b/rpm/packetfence.spec
@@ -447,6 +447,8 @@ done
 # systemd modules
 %{__install} -D packetfence.modules-load %{buildroot}/etc/modules-load.d/packetfence.conf
 %{__install} -D packetfence.modprobe %{buildroot}/etc/modprobe.d/packetfence.conf
+# kernel tuning for UDP receive buffers (pfacct/pfdns/pfdhcp)
+%{__install} -D -m0644 packetfence.sysctl %{buildroot}/etc/sysctl.d/99-packetfence-udp.conf
 # override docker-ce unit file
 %{__install} -D -m0644 packetfence.docker-drop-in.service %{buildroot}/etc/systemd/system/docker.service
 
@@ -892,6 +894,7 @@ fi
 %attr(0644, root, root) /etc/systemd/system/packetfence*.slice
 %attr(0644, root, root) /etc/modules-load.d/packetfence.conf
 %attr(0644, root, root) /etc/modprobe.d/packetfence.conf
+%attr(0644, root, root) /etc/sysctl.d/99-packetfence-udp.conf
 
 %attr(0644, root, root) %{_unitdir}/packetfence-*.service
 %attr(0644, root, root) %{_unitdir}/packetfence-*.path


### PR DESCRIPTION
# Description
On busy switches (thousands of devices) pfacct falls behind the accounting stream and nodes get stuck showing offline until the service is restarted. The kernel was dropping UDP datagrams before pfacct could read them ("receive buffer errors" in netstat -su), and internally the per-packet synchronous httpd.aaa call plus an unbounded overflow-goroutine fallback let the backlog grow without bound while reordering a MAC's packets.

(a) Size the accounting socket via SO_RCVBUF instead of relying on the tiny
    net.core.rmem_default. New knob radius_configuration.pfacct_socket_recv_buffer
    (default 16MB, capped by net.core.rmem_max).

(b) Replace the unbounded overflow-goroutine spawn in sendRadiusRequestToQueue
    with a blocking send (natural backpressure, bounded memory, preserved
    per-queue FIFO). The switch is now acknowledged before queuing so blocking
    cannot cause accounting retransmits.

(c) Decouple the radius_accounting httpd.aaa notification onto a MAC-sharded
    notifier pool so node online/offline DB updates no longer wait on the
    (remote, in k8s) AAA round-trip. Non-blocking enqueue drops with a counter
    and a throttled warning when httpd.aaa can't keep up. New knobs
    pfacct_aaa_notify_workers and pfacct_aaa_notify_queue_size.

Ship /etc/sysctl.d/99-packetfence-udp.conf (Debian + RPM) raising rmem_max, rmem_default and netdev_max_backlog.

# Impacts
- RADIUS accounting workflow

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* Better accounting handling in pfacct
