### PR TITLE
feat(api): proxy non sql report requests to the perl API

### DIFF
--- a/go/plugin/caddy2/api/api.go
+++ b/go/plugin/caddy2/api/api.go
@@ -154,6 +154,11 @@ func (h *APIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request, next cadd
 
 	defer panichandler.Http(ctx, w)
 
+	// Searches and options of non sql reports are proxied to the perl API
+	if rewriteNonSqlReportRequest(r) {
+		return next.ServeHTTP(w, r)
+	}
+
 	if handle, params, _ := h.router.Lookup(r.Method, r.URL.Path); handle != nil {
 		// We always default to application/json
 		w.Header().Set("Content-Type", "application/json")

--- a/go/plugin/caddy2/api/reports.go
+++ b/go/plugin/caddy2/api/reports.go
@@ -108,6 +108,65 @@ func (a *DynamicReport) AddToRouter(r *httprouter.Router) {
 	r.POST("/api/v1.1/report/:id/search", a.SearchItem)
 }
 
+const (
+	reportPathPrefix        = "/api/v1.1/report/"
+	dynamicReportPathPrefix = "/api/v1/dynamic_report/"
+	reportSearchAction      = "search"
+	reportTypeSql           = "sql"
+)
+
+// rewriteNonSqlReportRequest rewrites the path of a v1.1 report request to its
+// perl API equivalent /api/v1/dynamic_report/... when the report is not a sql
+// report. Non sql (abstract) reports are not supported here, both their search
+// and their options are still handled by the perl API.
+// It returns true when the request was rewritten and must be handed over to the
+// next handler, which reverse proxies /api/v1/* to the perl API.
+func rewriteNonSqlReportRequest(r *http.Request) bool {
+	id := reportIdForPerlApi(r.Method, r.URL.Path)
+	if len(id) == 0 {
+		return false
+	}
+	reports, err := getReports(r)
+	if err != nil {
+		return false
+	}
+	report, ok := reports[id]
+	if !ok || report.Type == reportTypeSql {
+		return false
+	}
+	r.URL.Path = dynamicReportPathPrefix + strings.TrimPrefix(r.URL.Path, reportPathPrefix)
+	r.URL.RawPath = "" // let the url escape the path for us
+	r.RequestURI = r.URL.RequestURI()
+	return true
+}
+
+// reportIdForPerlApi returns the report id of a v1.1 report request the perl
+// API can handle: POST /api/v1.1/report/:id/search and
+// OPTIONS /api/v1.1/report/:id. It returns an empty string for any other request
+func reportIdForPerlApi(method, path string) string {
+	rest, ok := strings.CutPrefix(path, reportPathPrefix)
+	if !ok {
+		return ""
+	}
+	id, action, _ := strings.Cut(rest, "/")
+	if len(id) == 0 {
+		return ""
+	}
+	switch method {
+	case http.MethodPost:
+		if action != reportSearchAction {
+			return ""
+		}
+	case http.MethodOptions:
+		if len(action) != 0 {
+			return ""
+		}
+	default:
+		return ""
+	}
+	return id
+}
+
 func (a *DynamicReport) List(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 	var body ApiBody
 	reports, err := getReports(r)
@@ -154,7 +213,8 @@ func (a *DynamicReport) SearchItem(w http.ResponseWriter, r *http.Request, p htt
 		return
 	}
 	defer r.Body.Close()
-	if inReport.Type != "sql" {
+	if inReport.Type != reportTypeSql {
+		// Should not happen, non sql reports are proxied to the perl API, see rewriteNonSqlReportSearch
 		body.QuickError(w, http.StatusBadRequest, "abstract report are deprecated, only sql reports are supported")
 		return
 	}

--- a/go/plugin/caddy2/api/reports_test.go
+++ b/go/plugin/caddy2/api/reports_test.go
@@ -248,6 +248,34 @@ func TestReporSearch(t *testing.T) {
 	})
 }
 
+func TestReportIdForPerlApi(t *testing.T) {
+	tests := []struct {
+		method   string
+		path     string
+		expected string
+	}{
+		{http.MethodPost, "/api/v1.1/report/Node::Report::Test/search", "Node::Report::Test"},
+		{http.MethodOptions, "/api/v1.1/report/Node::Report::Test", "Node::Report::Test"},
+		{http.MethodGet, "/api/v1.1/report/Node::Report::Test/search", ""},
+		{http.MethodGet, "/api/v1.1/report/Node::Report::Test", ""},
+		{http.MethodPost, "/api/v1.1/report/Node::Report::Test", ""},
+		{http.MethodOptions, "/api/v1.1/report/Node::Report::Test/search", ""},
+		{http.MethodOptions, "/api/v1.1/reports", ""},
+		{http.MethodPost, "/api/v1.1/reports", ""},
+		{http.MethodPost, "/api/v1.1/report//search", ""},
+		{http.MethodPost, "/api/v1.1/report/Node::Report::Test/foo/search", ""},
+		{http.MethodPost, "/api/v1/dynamic_report/Node::Report::Test/search", ""},
+	}
+	for _, test := range tests {
+		utils_test.IsEqStr(
+			t,
+			test.method+" "+test.path,
+			reportIdForPerlApi(test.method, test.path),
+			test.expected,
+		)
+	}
+}
+
 func TestMain(m *testing.M) {
 	var err error
 	router, err = initRouterAndDb()

--- a/lib/pf/UnifiedApi.pm
+++ b/lib/pf/UnifiedApi.pm
@@ -262,6 +262,7 @@ sub setup_api_v1_routes {
     $self->setup_api_v1_config_routes($api_v1_route->any("/config")->name("api.v1.Config"));
     $self->setup_api_v1_configurator_routes($api_v1_route->under("/configurator")->to(controller => "Configurator", action => "allowed")->name("api.v1.Configurator"));
     $self->setup_api_v1_fingerbank_routes($api_v1_route);
+    $self->setup_api_v1_dynamic_reports_routes($api_v1_route);
     $self->setup_api_v1_current_user_routes($api_v1_route);
     $self->setup_api_v1_services_routes($api_v1_route);
     $self->setup_api_v1_k8s_services_routes($api_v1_route);


### PR DESCRIPTION
# Description
The v1.1 report endpoints only support sql reports: searching a non sql (abstract) report returned a 400 and its options were built from sql only fields, so query_fields was missing and has_cursor, has_limit and has_date_range were always false.

Rewrite POST /api/v1.1/report/:id/search and OPTIONS /api/v1.1/report/:id to /api/v1/dynamic_report/:id[/search] when the report is not a sql report, and hand the request over to the next caddy handler which reverse proxies /api/v1/* to the perl API.

# Delete branch after merge
YES | NO

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
## Bug Fixes
* Add back abstract base reports

