### PR TITLE
Switch role pool (Filter-Id pooling) via username hash

### DIFF
--- a/docs/installation/introduction_to_role_based_access_control.asciidoc
+++ b/docs/installation/introduction_to_role_based_access_control.asciidoc
@@ -51,6 +51,35 @@ algorithms: one based on a hash of the username (default one), another one based
 on a round-robin (last registered device +1) and one that selects a VLAN
 randomly in the pool.
 
+The same pooling mechanism is available for the _Switch Role_ mapping (_Role
+mapping by Switch Role_), which is useful when a controller distributes clients
+through a role attribute such as `Filter-Id` instead of a VLAN. Instead of a
+single role, set a comma-separated list of roles, e.g. `role_a,role_b,role_c` -
+PacketFence then returns one of these roles. Because roles are arbitrary strings
+(not numeric ranges), the `..` range syntax does not apply; list every role
+explicitly. The selection always uses the username hash, so a given user is
+mapped to the same role on every re-authentication and keeps that role while
+roaming between access points. For this stability to hold, configure the same
+role pool (same list, same order) on every switch the user can roam across - a
+_Switch Group_ is the simplest way to guarantee that.
+
+The pool member is chosen from the node owner (username): all devices of a user
+share the same role. For machine authentication, MAC authentication or otherwise
+unowned nodes - which have no username - the device MAC address is used instead,
+so those clients are spread across the pool per device (and each device keeps its
+role while roaming).
+
+IMPORTANT: All members of a role pool must be equally privileged. The selection
+is deterministic and therefore predictable/influenceable by the client (in
+particular with MAC authentication, where the MAC is spoofable); a client can
+only ever land on a member of the pool of its own already-assigned role, but if
+the members grant different access levels a client could steer towards the more
+privileged one. Treat a role pool strictly as a set of interchangeable networks.
+
+NOTE: Role pooling applies to the _Switch Role_ (Filter-Id) mapping. It does not
+apply to downloadable-ACL (push ACL) enforcement, where the global role name is
+sent instead, nor to the VoIP voice role.
+
 _Configuration -> Policies and Access Control -> Roles_, click on `New Role`.
 Provide the following information:
 

--- a/lib/pf/Switch.pm
+++ b/lib/pf/Switch.pm
@@ -54,6 +54,7 @@ use pf::cluster;
 # RADIUS constants (RADIUS:: namespace)
 use pf::radius::constants;
 use pf::roles::custom $ROLES_API_LEVEL;
+use pf::role::pool;
 # SNMP constants (several standard-based and vendor-based namespaces)
 use pf::error::switch;
 use pf::util;
@@ -653,23 +654,28 @@ Get the switch-specific role of a given global role in switches.conf
 =cut
 
 sub getRoleByName {
-    my ($self, $roleName) = @_;
+    my ($self, $roleName, $args) = @_;
     my $logger = $self->logger;
 
 
     if (!defined($self->{'_roles'}) || !defined($self->{'_roles'}{$roleName})) {
         my $parent = _parentRoleForRole($roleName);
         if (defined $parent && length($parent)) {
-            return $self->getRoleByName($parent);
+            return $self->getRoleByName($parent, $args);
         }
-        # VLAN name doesn't exist
+        # role name doesn't exist
         $pf::StatsD::statsd->increment(called() . ".error" );
         $logger->warn("No parameter ${roleName}Role found in conf/switches.conf for the switch " . $self->{_id});
         return undef;
     }
 
-    # return if found
-    return $self->{'_roles'}->{$roleName} if (defined($self->{'_roles'}->{$roleName}));
+    # return if found, resolving a role pool ("net_a,net_b,...") to a single role
+    # when the node context ($args) is available (RADIUS Access-Accept path)
+    if (defined($self->{'_roles'}->{$roleName})) {
+        my $role = $self->{'_roles'}->{$roleName};
+        return $role if (!defined($args) || $role eq '');
+        return pf::role::pool->new->getRoleFromPool({ %$args, role => $role });
+    }
 
     # otherwise log and return undef
     $logger->trace("(".$self->{_id}.") No parameter ${roleName}Role found in conf/switches.conf");
@@ -3081,7 +3087,7 @@ sub returnRadiusAccessAccept {
     if ( isenabled($self->{_RoleMap}) && $self->supportsRoleBasedEnforcement()) {
         $logger->debug("Network device (".$self->{'_id'}.") supports roles. Evaluating role to be returned");
         if ( defined($args->{'user_role'}) && $args->{'user_role'} ne "" ) {
-            $role = $self->getRoleByName($args->{'user_role'});
+            $role = $self->getRoleByName($args->{'user_role'}, $args);
         }
         if ( (defined($role) && $role ne "") || $self->usePushACLs ) {
             if ($self->usePushACLs && exists $ConfigRoles{$args->{'user_role'}} && !exists $self->{'_access_lists'}->{$args->{'user_role'}}) {

--- a/lib/pf/Switch/AeroHIVE.pm
+++ b/lib/pf/Switch/AeroHIVE.pm
@@ -343,7 +343,7 @@ sub returnRadiusAccessAccept {
 
     $logger->debug("Network device (".$self->{'_id'}.") supports roles. Evaluating role to be returned.");
     if ( isenabled($self->{_RoleMap}) && $self->supportsRoleBasedEnforcement()) {
-        my $role = $self->getRoleByName($args->{'user_role'});
+        my $role = $self->getRoleByName($args->{'user_role'}, $args);
 
         # Roles are configured and the user should have one
         if (defined($role) && $role ne ""  && isenabled($self->{_RoleMap})) {

--- a/lib/pf/Switch/Arista/AristaSwitch.pm
+++ b/lib/pf/Switch/Arista/AristaSwitch.pm
@@ -280,7 +280,7 @@ sub returnRadiusAccessAccept {
         }
     }
 
-    my $role = $self->getRoleByName($args->{'user_role'});
+    my $role = $self->getRoleByName($args->{'user_role'}, $args);
     if ( isenabled($self->{_UrlMap}) && $self->externalPortalEnforcement ) {
         if( defined($args->{'user_role'}) && $args->{'user_role'} ne "" && defined($self->getUrlByName($args->{'user_role'}))){
             my $mac = $args->{'mac'};
@@ -290,7 +290,7 @@ sub returnRadiusAccessAccept {
             $redirect_url .= $args->{'session_id'};
             #override role if a role in role map is defined
             if (isenabled($self->{_RoleMap}) && $self->supportsRoleBasedEnforcement()) {
-                my $role_map = $self->getRoleByName($args->{'user_role'});
+                my $role_map = $self->getRoleByName($args->{'user_role'}, $args);
                 $role = $role_map if (defined($role_map));
                 # remove the role if any as we push the redirection ACL along with it's role
                 delete $radius_reply_ref->{$self->returnRoleAttribute()};

--- a/lib/pf/Switch/Aruba.pm
+++ b/lib/pf/Switch/Aruba.pm
@@ -698,7 +698,7 @@ sub returnRadiusAccessAccept {
     if ( isenabled($self->{_RoleMap}) && $self->supportsRoleBasedEnforcement()) {
         $logger->debug("Network device (".$self->{'_id'}.") supports roles. Evaluating role to be returned");
         if ( defined($args->{'user_role'}) && $args->{'user_role'} ne "" ) {
-            $role = $self->getRoleByName($args->{'user_role'});
+            $role = $self->getRoleByName($args->{'user_role'}, $args);
         }
         if ( defined($role) && $role ne "" ) {
             $radius_reply_ref = {

--- a/lib/pf/Switch/Cisco/ASA.pm
+++ b/lib/pf/Switch/Cisco/ASA.pm
@@ -179,7 +179,7 @@ sub returnAuthorizeVPN {
         if ( !defined($self->getUrlByName($args->{'user_role'}) ) ) {
             $logger->debug("Network device (".$self->{'_id'}.") supports roles. Evaluating role to be returned");
             if ( defined($args->{'user_role'}) && $args->{'user_role'} ne "" ) {
-                $role = $self->getRoleByName($args->{'user_role'});
+                $role = $self->getRoleByName($args->{'user_role'}, $args);
             }
             if ( defined($role) && $role ne "" ) {
                 push(@av_pairs, $self->returnRoleAttribute."=".$self->returnRoleAttributes($role));
@@ -233,8 +233,8 @@ sub returnAuthorizeVPN {
             $redirect_url .= "?";
             #override role if a role in role map is define
             if (isenabled($self->{_RoleMap}) && $self->supportsRoleBasedEnforcement()) {
-                $role = $self->getRoleByName($args->{'user_role'});
-                my $role_map = $self->getRoleByName($args->{'user_role'});
+                $role = $self->getRoleByName($args->{'user_role'}, $args);
+                my $role_map = $self->getRoleByName($args->{'user_role'}, $args);
                 $role = $role_map if (defined($role_map));
                 # remove the role if any as we push the redirection ACL along with it's role
                 delete $radius_reply_ref->{$self->returnRoleAttribute()};

--- a/lib/pf/Switch/Cisco/Cisco_IOS_12_x.pm
+++ b/lib/pf/Switch/Cisco/Cisco_IOS_12_x.pm
@@ -1247,7 +1247,7 @@ sub returnRadiusAccessAccept {
         }
     }
 
-    my $role = $self->getRoleByName($args->{'user_role'});
+    my $role = $self->getRoleByName($args->{'user_role'}, $args);
     if ( isenabled($self->{_UrlMap}) && $self->externalPortalEnforcement ) {
         if( defined($args->{'user_role'}) && $args->{'user_role'} ne "" && defined($self->getUrlByName($args->{'user_role'}))){
             my $mac = $args->{'mac'};
@@ -1257,7 +1257,7 @@ sub returnRadiusAccessAccept {
             $redirect_url .= $args->{'session_id'};
             #override role if a role in role map is defined
             if (isenabled($self->{_RoleMap}) && $self->supportsRoleBasedEnforcement()) {
-                my $role_map = $self->getRoleByName($args->{'user_role'});
+                my $role_map = $self->getRoleByName($args->{'user_role'}, $args);
                 $role = $role_map if (defined($role_map));
                 # remove the role if any as we push the redirection ACL along with it's role
                 delete $radius_reply_ref->{$self->returnRoleAttribute()};

--- a/lib/pf/Switch/Cisco/Cisco_WLC_AireOS.pm
+++ b/lib/pf/Switch/Cisco/Cisco_WLC_AireOS.pm
@@ -414,7 +414,7 @@ sub returnRadiusAccessAccept {
 
     my @av_pairs = defined($radius_reply_ref->{'Cisco-AVPair'}) ? @{$radius_reply_ref->{'Cisco-AVPair'}} : ();
 
-    my $role = $self->getRoleByName($args->{'user_role'});
+    my $role = $self->getRoleByName($args->{'user_role'}, $args);
     if ( isenabled($self->{_UrlMap}) && $self->externalPortalEnforcement ) {
         if ( defined($args->{'user_role'}) && $args->{'user_role'} ne "" && defined($self->getUrlByName($args->{'user_role'}) ) ) {
             $args->{'session_id'} = "sid".$self->setSession($args);
@@ -427,7 +427,7 @@ sub returnRadiusAccessAccept {
             $redirect_url .= "?";
             #override role if a role in role map is define
             if (isenabled($self->{_RoleMap}) && $self->supportsRoleBasedEnforcement()) {
-                my $role_map = $self->getRoleByName($args->{'user_role'});
+                my $role_map = $self->getRoleByName($args->{'user_role'}, $args);
                 $role = $role_map if (defined($role_map));
                 # remove the role if any as we push the redirection ACL along with it's role
                 delete $radius_reply_ref->{$self->returnRoleAttribute()};

--- a/lib/pf/Switch/Dell/N1500.pm
+++ b/lib/pf/Switch/Dell/N1500.pm
@@ -375,7 +375,7 @@ sub returnRadiusAccessAccept {
         }
     }
 
-    my $role = $self->getRoleByName($args->{'user_role'});
+    my $role = $self->getRoleByName($args->{'user_role'}, $args);
     if ( isenabled($self->{_UrlMap}) && $self->externalPortalEnforcement ) {
         if( defined($args->{'user_role'}) && $args->{'user_role'} ne "" && defined($self->getUrlByName($args->{'user_role'}))){
             my $mac = $args->{'mac'};
@@ -385,7 +385,7 @@ sub returnRadiusAccessAccept {
             $redirect_url .= $args->{'session_id'};
             #override role if a role in role map is defined
             if (isenabled($self->{_RoleMap}) && $self->supportsRoleBasedEnforcement()) {
-                my $role_map = $self->getRoleByName($args->{'user_role'});
+                my $role_map = $self->getRoleByName($args->{'user_role'}, $args);
                 $role = $role_map if (defined($role_map));
                 # remove the role if any as we push the redirection ACL along with it's role
                 delete $radius_reply_ref->{$self->returnRoleAttribute()};

--- a/lib/pf/Switch/Juniper/MistAP.pm
+++ b/lib/pf/Switch/Juniper/MistAP.pm
@@ -198,7 +198,7 @@ sub returnRadiusAccessAccept {
 
     my @av_pairs = defined($radius_reply_ref->{'Cisco-AVPair'}) ? @{$radius_reply_ref->{'Cisco-AVPair'}} : ();
 
-    my $role = $self->getRoleByName($args->{'user_role'});
+    my $role = $self->getRoleByName($args->{'user_role'}, $args);
     if ( isenabled($self->{_UrlMap}) && $self->externalPortalEnforcement ) {
         if ( defined($args->{'user_role'}) && $args->{'user_role'} ne "" && defined($self->getUrlByName($args->{'user_role'}) ) ) {
             $args->{'session_id'} = "sid".$self->setSession($args);
@@ -211,7 +211,7 @@ sub returnRadiusAccessAccept {
             $redirect_url .= "?";
             #override role if a role in role map is define
             if (isenabled($self->{_RoleMap}) && $self->supportsRoleBasedEnforcement()) {
-                my $role_map = $self->getRoleByName($args->{'user_role'});
+                my $role_map = $self->getRoleByName($args->{'user_role'}, $args);
                 $role = $role_map if (defined($role_map));
                 # remove the role if any as we push the redirection ACL along with it's role
                 delete $radius_reply_ref->{$self->returnRoleAttribute()};

--- a/lib/pf/Switch/Template.pm
+++ b/lib/pf/Switch/Template.pm
@@ -165,7 +165,7 @@ sub returnRadiusAccessAccept {
     if ( isenabled($self->{_RoleMap}) ) {
         $logger->debug("Network device (".$self->{'_id'}.") supports roles. Evaluating role to be returned");
         if ( defined($args->{'user_role'}) && $args->{'user_role'} ne "" ) {
-            $role = $self->getRoleByName($args->{'user_role'});
+            $role = $self->getRoleByName($args->{'user_role'}, $args);
         }
         my $roleTemplate = $self->{_template}{acceptRole};
         $tmp_args{role} = $role;

--- a/lib/pf/Switch/Trapeze/WLC.pm
+++ b/lib/pf/Switch/Trapeze/WLC.pm
@@ -74,7 +74,7 @@ sub returnRadiusAccessAccept {
     if ( isenabled($self->{_RoleMap}) && $self->supportsRoleBasedEnforcement()) {
         $logger->debug("Network device (".$self->{'_id'}.") supports roles. Evaluating role to be returned");
         if ( defined($args->{'user_role'}) && $args->{'user_role'} ne "" ) {
-            $role = $self->getRoleByName($args->{'user_role'});
+            $role = $self->getRoleByName($args->{'user_role'}, $args);
         }
         if ( defined($role) && $role ne "" ) {
             $radius_reply_ref = {

--- a/lib/pf/role/pool.pm
+++ b/lib/pf/role/pool.pm
@@ -71,6 +71,77 @@ sub getVlanFromPool {
     return $vlan;
 }
 
+=head2 getRoleFromPool
+
+Resolve a switch role pool to a single role. A role pool is a comma-separated
+list of role strings (e.g. "net_a,net_b,net_c") returned by getRoleByName. Unlike
+the VLAN pool, roles are arbitrary strings, so the members are taken verbatim
+(no Number::Range expansion). The selection always uses the username hash: it is
+a deterministic function of the node owner (pid), so a given user is mapped to
+the same role on every re-authentication and while roaming between APs. A plain
+single role (no pool) is returned unchanged.
+
+=cut
+
+sub getRoleFromPool {
+    my ($self, $args) = @_;
+    my $logger = pf::log::get_logger();
+
+    return unless (defined($args->{'role'}));
+
+    return $args->{'role'} unless $self->_isRolePool($args->{'role'});
+
+    my @roles = _poolMembers($args->{'role'});
+    # Hash on the owner (pid) so a user's devices share one role and stay stable
+    # while roaming. Machine auth / MAB / unowned nodes have no usable pid
+    # (undef / "" / "default"); fall back to the device MAC so those clients are
+    # spread per-device instead of all landing on the same member -- still
+    # deterministic, so a given device is roaming-stable.
+    my $pid = $args->{'node_info'}->{'pid'};
+    my $key = (defined($pid) && length($pid) && $pid ne 'default') ? $pid : ($args->{'mac'} // '');
+    my $index = $self->_usernameHashIndex($key);
+    my $role = $roles[($index + 1) % scalar(@roles)];
+    $logger->trace("Selected role '$role' from pool for key '$key'");
+    return $role;
+}
+
+=head2 _isRolePool
+
+Return true when the value is a role pool, i.e. a comma-separated list with at
+least two non-empty members. A single role (no comma) is not a pool.
+
+=cut
+
+sub _isRolePool {
+    my ($self, $value) = @_;
+    return 0 unless (defined($value));
+    return (scalar(_poolMembers($value)) >= 2) ? 1 : 0;
+}
+
+=head2 _poolMembers
+
+Split a comma-separated pool string into a list of trimmed, non-empty members.
+
+=cut
+
+sub _poolMembers {
+    my ($value) = @_;
+    return grep { length($_) } map { s/^\s+|\s+$//gr } split(/,/, $value);
+}
+
+=head2 _usernameHashIndex
+
+Compute the pool index from the username (pid): a checksum of the characters
+plus the length. Shared by the VLAN and the role username-hash selection so both
+stay deterministic and identical for a given user.
+
+=cut
+
+sub _usernameHashIndex {
+    my ($self, $pid) = @_;
+    return unpack("%16C*", $pid) + length($pid);
+}
+
 =head2 rangeValidator
 
 Validate the range definition
@@ -176,7 +247,7 @@ Return the vlan id based on a hash of the username
 sub getVlanByUsername {
     my ( $self, $args, $range ) = @_;
     my $logger = pf::log::get_logger();
-    my $index = unpack( "%16C*", $args->{'node_info'}->{'pid'} ) + length($args->{'node_info'}->{'pid'});
+    my $index = $self->_usernameHashIndex($args->{'node_info'}->{'pid'});
 
     my $vlan_count = $range->size;
     my @array = $range->range;

--- a/lib/pf/roles.pm
+++ b/lib/pf/roles.pm
@@ -135,7 +135,12 @@ sub performRoleLookup {
     my $globalRoleName = $self->_assignRoleFromCategory($node_attributes);
     return if (!defined($globalRoleName));
 
-    my $switchRoleName = $switch->getRoleByName($globalRoleName);
+    # Pass the node context so that a switch role pool (e.g. "role_a,role_b,role_c")
+    # is resolved to a concrete role here as well. node_attributes carries the pid,
+    # so the username hash picks the same member as the RADIUS Access-Accept path,
+    # keeping CoA / deauth role enforcement consistent with the initial assignment.
+    my $args = { node_info => $node_attributes, user_role => $globalRoleName, mac => $mac };
+    my $switchRoleName = $switch->getRoleByName($globalRoleName, $args);
     return if (!defined($switchRoleName));
 
     $logger->debug("MAC: $mac is assigned the $switchRoleName role.");

--- a/t/unittest/role/pool.t
+++ b/t/unittest/role/pool.t
@@ -1,0 +1,173 @@
+#!/usr/bin/perl
+
+=head1 NAME
+
+pool
+
+=head1 DESCRIPTION
+
+unit test for pf::role::pool - VLAN pool and switch role pool selection
+
+=cut
+
+use strict;
+use warnings;
+
+BEGIN {
+    #include test libs
+    use lib qw(/usr/local/pf/t);
+    #Module for overriding configuration paths
+    use setup_test_config;
+}
+
+use Test::More;
+use Number::Range;
+use pf::Switch;
+
+use_ok('pf::role::pool');
+
+my $pool = pf::role::pool->new;
+
+my @members = qw(net_a net_b net_c);
+my $poolstr = join( ',', @members );
+
+# --- _isRolePool ---------------------------------------------------------
+ok( !$pool->_isRolePool('net_a'),           'single role is not a pool' );
+ok( !$pool->_isRolePool(''),                'empty string is not a pool' );
+ok( !$pool->_isRolePool(undef),             'undef is not a pool' );
+ok( !$pool->_isRolePool('net_a,'),          'single member + trailing comma is not a pool' );
+ok( $pool->_isRolePool('net_a,net_b'),      'comma list is a pool' );
+ok( $pool->_isRolePool('net_a, net_b , net_c'), 'whitespaced comma list is a pool' );
+
+# --- getRoleFromPool: single value passes through unchanged --------------
+is( $pool->getRoleFromPool( { role => 'net_a', node_info => { pid => 'alice' } } ),
+    'net_a', 'single role returned unchanged' );
+
+# --- getRoleFromPool: always returns a member of the pool ----------------
+my %seen;
+for my $u (qw(alice bob carol dave erin frank grace heidi ivan judy)) {
+    my $r = $pool->getRoleFromPool( { role => $poolstr, node_info => { pid => $u } } );
+    ok( ( grep { $_ eq $r } @members ), "pid '$u' -> valid pool member ($r)" );
+    $seen{$r}++;
+}
+
+# --- determinism == roaming stability: same pid always the same role -----
+my $first = $pool->getRoleFromPool( { role => $poolstr, node_info => { pid => 'alice' } } );
+my $stable = 1;
+for ( 1 .. 50 ) {
+    $stable = 0
+      if $pool->getRoleFromPool( { role => $poolstr, node_info => { pid => 'alice' } } ) ne $first;
+}
+ok( $stable, 'same pid maps to the same role across 50 calls (roaming stable)' );
+
+# --- even-ish distribution: more than one member is used -----------------
+ok( scalar( keys %seen ) > 1, 'pool spreads users across multiple roles' );
+
+# --- DRY parity: role hash uses the same index as the VLAN username hash --
+my $range = Number::Range->new("10..12");
+my @vlans = $range->range;
+for my $u (qw(alice bob carol)) {
+    my $args = { node_info => { pid => $u } };
+    my $vlan = $pool->getVlanByUsername( $args, $range );
+    my $role = $pool->getRoleFromPool( { role => join( ',', @vlans ), node_info => { pid => $u } } );
+    is( $role, $vlan, "role hash matches vlan hash for pid '$u' (shared _usernameHashIndex)" );
+}
+
+# --- integration through pf::Switch::getRoleByName -----------------------
+my $switch = pf::Switch->new(
+    { id => 'test', roles => { staff => $poolstr, guest => 'guestnet' } } );
+my $args = { user_role => 'staff', node_info => { pid => 'alice' } };
+
+my $picked = $switch->getRoleByName( 'staff', $args );
+ok( ( grep { $_ eq $picked } @members ), "getRoleByName resolves a pool when args given ($picked)" );
+is( $switch->getRoleByName( 'staff', $args ), $picked,
+    'getRoleByName pool selection is deterministic per pid' );
+is( $switch->getRoleByName('staff'), $poolstr,
+    'getRoleByName without args returns the raw pool string' );
+is( $switch->getRoleByName( 'guest', $args ), 'guestnet',
+    'a single (non-pool) role is unaffected' );
+
+# --- CoA / deauth path: performRoleLookup must pick the same pool member ------
+# so that the role re-applied on a Change-of-Authorization matches the one
+# handed out in the initial RADIUS Access-Accept.
+use pf::roles::custom;
+my $resolver = pf::roles::custom->instance();
+for my $pid (qw(alice bob carol dave)) {
+    my $node = { mac => 'aa:bb:cc:00:00:01', status => 'reg', category => 'staff', pid => $pid };
+    my $via_coa    = $resolver->performRoleLookup( $node, $switch );
+    my $via_accept = $switch->getRoleByName( 'staff', { node_info => { pid => $pid }, user_role => 'staff' } );
+    ok( ( grep { $_ eq $via_coa } @members ), "performRoleLookup returns a pool member for pid '$pid' ($via_coa)" );
+    is( $via_coa, $via_accept, "CoA role matches Access-Accept role for pid '$pid'" );
+}
+is( $resolver->performRoleLookup( { mac => 'x', status => 'reg', category => 'guest', pid => 'alice' }, $switch ),
+    'guestnet', 'performRoleLookup leaves a single (non-pool) role unchanged' );
+
+# --- machine auth / MAB / unowned nodes: no usable pid -> hash on the MAC -----
+# Those clients must be spread per-device (by MAC), not all land on one member,
+# and each MAC must be deterministic (roaming-stable per device).
+{
+    my @macs = map { sprintf( '00:11:22:33:44:%02x', $_ ) } 1 .. 12;
+    my %used;
+    my $stable = 1;
+    for my $mac (@macs) {
+        my @res = map {
+            $pool->getRoleFromPool( { role => $poolstr, node_info => { pid => $_ }, mac => $mac } )
+        } ( undef, '', 'default' );
+        $stable = 0 if grep { $_ ne $res[0] } @res;
+        ok( ( grep { $_ eq $res[0] } @members ), "no-pid node (mac $mac) -> valid pool member ($res[0])" );
+        $used{ $res[0] }++;
+    }
+    ok( $stable, 'undef / "" / "default" pid all fall back to the same MAC-based member' );
+    ok( scalar( keys %used ) > 1, 'no-pid nodes are distributed across the pool by MAC' );
+}
+
+# --- _poolMembers edge cases: empty members dropped, members trimmed ---------
+is_deeply( [ pf::role::pool::_poolMembers('net_a,,net_b') ], [ 'net_a', 'net_b' ],
+    'empty members are dropped' );
+is_deeply( [ pf::role::pool::_poolMembers(' net_a , net_b ') ], [ 'net_a', 'net_b' ],
+    'members are trimmed' );
+{
+    my $r = $pool->getRoleFromPool( { role => ' net_a , net_b ', node_info => { pid => 'alice' } } );
+    ok( $r eq 'net_a' || $r eq 'net_b', "whitespaced pool returns a trimmed member ($r)" );
+    unlike( $r, qr/\s/, 'returned pool member has no surrounding whitespace' );
+}
+
+# --- inherited (parent) role resolves the parent's pool ----------------------
+{
+    local %pf::config::ConfigRoles = (
+        child => { inherit_role => 'enabled', parent_id => 'staff' },
+    );
+    my $sw = pf::Switch->new( { id => 'inh', roles => { staff => $poolstr } } );
+    my $r = $sw->getRoleByName( 'child', { node_info => { pid => 'alice' } } );
+    ok( ( grep { $_ eq $r } @members ),
+        "getRoleByName('child') inherits staff's pool and resolves one member ($r)" );
+}
+
+done_testing();
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2026 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut


### PR DESCRIPTION
## Summary

Adds pooling for the *Switch Role* mapping, mirroring the existing VLAN pool but for the per-switch role (`${role}Role`) that is returned as a role attribute such as `Filter-Id`. A `${role}Role` may now hold a comma-separated list of roles (e.g. `role_a,role_b,role_c`); PacketFence returns a single member per client, so role-based enforcement can spread devices evenly across several networks.

This addresses an open customer requirement (ticket 0011256): a WLAN controller enforces network segmentation through `Filter-Id`, and a large number of BYOD devices must be distributed evenly across several networks without a client hopping between them while roaming.

## Behaviour

Selection is a **deterministic hash** of the node owner (username), falling back to the device MAC when there is no username (MAC auth / machine auth / unowned nodes). Because it is a pure function of that key:

- a given user (or device) is mapped to the **same role on every re-authentication and while roaming** between APs;
- different users/devices **spread across the pool**;
- CoA / deauth re-enforcement picks the **same member** as the initial Access-Accept.

Only the deterministic username-hash technique is offered for role pools (unlike VLAN pools, which also offer random / round-robin): those are not roaming-stable for role strings, whose assigned value is not persisted.

## Changes

- `pf::role::pool`: `getRoleFromPool()` + `_isRolePool()` / `_poolMembers()`. The username-hash index is factored out into `_usernameHashIndex()` and shared with the existing VLAN `getVlanByUsername()`, so **VLAN pooling behaviour is unchanged**.
- `pf::Switch::getRoleByName($role, $args)`: resolves a role pool to a single member when node context is available; without `$args` it returns the raw value (backward compatible). The base `returnRadiusAccessAccept` and every vendor module that resolves the role itself pass `$args`.
- `pf::roles::performRoleLookup`: passes node context too (CoA / deauth path).
- Documentation and a unit test (`t/unittest/role/pool.t`).

## Notes / limitations

- All members of a role pool must be configured as **equally privileged** — the selection is deterministic and therefore predictable/influenceable by the client (notably under MAC auth). A client can only ever land on a member of the pool of its own already-assigned role.
- Role pooling applies to the *Switch Role* (Filter-Id) mapping; it does not apply to downloadable-ACL (push ACL) enforcement (the global role name is sent there) nor to the VoIP voice role.

## Testing

- Unit test covering: single (non-pool) pass-through, membership, determinism (roaming stability), distribution, VLAN hash parity, `getRoleByName` integration (with/without args), CoA parity via `performRoleLookup`, MAC fallback for pid-less nodes, trimming / empty members, and inherited (parent) role pools.
- Verified end-to-end on a 3-node cluster: PEAP-MSCHAPv2 authentication returns a pool member as `Filter-Id`, stable across repeated authentications, and a CoA carries the same member.
