### PR TITLE
Add source_type column to auth_log

### DIFF
--- a/db/pf-schema-X.Y.sql
+++ b/db/pf-schema-X.Y.sql
@@ -1239,6 +1239,7 @@ CREATE TABLE auth_log (
   `attempted_at` datetime NOT NULL,
   `completed_at` datetime,
   `source` varchar(255) NOT NULL,
+  `source_type` varchar(255) DEFAULT NULL,
   `profile` VARCHAR(255) DEFAULT NULL,
   KEY pid (pid),
   KEY attempted_at (attempted_at),

--- a/db/upgrade-X.X-X.Y.sql
+++ b/db/upgrade-X.X-X.Y.sql
@@ -198,6 +198,13 @@ CALL AddIndexUnlessExists('switch_observability_acls', 'switch_observability_acl
     'KEY `switch_observability_acls_mac_enforcement` (`mac`,`enforcement_timestamp`)');
 
 --
+-- Record the authentication source type alongside the source id
+--
+\! echo "Adding column source_type to auth_log...";
+CALL AddColumnUnlessExists('auth_log', 'source_type',
+    'VARCHAR(255) DEFAULT NULL AFTER `source`');
+
+--
 -- Clean up the helper / validation procedures
 --
 DROP PROCEDURE IF EXISTS ValidateVersion;

--- a/go/dal/models/auth_log_model.go
+++ b/go/dal/models/auth_log_model.go
@@ -19,6 +19,7 @@ type AuthLog struct {
 	AttemptedAt *time.Time `json:"attempted_at"`
 	CompletedAt *time.Time `json:"completed_at"`
 	Source      string     `json:"source,omitempty"`
+	SourceType  string     `json:"source_type,omitempty"`
 	Profile     string     `json:"profile,omitempty"`
 
 	DB  *gorm.DB         `json:"-" gorm:"-"`

--- a/lib/pf/auth_log.pm
+++ b/lib/pf/auth_log.pm
@@ -31,6 +31,24 @@ use pf::constants qw($ZERO_DATE);
 use pf::error qw(is_error is_success);
 use pf::log;
 
+=head2 source_type_for
+
+Resolve the authentication source type(s) from a source id, or from the
+comma-separated list of source ids recorded on failed multi-source attempts.
+
+=cut
+
+sub source_type_for {
+    my ($source) = @_;
+    return undef unless defined $source && length $source;
+    require pf::authentication;
+    my @types = map {
+        my $s = pf::authentication::getAuthenticationSource($_);
+        defined $s ? ($s->type) : ()
+    } split(/\s*,\s*/, $source);
+    return @types ? join(',', @types) : undef;
+}
+
 =head2 invalidate_previous
 
 =cut
@@ -59,6 +77,7 @@ sub record_oauth_attempt {
     my $status = pf::dal::auth_log->create({
         process_name => process_name,
         source => $source,
+        source_type => source_type_for($source),
         mac => $mac,
         attempted_at => \'NOW()',
         status => $INCOMPLETE,
@@ -93,6 +112,7 @@ sub record_guest_attempt {
     my $status = pf::dal::auth_log->create({
         process_name => process_name,
         source => $source,
+        source_type => source_type_for($source),
         mac => $mac,
         pid => ($pid // ''),
         attempted_at => \'NOW()',
@@ -126,6 +146,7 @@ sub record_auth {
     my $status = pf::dal::auth_log->create({
         process_name => process_name,
         source => $source,
+        source_type => source_type_for($source),
         mac => $mac,
         pid => ($pid // ''),
         attempted_at => \'NOW()',

--- a/lib/pf/dal/_auth_log.pm
+++ b/lib/pf/dal/_auth_log.pm
@@ -41,6 +41,7 @@ BEGIN {
         attempted_at
         completed_at
         source
+        source_type
         profile
     );
 
@@ -52,6 +53,7 @@ BEGIN {
         attempted_at => '',
         completed_at => undef,
         source => '',
+        source_type => undef,
         profile => undef,
     );
 
@@ -63,6 +65,7 @@ BEGIN {
         attempted_at
         completed_at
         source
+        source_type
         profile
     );
 
@@ -115,6 +118,12 @@ BEGIN {
             is_primary_key => 0,
             is_nullable => 0,
         },
+        source_type => {
+            type => 'VARCHAR',
+            is_auto_increment => 0,
+            is_primary_key => 0,
+            is_nullable => 1,
+        },
         profile => {
             type => 'VARCHAR',
             is_auto_increment => 0,
@@ -136,6 +145,7 @@ BEGIN {
         auth_log.attempted_at
         auth_log.completed_at
         auth_log.source
+        auth_log.source_type
         auth_log.profile
     );
 


### PR DESCRIPTION
## Description

The `auth_log` table stores the authentication source id but not its type. This adds a `source_type` column recording the source type (`SMS`, `AD`, `SAML`, ...) alongside the id.

## Changes

- **Schema** (`pf-schema-X.Y.sql`): new nullable `source_type` varchar(255) column after `source`.
- **Upgrade** (`upgrade-X.X-X.Y.sql`): idempotent `AddColumnUnlessExists` call; existing rows keep `NULL`.
- **`pf::auth_log`**: new `source_type_for()` helper resolves the type from the source id via `getAuthenticationSource`, so the captive-portal callers are unchanged. Comma-joined source ids on failed multi-source attempts yield comma-joined types; unknown/deleted source ids yield `NULL`. Only the row-creating functions populate it (`record_auth`, `record_oauth_attempt`, `record_guest_attempt`).
- **`pf::dal::_auth_log`**: field lists/meta updated, which exposes the field through the `/api/v1/auth_logs` UnifiedApi endpoints.
- **Go** (`go/dal/models/auth_log_model.go`): `SourceType` added to the gorm model.

Note: `docs/api/spec/openapi.*` is generator-produced and will pick up the new field on the next regeneration.