### PR TITLE
fix(pfcron): stop empty management-network panic and self-heal on boot

### DIFF
--- a/conf/systemd/packetfence-pfcron.service
+++ b/conf/systemd/packetfence-pfcron.service
@@ -3,6 +3,8 @@
 Description=PacketFence pfcron Service
 Wants=packetfence-base.target packetfence-config.service
 After=packetfence-base.target packetfence-config.service
+# Retry forever: at boot pfcron may start before pfconfig is ready to serve.
+StartLimitIntervalSec=0
 
 [Service]
 Type=notify
@@ -12,6 +14,7 @@ ExecStartPre=/bin/perl -I/usr/local/pf/lib -I/usr/local/pf/lib_perl/lib/perl5 '-
 ExecStart=/usr/local/pf/sbin/pfcron-docker-wrapper
 ExecStop=/bin/bash -c "docker stop pfcron ; echo Stopped"
 Restart=on-failure
+RestartSec=30
 Slice=packetfence.slice
 
 [Install]

--- a/debian/patches/debianize.patch
+++ b/debian/patches/debianize.patch
@@ -1,5 +1,5 @@
 diff --git a/conf/pf.conf.defaults b/conf/pf.conf.defaults
-index f32d4110b2..873bb5160b 100644
+index 7735164bfe..be3978df0a 100644
 --- a/conf/pf.conf.defaults
 +++ b/conf/pf.conf.defaults
 @@ -489,7 +489,7 @@ radiusd=enabled
@@ -454,10 +454,10 @@ index 46b4acdcb4..f4a51668dd 100644
  [Install]
  WantedBy=packetfence.target
 diff --git a/conf/systemd/packetfence-pfcron.service b/conf/systemd/packetfence-pfcron.service
-index e2840cc3b8..e541c1e102 100644
+index 75c6419fac..786648024a 100644
 --- a/conf/systemd/packetfence-pfcron.service
 +++ b/conf/systemd/packetfence-pfcron.service
-@@ -8,7 +8,7 @@ After=packetfence-base.target packetfence-config.service
+@@ -10,7 +10,7 @@ StartLimitIntervalSec=0
  Type=notify
  NotifyAccess=all
  Environment=LOG_LEVEL=INFO

--- a/go/cmd/pfcron/main.go
+++ b/go/cmd/pfcron/main.go
@@ -22,7 +22,16 @@ import (
 func setProcessing() {
 	var Management pfconfigdriver.ManagementNetwork
 	ctx := context.Background()
-	pfconfigdriver.FetchDecodeSocket(ctx, &Management)
+	logger := log.LoggerWContext(ctx)
+	// Wait for the management network; an empty interface panics downstream.
+	for {
+		if err := pfconfigdriver.FetchDecodeSocket(ctx, &Management); err != nil || Management.Int == "" {
+			logger.Warn(fmt.Sprintf("Management network not available yet, retrying: %v", err))
+			time.Sleep(5 * time.Second)
+			continue
+		}
+		break
+	}
 	for {
 		if isMaster(ctx, &Management) {
 			atomic.StoreUint32(&processJobs, 1)
@@ -46,7 +55,10 @@ func isMaster(ctx context.Context, management *pfconfigdriver.ManagementNetwork)
 			return true
 		}
 
-		eth, _ := net.InterfaceByName(management.Int)
+		eth, err := net.InterfaceByName(management.Int)
+		if err != nil || eth == nil {
+			return false
+		}
 		addresses, _ := eth.Addrs()
 		clusterIp := net.ParseIP(keyConfCluster.Ip)
 

--- a/go/pfconfigdriver/fetch.go
+++ b/go/pfconfigdriver/fetch.go
@@ -416,10 +416,10 @@ func FetchDecodeSocket(ctx context.Context, o PfconfigObject) error {
 		if receiver.Element != nil {
 			b, _ := receiver.Element.MarshalJSON()
 			if err := decodeJsonInterfaceErr(ctx, b, &o); err != nil {
-				return errors.New(fmt.Sprintf("Could not decode element in response (%s). Response was: %s", err, jsonResponse))
+				return fmt.Errorf("could not decode element in response for %s: %w. Response was: %s", query.GetIdentifier(), err, jsonResponse)
 			}
 		} else {
-			return errors.New(fmt.Sprintf("Element in response was invalid. Response was: %s", jsonResponse))
+			return fmt.Errorf("element in response for %s was invalid. Response was: %s", query.GetIdentifier(), jsonResponse)
 		}
 	}
 

--- a/go/pfconfigdriver/fetch.go
+++ b/go/pfconfigdriver/fetch.go
@@ -225,6 +225,20 @@ func decodeJsonInterface(ctx context.Context, b []byte, o interface{}) {
 	}
 }
 
+// Like decodeJsonInterface but returns the error instead of panicking, so an
+// empty/scalar element (e.g. an unset management_network) can't crash the daemon.
+func decodeJsonInterfaceErr(ctx context.Context, b []byte, o interface{}) error {
+	decoder := json.NewDecoder(bytes.NewReader(b))
+	for {
+		if err := decoder.Decode(&o); err == io.EOF {
+			break
+		} else if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func listPfconfigFields(ctx context.Context, t reflect.Type, previousFields []string) []string {
 	for i := 0; i < t.NumField(); i++ {
 		f := t.Field(i)
@@ -401,7 +415,9 @@ func FetchDecodeSocket(ctx context.Context, o PfconfigObject) error {
 
 		if receiver.Element != nil {
 			b, _ := receiver.Element.MarshalJSON()
-			decodeInterface(ctx, query.encoding, b, &o)
+			if err := decodeJsonInterfaceErr(ctx, b, &o); err != nil {
+				return errors.New(fmt.Sprintf("Could not decode element in response (%s). Response was: %s", err, jsonResponse))
+			}
 		} else {
 			return errors.New(fmt.Sprintf("Element in response was invalid. Response was: %s", jsonResponse))
 		}

--- a/go/pfconfigdriver/fetch_test.go
+++ b/go/pfconfigdriver/fetch_test.go
@@ -91,6 +91,22 @@ func TestFetchDecodeSocket(t *testing.T) {
 
 }
 
+func TestDecodeJsonInterfaceErr(t *testing.T) {
+	// A scalar/empty element must return an error, not panic.
+	var o PfconfigObject = &ManagementNetwork{}
+	if err := decodeJsonInterfaceErr(ctx, []byte(`"eth0"`), &o); err == nil {
+		t.Error("Decoding a scalar into ManagementNetwork should return an error, not panic")
+	}
+
+	var valid PfconfigObject = &ManagementNetwork{}
+	if err := decodeJsonInterfaceErr(ctx, []byte(`{"int":"eth0"}`), &valid); err != nil {
+		t.Errorf("Decoding a valid element shouldn't error: %s", err)
+	}
+	if valid.(*ManagementNetwork).Int != "eth0" {
+		t.Error("Valid element wasn't decoded correctly")
+	}
+}
+
 func TestFetchDecodeSocketCache(t *testing.T) {
 	gen := PfConfGeneral{}
 

--- a/t/venom/test_suites/cluster_wrapup/00_updatesystemd_restart.yml
+++ b/t/venom/test_suites/cluster_wrapup/00_updatesystemd_restart.yml
@@ -34,6 +34,15 @@ testcases:
     assertions:
       - result.code ShouldEqual 0
 
+# Hard reload rebuilds all namespaces (incl. host overlays) from synced config
+# before services start, so daemons don't read a cold/empty cache. All nodes.
+- name: configreload_hard
+  steps:
+  - type: exec
+    script: '/usr/local/pf/bin/pfcmd configreload hard'
+    assertions:
+      - result.code ShouldEqual 0
+
 - name: restart_pf
   steps:
   - type: exec


### PR DESCRIPTION

# Description
(REQUIRED)
At boot, pfcron (and any Go daemon fetching `ManagementNetwork`) panicked when pfconfig served an empty/scalar element for `interfaces::management_network` — e.g. a cold/stale cluster cache before the host's management interface is resolved. The panic exited the process, and the default systemd restart rate-limit left the unit dead.

This PR:
- `pfconfigdriver`: decode the element without panicking; return an error on an empty/scalar payload so a daemon can recover instead of crashing.
- `pfcron` systemd unit: self-heal on boot (`RestartSec=30`, `StartLimitIntervalSec=0`) instead of tripping the start limit.
- cluster venom: `configreload hard` before the final service restart so daemons read fresh, fully-synced config.

# Impacts
(REQUIRED)
- `go/pfconfigdriver` element-decode path — used by every daemon via `FetchDecodeSocket` (pfcron, pfacct, pfstats, pfudpproxy, firewallsso, connectors, chisel, pfsso). Verify normal namespaces still decode.
- `packetfence-pfcron.service` restart behavior at boot (never permanently gives up).
- cluster bring-up (`cluster_wrapup`): extra hard reload before restart.

# Delete branch after merge
(REQUIRED)
NO

# Checklist
(REQUIRED) - [yes, no or n/a]
- [n/a] Document the feature
- [n/a] Add OpenAPI specification
- [no] Add unit tests
- [yes] Add acceptance tests (TestLink)

# NEWS file entries
(REQUIRED, but may be optional...)

## Bug Fixes
* pfcron and other Go daemons no longer crash when pfconfig serves an empty management network (cluster boot)