### PR TITLE
fix(connector): reject duplicate/overlapping networks across connectors (#9125)

### DIFF
--- a/html/pfappserver/lib/pfappserver/Form/Config/Connector.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Connector.pm
@@ -12,6 +12,10 @@ Form definition to create or update a connector
 
 use HTML::FormHandler::Moose;
 use pf::ConfigStore::Connector::DomainsConnectors;
+use pfconfig::cached_hash;
+
+tie my %ConnectorConfig, "pfconfig::cached_hash" , "config::Connector";
+
 extends 'pfappserver::Base::Form';
 with qw(
     pfappserver::Base::Form::Role::Help
@@ -52,6 +56,27 @@ has_field 'fingerbank_environment' => (
 has_field 'fingerbank_environment.contains' => (
    type => 'EnvVar',
 );
+
+sub validate_networks {
+    my ($self, $field) = @_;
+    my $networks = $field->value;
+    my %counts;
+    for my $n (@$networks) {
+        $counts{$n}++;
+        if ($counts{$n} == 2) {
+            $field->add_error("Cannot have network '$n' defined multiple times");
+        }
+    }
+
+    my $id = $self->field("id")->value;
+    for my $k (grep { $_ ne $id && $_ ne 'local_connector' } keys %ConnectorConfig) {
+        for my $n (@{$ConnectorConfig{$k}{networks} // []}) {
+            if (exists $counts{$n}) {
+                $field->add_error("network '$n' is defined in '$k'");
+            }
+        }
+    }
+}
 
 =over
 

--- a/html/pfappserver/lib/pfappserver/Form/Config/Connector.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Connector.pm
@@ -36,7 +36,7 @@ has_field 'networks' =>
 
 has_field 'networks.contains' =>
   (
-   type => 'Text',
+   type => 'CIDR',
   );
 
 has_field 'secret' =>

--- a/html/pfappserver/lib/pfappserver/Form/Field/CIDR.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Field/CIDR.pm
@@ -1,0 +1,85 @@
+package pfappserver::Form::Field::CIDR;
+
+=head1 NAME
+
+pfappserver::Form::Field::CIDR - IPv4 CIDR input field
+
+=head1 DESCRIPTION
+
+This field extends the default Text field and checks that the input
+value is a valid IPv4 network in CIDR notation (e.g. 192.168.1.0/24).
+The prefix length is mandatory and must be between 0 and 32.
+
+=cut
+
+use HTML::FormHandler::Moose;
+extends 'HTML::FormHandler::Field::Text';
+
+use pf::util;
+use namespace::autoclean;
+
+# If the field value matches one of the values defined in "accept", the field will pass validation.
+# Otherwise, the field value must be a valid IPv4 address in CIDR notation.
+has 'accept' => ( is => 'rw', isa => 'ArrayRef' );
+
+our $class_messages = {
+    'cidr' => 'Value must be an IPv4 address in CIDR notation (e.g. 192.168.1.0/24)',
+};
+
+sub get_class_messages {
+    my $self = shift;
+    return {
+       %{ $self->next::method },
+       %$class_messages,
+    }
+}
+
+apply
+  (
+   [
+    {
+     check => sub {
+         my ( $value, $field ) = @_;
+         return 1 if ($field->accept && grep { $_ eq $value } @{$field->accept});
+         my ( $ip, $prefix, $extra ) = split( m!/!, $value, 3 );
+         return 0 if defined $extra;                    # only one slash allowed
+         return 0 unless defined $prefix
+             && $prefix =~ /^\d+$/ && $prefix >= 0 && $prefix <= 32;
+         # 0.0.0.0/x is a valid network (e.g. the "any" CIDR) even though
+         # valid_ip() rejects the all-zeros address as a host IP.
+         return 1 if $ip eq '0.0.0.0';
+         return valid_ip( $ip );
+     },
+     message => sub {
+         my ( $value, $field ) = @_;
+         return $field->get_message('cidr');
+     },
+    }
+   ]
+  );
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2026 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+__PACKAGE__->meta->make_immutable unless $ENV{"PF_SKIP_MAKE_IMMUTABLE"};
+1;

--- a/t/data/connectors.conf
+++ b/t/data/connectors.conf
@@ -1,0 +1,8 @@
+[test_networks]
+secret=secret
+description=asasas
+networks=12.36.24.0/24
+fingerbank_environment=<<EOT
+BOB=kas
+BOB2=james
+EOT

--- a/t/test_paths.pm
+++ b/t/test_paths.pm
@@ -67,6 +67,7 @@ BEGIN {
     $pf::file_paths::radius_ca_cert             = catfile( $test_dir, 'data/radius_ca.pem' );
     $pf::file_paths::system_init_key_file       = catfile( $test_dir, 'data/system_init_key' );
     $pf::file_paths::dns_connectors_config_file = catfile( $test_dir, 'data/dns_connectors.conf' );
+    $pf::file_paths::connectors_config_file = catfile( $test_dir, 'data/connectors.conf' );
 
     $pfconfig::constants::CONFIG_FILE_PATH = catfile( $test_paths::test_dir, 'data/pfconfig.conf' );
     $pfconfig::constants::SOCKET_PATH      = "/usr/local/pf/var/run/pfconfig-test.sock";

--- a/t/unittest/UnifiedApi/Controller/Config/Connector.t
+++ b/t/unittest/UnifiedApi/Controller/Config/Connector.t
@@ -1,0 +1,96 @@
+#!/usr/bin/perl
+
+=head1 NAME
+
+Connector
+
+=head1 DESCRIPTION
+
+unit test for Connector
+
+=cut
+
+use strict;
+use warnings;
+
+BEGIN {
+    #include test libs
+    use lib qw(/usr/local/pf/t);
+    #Module for overriding configuration paths
+    use setup_test_config;
+}
+
+use Test::More tests => 9;
+use Test::Mojo;
+use Utils;
+use pf::ConfigStore::Connector;
+
+my ($fh, $filename) = Utils::tempfileForConfigStore("pf::ConfigStore::Connector");
+
+#This test will running last
+use Test::NoWarnings;
+my $t = Test::Mojo->new('pf::UnifiedApi');
+
+my $collection_base_url = '/api/v1/config/connectors';
+
+my $base_url = '/api/v1/config/connector';
+
+my $true = bless( do { \( my $o = 1 ) }, 'JSON::PP::Boolean' );
+my $false = bless( do { \( my $o = 0 ) }, 'JSON::PP::Boolean' );
+$t->options_ok($collection_base_url)
+  ->status_is(200);
+
+$t->post_ok($collection_base_url => json => {
+        id=> "bob",
+        secret => "secret",
+        description => "dsfdf",
+        networks => ["12.36.23.0/23", "12.36.23.0/23"],
+    })
+  ->status_is(422);
+
+$t->post_ok($collection_base_url => json => {
+        id=> "bob",
+        secret => "secret",
+        description => "dsfdf",
+        networks => ["12.36.23.32/23"],
+    })
+  ->status_is(201);
+
+$t->post_ok($collection_base_url => json => {
+        id=> "test_networks2",
+        secret => "secret",
+        description => "dsfdf",
+        networks => ["12.36.24.0/24"],
+    })
+  ->status_is(422);
+
+
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2026 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;

--- a/t/unittest/pfappserver/Form/Field/CIDR.t
+++ b/t/unittest/pfappserver/Form/Field/CIDR.t
@@ -1,0 +1,97 @@
+#!/usr/bin/perl
+
+=head1 NAME
+
+CIDR
+
+=head1 DESCRIPTION
+
+unit test for CIDR
+
+=cut
+
+use strict;
+use warnings;
+#
+use lib '/usr/local/pf/lib';
+
+BEGIN {
+    #include test libs
+    use lib qw(/usr/local/pf/t);
+    #Module for overriding configuration paths
+    use setup_test_config;
+}
+
+use Test::More tests => 12;
+use pfappserver::Form::Field::CIDR;
+
+{
+    package Form::Test;
+    use HTML::FormHandler::Moose;
+    extends 'HTML::FormHandler';
+    has_field cidr => (
+        type => '+pfappserver::Form::Field::CIDR',
+        required => 1,
+    );
+}
+
+#This test will running last
+use Test::NoWarnings;
+
+my @valid = qw(
+    192.168.1.0/24
+    10.0.0.0/8
+    0.0.0.0/0
+    172.16.5.4/32
+);
+
+my @invalid = (
+    '192.168.1.0',      # missing prefix
+    '192.168.1.0/33',   # prefix out of range
+    '999.168.1.0/33',   # prefix out of range
+    '192.168.1.0/',     # empty prefix
+    '2001:db8::/32',    # IPv6 not accepted
+    'not-an-ip/24',     # invalid address
+    '192.168.1.0/24/1', # more than one slash
+);
+
+for my $value (@valid) {
+    my $form = Form::Test->new;
+    $form->process(params => {cidr => $value}, posted => 1);
+    ok(!$form->has_errors(), "Valid CIDR $value");
+}
+
+for my $value (@invalid) {
+    my $form = Form::Test->new;
+    $form->process(params => {cidr => $value}, posted => 1);
+    ok($form->has_errors(), "Invalid CIDR $value");
+}
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2026 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;


### PR DESCRIPTION
# Description
Prevents the same network from being assigned to more than one connector, and validates that connector networks are entered as proper IPv4 CIDRs.

Two things change on the connector configuration form (Configuration → Connectors):

- **Duplicate / cross-connector network detection.** When saving a connector, the `networks` list is rejected if it contains the same network twice, or if one of its networks is already defined on another connector. The error names the offending network (and the other connector when applicable).
- **New `CIDR` form field.** The `networks` entries now use a dedicated `pfappserver::Form::Field::CIDR` field that enforces IPv4 CIDR notation (e.g. `192.168.1.0/24`) — a mandatory prefix length between 0 and 32. It reuses `valid_ip()` from `pf::util` and admits the all-zeros network (`0.0.0.0/x`).

# Impacts
- Connector create/update in pfappserver and the UnifiedApi `Config/Connector` endpoint.
- `networks` field validation on connectors — reviewers should confirm valid CIDRs pass, malformed values are rejected, and duplicate/overlapping networks across connectors are caught. The check compares network entries against all other connectors (excluding the connector being edited and `local_connector`).

# Issue
fixes #9125

# Delete branch after merge
YES

# Checklist
- [n/a] Document the feature
- [n/a] Add OpenAPI specification
- [yes] Add unit tests
- [no] Add acceptance tests (TestLink)

# NEWS file entries
## Bug Fixes
* Connector Network Overlap (#9125)
