### PR TITLE
fix(radius): fail the request when the node can't be read instead of fabricating an unreg node

### DIFF
--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -209,7 +209,13 @@ sub authorize {
 
     my ($status_code, $node_obj) = pf::dal::node->find_or_create({"mac" => $mac});
     if (is_error($status_code)) {
-        $node_obj = pf::dal::node->new({"mac" => $mac});
+        # The node could not be read (e.g. the DB is down). Answering with a
+        # fabricated default node would move a registered device to the
+        # registration VLAN and saving it at CLEANUP would clobber the real
+        # row once the DB comes back; fail the request so the NAS retries.
+        $logger->error("Unable to read node $mac from the database ($status_code). This request will be failed to avoid altering the access of the device.");
+        $RAD_REPLY_REF = [ $RADIUS::RLM_MODULE_FAIL, ('Reply-Message' => "Database is unavailable") ];
+        goto AUDIT;
     }
     $node_obj->_load_locationlog;
     if ($status_code != $STATUS::CREATED) {
@@ -976,7 +982,10 @@ sub vpn {
 
         my ($status_code, $node_obj) = pf::dal::node->find_or_create({"mac" => $mac});
         if (is_error($status_code)) {
-            $node_obj = pf::dal::node->new({"mac" => $mac});
+            # Node unreadable (e.g. DB down): fail instead of proceeding with
+            # a fabricated default node that would be saved over the real row.
+            $logger->error("Unable to read node $mac from the database ($status_code). This request will be failed to avoid altering the access of the device.");
+            return [ $RADIUS::RLM_MODULE_FAIL, ('Reply-Message' => "Database is unavailable") ];
         }
         $node_obj->_load_locationlog;
         if ($status_code != $STATUS::CREATED) {
@@ -1373,7 +1382,10 @@ sub radius_filter {
     Log::Log4perl::MDC->put( 'mac', $mac );
     my ($status_code, $node_obj) = pf::dal::node->find_or_create({"mac" => $mac});
     if (is_error($status_code)) {
-        $node_obj = pf::dal::node->new({"mac" => $mac});
+        # Node unreadable (e.g. DB down): don't evaluate filters against a
+        # fabricated default node; decline like the unknown-switch case above.
+        $logger->error("Unable to read node $mac from the database ($status_code). Skipping radius filters.");
+        return [ $RADIUS::RLM_MODULE_NOOP, ('Reply-Message' => "Database is unavailable") ];
     }
     my $connection = pf::Connection->new;
     $connection->identifyType($nas_port_type, $eap_type, $mac, $user_name, $switch, $radius_request);


### PR DESCRIPTION
# Description
Follow-up to #51aff68d3c-era fix (`fix/find-or-create-db-down-clobber`): `pf::dal::find_or_create` no longer clobbers an existing row when the DB read fails, but all three call sites in `pf::radius` caught that error and fell back to `pf::dal::node->new({mac})` — a fresh in-memory default node (`status=unreg`, `pid=default`). During a MySQL outage this still caused two problems:

- the role engine saw `status=unreg` on the fabricated object and answered the Access-Accept with the **registration VLAN**, moving a registered device off its role VLAN;
- when the DB recovered mid-request, the `CLEANUP` `$node_obj->save` (an `INSERT ... ON DUPLICATE KEY UPDATE` upsert) overwrote the real node row with the default record, re-unregistering the device through a different path than the one the dal fix closed (also producing `NULL last_seen` validation errors, since `update_last_seen`'s `SELECT NOW()` had failed while the DB was down).

This PR removes the fabricated-object fallback entirely. On a node read error:
- `authorize` and `vpn` return `RLM_MODULE_FAIL` (`Reply-Message: "Database is unavailable"`), so the NAS retries and the device keeps its current access instead of being bounced to registration;
- `radius_filter` returns `RLM_MODULE_NOOP`, matching its existing unknown-switch precedent — it declines to evaluate filters against fabricated node data (this path never saves the node).

# Impacts
- RADIUS authorize workflow (`pf::radius::authorize`) when MySQL is unreachable: the request is now failed instead of answered with the registration VLAN, and nothing is saved over the existing node row.
- VPN authorization (`pf::radius::vpn`) — same early-fail behavior.
- `radius_filter` scopes — filters are skipped (NOOP) when the node can't be read.
- Behavior change to be aware of when the DB is down: new/unknown devices get no immediate answer; the switch's retry / critical-auth handling takes over.

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature [n/a]
- [ ] Add OpenAPI specification [n/a]
- [ ] Add unit tests [no]
- [ ] Add acceptance tests (TestLink) [no]

# NEWS file entries
## Bug Fixes
* A MySQL outage during a RADIUS authorize no longer sends a registered device to the registration VLAN nor overwrites its node entry with an unregistered default record once the database recovers