### PR TITLE
fix(connector): don't dereference undef when pfdns-connector resolution fails

### DIFF
--- a/lib/pf/factory/connector.pm
+++ b/lib/pf/factory/connector.pm
@@ -96,7 +96,8 @@ sub resolve {
             $ip = $ip.".";
         }
         my ($resolved_ips, $error) = resolve_dns_with_custom_resolver($ip, $Config{pfdns_connector}{pfdns_connector_server});
-        if (!@{$resolved_ips}) {
+        if ($error || !defined($resolved_ips) || !@{$resolved_ips}) {
+            get_logger->error("Unable to resolve $fqdn through pfdns-connector: " . ($error // "no A records returned"));
             return undef; # No valid IPs resolved
         }
         # If we have multiple IPs, we take the first one


### PR DESCRIPTION
## Description

On PacketFence 15.1+, when a connector target is a hostname and the pfdns-connector DNS resolution fails, `pf::factory::connector::resolve()` dies with:

```
Can't use an undefined value as an ARRAY reference at /usr/local/pf/lib/pf/factory/connector.pm line 99.
```

`resolve_dns_with_custom_resolver()` returns `(undef, $error)` on every failure path (DNS server not configured, timeout, NXDOMAIN, no usable servers), and `resolve()` dereferenced the undef arrayref without checking. The `$error` value was also captured but never logged, hiding the actual resolution failure reason.

## Fix

Guard on the error/undef case before dereferencing, log the actual resolution error, and return undef so the caller falls through to its normal no-connector handling.