### PR TITLE
feat(pfconnector): enable chisel pprof via CHISEL_PPROF env var

### DIFF
--- a/addons/pfconnector/containers/systemd-service
+++ b/addons/pfconnector/containers/systemd-service
@@ -35,6 +35,11 @@ function base_args {
     args="$args --env-file /usr/local/pfconnector-remote/var/conf/$name.env"
   fi
 
+  # Pass CHISEL_PPROF to container if set (enables the pfconnector pprof server)
+  if ! [ -z "$CHISEL_PPROF" ]; then
+    args="$args -eCHISEL_PPROF=$CHISEL_PPROF"
+  fi
+
   echo "$args"
 }
 

--- a/addons/pfconnector/systemd/packetfence-pfconnector-remote-combined.service
+++ b/addons/pfconnector/systemd/packetfence-pfconnector-remote-combined.service
@@ -6,6 +6,11 @@ After=network.service
 
 [Service]
 LimitNOFILE=infinity
+# Enable the Go pprof profiler in the pfconnector process. The container runs
+# with --network=host, so the address below is reachable on the host itself.
+# Set to 1/true for localhost:6060, or an explicit host:port. After changing,
+# run `systemctl daemon-reload` and restart the service.
+#Environment=CHISEL_PPROF=localhost:6060
 ExecStart=/usr/local/pfconnector-remote/bin/pfconnector-remote-combined-docker-wrapper
 ExecStop=/bin/bash -c "docker stop pfconnector-remote-combined ; echo Stopped"
 Restart=always

--- a/conf/systemd/packetfence-pfconnector-client.service
+++ b/conf/systemd/packetfence-pfconnector-client.service
@@ -7,6 +7,12 @@ After=packetfence-base.target packetfence-config.service packetfence-iptables.se
 [Service]
 LimitNOFILE=infinity
 Environment=LOG_LEVEL=INFO
+# Enable the Go pprof profiler in the pfconnector process. The container runs
+# with --network=host, so the address below is reachable on the host itself.
+# A distinct port from the server (6060) is used so both can profile on the
+# same host. Set to 1/true for localhost:6060, or an explicit host:port. After
+# changing, run `systemctl daemon-reload` and restart the service.
+#Environment=CHISEL_PPROF=localhost:6061
 ExecStartPre=/bin/perl -I/usr/local/pf/lib -I/usr/local/pf/lib_perl/lib/perl5 '-Mpf::services::manager::pfconnector_client' -e 'pf::services::manager::pfconnector_client->new()->generateConfig()'
 ExecStart=/usr/local/pf/sbin/pfconnector-client-docker-wrapper
 ExecStop=/bin/bash -c "docker stop pfconnector-client ; echo Stopped"

--- a/conf/systemd/packetfence-pfconnector-server.service
+++ b/conf/systemd/packetfence-pfconnector-server.service
@@ -7,6 +7,11 @@ After=packetfence-base.target packetfence-config.service packetfence-iptables.se
 [Service]
 LimitNOFILE=infinity
 Environment=LOG_LEVEL=INFO
+# Enable the Go pprof profiler in the pfconnector process. The container runs
+# with --network=host, so the address below is reachable on the host itself.
+# Set to 1/true for localhost:6060, or an explicit host:port. After changing,
+# run `systemctl daemon-reload` and restart the service.
+#Environment=CHISEL_PPROF=localhost:6060
 ExecStartPre=/bin/perl -I/usr/local/pf/lib -I/usr/local/pf/lib_perl/lib/perl5 '-Mpf::services::manager::pfconnector_server' -e 'pf::services::manager::pfconnector_server->new()->generateConfig()'
 ExecStart=/usr/local/pf/sbin/pfconnector-server-docker-wrapper
 ExecStop=/bin/bash -c "docker stop pfconnector-server ; echo Stopped"

--- a/containers/systemd-service
+++ b/containers/systemd-service
@@ -44,6 +44,11 @@ function base_args {
     args="$args -eLOG_LEVEL=$LOG_LEVEL"
   fi
 
+  # Pass CHISEL_PPROF to container if set (enables the pfconnector pprof server)
+  if ! [ -z "$CHISEL_PPROF" ]; then
+    args="$args -eCHISEL_PPROF=$CHISEL_PPROF"
+  fi
+
   echo "$args"
 }
 

--- a/debian/patches/debianize.patch
+++ b/debian/patches/debianize.patch
@@ -252,10 +252,10 @@ index cb8f01c0c5..dca05ec908 100644
  [Install]
  WantedBy=packetfence.target
 diff --git a/conf/systemd/packetfence-ip6tables.service b/conf/systemd/packetfence-ip6tables.service
-index 23d3d3d7b7..4a17261e38 100644
+index ef9c7c9e03..7fad187f97 100644
 --- a/conf/systemd/packetfence-ip6tables.service
 +++ b/conf/systemd/packetfence-ip6tables.service
-@@ -10,13 +10,13 @@ After=packetfence-iptables.service
+@@ -11,13 +11,13 @@ After=packetfence-iptables.service
  Type=simple
  ExecStart=/usr/local/pf/sbin/ip6tables_monitor.pl
  ExecStop=-/usr/bin/kill -TERM $MAINPID
@@ -418,26 +418,26 @@ index 35fc71303a..69f7fa5774 100644
  [Install]
  WantedBy=packetfence.target
 diff --git a/conf/systemd/packetfence-pfconnector-client.service b/conf/systemd/packetfence-pfconnector-client.service
-index 7a59957515..fcc47cd8ff 100644
+index d6b0e1c975..7068194aae 100644
 --- a/conf/systemd/packetfence-pfconnector-client.service
 +++ b/conf/systemd/packetfence-pfconnector-client.service
-@@ -7,7 +7,7 @@ After=packetfence-base.target packetfence-config.service packetfence-iptables.se
- [Service]
- LimitNOFILE=infinity
- Environment=LOG_LEVEL=INFO
+@@ -13,7 +13,7 @@ Environment=LOG_LEVEL=INFO
+ # same host. Set to 1/true for localhost:6060, or an explicit host:port. After
+ # changing, run `systemctl daemon-reload` and restart the service.
+ #Environment=CHISEL_PPROF=localhost:6061
 -ExecStartPre=/bin/perl -I/usr/local/pf/lib -I/usr/local/pf/lib_perl/lib/perl5 '-Mpf::services::manager::pfconnector_client' -e 'pf::services::manager::pfconnector_client->new()->generateConfig()'
 +ExecStartPre=/usr/bin/perl -I/usr/local/pf/lib -I/usr/local/pf/lib_perl/lib/perl5 '-Mpf::services::manager::pfconnector_client' -e 'pf::services::manager::pfconnector_client->new()->generateConfig()'
  ExecStart=/usr/local/pf/sbin/pfconnector-client-docker-wrapper
  ExecStop=/bin/bash -c "docker stop pfconnector-client ; echo Stopped"
  Restart=always
 diff --git a/conf/systemd/packetfence-pfconnector-server.service b/conf/systemd/packetfence-pfconnector-server.service
-index 46b4acdcb4..f4a51668dd 100644
+index 668a0ebd4c..06dc0a0925 100644
 --- a/conf/systemd/packetfence-pfconnector-server.service
 +++ b/conf/systemd/packetfence-pfconnector-server.service
-@@ -7,15 +7,15 @@ After=packetfence-base.target packetfence-config.service packetfence-iptables.se
- [Service]
- LimitNOFILE=infinity
- Environment=LOG_LEVEL=INFO
+@@ -12,15 +12,15 @@ Environment=LOG_LEVEL=INFO
+ # Set to 1/true for localhost:6060, or an explicit host:port. After changing,
+ # run `systemctl daemon-reload` and restart the service.
+ #Environment=CHISEL_PPROF=localhost:6060
 -ExecStartPre=/bin/perl -I/usr/local/pf/lib -I/usr/local/pf/lib_perl/lib/perl5 '-Mpf::services::manager::pfconnector_server' -e 'pf::services::manager::pfconnector_server->new()->generateConfig()'
 +ExecStartPre=/usr/bin/perl -I/usr/local/pf/lib -I/usr/local/pf/lib_perl/lib/perl5 '-Mpf::services::manager::pfconnector_server' -e 'pf::services::manager::pfconnector_server->new()->generateConfig()'
  ExecStart=/usr/local/pf/sbin/pfconnector-server-docker-wrapper

--- a/go/chisel/share/cos/pprof.go
+++ b/go/chisel/share/cos/pprof.go
@@ -1,17 +1,49 @@
-//go:build pprof
-// +build pprof
-
 package cos
 
 import (
 	"log"
 	"net/http"
 	_ "net/http/pprof" //import http profiler api
+	"os"
+	"strings"
 )
 
+//pprofEnv is the environment variable used to enable the net/http/pprof
+//profiling server at runtime.
+const pprofEnv = "CHISEL_PPROF"
+
+//defaultPprofAddr is used when CHISEL_PPROF is set to a plain truthy value
+//rather than an explicit listen address.
+const defaultPprofAddr = "localhost:6060"
+
+//pprofAddr resolves the CHISEL_PPROF environment variable into a listen
+//address. It returns ("", false) when profiling should stay disabled.
+//  unset / "" / "0" / "false" / "no" / "off" -> disabled
+//  "1" / "true" / "yes" / "on"               -> localhost:6060
+//  "host:port"                               -> that address (lets client
+//                                              and server avoid colliding
+//                                              on the same port)
+func pprofAddr() (string, bool) {
+	v := strings.TrimSpace(os.Getenv(pprofEnv))
+	switch strings.ToLower(v) {
+	case "", "0", "false", "no", "off":
+		return "", false
+	case "1", "true", "yes", "on":
+		return defaultPprofAddr, true
+	default:
+		return v, true
+	}
+}
+
 func init() {
+	addr, enabled := pprofAddr()
+	if !enabled {
+		return
+	}
 	go func() {
-		log.Fatal(http.ListenAndServe("localhost:6060", nil))
+		log.Printf("[pprof] listening on %s", addr)
+		if err := http.ListenAndServe(addr, nil); err != nil {
+			log.Printf("[pprof] listener on %s stopped: %s", addr, err)
+		}
 	}()
-	log.Printf("[pprof] listening on 6060")
 }


### PR DESCRIPTION
# Description
Replace the compile-time 'pprof' build tag with a runtime CHISEL_PPROF environment variable. Unset/0/false keeps profiling off; 1/true listens on localhost:6060; a host:port value binds that address (lets client and server profile on the same host without colliding on 6060).

Forward CHISEL_PPROF into the containers from the systemd-service wrappers (mirrors the LOG_LEVEL pattern) and add commented Environment= examples to the pfconnector server/client/remote-combined units, disabled by default.

# Impacts
-pfconnector pprof

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
(REQUIRED, but may be optional...)
## New Features
* Feature 1
* Feature 2

## Enhancements
* Use env variable to enable pprof in pfconnector
