### PR TITLE
fix(httpd.aaa): fingerbank config memory leak + effective mod_perl child recycling

### DIFF
--- a/addons/perl-client/lib/fingerbank/Config.pm
+++ b/addons/perl-client/lib/fingerbank/Config.pm
@@ -26,6 +26,13 @@ use Time::HiRes qw(time stat);
 our %Config;
 our $CACHE = fingerbank::NullCache->new;
 
+# Timestamp of the config generation this process has currently materialized
+# in %Config. Guards read_config against re-deserializing the whole tied
+# IniFiles object graph from $CACHE on every call: the graphs are pinned by
+# the Config::IniFiles section back-references and re-creating one per call
+# leaks the previous copy (multi-MB per request in httpd.aaa).
+our $LOCAL_CACHED_AT;
+
 =head1 METHODS
 
 =head2 read_config
@@ -42,16 +49,29 @@ sub read_config {
         return;
     }
 
+    my $conf_timestamp = ( stat($CONF_FILE) )[9] // 0;
+    my $conf_defaults_timestamp = ( stat($CONFIG_DEFAULTS_FILE) )[9];
+
+    # Fast path: the config this process already materialized is still
+    # current. Costs one small cache get and two stats instead of
+    # rebuilding the tied IniFiles object graph on every call.
+    if(defined($LOCAL_CACHED_AT) && tied(%Config)
+        && $LOCAL_CACHED_AT > $conf_timestamp && $LOCAL_CACHED_AT > $conf_defaults_timestamp) {
+        my $current_cached_at = $CACHE->get('fingerbank::Config::read_config-cached_at');
+        if(defined($current_cached_at) && $current_cached_at == $LOCAL_CACHED_AT) {
+            $logger->trace("Local cache hit for fingerbank config");
+            return;
+        }
+    }
+
     # Check in the cache first
     my $config_cached = $CACHE->get('fingerbank::Config::read_config');
     my $cached_at = $CACHE->get('fingerbank::Config::read_config-cached_at');
     if(defined($config_cached) && defined($cached_at)) {
-        my $conf_timestamp = ( stat($CONF_FILE) )[9];
-        my $conf_defaults_timestamp = ( stat($CONFIG_DEFAULTS_FILE) )[9];
-
         if($cached_at > $conf_timestamp && $cached_at > $conf_defaults_timestamp) {
             $logger->trace("Cache hit for fingerbank config");
             tie %Config, 'fingerbank::ConfigRestore', $config_cached;
+            $LOCAL_CACHED_AT = $cached_at;
             return;
         }
         else {
@@ -93,8 +113,10 @@ sub read_config {
 
         tied(%Config)->SetFileName($CONF_FILE);
     }
+    my $now = time;
     $CACHE->set('fingerbank::Config::read_config', tied(%Config));
-    $CACHE->set('fingerbank::Config::read_config-cached_at', time);
+    $CACHE->set('fingerbank::Config::read_config-cached_at', $now);
+    $LOCAL_CACHED_AT = $now;
 }
 
 =head2 read_defaults

--- a/conf/httpd.conf.d/httpd.aaa.tt.example
+++ b/conf/httpd.conf.d/httpd.aaa.tt.example
@@ -83,7 +83,10 @@ StartServers  4
 MinSpareServers  2
 MaxSpareServers  10
 HostnameLookups  off
-MaxRequestsPerChild  1000
+# Counts connections, not requests: persistent keep-alive clients (pfacct,
+# rlm_rest) carry up to MaxKeepAliveRequests (100) requests per connection,
+# so 100 connections ~= 10k requests before the child is recycled.
+MaxConnectionsPerChild  100
 
 SSLPassPhraseDialog  builtin
 SSLSessionCacheTimeout  300

--- a/conf/httpd.conf.d/httpd.webservices.tt.example
+++ b/conf/httpd.conf.d/httpd.webservices.tt.example
@@ -83,7 +83,10 @@ StartServers  4
 MinSpareServers  2
 MaxSpareServers  10
 HostnameLookups  off
-MaxRequestsPerChild  1000
+# Counts connections, not requests: persistent keep-alive clients carry up to
+# MaxKeepAliveRequests (100) requests per connection, so 100 connections
+# ~= 10k requests before the child is recycled.
+MaxConnectionsPerChild  100
 
 SSLPassPhraseDialog  builtin
 SSLSessionCacheTimeout  300


### PR DESCRIPTION
## Problem

httpd.aaa children grow ~2.6MB **per accounting Start/Interim request** and reach multi-GB RSS (observed: 2.4GB/child, 15GB total, host OOM). Two compounding issues:

### 1. The leak: fingerbank config graph re-materialized on every read
`fingerbank::Config::get_config` calls `read_config()` unconditionally. The cache-hit path deserializes the **entire tied `fingerbank::IniFiles` object graph** from the CHI cache and re-ties `%Config` on every invocation. One accounting request reads the config ~40 times (security-event trigger model lookups, collector/LocalDB sources, `is_api_key_configured`), and in mod_perl children the replaced graphs are never freed — the `Config::IniFiles::_section` back-references pin them. Arena profiling showed **+81 leaked `fingerbank::IniFiles` objects per request**.

### 2. The masked safety net: MaxRequestsPerChild counts connections
In Apache 2.4 `MaxRequestsPerChild` is an alias for `MaxConnectionsPerChild` — it counts **connections**. httpd.aaa/webservices clients (pfacct, rlm_rest) use persistent keep-alive connections carrying up to `MaxKeepAliveRequests` (100) requests each, so the intended 1000-request recycle point was really **~100k requests (~30h)** per child.

## Fix

- `addons/perl-client`: process-local `$LOCAL_CACHED_AT` fast path in `read_config` — one small cache get + two stats when the already-materialized config is current, instead of a full graph deserialization per call. Also a perf win (~40 Redis GET + Sereal decodes per accounting packet eliminated).
- `conf/httpd.conf.d`: `MaxConnectionsPerChild 100` in the aaa and webservices templates (portal already runs `KeepAlive Off` + `PERL_RLIMIT_AS`, unaffected).

## Validation

On a live 15.1 deployment, bursts of 300 forced `fingerbank_process` JSONRPC calls (random MACs → full processing path):

| | RSS growth per child |
|---|---|
| before | ~50 MB (~1MB/request, unbounded) |
| after (config fix only) | ~100 kB |

Leak attribution chain: per-request RSS deltas by URI → per-sub RSS probes → `Devel::Gladiator` arena type diffs → `Devel::FindRef` holder chains.

Applies cleanly to maintenance/15.1 (vendored `Config.pm` identical).