### PR TITLE
Cloud Improvment

### DIFF
--- a/addons/pfconnector/conf/radiusd/auth.conf
+++ b/addons/pfconnector/conf/radiusd/auth.conf
@@ -24,6 +24,13 @@ listen {
 
 listen {
         ipaddr = *
+        port = 1813
+        type = acct
+        virtual_server = pf-remote
+}
+
+listen {
+        ipaddr = *
         port = 2083
         type = auth+acct
         proto = tcp

--- a/addons/pfconnector/conf/radiusd/packetfence
+++ b/addons/pfconnector/conf/radiusd/packetfence
@@ -26,9 +26,25 @@ home_server_pool pf_auth_pool {
 	home_server =  degraded
 }
 
+home_server pf.remote.acct {
+        type = acct
+        ipaddr = 100.64.0.1
+        src_ipaddr = %mgmt_ip%
+        port = 18132
+        secret = '%password%'
+        response_window = 3
+        zombie_period = 10
+        revive_interval = 60
+
+        # No status_check: a Status-Server here would be code-routed by the cloud
+        # proxy to radiusd-auth (not pfacct), so it wouldn't actually probe pfacct.
+        # Rely on response_window/zombie_period/revive_interval for liveness instead.
+}
+
 home_server_pool pf_acct_pool {
 	type = fail-over
-	home_server =  pf.remote
+	home_server =  pf.remote.acct
+	home_server =  degraded
 }
 
 realm remote {
@@ -42,6 +58,7 @@ home_server_pool degraded_pool {
 
 realm degraded {
 	auth_pool = degraded_pool
+	acct_pool = degraded_pool
 }
 
 
@@ -103,6 +120,12 @@ server pf-remote {
 	authenticate {
 	}
 	accounting {
+		# rest-remote queries the local API, which knows tunnel/cloud state and sets
+		# control:Proxy-To-Realm to "remote" (cloud up -> proxy acct to pf.remote.acct
+		# on udp 18132) or "degraded" (cloud down -> realm degraded answers locally with
+		# Accounting-Response OK). Same cloud-down detection as the authorize section.
+		# pre-proxy{} tags PacketFence-ConnectorID and the home_server signs with the
+		# unified secret, mirroring the auth path.
 		rest-remote
 		if(!NAS-IP-Address){
 			update request {
@@ -174,13 +197,12 @@ server pf.degraded {
 	}
 
 	#
-	#  Accounting.  Log the accounting data.
+	#  Accounting.  Tunnel is down (failed over here from pf_acct_pool), so just
+	#  acknowledge the request locally with Accounting-Response OK to stop the NAS
+	#  retransmitting; there is no cloud reachable to record it.
 	#
 	accounting {
-		if (noop) {
-			ok
-		}
-
+		ok
 		attr_filter.accounting_response
 	}
 

--- a/bin/pyntlm_auth/t_worker_register.py
+++ b/bin/pyntlm_auth/t_worker_register.py
@@ -11,14 +11,21 @@ is_me = Event()
 
 def primary_worker_register(worker):
     key = f"{redis_client.namespace}:primary_worker"
+    pid = str(worker.pid)
     while not stop_event.is_set():
         try:
-            res = redis_client.r.set(name=key, value=worker.pid, nx=True, ex=5, get=True)
-            if res is None:
+            # Best-effort primary-worker election, written to work on older Redis
+            # servers. Avoid `SET ... NX GET` (Redis 6.2+) and `EXPIRE ... XX GT`
+            # (Redis 7.0+): claim with `SET NX EX`, then read the holder with a
+            # follow-up GET and refresh the lease with a plain EXPIRE. The 5s TTL is
+            # refreshed every 2s, so the tiny set/get non-atomicity is harmless.
+            claimed = redis_client.r.set(name=key, value=pid, nx=True, ex=5)
+            if claimed:
                 worker.log.info(f"primary worker is registered on PID: {worker.pid}.")
                 is_me.set()
-            if str(worker.pid) == res:
-                redis_client.r.expire(name=key, time=10, xx=True, gt=True)
+            elif redis_client.r.get(key) == pid:
+                redis_client.r.expire(name=key, time=10)
+                is_me.set()
 
         except redis.ConnectionError:
             worker.log.warning("failed registering primary worker: redis connection error.")

--- a/bin/pyntlm_auth/t_worker_register.py
+++ b/bin/pyntlm_auth/t_worker_register.py
@@ -11,21 +11,14 @@ is_me = Event()
 
 def primary_worker_register(worker):
     key = f"{redis_client.namespace}:primary_worker"
-    pid = str(worker.pid)
     while not stop_event.is_set():
         try:
-            # Best-effort primary-worker election, written to work on older Redis
-            # servers. Avoid `SET ... NX GET` (Redis 6.2+) and `EXPIRE ... XX GT`
-            # (Redis 7.0+): claim with `SET NX EX`, then read the holder with a
-            # follow-up GET and refresh the lease with a plain EXPIRE. The 5s TTL is
-            # refreshed every 2s, so the tiny set/get non-atomicity is harmless.
-            claimed = redis_client.r.set(name=key, value=pid, nx=True, ex=5)
-            if claimed:
+            res = redis_client.r.set(name=key, value=worker.pid, nx=True, ex=5, get=True)
+            if res is None:
                 worker.log.info(f"primary worker is registered on PID: {worker.pid}.")
                 is_me.set()
-            elif redis_client.r.get(key) == pid:
-                redis_client.r.expire(name=key, time=10)
-                is_me.set()
+            if str(worker.pid) == res:
+                redis_client.r.expire(name=key, time=10, xx=True, gt=True)
 
         except redis.ConnectionError:
             worker.log.warning("failed registering primary worker: redis connection error.")

--- a/containers/radiusd/Dockerfile
+++ b/containers/radiusd/Dockerfile
@@ -4,7 +4,7 @@ FROM ${KNK_REGISTRY_URL}/pfdebian:${IMAGE_TAG}
 
 RUN apt-get -qq update \
     && apt-get clean \
-    && apt-get -qq install -y freeradius=4:3.2.10+git freeradius-common=4:3.2.10+git freeradius-config=4:3.2.10+git freeradius-ldap=4:3.2.10+git freeradius-mysql=4:3.2.10+git freeradius-redis=4:3.2.10+git freeradius-rest=4:3.2.10+git freeradius-utils=4:3.2.10+git \
+    && apt-get -qq install -y freeradius=4:3.2.10 freeradius-common=4:3.2.10 freeradius-config=4:3.2.10 freeradius-ldap=4:3.2.10 freeradius-mysql=4:3.2.10 freeradius-redis=4:3.2.10 freeradius-rest=4:3.2.10 freeradius-utils=4:3.2.10 \
     && apt-get clean
 
 WORKDIR /usr/local/pf/

--- a/containers/radiusd/Dockerfile
+++ b/containers/radiusd/Dockerfile
@@ -4,7 +4,7 @@ FROM ${KNK_REGISTRY_URL}/pfdebian:${IMAGE_TAG}
 
 RUN apt-get -qq update \
     && apt-get clean \
-    && apt-get -qq install -y freeradius=4:3.2.8+git freeradius-common=4:3.2.8+git freeradius-config=4:3.2.8+git freeradius-ldap=4:3.2.8+git freeradius-mysql=4:3.2.8+git freeradius-redis=4:3.2.8+git freeradius-rest=4:3.2.8+git freeradius-utils=4:3.2.8+git \
+    && apt-get -qq install -y freeradius=4:3.2.10+git freeradius-common=4:3.2.10+git freeradius-config=4:3.2.10+git freeradius-ldap=4:3.2.10+git freeradius-mysql=4:3.2.10+git freeradius-redis=4:3.2.10+git freeradius-rest=4:3.2.10+git freeradius-utils=4:3.2.10+git \
     && apt-get clean
 
 WORKDIR /usr/local/pf/

--- a/containers/radiusd/Dockerfile
+++ b/containers/radiusd/Dockerfile
@@ -4,7 +4,7 @@ FROM ${KNK_REGISTRY_URL}/pfdebian:${IMAGE_TAG}
 
 RUN apt-get -qq update \
     && apt-get clean \
-    && apt-get -qq install -y freeradius=4:3.2.10 freeradius-common=4:3.2.10 freeradius-config=4:3.2.10 freeradius-ldap=4:3.2.10 freeradius-mysql=4:3.2.10 freeradius-redis=4:3.2.10 freeradius-rest=4:3.2.10 freeradius-utils=4:3.2.10 \
+    && apt-get -qq install -y freeradius=4:3.2.11+git freeradius-common=4:3.2.11+git freeradius-config=4:3.2.11+git freeradius-ldap=4:3.2.11+git freeradius-mysql=4:3.2.11+git freeradius-redis=4:3.2.11+git freeradius-rest=4:3.2.11+git freeradius-utils=4:3.2.11+git \
     && apt-get clean
 
 WORKDIR /usr/local/pf/

--- a/debian/control
+++ b/debian/control
@@ -208,8 +208,8 @@ Description: GPG keys provided by PacketFence project
 Package: packetfence-pfconnector-remote
 Architecture: all
 Depends: docker-ce, docker-ce-cli, containerd.io, iproute2, jq, make
-Conflicts: fingerbank-collector, freeradius-common
-Replaces: fingerbank-collector, freeradius-common
+Conflicts: fingerbank-collector, fingerbank-collector-remote, freeradius-common
+Replaces: fingerbank-collector, fingerbank-collector-remote, freeradius-common
 Description: PacketFence Connector
  PacketFence Connector files. This package contains all files related to PacketFence Connector.
 

--- a/debian/control
+++ b/debian/control
@@ -19,7 +19,7 @@ Pre-Depends:  ca-certificates,
  packetfence-pfcmd-suid (>= ${source:Version}), packetfence-config (>= ${source:Version}),
 # CAUTION: we need to require the version we want for Fingerbank and ensure we don't want anything equal or above the next major release as it can add breaking changes
  fingerbank (>= 4.3.3), fingerbank (<< 5.0.0),
- fingerbank-collector (>= 1.4.1), fingerbank-collector (<< 2.0.0),
+ fingerbank-collector (>= 1.6.1), fingerbank-collector (<< 2.0.0),
  packetfence-redis-cache (>= ${source:Version}),
  packetfence-perl (>= 1.2.4),
 # Removed for now

--- a/debian/control
+++ b/debian/control
@@ -208,6 +208,8 @@ Description: GPG keys provided by PacketFence project
 Package: packetfence-pfconnector-remote
 Architecture: all
 Depends: docker-ce, docker-ce-cli, containerd.io, iproute2, jq, make
+Conflicts: fingerbank-collector, freeradius-common
+Replaces: fingerbank-collector, freeradius-common
 Description: PacketFence Connector
  PacketFence Connector files. This package contains all files related to PacketFence Connector.
 

--- a/debian/packetfence-pfconnector-remote.postinst
+++ b/debian/packetfence-pfconnector-remote.postinst
@@ -38,6 +38,11 @@ case "$1" in
     fi
     # get containers image and tag them locally
     /usr/local/pfconnector-remote/containers/manage-images.sh
+    # stop and disable legacy pfconnector-remote service in favor of the combined one
+    if systemctl is-enabled --quiet "packetfence-pfconnector-remote.service" 2>/dev/null; then
+        /bin/systemctl stop packetfence-pfconnector-remote.service 2>/dev/null || true
+        /bin/systemctl disable packetfence-pfconnector-remote.service 2>/dev/null || true
+    fi
     /bin/systemctl daemon-reload
     /bin/systemctl enable packetfence-pfconnector-remote-combined.service
     if [ -n "$2" ]; then

--- a/go/chisel/server/ntlm_auth_api_env_test.go
+++ b/go/chisel/server/ntlm_auth_api_env_test.go
@@ -125,6 +125,44 @@ func TestMaskDomainSecretsForConnector_NonIPAdServer(t *testing.T) {
 	}
 }
 
+// TestStripDomainHostPrefix covers the "<host_id> <id>" -> "<id>" mapping and
+// the already-raw passthrough.
+func TestStripDomainHostPrefix(t *testing.T) {
+	cases := map[string]string{
+		"WIN-SDFCMFQ69C9 inverseINC": "inverseINC", // cloud pod hostname prefix
+		"pf1.example.com domA":       "domA",        // FQDN prefix (dots)
+		"packetfence-node1 domB":     "domB",        // dash in hostname
+		"domA":                       "domA",        // already raw, no prefix
+		"":                           "",            // empty
+	}
+	for in, want := range cases {
+		if got := stripDomainHostPrefix(in); got != want {
+			t.Errorf("stripDomainHostPrefix(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestMaskDomainSecretsForConnector_StripsHostPrefix ensures the host_id
+// namespace prefix is stripped from the served keys so the pfconnector-remote
+// receives raw, space-free domain ids (matching pfconnector-remote-load.sh).
+func TestMaskDomainSecretsForConnector_StripsHostPrefix(t *testing.T) {
+	src := map[string]pfconfigdriver.Domain{
+		"WIN-SDFCMFQ69C9 inverseINC": {AdServer: "10.0.0.5", UseConnector: "enabled", MachineAccountPassword: "real"},
+	}
+	got := maskDomainSecretsForConnector(src, "connectorA", ownerLookup(map[string]string{"10.0.0.5": "connectorA"}))
+
+	if _, ok := got["WIN-SDFCMFQ69C9 inverseINC"]; ok {
+		t.Errorf("output key should be stripped of the host_id prefix, got prefixed key %v", keys(got))
+	}
+	d, ok := got["inverseINC"]
+	if !ok {
+		t.Fatalf("expected raw key %q in output, got %v", "inverseINC", keys(got))
+	}
+	if d.MachineAccountPassword != "real" {
+		t.Errorf("owner should get real secret, got %q", d.MachineAccountPassword)
+	}
+}
+
 func keys(m map[string]pfconfigdriver.Domain) []string {
 	out := make([]string, 0, len(m))
 	for k := range m {

--- a/go/chisel/server/server_handler.go
+++ b/go/chisel/server/server_handler.go
@@ -963,6 +963,17 @@ func (s *Server) handleRemoteNtlmAuthAPIEnv(w http.ResponseWriter, req *http.Req
 		}
 		return owner.PfconfigHashNS
 	})
+	// On a pfconnector-remote the ntlm-auth-api is always a local container,
+	// reachable at containers-gateway.internal — never the cloud pfconnector
+	// Service ClusterIP. resource::domains rewrites ntlm_auth_host to that ClusterIP
+	// for cloud-side radiusd, and that value can leak into the served config; the
+	// remote's on-host readiness monitor (and its clients) can't reach the ClusterIP.
+	// Force the local address so a drifted/overridden ntlm_auth_host can't break the
+	// remote's ntlm-auth-api startup.
+	for id, d := range Domains {
+		d.NtlmAuthHost = "containers-gateway.internal"
+		Domains[id] = d
+	}
 	jsonData, err := json.Marshal(Domains)
 	w.Header().Set("Content-Type", "application/json")
 	if err != nil {

--- a/go/chisel/server/server_handler.go
+++ b/go/chisel/server/server_handler.go
@@ -840,9 +840,25 @@ func maskDomainSecretsForConnector(domains map[string]pfconfigdriver.Domain, con
 		if connectorId == "" || ownerForIP(net.ParseIP(d.AdServer)) != connectorId {
 			d.MachineAccountPassword = fakeMachineAccountPassword
 		}
-		out[domain] = d
+		out[stripDomainHostPrefix(domain)] = d
 	}
 	return out
+}
+
+// stripDomainHostPrefix removes the "<host_id> " namespace prefix that
+// PacketFence prepends to a domain identifier when it is stored in
+// domain.conf (see pf::UnifiedApi::Controller::Config::Domains, which keys
+// each section as "<hostname> <id>"). A pfconnector-remote re-namespaces every
+// domain under its own hostname (see pfconnector-remote-load.sh, which builds
+// "[<local-hostname> <id>]" sections and "<id>.env" files), so it needs the
+// raw id and cannot cope with a space in the key. Domain ids are alphanumeric
+// and host_ids (hostnames) contain no spaces, so the raw id is the token after
+// the last space; a key without a space (already raw) is returned unchanged.
+func stripDomainHostPrefix(id string) string {
+	if i := strings.LastIndex(id, " "); i >= 0 {
+		return id[i+1:]
+	}
+	return id
 }
 
 func (s *Server) handleRemoteNtlmAuthAPIDB(w http.ResponseWriter, req *http.Request) {

--- a/go/chisel/server/server_handler.go
+++ b/go/chisel/server/server_handler.go
@@ -25,6 +25,7 @@ import (
 	"github.com/inverse-inc/packetfence/go/chisel/share/tunnel"
 	"github.com/inverse-inc/packetfence/go/cluster"
 	connector "github.com/inverse-inc/packetfence/go/connector"
+	"github.com/inverse-inc/packetfence/go/jsonrpc2"
 	"github.com/inverse-inc/packetfence/go/pfconfigdriver"
 	"github.com/inverse-inc/packetfence/go/pfk8s"
 	"github.com/inverse-inc/packetfence/go/unifiedapiclient"
@@ -127,6 +128,9 @@ func (s *Server) handleClientHandler(w http.ResponseWriter, r *http.Request) {
 	case apiPrefix + "/health":
 		s.handleConnectorHealth(w, r)
 		return
+	case apiPrefix + "/process-dhcp":
+		s.handleProcessDhcp(w, r)
+		return
 	}
 	if strings.HasPrefix(r.URL.Path, credcachePathPrefix) {
 		s.handleCredcacheForward(w, r)
@@ -135,6 +139,112 @@ func (s *Server) handleClientHandler(w http.ResponseWriter, r *http.Request) {
 	//missing :O
 	w.WriteHeader(404)
 	w.Write([]byte("Not found"))
+}
+
+// dhcpEvent mirrors the fingerbank-collector's dhcp_forwarder.DhcpEvent JSON.
+// The collector sniffs raw DHCP frames (the pfdhcplistener replacement) and
+// POSTs them to /api/v1/pfconnector/process-dhcp through the connector tunnel.
+// Payload stays a base64 string end-to-end: the collector base64-encodes it in
+// JSON and pf::api base64-decodes it, so we forward it verbatim with no
+// decode/re-encode round trip. The collector's message_type/timestamp fields
+// are intentionally not modelled — pf::api derives everything it needs from the
+// payload — and are simply ignored on decode.
+type dhcpEvent struct {
+	Version int    `json:"version"`
+	Payload string `json:"payload"` // base64 DHCP UDP payload, forwarded verbatim
+	SrcMac  string `json:"src_mac"`
+	DstMac  string `json:"dst_mac"`
+	SrcIp   string `json:"src_ip"`
+	DstIp   string `json:"dst_ip"`
+}
+
+// The webservices JSON-RPC client is resolved from pfconfig once and reused:
+// process-dhcp is a hot path and NewClientFromConfig does a pfconfig socket
+// round-trip on every call. dhcpDispatchSem bounds the number of in-flight
+// async forwards so a slow/unreachable webservices endpoint can't spawn an
+// unbounded goroutine pile-up under DHCP volume.
+var (
+	dhcpRpcClientMu sync.Mutex
+	dhcpRpcClient   *jsonrpc2.Client
+	dhcpDispatchSem = make(chan struct{}, 128)
+)
+
+// getDhcpRpcClient returns a memoized webservices JSON-RPC client. It only
+// caches once pfconfig actually returns a usable endpoint; NewClientFromConfig
+// swallows fetch errors, so caching an empty-Host client would strand every
+// future packet. Until pfconfig is ready it keeps returning transient clients.
+func getDhcpRpcClient(ctx context.Context) *jsonrpc2.Client {
+	dhcpRpcClientMu.Lock()
+	defer dhcpRpcClientMu.Unlock()
+	if dhcpRpcClient != nil {
+		return dhcpRpcClient
+	}
+	c := jsonrpc2.NewClientFromConfig(ctx)
+	if c.Host == "" {
+		return c
+	}
+	dhcpRpcClient = c
+	return dhcpRpcClient
+}
+
+// handleProcessDhcp relays a collector-forwarded DHCP packet to
+// pf::api::process_dhcp_event over the webservices JSON-RPC endpoint. This runs
+// on the pfconnector-server, the only side with pfconfig access to resolve that
+// endpoint (host/port/proto) and its credentials. DHCP fingerprinting is
+// best-effort (like pfdhcplistener's async notify_hashed), so the forward is
+// handed to a bounded background dispatcher and we return 202 immediately —
+// never blocking the collector on the webservices round trip.
+func (s *Server) handleProcessDhcp(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		json.NewEncoder(w).Encode(unifiedapiclient.ErrorReply{Status: http.StatusMethodNotAllowed, Message: "process-dhcp only accepts POST"})
+		return
+	}
+
+	var ev dhcpEvent
+	if err := json.NewDecoder(r.Body).Decode(&ev); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(unifiedapiclient.ErrorReply{Status: http.StatusBadRequest, Message: fmt.Sprintf("Unable to decode DHCP event: %s", err)})
+		return
+	}
+	if ev.Payload == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(unifiedapiclient.ErrorReply{Status: http.StatusBadRequest, Message: "Empty DHCP payload"})
+		return
+	}
+
+	// pf::api methods take a flat alternating key/value param list (%postdata).
+	// Payload is already base64 (see dhcpEvent) and forwarded verbatim.
+	params := []interface{}{
+		"version", ev.Version,
+		"payload", ev.Payload,
+		"src_mac", ev.SrcMac,
+		"dst_mac", ev.DstMac,
+		"src_ip", ev.SrcIp,
+		"dst_ip", ev.DstIp,
+	}
+
+	client := getDhcpRpcClient(r.Context())
+	logger := log.LoggerWContext(r.Context())
+
+	select {
+	case dhcpDispatchSem <- struct{}{}:
+		go func() {
+			defer func() { <-dhcpDispatchSem }()
+			// Detached context: the request context is cancelled once we return
+			// 202 below. Notify does not surface HTTP status, so a rejected
+			// event can only be logged on transport error, not recovered.
+			if err := client.Notify(context.Background(), "process_dhcp_event", params); err != nil {
+				logger.Error(fmt.Sprintf("process-dhcp: notify pf::api failed: %s", err))
+			}
+		}()
+		w.WriteHeader(http.StatusAccepted)
+	default:
+		// Dispatcher saturated (slow/unreachable webservices). Drop rather than
+		// block the collector, mirroring the collector's own full-channel drop.
+		logger.Warn("process-dhcp: dispatch queue full, dropping DHCP event")
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}
 }
 
 // handleCredcacheForward routes /api/v1/pfconnector/credcache/<connector-id>/...

--- a/go/chisel/server/server_handler.go
+++ b/go/chisel/server/server_handler.go
@@ -527,6 +527,11 @@ func (s *Server) handleWebsocket(w http.ResponseWriter, req *http.Request) {
 	})
 	if user != nil {
 		l.Infof("Connector %s has just connected to this server", user.Name)
+		// After a reconnect the pod no longer listens on this connector's previous
+		// dynreverse ports, so drop their k8s Service ports before we clear the
+		// ActiveDynReverse entries below (removeConnectorDynReverseServicePorts reads
+		// them). Otherwise stale, unroutable ports would accumulate in the Service.
+		s.removeConnectorDynReverseServicePorts(ctx, user.Name)
 		settings.ClearActiveDynReverseConnector(ctx, user.Name)
 		activeTunnels.Store(user.Name, tunnel)
 		tunnel.ConnectorID = user.Name
@@ -557,6 +562,11 @@ func (s *Server) handleDynReverse(w http.ResponseWriter, req *http.Request) {
 		ConnectorID string `json:"connector_id"`
 		To          string `json:"to"`
 		LocalPort   string `json:"local_port,omitempty"`
+		// ExposeService opts this dynreverse port into being published on the
+		// pfconnector k8s Service (needed when the caller reaches it via the Service
+		// ClusterIP, e.g. the domain-join flow). Left off by the RADIUS/SNMP callers
+		// so their behavior is unchanged.
+		ExposeService bool `json:"expose_service,omitempty"`
 	}{}
 
 	err := json.NewDecoder(req.Body).Decode(&payload)
@@ -574,6 +584,10 @@ func (s *Server) handleDynReverse(w http.ResponseWriter, req *http.Request) {
 		remote.Lock()
 		defer remote.Unlock()
 		remote.LastTouched = time.Now()
+		// No need to (re)patch the Service here: a live ActiveDynReverse entry implies
+		// the port was patched on its fresh bind and hasn't been pruned (pruning only
+		// happens on reconnect, which also clears this map). Keeping the hot reuse path
+		// free of a k8s API call matters for the RADIUS/SNMP dynreverse callers.
 		json.NewEncoder(w).Encode(gin.H{"host": host, "port": remote.LocalPort, "message": fmt.Sprintf("Reusing existing port %s", remote.LocalPort)})
 		return
 	}
@@ -635,6 +649,13 @@ func (s *Server) handleDynReverse(w http.ResponseWriter, req *http.Request) {
 			err = <-doneChan
 
 			if err == nil {
+				// Expose the freshly-bound port on the pfconnector k8s Service so the
+				// caller can reach it through the Service ClusterIP. Must complete
+				// before we return the port, otherwise the caller's dial races the
+				// Service update. No-op outside k8s or when the caller didn't opt in.
+				if payload.ExposeService {
+					s.ensureDynReverseServicePort(req.Context(), dynPort, remote.LocalProto)
+				}
 				json.NewEncoder(w).Encode(gin.H{"host": host, "port": dynPort, "message": fmt.Sprintf("Setup remote %s", remoteStr)})
 				return
 			} else {
@@ -649,6 +670,112 @@ func (s *Server) handleDynReverse(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 		json.NewEncoder(w).Encode(unifiedapiclient.ErrorReply{Status: http.StatusNotFound, Message: fmt.Sprintf("Unable to find active connector tunnel: %s", connectorId)})
 		return
+	}
+}
+
+// dynReverseServicePortName builds the k8s Service port name for a dynreverse
+// local port. It intentionally uses the same "port-<proto>-<port>" scheme as the
+// static ports in handleClientHandshake so the two never disagree on a name, and
+// it stays within the 15-char IANA_SVC_NAME limit (e.g. "port-tcp-65535").
+func dynReverseServicePortName(proto, port string) string {
+	return "port-" + strings.ToLower(proto) + "-" + port
+}
+
+// ensureDynReverseServicePort exposes a dynreverse local port on the pfconnector
+// k8s Service so it is reachable through the Service ClusterIP. In k8s the caller
+// (e.g. the domain-join flow) dials PFCONNECTOR_SERVICE_HOST:<dynPort>, which only
+// routes to the pod when the port is present in the Service spec. Unlike the
+// static tunnels bound at handshake, dynreverse ports are created on demand, so
+// nothing else adds them. Outside k8s (no admin client) this is a no-op, and it is
+// idempotent: it skips the patch when the port already exists.
+func (s *Server) ensureDynReverseServicePort(ctx context.Context, port, proto string) {
+	client := pfk8s.NewAdminClientFromEnv()
+	if client == nil {
+		return
+	}
+	l := log.LoggerWContext(ctx)
+	services, err := client.GetService("pfconnector")
+	if err != nil {
+		l.Error(fmt.Sprintf("Unable to get pfconnector service to expose dynreverse port %s: %s", port, err))
+		return
+	}
+	name := dynReverseServicePortName(proto, port)
+	for _, svcPort := range services.Spec.Ports {
+		if svcPort.Name == name {
+			return // already exposed
+		}
+	}
+	portNum, err := strconv.ParseUint(port, 10, 16)
+	if err != nil {
+		l.Error(fmt.Sprintf("Invalid dynreverse port %q, not patching service: %s", port, err))
+		return
+	}
+	patch := []pfk8s.PatchPorts{{
+		Op:   "add",
+		Path: "/spec/ports/-",
+		Value: pfk8s.PatchPortAdd{
+			Port:       int(portNum),
+			TargetPort: int(portNum),
+			Protocol:   strings.ToUpper(proto),
+			Name:       name,
+		},
+	}}
+	if err := client.PatchPorts(patch); err != nil {
+		l.Error(fmt.Sprintf("Unable to expose dynreverse port %s on pfconnector service: %s", port, err))
+	}
+}
+
+// removeConnectorDynReverseServicePorts drops the k8s Service ports previously
+// added for this connector's dynreverse tunnels. It must be called at handshake
+// before the connector's ActiveDynReverse entries are cleared, since it derives
+// the port names from those entries. (On a server-process restart the in-memory
+// map is empty, so any ports from before the restart cannot be reconciled here;
+// that is an accepted edge case as the pod/Service would typically be recreated.)
+func (s *Server) removeConnectorDynReverseServicePorts(ctx context.Context, connectorId string) {
+	client := pfk8s.NewAdminClientFromEnv()
+	if client == nil {
+		return
+	}
+	l := log.LoggerWContext(ctx)
+
+	names := map[string]bool{}
+	settings.ActiveDynReverse.Range(func(kInt, v interface{}) bool {
+		if k, ok := kInt.(string); ok && strings.HasPrefix(k, connectorId+":") {
+			remote := v.(*settings.Remote)
+			names[dynReverseServicePortName(remote.LocalProto, remote.LocalPort)] = true
+		}
+		return true
+	})
+	if len(names) == 0 {
+		return
+	}
+
+	services, err := client.GetService("pfconnector")
+	if err != nil {
+		l.Error(fmt.Sprintf("Unable to get pfconnector service to prune dynreverse ports: %s", err))
+		return
+	}
+	delIndexes := []int{}
+	for index, svcPort := range services.Spec.Ports {
+		if names[svcPort.Name] {
+			delIndexes = append(delIndexes, index)
+		}
+	}
+	if len(delIndexes) == 0 {
+		return
+	}
+	// Remove from highest index to lowest so each removal doesn't shift the
+	// indexes of the ones still to be removed.
+	sort.Sort(sort.Reverse(sort.IntSlice(delIndexes)))
+	patch := make([]pfk8s.PatchPorts, 0, len(delIndexes))
+	for _, index := range delIndexes {
+		patch = append(patch, pfk8s.PatchPorts{
+			Op:   "remove",
+			Path: "/spec/ports/" + strconv.Itoa(index),
+		})
+	}
+	if err := client.PatchPorts(patch); err != nil {
+		l.Error(fmt.Sprintf("Unable to prune dynreverse ports from pfconnector service: %s", err))
 	}
 }
 

--- a/go/chisel/server/server_handler.go
+++ b/go/chisel/server/server_handler.go
@@ -444,6 +444,13 @@ func (s *Server) handleWebsocket(w http.ResponseWriter, req *http.Request) {
 	// Record what this connector has bound so a later reprovision (triggered when a
 	// domain is added) only binds/patches the newly-added tunnels. A reconnect
 	// re-runs this and overwrites the set with the fresh state.
+	//
+	// Keyed by user.Name, which IS the connector id: connectors authenticate to the
+	// chisel tunnel with their connector id as the username, so user.Name equals the
+	// `connector_id` that handleReprovisionStaticConnections looks up, and the key
+	// under which PfconnectorStaticConnections.Element is stored (find_connector
+	// returns the connector id). This is the same invariant activeTunnels relies on
+	// (Store(user.Name) here vs Load(connectorId) there).
 	connectorBoundRemotes.Store(user.Name, boundStatic)
 
 	if client := pfk8s.NewAdminClientFromEnv(); client != nil {
@@ -781,6 +788,9 @@ func (s *Server) handleReprovisionStaticConnections(w http.ResponseWriter, req *
 	}
 
 	// Copy the recorded bound-set so we can extend it without mutating shared state.
+	// connectorId is the tunnel username the set was stored under at handshake (see
+	// the connectorBoundRemotes.Store in handleWebsocket); a stale/missing set only
+	// costs a redundant bind attempt, which fails harmlessly on an in-use port.
 	bound := map[string]bool{}
 	if boundIface, found := connectorBoundRemotes.Load(connectorId); found {
 		for k, v := range boundIface.(map[string]bool) {

--- a/go/chisel/server/server_handler.go
+++ b/go/chisel/server/server_handler.go
@@ -566,7 +566,10 @@ func (s *Server) handleRemoteBinds(w http.ResponseWriter, req *http.Request) {
 			fmt.Sprintf("80:%s", sharedutils.EnvOrDefault("PFCONNECTOR_BINDS_HOST_PORT_80", fmt.Sprintf("%s:80", managementIP))),
 			fmt.Sprintf("443:%s", sharedutils.EnvOrDefault("PFCONNECTOR_BINDS_HOST_PORT_443", fmt.Sprintf("%s:443", managementIP))),
 			fmt.Sprintf("100.64.0.1:18122:%s", sharedutils.EnvOrDefault("PFCONNECTOR_BINDS_HOST_PORT_1812", fmt.Sprintf("%s:1812/udp|radius", managementIP))),
-			fmt.Sprintf("1813:%s", sharedutils.EnvOrDefault("PFCONNECTOR_BINDS_HOST_PORT_1813", fmt.Sprintf("%s:1813/udp|radius", managementIP))),
+			// Accounting tunnel: FreeRADIUS on the connector owns local UDP 1813 (NAS
+			// accounting) and proxies to this bind, which tunnels to the cloud pfacct.
+			// Mirrors the 1812 auth tunnel (100.64.0.1:18122) on a dedicated acct port.
+			fmt.Sprintf("100.64.0.1:18132:%s", sharedutils.EnvOrDefault("PFCONNECTOR_BINDS_HOST_PORT_1813", fmt.Sprintf("%s:1813/udp|radius", managementIP))),
 			fmt.Sprintf("1815:%s", sharedutils.EnvOrDefault("PFCONNECTOR_BINDS_HOST_PORT_1815", fmt.Sprintf("%s:1815/udp|radius", managementIP))),
 			fmt.Sprintf("9096:%s", sharedutils.EnvOrDefault("PFCONNECTOR_BINDS_HOST_PORT_9096", fmt.Sprintf("%s:9096", managementIP))),
 			fmt.Sprintf("containers-gateway.internal:3306:%s", sharedutils.EnvOrDefault("PFCONNECTOR_BINDS_HOST_PORT_3306", fmt.Sprintf("%s:3306", managementIP))),

--- a/go/chisel/server/server_handler.go
+++ b/go/chisel/server/server_handler.go
@@ -39,6 +39,14 @@ var credcachePathPrefix = apiPrefix + "/credcache/"
 const credcacheClientTarget = "127.0.0.1:8081"
 
 var activeTunnels = sync.Map{}
+
+// connectorBoundRemotes tracks the static reverse-remote definitions already
+// bound per connector (connectorId -> map[remoteDef]bool). Recorded at handshake
+// and updated on reprovision so a rebind only binds/patches the newly-added
+// tunnels. Best-effort: reprovision binds per-remote and tolerates an already-in-
+// use port, so a stale/missing entry degrades gracefully.
+var connectorBoundRemotes = sync.Map{}
+
 var apiPrefix = "/api/v1/pfconnector"
 
 const (
@@ -89,6 +97,9 @@ func (s *Server) handleClientHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	case apiPrefix + "/remote-binds":
 		s.handleRemoteBinds(w, r)
+		return
+	case apiPrefix + "/reprovision-static-connections":
+		s.handleReprovisionStaticConnections(w, r)
 		return
 	case apiPrefix + "/all-fingerbank-collector-endpoints":
 		s.handleAllFingerbankCollectorEndpoints(w, r)
@@ -421,13 +432,19 @@ func (s *Server) handleWebsocket(w http.ResponseWriter, req *http.Request) {
 		l.Infof("Failed to fetch pfconnector static connections from pfconfig, continuing without them: %s", err)
 	}
 	additionalRemotes := chshare.Remotes{}
+	boundStatic := map[string]bool{}
 	if remotes, found := pfconnectorStaticConnections.Element[user.Name]; found {
 		for _, remoteDef := range remotes {
 			if remote, err := settings.DecodeRemote(remoteDef); err == nil {
 				additionalRemotes = append(additionalRemotes, remote)
+				boundStatic[remoteDef] = true
 			}
 		}
 	}
+	// Record what this connector has bound so a later reprovision (triggered when a
+	// domain is added) only binds/patches the newly-added tunnels. A reconnect
+	// re-runs this and overwrites the set with the fresh state.
+	connectorBoundRemotes.Store(user.Name, boundStatic)
 
 	if client := pfk8s.NewAdminClientFromEnv(); client != nil {
 		services, err := client.GetService("pfconnector")
@@ -717,6 +734,149 @@ func (s *Server) handleRemoteBinds(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 		json.NewEncoder(w).Encode(unifiedapiclient.ErrorReply{Status: http.StatusNotFound, Message: fmt.Sprintf("Unable to find active connector tunnel: %s", connectorId)})
 		return
+	}
+}
+
+// handleReprovisionStaticConnections binds (and exposes on the k8s Service) the
+// static reverse tunnels for a connector that were added since it last
+// handshaked — e.g. the NTLM-auth tunnel created when a connector-backed domain
+// is committed. It lets a domain become usable without a manual connector
+// reconnect. No active tunnel => no-op (the connector will pick everything up on
+// its next connect). Only newly-added remotes are touched.
+func (s *Server) handleReprovisionStaticConnections(w http.ResponseWriter, req *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	payload := struct {
+		ConnectorID string `json:"connector_id"`
+	}{}
+	if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(unifiedapiclient.ErrorReply{Status: http.StatusBadRequest, Message: fmt.Sprintf("Unable to decode JSON payload: %s", err)})
+		return
+	}
+	connectorId := payload.ConnectorID
+	if connectorId == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(unifiedapiclient.ErrorReply{Status: http.StatusBadRequest, Message: "connector_id is required"})
+		return
+	}
+
+	l := log.LoggerWContext(req.Context())
+
+	o, ok := activeTunnels.Load(connectorId)
+	if !ok {
+		// Not connected right now: the static connections will be provisioned when
+		// the connector next handshakes, so this isn't an error.
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(gin.H{"message": fmt.Sprintf("No active tunnel for connector %s; will provision on next connect", connectorId), "bound": 0})
+		return
+	}
+	tun := o.(*tunnel.Tunnel)
+
+	pfconnectorStaticConnections := pfconfigdriver.PfconnectorStaticConnections{}
+	if err := pfconfigdriver.FetchDecodeSocket(req.Context(), &pfconnectorStaticConnections); err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(unifiedapiclient.ErrorReply{Status: http.StatusInternalServerError, Message: fmt.Sprintf("Unable to fetch static connections: %s", err)})
+		return
+	}
+
+	// Copy the recorded bound-set so we can extend it without mutating shared state.
+	bound := map[string]bool{}
+	if boundIface, found := connectorBoundRemotes.Load(connectorId); found {
+		for k, v := range boundIface.(map[string]bool) {
+			bound[k] = v
+		}
+	}
+
+	newRemotes := chshare.Remotes{}
+	for _, remoteDef := range pfconnectorStaticConnections.Element[connectorId] {
+		if bound[remoteDef] {
+			continue
+		}
+		remote, err := settings.DecodeRemote(remoteDef)
+		if err != nil {
+			l.Error(fmt.Sprintf("reprovision: invalid remote %q for connector %s: %s", remoteDef, connectorId, err))
+			continue
+		}
+		newRemotes = append(newRemotes, remote)
+		bound[remoteDef] = true
+	}
+
+	if len(newRemotes) == 0 {
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(gin.H{"message": "static connections already provisioned", "bound": 0})
+		return
+	}
+
+	// Publish the new ports on the k8s Service (no-op off-k8s; skips ports already
+	// present, so it's safe even if the bound-set was stale).
+	s.addStaticServicePorts(req.Context(), newRemotes)
+
+	// Bind each new reverse listener on the live tunnel, tied to the connection
+	// lifetime (cleaned up on disconnect). One remote per BindDynamicRemotes call
+	// so an already-in-use port (stale bound-set) fails only itself, not the batch.
+	// BindRemotes blocks for the listener's lifetime, so run each in the background.
+	for _, remote := range newRemotes {
+		r := remote
+		go func() {
+			if err := tun.BindDynamicRemotes([]*settings.Remote{r}); err != nil {
+				log.LoggerWContext(context.Background()).Error(fmt.Sprintf("reprovision: failed binding %s for connector %s: %s", r.String(), connectorId, err))
+			}
+		}()
+	}
+
+	connectorBoundRemotes.Store(connectorId, bound)
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(gin.H{"message": fmt.Sprintf("Provisioned %d static connection(s) for connector %s", len(newRemotes), connectorId), "bound": len(newRemotes)})
+}
+
+// addStaticServicePorts adds the given reverse-remote local ports to the
+// pfconnector k8s Service so they're reachable via the ClusterIP. No-op off-k8s.
+// Idempotent: skips ports already present in the Service spec.
+func (s *Server) addStaticServicePorts(ctx context.Context, remotes []*settings.Remote) {
+	client := pfk8s.NewAdminClientFromEnv()
+	if client == nil {
+		return
+	}
+	l := log.LoggerWContext(ctx)
+	services, err := client.GetService("pfconnector")
+	if err != nil {
+		l.Error(fmt.Sprintf("Unable to get pfconnector service to add static ports: %s", err))
+		return
+	}
+	existing := map[string]bool{}
+	for _, svcPort := range services.Spec.Ports {
+		existing[svcPort.Name] = true
+	}
+	seen := map[string]bool{}
+	patch := []pfk8s.PatchPorts{}
+	for _, remote := range remotes {
+		portName := "port-" + strings.ToLower(remote.LocalProto) + "-" + remote.LocalPort
+		if existing[portName] || seen[portName] {
+			continue
+		}
+		seen[portName] = true
+		port, err := strconv.ParseUint(remote.LocalPort, 10, 16)
+		if err != nil {
+			l.Error(fmt.Sprintf("Invalid static port %q, skipping: %s", remote.LocalPort, err))
+			continue
+		}
+		patch = append(patch, pfk8s.PatchPorts{
+			Op:   "add",
+			Path: "/spec/ports/-",
+			Value: pfk8s.PatchPortAdd{
+				Port:       int(port),
+				TargetPort: int(port),
+				Protocol:   strings.ToUpper(remote.LocalProto),
+				Name:       portName,
+			},
+		})
+	}
+	if len(patch) > 0 {
+		if err := client.PatchPorts(patch); err != nil {
+			l.Error(fmt.Sprintf("Unable to add static ports to pfconnector service: %s", err))
+		}
 	}
 }
 

--- a/go/chisel/server/server_handler.go
+++ b/go/chisel/server/server_handler.go
@@ -527,11 +527,6 @@ func (s *Server) handleWebsocket(w http.ResponseWriter, req *http.Request) {
 	})
 	if user != nil {
 		l.Infof("Connector %s has just connected to this server", user.Name)
-		// After a reconnect the pod no longer listens on this connector's previous
-		// dynreverse ports, so drop their k8s Service ports before we clear the
-		// ActiveDynReverse entries below (removeConnectorDynReverseServicePorts reads
-		// them). Otherwise stale, unroutable ports would accumulate in the Service.
-		s.removeConnectorDynReverseServicePorts(ctx, user.Name)
 		settings.ClearActiveDynReverseConnector(ctx, user.Name)
 		activeTunnels.Store(user.Name, tunnel)
 		tunnel.ConnectorID = user.Name
@@ -562,11 +557,6 @@ func (s *Server) handleDynReverse(w http.ResponseWriter, req *http.Request) {
 		ConnectorID string `json:"connector_id"`
 		To          string `json:"to"`
 		LocalPort   string `json:"local_port,omitempty"`
-		// ExposeService opts this dynreverse port into being published on the
-		// pfconnector k8s Service (needed when the caller reaches it via the Service
-		// ClusterIP, e.g. the domain-join flow). Left off by the RADIUS/SNMP callers
-		// so their behavior is unchanged.
-		ExposeService bool `json:"expose_service,omitempty"`
 	}{}
 
 	err := json.NewDecoder(req.Body).Decode(&payload)
@@ -584,10 +574,6 @@ func (s *Server) handleDynReverse(w http.ResponseWriter, req *http.Request) {
 		remote.Lock()
 		defer remote.Unlock()
 		remote.LastTouched = time.Now()
-		// No need to (re)patch the Service here: a live ActiveDynReverse entry implies
-		// the port was patched on its fresh bind and hasn't been pruned (pruning only
-		// happens on reconnect, which also clears this map). Keeping the hot reuse path
-		// free of a k8s API call matters for the RADIUS/SNMP dynreverse callers.
 		json.NewEncoder(w).Encode(gin.H{"host": host, "port": remote.LocalPort, "message": fmt.Sprintf("Reusing existing port %s", remote.LocalPort)})
 		return
 	}
@@ -649,13 +635,6 @@ func (s *Server) handleDynReverse(w http.ResponseWriter, req *http.Request) {
 			err = <-doneChan
 
 			if err == nil {
-				// Expose the freshly-bound port on the pfconnector k8s Service so the
-				// caller can reach it through the Service ClusterIP. Must complete
-				// before we return the port, otherwise the caller's dial races the
-				// Service update. No-op outside k8s or when the caller didn't opt in.
-				if payload.ExposeService {
-					s.ensureDynReverseServicePort(req.Context(), dynPort, remote.LocalProto)
-				}
 				json.NewEncoder(w).Encode(gin.H{"host": host, "port": dynPort, "message": fmt.Sprintf("Setup remote %s", remoteStr)})
 				return
 			} else {
@@ -670,112 +649,6 @@ func (s *Server) handleDynReverse(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 		json.NewEncoder(w).Encode(unifiedapiclient.ErrorReply{Status: http.StatusNotFound, Message: fmt.Sprintf("Unable to find active connector tunnel: %s", connectorId)})
 		return
-	}
-}
-
-// dynReverseServicePortName builds the k8s Service port name for a dynreverse
-// local port. It intentionally uses the same "port-<proto>-<port>" scheme as the
-// static ports in handleClientHandshake so the two never disagree on a name, and
-// it stays within the 15-char IANA_SVC_NAME limit (e.g. "port-tcp-65535").
-func dynReverseServicePortName(proto, port string) string {
-	return "port-" + strings.ToLower(proto) + "-" + port
-}
-
-// ensureDynReverseServicePort exposes a dynreverse local port on the pfconnector
-// k8s Service so it is reachable through the Service ClusterIP. In k8s the caller
-// (e.g. the domain-join flow) dials PFCONNECTOR_SERVICE_HOST:<dynPort>, which only
-// routes to the pod when the port is present in the Service spec. Unlike the
-// static tunnels bound at handshake, dynreverse ports are created on demand, so
-// nothing else adds them. Outside k8s (no admin client) this is a no-op, and it is
-// idempotent: it skips the patch when the port already exists.
-func (s *Server) ensureDynReverseServicePort(ctx context.Context, port, proto string) {
-	client := pfk8s.NewAdminClientFromEnv()
-	if client == nil {
-		return
-	}
-	l := log.LoggerWContext(ctx)
-	services, err := client.GetService("pfconnector")
-	if err != nil {
-		l.Error(fmt.Sprintf("Unable to get pfconnector service to expose dynreverse port %s: %s", port, err))
-		return
-	}
-	name := dynReverseServicePortName(proto, port)
-	for _, svcPort := range services.Spec.Ports {
-		if svcPort.Name == name {
-			return // already exposed
-		}
-	}
-	portNum, err := strconv.ParseUint(port, 10, 16)
-	if err != nil {
-		l.Error(fmt.Sprintf("Invalid dynreverse port %q, not patching service: %s", port, err))
-		return
-	}
-	patch := []pfk8s.PatchPorts{{
-		Op:   "add",
-		Path: "/spec/ports/-",
-		Value: pfk8s.PatchPortAdd{
-			Port:       int(portNum),
-			TargetPort: int(portNum),
-			Protocol:   strings.ToUpper(proto),
-			Name:       name,
-		},
-	}}
-	if err := client.PatchPorts(patch); err != nil {
-		l.Error(fmt.Sprintf("Unable to expose dynreverse port %s on pfconnector service: %s", port, err))
-	}
-}
-
-// removeConnectorDynReverseServicePorts drops the k8s Service ports previously
-// added for this connector's dynreverse tunnels. It must be called at handshake
-// before the connector's ActiveDynReverse entries are cleared, since it derives
-// the port names from those entries. (On a server-process restart the in-memory
-// map is empty, so any ports from before the restart cannot be reconciled here;
-// that is an accepted edge case as the pod/Service would typically be recreated.)
-func (s *Server) removeConnectorDynReverseServicePorts(ctx context.Context, connectorId string) {
-	client := pfk8s.NewAdminClientFromEnv()
-	if client == nil {
-		return
-	}
-	l := log.LoggerWContext(ctx)
-
-	names := map[string]bool{}
-	settings.ActiveDynReverse.Range(func(kInt, v interface{}) bool {
-		if k, ok := kInt.(string); ok && strings.HasPrefix(k, connectorId+":") {
-			remote := v.(*settings.Remote)
-			names[dynReverseServicePortName(remote.LocalProto, remote.LocalPort)] = true
-		}
-		return true
-	})
-	if len(names) == 0 {
-		return
-	}
-
-	services, err := client.GetService("pfconnector")
-	if err != nil {
-		l.Error(fmt.Sprintf("Unable to get pfconnector service to prune dynreverse ports: %s", err))
-		return
-	}
-	delIndexes := []int{}
-	for index, svcPort := range services.Spec.Ports {
-		if names[svcPort.Name] {
-			delIndexes = append(delIndexes, index)
-		}
-	}
-	if len(delIndexes) == 0 {
-		return
-	}
-	// Remove from highest index to lowest so each removal doesn't shift the
-	// indexes of the ones still to be removed.
-	sort.Sort(sort.Reverse(sort.IntSlice(delIndexes)))
-	patch := make([]pfk8s.PatchPorts, 0, len(delIndexes))
-	for _, index := range delIndexes {
-		patch = append(patch, pfk8s.PatchPorts{
-			Op:   "remove",
-			Path: "/spec/ports/" + strconv.Itoa(index),
-		})
-	}
-	if err := client.PatchPorts(patch); err != nil {
-		l.Error(fmt.Sprintf("Unable to prune dynreverse ports from pfconnector service: %s", err))
 	}
 }
 

--- a/go/chisel/server/server_handler.go
+++ b/go/chisel/server/server_handler.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -429,44 +430,71 @@ func (s *Server) handleWebsocket(w http.ResponseWriter, req *http.Request) {
 	}
 
 	if client := pfk8s.NewAdminClientFromEnv(); client != nil {
-		patchPortsAdd := []pfk8s.PatchPorts{}
-		patchPortsDel := []pfk8s.PatchPorts{}
-
 		services, err := client.GetService("pfconnector")
 		if err != nil {
-			l.Printf("Error getting pfconnector service: %v", err)
-			// If we can't get the service, we can't patch it, so we just return
-		}
+			// If we can't read the service we can't safely diff its ports, so skip
+			// patching entirely rather than blindly adding (and duplicating) ports.
+			l.Printf("Error getting pfconnector service, skipping port patching: %v", err)
+		} else {
+			patchPortsAdd := []pfk8s.PatchPorts{}
+			delIndexes := []int{}
+			seenNames := map[string]bool{}
 
-		for _, remote := range additionalRemotes {
-			port, _ := strconv.ParseUint(remote.LocalPort, 10, 16)
-			for index, port := range services.Spec.Ports {
-				if port.Name == "port-"+strings.ToLower(remote.LocalProto)+"-"+remote.LocalPort {
-					// If the port already exists, we need to remove it first
+			for _, remote := range additionalRemotes {
+				port, _ := strconv.ParseUint(remote.LocalPort, 10, 16)
+				portName := "port-" + strings.ToLower(remote.LocalProto) + "-" + remote.LocalPort
 
-					patchPortsDel = append(patchPortsDel, pfk8s.PatchPorts{
-						Op:   "remove",
-						Path: "/spec/ports/" + strconv.Itoa(index),
-					})
+				// Skip duplicate remote definitions so we never add the same port
+				// name twice in a single patch.
+				if seenNames[portName] {
+					continue
 				}
+				seenNames[portName] = true
+
+				// Collect every existing port carrying this name so they get removed
+				// first. There may be more than one if a previous run left stale
+				// duplicates behind.
+				for index, svcPort := range services.Spec.Ports {
+					if svcPort.Name == portName {
+						delIndexes = append(delIndexes, index)
+					}
+				}
+
+				patchPortsAdd = append(patchPortsAdd, pfk8s.PatchPorts{
+					Op:   "add",
+					Path: "/spec/ports/-",
+					Value: pfk8s.PatchPortAdd{
+						Port:       int(port),
+						TargetPort: int(port),
+						Protocol:   strings.ToUpper(remote.LocalProto),
+						Name:       portName,
+					},
+				})
 			}
 
-			patchPortsAdd = append(patchPortsAdd, pfk8s.PatchPorts{
-				Op:   "add",
-				Path: "/spec/ports/-",
-				Value: pfk8s.PatchPortAdd{
-					Port:       int(port),
-					TargetPort: int(port),
-					Protocol:   strings.ToUpper(remote.LocalProto),
-					Name:       "port-" + strings.ToLower(remote.LocalProto) + "-" + remote.LocalPort,
-				},
-			})
-		}
-		if err := client.PatchPorts(patchPortsDel); err != nil {
-			l.Printf("Error deleting ports: %v", err)
-		}
-		if err := client.PatchPorts(patchPortsAdd); err != nil {
-			l.Printf("Error adding ports: %v", err)
+			// A JSON Patch applies its operations sequentially, so removing a lower
+			// index first shifts every following element down and makes the later
+			// indexes point at the wrong port (or out of range). Applying the
+			// removals from highest index to lowest keeps every recorded index valid.
+			sort.Sort(sort.Reverse(sort.IntSlice(delIndexes)))
+
+			// Send removals and adds as a single atomic patch, removals first. This
+			// guarantees we never re-add a name that still exists, which is what
+			// produced the k8s "Duplicate value" 422s when a connector reconnected.
+			patch := make([]pfk8s.PatchPorts, 0, len(delIndexes)+len(patchPortsAdd))
+			for _, index := range delIndexes {
+				patch = append(patch, pfk8s.PatchPorts{
+					Op:   "remove",
+					Path: "/spec/ports/" + strconv.Itoa(index),
+				})
+			}
+			patch = append(patch, patchPortsAdd...)
+
+			if len(patch) > 0 {
+				if err := client.PatchPorts(patch); err != nil {
+					l.Printf("Error patching ports: %v", err)
+				}
+			}
 		}
 	}
 

--- a/go/chisel/server/server_handler.go
+++ b/go/chisel/server/server_handler.go
@@ -297,9 +297,13 @@ func (s *Server) handleWebsocket(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 
-	localSecret := pfconfigdriver.LocalSecret{}
-	if err := pfconfigdriver.FetchDecodeSocket(req.Context(), &localSecret); err != nil {
-		l.Infof("Failed to fetch local secret from pfconfig, continuing without it: %s", err)
+	// The RADIUS proxy re-signs connector traffic with the secret the cloud
+	// FreeRADIUS expects for the `pfconnector` NAS client, which is
+	// unified_api_system_user.pass. Fetch it here so it is cached for the life of
+	// this tunnel/SSH connection.
+	unifiedApiSystemUser := pfconfigdriver.UnifiedApiSystemUser{}
+	if err := pfconfigdriver.FetchDecodeSocket(req.Context(), &unifiedApiSystemUser); err != nil {
+		l.Infof("Failed to fetch unified api system user from pfconfig, continuing without it: %s", err)
 	}
 	pfconnectorStaticConnections := pfconfigdriver.PfconnectorStaticConnections{}
 	if err := pfconfigdriver.FetchDecodeSocket(req.Context(), &pfconnectorStaticConnections); err != nil {
@@ -365,7 +369,7 @@ func (s *Server) handleWebsocket(w http.ResponseWriter, req *http.Request) {
 		Outbound:     true, //server always accepts outbound
 		Socks:        s.config.Socks5,
 		KeepAlive:    s.config.KeepAlive,
-		RadiusSecret: localSecret.Element,
+		RadiusSecret: unifiedApiSystemUser.Pass,
 	})
 	//bind
 	eg, ctx := errgroup.WithContext(req.Context())

--- a/go/chisel/share/radius_proxy/proxy.go
+++ b/go/chisel/share/radius_proxy/proxy.go
@@ -9,14 +9,10 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/inverse-inc/packetfence/go/chisel/share/cio"
+	"github.com/inverse-inc/packetfence/go/pfradius"
 	"layeh.com/radius"
 	"layeh.com/radius/rfc2865"
 	"layeh.com/radius/rfc2869"
-)
-
-const (
-	packetFenceVendorID            = 29464
-	packetFenceConnectorIDAttrType = 40
 )
 
 type Proxy struct {
@@ -119,11 +115,11 @@ func (rp *Proxy) ProxyPacket(payload []byte, connectorID string) ([]byte, string
 		}
 
 		vendorConnectorAttr := make(radius.Attribute, 2+len(connectorAttr))
-		vendorConnectorAttr[0] = packetFenceConnectorIDAttrType
+		vendorConnectorAttr[0] = pfradius.ConnectorIDAttrType
 		vendorConnectorAttr[1] = byte(len(vendorConnectorAttr))
 		copy(vendorConnectorAttr[2:], connectorAttr)
 
-		vsa, err := radius.NewVendorSpecific(packetFenceVendorID, vendorConnectorAttr)
+		vsa, err := radius.NewVendorSpecific(pfradius.VendorID, vendorConnectorAttr)
 		if err != nil {
 			return nil, "", err
 		}
@@ -175,8 +171,8 @@ func hasPacketFenceConnectorID(packet *radius.Packet) bool {
 		}
 		attr := avp.Attribute
 		if len(attr) >= 5 &&
-			binary.BigEndian.Uint32(attr[:4]) == packetFenceVendorID &&
-			attr[4] == packetFenceConnectorIDAttrType {
+			binary.BigEndian.Uint32(attr[:4]) == pfradius.VendorID &&
+			attr[4] == pfradius.ConnectorIDAttrType {
 			return true
 		}
 	}

--- a/go/chisel/share/radius_proxy/proxy.go
+++ b/go/chisel/share/radius_proxy/proxy.go
@@ -1,18 +1,14 @@
 package radius_proxy
 
 import (
-	"context"
 	"crypto/hmac"
 	"crypto/md5"
 	"encoding/binary"
 	"errors"
-	"net"
-	"strings"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/inverse-inc/packetfence/go/chisel/share/cio"
-	"github.com/inverse-inc/packetfence/go/pfconfigdriver"
 	"layeh.com/radius"
 	"layeh.com/radius/rfc2865"
 	"layeh.com/radius/rfc2869"
@@ -136,13 +132,12 @@ func (rp *Proxy) ProxyPacket(payload []byte, connectorID string) ([]byte, string
 		packet.Attributes.Add(26, vsa)
 	}
 
-	secret, err := rp.foundSecret(context.Background(), packet)
-
-	if err != nil {
-		secret = string(rp.secret)
-	}
-
-	err = addMessageAuthenticator(packet, []byte(secret))
+	// All traffic reaching this proxy is connector traffic (the proxy is only
+	// instantiated on the cloud side). The cloud FreeRADIUS validates it against
+	// the `pfconnector` NAS client, whose shared secret is
+	// unified_api_system_user.pass — the same secret rp.secret is wired to. Sign
+	// the Message-Authenticator with it so validation succeeds end-to-end.
+	err = addMessageAuthenticator(packet, rp.secret)
 	if err != nil {
 		return nil, "", err
 	}
@@ -192,63 +187,4 @@ func addMessageAuthenticator(p *radius.Packet, secret []byte) error {
 	hash.Write(encode)
 	rfc2869.MessageAuthenticator_Set(p, hash.Sum(nil))
 	return nil
-}
-
-func (rp *Proxy) foundSecret(ctx context.Context, packet *radius.Packet) (string, error) {
-
-	var SwitchID []string
-	SwitchMAC := rfc2865.CallingStationID_GetString(packet)
-	if SwitchMAC != "" {
-		MacHW, err := net.ParseMAC(SwitchMAC)
-		if err == nil {
-			SwitchMAC = MacHW.String()
-			SwitchID = append(SwitchID, SwitchMAC)
-		}
-	}
-
-	SwitchNasIP := rfc2865.NASIPAddress_Get(packet)
-	if SwitchNasIP != nil {
-		SwitchID = append(SwitchID, SwitchNasIP.String())
-	}
-
-	switches := pfconfigdriver.PfSwitches{}
-	pfconfigdriver.FetchDecodeSocket(ctx, &switches)
-
-	for _, switchID := range SwitchID {
-
-		// Find the switch with the given ID
-		for _, sw := range switches.PfconfigKeys.Keys {
-			if sw != switchID {
-				continue
-			}
-			switche := pfconfigdriver.PfConfSwitch{}
-			switche.PfconfigHashNS = sw
-			pfconfigdriver.FetchDecodeSocket(ctx, &switche)
-			if switche.RadiusSecret.String() != "" {
-				return switche.RadiusSecret.String(), nil
-			}
-		}
-		// Find the switch within the ip ranges
-		if IsIPv4(net.ParseIP(switchID)) {
-			for _, sw := range switches.PfconfigKeys.Keys {
-				_, network, err := net.ParseCIDR(sw)
-				if err != nil {
-					continue
-				}
-				if network.Contains(net.ParseIP(switchID)) {
-					switche := pfconfigdriver.PfConfSwitch{}
-					switche.PfconfigHashNS = sw
-					pfconfigdriver.FetchDecodeSocket(ctx, &switche)
-					if switche.RadiusSecret.String() != "" {
-						return switche.RadiusSecret.String(), nil
-					}
-				}
-			}
-		}
-	}
-	return "", errors.New("No secret found")
-}
-
-func IsIPv4(address net.IP) bool {
-	return strings.Count(address.String(), ":") < 2
 }

--- a/go/chisel/share/radius_proxy/proxy.go
+++ b/go/chisel/share/radius_proxy/proxy.go
@@ -110,8 +110,7 @@ func (rp *Proxy) ProxyPacket(payload []byte, connectorID string) ([]byte, string
 		LogPacket(l, packet)
 	})
 
-	added := rp.addProxyState(packet)
-	_ = added
+	mutated := rp.addProxyState(packet)
 
 	if !hasPacketFenceConnectorID(packet) {
 		connectorAttr, err := radius.NewString(connectorID)
@@ -130,13 +129,27 @@ func (rp *Proxy) ProxyPacket(payload []byte, connectorID string) ([]byte, string
 		}
 
 		packet.Attributes.Add(26, vsa)
+		mutated = true
 	}
 
-	// All traffic reaching this proxy is connector traffic (the proxy is only
-	// instantiated on the cloud side). The cloud FreeRADIUS validates it against
-	// the `pfconnector` NAS client, whose shared secret is
-	// unified_api_system_user.pass — the same secret rp.secret is wired to. Sign
-	// the Message-Authenticator with it so validation succeeds end-to-end.
+	be := rp.backendsForPacket(packet).getBackend(packet)
+	if be == nil {
+		return nil, "", errors.New("No backend available")
+	}
+
+	// When the remote FreeRADIUS already proxied the packet it arrives signed with
+	// the unified secret and tagged with Proxy-State + PacketFence-ConnectorID, so we
+	// add nothing above. Forward the original bytes verbatim: this preserves the
+	// original authenticator — essential for Accounting-Request, whose Request
+	// Authenticator is keyed by the secret — and avoids a pointless re-sign that would
+	// also inject a bogus Message-Authenticator. We only re-sign when we actually
+	// mutated the packet (e.g. bare Status-Server liveness checks, which arrive
+	// untagged and get a freshly added Proxy-State/ConnectorID here).
+	if !mutated {
+		rp.Debugf("Proxy %s to %s for connector %s (verbatim)", packet.Code, be.addr, connectorID)
+		return payload, be.addr, nil
+	}
+
 	err = addMessageAuthenticator(packet, rp.secret)
 	if err != nil {
 		return nil, "", err
@@ -145,11 +158,6 @@ func (rp *Proxy) ProxyPacket(payload []byte, connectorID string) ([]byte, string
 	b2, err := packet.Encode()
 	if err != nil {
 		return nil, "", err
-	}
-
-	be := rp.backendsForPacket(packet).getBackend(packet)
-	if be == nil {
-		return nil, "", errors.New("No backend available")
 	}
 
 	rp.Debugf("Proxy %s to %s for connector %s", packet.Code, be.addr, connectorID)

--- a/go/chisel/share/radius_proxy/proxy_test.go
+++ b/go/chisel/share/radius_proxy/proxy_test.go
@@ -1,10 +1,12 @@
 package radius_proxy
 
 import (
+	"bytes"
 	"testing"
 	"time"
 
 	"layeh.com/radius"
+	"layeh.com/radius/rfc2865"
 )
 
 const (
@@ -61,5 +63,79 @@ func TestProxyPicksBackendFromCorrectPool(t *testing.T) {
 	access := radius.New(radius.CodeAccessRequest, []byte("testing123"))
 	if be := rp.backendsForPacket(access).pickBackend(access); be == nil || be.addr != testAuthAddr {
 		t.Fatalf("access packet picked %v, want %s", be, testAuthAddr)
+	}
+}
+
+// addConnectorID stamps the PacketFence-ConnectorID VSA (vendor 29464, attr 40)
+// the way the remote FreeRADIUS does on a proxied request, mirroring the
+// construction inside ProxyPacket.
+func addConnectorID(p *radius.Packet, id string) {
+	v, _ := radius.NewString(id)
+	vendorAttr := make(radius.Attribute, 2+len(v))
+	vendorAttr[0] = packetFenceConnectorIDAttrType
+	vendorAttr[1] = byte(len(vendorAttr))
+	copy(vendorAttr[2:], v)
+	vsa, _ := radius.NewVendorSpecific(packetFenceVendorID, vendorAttr)
+	p.Attributes.Add(26, vsa)
+}
+
+// A request the remote FreeRADIUS already proxied arrives tagged with
+// Proxy-State + PacketFence-ConnectorID and signed with the unified secret.
+// ProxyPacket must forward those exact bytes: re-encoding an Accounting-Request
+// would recompute a Request Authenticator that the cloud pfacct then rejects,
+// and would inject a bogus Message-Authenticator. It must still route by code.
+func TestProxyPacketForwardsPreTaggedVerbatim(t *testing.T) {
+	rp := newTestProxy()
+
+	p := radius.New(radius.CodeAccountingRequest, rp.secret)
+	rfc2865.ProxyState_SetString(p, "already-proxied")
+	addConnectorID(p, "connX")
+	payload, err := p.Encode()
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	out, addr, err := rp.ProxyPacket(payload, "connX")
+	if err != nil {
+		t.Fatalf("ProxyPacket returned error: %v", err)
+	}
+	if !bytes.Equal(out, payload) {
+		t.Errorf("pre-tagged packet was not forwarded verbatim:\n got %v\nwant %v", out, payload)
+	}
+	if addr != testAcctAddr {
+		t.Errorf("accounting packet routed to %q, want %q", addr, testAcctAddr)
+	}
+}
+
+// A bare request (e.g. a Status-Server liveness probe) arrives untagged.
+// ProxyPacket must add Proxy-State + ConnectorID and re-sign with the unified
+// secret, so the output differs from the input, carries the ConnectorID VSA,
+// and still parses under the unified secret.
+func TestProxyPacketResignsUntaggedPacket(t *testing.T) {
+	rp := newTestProxy()
+
+	p := radius.New(radius.CodeAccessRequest, rp.secret)
+	payload, err := p.Encode()
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+
+	out, addr, err := rp.ProxyPacket(payload, "connX")
+	if err != nil {
+		t.Fatalf("ProxyPacket returned error: %v", err)
+	}
+	if bytes.Equal(out, payload) {
+		t.Error("untagged packet was forwarded verbatim; expected it to be re-signed")
+	}
+	if addr != testAuthAddr {
+		t.Errorf("access packet routed to %q, want %q", addr, testAuthAddr)
+	}
+
+	reparsed, err := radius.Parse(out, rp.secret)
+	if err != nil {
+		t.Fatalf("re-signed packet does not parse under the unified secret: %v", err)
+	}
+	if !hasPacketFenceConnectorID(reparsed) {
+		t.Error("re-signed packet is missing the PacketFence-ConnectorID VSA")
 	}
 }

--- a/go/chisel/share/radius_proxy/proxy_test.go
+++ b/go/chisel/share/radius_proxy/proxy_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/inverse-inc/packetfence/go/pfradius"
 	"layeh.com/radius"
 	"layeh.com/radius/rfc2865"
 )
@@ -72,10 +73,10 @@ func TestProxyPicksBackendFromCorrectPool(t *testing.T) {
 func addConnectorID(p *radius.Packet, id string) {
 	v, _ := radius.NewString(id)
 	vendorAttr := make(radius.Attribute, 2+len(v))
-	vendorAttr[0] = packetFenceConnectorIDAttrType
+	vendorAttr[0] = pfradius.ConnectorIDAttrType
 	vendorAttr[1] = byte(len(vendorAttr))
 	copy(vendorAttr[2:], v)
-	vsa, _ := radius.NewVendorSpecific(packetFenceVendorID, vendorAttr)
+	vsa, _ := radius.NewVendorSpecific(pfradius.VendorID, vendorAttr)
 	p.Attributes.Add(26, vsa)
 }
 

--- a/go/chisel/share/radius_proxy/tunnel_radius.go
+++ b/go/chisel/share/radius_proxy/tunnel_radius.go
@@ -42,28 +42,14 @@ func isPodReady(pod *v1.Pod) bool {
 	return false
 }
 
+// getPodHostPort returns the pod IP paired with defaultPort, the port for the
+// pool this pod belongs to (1812 for auth, 1813 for acct). We deliberately do
+// NOT trust the pod's declared containerPort: pfacct pods advertise 1812 as
+// metadata while their accounting listener is on 1813/UDP, so honoring the
+// declared port would ship Accounting-Requests to a dead port (connection
+// refused). The auth/acct informers are each handed the correct defaultPort.
 func getPodHostPort(pod *v1.Pod, defaultPort int) string {
-	port, err := getPodPort(pod)
-	if err != nil {
-		return fmt.Sprintf("%s:%d", pod.Status.PodIP, defaultPort)
-	}
-
-	return fmt.Sprintf("%s:%d", pod.Status.PodIP, port)
-}
-
-func getPodPort(pod *v1.Pod) (int, error) {
-	if len(pod.Spec.Containers) == 0 {
-		return -1, errors.New("No Containers found")
-	}
-
-	ports := pod.Spec.Containers[0].Ports
-
-	if len(ports) == 0 {
-		return -1, errors.New("No port found")
-	}
-
-	return int(ports[0].ContainerPort), nil
-
+	return fmt.Sprintf("%s:%d", pod.Status.PodIP, defaultPort)
 }
 
 func clientSetFromEnv() (*kubernetes.Clientset, error) {

--- a/go/chisel/share/radius_proxy/tunnel_radius.go
+++ b/go/chisel/share/radius_proxy/tunnel_radius.go
@@ -42,14 +42,28 @@ func isPodReady(pod *v1.Pod) bool {
 	return false
 }
 
-// getPodHostPort returns the pod IP paired with defaultPort, the port for the
-// pool this pod belongs to (1812 for auth, 1813 for acct). We deliberately do
-// NOT trust the pod's declared containerPort: pfacct pods advertise 1812 as
-// metadata while their accounting listener is on 1813/UDP, so honoring the
-// declared port would ship Accounting-Requests to a dead port (connection
-// refused). The auth/acct informers are each handed the correct defaultPort.
 func getPodHostPort(pod *v1.Pod, defaultPort int) string {
-	return fmt.Sprintf("%s:%d", pod.Status.PodIP, defaultPort)
+	port, err := getPodPort(pod)
+	if err != nil {
+		return fmt.Sprintf("%s:%d", pod.Status.PodIP, defaultPort)
+	}
+
+	return fmt.Sprintf("%s:%d", pod.Status.PodIP, port)
+}
+
+func getPodPort(pod *v1.Pod) (int, error) {
+	if len(pod.Spec.Containers) == 0 {
+		return -1, errors.New("No Containers found")
+	}
+
+	ports := pod.Spec.Containers[0].Ports
+
+	if len(ports) == 0 {
+		return -1, errors.New("No port found")
+	}
+
+	return int(ports[0].ContainerPort), nil
+
 }
 
 func clientSetFromEnv() (*kubernetes.Clientset, error) {

--- a/go/cmd/pfacct/bandwidth_accounting.go
+++ b/go/cmd/pfacct/bandwidth_accounting.go
@@ -5,7 +5,6 @@ import (
 )
 
 type BandwidthAccountingRecord struct {
-	TenantId   int32
 	Mac        string
 	TimeBucket time.Time
 	InBytes    uint64

--- a/go/cmd/pfacct/nodes.go
+++ b/go/cmd/pfacct/nodes.go
@@ -9,8 +9,7 @@ import (
 type SessionID [16]byte
 
 type NodeKey struct {
-	TenantId int
-	Mac      mac.Mac
+	Mac mac.Mac
 }
 
 type Node struct {
@@ -189,20 +188,20 @@ func NewNodes() *Nodes {
 	return &Nodes{Nodes: make(map[NodeKey]*Node)}
 }
 
-func (n *Nodes) Add(tenantId int, mac mac.Mac, sessionID SessionID, timeBucket time.Time, in, out int64) {
-	node := n.getOrAddNode(tenantId, mac)
+func (n *Nodes) Add(mac mac.Mac, sessionID SessionID, timeBucket time.Time, in, out int64) {
+	node := n.getOrAddNode(mac)
 	node.AddToTimeBucket(sessionID, timeBucket, in, out)
 }
 
-func (n *Nodes) Update(tenantId int, mac mac.Mac, sessionID SessionID, timeBucket time.Time, in, out int64) {
-	node := n.getOrAddNode(tenantId, mac)
+func (n *Nodes) Update(mac mac.Mac, sessionID SessionID, timeBucket time.Time, in, out int64) {
+	node := n.getOrAddNode(mac)
 	node.UpdateTimeBucket(sessionID, timeBucket, in, out)
 }
 
-func (n *Nodes) getOrAddNode(tenantId int, mac mac.Mac) *Node {
+func (n *Nodes) getOrAddNode(mac mac.Mac) *Node {
 	var item *Node
 	var found bool
-	key := NodeKey{TenantId: tenantId, Mac: mac}
+	key := NodeKey{Mac: mac}
 	n.lock.RLock() //First try to get a read Only lock
 	if item, found = n.Nodes[key]; !found {
 		// Not Found drop read lock get write lock
@@ -220,10 +219,10 @@ func (n *Nodes) getOrAddNode(tenantId int, mac mac.Mac) *Node {
 	return item
 }
 
-func (n *Nodes) GetBucket(tenantId int, mac mac.Mac, sessionID SessionID, timeBucket time.Time) (BandwidthBucket, bool) {
+func (n *Nodes) GetBucket(mac mac.Mac, sessionID SessionID, timeBucket time.Time) (BandwidthBucket, bool) {
 	var node *Node
 	var found bool
-	key := NodeKey{TenantId: tenantId, Mac: mac}
+	key := NodeKey{Mac: mac}
 	n.lock.RLock() //First try to get a read Only lock
 	if node, found = n.Nodes[key]; !found {
 		n.lock.RUnlock()
@@ -233,10 +232,10 @@ func (n *Nodes) GetBucket(tenantId int, mac mac.Mac, sessionID SessionID, timeBu
 	return node.GetBucket(sessionID, timeBucket)
 }
 
-func (n *Nodes) RemoveSession(tenantId int, mac mac.Mac, sessionID SessionID) *Session {
+func (n *Nodes) RemoveSession(mac mac.Mac, sessionID SessionID) *Session {
 	var item *Node
 	var found bool
-	key := NodeKey{TenantId: tenantId, Mac: mac}
+	key := NodeKey{Mac: mac}
 	n.lock.RLock() //First try to get a read Only lock
 	if item, found = n.Nodes[key]; !found {
 		return nil

--- a/go/cmd/pfacct/nodes_test.go
+++ b/go/cmd/pfacct/nodes_test.go
@@ -11,9 +11,9 @@ func TestBucketAdd(t *testing.T) {
 	now := time.Now()
 	mac, _ := mac.NewFromString("00:22:33:44:55:11")
 	session := SessionID([16]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15})
-	n.Add(1, mac, session, now, 10, 100)
-	n.Add(1, mac, session, now, 10, 100)
-	totals, _ := n.GetBucket(1, mac, session, now)
+	n.Add(mac, session, now, 10, 100)
+	n.Add(mac, session, now, 10, 100)
+	totals, _ := n.GetBucket(mac, session, now)
 	if totals.InBytes != 20 {
 		t.Errorf("InBytes wrong total")
 	}
@@ -21,8 +21,8 @@ func TestBucketAdd(t *testing.T) {
 		t.Errorf("OutBytes wrong total")
 	}
 
-	n.Update(1, mac, session, now, 30, 300)
-	totals, _ = n.GetBucket(1, mac, session, now)
+	n.Update(mac, session, now, 30, 300)
+	totals, _ = n.GetBucket(mac, session, now)
 	if totals.InBytes != 30 {
 		t.Errorf("InBytes wrong total")
 	}
@@ -32,8 +32,8 @@ func TestBucketAdd(t *testing.T) {
 
 	next := now.Add(1 * time.Second)
 
-	n.Update(1, mac, session, next, 40, 400)
-	totals, _ = n.GetBucket(1, mac, session, next)
+	n.Update(mac, session, next, 40, 400)
+	totals, _ = n.GetBucket(mac, session, next)
 	if totals.InBytes != 10 {
 		t.Errorf("InBytes wrong total")
 	}

--- a/go/cmd/pfacct/pfacct.go
+++ b/go/cmd/pfacct/pfacct.go
@@ -60,6 +60,7 @@ type PfAcct struct {
 	radiusRequests          []chan<- radiusRequest
 	overflows               []atomic.Int64
 	localSecret             string
+	unifiedSecret           string
 	StatsdOnce              tryableonce.TryableOnce
 	isProxied               bool
 	radiusdAcctEnabled      bool
@@ -201,6 +202,12 @@ func (pfAcct *PfAcct) SetupConfig(ctx context.Context) {
 	localSecret := pfconfigdriver.LocalSecret{}
 	pfconfigdriver.FetchDecodeSocket(ctx, &localSecret)
 	pfAcct.localSecret = localSecret.Element
+
+	// Connector accounting rides the connector tunnel signed with the unified
+	// secret (the same one the cloud FreeRADIUS validates connector auth with).
+	unifiedApiSystemUser := pfconfigdriver.UnifiedApiSystemUser{}
+	pfconfigdriver.FetchDecodeSocket(ctx, &unifiedApiSystemUser)
+	pfAcct.unifiedSecret = unifiedApiSystemUser.Pass
 
 	pfAcct.isProxied = isProxied(pfAcct)
 }

--- a/go/cmd/pfacct/radius.go
+++ b/go/cmd/pfacct/radius.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/inverse-inc/go-radius"
 	"github.com/inverse-inc/go-radius/dictionary"
-	"github.com/inverse-inc/go-radius/inversedict"
 	"github.com/inverse-inc/go-radius/rfc2865"
 	"github.com/inverse-inc/go-radius/rfc2866"
 	"github.com/inverse-inc/go-radius/rfc2869"
@@ -174,7 +173,7 @@ func (h *PfAcct) handleAccountingRequest(rr radiusRequest) {
 	}
 
 	timestamp = timestamp.Truncate(h.TimeDuration)
-	node_id := mac.NodeId(uint16(switchInfo.TenantId))
+	node_id := mac.NodeId(0)
 	if h.ProcessBandwidthAcct {
 		if err := h.InsertBandwidthAccounting(
 			status,
@@ -533,8 +532,8 @@ func (h *PfAcct) RADIUSSecret(ctx context.Context, remoteAddr net.Addr, raw []by
 		return nil, nil, err
 	}
 
-	packet, err := radius.Parse(raw, []byte(switchInfo.Secret))
-	if err != nil {
+	// Validate that the packet authenticates with the resolved secret.
+	if _, err := radius.Parse(raw, []byte(switchInfo.Secret)); err != nil {
 		logError(h.LoggerCtx, "RADIUSSecret: "+err.Error())
 		return nil, nil, err
 	}
@@ -544,18 +543,11 @@ func (h *PfAcct) RADIUSSecret(ctx context.Context, remoteAddr net.Addr, raw []by
 
 	// Connector accounting: the packet rode the connector tunnel and was signed
 	// with the unified secret, not the inner switch's secret. Keep the switch
-	// identity (tenant / attributes) resolved above, but validate and respond with
+	// identity (attributes) resolved above, but validate and respond with
 	// the unified secret, mirroring the auth dynamic-clients ConnectorID resolution.
 	if h.unifiedSecret != "" && hasPacketFenceConnectorID(attrs) {
 		cp := *info
 		cp.Secret = h.unifiedSecret
-		info = &cp
-	}
-
-	// If the request overrides the tenant ID, copy and set it.
-	if val := inversedict.PacketFenceTenantID_Get(packet); val != 0 {
-		cp := *info
-		cp.TenantId = int(val)
 		info = &cp
 	}
 
@@ -967,7 +959,6 @@ func (rs *RadiusStatements) NodeBandwidthBalanceSubtract(mac mac.Mac, balance in
 
 type SwitchInfo struct {
 	Nasname, Secret  string
-	TenantId         int
 	RadiusAttributes db.CsvArray
 }
 

--- a/go/cmd/pfacct/radius.go
+++ b/go/cmd/pfacct/radius.go
@@ -539,15 +539,46 @@ func (h *PfAcct) RADIUSSecret(ctx context.Context, remoteAddr net.Addr, raw []by
 		return nil, nil, err
 	}
 
-	// If the request overrides the tenant ID, we create a copy of the switchInfo and return it with an updated tenant ID
-	if val := inversedict.PacketFenceTenantID_Get(packet); val != 0 {
-		switchInfo2 := *switchInfo
-		switchInfo2.TenantId = int(val)
-		return []byte(switchInfo.Secret), log.TranferLogContext(h.LoggerCtx, context.WithValue(ctx, switchInfoKey, &switchInfo2)), nil
-	} else {
-		return []byte(switchInfo.Secret), log.TranferLogContext(h.LoggerCtx, context.WithValue(ctx, switchInfoKey, switchInfo)), nil
+	// switchInfo is a shared cached pointer; never mutate it. Copy before overriding.
+	info := switchInfo
+
+	// Connector accounting: the packet rode the connector tunnel and was signed
+	// with the unified secret, not the inner switch's secret. Keep the switch
+	// identity (tenant / attributes) resolved above, but validate and respond with
+	// the unified secret, mirroring the auth dynamic-clients ConnectorID resolution.
+	if h.unifiedSecret != "" && hasPacketFenceConnectorID(attrs) {
+		cp := *info
+		cp.Secret = h.unifiedSecret
+		info = &cp
 	}
 
+	// If the request overrides the tenant ID, copy and set it.
+	if val := inversedict.PacketFenceTenantID_Get(packet); val != 0 {
+		cp := *info
+		cp.TenantId = int(val)
+		info = &cp
+	}
+
+	return []byte(info.Secret), log.TranferLogContext(h.LoggerCtx, context.WithValue(ctx, switchInfoKey, info)), nil
+}
+
+const (
+	packetFenceVendorID            = 29464
+	packetFenceConnectorIDAttrType = 40
+)
+
+// hasPacketFenceConnectorID reports whether the request carries the
+// PacketFence-ConnectorID VSA (vendor 29464, attr 40), i.e. it arrived via a
+// connector tunnel. Mirrors the detection in chisel/share/radius_proxy/proxy.go.
+func hasPacketFenceConnectorID(attrs radius.Attributes) bool {
+	for _, vsa := range attrs[radius.Type(26)] {
+		if len(vsa) >= 5 &&
+			binary.BigEndian.Uint32(vsa[:4]) == packetFenceVendorID &&
+			vsa[4] == packetFenceConnectorIDAttrType {
+			return true
+		}
+	}
+	return false
 }
 
 type Error string

--- a/go/cmd/pfacct/radius.go
+++ b/go/cmd/pfacct/radius.go
@@ -27,6 +27,7 @@ import (
 	"github.com/inverse-inc/go-utils/sharedutils"
 	"github.com/inverse-inc/packetfence/go/db"
 	"github.com/inverse-inc/packetfence/go/pfconfigdriver"
+	"github.com/inverse-inc/packetfence/go/pfradius"
 )
 
 const TRIGGER_TYPE_ACCOUNTING = "accounting"
@@ -554,19 +555,15 @@ func (h *PfAcct) RADIUSSecret(ctx context.Context, remoteAddr net.Addr, raw []by
 	return []byte(info.Secret), log.TranferLogContext(h.LoggerCtx, context.WithValue(ctx, switchInfoKey, info)), nil
 }
 
-const (
-	packetFenceVendorID            = 29464
-	packetFenceConnectorIDAttrType = 40
-)
-
 // hasPacketFenceConnectorID reports whether the request carries the
 // PacketFence-ConnectorID VSA (vendor 29464, attr 40), i.e. it arrived via a
-// connector tunnel. Mirrors the detection in chisel/share/radius_proxy/proxy.go.
+// connector tunnel. Mirrors the detection in chisel/share/radius_proxy/proxy.go
+// (both read the shared pfradius constants).
 func hasPacketFenceConnectorID(attrs radius.Attributes) bool {
 	for _, vsa := range attrs[radius.Type(26)] {
 		if len(vsa) >= 5 &&
-			binary.BigEndian.Uint32(vsa[:4]) == packetFenceVendorID &&
-			vsa[4] == packetFenceConnectorIDAttrType {
+			binary.BigEndian.Uint32(vsa[:4]) == pfradius.VendorID &&
+			vsa[4] == pfradius.ConnectorIDAttrType {
 			return true
 		}
 	}

--- a/go/cmd/pfacct/radius_test.go
+++ b/go/cmd/pfacct/radius_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"net"
 	"reflect"
@@ -150,5 +151,79 @@ func TestPacketToMap(t *testing.T) {
 	expected := map[string]interface{}{"User-Name": "tim", "Cisco-AVPair": []interface{}{"bob=bobby", "j=r"}}
 	if reflect.DeepEqual(expected, attributeMap) == false {
 		t.Errorf("expected : %v, got : %v", expected, attributeMap)
+	}
+}
+
+// vendorVSA builds an attribute-26 Vendor-Specific value the way RADIUSSecret
+// sees it after radius.ParseAttributes:
+// [vendor-id:4][vendor-type:1][vendor-length:1][data...].
+func vendorVSA(vendorID uint32, vendorType byte, data string) radius.Attribute {
+	vsa := make(radius.Attribute, 6+len(data))
+	binary.BigEndian.PutUint32(vsa[:4], vendorID)
+	vsa[4] = vendorType
+	vsa[5] = byte(2 + len(data))
+	copy(vsa[6:], data)
+	return vsa
+}
+
+func attrsWith(vsas ...radius.Attribute) radius.Attributes {
+	a := radius.Attributes{}
+	for _, v := range vsas {
+		a.Add(26, v)
+	}
+	return a
+}
+
+// hasPacketFenceConnectorID gates whether accounting is validated/answered with
+// the unified connector secret instead of the inner switch's secret. A false
+// negative would reject legitimate connector accounting; a false positive would
+// answer normal NAS accounting with the wrong secret.
+func TestHasPacketFenceConnectorID(t *testing.T) {
+	tests := []struct {
+		name  string
+		attrs radius.Attributes
+		want  bool
+	}{
+		{
+			name:  "no attributes",
+			attrs: radius.Attributes{},
+			want:  false,
+		},
+		{
+			name:  "matching PacketFence-ConnectorID VSA",
+			attrs: attrsWith(vendorVSA(packetFenceVendorID, packetFenceConnectorIDAttrType, "connectorA")),
+			want:  true,
+		},
+		{
+			name:  "right vendor, wrong attribute type",
+			attrs: attrsWith(vendorVSA(packetFenceVendorID, packetFenceConnectorIDAttrType-1, "connectorA")),
+			want:  false,
+		},
+		{
+			name:  "wrong vendor id",
+			attrs: attrsWith(vendorVSA(9, packetFenceConnectorIDAttrType, "connectorA")),
+			want:  false,
+		},
+		{
+			name: "unrelated VSA present alongside the ConnectorID VSA",
+			attrs: attrsWith(
+				vendorVSA(9, 1, "somethingelse"),
+				vendorVSA(packetFenceVendorID, packetFenceConnectorIDAttrType, "connectorA"),
+			),
+			want: true,
+		},
+		{
+			name:  "truncated VSA (shorter than 5 bytes) is ignored, not a panic",
+			attrs: attrsWith(radius.Attribute{0x00, 0x00, 0x73}),
+			want:  false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hasPacketFenceConnectorID(tc.attrs); got != tc.want {
+				t.Errorf("hasPacketFenceConnectorID() = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }

--- a/go/cmd/pfacct/radius_test.go
+++ b/go/cmd/pfacct/radius_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/inverse-inc/go-radius/rfc2865"
 	"github.com/inverse-inc/go-radius/rfc2866"
 	"github.com/inverse-inc/go-radius/vendors/cisco"
+	"github.com/inverse-inc/packetfence/go/pfradius"
 )
 
 type SecretSourceFunc func(ctx context.Context, remoteAddr net.Addr, raw []byte) ([]byte, context.Context, error)
@@ -191,24 +192,24 @@ func TestHasPacketFenceConnectorID(t *testing.T) {
 		},
 		{
 			name:  "matching PacketFence-ConnectorID VSA",
-			attrs: attrsWith(vendorVSA(packetFenceVendorID, packetFenceConnectorIDAttrType, "connectorA")),
+			attrs: attrsWith(vendorVSA(pfradius.VendorID, pfradius.ConnectorIDAttrType, "connectorA")),
 			want:  true,
 		},
 		{
 			name:  "right vendor, wrong attribute type",
-			attrs: attrsWith(vendorVSA(packetFenceVendorID, packetFenceConnectorIDAttrType-1, "connectorA")),
+			attrs: attrsWith(vendorVSA(pfradius.VendorID, pfradius.ConnectorIDAttrType-1, "connectorA")),
 			want:  false,
 		},
 		{
 			name:  "wrong vendor id",
-			attrs: attrsWith(vendorVSA(9, packetFenceConnectorIDAttrType, "connectorA")),
+			attrs: attrsWith(vendorVSA(9, pfradius.ConnectorIDAttrType, "connectorA")),
 			want:  false,
 		},
 		{
 			name: "unrelated VSA present alongside the ConnectorID VSA",
 			attrs: attrsWith(
 				vendorVSA(9, 1, "somethingelse"),
-				vendorVSA(packetFenceVendorID, packetFenceConnectorIDAttrType, "connectorA"),
+				vendorVSA(pfradius.VendorID, pfradius.ConnectorIDAttrType, "connectorA"),
 			),
 			want: true,
 		},

--- a/go/jsonrpc2/client.go
+++ b/go/jsonrpc2/client.go
@@ -82,11 +82,18 @@ func NewAAAClientFromConfig(ctx context.Context) *Client {
 	var ports pfconfigdriver.PfConfPorts
 	pfconfigdriver.FetchDecodeSocket(ctx, &webservices)
 	pfconfigdriver.FetchDecodeSocket(ctx, &ports)
+	// The AAA endpoint is addressed by the aaa_host/aaa_proto/aaa port triad.
+	// Fall back to the generic webservices host when aaa_host is unset so
+	// bare-metal/compose deployments that only configure `host` keep working.
+	host := webservices.AAAHost
+	if host == "" {
+		host = webservices.Host
+	}
 	return &Client{
 		Username: webservices.User,
 		Password: webservices.Pass.String(),
 		Proto:    webservices.AAAProto,
-		Host:     webservices.Host,
+		Host:     host,
 		Port:     ports.AAA,
 	}
 }

--- a/go/pfradius/pfradius.go
+++ b/go/pfradius/pfradius.go
@@ -1,0 +1,21 @@
+// Package pfradius holds constants for PacketFence's RADIUS vendor dictionary
+// that are shared across binaries (pfacct, pfconnector, ...) so the values
+// cannot drift between independent copies.
+//
+// It is intentionally a zero-dependency leaf package: it must stay importable
+// from anywhere (including packages with their own dictionary-loading init())
+// without pulling in side effects.
+package pfradius
+
+// The constants are deliberately untyped so they adapt to both the uint32
+// vendor-id context and the byte attribute-type context at their call sites.
+const (
+	// VendorID is the PacketFence RADIUS vendor id (dictionary.packetfence,
+	// "Vendor-Id 29464").
+	VendorID = 29464
+
+	// ConnectorIDAttrType is the vendor attribute number of the
+	// PacketFence-ConnectorID VSA, used to identify traffic that arrived via a
+	// pfconnector tunnel.
+	ConnectorIDAttrType = 40
+)

--- a/html/pfappserver/lib/pfappserver/Form/Config/Domain.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Domain.pm
@@ -422,7 +422,7 @@ Validate NTLM cache fields if ntlm_cache is enabled
 sub validate {
     my ($self) = @_;
 
-    if (($self->field('id')->value() // '') !~ /^[0-9a-zA-Z\.\-_]+ [0-9a-zA-Z]+$/) {
+    if (($self->field('id')->value() // '') !~ /^[0-9a-zA-Z]+$/) {
         $self->field('id')->add_error("The id is invalid. The id can only contain alphanumeric characters.");
     }
 

--- a/html/pfappserver/root/src/views/Configuration/_components/TheTabsDomains.vue
+++ b/html/pfappserver/root/src/views/Configuration/_components/TheTabsDomains.vue
@@ -20,8 +20,7 @@ const tabs = {
   domains: {
     title: 'Active Directory Domains', // i18n defer
     component: DomainsSearch,
-    props: ({ autoJoinDomain }) => ({ autoJoinDomain }),
-    class: 'no-saas'
+    props: ({ autoJoinDomain }) => ({ autoJoinDomain })
   },
   realms: {
     title: 'Realms', // i18n defer

--- a/html/pfappserver/root/src/views/Configuration/_composables/useSections.js
+++ b/html/pfappserver/root/src/views/Configuration/_composables/useSections.js
@@ -12,7 +12,7 @@ export const useSections = () => {
         { name: i18n.t('Roles'), path: '/configuration/roles' },
         { name: i18n.t('Domains'),
           items: [
-            { name: i18n.t('Active Directory Domains'), path: '/configuration/domains', class: 'no-saas' },
+            { name: i18n.t('Active Directory Domains'), path: '/configuration/domains' },
             { name: i18n.t('Realms'), path: '/configuration/realms' }
           ]
         },

--- a/html/pfappserver/root/src/views/Configuration/domains/_router.js
+++ b/html/pfappserver/root/src/views/Configuration/domains/_router.js
@@ -30,16 +30,11 @@ export const beforeEnter = (to, from, next = () => {}) => {
   next()
 }
 
-const can = () => !store.getters['system/isSaas']
-
 export default [
   {
     path: 'domains',
     name: 'domains',
     component: TheTabs,
-    meta: {
-      can
-    },
     props: (route) => ({ tab: 'domains', autoJoinDomain: route.params.autoJoinDomain }),
     beforeEnter
   },
@@ -47,9 +42,6 @@ export default [
     path: 'domains/new',
     name: 'newDomain',
     component: TheView,
-    meta: {
-      can
-    },
     props: () => ({ isNew: true }),
     beforeEnter
   },
@@ -57,9 +49,6 @@ export default [
     path: 'domain/:id',
     name: 'domain',
     component: TheView,
-    meta: {
-      can
-    },
     props: (route) => ({ id: route.params.id }),
     beforeEnter: (to, from, next) => {
       beforeEnter()
@@ -72,9 +61,6 @@ export default [
     path: 'domain/:id/clone',
     name: 'cloneDomain',
     component: TheView,
-    meta: {
-      can
-    },
     props: (route) => ({ id: route.params.id, isClone: true }),
     beforeEnter: (to, from, next) => {
       beforeEnter()

--- a/lib/pf/ConfigStore/Domain.pm
+++ b/lib/pf/ConfigStore/Domain.pm
@@ -26,8 +26,10 @@ sub configFile { $domain_config_file };
 
 sub canDelete {
     my ($self, $id) = @_;
-    my $host_id = hostname();
-    $id =~ s/$host_id //i;
+    # Strip whatever namespace prefix the section carries ('<hostname> <id>' for
+    # classic domains, 'connector <id>' for connector-backed ones) to get the bare
+    # id the realm references.
+    $id =~ s/^\S+\s+//;
     if ($self->isInRealm('domain', $id)) {
         return "Used in a realm", $FALSE;
     }

--- a/lib/pf/UnifiedApi/Controller/Config/Domains.pm
+++ b/lib/pf/UnifiedApi/Controller/Config/Domains.pm
@@ -121,8 +121,6 @@ sub create {
         return 0;
     }
 
-    $id = $host_id . " " . $item->{id};
-    $item->{id} = $id;
     my $cs = $self->config_store;
     my $sections = $cs->readAllIds;
     my $max_port = 4999;
@@ -139,13 +137,16 @@ sub create {
     }
     $max_port = $max_port + 1;
 
+    # Validate against the raw, user-supplied id. The host_id prefix below is an
+    # internal namespacing detail for the config-store section and must not count
+    # against the id field's maxlength (would spuriously fail on long cloud hostnames).
     $item = $self->cleanupItemForCreate($item);
     (my $status, $item, my $form) = $self->validate_item($item);
     if (is_error($status)) {
         return $self->render(status => $status, json => $item);
     }
 
-    $id = delete $item->{id} // $id;
+    $id = $host_id . " " . (delete $item->{id} // $id);
     if ($cs->hasId($id)) {
         return $self->render_error(409, "An attempt to add a duplicate entry was stopped. Entry already exists and should be modified instead of created");
     }

--- a/lib/pf/UnifiedApi/Controller/Config/Domains.pm
+++ b/lib/pf/UnifiedApi/Controller/Config/Domains.pm
@@ -24,6 +24,7 @@ has 'primary_key' => 'domain_id';
 use pf::ConfigStore::Domain;
 use pfappserver::Form::Config::Domain;
 use pf::domain;
+use pf::factory::connector;
 use pf::error qw(is_error);
 use pf::pfqueue::producer::redis;
 use pf::util;
@@ -40,6 +41,13 @@ use pf::config qw(%Config);
 use pf::log;
 
 use constant JOIN_REMOTE_PORT_OFFSET => 200;
+
+# The ntlm-join-remote service listens on this address:port on the connector-remote
+# side (see go/cmd/ntlm-join-remote and resource::pfconnector_static_connections).
+# For connector-backed domains we reach it on demand through a dynreverse tunnel
+# rather than a pre-provisioned static tunnel.
+use constant JOIN_REMOTE_TARGET_HOST => '100.64.0.1';
+use constant JOIN_REMOTE_TARGET_PORT => 23000;
 
 my $host_id = hostname();
 
@@ -214,6 +222,18 @@ sub create {
         my $api_host = $Config{'services_host'}{'pfconnector_service_host'};
         my $api_port = $max_port + JOIN_REMOTE_PORT_OFFSET;
 
+        # For connector-backed domains, reach ntlm-join-remote through an on-demand
+        # dynreverse tunnel instead of a pre-provisioned static tunnel. This removes
+        # the chicken-and-egg where the join needed a tunnel that only appeared after
+        # the domain was committed and the connector reconnected.
+        if ($use_connector) {
+            my $err_msg;
+            ($api_host, $api_port, $err_msg) = $self->connector_join_endpoint($ad_server_ip);
+            if (defined($err_msg)) {
+                return $self->render_error(422, $err_msg);
+            }
+        }
+
         my @real_computer_names = ($real_computer_name);
         if ($additional_machine_accounts + 0 > 0) {
             for my $i (0 .. $additional_machine_accounts - 1) {
@@ -359,6 +379,16 @@ sub update {
     my $api_host = $Config{'services_host'}{'pfconnector_service_host'};
     my $api_port = $old_item->{ntlm_auth_port} + JOIN_REMOTE_PORT_OFFSET;
 
+    # For connector-backed domains, reach ntlm-join-remote through an on-demand
+    # dynreverse tunnel (see connector_join_endpoint / create()).
+    if ($use_connector && !is_nt_hash_pattern($new_data->{machine_account_password})) {
+        my $err_msg;
+        ($api_host, $api_port, $err_msg) = $self->connector_join_endpoint($ad_server_ip);
+        if (defined($err_msg)) {
+            return $self->render_error(422, $err_msg);
+        }
+    }
+
     my @real_computer_names = ($real_computer_name);
 
     if ($additional_machine_accounts + 0 > 0) {
@@ -446,6 +476,36 @@ sub is_nt_hash_pattern {
         return 1;
     }
     return 0;
+}
+
+=head2 connector_join_endpoint
+
+Resolve the host:port to reach the ntlm-join-remote service through the connector
+that owns the given AD server IP. Sets up (or reuses) a dynreverse tunnel on the
+fly, so no static tunnel or connector reconnect is required before a domain can be
+joined. Returns ($host, $port, undef) on success or (undef, undef, $error_message)
+when no connector matches the AD server IP or the connector is not reachable.
+
+=cut
+
+sub connector_join_endpoint {
+    my ($self, $ad_server_ip) = @_;
+    my $connector = pf::factory::connector->for_ip($ad_server_ip);
+    unless (defined($connector) && defined($connector->id) && $connector->id ne 'local_connector') {
+        return (undef, undef, "No connector matches the AD server IP '$ad_server_ip'. Ensure the domain's ad_server falls within a connector's configured networks.");
+    }
+
+    my $to = JOIN_REMOTE_TARGET_HOST . ":" . JOIN_REMOTE_TARGET_PORT . "/tcp";
+    my $conn = eval { $connector->dynreverse($to, { expose_service => 1 }) };
+    if ($@) {
+        get_logger->error("Failed to obtain dynreverse tunnel to ntlm-join-remote via connector '" . $connector->id . "': $@");
+        return (undef, undef, "Unable to reach the connector '" . $connector->id . "' to set up the domain-join tunnel. Verify the connector is connected. ($@)");
+    }
+    unless (ref($conn) eq 'HASH' && $conn->{host} && $conn->{port}) {
+        return (undef, undef, "The connector '" . $connector->id . "' did not return a usable domain-join tunnel endpoint.");
+    }
+
+    return ($conn->{host}, $conn->{port}, undef);
 }
 
 =head2 validate_input

--- a/lib/pf/UnifiedApi/Controller/Config/Domains.pm
+++ b/lib/pf/UnifiedApi/Controller/Config/Domains.pm
@@ -49,16 +49,32 @@ use constant JOIN_REMOTE_PORT_OFFSET => 200;
 use constant JOIN_REMOTE_TARGET_HOST => '100.64.0.1';
 use constant JOIN_REMOTE_TARGET_PORT => 23000;
 
+# Connector-backed domains are namespaced under this stable, tenant-wide prefix
+# instead of the (ephemeral, per-pod) hostname. A domain served through a
+# connector isn't owned by any single PF host — it may even be served by several
+# connectors at once (AD on one side, cache-only ntlm-auth-api on another) — so
+# every pod/host must resolve the same section and config::Domain must surface it
+# cluster-wide. Classic, host-local domains keep the hostname prefix.
+use constant CONNECTOR_HOST_ID => 'connector';
+
 my $host_id = hostname();
 
 sub id {
     my ($self) = @_;
     my $primary_key = $self->primary_key;
     my $stash = $self->stash;
-    if (exists $stash->{$primary_key}) {
-        return $host_id . " " . $stash->{$primary_key};
+    return undef unless exists $stash->{$primary_key};
+    my $bare = $stash->{$primary_key};
+    # Resolve the stored section for this bare id. Connector-backed domains live
+    # under the stable CONNECTOR_HOST_ID prefix; classic domains under this host's
+    # hostname. Prefer an existing section; fall back to the host prefix for ids
+    # that don't exist yet.
+    my $cs = $self->config_store;
+    for my $prefix (CONNECTOR_HOST_ID, $host_id) {
+        my $candidate = "$prefix $bare";
+        return $candidate if $cs->hasId($candidate);
     }
-    return undef;
+    return "$host_id $bare";
 }
 
 =head2 get
@@ -71,7 +87,7 @@ sub get {
     my ($self) = @_;
     my $item = $self->item;
     if ($item) {
-        $item->{id} =~ s/$host_id //i;
+        $item->{id} =~ s/^\S+\s+//;
         $item = $self->cleanupItemForGet($item);
         return $self->render(json => { item => $item }, status => 200);
     }
@@ -80,7 +96,7 @@ sub get {
 
 sub item_shown {
     my ($self, $item) = @_;
-    if ($item->{id} =~ s/$host_id //i) {
+    if ($item->{id} =~ s/^\S+\s+//) {
         return $TRUE;
     }
     return $FALSE;
@@ -102,7 +118,7 @@ sub handle_search {
     }
 
     foreach my $item (@{$response->{items}}) {
-        $item->{id} =~ s/$host_id //i;
+        $item->{id} =~ s/^\S+\s+//;
     }
 
     my $fields = $search_info->{fields};
@@ -129,11 +145,17 @@ sub create {
         return 0;
     }
 
+    my $use_connector = isenabled($item->{use_connector});
+    # Connector-backed domains share the stable CONNECTOR_HOST_ID namespace; classic
+    # domains are namespaced under this host. ntlm_auth_port is allocated per
+    # namespace, so scan (below) and section id (further down) both key off it.
+    my $host_prefix = $use_connector ? CONNECTOR_HOST_ID : $host_id;
+
     my $cs = $self->config_store;
     my $sections = $cs->readAllIds;
     my $max_port = 4999;
     for my $section (@$sections) {
-        unless ($section =~ /^$host_id /) {
+        unless ($section =~ /^\Q$host_prefix\E /) {
             next;
         }
         my $ntlm_auth_port = $cs->cachedConfig->val($section, "ntlm_auth_port");
@@ -154,7 +176,7 @@ sub create {
         return $self->render(status => $status, json => $item);
     }
 
-    $id = $host_id . " " . (delete $item->{id} // $id);
+    $id = $host_prefix . " " . (delete $item->{id} // $id);
     if ($cs->hasId($id)) {
         return $self->render_error(409, "An attempt to add a duplicate entry was stopped. Entry already exists and should be modified instead of created");
     }
@@ -192,7 +214,6 @@ sub create {
     my $ad_server_host = "";
     my $ad_server_ip = "";
 
-    my $use_connector = isenabled($item->{use_connector});
     my $dns_servers = $item->{dns_servers};
     if ($use_connector) {
         # Connector-backed domain: the cloud cannot reach the customer's on-prem
@@ -301,7 +322,7 @@ sub create {
     $self->post_create($id);
     my $additional_out = $self->additional_create_out($form, $item);
 
-    $id =~ s/$host_id //i;
+    $id =~ s/^\S+\s+//;
     $self->stash($self->primary_key => $id);
     $self->res->headers->location($self->make_location_url($id));
     $self->render(status => 201, json => $self->create_response($id, $additional_out));
@@ -322,7 +343,7 @@ sub update {
     # mergeUpdate sets the id to the host_id-namespaced value ($self->id); validate
     # against the raw id so the field's maxlength/pattern apply to the user-supplied
     # portion only (the prefix is an internal storage detail, not user input).
-    $new_item->{id} =~ s/^\Q$host_id\E //;
+    $new_item->{id} =~ s/^\S+\s+//;
 
     my ($status, $new_data, $form) = $self->validate_item($new_item);
     if (is_error($status)) {
@@ -465,7 +486,7 @@ sub update {
 sub update_response {
     my ($self, $form) = @_;
     my $id = $self->id;
-    $id =~ s/$host_id //i;
+    $id =~ s/^\S+\s+//;
     my %response = (message => "Settings updated", id => $id);
     for my $field ($form->fields) {
         my $type = $field->type;
@@ -493,7 +514,7 @@ sub remove {
     }
 
     return unless ($self->commit($cs));
-    $id =~ s/$host_id //i;
+    $id =~ s/^\S+\s+//;
     return $self->render(json => { message => "Deleted $id successfully" }, status => 200);
 }
 

--- a/lib/pf/UnifiedApi/Controller/Config/Domains.pm
+++ b/lib/pf/UnifiedApi/Controller/Config/Domains.pm
@@ -496,7 +496,7 @@ sub connector_join_endpoint {
     }
 
     my $to = JOIN_REMOTE_TARGET_HOST . ":" . JOIN_REMOTE_TARGET_PORT . "/tcp";
-    my $conn = eval { $connector->dynreverse($to, { expose_service => 1 }) };
+    my $conn = eval { $connector->dynreverse($to, { pod_direct => 1 }) };
     if ($@) {
         get_logger->error("Failed to obtain dynreverse tunnel to ntlm-join-remote via connector '" . $connector->id . "': $@");
         return (undef, undef, "Unable to reach the connector '" . $connector->id . "' to set up the domain-join tunnel. Verify the connector is connected. ($@)");

--- a/lib/pf/UnifiedApi/Controller/Config/Domains.pm
+++ b/lib/pf/UnifiedApi/Controller/Config/Domains.pm
@@ -320,6 +320,9 @@ sub create {
     $cs->create($id, $item);
     return unless ($self->commit($cs));
     $self->post_create($id);
+    # Bind the new domain's static tunnels on the connector now, so it's usable
+    # without waiting for the connector to reconnect.
+    $self->reprovision_connector_static($ad_server_ip) if $use_connector;
     my $additional_out = $self->additional_create_out($form, $item);
 
     $id =~ s/^\S+\s+//;
@@ -480,6 +483,7 @@ sub update {
     $cs->update($id, $new_data);
     return unless ($self->commit($cs));
     $self->post_update($id);
+    $self->reprovision_connector_static($ad_server_ip) if $use_connector;
     $self->render(status => 200, json => $self->update_response($form));
 }
 
@@ -555,6 +559,24 @@ sub connector_join_endpoint {
     }
 
     return ($conn->{host}, $conn->{port}, undef);
+}
+
+=head2 reprovision_connector_static
+
+After committing a connector-backed domain, ask the owning connector's
+pfconnector server to bind the domain's newly-added static tunnels (e.g. the
+NTLM-auth tunnel on port ntlm_auth_port+CONNECTOR_PORT_OFFSET) on the live
+tunnel, so the domain is usable without a manual connector reconnect.
+Best-effort — never blocks the API response on connector reachability.
+
+=cut
+
+sub reprovision_connector_static {
+    my ($self, $ad_server_ip) = @_;
+    my $connector = pf::factory::connector->for_ip($ad_server_ip);
+    return unless defined($connector) && defined($connector->id) && $connector->id ne 'local_connector';
+    $connector->reprovision_static();
+    return;
 }
 
 =head2 validate_input

--- a/lib/pf/UnifiedApi/Controller/Config/Domains.pm
+++ b/lib/pf/UnifiedApi/Controller/Config/Domains.pm
@@ -284,6 +284,11 @@ sub update {
 
     my $new_item = $self->mergeUpdate($data, $self->item);
 
+    # mergeUpdate sets the id to the host_id-namespaced value ($self->id); validate
+    # against the raw id so the field's maxlength/pattern apply to the user-supplied
+    # portion only (the prefix is an internal storage detail, not user input).
+    $new_item->{id} =~ s/^\Q$host_id\E //;
+
     my ($status, $new_data, $form) = $self->validate_item($new_item);
     if (is_error($status)) {
         return $self->render(status => $status, json => $new_data);

--- a/lib/pf/UnifiedApi/Controller/Config/Domains.pm
+++ b/lib/pf/UnifiedApi/Controller/Config/Domains.pm
@@ -192,8 +192,24 @@ sub create {
     my $ad_server_host = "";
     my $ad_server_ip = "";
 
+    my $use_connector = isenabled($item->{use_connector});
     my $dns_servers = $item->{dns_servers};
-    if (defined($dns_servers)) {
+    if ($use_connector) {
+        # Connector-backed domain: the cloud cannot reach the customer's on-prem
+        # dns_servers directly, so querying them here would stall ~75s before
+        # falling back. Resolve the AD server through the connector instead — a bare
+        # IP is used as-is, a hostname goes through pfdns-connector (and is checked
+        # against the connector networks).
+        my $resolved_ip = pf::factory::connector->resolve($ad_server);
+        if (defined($resolved_ip) && valid_ip($resolved_ip)) {
+            $ad_server_host = $ad_fqdn;
+            $ad_server_ip = $resolved_ip;
+        }
+        else {
+            return $self->render_error(422, "Unable to resolve AD server '$ad_server' through the connector. Provide an IP within a connector's networks, or a name resolvable via pfdns-connector.\n");
+        }
+    }
+    elsif (defined($dns_servers)) {
         my ($hostname, $ip, $error) = pf::util::dns_resolve($ad_fqdn, $dns_servers, $dns_name);
         if (defined($ip)) {
             $ad_server_host = $ad_fqdn;
@@ -218,7 +234,6 @@ sub create {
     }
 
     if (!is_nt_hash_pattern($computer_password)) {
-        my $use_connector = isenabled($item->{use_connector});
         my $api_host = $Config{'services_host'}{'pfconnector_service_host'};
         my $api_port = $max_port + JOIN_REMOTE_PORT_OFFSET;
 
@@ -350,8 +365,22 @@ sub update {
     my $ad_server_host = "";
     my $ad_server_ip = "";
 
+    my $use_connector = isenabled($new_item->{use_connector} // $old_item->{use_connector});
     my $dns_servers = $new_item->{dns_servers};
-    if (defined($dns_servers)) {
+    if ($use_connector) {
+        # Connector-backed domain: resolve the AD server through the connector
+        # rather than the customer's on-prem dns_servers (unreachable from the
+        # cloud, would stall ~75s). Bare IP used as-is; hostname via pfdns-connector.
+        my $resolved_ip = pf::factory::connector->resolve($ad_server);
+        if (defined($resolved_ip) && valid_ip($resolved_ip)) {
+            $ad_server_host = $ad_fqdn;
+            $ad_server_ip = $resolved_ip;
+        }
+        else {
+            return $self->render_error(422, "Unable to resolve AD server '$ad_server' through the connector. Provide an IP within a connector's networks, or a name resolvable via pfdns-connector.\n");
+        }
+    }
+    elsif (defined($dns_servers)) {
         my ($hostname, $ip, $error) = pf::util::dns_resolve($ad_fqdn, $dns_servers, $dns_name);
         if (defined($ip)) {
             $ad_server_host = $ad_fqdn;
@@ -375,7 +404,6 @@ sub update {
         return $self->render_error(422, "Unable to determine AD server's IP address\n")
     }
 
-    my $use_connector = isenabled($new_item->{use_connector} // $old_item->{use_connector});
     my $api_host = $Config{'services_host'}{'pfconnector_service_host'};
     my $api_port = $old_item->{ntlm_auth_port} + JOIN_REMOTE_PORT_OFFSET;
 

--- a/lib/pf/api.pm
+++ b/lib/pf/api.pm
@@ -74,7 +74,9 @@ use pf::password();
 use pf::web::guest();
 use pf::dhcp::processor_v4();
 use pf::dhcp::processor_v6();
+use pf::util::dhcp();
 use pf::util::dhcpv6();
+use MIME::Base64();
 use pf::domain::ntlm_cache();
 use pf::access_filter::switch;
 use Hash::Merge qw (merge);
@@ -1359,6 +1361,108 @@ sub process_dhcpv6 : Public {
 
     my $dhcpv6Processor = pf::dhcp::processor_v6->new();
     $dhcpv6Processor->process_packet($udp_payload);
+}
+
+=head2 process_dhcp_event
+
+Processes a DHCP packet forwarded by the fingerbank-collector (the
+pfdhcplistener replacement). The collector sniffs raw DHCP frames off the wire
+and ships the base64-encoded UDP payload here through the pfconnector-server,
+which relays it over the webservices JSON-RPC endpoint.
+
+Unlike pfdhcplistener, the collector has no listening interface, so it cannot
+provide the interface/VLAN context process_dhcpv4 normally receives. We
+synthesize it: collector-forwarded traffic is never inline (is_inline_vlan=0),
+which is the only code path that reads interface/interface_ip/interface_vlan;
+the remaining uses are log/statsd strings. net_type is set to 'internal' so
+pf::util::is_prod_interface() returns false and DHCP packets do not trigger
+per-packet post-registration conformity scans (which is how pfdhcplistener
+behaved on a normal 'internal' capture interface).
+
+Expects: version (4 or 6), payload (base64 UDP payload), and optionally
+src_mac, dst_mac, src_ip, dst_ip. DHCPv6 is delegated to process_dhcpv6, whose
+processor base64-decodes the payload itself.
+
+=cut
+
+sub process_dhcp_event : Public {
+    my ($class, %postdata) = @_;
+    my @require = qw(version payload);
+    my @found = grep { exists $postdata{$_} } @require;
+    return unless pf::util::validate_argv(\@require, \@found);
+
+    my $version = $postdata{'version'};
+
+    # DHCPv6: the v6 processor base64-decodes the payload itself, so hand it the
+    # base64 string verbatim through the existing entry point.
+    if ($version == 6) {
+        return $class->process_dhcpv6($postdata{'payload'});
+    }
+
+    if ($version != 4) {
+        $logger->warn("process_dhcp_event: unsupported DHCP version '$version'");
+        return;
+    }
+
+    my $payload = MIME::Base64::decode_base64($postdata{'payload'});
+    unless (length($payload)) {
+        $logger->warn("process_dhcp_event: empty DHCPv4 payload");
+        return;
+    }
+
+    my $dhcp;
+    eval { $dhcp = pf::util::dhcp::decode_dhcp($payload); };
+    if ($@ || !$dhcp) {
+        $logger->warn("process_dhcp_event: unable to decode DHCPv4 packet: $@");
+        return;
+    }
+
+    # Frame massaging mirrors pfdhcplistener: chaddr is the full 16-byte hardware
+    # address field; the node MAC is its first 6 bytes.
+    my $dhcp_mac = pf::util::clean_mac(substr($dhcp->{'chaddr'}, 0, 12));
+    if ($dhcp_mac ne "00:00:00:00:00:00" && !pf::util::valid_mac($dhcp_mac)) {
+        $logger->debug("process_dhcp_event: invalid CHADDR ($dhcp_mac), skipping");
+        return;
+    }
+    unless ($dhcp_mac) {
+        $logger->debug("process_dhcp_event: chaddr is undefined, skipping");
+        return;
+    }
+    $dhcp->{'chaddr'}   = $dhcp_mac;
+    $dhcp->{'src_mac'}  = pf::util::clean_mac($postdata{'src_mac'} // '');
+    $dhcp->{'dest_mac'} = pf::util::clean_mac($postdata{'dst_mac'}) if defined $postdata{'dst_mac'};
+    $dhcp->{'src_ip'}   = $postdata{'src_ip'} if defined $postdata{'src_ip'};
+    $dhcp->{'dest_ip'}  = $postdata{'dst_ip'} if defined $postdata{'dst_ip'};
+
+    # Match pfdhcplistener, which always sets src_mac from the L2 frame and drops
+    # the packet on an invalid source MAC. Validate unconditionally so a
+    # missing/empty src_mac is skipped rather than processed with a bogus MAC
+    # (which would emit rogue-DHCP alerts with an empty server MAC).
+    unless (pf::util::valid_mac($dhcp->{'src_mac'})) {
+        $logger->debug("process_dhcp_event: source MAC '" . $dhcp->{'src_mac'} . "' is invalid, skipping");
+        return;
+    }
+
+    my $processor = pf::dhcp::processor_v4->new(
+        dhcp     => $dhcp,
+        src_mac  => $dhcp->{'src_mac'},
+        dest_mac => $dhcp->{'dest_mac'},
+        src_ip   => $dhcp->{'src_ip'},
+        dest_ip  => $dhcp->{'dest_ip'},
+        # Collector-forwarded DHCP carries no interface/VLAN context. It is never
+        # inline, so interface/interface_ip/interface_vlan (only read in the
+        # inline branch and in log/statsd strings) get safe sentinels. net_type
+        # is 'internal' (not 'dhcp-listener') so is_prod_interface() is false and
+        # DHCP traffic does not trigger per-packet post-registration scans.
+        is_inline_vlan => 0,
+        interface      => 'dhcp-listener',
+        interface_ip   => undef,
+        interface_vlan => $pf::config::NO_VLAN,
+        net_type       => 'internal',
+    );
+    $processor->process_packet();
+
+    return $pf::config::TRUE;
 }
 
 =head2 copy_directory

--- a/lib/pf/connector.pm
+++ b/lib/pf/connector.pm
@@ -7,6 +7,7 @@ use pf::AtFork;
 use pf::config qw(%Config);
 use pf::log;
 use pf::util qw(isenabled);
+use JSON;
 
 has id => (is => 'rw');
 
@@ -53,11 +54,17 @@ sub connectorServerApiClient {
 }
 
 sub dynreverse {
-    my ($self, $to) = @_;
-    my $connector_conn = $self->connectorServerApiClient->call("POST", "/api/v1/pfconnector/dynreverse", {
+    my ($self, $to, $opts) = @_;
+    $opts //= {};
+    my %body = (
         to => $to,
         connector_id => $self->id,
-    });
+    );
+    # Opt this port into being published on the pfconnector k8s Service. Only
+    # callers that reach the port through the Service ClusterIP (e.g. the domain
+    # join) need this; the RADIUS/SNMP callers omit it to keep their behavior.
+    $body{expose_service} = JSON::true if $opts->{expose_service};
+    my $connector_conn = $self->connectorServerApiClient->call("POST", "/api/v1/pfconnector/dynreverse", \%body);
 
     #Override the host value returned by the connector server's dynreverse API.
     #In K8S/SaaS the connector is reached through PFCONNECTOR_SERVICE_HOST; the host the

--- a/lib/pf/connector.pm
+++ b/lib/pf/connector.pm
@@ -88,5 +88,28 @@ sub dynreverse {
     return $connector_conn;
 }
 
+=head2 reprovision_static
+
+Ask the pfconnector server to (re)provision this connector's static reverse
+tunnels on its already-connected tunnel, so tunnels added since the connector
+last handshaked (e.g. the NTLM-auth tunnel of a freshly-committed domain) become
+usable without a manual connector reconnect. Best-effort: logs and swallows
+errors (a disconnected connector will pick everything up on its next connect).
+
+=cut
+
+sub reprovision_static {
+    my ($self) = @_;
+    eval {
+        $self->connectorServerApiClient->call("POST", "/api/v1/pfconnector/reprovision-static-connections", {
+            connector_id => $self->id,
+        });
+    };
+    if ($@) {
+        get_logger->warn("Failed to reprovision static connections for connector '".$self->id."': $@");
+    }
+    return;
+}
+
 1;
 

--- a/lib/pf/connector.pm
+++ b/lib/pf/connector.pm
@@ -7,7 +7,6 @@ use pf::AtFork;
 use pf::config qw(%Config);
 use pf::log;
 use pf::util qw(isenabled);
-use JSON;
 
 has id => (is => 'rw');
 
@@ -56,23 +55,28 @@ sub connectorServerApiClient {
 sub dynreverse {
     my ($self, $to, $opts) = @_;
     $opts //= {};
-    my %body = (
+    my $client = $self->connectorServerApiClient;
+    my $connector_conn = $client->call("POST", "/api/v1/pfconnector/dynreverse", {
         to => $to,
         connector_id => $self->id,
-    );
-    # Opt this port into being published on the pfconnector k8s Service. Only
-    # callers that reach the port through the Service ClusterIP (e.g. the domain
-    # join) need this; the RADIUS/SNMP callers omit it to keep their behavior.
-    $body{expose_service} = JSON::true if $opts->{expose_service};
-    my $connector_conn = $self->connectorServerApiClient->call("POST", "/api/v1/pfconnector/dynreverse", \%body);
+    });
 
     #Override the host value returned by the connector server's dynreverse API.
-    #In K8S/SaaS the connector is reached through PFCONNECTOR_SERVICE_HOST; the host the
-    #server returns (e.g. containers-gateway.internal) doesn't resolve from this pod, so
-    #whenever PFCONNECTOR_SERVICE_HOST is defined we always prefer it.
+    #pod_direct: dial the exact pfconnector instance that owns this tunnel instead of
+    #the k8s Service ClusterIP. A freshly-bound dynreverse port isn't reliably routed
+    #by kube-proxy through the ClusterIP (the static tunnels work only because they've
+    #been programmed for a while), whereas the instance address we just used for this
+    #API call is directly reachable. Required for long-lived calls like the domain join
+    #where dialing the ClusterIP hangs and the tunnel gets reaped mid-request.
+    #In K8S/SaaS the connector is otherwise reached through PFCONNECTOR_SERVICE_HOST; the
+    #host the server returns (e.g. containers-gateway.internal) doesn't resolve from this
+    #pod, so whenever PFCONNECTOR_SERVICE_HOST is defined we prefer it.
     #Otherwise, on a 'Classic PF' container, force the local containers interface so that
     #the docker proxy gets the packets back on the containers network.
-    if ($ENV{PFCONNECTOR_SERVICE_HOST}) {
+    if ($opts->{pod_direct}) {
+        $connector_conn->{host} = $client->host;
+    }
+    elsif ($ENV{PFCONNECTOR_SERVICE_HOST}) {
         $connector_conn->{host} = $ENV{PFCONNECTOR_SERVICE_HOST};
     }
     elsif ( ($ENV{IS_A_CLASSIC_PF_CONTAINER} && !$ENV{DOCKER_NETWORK_IS_HOST}) || (exists $ENV{PF_SAAS} && !isenabled($ENV{PF_SAAS})) ) {

--- a/lib/pf/dhcp/processor_v4.pm
+++ b/lib/pf/dhcp/processor_v4.pm
@@ -406,7 +406,9 @@ sub parse_dhcp_ack {
 
     my $s_ip = $dhcp->{'src_ip'};
     my $s_mac = $dhcp->{'src_mac'};
-    my $client_mask = join( '.', @{$dhcp->{'options'}->{'1'}});
+    # Option 1 (subnet mask) is optional: DHCPINFORM-triggered ACKs and some
+    # servers omit it. Guard the array deref so a missing option doesn't die.
+    my $client_mask = defined($dhcp->{'options'}->{'1'}) ? join( '.', @{$dhcp->{'options'}->{'1'}}) : undef;
     my $lease_length = $dhcp->{'options'}->{'51'};
 
     my $client_ip;

--- a/lib/pfconfig/namespaces/config/Domain.pm
+++ b/lib/pfconfig/namespaces/config/Domain.pm
@@ -22,6 +22,7 @@ use JSON;
 use pfconfig::namespaces::config;
 use pf::log;
 use pf::file_paths qw($domain_config_file);
+use pf::util qw(isenabled);
 use Sys::Hostname;
 
 use base 'pfconfig::namespaces::config';
@@ -63,8 +64,14 @@ sub build_child {
         $host_id = $self->{host_id};
     }
     foreach my $key (keys %tmp_cfg) {
-        if (index($key, $host_id) == 0 && $key =~/^\S+\s+(\S+)$/) {
-            $filtered{$1} = $tmp_cfg{$key};
+        next unless $key =~ /^\S+\s+(\S+)$/;
+        my $bare = $1;
+        # Classic, host-local domains: only this host's own sections. Connector-backed
+        # domains are tenant-wide (stored under a stable, non-host prefix, e.g.
+        # 'connector <id>') and must be visible on every host/pod, so include them
+        # regardless of the prefix.
+        if (index($key, $host_id) == 0 || isenabled($tmp_cfg{$key}{use_connector})) {
+            $filtered{$bare} = $tmp_cfg{$key};
         }
     }
     return \%filtered;

--- a/lib/pfconfig/namespaces/resource/pfconnector_static_connections.pm
+++ b/lib/pfconfig/namespaces/resource/pfconnector_static_connections.pm
@@ -35,8 +35,6 @@ sub init {
       $self->{cache}->get_cache('config::DnsConnectors');
     $self->{_domain_config} =
       $self->{cache}->get_cache('config::Domain');
-    $self->{_pf_config} =
-      $self->{cache}->get_cache('config::Pf');
 }
 
 sub find_connector {
@@ -58,7 +56,6 @@ sub find_connector {
 sub build {
     my ($self) = @_;
     my %hash;
-    my $dns_host = $self->{_pf_config}{'services_host'}{'pfdns_connector_service_host'} // '100.64.0.1';
 
     while ( my ( $id, $data ) =
         each %{ $self->{_authentication_config}{authentication_config_hash} } )
@@ -80,9 +77,13 @@ sub build {
         my $port = $data->{'pfconnector_port'};
         next unless defined $port;
         my $connector = $self->find_connector( $data->{ip} );
-        my $r         = "${dns_host}:${port}:$data->{ip}:$data->{port}/udp";
+        # No local bind host: bind 0.0.0.0 so the pfconnector server listens on
+        # all interfaces (matches the RADIUS/NTLM branches). In k8s the front-end
+        # IP is provided by the pfconnector Service, and binding a specific
+        # Service/cluster IP on the pod fails with "cannot assign requested address".
+        my $r         = "${port}:$data->{ip}:$data->{port}/udp";
         push @{ $hash{$connector} }, $r;
-        $r         = "${dns_host}:${port}:$data->{ip}:$data->{port}";
+        $r         = "${port}:$data->{ip}:$data->{port}";
         push @{ $hash{$connector} }, $r;
     }
     for my $id ( keys %{ $self->{_domain_config} } ) {

--- a/lib/pfconfig/namespaces/resource/pfconnector_static_connections.pm
+++ b/lib/pfconfig/namespaces/resource/pfconnector_static_connections.pm
@@ -19,10 +19,6 @@ use pf::util qw(listify isenabled);
 # Port offset added when using a connector for NTLM auth
 use constant CONNECTOR_PORT_OFFSET => 100;
 
-# Port offset and target port for the ntlm-join-remote service
-use constant JOIN_REMOTE_PORT_OFFSET => 200;
-use constant JOIN_REMOTE_TARGET_PORT => 23000;
-
 sub init {
     my ($self) = @_;
     $self->{_authentication_config} =
@@ -96,23 +92,13 @@ sub build {
         my $r         = "${port}:127.0.0.1:$data->{ntlm_auth_port}/tcp";
         push @{ $hash{$connector} }, $r;
     }
-    # Join-remote tunnels to reach ntlm-join-remote on port 23000
-    # Deduplicate by connector + local_port to avoid duplicate tunnels
-    # while still allowing multiple domains behind the same connector
-    my %join_remote_seen;
-    for my $id ( keys %{ $self->{_domain_config} } ) {
-        my $data = $self->{_domain_config}{$id};
-        next unless isenabled($data->{'use_connector'});
-        my $port = $data->{'ntlm_auth_port'};
-        next unless defined $port;
-        my $connector = $self->find_connector( $data->{ad_server} );
-        my $local_port = $port + JOIN_REMOTE_PORT_OFFSET;
-        my $key = "${connector}:${local_port}";
-        next if $join_remote_seen{$key};
-        $join_remote_seen{$key} = 1;
-        my $r = "${local_port}:100.64.0.1:" . JOIN_REMOTE_TARGET_PORT . "/tcp";
-        push @{ $hash{$connector} }, $r;
-    }
+    # NOTE: ntlm-join-remote (port 23000 on the connector-remote) is no longer
+    # exposed via a static tunnel here. Connector-backed domain joins now set up an
+    # on-demand dynreverse tunnel at join time (see connector_join_endpoint() in
+    # pf::UnifiedApi::Controller::Config::Domains), which also patches the k8s
+    # pfconnector Service on the fly. A static tunnel required the connector to
+    # reconnect after the domain was committed before the port existed, which
+    # deadlocked first-time joins.
     return \%hash;
 }
 

--- a/raddb/dictionary.inverse
+++ b/raddb/dictionary.inverse
@@ -40,7 +40,6 @@ ATTRIBUTE       PacketFence-Request-Time              24       integer
 ATTRIBUTE       PacketFence-NasName                   25       string
 ATTRIBUTE       PacketFence-Proxied-To                26       string
 ATTRIBUTE       PacketFence-Authorization-Status      27       string
-# ATTRIBUTE       PacketFence-Tenant-Id                 28       integer
 ATTRIBUTE       PacketFence-ShortName                 29       string
 ATTRIBUTE       PacketFence-Proxied-From              30       string 
 ATTRIBUTE       PacketFence-UserNameAttribute         31       string

--- a/raddb/mods-enabled/soh
+++ b/raddb/mods-enabled/soh
@@ -1,1 +1,0 @@
-../mods-available/soh

--- a/raddb/sites-available/dynamic-clients
+++ b/raddb/sites-available/dynamic-clients
@@ -115,9 +115,11 @@ server dynamic_clients {
         }
 
         # Connector traffic: identify by PacketFence-ConnectorID VSA and resolve to the shared 'pfconnector' row.
-        # Use an attribute-existence test (not a bare %{} xlat) so it fires reliably in the dynamic-client fake
-        # request, mirroring the %{raw:...} pattern used by the MAC/IP lookups above and below.
-        if ( &control:PacketFence-NasName == '0' && &PacketFence-ConnectorID ) {
+        # The dynamic-client fake request has an empty VPS list, so neither a bare %{PacketFence-ConnectorID}
+        # xlat nor an &PacketFence-ConnectorID existence test can see the attribute. Read it straight from the
+        # raw packet bytes with %{raw:...} (the MSG_PEEK'd triggering packet), mirroring the MAC/IP lookups.
+        # Requires the rlm_raw vendor-matching fix so the VSA (vendor 29464, attr 40) is found.
+        if ( &control:PacketFence-NasName == '0' && "%{raw:PacketFence-ConnectorID}" != "" ) {
             update control {
                 &PacketFence-NasName := "pfconnector"
             }

--- a/raddb/sites-available/dynamic-clients
+++ b/raddb/sites-available/dynamic-clients
@@ -114,8 +114,10 @@ server dynamic_clients {
             }
         }
 
-        # Connector traffic: identify by PacketFence-ConnectorID VSA and resolve to the shared 'pfconnector' row
-        if ( &control:PacketFence-NasName == '0' && "%{PacketFence-ConnectorID}" != "" ) {
+        # Connector traffic: identify by PacketFence-ConnectorID VSA and resolve to the shared 'pfconnector' row.
+        # Use an attribute-existence test (not a bare %{} xlat) so it fires reliably in the dynamic-client fake
+        # request, mirroring the %{raw:...} pattern used by the MAC/IP lookups above and below.
+        if ( &control:PacketFence-NasName == '0' && &PacketFence-ConnectorID ) {
             update control {
                 &PacketFence-NasName := "pfconnector"
             }


### PR DESCRIPTION
  # Description
  This PR brings the changes required to run **PacketFence Connector remotes against a
  cloud / SaaS PacketFence**. It covers four areas:
  
  1. **RADIUS & accounting proxying to the cloud** — remotes now proxy RADIUS auth and
     accounting to the central cluster over the connector tunnel, signing the cloud hop
     with a unified secret and identifying connector traffic by the
     `PacketFence-ConnectorID` VSA. Accounting gets its own dedicated tunnel and is
     forwarded verbatim.
     
  2. **fingerbank-collector on the remote** — the pfconnector-remote-combined image now
     ships `fingerbank-collector-remote`; the collector sniffs DHCP locally and forwards
     packets to the cloud `pf::api` over the tunnel (replacing pfdhcplistener on the
     remote). Legacy `fingerbank-collector`/`freeradius-common` packages and the old
     standalone service are removed/stopped on install and upgrade.

  3. **Active Directory domain join via the connector** — for connector-backed domains,
     the AD join no longer needs a static tunnel: it goes through an on-demand
     `dynreverse` that patches the k8s pfconnector Service on the fly, dials the
     tunnel-owning pod directly, resolves the AD server through the connector, and
     namespaces connector domains tenant-wide so `config::Domain` surfaces them. The
     "Active Directory Domains" admin menu is now shown in SaaS mode.
     
  4. **FreeRADIUS bump & cleanup** — FreeRADIUS pinned to `4:3.2.11+git` (for the
     `rlm_raw` VSA fix used by connector detection), `soh` dropped from mods-enabled
     (`rlm_soh.so` isn't shipped), and dead pfacct multi-tenancy (TenantId) plumbing
     removed.
     
  # Impacts
  Reviewers should look at:
  - **RADIUS authorize/accounting workflow through a connector** — cloud-hop secret
    signing, connector-traffic detection via `%{raw:PacketFence-ConnectorID}`, dedicated
    accounting tunnel, and pfacct's AAA client now dialing `webservices.aaa_host`
    (not `host`).
  - **pfconnector-server API handlers** (`go/chisel/server/server_handler.go`) — the new
    `process-dhcp`, `remote-fingerbank-collector-*`, domain/dynreverse and ntlm_auth_host
    endpoints.
  - **AD domain join path** for connector-backed domains (`lib/pf/api.pm`,
    `lib/pf/connector.pm`, `lib/pf/UnifiedApi/Controller/Config/Domains.pm`,
    `lib/pf/ConfigStore/Domain.pm`, `lib/pfconfig/namespaces/config/Domain.pm`) —
    especially raw-vs-`host_id`-prefixed domain id validation.
  - **pfconnector-remote packaging** (`debian/control`, `debian/packetfence-pfconnector-remote.postinst`)
    — new Conflicts/Replaces and the legacy-service stop/disable on upgrade.
  - **radiusd dynamic-clients** (`raddb/sites-available/dynamic-clients`, `addons/pfconnector/conf/radiusd/*`).

  # NEW Package(s) required
  - `fingerbank-collector` bumped: **>= 1.6.1** (was >= 1.4.1) — `debian/control`.
  - FreeRADIUS pinned to **`4:3.2.11+git`** (was `3.2.8+git`) in `containers/radiusd/Dockerfile`.
  - pfconnector-remote-combined image now installs **`fingerbank-collector-remote`**
    (and `packetfence-connector-cache=0.1.3-1`).
  - `packetfence-pfconnector-remote` now declares **Conflicts/Replaces** on
    `fingerbank-collector`, `fingerbank-collector-remote`, `freeradius-common`.
    
  # Delete branch after merge
  NO (this is the long-lived `cloudDevel` integration branch)

  # Checklist
  - [ ] Document the feature — n/a (cloud/SaaS internal)
  - [ ] Add OpenAPI specification — n/a
  - [yes] Add unit tests — `ntlm_auth_api_env_test.go`, `pfacct/nodes_test.go` updated
  - [ ] Add acceptance tests (TestLink) — no

  # NEWS file entries
  ## New Features
  * PacketFence Connector remotes can now proxy RADIUS authentication and accounting to a cloud/SaaS PacketFence over the connector tunnel
  * fingerbank-collector now runs on the connector remote and forwards DHCP fingerprinting to the cloud over the tunnel
  * Active Directory domains can be joined through a connector using on-demand dynamic reverse tunnels, with no static tunnel required
  
  ## Enhancements
  * Connector RADIUS traffic is now identified by the `PacketFence-ConnectorID` VSA and signed with a unified secret on the cloud hop
  * Accounting is routed through a dedicated connector tunnel and forwarded verbatim
  * "Active Directory Domains" menu is now shown in SaaS mode
  * FreeRADIUS bumped to 4:3.2.11+git

  ## Bug Fixes
  * pfacct AAA client now uses `webservices.aaa_host` instead of `host`
  * Connector DNS tunnels now bind on 0.0.0.0 and k8s port patching is idempotent 
  * Removed dead pfacct multi-tenancy (TenantId) plumbing
  * Dropped `soh` from radiusd mods-enabled (`rlm_soh.so` not shipped)

  # UPGRADE file entries
  * On `packetfence-pfconnector-remote` upgrade, the legacy `packetfence-pfconnector-remote.service`
    is stopped and disabled in favour of `packetfence-pfconnector-remote-combined.service`, and the
    standalone `fingerbank-collector` / `freeradius-common` packages are removed (superseded by the
    combined container image).