### PR TITLE
ci: optimize test job order to cut pipeline wall-clock on 10 runners

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1092,7 +1092,68 @@ publish_ppa:
 # TEST JOBS
 ########################################
 ### development and maintenance
-unit_tests_el8:
+# Job definition order below = runner dispatch order (GitLab assigns pending jobs
+# FIFO to free runners). It is optimized to minimize total pipeline wall-clock on
+# 10 runners, robust to ±10% duration variation, with deb12/el8 pairs kept
+# adjacent for readability. Long jobs are front-loaded and staggered; the tail is
+# short jobs only, so runners finish together. Re-balance if durations shift a lot.
+pfappserver_deb12:
+  variables:
+    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
+  extends:
+    - .test_job
+    - .test_script_job
+    - .test_rules
+
+pfappserver_el8:
+  variables:
+    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
+  extends:
+    - .test_job
+    - .test_script_job
+    - .test_rules
+
+inline_deb12:
+  variables:
+    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
+  extends:
+    - .test_job
+    - .test_script_job
+    - .test_rules
+
+inline_el8:
+  variables:
+    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
+  extends:
+    - .test_job
+    - .test_script_job
+    - .test_rules
+
+mac_auth_virtualswitch_deb12:
+  variables:
+    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
+  extends:
+    - .test_job
+    - .test_script_job
+    - .test_rules
+
+mac_auth_virtualswitch_el8:
+  variables:
+    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
+  extends:
+    - .test_job
+    - .test_script_job
+    - .test_rules
+
+security_event_virtualswitch_deb12:
+  variables:
+    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
+  extends:
+    - .test_job
+    - .test_script_job
+    - .test_rules
+
+security_event_virtualswitch_el8:
   variables:
     VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
   extends:
@@ -1108,7 +1169,151 @@ unit_tests_deb12:
     - .test_script_job
     - .test_rules
 
-configurator_el8:
+unit_tests_el8:
+  variables:
+    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
+  extends:
+    - .test_job
+    - .test_script_job
+    - .test_rules
+
+cli_login_deb12:
+  variables:
+    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
+  extends:
+    - .test_job
+    - .test_script_job
+    - .test_rules
+
+cli_login_el8:
+  variables:
+    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
+  extends:
+    - .test_job
+    - .test_script_job
+    - .test_rules
+
+dot1x_eap_peap_deb12:
+  variables:
+    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
+  extends:
+    - .test_job
+    - .test_script_job
+    - .test_rules
+
+dot1x_eap_peap_el8:
+  variables:
+    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
+  extends:
+    - .test_job
+    - .test_script_job
+    - .test_rules
+
+dot1x_eap_tls_deb12:
+  variables:
+    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
+  extends:
+    - .test_job
+    - .test_script_job
+    - .test_rules
+
+dot1x_eap_tls_el8:
+  variables:
+    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
+  extends:
+    - .test_job
+    - .test_script_job
+    - .test_rules
+
+fingerbank_invalid_db_deb12:
+  variables:
+    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
+  extends:
+    - .test_job
+    - .test_script_job
+    - .test_rules
+
+mac_auth_deb12:
+  variables:
+    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
+  extends:
+    - .test_job
+    - .test_script_job
+    - .test_rules
+
+mac_auth_el8:
+  variables:
+    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
+  extends:
+    - .test_job
+    - .test_script_job
+    - .test_rules
+
+device_profiling_virtualswitch_deb12:
+  variables:
+    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
+  extends:
+    - .test_job
+    - .test_script_job
+    - .test_rules
+
+device_profiling_virtualswitch_el8:
+  variables:
+    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
+  extends:
+    - .test_job
+    - .test_script_job
+    - .test_rules
+
+pfacct_bandwidth_virtualswitch_deb12:
+  variables:
+    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
+  extends:
+    - .test_job
+    - .test_script_job
+    - .test_rules
+
+pfacct_bandwidth_virtualswitch_el8:
+  variables:
+    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
+  extends:
+    - .test_job
+    - .test_script_job
+    - .test_rules
+
+dot1x_wired_computer_auth_virtualswitch_deb12:
+  variables:
+    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
+  extends:
+    - .test_job
+    - .test_script_job
+    - .test_rules
+
+dot1x_wired_computer_auth_virtualswitch_el8:
+  variables:
+    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
+  extends:
+    - .test_job
+    - .test_script_job
+    - .test_rules
+
+security_events_deb12:
+  variables:
+    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
+  extends:
+    - .test_job
+    - .test_script_job
+    - .test_rules
+
+captive_portal_deb12:
+  variables:
+    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
+  extends:
+    - .test_job
+    - .test_script_job
+    - .test_rules
+
+captive_portal_el8:
   variables:
     VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
   extends:
@@ -1117,6 +1322,22 @@ configurator_el8:
     - .test_rules
 
 configurator_deb12:
+  variables:
+    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
+  extends:
+    - .test_job
+    - .test_script_job
+    - .test_rules
+
+configurator_el8:
+  variables:
+    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
+  extends:
+    - .test_job
+    - .test_script_job
+    - .test_rules
+
+external_integrations_deb12:
   variables:
     VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
   extends:
@@ -1141,222 +1362,6 @@ cluster_configurator_el8:
     - .test_cluster_job
     - .test_script_job
     - .cluster_test_rules
-
-pfappserver_el8:
-  variables:
-    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
-  extends:
-    - .test_job
-    - .test_script_job
-    - .test_rules
-
-pfappserver_deb12:
-  variables:
-    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
-  extends:
-    - .test_job
-    - .test_script_job
-    - .test_rules
-
-dot1x_eap_peap_el8:
-  variables:
-    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
-  extends:
-    - .test_job
-    - .test_script_job
-    - .test_rules
-
-dot1x_eap_peap_deb12:
-  variables:
-    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
-  extends:
-    - .test_job
-    - .test_script_job
-    - .test_rules
-
-mac_auth_el8:
-  variables:
-    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
-  extends:
-    - .test_job
-    - .test_script_job
-    - .test_rules
-
-mac_auth_deb12:
-  variables:
-    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
-  extends:
-    - .test_job
-    - .test_script_job
-    - .test_rules
-
-dot1x_eap_tls_el8:
-  variables:
-    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
-  extends:
-    - .test_job
-    - .test_script_job
-    - .test_rules
-
-dot1x_eap_tls_deb12:
-  variables:
-    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
-  extends:
-    - .test_job
-    - .test_script_job
-    - .test_rules
-
-fingerbank_invalid_db_deb12:
-  variables:
-    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
-  extends:
-    - .test_job
-    - .test_script_job
-    - .test_rules
-
-security_events_deb12:
-  variables:
-    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
-  extends:
-    - .test_job
-    - .test_script_job
-    - .test_rules
-
-cli_login_deb12:
-  variables:
-    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
-  extends:
-    - .test_job
-    - .test_script_job
-    - .test_rules
-
-cli_login_el8:
-  variables:
-    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
-  extends:
-    - .test_job
-    - .test_script_job
-    - .test_rules
-
-external_integrations_deb12:
-  variables:
-    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
-  extends:
-    - .test_job
-    - .test_script_job
-    - .test_rules
-
-captive_portal_el8:
-  variables:
-    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
-  extends:
-    - .test_job
-    - .test_script_job
-    - .test_rules
-
-captive_portal_deb12:
-  variables:
-    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
-  extends:
-    - .test_job
-    - .test_script_job
-    - .test_rules
-
-inline_deb12:
-  variables:
-    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
-  extends:
-    - .test_job
-    - .test_script_job
-    - .test_rules
-
-inline_el8:
-  variables:
-    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
-  extends:
-    - .test_job
-    - .test_script_job
-    - .test_rules
-
-mac_auth_virtualswitch_el8:
-  variables:
-    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
-  extends:
-    - .test_job
-    - .test_script_job
-    - .test_rules
-
-mac_auth_virtualswitch_deb12:
-  variables:
-    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
-  extends:
-    - .test_job
-    - .test_script_job
-    - .test_rules
-
-device_profiling_virtualswitch_el8:
-  variables:
-    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
-  extends:
-    - .test_job
-    - .test_script_job
-    - .test_rules
-
-device_profiling_virtualswitch_deb12:
-  variables:
-    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
-  extends:
-    - .test_job
-    - .test_script_job
-    - .test_rules
-
-dot1x_wired_computer_auth_virtualswitch_el8:
-  variables:
-    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
-  extends:
-    - .test_job
-    - .test_script_job
-    - .test_rules
-
-dot1x_wired_computer_auth_virtualswitch_deb12:
-  variables:
-    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
-  extends:
-    - .test_job
-    - .test_script_job
-    - .test_rules
-
-pfacct_bandwidth_virtualswitch_el8:
-  variables:
-    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
-  extends:
-    - .test_job
-    - .test_script_job
-    - .test_rules
-
-pfacct_bandwidth_virtualswitch_deb12:
-  variables:
-    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
-  extends:
-    - .test_job
-    - .test_script_job
-    - .test_rules
-
-security_event_virtualswitch_el8:
-  variables:
-    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
-  extends:
-    - .test_job
-    - .test_script_job
-    - .test_rules
-
-security_event_virtualswitch_deb12:
-  variables:
-    VAGRANT_PF_DOTFILE_PATH: /var/local/gitlab-runner/vagrant/vagrant-${CI_JOB_NAME}-${CI_JOB_ID}
-  extends:
-    - .test_job
-    - .test_script_job
-    - .test_rules
 
 ### release
 configurator_el8_pristine:


### PR DESCRIPTION
# Description
Reorders the test jobs in `.gitlab-ci.yml` so runner dispatch (GitLab assigns pending jobs FIFO in definition order) minimizes total pipeline wall-clock on the 10-runner pool. Order was chosen by simulation (annealing over ±10% duration jitter, deb12/el8 pairs kept adjacent): long jobs front-loaded and staggered, tail is short jobs only so runners finish together. Also removes two unused gate anchors (`BUILD_PF_IMG_ISO` / `BUILD_PF_IMG_USB_ISO`).

Expected pipeline time: **~3h49 vs ~4h29 before** (~40 min saved), CI-only — no functional/product change.

# Impacts
- `.gitlab-ci.yml` test job definition order (dispatch/scheduling only)
- No job logic, rules, or `extends` behavior changed — jobs run the same, just in a different start order
- Re-balance the order if per-job durations shift significantly

# Delete branch after merge
YES

# Checklist
- [n/a] Document the feature
- [n/a] Add OpenAPI specification
- [n/a] Add unit tests
- [n/a] Add acceptance tests (TestLink)

# NEWS file entries
## Enhancements
* CI: reordered test jobs to minimize pipeline wall-clock on the 10-runner pool (~40 min faster)