### PR TITLE
feat(pfcron): add switch_observability_acls_cleanup task

### DIFF
--- a/conf/pfcron.conf.defaults
+++ b/conf/pfcron.conf.defaults
@@ -1192,3 +1192,40 @@ fingerprint_networks=
 #
 # Local task
 local=0
+
+[switch_observability_acls_cleanup]
+#
+# type
+#
+# Task type
+type=switch_observability_acls_cleanup
+#
+# status
+#
+# If the task is enabled
+status=enabled
+#
+# description
+#
+# The description of task
+description=Controls the cleanup of the switch_observability_acls table. Entries for MAC addresses that no longer exist in the node table will be removed.
+#
+# batch
+#
+# How many switch_observability_acls entries to clean up in one run
+batch=100
+#
+# timeout
+#
+# How long a switch_observability_acls_cleanup job can run
+timeout=10s
+#
+# schedule
+#
+# The schedule of task
+schedule=@every 1h
+#
+# local
+#
+# Local task
+local=0

--- a/db/pf-schema-X.Y.sql
+++ b/db/pf-schema-X.Y.sql
@@ -1672,7 +1672,8 @@ CREATE TABLE switch_observability_acls (
   `acls` MEDIUMTEXT NOT NULL,
   `enforcement_timestamp` DATETIME default NULL,
   PRIMARY KEY (`switch_id`, `mac`, `role_id`),
-  UNIQUE KEY `switch_observability_acls_switch_port` (`switch_id`, `port`)
+  UNIQUE KEY `switch_observability_acls_switch_port` (`switch_id`, `port`),
+  KEY `switch_observability_acls_mac_enforcement` (`mac`, `enforcement_timestamp`)
 ) ENGINE=InnoDB DEFAULT CHARACTER SET = 'utf8mb4' COLLATE = 'utf8mb4_general_ci';
 
 --

--- a/db/upgrade-X.X-X.Y.sql
+++ b/db/upgrade-X.X-X.Y.sql
@@ -190,6 +190,14 @@ call ValidateVersion;
 --
 
 --
+-- Index switch_observability_acls by mac for the switch_observability_acls_cleanup task
+-- and for per-device ACL lookups
+--
+\! echo "Adding index switch_observability_acls_mac_enforcement to switch_observability_acls...";
+CALL AddIndexUnlessExists('switch_observability_acls', 'switch_observability_acls_mac_enforcement',
+    'KEY `switch_observability_acls_mac_enforcement` (`mac`,`enforcement_timestamp`)');
+
+--
 -- Clean up the helper / validation procedures
 --
 DROP PROCEDURE IF EXISTS ValidateVersion;

--- a/go/cron/batch_sql_task.go
+++ b/go/cron/batch_sql_task.go
@@ -1,0 +1,41 @@
+package maint
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/inverse-inc/go-utils/log"
+)
+
+// BatchSqlCleanup runs a batched SQL statement that has no time window: the
+// statement's own predicates decide what is affected. The only bind parameter
+// is the LIMIT.
+type BatchSqlCleanup struct {
+	Task
+	Batch   int
+	Timeout time.Duration
+	Sql     string
+}
+
+func NewBatchSqlCleanup(config map[string]interface{}, sql string) JobSetupConfig {
+	return &BatchSqlCleanup{
+		Task:    SetupTask(config),
+		Batch:   int(config["batch"].(float64)),
+		Timeout: time.Duration((config["timeout"].(float64))) * time.Second,
+		Sql:     sql,
+	}
+}
+
+func MakeBatchSqlJobSetupConfig(sql string) func(config map[string]interface{}) JobSetupConfig {
+	return func(config map[string]interface{}) JobSetupConfig {
+		return NewBatchSqlCleanup(config, sql)
+	}
+}
+
+func (c *BatchSqlCleanup) Run() {
+	count, _ := BatchSql(context.Background(), c.Timeout, c.Sql, c.Batch)
+	if count > -1 {
+		log.LogInfo(context.Background(), fmt.Sprintf("%s cleaned items %d", c.Name(), count))
+	}
+}

--- a/go/cron/batch_sql_task_test.go
+++ b/go/cron/batch_sql_task_test.go
@@ -1,0 +1,82 @@
+package maint
+
+import (
+	"testing"
+	"time"
+)
+
+func testBatchSqlCleanup(t *testing.T, name string, additional_args map[string]interface{}, setupSql []string, pause time.Duration, tests []sqlCountTest, cleanupSQL []string) {
+	config, found := jobsConfig[name]
+	if !found {
+		t.Fatalf("config for %s not found", name)
+	}
+
+	testCronTask(
+		t,
+		BuildJob(
+			name,
+			MergeArgs(
+				config.(map[string]interface{}),
+				additional_args,
+			),
+		),
+		setupSql,
+		pause,
+		tests,
+		cleanupSQL,
+	)
+}
+
+func TestSwitchObservabilityAclsCleanup(t *testing.T) {
+
+	testBatchSqlCleanup(
+		t,
+		"switch_observability_acls_cleanup",
+		map[string]interface{}{
+			"timeout": 10.0,
+			"batch":   100.0,
+		},
+		[]string{
+			`DELETE FROM switch_observability_acls WHERE switch_id = 'test-switch-obs'`,
+			`DELETE FROM node WHERE mac = '02:00:00:00:00:01'`,
+			`INSERT INTO node (mac, status) VALUES ('02:00:00:00:00:01', 'unreg')`,
+			// The role scoped row (mac = '') and the row whose node still
+			// exists must survive. Both orphans must go, including the one
+			// enforced a second ago -- there is no grace window.
+			`
+     INSERT INTO switch_observability_acls (switch_id, mac, port, role_id, acl_type, acls, enforcement_timestamp) VALUES
+        ('test-switch-obs', '02:00:00:00:00:01', NULL, 'default', 'role', 'permit ip any any', DATE_SUB(NOW(), INTERVAL 1 DAY) ),
+        ('test-switch-obs', '02:00:00:00:00:02', NULL, 'default', 'role', 'permit ip any any', DATE_SUB(NOW(), INTERVAL 1 DAY) ),
+        ('test-switch-obs', '02:00:00:00:00:03', NULL, 'default', 'asset', 'permit ip any any', NOW() ),
+        ('test-switch-obs', '',                  NULL, 'default', 'role', 'permit ip any any', DATE_SUB(NOW(), INTERVAL 1 DAY) )
+            `,
+		},
+		0,
+		[]sqlCountTest{
+			{
+				name:          "orphaned switch_observability_acls entries gone",
+				sql:           `SELECT COUNT(*) FROM switch_observability_acls WHERE switch_id = 'test-switch-obs' AND mac IN ('02:00:00:00:00:02', '02:00:00:00:00:03')`,
+				expectedCount: 0,
+			},
+			{
+				name:          "switch_observability_acls entry of an existing node kept",
+				sql:           `SELECT COUNT(*) FROM switch_observability_acls WHERE switch_id = 'test-switch-obs' AND mac = '02:00:00:00:00:01'`,
+				expectedCount: 1,
+			},
+			{
+				name:          "role scoped switch_observability_acls entry kept",
+				sql:           `SELECT COUNT(*) FROM switch_observability_acls WHERE switch_id = 'test-switch-obs' AND mac = ''`,
+				expectedCount: 1,
+			},
+			{
+				name:          "switch_observability_acls entries left",
+				sql:           `SELECT COUNT(*) FROM switch_observability_acls WHERE switch_id = 'test-switch-obs'`,
+				expectedCount: 2,
+			},
+		},
+		[]string{
+			`DELETE FROM switch_observability_acls WHERE switch_id = 'test-switch-obs'`,
+			`DELETE FROM node WHERE mac = '02:00:00:00:00:01'`,
+		},
+	)
+}

--- a/go/cron/config.go
+++ b/go/cron/config.go
@@ -47,6 +47,9 @@ var builders = map[string]func(map[string]interface{}) JobSetupConfig{
 		`DELETE FROM radacct_log WHERE timestamp < DATE_SUB(?, INTERVAL ? SECOND) LIMIT ?`,
 	),
 	"flush_radius_audit_log": NewFlushRadiusAuditLogJob,
+	"switch_observability_acls_cleanup": MakeBatchSqlJobSetupConfig(
+		`DELETE FROM switch_observability_acls WHERE mac != '' AND NOT EXISTS (SELECT 1 FROM node WHERE node.mac = switch_observability_acls.mac) LIMIT ?`,
+	),
 }
 
 func GetMaintenanceConfig(ctx context.Context) map[string]interface{} {

--- a/html/pfappserver/lib/pfappserver/Form/Config/Pfcron/switch_observability_acls_cleanup.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Pfcron/switch_observability_acls_cleanup.pm
@@ -1,0 +1,81 @@
+package pfappserver::Form::Config::Pfcron::switch_observability_acls_cleanup;
+
+=head1 NAME
+
+pfappserver::Form::Config::Pfcron::switch_observability_acls_cleanup - Web form for switch_observability_acls_cleanup pfcron task
+
+=head1 DESCRIPTION
+
+Web form for switch_observability_acls_cleanup pfcron task
+
+=cut
+
+use strict;
+use warnings;
+
+use HTML::FormHandler::Moose;
+
+use pfappserver::Form::Config::Pfcron qw(default_field_method batch_help_text timeout_help_text);
+
+extends 'pfappserver::Form::Config::Pfcron';
+with 'pfappserver::Base::Form::Role::Help';
+
+has_field 'batch' => (
+    type => 'PosInteger',
+    default_method => \&default_field_method,
+    tags => { after_element => \&help,
+             help => \&batch_help_text },
+);
+
+has_field 'timeout' => (
+    type => 'Duration',
+    default_method => \&default_field_method,
+    tags => { after_element => \&help,
+             help => \&timeout_help_text },
+);
+
+=head2 default_type
+
+default value of type
+
+=cut
+
+sub default_type {
+    return "switch_observability_acls_cleanup";
+}
+
+has_block  definition =>
+  (
+    render_list => [qw(type status interval batch timeout)],
+  );
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2026 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+__PACKAGE__->meta->make_immutable unless $ENV{"PF_SKIP_MAKE_IMMUTABLE"};
+
+1;

--- a/lib/pf/UnifiedApi/Controller/Config/MaintenanceTasks.pm
+++ b/lib/pf/UnifiedApi/Controller/Config/MaintenanceTasks.pm
@@ -54,6 +54,7 @@ use pfappserver::Form::Config::Pfcron::security_event_purge;
 use pfappserver::Form::Config::Pfcron::flush_radius_audit_log;
 use pfappserver::Form::Config::Pfcron::flush_dns_audit_log;
 use pfappserver::Form::Config::Pfcron::pfflow;
+use pfappserver::Form::Config::Pfcron::switch_observability_acls_cleanup;
 
 our %TYPES_TO_FORMS = (
     map { $_ => "pfappserver::Form::Config::Pfcron::$_" } qw(
@@ -87,6 +88,7 @@ our %TYPES_TO_FORMS = (
       flush_radius_audit_log
       flush_dns_audit_log
       pfflow
+      switch_observability_acls_cleanup
     )
 );
 


### PR DESCRIPTION
# Description

`switch_observability_acls` is written on every RADIUS authorization by `pf::Switch::getAccessListByName` (device-scoped row, real MAC) and `pf::Switch::getRoleAccessListByName` (role-scoped row, empty-string MAC sentinel). Both do a narrow `remove_items` + `upsert` for the exact key they are rewriting, and nothing else ever deletes from the table. Once a node is removed from `node`, its ACL rows are orphaned forever, so the table grows unbounded.

This adds a `switch_observability_acls_cleanup` pfcron task that removes the rows whose `mac` is no longer present in the `node` table:

```sql
DELETE FROM switch_observability_acls
 WHERE mac != ''
   AND NOT EXISTS (SELECT 1 FROM node WHERE node.mac = switch_observability_acls.mac)
 LIMIT ?
```

There is deliberately no time window — membership in `node` is the only criterion. The `mac != ''` guard is load-bearing: `getRoleAccessListByName` writes role-scoped rows with an empty MAC, and those must survive.

**New job type.** The three existing SQL-cleanup helpers in `go/cron/window_batch_task.go` all require a `window` config key and pass `(now, window, batch)` to `BatchSql`, so none fit a window-less cleanup. `BatchSqlCleanup` (`go/cron/batch_sql_task.go`) reads only `batch` + `timeout` and binds a single `LIMIT` placeholder. It is generic, so future batch-only cleanups can reuse it.

**Index.** `switch_observability_acls` gains `KEY (mac, enforcement_timestamp)`. The table had no `mac`-leading index, its primary key being `(switch_id, mac, role_id)`.

# Impacts

- **pfcron** — new task, `status=enabled` by default, `@every 1h`, `batch=100`, `timeout=10s`. Registered in the Go `builders` map; there is no Perl task module, so `pfcmd pfcron switch_observability_acls_cleanup` reaches it through the existing exec-to-Go fallback.
- **Admin GUI** — Configuration → Maintenance gains the task. The form exposes Status / Schedule / Batch / Timeout and **no** Window field. No Vue change was needed: `TheForm.vue` drives `wants()` off the API `meta` keys, which come from the Perl form.
- **Database** — one new secondary index on `switch_observability_acls`, added inline in `db/pf-schema-X.Y.sql` for fresh installs and via `AddIndexUnlessExists` in `db/upgrade-X.X-X.Y.sql` for upgrades. This replicates under Galera TOI, so it briefly blocks the cluster; the table is small, but it is not online DDL.
- **RADIUS write path** — one additional secondary index is now maintained on every authorization, since `pf::Switch` does `remove_items` + `upsert` per auth.

## What reviewers should look at

1. **The `NOT EXISTS` shape** in `go/cron/config.go`. A `DELETE ... LEFT JOIN ... LIMIT` rewrite is a syntax error in MariaDB, and multi-table DELETE does not support `LIMIT`, so this is the only form compatible with `BatchSql`'s placeholder contract. The correlated reference to the delete target is legal — `ER_UPDATE_TABLE_USED` only fires when the target appears in the subquery's `FROM`.
2. **The `mac != ''` guard.** Dropping it would wipe every role-scoped row.
3. **Index column order.** `(mac, enforcement_timestamp)` does *not* accelerate this DELETE — the statement no longer references `enforcement_timestamp`, and `mac != ''` matches ~100% of rows, so the optimizer takes a full clustered scan. Its value is giving the table its first `mac`-leading index for per-device lookups. Every other cleanup table here indexes the time column first (`auth_log.attempted_at`, `radius_audit_log.created_at`, `locationlog.end_time`); happy to flip it to `(enforcement_timestamp, mac)` if preferred.
4. **No grace period.** A device that authenticates before its `node` row exists gets a row eligible for deletion on the next run. `parseRequest` normally creates the node first and `@every 1h` keeps the race narrow, but it is not impossible the way a time window would have made it.
5. **Re-scan cost.** `BatchStmt` re-executes until it deletes nothing, and rows whose node still exists are "sticky" — re-examined on every pass. Cost is roughly `ceil(orphans/batch)` scans. It terminates correctly; sites with large tables can raise `batch`.

## Not covered by this task

Rows for `switch_id`s removed from `switches.conf`, role-scoped rows for roles that no longer exist, and the sibling `switch_observability` table.

## Testing done

- **Upgrade path** — loaded `pf-schema-15.1.sql` into a scratch DB, applied the upgrade (15.1 → 15.2, index created), then re-ran it with the version rewound to confirm `AddIndexUnlessExists` is a clean no-op. `SHOW CREATE TABLE` is byte-identical between a fresh install and an upgraded DB.
- **DELETE semantics** — against a real fixture: both orphans deleted (including one enforced seconds earlier, confirming no grace window), the row with a live node kept, the `mac=''` role row kept, and the second batch pass deleted 0 so the loop terminates.
- **Go** — `gofmt` and `go vet` clean; new test passes; all 20 existing cleanup/batch cron tests still pass.
- **Perl** — `pfappserver_libs.t` 325/325, `MaintenanceTasks.t` 9/9, `coding-style.t` 0 failures.
- **Form meta** resolves to `id, type, status, schedule, batch, timeout` with defaults read from the config; `%TYPES_TO_FORMS` went 30 → 31.
- **DAL** — the `update_dal.sh` pre-commit hook fires on any `pf-schema-X.Y.sql` change, but regeneration is a no-op here: `generator-data-access-layer.pl` collects index metadata only to derive primary keys, and `pf-dal.pm.tt` has no index references. Confirmed by re-running the generator for this table — both DAL files came back byte-identical.

# Delete branch after merge

YES

# Checklist

- [x] Document the feature — n/a. No asciidoc guide enumerates maintenance tasks; the inline `description=` in `pfcron.conf.defaults` is the documentation, consistent with the other 30 tasks.
- [ ] Add OpenAPI specification — **not in this PR.** `docs/api/spec/openapi.{yaml,json}` are generated artifacts landed in dedicated commits here (cf. a7eb05c5f2 `fix(OAS): update OAS`), and regenerating produces a 20k+ line diff. Regenerate with `perl docs/api/spec/generate-openapi-from-routes.pl && perl docs/api/spec/generate-openapi-spec.pl`.
- [x] Add unit tests — `go/cron/batch_sql_task_test.go` covers orphan deleted / live-node row kept / `mac=''` role row kept.
- [ ] Add acceptance tests (TestLink) — no.

# NEWS file entries

Not committed to `NEWS.asciidoc` — the current section is `Version 15.2.0 released on 2026-07-21`, so this belongs to the next release. Proposed entry:

## Enhancements
* New `switch_observability_acls_cleanup` maintenance task removes switch observability ACL entries for MAC addresses that no longer exist in the node table
