### PR TITLE
fix(cluster): retain source file permissions during sync (#8984)

### DIFF
--- a/bin/cluster/sync
+++ b/bin/cluster/sync
@@ -148,7 +148,11 @@ if($master_server){
             print $fh $result;
             close($fh);
             safe_pf_run("chown", "pf:pf", $file);
-            chmod($mode, $file) if defined $mode;
+            # apply the mode returned by the master; log if chmod fails
+            if (defined $mode) {
+                chmod($mode, $file)
+                  or get_logger->warn("Couldn't set mode on $file: $!");
+            }
         };
         if($@){
             get_logger->error("Failed to sync file : $file . $@");

--- a/bin/cluster/sync
+++ b/bin/cluster/sync
@@ -143,11 +143,12 @@ if($master_server){
         eval {
             get_logger->info("Synching file : $file");
             my %data = ( conf_file => $file );
-            my ($result) = $apiclient->call( 'download_configfile', %data );
+            my ($result, $mode) = $apiclient->call( 'download_configfile', %data );
             open(my $fh, '>', $file);
             print $fh $result;
             close($fh);
             safe_pf_run("chown", "pf:pf", $file);
+            chmod($mode, $file) if defined $mode;
         };
         if($@){
             get_logger->error("Failed to sync file : $file . $@");

--- a/lib/pf/api.pm
+++ b/lib/pf/api.pm
@@ -729,8 +729,8 @@ sub notify_configfile_changed : Public {
 
     eval {
         my %data = ( conf_file => $postdata{conf_file} );
-        my ($result) = $apiclient->call( 'download_configfile', %data );
-        pf::util::safe_file_update($postdata{conf_file}, $result);
+        my ($result, $mode) = $apiclient->call( 'download_configfile', %data );
+        pf::util::safe_file_update($postdata{conf_file}, $result, undef, $mode);
 
         $logger->info("Successfully downloaded configuration $postdata{conf_file} from $postdata{server}");
     };
@@ -750,8 +750,10 @@ sub download_configfile : Public {
 
     die "Config file $postdata{conf_file} doesn't exist" unless(-e $postdata{conf_file});
     my $config = read_file($postdata{conf_file});
+    # Preserve the source's permission bits (excluding setuid/setgid/sticky)
+    my $mode = (stat($postdata{conf_file}))[2] & 0777;
 
-    return $config;
+    return ($config, $mode);
 }
 
 sub distant_download_configfile : Public {
@@ -763,8 +765,8 @@ sub distant_download_configfile : Public {
     my $file = $postdata{conf_file};
     my %data = ( conf_file => $file );
     my $apiclient = pf::api::jsonrpcclient->new(host => $postdata{from}, proto => 'https');
-    my ($result) = $apiclient->call( 'download_configfile', %data );
-    pf::util::safe_file_update($file, $result);
+    my ($result, $mode) = $apiclient->call( 'download_configfile', %data );
+    pf::util::safe_file_update($file, $result, undef, $mode);
     return 1;
 }
 

--- a/lib/pf/api.pm
+++ b/lib/pf/api.pm
@@ -750,8 +750,8 @@ sub download_configfile : Public {
 
     die "Config file $postdata{conf_file} doesn't exist" unless(-e $postdata{conf_file});
     my $config = read_file($postdata{conf_file});
-    # Preserve the source's permission bits (excluding setuid/setgid/sticky)
-    my $mode = (stat($postdata{conf_file}))[2] & 0777;
+    # Apply the original source file's mode as-is
+    my $mode = (stat($postdata{conf_file}))[2];
 
     return ($config, $mode);
 }

--- a/lib/pf/util.pm
+++ b/lib/pf/util.pm
@@ -528,9 +528,11 @@ sub sort_ip {
         map { [$_,ip2int($_)] } @_;
 }
 
-=item safe_file_update($file, $content)
+=item safe_file_update($file, $content, $binmode, $mode)
 
-This safely modifies the contents of a file using a rename
+This safely modifies the contents of a file using a rename.
+Optional $binmode sets the layer used to write the content. Optional $mode is
+applied with chmod once the file is in place; a chmod failure is logged.
 
 =cut
 
@@ -554,8 +556,11 @@ sub safe_file_update {
     }
     $temp->unlink_on_destroy(0);
     fix_file_permissions($file);
-    # fix_file_permissions resets the mode; restore the source's mode last when provided
-    chmod($mode, $file) if defined $mode;
+    # fix_file_permissions resets the mode; restore the provided mode last and log if chmod fails
+    if (defined $mode) {
+        chmod($mode, $file)
+          or pf::log::get_logger()->warn("cannot set mode on $file: $!");
+    }
 }
 
 =item empty_dir

--- a/lib/pf/util.pm
+++ b/lib/pf/util.pm
@@ -535,7 +535,7 @@ This safely modifies the contents of a file using a rename
 =cut
 
 sub safe_file_update {
-    my ($file, $contents, $binmode) = @_;
+    my ($file, $contents, $binmode, $mode) = @_;
     my ($volume, $dir, $filename) = File::Spec->splitpath($file);
     $dir = '.' if $dir eq '';
     # Creates a new file in the same directory to ensure it is on the same filesystem
@@ -554,6 +554,8 @@ sub safe_file_update {
     }
     $temp->unlink_on_destroy(0);
     fix_file_permissions($file);
+    # fix_file_permissions resets the mode; restore the source's mode last when provided
+    chmod($mode, $file) if defined $mode;
 }
 
 =item empty_dir

--- a/t/venom/test_suites/cluster_first_server/70_seed_exec_sync_file.yml
+++ b/t/venom/test_suites/cluster_first_server/70_seed_exec_sync_file.yml
@@ -1,0 +1,22 @@
+name: First server — seed an executable file for cluster-files.txt sync (#8984)
+testcases:
+# Regression coverage for #8984: cluster sync must preserve the executable bit
+# on files listed in cluster-files.txt. Create an executable helper on pf1 and
+# register its path so joiners pull it during `cluster/sync --from`.
+- name: create_executable_sync_file
+  steps:
+  - type: exec
+    script: "printf '#!/bin/sh\\necho packetfence-8984\\n' > /usr/local/pf/conf/venom_exec_sync_test.sh && chmod 0755 /usr/local/pf/conf/venom_exec_sync_test.sh"
+    assertions:
+      - result.code ShouldEqual 0
+  - type: exec
+    script: 'test -x /usr/local/pf/conf/venom_exec_sync_test.sh'
+    assertions:
+      - result.code ShouldEqual 0
+
+- name: register_file_in_cluster_files
+  steps:
+  - type: exec
+    script: 'grep -qxF /usr/local/pf/conf/venom_exec_sync_test.sh /usr/local/pf/conf/cluster-files.txt 2>/dev/null || echo /usr/local/pf/conf/venom_exec_sync_test.sh >> /usr/local/pf/conf/cluster-files.txt'
+    assertions:
+      - result.code ShouldEqual 0

--- a/t/venom/test_suites/cluster_first_server/TESTSUITE.md
+++ b/t/venom/test_suites/cluster_first_server/TESTSUITE.md
@@ -45,3 +45,6 @@ with `--force-new-cluster`. Maps to `docs/cluster/cluster_setup.asciidoc`.
   interfaces, not the doc's VLAN subinterfaces.
 - configreload/checkup tolerate non-zero exits here: they warn about the DB
   being unavailable until the cluster is fully up, which the doc says to ignore.
+- `70_seed_exec_sync_file` only creates the source file; the matching
+  assertion runs on the joiners (`cluster_joining_servers/15_assert_synced_exec_perms`).
+  Keep the file path in sync between the two suites.

--- a/t/venom/test_suites/cluster_first_server/TESTSUITE.md
+++ b/t/venom/test_suites/cluster_first_server/TESTSUITE.md
@@ -23,6 +23,7 @@ with `--force-new-cluster`. Maps to `docs/cluster/cluster_setup.asciidoc`.
 | 40_bootstrap_galera | `generatemariadbconfig`, `MARIADB_ARGS=--force-new-cluster`, start | done |
 | 50_restart_pf_set_default | `pfcmd service pf restart`, `set-default packetfence-cluster`, stop iptables | done |
 | 60_assert_galera_up | Assert `wsrep_on=ON`, status `Primary`, size `1` | done |
+| 70_seed_exec_sync_file | Create an executable helper + register it in `cluster-files.txt` (#8984 sync-permissions coverage) | done |
 
 ## Deferred to later phases
 

--- a/t/venom/test_suites/cluster_joining_servers/05_register_cluster_file.yml
+++ b/t/venom/test_suites/cluster_joining_servers/05_register_cluster_file.yml
@@ -1,0 +1,10 @@
+name: Joining servers — register the exec test file before sync (#8984)
+testcases:
+# `cluster/sync --from` pulls the paths listed in THIS node's cluster-files.txt,
+# so the joiner must know about the #8984 test file before the sync step runs.
+- name: register_exec_file_in_cluster_files
+  steps:
+  - type: exec
+    script: 'grep -qxF /usr/local/pf/conf/venom_exec_sync_test.sh /usr/local/pf/conf/cluster-files.txt 2>/dev/null || echo /usr/local/pf/conf/venom_exec_sync_test.sh >> /usr/local/pf/conf/cluster-files.txt'
+    assertions:
+      - result.code ShouldEqual 0

--- a/t/venom/test_suites/cluster_joining_servers/15_assert_synced_exec_perms.yml
+++ b/t/venom/test_suites/cluster_joining_servers/15_assert_synced_exec_perms.yml
@@ -1,0 +1,15 @@
+name: Joining servers — assert synced file kept its executable bit (#8984)
+testcases:
+# The bug: sync transferred file content only, so the pulled file arrived as
+# 0664 (no exec bit). `test -x` is false when no exec bit is set — even for
+# root — so it fails on the buggy behavior and passes once the mode is kept.
+- name: synced_file_is_executable
+  steps:
+  - type: exec
+    script: 'test -x /usr/local/pf/conf/venom_exec_sync_test.sh'
+    assertions:
+      - result.code ShouldEqual 0
+  - type: exec
+    script: 'grep -qF packetfence-8984 /usr/local/pf/conf/venom_exec_sync_test.sh'
+    assertions:
+      - result.code ShouldEqual 0

--- a/t/venom/test_suites/cluster_joining_servers/TESTSUITE.md
+++ b/t/venom/test_suites/cluster_joining_servers/TESTSUITE.md
@@ -31,3 +31,9 @@ two other nodes".
   independently — this node can be Synced before the other has joined.
 - Credentials come from `venom_local_vars.yml`, matching the `[webservices]`
   block cluster_first_server wrote into pf.conf on pf1.
+- `05_register_cluster_file` + `15_assert_synced_exec_perms` are the #8984
+  regression pair: they depend on `cluster_first_server/70_seed_exec_sync_file`
+  having created the executable source on pf1. `05` must run before the sync
+  because `cluster/sync --from` reads *this* node's `cluster-files.txt`.
+  `test -x` is the discriminator — it is false when no exec bit is set (even
+  for root), so it fails on the pre-fix behavior (file pulled as 0664).

--- a/t/venom/test_suites/cluster_joining_servers/TESTSUITE.md
+++ b/t/venom/test_suites/cluster_joining_servers/TESTSUITE.md
@@ -17,7 +17,9 @@ two other nodes".
 | File | Doc step | Status |
 |------|----------|--------|
 | 00_stop_iptables | Stop `packetfence-iptables` | done |
+| 05_register_cluster_file | Add the #8984 exec test file to this node's `cluster-files.txt` before sync | done |
 | 10_cluster_sync | `cluster/sync --from=pf1`; restart packetfence-config, configreload, proxysql, httpd.webservices | done |
+| 15_assert_synced_exec_perms | Assert the synced file kept its executable bit (#8984) | done |
 | 20_mariadb_join | Stop mariadb, `rm -rf /var/lib/mysql/*` (guarded against pf1), restart to join | done |
 | 30_assert_joined | Wait `wsrep_local_state_comment=Synced`, then `wsrep_cluster_size=3` | done |
 


### PR DESCRIPTION
# Description
Cluster sync transferred file **content only**, so files listed in `cluster-files.txt` lost their permissions on slaves — executable files (e.g. `httpd.aaa-docker-wrapper`, `ddi_lookup.sh`) arrived as `0664` instead of `0775`. `download_configfile` now also returns the source file's mode, which is re-applied on the destination after ownership is fixed.

# Impacts
- `lib/pf/api.pm` — `download_configfile` returns `($config, $mode)` (`& 0777`, no setuid/setgid/sticky); `distant_download_configfile` + `notify_configfile_changed` pass it through.
- `lib/pf/util.pm` — `safe_file_update` takes an optional `$mode` and `chmod`s it after `fix_file_permissions`.
- `bin/cluster/sync` — `--from` (slave-pull) path applies the mode after write/chown.
- Verify cluster sync (both `--as-master` and `--from`) preserves modes for exec and non-exec files. Backward-compatible: an old master returns no mode → destination keeps current behavior.

# Issue
fixes #8984

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature — n/a
- [ ] Add OpenAPI specification — n/a
- [ ] Add unit tests — no
- [ ] Add acceptance tests (TestLink) — no

# NEWS file entries
## Bug Fixes
* Cluster sync now retains the source file permissions, so executable synced files keep their exec bit on slaves (#8984)