### PR TITLE
fix(pfcron): don't reconnect Kafka on idle read timeout in pfflowjob

### DIFF
--- a/go/cron/pfflowjob.go
+++ b/go/cron/pfflowjob.go
@@ -194,8 +194,10 @@ func (j *PfFlowJob) Run() {
 		m, err := r.ReadMessage(ctx)
 		cancel()
 		if err != nil {
-			// Check if it's just a timeout (no messages available) vs a real error
-			if err == context.DeadlineExceeded {
+			// Check if it's just a timeout (no messages available) vs a real error.
+			// kafka-go's ReadMessage wraps the error ("fetching message: %w"), so a
+			// plain == comparison never matches — use errors.Is to unwrap.
+			if errors.Is(err, context.DeadlineExceeded) {
 				// Timeout waiting for messages is normal, just retry without reconnecting
 				continue
 			}


### PR DESCRIPTION
# Description
kafka-go's ReadMessage always wraps its error (fmt.Errorf("fetching message: %w", err)), so the == context.DeadlineExceeded check never matched. A normal idle timeout (no flow messages in the 60s window) was misclassified as a real error, closing the reader and reconnecting with backoff every cycle — producing spurious "Error reading from Kafka (attempt N)" / "Reconnecting to Kafka" log noise on quiet topics.

Use errors.Is to unwrap so genuine errors still trigger reconnect while idle timeouts silently retry as intended.

# Impacts
pfflow task

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries

## Enhancements
* don't trigger an error if there is nothing in kafka for 60s.
