### PR TITLE
Increase timeout for CPAN module installation

### DIFF
--- a/addons/packetfence-perl/install_cpan.py
+++ b/addons/packetfence-perl/install_cpan.py
@@ -76,7 +76,7 @@ def install_perl_module(dict_data):
     print(f"Installing perl module: {dict_data['ModName']} \n" )
     with open(file_log, 'w') as f:
         try:
-            process = subprocess.run(command,stdout=f,stderr=f,text=True, timeout=720)
+            process = subprocess.run(command,stdout=f,stderr=f,text=True, timeout=1440)
         except subprocess.TimeoutExpired as e:
             print('Error, timeout expired: ', e)
             return 2, file_name


### PR DESCRIPTION
Try to increase the timeout to install perl modules from 12minutes to 24 minutes

# Description
(REQUIRED)
Describe what the new code is used for.
ie: Allow PacketFence to trigger the coffee machine on wireless EAP 802.1X connection to brew a fresh espresso.

# Impacts
(REQUIRED)
Describe what to reviewer should look at. Will also help for testing purposes.
ie: - RADIUS authorize workflow

# Code / PR Dependencies
(OPTIONAL. REMOVE IF NOT NEEDED)
List the PRs or other factors on which this PR depends

# NEW Package(s) required
(OPTIONAL. REMOVE IF NOT NEEDED)
Which new package(s) (all supported distributions) are required for this PR to work.

# Issue
(OPTIONAL. REMOVE IF NOT NEEDED)
The following syntax 'fixes #ISSUE_NUMBER' will automatically closes a Github issue on pull-request merge time.
Modify the ISSUE_NUMBER in order to reflect the Github issue that need to be closed
fixes #ISSUE_NUMBER

# Delete branch after merge
(REQUIRED)
YES | NO

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ ] Document the feature
- [ ] Add OpenAPI specification
- [ ] Add unit tests
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
(REQUIRED, but may be optional...)
## New Features
* Feature 1
* Feature 2

## Enhancements
* Enhancement 1
* Enhancement 2

## Bug Fixes
If an issue exists on Github, please refer to it (name) along with it's number...
* Issue with Zammitbug in sandwich context (#42)
* Issue with Zammitbug in dinde context (#43)

# UPGRADE file entries
(OPTIONAL, but may be required...)
