### PR TITLE
ci(build_pf_img): reclaim runner disk before build, else fail fast

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -395,6 +395,8 @@ variables:
 # via vagrant-in-docker.sh (shell executors ignore `image:`).
 .build_pf_img_vagrant_job:
   stage: build_pf_img
+  before_script:
+    - ci/lib/ensure-runner-disk-free.sh
   variables:
     RESULT_DIR: ${CI_PROJECT_DIR}/ci/packer/vagrant_img/results
     # ci_related pushes the slug tag in every context; tag pipelines
@@ -578,6 +580,8 @@ variables:
 
 .build_pf_img_job:
   stage: build_pf_img
+  before_script:
+    - ci/lib/ensure-runner-disk-free.sh
   script:
     - timeout ${PIPELINE_TIMEOUT_SCRIPT} make -e -C ${BUILD_DIR} ${BUILD_TARGET}
   # implicit timeout = 5 minutes, see https://gitlab.com/gitlab-runner/-/issues/2716

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -396,6 +396,9 @@ variables:
 .build_pf_img_vagrant_job:
   stage: build_pf_img
   before_script:
+    # Keep the global before_script steps (a job-level one replaces it), then preflight.
+    - unset http_proxy ; unset https_proxy
+    - env | grep ^CI_
     - ci/lib/ensure-runner-disk-free.sh
   variables:
     RESULT_DIR: ${CI_PROJECT_DIR}/ci/packer/vagrant_img/results
@@ -581,6 +584,9 @@ variables:
 .build_pf_img_job:
   stage: build_pf_img
   before_script:
+    # Keep the global before_script steps (a job-level one replaces it), then preflight.
+    - unset http_proxy ; unset https_proxy
+    - env | grep ^CI_
     - ci/lib/ensure-runner-disk-free.sh
   script:
     - timeout ${PIPELINE_TIMEOUT_SCRIPT} make -e -C ${BUILD_DIR} ${BUILD_TARGET}

--- a/ci/lib/ensure-runner-disk-free.sh
+++ b/ci/lib/ensure-runner-disk-free.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# build_pf_img preflight: reclaim runner disk if low, else abort before the long
+# build instead of failing mid-convert with "No space left on device". CI-only:
+# the purge is destructive. Guards both / and /var/lib (separate volumes on the
+# lab runners: build dir + boxes on /, libvirt pool on /var/lib).
+set -o nounset -o pipefail
+
+MIN_FREE_GB=${RUNNER_MIN_FREE_GB:-40}
+read -r -a CHECK_PATHS <<< "${RUNNER_DISK_CHECK_PATHS:-/ /var/lib}"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+RECLAIM_SCRIPT=${RECLAIM_SCRIPT:-${SCRIPT_DIR}/vagrant/cleanup-runner-disk.sh}
+
+free_gb() { df -B1G --output=avail "$1" 2>/dev/null | awk 'NR==2 {print $1+0}'; }
+
+# stderr: per-volume report; stdout: under-floor paths for the caller to capture.
+below_floor() {
+    local p f
+    for p in "${CHECK_PATHS[@]}"; do
+        [ -e "${p}" ] || continue
+        f=$(free_gb "${p}")
+        echo "  ${p}: ${f:-0}G free (floor ${MIN_FREE_GB}G)" >&2
+        [ "${f:-0}" -lt "${MIN_FREE_GB}" ] && echo "${p}"
+    done
+}
+
+echo "===> runner disk preflight"
+short=$(below_floor)
+[ -z "${short}" ] && { echo "===> all guarded volumes above floor"; exit 0; }
+
+echo "===> below floor on: ${short//$'\n'/ } -- purging vagrant boxes and libvirt pool volumes"
+if [ -x "${RECLAIM_SCRIPT}" ]; then
+    # --purge is host-idle-guarded; non-zero here just means busy, so re-check.
+    "${RECLAIM_SCRIPT}" --purge --apply || echo "WARN: reclaim non-zero (busy?)" >&2
+else
+    echo "WARN: ${RECLAIM_SCRIPT} not executable -- skipping reclaim" >&2
+fi
+
+echo "===> free space after reclaim:"
+short=$(below_floor)
+if [ -n "${short}" ]; then
+    echo "ERROR: still below ${MIN_FREE_GB}G floor on: ${short//$'\n'/ } -- aborting" >&2
+    exit 1
+fi

--- a/ci/lib/ensure-runner-disk-free.sh
+++ b/ci/lib/ensure-runner-disk-free.sh
@@ -5,6 +5,12 @@
 # lab runners: build dir + boxes on /, libvirt pool on /var/lib).
 set -o nounset -o pipefail
 
+# --purge wipes vagrant boxes + libvirt volumes; never do that on a dev box.
+if [ -z "${CI:-}" ] && [ "${FORCE_RUNNER_DISK_RECLAIM:-}" != yes ]; then
+    echo "===> not in CI -- skipping (set FORCE_RUNNER_DISK_RECLAIM=yes to override)"
+    exit 0
+fi
+
 MIN_FREE_GB=${RUNNER_MIN_FREE_GB:-40}
 read -r -a CHECK_PATHS <<< "${RUNNER_DISK_CHECK_PATHS:-/ /var/lib}"
 

--- a/ci/lib/vagrant/cleanup-runner-disk.sh
+++ b/ci/lib/vagrant/cleanup-runner-disk.sh
@@ -69,6 +69,11 @@ run() {
 
 hdr() { printf '\n=== %s\n' "$*"; }
 
+# True if user $1 runs the vagrant CLI. Match the executable, not the substring:
+# plain -f vagrant also hits paths like ci/lib/vagrant/ and vim on *vagrant* files.
+VAGRANT_PROC_RE='(^|[ /])vagrant( |$)'
+vagrant_running() { pgrep -u "$1" -af "${VAGRANT_PROC_RE}"; }
+
 # Emit "user:home" lines for every $VAR_LOCAL/<name> dir whose <name>
 # resolves to a real account whose $HOME equals the dir. Filter with
 # ONLY_USERS="a b c" if you want a subset.
@@ -169,9 +174,9 @@ clean_user_home() {
         fi
     else
         hdr "User ${user} — Vagrant Tempfiles older than ${TMP_AGE_MIN}min"
-        if pgrep -u "${user}" -af vagrant >/dev/null; then
+        if vagrant_running "${user}" >/dev/null; then
             echo "  SKIPPED — vagrant process is running as ${user}:"
-            pgrep -u "${user}" -af vagrant | sed 's/^/    /'
+            vagrant_running "${user}" | sed 's/^/    /'
         else
             local stale
             stale=$(find "${VAGRANT_TMP}" -mindepth 1 -mmin "+${TMP_AGE_MIN}" 2>/dev/null || true)
@@ -219,7 +224,7 @@ if [ "${PURGE}" = yes ]; then
     busy=
     for ent in ${USERS}; do
         user=${ent%%:*}
-        if pgrep -u "${user}" -af vagrant >/dev/null; then
+        if vagrant_running "${user}" >/dev/null; then
             busy="${busy}vagrant process running as ${user}\n"
         fi
     done


### PR DESCRIPTION
# Description
Add a disk preflight to every `build_pf_img` job. Before the build, it checks
free space on `/` and `/var/lib` (separate volumes on the lab runners); if either
is under the floor (`RUNNER_MIN_FREE_GB`, default 40G) it purges vagrant boxes and
libvirt pool volumes, then aborts early if still short — instead of failing an hour
in with `qemu-img: No space left on device`.

Also fixes the reclaim's idle guard: `pgrep -f vagrant` matched the script's own
`ci/lib/vagrant/` path, so `--purge` was refused on every CI run.

# Impacts
- `build_pf_img` stage: `zen`, `cd_iso`, `dvd_usb_iso`, and all `vagrant` bakes now
  run `ci/lib/ensure-runner-disk-free.sh` in `before_script`.
- Reclaim (`cleanup-runner-disk.sh --purge`) is host-idle-guarded and CI-only;
  it does not run on local `make` builds.
- Tunable per job via `RUNNER_MIN_FREE_GB` / `RUNNER_DISK_CHECK_PATHS`.

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature — n/a (CI-only)
- [ ] Add OpenAPI specification — n/a
- [ ] Add unit tests — n/a
- [ ] Add acceptance tests (TestLink) — n/a

# NEWS file entries
## Bug Fixes
* build_pf_img jobs no longer fail late on a full runner; disk is reclaimed or the
  job aborts early with a clear message