### PR TITLE
fix(dal): don't clobber existing rows in find_or_create when the DB read fails

### DIFF
--- a/lib/pf/dal.pm
+++ b/lib/pf/dal.pm
@@ -816,13 +816,18 @@ sub find_or_create {
         -from => $proto->find_from_tables,
         -where => $obj->primary_keys_where_clause,
     );
-    if (is_success($status)) {
-        my $row = $sth->fetchrow_hashref;
-        $sth->finish;
-        if ($row) {
-            my $obj = $proto->new_from_row($row);
-            return $STATUS::OK, $obj;
-        }
+    # Only treat the row as absent when the SELECT actually succeeded. On a
+    # read error (e.g. the DB is down) we cannot tell "not found" from "query
+    # failed"; falling through to save() here would overwrite an existing row
+    # with a fresh default record (for a node: status=unreg, pid=default).
+    if (is_error($status)) {
+        return $status, undef;
+    }
+    my $row = $sth->fetchrow_hashref;
+    $sth->finish;
+    if ($row) {
+        my $obj = $proto->new_from_row($row);
+        return $STATUS::OK, $obj;
     }
     $status =  $obj->save;
     if (is_error($status)) {


### PR DESCRIPTION
# Description
find_or_create only returned the existing row when the SELECT succeeded; on a read error (is_success false) it fell straight through to save(), which for a node issues an INSERT ... ON DUPLICATE KEY UPDATE of a fresh default record (status=unreg, pid=default, regdate=0). A transient MySQL outage during a RADIUS authorize therefore mistook an existing registered node for a missing one and unregistered it once the DB recovered.

Return the error early instead of falling through to save. All callers already handle the ($status, undef) error contract (it also occurs on save failure), so they leave the row untouched on a DB read error rather than overwriting it.

# Impacts
- RADIUS authorize workflow

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries


## Bug Fixes
* When the db is not available then a register node can be set as unregistered
