### PR TITLE
fix(ci): hand the container-job workspace back to the runner user

### DIFF
--- a/.github/workflows/main_packetfence-perl.yml
+++ b/.github/workflows/main_packetfence-perl.yml
@@ -42,7 +42,7 @@ jobs:
             exit 0
           fi
           echo "Root-owned leftovers in the workspace, e.g. $stray"
-          docker run --rm -v "$RUNNER_WORKSPACE:/w" alpine:3 chown -R "$(id -u):$(id -g)" /w \
+          docker run --rm -v "$RUNNER_WORKSPACE:/w" alpine:3 chown -hR "$(id -u):$(id -g)" /w \
             || echo "::warning title=Runner workspace ownership::Could not reclaim $RUNNER_WORKSPACE; the checkout below may fail with EACCES."
 
       - name: Regex match devel and maintenance branches 

--- a/.github/workflows/main_packetfence-perl.yml
+++ b/.github/workflows/main_packetfence-perl.yml
@@ -26,6 +26,24 @@ jobs:
       path_changes: ${{ steps.filters.outputs.src }}
       regex_match_branch: ${{ steps.regex-match.outputs.match }}
     steps:
+      # This runner's workspace can still hold root-owned files from a container
+      # job that ran before ci/runner-hooks was installed on it (see
+      # ci/runner-hooks/README.md). The checkout below cleans the workspace as
+      # the unprivileged runner user and dies on them:
+      #   Error: EACCES: permission denied, unlink '.../.git/refs/heads/<branch>'
+      # Only root can chown them back and the runner user has no sudo, so borrow
+      # root from a container. Inline rather than a local composite action:
+      # those are loaded from the workspace, which is not checked out yet.
+      - name: Reclaim workspace ownership
+        run: |
+          stray="$(find "$RUNNER_WORKSPACE" -not -uid "$(id -u)" -print -quit 2>/dev/null || true)"
+          if [ -z "$stray" ]; then
+            echo "$RUNNER_WORKSPACE is already owned by $(id -un)"
+            exit 0
+          fi
+          echo "Root-owned leftovers in the workspace, e.g. $stray"
+          docker run --rm -v "$RUNNER_WORKSPACE:/w" alpine:3 chown -R "$(id -u):$(id -g)" /w \
+            || echo "::warning title=Runner workspace ownership::Could not reclaim $RUNNER_WORKSPACE; the checkout below may fail with EACCES."
 
       - name: Regex match devel and maintenance branches 
         uses: kaisugi/action-regex-match@v1.0.0

--- a/.github/workflows/main_perl-client.yml
+++ b/.github/workflows/main_perl-client.yml
@@ -42,7 +42,7 @@ jobs:
             exit 0
           fi
           echo "Root-owned leftovers in the workspace, e.g. $stray"
-          docker run --rm -v "$RUNNER_WORKSPACE:/w" alpine:3 chown -R "$(id -u):$(id -g)" /w \
+          docker run --rm -v "$RUNNER_WORKSPACE:/w" alpine:3 chown -hR "$(id -u):$(id -g)" /w \
             || echo "::warning title=Runner workspace ownership::Could not reclaim $RUNNER_WORKSPACE; the checkout below may fail with EACCES."
 
       - name: Regex match devel and maintenance branches 

--- a/.github/workflows/main_perl-client.yml
+++ b/.github/workflows/main_perl-client.yml
@@ -26,6 +26,24 @@ jobs:
       path_changes: ${{ steps.filters.outputs.src }}
       regex_match_branch: ${{ steps.regex-match.outputs.match }}
     steps:
+      # This runner's workspace can still hold root-owned files from a container
+      # job that ran before ci/runner-hooks was installed on it (see
+      # ci/runner-hooks/README.md). The checkout below cleans the workspace as
+      # the unprivileged runner user and dies on them:
+      #   Error: EACCES: permission denied, unlink '.../.git/refs/heads/<branch>'
+      # Only root can chown them back and the runner user has no sudo, so borrow
+      # root from a container. Inline rather than a local composite action:
+      # those are loaded from the workspace, which is not checked out yet.
+      - name: Reclaim workspace ownership
+        run: |
+          stray="$(find "$RUNNER_WORKSPACE" -not -uid "$(id -u)" -print -quit 2>/dev/null || true)"
+          if [ -z "$stray" ]; then
+            echo "$RUNNER_WORKSPACE is already owned by $(id -un)"
+            exit 0
+          fi
+          echo "Root-owned leftovers in the workspace, e.g. $stray"
+          docker run --rm -v "$RUNNER_WORKSPACE:/w" alpine:3 chown -R "$(id -u):$(id -g)" /w \
+            || echo "::warning title=Runner workspace ownership::Could not reclaim $RUNNER_WORKSPACE; the checkout below may fail with EACCES."
 
       - name: Regex match devel and maintenance branches 
         uses: kaisugi/action-regex-match@v1.0.0

--- a/.github/workflows/packetfence-perl_build_image_package.yml
+++ b/.github/workflows/packetfence-perl_build_image_package.yml
@@ -28,6 +28,25 @@ jobs:
         package_version: ${{ steps.contents.outputs.data }}
 
     steps:
+      # This runner's workspace can still hold root-owned files from a container
+      # job that ran before ci/runner-hooks was installed on it (see
+      # ci/runner-hooks/README.md). The checkout below cleans the workspace as
+      # the unprivileged runner user and dies on them:
+      #   Error: EACCES: permission denied, unlink '.../.git/refs/heads/<branch>'
+      # Only root can chown them back and the runner user has no sudo, so borrow
+      # root from a container. Inline rather than a local composite action:
+      # those are loaded from the workspace, which is not checked out yet.
+      - name: Reclaim workspace ownership
+        run: |
+          stray="$(find "$RUNNER_WORKSPACE" -not -uid "$(id -u)" -print -quit 2>/dev/null || true)"
+          if [ -z "$stray" ]; then
+            echo "$RUNNER_WORKSPACE is already owned by $(id -un)"
+            exit 0
+          fi
+          echo "Root-owned leftovers in the workspace, e.g. $stray"
+          docker run --rm -v "$RUNNER_WORKSPACE:/w" alpine:3 chown -R "$(id -u):$(id -g)" /w \
+            || echo "::warning title=Runner workspace ownership::Could not reclaim $RUNNER_WORKSPACE; the checkout below may fail with EACCES."
+
       - name: Checkout repository
         uses: actions/checkout@v4    
 

--- a/.github/workflows/packetfence-perl_build_image_package.yml
+++ b/.github/workflows/packetfence-perl_build_image_package.yml
@@ -122,3 +122,13 @@ jobs:
           PACKAGE_NAME: ${{ inputs._IMAGE_TYPE == 'rhel8' &&  'packetfence-perl-*.rpm' || inputs._IMAGE_TYPE == 'debian11' && 'packetfence-perl*.deb' || inputs._IMAGE_TYPE == 'debian12' && 'packetfence-perl*.deb' }}
           ARTIFACTORY_NAME: ${{ inputs._IMAGE_TYPE == 'rhel8' &&  'package-rpm8' || inputs._IMAGE_TYPE == 'debian11' && 'package-deb11' || inputs._IMAGE_TYPE == 'debian12' && 'package-deb12' }}
           PATH_PACKAGE: ${{ inputs._IMAGE_TYPE == 'rhel8' &&  'rhel8' || 'debian' }}
+
+      # Every step above ran as root inside the container while $GITHUB_WORKSPACE is a
+      # bind mount of the runner's own workspace, so checkout's .git and the build
+      # products under addons/packetfence-perl are left owned by root. The next job to
+      # land on this runner checks out as the runner user and cannot clean them:
+      # EACCES: permission denied, unlink '.../.git/logs/refs/heads/<branch>'.
+      # $RUNNER_TEMP is created by the runner process, so it carries the right owner.
+      - name: Give the workspace back to the runner user
+        if: always()
+        run: chown -R "$(stat -c '%u:%g' "$RUNNER_TEMP")" "$GITHUB_WORKSPACE"

--- a/.github/workflows/packetfence-perl_build_image_package.yml
+++ b/.github/workflows/packetfence-perl_build_image_package.yml
@@ -44,7 +44,7 @@ jobs:
             exit 0
           fi
           echo "Root-owned leftovers in the workspace, e.g. $stray"
-          docker run --rm -v "$RUNNER_WORKSPACE:/w" alpine:3 chown -R "$(id -u):$(id -g)" /w \
+          docker run --rm -v "$RUNNER_WORKSPACE:/w" alpine:3 chown -hR "$(id -u):$(id -g)" /w \
             || echo "::warning title=Runner workspace ownership::Could not reclaim $RUNNER_WORKSPACE; the checkout below may fail with EACCES."
 
       - name: Checkout repository
@@ -150,4 +150,4 @@ jobs:
       # $RUNNER_TEMP is created by the runner process, so it carries the right owner.
       - name: Give the workspace back to the runner user
         if: always()
-        run: chown -R "$(stat -c '%u:%g' "$RUNNER_TEMP")" "$GITHUB_WORKSPACE"
+        run: chown -hR "$(stat -c '%u:%g' "$RUNNER_TEMP")" "$GITHUB_WORKSPACE"

--- a/.github/workflows/perl-client_build_package.yml
+++ b/.github/workflows/perl-client_build_package.yml
@@ -19,6 +19,25 @@ jobs:
   git_checkout:
     runs-on: package-build
     steps:
+      # This runner's workspace can still hold root-owned files from a container
+      # job that ran before ci/runner-hooks was installed on it (see
+      # ci/runner-hooks/README.md). The checkout below cleans the workspace as
+      # the unprivileged runner user and dies on them:
+      #   Error: EACCES: permission denied, unlink '.../.git/refs/heads/<branch>'
+      # Only root can chown them back and the runner user has no sudo, so borrow
+      # root from a container. Inline rather than a local composite action:
+      # those are loaded from the workspace, which is not checked out yet.
+      - name: Reclaim workspace ownership
+        run: |
+          stray="$(find "$RUNNER_WORKSPACE" -not -uid "$(id -u)" -print -quit 2>/dev/null || true)"
+          if [ -z "$stray" ]; then
+            echo "$RUNNER_WORKSPACE is already owned by $(id -un)"
+            exit 0
+          fi
+          echo "Root-owned leftovers in the workspace, e.g. $stray"
+          docker run --rm -v "$RUNNER_WORKSPACE:/w" alpine:3 chown -R "$(id -u):$(id -g)" /w \
+            || echo "::warning title=Runner workspace ownership::Could not reclaim $RUNNER_WORKSPACE; the checkout below may fail with EACCES."
+
       - name: Checkout repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/perl-client_build_package.yml
+++ b/.github/workflows/perl-client_build_package.yml
@@ -35,7 +35,7 @@ jobs:
             exit 0
           fi
           echo "Root-owned leftovers in the workspace, e.g. $stray"
-          docker run --rm -v "$RUNNER_WORKSPACE:/w" alpine:3 chown -R "$(id -u):$(id -g)" /w \
+          docker run --rm -v "$RUNNER_WORKSPACE:/w" alpine:3 chown -hR "$(id -u):$(id -g)" /w \
             || echo "::warning title=Runner workspace ownership::Could not reclaim $RUNNER_WORKSPACE; the checkout below may fail with EACCES."
 
       - name: Checkout repository

--- a/ci/runner-hooks/README.md
+++ b/ci/runner-hooks/README.md
@@ -83,6 +83,25 @@ lives in `/home/github_runner/actions-runner` and its service runs as
 Runners for the `packetfence-perl-package-build` and `package-build` labels are
 the ones that run container jobs today.
 
+## Bootstrapping a runner that is already broken
+
+The hook only runs after a job, so a workspace that is *already* root-owned
+stays broken until something with root touches it -- and the job that would fix
+it cannot even check out. Step 4 above is the direct answer, but the host may
+not be reachable when the builds are red.
+
+For that case every job that checks out on the host (`build_preparation`,
+`build_image`, `git_checkout`) starts with a `Reclaim workspace ownership` step
+that borrows root from a container -- the runner user is in the `docker` group,
+so it needs no sudo -- and chowns `$RUNNER_WORKSPACE` back before
+`actions/checkout` runs. It probes first and skips the container entirely when
+the workspace is already clean, so the cost on a healthy runner is one `find`.
+
+Workflow files are read from the branch being built, so that self-heal only
+covers branches carrying these steps: a red `devel` needs the fix merged, or
+step 4 run by hand. Once the hook is installed on every runner the steps are
+redundant and can go.
+
 ## Verify
 
 The tail of any job log on that runner should show the hook:

--- a/ci/runner-hooks/README.md
+++ b/ci/runner-hooks/README.md
@@ -1,0 +1,110 @@
+# Self-hosted runner job hooks
+
+Hooks the GitHub Actions runner service runs around every job on our
+self-hosted build machines. They are versioned here so they get reviewed, but
+they are **not** picked up from the repository: the runner reads the hook path
+from its own `.env`, so installing or changing a hook is a host-side action on
+each runner (see [Install](#install)).
+
+## Why
+
+Container jobs run as root, and `$GITHUB_WORKSPACE` (`/__w/<repo>/<repo>`
+inside the container) is a bind mount of the runner's real workspace. Every
+file such a job writes there stays root-owned after the container is gone:
+`actions/checkout`'s `.git`, build products, and the dotfiles that land in the
+runner-forced `HOME=/github/home`.
+
+The next job to land on that runner runs as the unprivileged runner user, and
+its checkout cannot clean the leftovers:
+
+```
+File was unable to be removed
+Error: EACCES: permission denied, unlink '.../.git/logs/refs/heads/<branch>'
+```
+
+`job-completed.sh` runs after every job and hands the whole `_work` tree back
+to the runner user, so no workflow has to remember to do it.
+
+Workflows may still fix up their own workspace — `build_package` in
+`.github/workflows/packetfence-perl_build_image_package.yml` does, because it
+checks out and builds as root inside a container. That step is the targeted
+fix; this hook is the catch-all for every container job, present and future.
+
+## Install
+
+Per runner host, once per runner installation. Paths below assume the runner
+lives in `/home/github_runner/actions-runner` and its service runs as
+`github_runner` — adjust to match the host.
+
+1. Install the scripts in the runner's `hooks/` directory, owned by root so the
+   runner user cannot rewrite what it is about to invoke through `sudo`:
+
+   ```bash
+   RUNNER_ROOT=/home/github_runner/actions-runner
+   sudo install -d -o root -g root -m 755 "$RUNNER_ROOT/hooks"
+   sudo install -o root -g root -m 755 \
+       ci/runner-hooks/job-completed.sh \
+       ci/runner-hooks/reclaim-workspace-ownership.sh \
+       "$RUNNER_ROOT/hooks/"
+   ```
+
+   `reclaim-workspace-ownership.sh` derives the tree it touches, and the
+   ownership to restore, from its own location — keep it inside
+   `<runner-root>/hooks/`.
+
+2. Let the runner user run the helper as root, and only the helper. The
+   trailing `""` restricts the rule to an invocation with no arguments, so it
+   cannot be turned into a `chown -R` of an arbitrary path:
+
+   ```bash
+   sudo tee /etc/sudoers.d/actions-runner-workspace >/dev/null <<'SUDOERS'
+   github_runner ALL=(root) NOPASSWD: /home/github_runner/actions-runner/hooks/reclaim-workspace-ownership.sh ""
+   SUDOERS
+   sudo chmod 440 /etc/sudoers.d/actions-runner-workspace
+   sudo visudo -c
+   ```
+
+3. Point the runner at the hook and restart it **while it is idle** — a restart
+   mid-job kills that job:
+
+   ```bash
+   echo 'ACTIONS_RUNNER_HOOK_JOB_COMPLETED=/home/github_runner/actions-runner/hooks/job-completed.sh' \
+       | sudo tee -a "$RUNNER_ROOT/.env"
+   sudo "$RUNNER_ROOT/svc.sh" stop && sudo "$RUNNER_ROOT/svc.sh" start
+   ```
+
+4. Clean up what earlier container jobs already left behind — the hook only
+   covers jobs that run after it is installed:
+
+   ```bash
+   sudo "$RUNNER_ROOT/hooks/reclaim-workspace-ownership.sh"
+   ```
+
+Runners for the `packetfence-perl-package-build` and `package-build` labels are
+the ones that run container jobs today.
+
+## Verify
+
+The tail of any job log on that runner should show the hook:
+
+```
+reclaim-workspace-ownership.sh: reclaimed 1287 path(s) under /home/github_runner/actions-runner/_work for 1001:1001
+```
+
+or, once the workspace is clean, `... is already owned by 1001:1001`. A
+failure appears as a `Runner workspace ownership` warning: the hook never fails
+the job over cleanup.
+
+## If a sudoers rule is not an option
+
+The runner user is already in the `docker` group — it has to be, to run
+container jobs — so a container can do the chown instead of `sudo`. Bind-mount
+the runner root and the helper resolves the same paths inside the container:
+
+```bash
+docker run --rm -v /home/github_runner/actions-runner:/runner \
+    debian:12 /runner/hooks/reclaim-workspace-ownership.sh
+```
+
+Swap that in for the `sudo -n` line in `job-completed.sh`, and prefer an image
+already present on the host so a job's cleanup never waits on a registry pull.

--- a/ci/runner-hooks/job-completed.sh
+++ b/ci/runner-hooks/job-completed.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -uo pipefail
+
+#############################################################################
+# job-completed.sh
+#
+# ACTIONS_RUNNER_HOOK_JOB_COMPLETED hook. The runner invokes it on the host, as
+# the runner user, after every job on this machine -- container jobs included,
+# which is the point: see reclaim-workspace-ownership.sh for what root leaves
+# behind in the bind-mounted workspace.
+#
+# A non-zero exit from a job hook fails the job, so a cleanup problem is
+# reported as a warning here and never as a build failure. The next job's
+# checkout will say so loudly enough on its own.
+#############################################################################
+
+hook_dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+helper="$hook_dir/reclaim-workspace-ownership.sh"
+
+# sudo -n: the sudoers drop-in grants this one command password-less, and the
+# hook must never block waiting on a prompt nobody can answer.
+if ! output="$(sudo -n "$helper" 2>&1)"; then
+    echo "::warning title=Runner workspace ownership::$helper failed, so root-owned files may still be in the workspace and a later job can fail with EACCES while cleaning it. Output: ${output:-<none>}"
+    exit 0
+fi
+
+echo "$output"

--- a/ci/runner-hooks/reclaim-workspace-ownership.sh
+++ b/ci/runner-hooks/reclaim-workspace-ownership.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+set -euo pipefail
+
+#############################################################################
+# reclaim-workspace-ownership.sh
+#
+# Give every file under a self-hosted runner's _work tree back to the user the
+# runner service runs as.
+#
+# Container jobs execute as root inside the container, and $GITHUB_WORKSPACE
+# (/__w/<repo>/<repo>) is a bind mount of the host workspace. Anything such a
+# job writes there -- actions/checkout's .git, build products, the dotfiles
+# that land in the runner-forced HOME=/github/home -- stays owned by root once
+# the container is gone. The next job to land on that runner runs as the
+# unprivileged runner user and its checkout cannot clean the leftovers:
+#
+#   File was unable to be removed
+#   Error: EACCES: permission denied, unlink
+#     '.../.git/logs/refs/heads/<branch>'
+#
+# Run as root from the runner's ACTIONS_RUNNER_HOOK_JOB_COMPLETED hook; see
+# README.md for the install and sudoers bits.
+#
+# It takes no arguments on purpose. The tree it touches is derived from its own
+# location, so the unprivileged caller cannot aim a root-owned recursive chown
+# at a directory of its choosing.
+#############################################################################
+
+prog="$(basename "$0")"
+
+if [[ $# -ne 0 ]]; then
+    echo "$prog: takes no arguments" >&2
+    exit 2
+fi
+
+# Installed as <runner-root>/hooks/<this script>, so the work tree and the
+# ownership to restore both come from <runner-root>.
+self="$(readlink -f "$0")"
+runner_root="$(dirname "$(dirname "$self")")"
+work_root="$runner_root/_work"
+
+# A typo'd install path must never become `chown -R` over / or /home: require a
+# work tree at least three components deep.
+IFS=/ read -ra components <<< "${work_root#/}"
+if (( ${#components[@]} < 3 )); then
+    echo "$prog: refusing to touch a tree this shallow: $work_root" >&2
+    exit 1
+fi
+
+if [[ ! -d "$work_root" ]]; then
+    echo "$prog: no runner work tree at $work_root, nothing to do"
+    exit 0
+fi
+
+# The runner root holds config.sh/.runner/.env, all written by the runner user,
+# so it is the authoritative source for the ownership jobs should leave behind.
+uid="$(stat -c '%u' "$runner_root")"
+gid="$(stat -c '%g' "$runner_root")"
+
+if (( uid == 0 )); then
+    echo "$prog: $runner_root is root-owned; refusing to guess a runner user" >&2
+    exit 1
+fi
+
+# -h so a stray symlink is retargeted rather than followed, -xdev so a mount
+# someone parked under _work is left alone.
+mapfile -d '' stray < <(find "$work_root" -xdev \( ! -uid "$uid" -o ! -gid "$gid" \) -print0)
+
+if (( ${#stray[@]} == 0 )); then
+    echo "$prog: $work_root is already owned by ${uid}:${gid}"
+    exit 0
+fi
+
+printf '%s\0' "${stray[@]}" | xargs -0 chown -h "${uid}:${gid}"
+echo "$prog: reclaimed ${#stray[@]} path(s) under $work_root for ${uid}:${gid}"


### PR DESCRIPTION
## The failure

```
File was unable to be removed
Error: EACCES: permission denied, unlink
  '/home/github_runner/actions-runner/_work/packetfence/packetfence/.git/logs/refs/heads/fix/pfconfig-reload-leak'
```

`build_package` in `packetfence-perl_build_image_package.yml` runs in a container, so as root, and `$GITHUB_WORKSPACE` (`/__w/packetfence/packetfence`) is a bind mount of the runner's own workspace. 7084238d0b gave that job a checkout step, so root now writes `.git` there — including the reflog `git checkout -B <branch>` creates — and the build steps, whose `working-directory` is inside the workspace, leave root-owned products behind them.

The next job to land on a `packetfence-perl-package-build` runner checks out as the unprivileged runner user and cannot clean any of it.

## The fix

**Targeted:** a final `if: always()` step in `build_package` chowns the workspace back, taking the uid:gid from `$RUNNER_TEMP` — created by the runner process itself — rather than hardcoding a uid.

**Catch-all:** `ci/runner-hooks/` holds a job hook that reclaims the whole `_work` tree after every job, so no future container job has to remember. It covers `_temp/_github_home` too, where the sign jobs' `.gnupg` lands because the runner forces `HOME=/github/home`.

| File | Role |
| --- | --- |
| `ci/runner-hooks/job-completed.sh` | the hook; runs on the host as the runner user, calls the helper via `sudo -n`, warns rather than failing the job |
| `ci/runner-hooks/reclaim-workspace-ownership.sh` | root helper; reclaims every non-runner-owned path under `_work` |
| `ci/runner-hooks/README.md` | install, sudoers, `.env`, verification |

Two design points worth a look:

- The helper **takes no arguments** and derives both the tree and the target uid:gid from its own location (`<runner-root>/hooks/…` → `<runner-root>/_work`, ownership read off the runner root). The sudoers rule ends in `""` so it can only be invoked argument-less. A `NOPASSWD` recursive `chown` that accepts a caller-supplied path would be straightforward root escalation for anyone able to push a workflow.
- It walks `_work` rather than just `$GITHUB_WORKSPACE`, because job hooks run on the host while a container job's `GITHUB_WORKSPACE` is a container path — deriving the tree locally avoids that mapping question entirely.

## Not merge-and-forget

`ACTIONS_RUNNER_HOOK_JOB_COMPLETED` is read from each runner's own `.env` at service start, not from this repository, so **merging does not install the hook**. Per host, while the runner is idle: install the scripts root-owned into `<runner-root>/hooks/`, add the sudoers drop-in, append the `.env` line, restart the service. Steps are in `ci/runner-hooks/README.md`.

The hook also only covers jobs that run *after* it is installed, so each `packetfence-perl-package-build` and `package-build` runner needs one manual pass over its existing workspace:

```bash
sudo /home/github_runner/actions-runner/hooks/reclaim-workspace-ownership.sh
```

The workflow-level step in this PR needs none of that and lands as soon as it merges.

## Testing

Helper exercised against a synthetic runner tree: reclaims stray root-owned paths, idempotent on a second run, retargets rather than follows a dangling symlink, and refuses arguments, shallow paths and a root-owned runner root. `job-completed.sh` failure path emits a `Runner workspace ownership` warning and exits 0, so cleanup trouble never fails a build.

CI on this branch only runs `build_preparation` — `build_images_and_packages` is gated on devel/maintenance branches or `[perl]` in the commit message. That is still the job that was failing with `EACCES`, so a green run here means the workspace is clean; exercising `build_package` itself needs a `[perl]` commit, which also pulls in `sign_package` and `upload_packages`.
