### PR TITLE
Log PEAP/TTLS rejects caused by server certificate rejection in radius_audit_log

### DIFF
--- a/conf/radiusd/packetfence.example
+++ b/conf/radiusd/packetfence.example
@@ -422,6 +422,13 @@ server packetfence {
 			if (! EAP-Type || (EAP-Type != TTLS  && EAP-Type != PEAP) ) {
 				packetfence-audit-log-reject
 			}
+			elsif ("%{request:Module-Failure-Message}" =~ /Alert read:fatal:/) {
+				# PEAP/TTLS reject caused by the supplicant rejecting the
+				# server certificate: the client sent a fatal TLS alert (e.g.
+				# unknown CA / bad certificate) before the inner tunnel ran, so
+				# the inner-tunnel virtual server never got to log this attempt.
+				packetfence-audit-log-reject
+			}
 			if ("%{%{control:PacketFence-Proxied-From}:-False}" == "True") {
 				packetfence-audit-log-reject
 			}

--- a/conf/radiusd/packetfence.example
+++ b/conf/radiusd/packetfence.example
@@ -422,11 +422,11 @@ server packetfence {
 			if (! EAP-Type || (EAP-Type != TTLS  && EAP-Type != PEAP) ) {
 				packetfence-audit-log-reject
 			}
-			elsif ("%{request:Module-Failure-Message}" =~ /Alert read:fatal:/) {
-				# PEAP/TTLS reject caused by the supplicant rejecting the
-				# server certificate: the client sent a fatal TLS alert (e.g.
-				# unknown CA / bad certificate) before the inner tunnel ran, so
-				# the inner-tunnel virtual server never got to log this attempt.
+			elsif (&request:Module-Failure-Message && ("%{request:Module-Failure-Message}" !~ /previously rejected|Failed continuing EAP/)) {
+				# Log EAP failures that happen before the inner tunnel could run (TLS alert
+				# from the supplicant, handshake or framing errors). The first message holds
+				# the root cause; the two excluded ones are all an inner-tunnel rejection
+				# leaves behind, and that attempt was already logged by the inner tunnel.
 				packetfence-audit-log-reject
 			}
 			if ("%{%{control:PacketFence-Proxied-From}:-False}" == "True") {


### PR DESCRIPTION
### Problem

When a PEAP/TTLS supplicant rejects the RADIUS server certificate during the TLS handshake, the attempt never reaches `radius_audit_log`.

The client sends a fatal TLS alert (e.g. `unknown CA`, `bad certificate`), FreeRADIUS emits a real Access-Reject and runs the outer `Post-Auth-Type REJECT`:

```
eap_peap: ERROR: (TLS) PEAP - Alert read:fatal:unknown CA
Login incorrect (eap_peap: (TLS) PEAP - Alert read:fatal:unknown CA): [anonymous]
```

But that section guards the audit call with `if (! EAP-Type || (EAP-Type != TTLS && EAP-Type != PEAP))`, which skips tunneled EAP because audit logging for PEAP/TTLS is normally done by the inner tunnel. Since the handshake failed *before* the tunnel was established, the inner tunnel never ran and nobody logged the attempt. The rejection ends up in `radius.log` only.

### Fix

Add an `elsif` that logs the reject when `Module-Failure-Message` carries a fatal TLS alert signature:

```
elsif ("%{request:Module-Failure-Message}" =~ /Alert read:fatal:/) {
    packetfence-audit-log-reject
}
```

`Module-Failure-Message` is available in that section — it is already read there by the degraded server. The signature is disjoint from inner-auth failures, so normal tunneled rejects continue to be logged exactly once by the inner tunnel.

The match is deliberately narrow. Matching all outer PEAP/TTLS rejects would also catch `eap_peap: The users session was previously rejected: returning reject (again)`, which is emitted repeatedly for an already-rejected session and would create duplicate entries.

### Scope

- Only PEAP/TTLS are affected. EAP-TLS (`EAP-Type == TLS`) already satisfies the existing guard and was logged before this change.
- Clients that abort the handshake silently (without sending a TLS alert) produce no Access-Reject at all and therefore remain unlogged. That case is out of scope here.

### Testing

Verified on a 3-node cluster running PF15.1 with FreeRADIUS 3.0.11:

- `freeradius -d <raddb> -n auth -Cxm` passes. A deliberately malformed variant of the same condition makes the check fail, confirming the section is actually validated.
- Client configured to distrust the server CA: every attempt now produces exactly one `radius_audit_log` row with `auth_status=Reject`, `user_name=anonymous` and `reason=eap_peap: (TLS) PEAP - Alert read:fatal:unknown CA`. Before the change no row was created.
- No double logging: a PEAP login with a wrong password produced exactly one row per attempt, logged by the inner tunnel (`reason=mschap_local: MS-CHAP2-Response is incorrect`); the new branch correctly did not fire.
- Successful PEAP login: exactly one Accept row.
