### PR TITLE
fix(pfconnector): stop leaking UDP exit-node conns in chisel tunnel

### DIFF
--- a/go/chisel/share/tunnel/tunnel_out_ssh_udp.go
+++ b/go/chisel/share/tunnel/tunnel_out_ssh_udp.go
@@ -96,17 +96,30 @@ func (h *udpHandler) handleWrite(p *udpPacket) error {
 	//  array of listeners where all listeners are
 	//  sweeped periodically, removing the idle ones
 	maxConns := sharedutils.EnvOrDefaultInt("PFCONNECTOR_UDP_MAX_CONNS", 1000)
+	oneShot := false
 	if !exists {
 		if h.udpConns.len() <= maxConns {
 			go h.handleRead(p, conn)
 		} else {
-			h.Infof("exceeded max udp connections (%d)", maxConns)
+			// Over the cap no reader goroutine is spawned, and the reader is the
+			// only thing that removes a conn from the map: keep the conn just
+			// long enough for the write below, otherwise it (and its socket)
+			// leak for the lifetime of the channel.
+			oneShot = true
+			h.Infof("exceeded max udp connections (%d), reply for %s will be dropped", maxConns, p.Src)
 		}
 	}
 	// TODO: Only apply this to remotes that are specific to RADIUS
 	_, err = conn.Write(packet)
+	if oneShot {
+		h.udpConns.remove(conn.id)
+	}
 	if err != nil {
-		return err
+		// A write error only concerns this conn (it may also have just been
+		// closed by its idle reader): drop the datagram and keep the channel
+		// alive rather than tearing down every other conn with it.
+		h.Debugf("write error %s: %s", conn.id, err)
+		h.udpConns.remove(conn.id)
 	}
 
 	return nil
@@ -193,9 +206,15 @@ func (cs *udpConns) len() int {
 	return l
 }
 
+// remove closes the conn in addition to dropping it from the map: the map
+// removal alone would strand the OS socket until the GC finalizer runs (or
+// forever while referenced), which is how idle exit-node conns used to pile up.
 func (cs *udpConns) remove(id string) {
 	cs.Lock()
-	delete(cs.m, id)
+	if conn, ok := cs.m[id]; ok {
+		conn.Close()
+		delete(cs.m, id)
+	}
 	cs.Unlock()
 }
 

--- a/lib/pf/connector.pm
+++ b/lib/pf/connector.pm
@@ -18,8 +18,10 @@ has fingerbank_environment => (is => 'rw');
 
 my %connections;
 my $redis;
+my %dynreverse_cache;
 sub CLONE {
     %connections = ();
+    %dynreverse_cache = ();
     $redis = undef;
 }
 pf::AtFork->add_to_child(\&CLONE);
@@ -52,9 +54,29 @@ sub connectorServerApiClient {
     }
 }
 
+# The TTL must stay at or below the server's LAST_TOUCHED_TIMEOUT (10s): the
+# dynreverse API call is what refreshes the tunnel's LastTouched, so a longer
+# client-side TTL could let an idle tunnel be reaped while its port is still
+# being served from this cache.
+our $DYNREVERSE_CACHE_TTL = 10;
+
 sub dynreverse {
     my ($self, $to, $opts) = @_;
     $opts //= {};
+
+    # Hot paths (SNMP/CoA on every RADIUS request when *UseConnector is
+    # enabled) call this per packet; serve the port from a short per-process
+    # cache instead of POSTing to the pfconnector server every time.
+    # pod_direct connections (rare, long-lived, e.g. domain join) bypass the
+    # cache since their host depends on which server instance answers.
+    my $cache_key = $self->id . ":" . $to;
+    if (!$opts->{pod_direct}) {
+        my $entry = $dynreverse_cache{$cache_key};
+        if ($entry && $entry->{expires_at} > time) {
+            return { %{$entry->{conn}} };
+        }
+    }
+
     my $client = $self->connectorServerApiClient;
     my $connector_conn = $client->call("POST", "/api/v1/pfconnector/dynreverse", {
         to => $to,
@@ -84,6 +106,11 @@ sub dynreverse {
     }
     
     get_logger->debug("Using pfconnector dynreverse ".$connector_conn->{host}.":".$connector_conn->{port}." via ".$self->id);
+
+    if (!$opts->{pod_direct}) {
+        # Store and return copies so a caller mutating the result can't poison the cache.
+        $dynreverse_cache{$cache_key} = { conn => { %$connector_conn }, expires_at => time + $DYNREVERSE_CACHE_TTL };
+    }
 
     return $connector_conn;
 }


### PR DESCRIPTION
## Problem

A customer running MAC authentication at scale (750 switches today, 25k planned) reported unbounded memory growth in the pfconnector (chisel). Two leaks in the exit-side UDP handler (`go/chisel/share/tunnel/tunnel_out_ssh_udp.go`) — the CoA/SNMP path on a pfconnector-remote, the RADIUS path on the pfconnector server:

1. **Sockets never closed on the normal path.** `udpConns.remove()` only deleted the conn from the map without `Close()`, leaving the OS socket to the GC finalizer. Every CoA, SNMP query or RADIUS request arriving from a fresh source port leaked an fd until the next GC cycle.

2. **Permanent leak once over the conn cap.** Over `PFCONNECTOR_UDP_MAX_CONNS` (1000) no reader goroutine is spawned, but `dial()` had already stored the conn in the map — and the reader is the *only* cleanup path. Every conn dialed while over the cap stayed referenced forever (not even GC-reclaimable). The stuck entries keep the count above the cap, so once crossed, **every** new source leaks and its replies are blackholed (CoA-ACK/SNMP responses lost → retries → more traffic → faster leak).

The traffic pattern that triggers it: with `SNMPUseConnector=Y` and `radiusDeauthUseConnector` enabled (both defaults), every wired RADIUS request drives SNMP/CoA through per-switch dynreverse tunnels, each Perl-side `Net::SNMP` session / CoA using a fresh ephemeral source port = one new exit-node conn.

## Fix

**Commit 1 (Go):**
- `udpConns.remove()` now closes the conn in addition to dropping it from the map.
- The over-cap path treats the conn as a one-shot: written, then removed and closed — no permanent map entry.
- A per-conn write error now drops only that conn instead of tearing down the whole SSH channel (and every other conn on it). The conn may simply have been closed by its idle reader, and a transient ICMP-unreachable from one RADIUS backend must not kill a shared tunnel channel.

**Commit 2 (Perl):** `pf::connector::dynreverse` results are cached per-process for 10s, collapsing the per-packet POSTs to `/api/v1/pfconnector/dynreverse` from `Switch::connectRead`/deauth. TTL deliberately matches the server's `LAST_TOUCHED_TIMEOUT` (10s) so a tunnel can't be reaped while its port is still served from cache; `pod_direct` calls (domain join) bypass the cache.

## Verification on an affected deployment

- `grep "exceeded max udp connections"` in pfconnector logs — this line appearing is the smoking gun for leak #2. Post-fix it's rephrased (`reply for <src> will be dropped`); if it still shows up often, raise `PFCONNECTOR_UDP_MAX_CONNS` for that burst rate.
- `ls /proc/$(pidof pfconnector)/fd | wc -l` should plateau instead of trending up.

## Scale notes (towards 25k switches)

The remaining footprint is proportional to *active switches*, not request volume: each switch holds ~2 permanent dynreverse tunnels (SNMP + CoA), each binding a dynamic UDP port on the pfconnector-server. At 25k switches that's ~50k ports — beyond the default `ip_local_port_range` — plus per-tunnel websocket throughput limits and the `maxCheckedInConnectors=256` per-server cap. Mitigations are deployment-level: shard switches across many connectors, raise port range/ulimits, and consider `UseSNMP=N` on switch groups that don't need SNMP-derived ifIndex/VoIP detection (removes the SNMP tunnel per switch entirely).

Build/vet clean; `settings` tests pass, `tunnel` has no test files, and the pre-existing `radius_proxy` test failure is environmental (needs `/usr/share/freeradius/dictionary`).