### PR TITLE
fix(fingerbank): restore rate-limited query cache and fix cache hygiene

### DIFF
--- a/addons/perl-client/lib/fingerbank/Source/Collector.pm
+++ b/addons/perl-client/lib/fingerbank/Source/Collector.pm
@@ -40,15 +40,12 @@ sub match {
         }
     }
 
-    my $Config = fingerbank::Config::get_config;    
-
     $logger->debug("Attempting to interrogate Fingerbank Collector");
 
-    my %upstream_args = map {lc($_) => $args->{lc($_)}} @fingerbank::Constant::QUERY_PARAMETERS;
-
+    # The collector builds the interrogate query from its own endpoint data;
+    # only the MAC is needed to identify the endpoint
     my $collector = fingerbank::Collector->new_from_config();
     my $ua = $collector->get_lwp_client();
-    my $query_args = encode_json(\%upstream_args);
 
     my $req = $collector->build_request("GET", "/endpoint_data/".$args->{mac}."/details");
 

--- a/addons/perl-client/lib/fingerbank/Source/LocalDB.pm
+++ b/addons/perl-client/lib/fingerbank/Source/LocalDB.pm
@@ -213,9 +213,10 @@ sub _getCombinationID {
         # If API is configured, we want an exact match to save us some time by avoiding a complex query
         my $resultset;
         if ( fingerbank::Config::configured_for_api ) {
-            # TODO : change cache key to CombinationMatchExact
-            # Should be done in a major or minor
-            my ($status, $id) = $self->cache->compute("CombinationMatch_$schema\_".encode_json(\@bindings), sub { 
+            # The key is distinct from the fuzzy CombinationMatch view below:
+            # adding/removing the API key switches which view computes the
+            # result and the two must not share cache entries
+            my ($status, $id) = $self->cache->compute("CombinationMatchExact_$schema\_".encode_json(\@bindings), sub {
                 my $view_class = "fingerbank::Schema::".$db->schema."::CombinationMatchExact";
                 my $bind_params = $view_class->view_bind_params(\@bindings);
                 $logger->trace("Bind params : ".join(',', @$bind_params));

--- a/lib/pf/fingerbank.pm
+++ b/lib/pf/fingerbank.pm
@@ -55,6 +55,10 @@ our %ACTION_MAP = (
     "update-upstream-db" => sub {
         pf::fingerbank::_update_fingerbank_component("Upstream database", sub{
             my ($status, $status_msg) = fingerbank::DB::update_upstream();
+            # The upstream SQLite file was replaced: the model and combination
+            # ids cached in the fingerbank CHI namespace refer to the old
+            # database, so clear them instead of serving them for up to 24h
+            clear_cache() if fingerbank::Util::is_success($status);
             return ($status, $status_msg);
         });
     },
@@ -89,6 +93,11 @@ sub process {
     my $timer = pf::StatsD::Timer->new();
     my ( $mac, $force, $overrides ) = @_;
     my $logger = pf::log::get_logger;
+
+    # pfqueue resets the log context before each task and nothing in the
+    # DHCP->fingerbank chain repopulates it, so without this every fingerbank
+    # log line from a queue task reads [mac:unknown]
+    Log::Log4perl::MDC->put('mac', $mac) if defined $mac;
 
     unless(fingerbank::Config::is_api_key_configured()) {
         $logger->debug("Skipping Fingerbank processing because no API key is configured");
@@ -152,7 +161,15 @@ sub process {
         $cache->set($cache_key, DateTime->now(time_zone => "local"));
         my $query_success = $TRUE;
 
-        my $query_result = _query($query_args);
+        # Rate limit the queries based on the query parameters: back-to-back
+        # lookups carrying the same profiling attributes (RADIUS interim
+        # updates, DHCP renews, ...) share the cached result for $RATE_LIMIT
+        # seconds instead of each interrogating the collector. The cache lives
+        # in the Redis-backed fingerbank namespace so the limit applies across
+        # all processes (pfqueue workers, RADIUS, portal).
+        my $query_result = $cache->compute_with_undef("fingerbank::_query-" . _query_cache_key($query_args), sub {
+            return _query($query_args);
+        }, {expires_in => $RATE_LIMIT});
 
         unless(defined($query_result)) {
             $logger->warn("Unable to perform a Fingerbank lookup for device with MAC address '$mac'");
@@ -186,9 +203,9 @@ sub process {
 Set the current Fingerbank API key as the C<Authorization> header on a collector request.
 
 The built request is cached (see L</endpoint_attributes> and L</update_collector_endpoint_data>)
-in the Redis-backed C<fingerbank> CHI namespace with no expiration, so the auth header baked in
-by C<fingerbank::Collector::build_request> would otherwise become stale when the API key is
-rotated, causing C<401 Unauthorized> from the collector until the cache is manually flushed.
+in the Redis-backed C<fingerbank> CHI namespace (24 hour default expiration), so the auth header
+baked in by C<fingerbank::Collector::build_request> would otherwise become stale when the API key
+is rotated, causing C<401 Unauthorized> from the collector until the cached request expires.
 Refreshing the header at request time keeps it in sync with C<fingerbank.conf> (which
 C<fingerbank::Config> reloads on file mtime change).
 
@@ -290,6 +307,23 @@ sub update_collector_endpoint_data {
         get_logger->error("Error while communicating with the Fingerbank collector. ".$res->status_line);
         return undef;
     }
+}
+
+=head2 _query_cache_key
+
+Build a cache key from the profiling-relevant query parameters (the ones
+consumed by L<fingerbank::Query>) so that repeated lookups with identical
+parameters can share a cached result. The remaining endpoint attributes
+returned by the collector (counters, timestamps, ...) change with almost any
+traffic and must not be part of the key.
+
+=cut
+
+sub _query_cache_key {
+    my ($query_args) = @_;
+    my %params = map { my $k = lc($_); ($k => $query_args->{$k}) } @fingerbank::Constant::QUERY_PARAMETERS;
+    $params{mac} = $query_args->{mac};
+    return JSON::MaybeXS->new->canonical->encode(\%params);
 }
 
 =head2 _query


### PR DESCRIPTION
## Problem

On busy deployments, pfqueue logs fill with lines like:

```
pfqueue(...) INFO: [mac:unknown] Successfully interrogate upstream Fingerbank project for matching. Got device : 81467 (fingerbank::Source::Collector::match)
```

Every one of those is a `pf::fingerbank::process()` run that fell through to the collector's `/endpoint_data/<mac>/details` endpoint. Nothing deduplicates identical back-to-back lookups:

- `pf::radius` calls `process($mac)` on **every** RADIUS accounting Start/Interim-Update (`lib/pf/radius.pm:482`), completely ungated — interim updates typically fire every few minutes per session.
- The per-MAC freshness guard in `process()` compares against the collector's `last_updated`, which advances with almost any endpoint traffic, so it rarely skips for active endpoints.
- The DHCP signature cache in `pf::dhcp::processor` is process-local, so each pfqueue worker keeps its own.

History shows this dedup used to exist: fingerbank queries were cached in the shared CHI for `$RATE_LIMIT` (60s) keyed on the query params (a752bc17d2, reworked in 7c3cd722ec), and the collector-architecture rewrite (35e972e9fe) dropped it — `pf::constants::fingerbank::$RATE_LIMIT` stayed imported but unused since.

## Fix

`pf::fingerbank::process` now caches the `_query` result via `compute_with_undef` in the Redis-backed `fingerbank` CHI namespace with a `$RATE_LIMIT` (60s) TTL, keyed on the canonical JSON of the profiling-relevant parameters (`@fingerbank::Constant::QUERY_PARAMETERS` + mac). Volatile collector attributes (counters, `last_updated`) are excluded so the key is stable across calls. Since the cache is shared, the limit applies across all pfqueue workers, RADIUS and portal processes. Collector/LocalDB failures (undef) are also cached for 60s, avoiding hammering a down collector.

Also included:

- **`[mac:unknown]` log context fix** — pfqueue resets the log MDC before each task and nothing in the DHCP→fingerbank chain repopulated it, so every fingerbank log line from a queue task read `mac:unknown`. `process()` now sets the `mac` context, same pattern as `pf::radius`.
- **Clear the fingerbank cache after `update-upstream-db`** — the pfcron-driven upstream DB update replaces the SQLite file but kept serving cached model/combination ids from the old file for up to 24h. The manual `sync_local_db`/`sync_upstream_db` paths already called `clear_cache()`; the action map now does too on success.
- **Resolve the old `TODO` in `fingerbank::Source::LocalDB`** — the exact (`CombinationMatchExact`) and fuzzy (`CombinationMatch`) views shared the same cache key prefix, so adding/removing the API key could serve results computed by the other view until expiry. The exact view now uses `CombinationMatchExact_` keys.
- **Dead code removal in `fingerbank::Source::Collector::match`** — `%upstream_args`/`$query_args` were built and never used (the collector builds the interrogate query from its own endpoint data).
- **POD fix** — `_refresh_collector_auth` claimed the cached collector request has "no expiration"; it expires with the namespace default (24h).

## Companion change

This composes with the fingerbank-collector rework (akainverse/fingerbank-collector#40): PF dedups identical lookups for 60s across processes, and the collector serves unchanged interrogate queries from its content-hash cache for the full `query_cache_time` instead of re-querying the cloud API on every `LastUpdated` bump.

## Testing

- Cache key logic validated standalone: canonical ordering (insertion-order independent), volatile fields excluded, undef params encode stably, distinct params produce distinct keys.
- The cached value is plain data on both source paths (Collector: decoded JSON; LocalDB: `read_hashref` hashrefs), so it serializes cleanly through Sereal/Redis like the historical implementation did.
- Full `perl -c` was not run locally (no Moose/PF deps on the dev box) — relying on CI for the compile check.