### PR TITLE
Add wired 802.1X and dynamic VLAN support to UniFi driver

### DIFF
--- a/lib/pf/Switch/Ubiquiti/Unifi.pm
+++ b/lib/pf/Switch/Ubiquiti/Unifi.pm
@@ -51,6 +51,8 @@ sub description { 'Unifi Controller' }
 # access technology supported
 use pf::SwitchSupports qw(
     ExternalPortal
+    RadiusDynamicVlanAssignment
+    WiredDot1x
     WirelessDot1x
     WirelessMacAuth
     Flow

--- a/t/switch_supports.t
+++ b/t/switch_supports.t
@@ -429,6 +429,8 @@ is(pf::Switch::Ubiquiti::EdgeSwitch->new->supportsLldp, 1, "pf::Switch::Ubiquiti
 is(pf::Switch::Ubiquiti::Unifi->new->supportsWirelessMacAuth, 1, "pf::Switch::Ubiquiti::Unifi supportsWirelessMacAuth still works");
 is(pf::Switch::Ubiquiti::Unifi->new->supportsExternalPortal, 1, "pf::Switch::Ubiquiti::Unifi supportsExternalPortal still works");
 is(pf::Switch::Ubiquiti::Unifi->new->supportsWirelessDot1x, 1, "pf::Switch::Ubiquiti::Unifi supportsWirelessDot1x still works");
+is(pf::Switch::Ubiquiti::Unifi->new->supportsWiredDot1x, 1, "pf::Switch::Ubiquiti::Unifi supportsWiredDot1x still works");
+is(pf::Switch::Ubiquiti::Unifi->new->supportsRadiusDynamicVlanAssignment, 1, "pf::Switch::Ubiquiti::Unifi supportsRadiusDynamicVlanAssignment still works");
 is(pf::Switch::WirelessModuleTemplate->new->supportsWirelessMacAuth, 1, "pf::Switch::WirelessModuleTemplate supportsWirelessMacAuth still works");
 is(pf::Switch::WirelessModuleTemplate->new->supportsWirelessDot1x, 1, "pf::Switch::WirelessModuleTemplate supportsWirelessDot1x still works");
 is(pf::Switch::Xirrus->new->supportsWirelessMacAuth, 1, "pf::Switch::Xirrus supportsWirelessMacAuth still works");


### PR DESCRIPTION
## Summary
- Declare wired 802.1X support for the UniFi controller driver.
- Declare RADIUS dynamic VLAN assignment support.
- Cover both advertised capabilities in `t/switch_supports.t`.

## Validation
- Validated in a wired EAP-TLS pilot using a UniFi switch.
- A domain-joined Windows endpoint authenticated successfully and received its RADIUS-assigned VLAN.
- Confirmed both capabilities in the PacketFence runtime.
