### PR TITLE
Sync PathUpload uploaded files to git storage

### DIFF
--- a/html/pfappserver/lib/pfappserver/Form/Field/PathUpload.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Field/PathUpload.pm
@@ -19,6 +19,7 @@ use pf::log;
 use pf::file_paths qw($conf_uploads);
 use MIME::Base64;
 use pf::cluster;
+use pfconfig::git_storage;
 has upload_namespace => ( is => 'rw', isa => 'Str', required => 1 );
 has config_prefix => ( is => 'rw', isa => 'Str', required => 1 );
 has '+writeonly' => (default => 1);
@@ -36,6 +37,14 @@ apply [
             eval { pf::cluster::sync_files([$file]) };
             if ($@) {
                 get_logger->error("Error syncing file $file: $@");
+            }
+
+            if (pfconfig::git_storage->is_enabled) {
+                my ($res, $msg) = pfconfig::git_storage->commit_file($file, strip_path_for_git_storage($file));
+                if (!$res) {
+                    get_logger->error("Error syncing file $file to git storage: $msg");
+                    $field->add_error($msg);
+                }
             }
 
             $field->noupdate(0);


### PR DESCRIPTION
## Problem

When `git_storage` is enabled (cloud/k8s deployments), files uploaded through `PathUpload` form fields were only written to the local pod (`conf/uploads/<namespace>/`) and synced across cluster members via `pf::cluster::sync_files`. In the cloud there is no cluster rsync — the file stayed on the single pod that handled the API call and was lost on pod restart, and other pods never saw it.

This affects every file-upload widget backed by `PathUpload`:
- SAML source (SP key/cert, IdP cert/CA/metadata)
- LDAP source (client cert/key, CA)
- Paypal, Htpasswd sources
- Domain (AD join certs)
- PKI providers (packetfence_local, packetfence_pki)
- mobileconfig provisioner
- any pf.conf setting of type `path` (auto-generated upload fields in `Form/Config/Pf.pm`)

## Fix

Reuse the same logic as connection profile files (`ConnectionProfiles::_sync_files`) and SSL certificates (`pf::ssl::install_file`): after writing the file, commit and push it to the git storage repository via `pfconfig::git_storage->commit_file`.

On failure, the error is logged and added to the form field, so the API returns an error instead of silently keeping the file pod-local.

Distribution to the other pods already works with the existing mechanism: saving the config triggers `ConfigStore::commitGitStorage` → `deploy` → `pull_expire` on the pfconfig pods → `git_storage->update()` copies `conf/*` (which includes `conf/uploads/`) into place.

No behavior change when `git_storage` is disabled (standalone/cluster installs).