### PR TITLE
feat(auth): add LocalDB authentication source with rule-based rights

### DIFF
--- a/docs/installation/authentication_sources.asciidoc
+++ b/docs/installation/authentication_sources.asciidoc
@@ -35,6 +35,7 @@ various methods:
  * Kickbox
  * LDAP
  * LinkedIn (OAuth 2)
+ * Local Database
  * Null
  * OpenID Connect (OAuth 2)
  * RADIUS
@@ -173,6 +174,33 @@ First unplug and unregister again the Microsoft Windows 7 endpoint. Then,
 connect the endpoint in switch port no. 10 - you should see the captive portal
 with the new SMS-based registration option. Note that the Null option will also
 be offered.
+
+=== Local Database Authentication
+
+The `Local Database` source authenticates the users stored in the PacketFence
+database, the same credential store as the internal SQL source, but it assigns
+rights through rules instead of reading them from the user account. Conditions
+can be written on the attributes stored on the user - access level, role,
+unregistration date, expiration and the person attributes - in addition to the
+common conditions such as SSID, connection type, time period, realm or switch.
+
+Add the source from _Configuration -> Policies and Access Control ->
+Authentication Sources_, click `New internal source -> Local Database`. Use
+administration rules to grant administration access levels, and authentication
+rules to assign network roles. As for every source, it then has to be added to a
+connection profile.
+
+When no rule matches, the source falls back to the attributes stored on the user
+account itself, the way the internal SQL source assigns them. This keeps an
+administrator whose rights only come from their account from losing access to
+the admin interface and to the switch CLI. Set `Fallback to Static User
+Attributes` to off for a strictly rule-based setup - rules can then be the only
+source of rights.
+
+[WARNING]
+An administration rule without conditions is a catchall: it changes the access
+level of every user of the local database, administrators included, and can lock
+them out. Always give administration rules a condition.
 
 === Troubleshooting Authentication Issues
 

--- a/html/pfappserver/lib/pfappserver/Form/Config/Source/LocalDB.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Source/LocalDB.pm
@@ -1,0 +1,68 @@
+package pfappserver::Form::Config::Source::LocalDB;
+
+=head1 NAME
+
+pfappserver::Form::Config::Source::LocalDB
+
+=cut
+
+=head1 DESCRIPTION
+
+Form definition to create or update a LocalDB authentication source.
+
+=cut
+
+BEGIN {
+    use pf::Authentication::Source::LocalDBSource;
+}
+use strict;
+use warnings;
+use HTML::FormHandler::Moose;
+extends 'pfappserver::Form::Config::Source';
+with 'pfappserver::Base::Form::Role::Help', 'pfappserver::Base::Form::Role::InternalSource';
+
+our $META = pf::Authentication::Source::LocalDBSource->meta;
+
+# Form fields
+has_field 'fallback_to_static_user_attributes' =>
+  (
+   type => 'Toggle',
+   checkbox_value => '1',
+   unchecked_value => '0',
+   default => $META->get_attribute('fallback_to_static_user_attributes')->default,
+   tags => { after_element => \&help,
+             help => 'Assign the static attributes stored on the user itself when no rule of this '
+                   . 'source matches. Those are the actions stored on the user, under '
+                   . 'Users -> (user) -> Actions. When disabled, only the actions configured in '
+                   . 'this source apply - administrator lockout possible. While enabled, rules can '
+                   . 'only grant rights on top of the static attributes, they cannot revoke them.' },
+  );
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2026 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;

--- a/html/pfappserver/root/src/views/Configuration/sources/_components/FormTypeLocalDB.vue
+++ b/html/pfappserver/root/src/views/Configuration/sources/_components/FormTypeLocalDB.vue
@@ -1,0 +1,87 @@
+<template>
+  <base-form
+    :form="form"
+    :meta="meta"
+    :schema="schema"
+    :isLoading="isLoading"
+  >
+    <form-group-identifier namespace="id"
+      :column-label="$i18n.t('Name')"
+      :disabled="!isNew && !isClone"
+    />
+
+    <form-group-description namespace="description"
+      :column-label="$i18n.t('Description')"
+    />
+
+    <form-group-realms namespace="realms"
+      :column-label="$i18n.t('Associated Realms')"
+      :text="$i18n.t('Realms that will be associated with this source.')"
+    />
+
+    <form-group-fallback-to-static-user-attributes namespace="fallback_to_static_user_attributes"
+      :column-label="$i18n.t('Fallback to Static User Attributes')"
+      :text="$i18n.t('Assign the static attributes stored on the user itself when no rule of this source matches.')"
+      enabled-value="1"
+      disabled-value="0"
+    />
+
+    <base-form-group>
+      <b-alert show variant="warning" class="w-100 mb-0">
+        <p class="mb-2">{{ $i18n.t('When disabled, only the actions configured in this source apply. Administrator lockout possible.') }}</p>
+        <p class="mb-0">{{ $i18n.t('The static user attributes are the actions stored on the user itself, under Users -> (user) -> Actions.') }}</p>
+      </b-alert>
+    </base-form-group>
+
+    <form-group-authentication-rules namespace="authentication_rules"
+      :column-label="$i18n.t('Authentication Rules')"
+    />
+
+    <base-form-group>
+      <b-alert show variant="warning" class="w-100 mb-0">
+        {{ $i18n.t('A catchall administration rule changes the access level of every user of the local database and can lock administrators out. Always give administration rules a condition.') }}
+      </b-alert>
+    </base-form-group>
+
+    <form-group-administration-rules namespace="administration_rules"
+      :column-label="$i18n.t('Administration Rules')"
+    />
+  </base-form>
+</template>
+<script>
+import {
+  BaseForm,
+  BaseFormGroup
+} from '@/components/new/'
+import {
+  FormGroupAdministrationRules,
+  FormGroupAuthenticationRules,
+  FormGroupDescription,
+  FormGroupFallbackToStaticUserAttributes,
+  FormGroupIdentifier,
+  FormGroupRealms,
+} from './'
+
+const components = {
+  BaseForm,
+  BaseFormGroup,
+
+  FormGroupAdministrationRules,
+  FormGroupAuthenticationRules,
+  FormGroupDescription,
+  FormGroupFallbackToStaticUserAttributes,
+  FormGroupIdentifier,
+  FormGroupRealms,
+}
+
+import { useForm as setup, useFormProps as props } from '../_composables/useForm'
+
+// @vue/component
+export default {
+  name: 'form-type-local-db',
+  inheritAttrs: false,
+  components,
+  props,
+  setup
+}
+</script>

--- a/html/pfappserver/root/src/views/Configuration/sources/_components/TheForm.vue
+++ b/html/pfappserver/root/src/views/Configuration/sources/_components/TheForm.vue
@@ -39,6 +39,7 @@ import FormTypeKerberos from './FormTypeKerberos'
 import FormTypeKickbox from './FormTypeKickbox'
 import FormTypeLdap from './FormTypeLdap'
 import FormTypeLinkedIn from './FormTypeLinkedIn'
+import FormTypeLocalDB from './FormTypeLocalDB'
 import FormTypeNull from './FormTypeNull'
 import FormTypeOpenId from './FormTypeOpenId'
 import FormTypePaypal from './FormTypePaypal'
@@ -72,6 +73,7 @@ const components = {
   FormTypeKickbox,
   FormTypeLdap,
   FormTypeLinkedIn,
+  FormTypeLocalDB,
   FormTypeNull,
   FormTypeOpenId,
   FormTypePaypal,
@@ -114,6 +116,7 @@ export const setup = (props) => {
       case 'Kickbox':             return FormTypeKickbox //break
       case 'LDAP':                return FormTypeLdap //break
       case 'LinkedIn':            return FormTypeLinkedIn //break
+      case 'LocalDB':             return FormTypeLocalDB //break
       case 'Null':                return FormTypeNull //break
       case 'OpenID':              return FormTypeOpenId //break
       case 'Paypal':              return FormTypePaypal //break

--- a/html/pfappserver/root/src/views/Configuration/sources/_components/index.js
+++ b/html/pfappserver/root/src/views/Configuration/sources/_components/index.js
@@ -68,6 +68,7 @@ export {
   BaseFormGroupInput                        as FormGroupEmailAddress,
   BaseFormGroupInput                        as FormGroupEmailAttribute,
   BaseFormGroupSwitch                       as FormGroupEmailRequired,
+  BaseFormGroupSwitch                       as FormGroupFallbackToStaticUserAttributes,
   BaseFormGroupInput                        as FormGroupGraphUrl,
   BaseFormGroupInput                        as FormGroupGroupHeader,
   BaseFormGroupChosenOne                    as FormGroupHashPasswords,

--- a/html/pfappserver/root/src/views/Configuration/sources/config.js
+++ b/html/pfappserver/root/src/views/Configuration/sources/config.js
@@ -12,6 +12,7 @@ export const internalTypes = {
   HTTP:                'HTTP',
   Kerberos:            'Kerberos',
   LDAP:                'LDAP',
+  LocalDB:             i18n.t('Local Database'),
   Potd:                i18n.t('Password Of The Day'),
   RADIUS:              'RADIUS',
   SAML:                'SAML',

--- a/lib/pf/Authentication/Source/LocalDBSource.pm
+++ b/lib/pf/Authentication/Source/LocalDBSource.pm
@@ -1,0 +1,331 @@
+package pf::Authentication::Source::LocalDBSource;
+
+=head1 NAME
+
+pf::Authentication::Source::LocalDBSource
+
+=head1 DESCRIPTION
+
+Authentication source for local database users (the C<password> / C<person>
+tables), same credential store as the C<SQL> source.
+
+Where C<SQLSource> overrides C<match> and reads the rights verbatim from the
+user's row, this source keeps the rule engine: rights are assigned by rules whose
+conditions can use the stored attributes of the local user on top of the common
+PacketFence conditions.
+
+When no rule matches, it falls back to the attributes stored on the user, the way
+C<SQLSource> does, so that an administrator whose rights only come from their
+account is not locked out. C<fallback_to_static_user_attributes> turns that off.
+
+=cut
+
+use strict;
+use warnings;
+
+use List::Util qw(none);
+
+use pf::constants qw($TRUE $FALSE);
+use pf::password;
+use pf::person;
+use pf::Authentication::constants;
+use pf::constants::authentication::messages;
+use pf::Authentication::Rule;
+use pf::Authentication::Source;
+use pf::Authentication::Source::SQLSource;
+use pf::log;
+use pf::util qw(isdisabled);
+
+use Moose;
+extends 'pf::Authentication::Source';
+with qw(pf::Authentication::InternalRole);
+
+has '+type' => (default => 'LocalDB');
+
+# Assign the attributes stored on the user when no rule of the requested class matched
+has 'fallback_to_static_user_attributes' => (is => 'rw', default => 1);
+
+# User lookups, kept for the duration of one match
+has '_user_lookup' => (is => 'rw', lazy => 1, default => sub { {} });
+
+# Convenience selection - the condition editor also accepts free-text attributes
+our @OWN_ATTRIBUTES = qw(
+    pid
+    firstname
+    lastname
+    email
+    company
+    title
+    nickname
+    notes
+    telephone
+    cell_phone
+    work_phone
+    custom_field_1
+    custom_field_2
+    custom_field_3
+    custom_field_4
+    custom_field_5
+    custom_field_6
+    custom_field_7
+    custom_field_8
+    custom_field_9
+    category
+    sponsor
+    access_level
+    unregdate
+    expiration
+);
+
+=head1 METHODS
+
+=head2 dynamic_routing_module
+
+Which module to use for DynamicRouting
+
+=cut
+
+sub dynamic_routing_module { 'Authentication::Login' }
+
+=head2 available_attributes
+
+The common attributes plus the local user attributes rules can be written on.
+
+=cut
+
+sub available_attributes {
+    my $self = shift;
+
+    my $super_attributes = $self->SUPER::available_attributes;
+    my $own_attributes = [ map { { value => $_, type => $Conditions::SUBSTRING } } @OWN_ATTRIBUTES ];
+
+    return [@$super_attributes, @$own_attributes];
+}
+
+=head2 authenticate
+
+Validate the credentials against the local C<password> table.
+
+=cut
+
+sub authenticate {
+    my ($self, $username, $password) = @_;
+
+    my $result = pf::password::validate_password($username, $password, 0);
+
+    if ($result == $pf::password::AUTH_SUCCESS) {
+        return ($TRUE, $AUTH_SUCCESS_MSG);
+    } elsif ($result == $pf::password::AUTH_FAILED_EXPIRED) {
+        return ($FALSE, $AUTH_PASSWD_EXPIRED);
+    }
+
+    return ($FALSE, $AUTH_FAIL_MSG);
+}
+
+=head2 password_entry
+
+The row of the password table the request is about, C<undef> when the user is
+unknown to the local database.
+
+=cut
+
+sub password_entry {
+    my ($self, $params) = @_;
+    my $cache = $self->_user_lookup;
+
+    if ($params->{'username'}) {
+        my $key = "password:$params->{'username'}";
+        $cache->{$key} = pf::password::view($params->{'username'}) unless exists $cache->{$key};
+        return $cache->{$key};
+    }
+    elsif ($params->{'email'}) {
+        my $key = "password_email:$params->{'email'}";
+        $cache->{$key} = pf::password::view_email($params->{'email'}) unless exists $cache->{$key};
+        return $cache->{$key};
+    }
+
+    return undef;
+}
+
+=head2 person_entry
+
+The row of the person table of a local user, cached like L</password_entry>.
+
+=cut
+
+sub person_entry {
+    my ($self, $pid) = @_;
+    my $cache = $self->_user_lookup;
+    my $key = "person:$pid";
+
+    $cache->{$key} = pf::person::person_view($pid) unless exists $cache->{$key};
+
+    return $cache->{$key};
+}
+
+=head2 match
+
+Rules first, and when none of them matched, the attributes stored on the user.
+
+=cut
+
+sub match {
+    my ($self, $params, $action, $extra) = @_;
+
+    $self->_user_lookup({});
+
+    my ($rule, $ignore_action, $matched) = $self->SUPER::match($params, $action, $extra);
+    if (my $warning = $self->unconditional_admin_rule_warning($rule)) {
+        get_logger->warn($warning);
+    }
+
+    ($rule, $ignore_action, $matched) = $self->match_static_user_attributes($params, $action)
+        unless defined $rule;
+
+    $self->_user_lookup({});
+
+    return ($rule, $ignore_action, $matched);
+}
+
+=head2 unconditional_admin_rule_warning
+
+A catchall administration rule sets the access level of every local user, the
+administrators included, and can therefore lock them out. Returns what to say
+about such a rule, C<undef> otherwise.
+
+=cut
+
+sub unconditional_admin_rule_warning {
+    my ($self, $rule) = @_;
+    local $_;
+
+    return undef unless defined $rule;
+    return undef unless ($rule->{'class'} // '') eq $Rules::ADMIN;
+    return undef if @{ $rule->{'conditions'} // [] };
+
+    my ($access_level) = grep { $_->type eq $Actions::SET_ACCESS_LEVEL } @{ $rule->{'actions'} // [] };
+    return undef unless $access_level;
+
+    return "Rule (" . ($rule->{'id'} // '') . ") of source " . $self->id
+        . " has no condition: it sets the access level '" . ($access_level->value // '')
+        . "' for every user of the local database, administrators included";
+}
+
+=head2 match_static_user_attributes
+
+Build a rule out of the attributes stored on the user, the way C<SQLSource> does,
+for a user that matched no rule at all. Rules always take precedence, and this can
+only grant what is stored on the user - it never revokes anything.
+
+=cut
+
+sub match_static_user_attributes {
+    my ($self, $params, $action) = @_;
+    local $_;
+
+    # Only an explicit "off" counts: an object built by an older pfconfig has no value at all
+    my $fallback = $self->fallback_to_static_user_attributes;
+    return (undef, undef, undef) if defined $fallback && (!$fallback || isdisabled($fallback));
+
+    my $password_entry = $self->password_entry($params);
+    return (undef, undef, undef) unless defined $password_entry;
+
+    my $rule_class = $params->{'rule_class'} // $Rules::AUTH;
+    my $actions = pf::Authentication::Source::SQLSource->static_user_attribute_actions($password_entry);
+    my @actions = grep { $_->class eq $rule_class } @$actions;
+    return (undef, undef, undef) unless @actions;
+
+    # Same action filtering as in pf::Authentication::Source::match
+    if (defined $action) {
+        my $allowed_actions = $Actions::ALLOWED_ACTIONS{$action} // {};
+        return (undef, undef, undef) if none { $allowed_actions->{$_->type} } @actions;
+    }
+
+    get_logger->info(
+        "No $rule_class rule matched in source " . $self->id
+        . ", falling back to the static attributes stored on the user"
+    );
+
+    my $rule = pf::Authentication::Rule->new({
+        id      => 'static_user_attributes',
+        class   => $rule_class,
+        match   => $Rules::ALL,
+        actions => \@actions,
+    });
+
+    return ($rule, undef, $password_entry->{'pid'});
+}
+
+=head2 match_in_subclass
+
+Confirm the user exists in the local database, then evaluate the source-specific
+conditions against the user's stored C<person> / C<password> attributes.
+
+=cut
+
+sub match_in_subclass {
+    my ($self, $params, $rule, $own_conditions, $matching_conditions) = @_;
+    local $_;
+
+    my $username = $params->{'username'} || $params->{'email'};
+    return (undef, undef) unless defined $username && length $username;
+
+    my $password_entry = $self->password_entry($params);
+    return (undef, undef) unless defined $password_entry;
+
+    my $pid = $password_entry->{'pid'} // $username;
+
+    # What the conditions are matched against: the person columns plus the relevant password ones
+    my %user_attrs;
+    my $person = $self->person_entry($pid);
+    if (ref($person) eq 'HASH') {
+        %user_attrs = %$person;
+    }
+    for my $col (qw(category sponsor access_level unregdate expiration)) {
+        $user_attrs{$col} = $password_entry->{$col} if defined $password_entry->{$col};
+    }
+    $user_attrs{'pid'} //= $pid;
+
+    foreach my $condition (@{ $own_conditions }) {
+        my $attribute = $condition->{'attribute'};
+        if ($condition->matches($attribute, $user_attrs{$attribute}, $params)) {
+            push(@{ $matching_conditions }, $condition);
+        }
+    }
+
+    return ($pid, undef);
+}
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2026 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+__PACKAGE__->meta->make_immutable unless $ENV{"PF_SKIP_MAKE_IMMUTABLE"};
+1;
+
+# vim: set shiftwidth=4:
+# vim: set expandtab:
+# vim: set backspace=indent,eol,start:

--- a/lib/pf/Authentication/Source/SQLSource.pm
+++ b/lib/pf/Authentication/Source/SQLSource.pm
@@ -90,8 +90,23 @@ sub match {
         return undef;
     }
 
+    return pf::Authentication::Rule->new(
+        id => "default",
+        class => $params->{rule_class},
+        actions => $self->static_user_attribute_actions($result),
+    );
+}
+
+=head2 static_user_attribute_actions
+
+Build the list of actions described by a row of the password table.
+
+=cut
+
+sub static_user_attribute_actions {
+    my ($self, $result) = @_;
+
     my @actions = ();
-    my $action;
 
     my $access_duration = $result->{'access_duration'};
     if (defined $access_duration) {
@@ -112,7 +127,7 @@ sub match {
     }
 
     my $sponsor = $result->{'sponsor'};
-    if ($sponsor == 1) {
+    if ($sponsor && $sponsor == 1) {
         push @actions, pf::Authentication::Action->new({
             type    => $Actions::MARK_AS_SPONSOR,
             value   => 1,
@@ -167,11 +182,7 @@ sub match {
 
     }
 
-    return pf::Authentication::Rule->new(
-        id => "default",
-        class => $params->{rule_class},
-        actions => \@actions,
-    );
+    return \@actions;
 }
 
 =head1 AUTHOR

--- a/lib/pf/UnifiedApi/Controller/Config/Sources.pm
+++ b/lib/pf/UnifiedApi/Controller/Config/Sources.pm
@@ -44,6 +44,7 @@ use pfappserver::Form::Config::Source::Kerberos;
 use pfappserver::Form::Config::Source::Kickbox;
 use pfappserver::Form::Config::Source::LDAP;
 use pfappserver::Form::Config::Source::LinkedIn;
+use pfappserver::Form::Config::Source::LocalDB;
 use pfappserver::Form::Config::Source::Null;
 use pfappserver::Form::Config::Source::OpenID;
 use pfappserver::Form::Config::Source::Paypal;
@@ -79,6 +80,7 @@ our %TYPES_TO_FORMS = (
       Kickbox
       LDAP
       LinkedIn
+      LocalDB
       Null
       OpenID
       Paypal

--- a/t/unittest/Authentication/Source/LocalDBSource.t
+++ b/t/unittest/Authentication/Source/LocalDBSource.t
@@ -1,0 +1,290 @@
+#!/usr/bin/perl
+
+=head1 NAME
+
+LocalDBSource
+
+=cut
+
+=head1 DESCRIPTION
+
+unit test for LocalDBSource
+
+=cut
+
+use strict;
+use warnings;
+#
+BEGIN {
+    #include test libs
+    use lib qw(/usr/local/pf/t);
+    #Module for overriding configuration paths
+    use setup_test_config;
+}
+
+use Test::More tests => 26;
+use Test::NoWarnings;
+use Test::MockModule;
+
+use pf::authentication;
+use pf::Authentication::constants;
+use pf::Authentication::Source::LocalDBSource;
+
+my %USERS = (
+    admin_user => {
+        pid          => 'admin_user',
+        access_level => 'SwitchRW',
+        category     => 'default',
+        unregdate    => '2038-01-01 00:00:00',
+        sponsor      => 0,
+    },
+    plain_user => {
+        pid      => 'plain_user',
+        category => 'guest',
+        sponsor  => 0,
+    },
+    full_user => {
+        pid                => 'full_user',
+        access_level       => 'SwitchRW',
+        access_duration    => '1D',
+        category           => 'default',
+        sponsor            => 1,
+        trigger_radius_mfa => 'radius_mfa',
+        trigger_portal_mfa => 'portal_mfa',
+    },
+);
+
+my $password_mock = Test::MockModule->new('pf::password');
+$password_mock->mock(view => sub { my ($pid) = @_; return $USERS{$pid} });
+$password_mock->mock(view_email => sub { return undef });
+
+my $person_mock = Test::MockModule->new('pf::person');
+$person_mock->mock(person_view => sub { my ($pid) = @_; return { pid => $pid } });
+
+=head2 admin_rule
+
+=cut
+
+sub admin_rule {
+    my ($id, $username) = @_;
+
+    return pf::Authentication::Rule->new({
+        id         => $id,
+        class      => $Rules::ADMIN,
+        match      => $Rules::ALL,
+        conditions => [
+            pf::Authentication::Condition->new({
+                attribute => 'username',
+                operator  => $Conditions::EQUALS,
+                value     => $username,
+            }),
+        ],
+        actions => [
+            pf::Authentication::Action->new({
+                type  => $Actions::SET_ACCESS_LEVEL,
+                value => 'RuleAccessLevel',
+            }),
+        ],
+    });
+}
+
+=head2 make_source
+
+=cut
+
+sub make_source {
+    my (%args) = @_;
+
+    my @rules;
+    if (my $username = $args{matching_username}) {
+        push @rules, admin_rule('switch_login', $username);
+    }
+
+    return pf::Authentication::Source::LocalDBSource->new({
+        id    => 'local_db',
+        rules => \@rules,
+        (exists $args{fallback} ? (fallback_to_static_user_attributes => $args{fallback}) : ()),
+    });
+}
+
+sub admin_params {
+    my ($username) = @_;
+    return {
+        username   => $username,
+        rule_class => $Rules::ADMIN,
+    };
+}
+
+=head2 A matching rule always wins over the stored attributes
+
+=cut
+
+{
+    my $source = make_source(matching_username => 'admin_user');
+    my ($rule) = $source->match(admin_params('admin_user'), $Actions::SET_ACCESS_LEVEL);
+    ok(defined $rule, "the administration rule matched");
+    is($rule->id, 'switch_login', "the configured rule is returned, not the fallback");
+    is($rule->actions->[0]->value, 'RuleAccessLevel', "the access level comes from the rule");
+}
+
+=head2 No matching rule falls back to the access level stored on the user
+
+=cut
+
+{
+    my $source = make_source(matching_username => 'somebody_else');
+    my ($rule, $ignore_action, $matched) = $source->match(admin_params('admin_user'), $Actions::SET_ACCESS_LEVEL);
+    ok(defined $rule, "the fallback provided a rule when no rule matched");
+    is($rule->id, 'static_user_attributes', "the fallback rule is returned");
+    is($rule->class, $Rules::ADMIN, "the fallback rule is in the requested class");
+    is($matched, 'admin_user', "the pid of the local user is returned");
+    my ($access_level) = grep { $_->type eq $Actions::SET_ACCESS_LEVEL } @{$rule->actions};
+    is($access_level->value, 'SwitchRW', "the access level comes from the password table");
+    is(scalar @{$rule->actions}, 1, "only the actions of the requested class are returned");
+}
+
+=head2 The fallback can be turned off
+
+=cut
+
+{
+    my $source = make_source(matching_username => 'somebody_else', fallback => 0);
+    my ($rule) = $source->match(admin_params('admin_user'), $Actions::SET_ACCESS_LEVEL);
+    is($rule, undef, "no match when the fallback is disabled");
+}
+
+=head2 A source that carries no value at all keeps the fallback
+
+=cut
+
+{
+    my $source = make_source(matching_username => 'somebody_else');
+    delete $source->{fallback_to_static_user_attributes};
+    my ($rule) = $source->match(admin_params('admin_user'), $Actions::SET_ACCESS_LEVEL);
+    ok(defined $rule && $rule->id eq 'static_user_attributes', "an unset option is treated as enabled");
+}
+
+=head2 The fallback also covers the authentication class
+
+=cut
+
+{
+    my $source = make_source();
+    my ($rule) = $source->match({ username => 'plain_user', rule_class => $Rules::AUTH }, $Actions::SET_ROLE);
+    ok(defined $rule, "the fallback provided a rule for the authentication class");
+    my ($role) = grep { $_->type eq $Actions::SET_ROLE } @{$rule->actions};
+    is($role->value, 'guest', "the role comes from the category of the password table");
+}
+
+=head2 Every action the SQL source builds is carried by the fallback
+
+=cut
+
+{
+    my $source = make_source();
+
+    my ($auth_rule) = $source->match({ username => 'full_user', rule_class => $Rules::AUTH });
+    my %auth = map { $_->type => $_->value } @{$auth_rule->actions};
+    is($auth{$Actions::TRIGGER_RADIUS_MFA}, 'radius_mfa', "the RADIUS MFA trigger is carried over");
+    is($auth{$Actions::TRIGGER_PORTAL_MFA}, 'portal_mfa', "the portal MFA trigger is carried over");
+    is($auth{$Actions::SET_ACCESS_DURATION}, '1D', "the access duration is carried over");
+
+    my ($admin_rule) = $source->match(admin_params('full_user'));
+    my %admin = map { $_->type => $_->value } @{$admin_rule->actions};
+    is($admin{$Actions::MARK_AS_SPONSOR}, 1, "the sponsor flag is carried over");
+    is($admin{$Actions::SET_ACCESS_LEVEL}, 'SwitchRW', "the access level is carried over");
+    ok(!exists $admin{$Actions::TRIGGER_RADIUS_MFA}, "an authentication action stays out of the administration class");
+}
+
+=head2 The user is read from the database once per match
+
+=cut
+
+{
+    my $reads = 0;
+    $password_mock->mock(view => sub { $reads++; return $USERS{$_[0]} });
+
+    my $source = pf::Authentication::Source::LocalDBSource->new({
+        id    => 'local_db',
+        rules => [ map { admin_rule("no_match_$_", "somebody_else_$_") } 1 .. 3 ],
+    });
+    $source->match(admin_params('admin_user'), $Actions::SET_ACCESS_LEVEL);
+    is($reads, 1, "three rules and the fallback share a single lookup");
+
+    $password_mock->mock(view => sub { return $USERS{$_[0]} });
+}
+
+=head2 An administration rule without conditions is worth a warning
+
+=cut
+
+{
+    my $source = make_source();
+
+    my $catchall = admin_rule('everyone', 'somebody');
+    $catchall->conditions([]);
+    like($source->unconditional_admin_rule_warning($catchall), qr/RuleAccessLevel/,
+        "a conditionless administration rule is reported with the access level it grants");
+
+    is($source->unconditional_admin_rule_warning(admin_rule('switch_login', 'admin_user')), undef,
+        "a rule with a condition is not reported");
+
+    my $network_catchall = pf::Authentication::Rule->new({
+        id         => 'catchall',
+        class      => $Rules::AUTH,
+        match      => $Rules::ALL,
+        conditions => [],
+        actions    => [ pf::Authentication::Action->new({ type => $Actions::SET_ROLE, value => 'guest' }) ],
+    });
+    is($source->unconditional_admin_rule_warning($network_catchall), undef,
+        "a conditionless authentication rule is left alone");
+}
+
+=head2 An unknown user never matches
+
+=cut
+
+{
+    my $source = make_source();
+    my ($rule) = $source->match(admin_params('unknown_user'), $Actions::SET_ACCESS_LEVEL);
+    is($rule, undef, "a user that is not in the password table does not match");
+}
+
+=head2 A user without the requested action does not match either
+
+=cut
+
+{
+    my $source = make_source();
+    my ($rule) = $source->match(admin_params('plain_user'), $Actions::SET_ACCESS_LEVEL);
+    is($rule, undef, "a user without an access level does not match an administration request");
+}
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2026 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;

--- a/t/unittest/UnifiedApi/Controller/Config/Sources/LocalDB.t
+++ b/t/unittest/UnifiedApi/Controller/Config/Sources/LocalDB.t
@@ -1,0 +1,103 @@
+#!/usr/bin/perl
+
+=head1 NAME
+
+LocalDB
+
+=head1 DESCRIPTION
+
+unit test for LocalDB
+
+=cut
+
+use strict;
+use warnings;
+#
+BEGIN {
+    #include test libs
+    use lib qw(/usr/local/pf/t);
+    #Module for overriding configuration paths
+    use setup_test_config;
+}
+
+use Test::More tests => 11;
+
+#This test will running last
+use Test::NoWarnings;
+use Test::Mojo;
+
+my $t = Test::Mojo->new('pf::UnifiedApi');
+use pf::ConfigStore::Source;
+use Utils;
+my ($fh, $filename) = Utils::tempfileForConfigStore("pf::ConfigStore::Source");
+
+my $collection_base_url = '/api/v1/config/sources';
+
+my $base_url = '/api/v1/config/source';
+my $id = "id_$$";
+
+$t->post_ok("$collection_base_url" =>
+    json => {
+        type        => 'LocalDB',
+        id          => $id,
+        description => "Test",
+        realms      => ["null"],
+        fallback_to_static_user_attributes => '0',
+        administration_rules => [
+            {
+                "actions" => [
+                    {
+                        "type"  => "set_access_level",
+                        "value" => ["ALL"]
+                    }
+                ],
+                "conditions"  => [],
+                "description" => "All admins",
+                "id"          => "admins",
+                "match"       => "all",
+                "status"      => "enabled"
+            }
+        ],
+        authentication_rules => [],
+    }
+  )
+  ->status_is(201);
+
+$t->get_ok("$base_url/$id")
+  ->status_is(200)
+  ->json_is('/item/class' => 'internal')
+  ->json_is('/item/realms' => ["null"])
+  ->json_is('/item/fallback_to_static_user_attributes' => '0');
+
+$t->options_ok("$collection_base_url?type=LocalDB")
+  ->status_is(200)
+  ->json_has('/meta/fallback_to_static_user_attributes');
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2026 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;


### PR DESCRIPTION
# Description

Adds a `Local Database` authentication source. It authenticates the users stored in the PacketFence database (`password` / `person` tables), the same credential store as the internal `SQL` source, but it keeps the rule and condition engine instead of acting as a rule-less catchall: administration access levels and network roles are assigned by rules whose conditions can use the attributes stored on the local user (access level, role, unregistration date, expiration, person attributes) on top of the common conditions such as SSID, connection type, time period, realm or switch.

When no rule of the requested class matches, the source falls back to the attributes stored on the user account, the way `SQLSource` builds them today. That fallback is deliberate. The first source that authenticates a user wins, and the administration match afterwards only runs against that one source (`pf::radius::returnRadiusCli`, `pf::authentication::adminAuthentication`) - so as soon as a `Local Database` source is placed in front of the internal SQL source in a connection profile, an administrator whose rights only come from their account would lose the admin interface and the switch CLI, with no way left to fix the rules. `fallback_to_static_user_attributes` (enabled by default) turns the fallback off for a strictly rule-based setup.

# Impacts

- `pf::Authentication::Source::SQLSource`: the actions built from a row of the `password` table moved from `match` into `static_user_attribute_actions` (first commit). Pure extraction, `match` returns the same rule as before; `LocalDBSource` reuses the method.
- RADIUS switch CLI login and web admin login for sources of the new type.
- New source type in _Configuration -> Policies and Access Control -> Authentication Sources_.
- No database schema change, no new package, no change to existing source types.

# Delete branch after merge

YES

# Checklist

- [yes] Document the feature
- [n/a] Add OpenAPI specification - the source schemas are generated from the forms (`pf::UnifiedApi::OpenAPI::Generator::Config` / `GenerateSpec::formsToSubTypeSchemas`) and the repository has no dumper script; happy to add a regenerated `docs/api/spec/openapi.yaml` to this PR if you prefer it to travel with the change
- [yes] Add unit tests
- [n/a] Add acceptance tests (TestLink)

Tests added:

- `t/unittest/Authentication/Source/LocalDBSource.t` - rule precedence, the fallback per rule class, the fallback switch, every action the SQL source builds (including the MFA triggers and the sponsor flag), a single database lookup per match, and the catchall warning.
- `t/unittest/UnifiedApi/Controller/Config/Sources/LocalDB.t` - create the source over the API and read it back, including the associated realms and the new option.

# NEWS file entries

## New Features

* New `Local Database` authentication source: authenticates users of the internal database like the SQL source, but assigns administration access levels and network roles through rules, with an optional fallback to the attributes stored on the user account
