### PR TITLE
fix(connector): don't dereference undef when pfdns-connector resolution fails (15.1 backport)

### DIFF
--- a/lib/pf/factory/connector.pm
+++ b/lib/pf/factory/connector.pm
@@ -96,7 +96,8 @@ sub resolve {
             $ip = $ip.".";
         }
         my ($resolved_ips, $error) = resolve_dns_with_custom_resolver($ip, $Config{pfdns_connector}{pfdns_connector_server});
-        if (!@{$resolved_ips}) {
+        if ($error || !defined($resolved_ips) || !@{$resolved_ips}) {
+            get_logger->error("Unable to resolve $fqdn through pfdns-connector: " . ($error // "no A records returned"));
             return undef; # No valid IPs resolved
         }
         # If we have multiple IPs, we take the first one


### PR DESCRIPTION
Backport of #9226 to maintenance/15.1.

When a connector target is a hostname and the pfdns-connector DNS resolution fails, `pf::factory::connector::resolve()` dies with:

```
Can't use an undefined value as an ARRAY reference at /usr/local/pf/lib/pf/factory/connector.pm line 99.
```

`resolve_dns_with_custom_resolver()` returns `(undef, $error)` on every failure path; the fix guards the dereference and logs the actual resolution error instead.