### PR TITLE
fix(domain): enforce lower case for domain DNS name and AD FQDN

### DIFF
--- a/html/pfappserver/lib/pfappserver/Form/Config/Domain.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Domain.pm
@@ -62,6 +62,7 @@ has_field 'ad_fqdn' =>
    label => 'Active Directory server',
    required => 1,
    messages => { required => 'Please specify the FQDN of the Active Directory server' },
+   apply => [ { check => qr/^[^A-Z]*$/, message => 'FQDN must be lower case.' } ],
    tags => { after_element => \&help,
              help => 'The FQDN of the Active Directory server' },
   );
@@ -140,6 +141,7 @@ has_field 'dns_name' =>
    label => 'DNS name of the domain',
    required => 1,
    messages => { required => 'Please specify the DNS name of the domain' },
+   apply => [ { check => qr/^[^A-Z]*$/, message => 'DNS name must be lower case.' } ],
    tags => { after_element => \&help,
              help => 'The DNS name (FQDN) of the domain.' },
   );

--- a/html/pfappserver/root/src/utils/yup.js
+++ b/html/pfappserver/root/src/utils/yup.js
@@ -413,6 +413,14 @@ yup.addMethod(yup.string, 'isFQDN', function (message) {
   })
 })
 
+yup.addMethod(yup.string, 'isLowerCase', function (message) {
+  return this.test({
+    name: 'isLowerCase',
+    message: message || i18n.t('Must be lower case.'),
+    test: value => ['', null, undefined].includes(value) || value === value.toLowerCase()
+  })
+})
+
 export const isHex = (value, length = 16) => {
   return `${value}`.toLowerCase().replace(/[^0-9a-f]/g, '').length === length
 }

--- a/html/pfappserver/root/src/views/Configuration/domains/schema.js
+++ b/html/pfappserver/root/src/views/Configuration/domains/schema.js
@@ -62,7 +62,8 @@ export default (props) => {
       .nullable()
       .required(i18n.t('FQDN required.'))
       .label(i18n.t('FQDN'))
-      .isFQDN('Invalid FQDN.'),
+      .isFQDN('Invalid FQDN.')
+      .isLowerCase(i18n.t('FQDN must be lower case.')),
     ad_server: yup.string()
       .when('id', {
         is: () => !ad_fqdn || !dns_servers,
@@ -72,6 +73,7 @@ export default (props) => {
     dns_name: yup.string().nullable().label(i18n.t('DNS name'))
       .required(i18n.t('Server required.'))
       .isFQDN()
+      .isLowerCase(i18n.t('DNS name must be lower case.'))
       .domainUniqueNamesNotExistsExcept({ id, ...form }),
     dns_servers: yup.string().nullable().label(i18n.t('Servers'))
       .required(i18n.t('DNS servers required.'))


### PR DESCRIPTION
## Description

The domain configuration (`Configuration → Connectors → Domains`) accepted mixed-case values for the domain's DNS name and the Active Directory FQDN, which must be lower case.

This enforces it in two places:

- **Admin UI** (`domains/schema.js`): `dns_name` and `ad_fqdn` now fail validation with an inline error ("DNS name must be lower case." / "FQDN must be lower case.") via a new reusable `isLowerCase` yup method in `utils/yup.js`.
- **Server side** (`Form/Config/Domain.pm`): matching `apply` checks on both fields, so direct API calls to `/api/v1/config/domains` are rejected with the same per-field messages.

Existing domains saved with uppercase values will fail validation on their next edit/save, forcing correction.

## Impacts

- Admin UI domain form validation
- `/api/v1/config/domains` create/update validation