### PR TITLE
fix(authentication): only query sources with admin rules on admin login

### DIFF
--- a/lib/pf/authentication.pm
+++ b/lib/pf/authentication.pm
@@ -484,10 +484,16 @@ sub adminAuthentication {
   $realm_source = ref($realm_source) eq 'ARRAY' ? $realm_source : [$realm_source];
 
   foreach my $source (@{$realm_source}) {
+    # A source can only grant an access level through one of its own administration rules,
+    # so sources without any are skipped to avoid needlessly querying them (RADIUS, LDAP, ...)
+    unless (any { $_->{class} eq $Rules::ADMIN } @{$source->rules}) {
+        get_logger->debug("Skipping source ".$source->id." for admin authentication of $stripped_username since it has no administration rules.");
+        next;
+    }
     get_logger->info("Found a realm source ".$source->id." for user $stripped_username in realm $realm.");
-    my ($result, $message, $source_id, $extra) = pf::authentication::authenticate( { 
-            'username' => $user, 
-            'password' => $password, 
+    my ($result, $message, $source_id, $extra) = pf::authentication::authenticate( {
+            'username' => $user,
+            'password' => $password,
             'rule_class' => $Rules::ADMIN,
             'context' => $pf::constants::realm::ADMIN_CONTEXT,
         }, $source);
@@ -497,9 +503,9 @@ sub adminAuthentication {
         }
 
         $extra //= {};
-        my $match = pf::authentication::match2([$source], { 
+        my $match = pf::authentication::match2([$source], {
                 username => $user,
-                rule_class => $Rules::ADMIN, 
+                rule_class => $Rules::ADMIN,
                 context => $pf::constants::realm::ADMIN_CONTEXT,
                 action => $Actions::SET_ACCESS_LEVEL,
             }, $extra);
@@ -508,7 +514,10 @@ sub adminAuthentication {
         my $roles = $values->{$Actions::SET_ACCESS_LEVEL} // "NONE";
         $roles = [split /\s*,\s*/,$roles];
 
-        return ((all{ $_ ne 'NONE'} @$roles), $roles);
+        if (all { $_ ne 'NONE' } @$roles) {
+            return ($LOGIN_SUCCESS, $roles);
+        }
+        get_logger->info("User $user authenticated on source ".$source->id." but no administration rule granted an access level. Trying next source.");
     }
   }
 

--- a/t/unittest/authentication.t
+++ b/t/unittest/authentication.t
@@ -22,13 +22,13 @@ BEGIN {
 
 use Date::Parse;
 
-use Test::More tests => 61;                      # last test to print
+use Test::More tests => 64;                      # last test to print
 
 use Test::NoWarnings;
 
 use pf::constants;
 use pf::constants::realm;
-use pf::Authentication::constants;
+use pf::Authentication::constants qw($LOGIN_SUCCESS $LOGIN_FAILURE);
 use pf::constants::authentication::messages;
 
 # pf core libs
@@ -566,6 +566,23 @@ is_deeply(
         $source->{message},
         "line1 \$pin\nline2",
     );
+}
+
+{
+    # adminAuthentication only queries sources that have at least one administration rule.
+    # The 'local' SQL source comes first and has no administration rules: it must be skipped.
+    my @sql_authenticate_calls;
+    no warnings qw(redefine);
+    my $orig_sql_authenticate = \&pf::Authentication::Source::SQLSource::authenticate;
+    local *pf::Authentication::Source::SQLSource::authenticate = sub {
+        push @sql_authenticate_calls, $_[0]->id;
+        return $orig_sql_authenticate->(@_);
+    };
+
+    my ($result, $roles) = pf::authentication::adminAuthentication('authtest', 'authtest');
+    is($result, $LOGIN_SUCCESS, "adminAuthentication succeeds for authtest against htpasswd1");
+    is_deeply($roles, ['ALL'], "adminAuthentication returns the ALL access level for authtest");
+    is_deeply(\@sql_authenticate_calls, [], "sources without administration rules are never queried by adminAuthentication");
 }
 
 =head1 AUTHOR


### PR DESCRIPTION
# Description
When logging in to the admin UI or via the API, `pf::authentication::adminAuthentication` tried every internal authentication source in configured order until one accepted the credentials — including sources that cannot grant an admin access level because they have no `administration`-class rules. With a RADIUS or LDAP source ordered before the source holding the admin accounts, every admin/API login triggered a needless request to the remote server.

This PR changes `adminAuthentication` to:
- Skip sources without at least one administration rule. Since the access level is always matched on the same source that authenticated the user, such sources can only ever yield a `NONE` access level, so querying them (RADIUS Access-Request, LDAP bind, SQL lookup) was pure waste.
- Continue with the next source when a source authenticates the user but no administration rule grants an access level, instead of returning immediately. Previously, a permissive source ordered first could lock out a valid admin defined in a later source.

The default configuration is unaffected: in `authentication.conf.example`, admin access is granted through the `file1` Htpasswd source (which has an administration rule), while `local`, `sms`, `email`, `sponsor` and `null` have none and are now skipped at admin login. Deployments granting admin access through any source keep working as long as that source has an administration rule — which was already required for the login to succeed.

The RADIUS CLI/VPN path (`pf::radius`) also authenticates with the admin rule class but gets its sources from connection profiles; it is intentionally left untouched to avoid regressing those flows.

# Impacts
- Admin UI / API login workflow (`/api/v1/authentication/admin_authentication`, api-aaa → pfperl-api)
- `pf::authentication::adminAuthentication` only — portal, RADIUS CLI/VPN and 802.1X flows are not modified

# Delete branch after merge
YES

# Checklist
- [n/a] Document the feature
- [n/a] Add OpenAPI specification
- [x] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
## Bug Fixes
* Admin UI/API login no longer queries authentication sources that have no administration rules, avoiding needless requests to remote RADIUS/LDAP servers
* Admin login now falls through to the next source when a source authenticates the user without granting an access level, instead of denying the login