### PR TITLE
fix(authentication): don't skip match-time rule sources on admin login

### DIFF
--- a/lib/pf/authentication.pm
+++ b/lib/pf/authentication.pm
@@ -485,8 +485,11 @@ sub adminAuthentication {
 
   foreach my $source (@{$realm_source}) {
     # A source can only grant an access level through one of its own administration rules,
-    # so sources without any are skipped to avoid needlessly querying them (RADIUS, LDAP, ...)
-    unless (any { $_->{class} eq $Rules::ADMIN } @{$source->rules}) {
+    # so sources without any are skipped to avoid needlessly querying them (RADIUS, LDAP, ...).
+    # Sources that override match (SQL, HTTP) build their rules at match time instead of
+    # taking them from the configuration, so they cannot be pre-filtered on configured rules.
+    my $builds_rules_at_match_time = $source->can('match') != pf::Authentication::Source->can('match');
+    unless ($builds_rules_at_match_time || any { $_->{class} eq $Rules::ADMIN } @{$source->rules}) {
         get_logger->debug("Skipping source ".$source->id." for admin authentication of $stripped_username since it has no administration rules.");
         next;
     }


### PR DESCRIPTION
## Problem

The admin-rules pre-filter added in 4d68fd9205 skips any source without a configured `class=administration` rule during admin login, to avoid needlessly querying sources (RADIUS, LDAP, ...) that can never grant an access level.

However, SQL and HTTP sources build their rules dynamically at match time — `SQLSource::match` synthesizes the actions (including `set_access_level`) from the `password` table row, and `HTTPSource::match` from its remote authorization endpoint. They legitimately have zero configured rules, so the filter skipped them and admins stored in the database could no longer log in:

```
DEBUG: Authenticating 'admin' from source(s) file1
ERROR: unable to read password file '/usr/local/pf/conf/admin.conf' (pf::Authentication::Source::HtpasswdSource::authenticate)
DEBUG: 401 Unauthorized
```

## Fix

Exempt any source whose `match` method is overridden from `pf::Authentication::Source`, since those synthesize their rules at match time and cannot be pre-filtered on configured rules. The coderef comparison is used instead of hardcoding class names so any future dynamic-rule source is exempted automatically.

Audit of all source types: only SQLSource, HTTPSource, SAMLSource and BlackholeSource truly override `match`; the latter two are not internal sources so they never reach admin authentication. All other sources only override `match_in_subclass`/`match_rule`, which run inside the base-class `match` over configured rules, so the pre-filter remains correct for them.