### PR TITLE
fix(ci): unbreak the perl-client and packetfence-perl package builds

### DIFF
--- a/.github/workflows/perl-client_build_package.yml
+++ b/.github/workflows/perl-client_build_package.yml
@@ -45,8 +45,11 @@ jobs:
     runs-on: package-build
     needs: git_checkout
     container:
-      # rpm, dpkg-dev, python3, pynacl, requests are pre-baked.
-      image: ghcr.io/inverse-inc/packetfence/signing-packages:latest
+      # Per-distro build image: signing-packages is debian:bookworm with signing
+      # tooling only, so 'make build_rpm' died there on a missing yum. These are
+      # the images the GitLab pipeline builds packages with (.gitlab-ci.yml:38-39),
+      # tagged with PFBUILD_DEFAULT_DEV_TAG.
+      image: ghcr.io/inverse-inc/packetfence/${{ inputs._IMAGE_TYPE == 'rhel8' && 'pfbuild-centos-8' || 'pfbuild-debian-bookworm' }}:latest
       credentials:
         username: ${{ vars.USER_GITHUB }}
         password: ${{ secrets.TOKEN_GITHUB }}
@@ -66,6 +69,18 @@ jobs:
           git config --global --add safe.directory '*'
           cd -
 
+      # psono.py needs requests + PyNaCl, which signing-packages pre-baked and the
+      # pfbuild images do not yet carry. Drop this step once they do.
+      - name: Ensure psono client deps
+        shell: bash
+        run: |
+          python3 -c 'import nacl, requests' 2>/dev/null && exit 0
+          if command -v dnf >/dev/null; then
+            dnf install -y python3-pynacl python3-requests
+          else
+            apt-get update -qq && apt-get install -y --no-install-recommends python3 python3-nacl python3-requests
+          fi
+
       - name: Build package ${{inputs._IMAGE_TYPE}}
         shell: bash
         run: |
@@ -80,7 +95,11 @@ jobs:
           set -e &&  make SHELL='sh' -e ${{ inputs._IMAGE_TYPE == 'rhel8' && 'build_rpm' || 'build_deb'}}
           ls -la "${EXECUTION_DIRECTORY}"/addons/perl-client/result/${{ inputs._IMAGE_TYPE == 'rhel8' && 'centos/8' || inputs._IMAGE_TYPE == 'debian11' && 'debian/bullseye' || inputs._IMAGE_TYPE == 'debian12' && 'debian/bookworm'}}
         env:
+          # Consumed by the package version suffix in addons/perl-client/vars.mk,
+          # which mirrors config.mk's GitLab-flavoured variables.
           CI_COMMIT_REF_NAME: ${{ inputs._BRANCH_NAME }}
+          CI_PIPELINE_ID: ${{ github.run_id }}
+          CI_COMMIT_TIMESTAMP: ${{ github.event.head_commit.timestamp }}
     
       - name: Upload the package to artifactory ${{inputs._IMAGE_TYPE}}
         uses: actions/upload-artifact@v4.4.3

--- a/.github/workflows/perl-client_build_package.yml
+++ b/.github/workflows/perl-client_build_package.yml
@@ -96,10 +96,12 @@ jobs:
           ls -la "${EXECUTION_DIRECTORY}"/addons/perl-client/result/${{ inputs._IMAGE_TYPE == 'rhel8' && 'centos/8' || inputs._IMAGE_TYPE == 'debian11' && 'debian/bullseye' || inputs._IMAGE_TYPE == 'debian12' && 'debian/bookworm'}}
         env:
           # Consumed by the package version suffix in addons/perl-client/vars.mk,
-          # which mirrors config.mk's GitLab-flavoured variables.
+          # which mirrors config.mk's GitLab-flavoured variables. CI_COMMIT_TIMESTAMP
+          # is deliberately not exported: it is unset for workflow_dispatch and
+          # schedule, and an empty value would win over vars.mk's git fallback under
+          # make -e, degrading the date component to midnight.
           CI_COMMIT_REF_NAME: ${{ inputs._BRANCH_NAME }}
           CI_PIPELINE_ID: ${{ github.run_id }}
-          CI_COMMIT_TIMESTAMP: ${{ github.event.head_commit.timestamp }}
     
       - name: Upload the package to artifactory ${{inputs._IMAGE_TYPE}}
         uses: actions/upload-artifact@v4.4.3

--- a/addons/perl-client/Makefile
+++ b/addons/perl-client/Makefile
@@ -174,7 +174,7 @@ build_rpm: dist
 	find $(HOME)/rpmbuild/$(OS_RELEASE_ID)-$(OS_RELEASE_NAME) -type f -name '*.rpm' \
 		-exec cp -fv {} $(PKG_RELEASE_DIR)/ \;
 
-# no dist dependencie because debian/source/format is 3.0 (native): debuild
+# no dist dependency because debian/source/format is 3.0 (native): debuild
 # builds straight from the tree
 .PHONY: build_deb
 build_deb: db/fingerbank_Upstream.db

--- a/addons/perl-client/Makefile
+++ b/addons/perl-client/Makefile
@@ -160,11 +160,34 @@ dist: distclean db/fingerbank_Upstream.db
 		-f fingerbank-$(FB_VERSION).tar fingerbank-$(FB_VERSION)
 	rm -rf fingerbank-$(FB_VERSION)
 
+# rpmbuild/debuild directly: gitlab-buildpkg-tools (ci-build-pkg) is gone from the
+# build images, which now come pre-baked with the toolchain. Mirrors the root
+# Makefile:248-278.
+.PHONY: build_rpm
 build_rpm: dist
-	yum install epel-release -y
-	ci-build-pkg
+	mkdir -p $(PKG_RELEASE_DIR)
+	sed -i -e "s/^Release:.*/Release:\t$(RPM_PKG_SUFFIX)%{?dist}/" $(SRC_RPMDIR)/fingerbank.spec
+	rpmbuild -ba --clean --rmsource \
+		--define "_topdir $(HOME)/rpmbuild/$(OS_RELEASE_ID)-$(OS_RELEASE_NAME)" \
+		--define "_sourcedir $(SRC_ROOT_DIR)" \
+		$(SRC_RPMDIR)/fingerbank.spec
+	find $(HOME)/rpmbuild/$(OS_RELEASE_ID)-$(OS_RELEASE_NAME) -type f -name '*.rpm' \
+		-exec cp -fv {} $(PKG_RELEASE_DIR)/ \;
 
-# no dist dependencie because build process will automatically create an archive
+# no dist dependencie because debian/source/format is 3.0 (native): debuild
+# builds straight from the tree
+.PHONY: build_deb
 build_deb: db/fingerbank_Upstream.db
 	cp $(SRC_CIDIR)/debian/.devscripts $(HOME)
-	ci-build-pkg
+	mkdir -p $(PKG_RELEASE_DIR)
+	cd $(SRC_ROOT_DIR) && DEBEMAIL="" dch \
+		--local "$(DEB_PKG_SUFFIX)" \
+		--controlmaint \
+		--release-heuristic changelog \
+		-t "build for $(CI_COMMIT_REF_NAME)"
+	sed -i -e "s/UNRELEASED/$(OS_RELEASE_NAME)/" $(SRC_DEBDIR)/changelog
+	cd $(SRC_ROOT_DIR) && debuild -us -uc --lintian-opts -i
+	find $(SRC_ROOT_DIR)/.. -maxdepth 1 -name "*$(DEB_PKG_SUFFIX)*" \
+		\( -name '*.deb' -o -name '*.dsc' -o -name '*.tar.*' -o -name '*.build*' -o -name '*.changes' \) \
+		-exec cp -fv {} $(PKG_RELEASE_DIR)/ \;
+	cd $(SRC_ROOT_DIR) && debclean

--- a/addons/perl-client/vars.mk
+++ b/addons/perl-client/vars.mk
@@ -37,3 +37,25 @@ files_to_include = $(shell find $(SRC_ROOT_DIR)/* \
 PF_DEV_RELEASE_PATH=https://raw.githubusercontent.com/inverse-inc/packetfence/devel/conf/pf-release
 # X.Y
 PF_DEV_MINOR_RELEASE=$(shell curl $(PF_DEV_RELEASE_PATH) | perl -ne 'print $$1 if (m/.*?(\d+\.\d+)./)')
+
+## Packaging
+# Mirrors config.mk:88-106 so fingerbank packages keep the version suffix that
+# ci-build-pkg produced (PKG_BUILD_SUFFIX_MODE=long). GitHub Actions exports
+# CI_COMMIT_REF_NAME and CI_PIPELINE_ID; fall back to git for manual builds.
+CI_COMMIT_REF_NAME  ?= $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null || echo local)
+CI_PIPELINE_ID      ?= 0
+CI_COMMIT_TIMESTAMP ?= $(shell git show -s --format=%cI HEAD 2>/dev/null)
+CI_COMMIT_DATE      := $(shell date -u -d "$(CI_COMMIT_TIMESTAMP)" +%Y%m%d%H%M%S 2>/dev/null || date -u +%Y%m%d%H%M%S)
+CI_COMMIT_REF_SLUG  ?= $(shell printf '%s' "$(CI_COMMIT_REF_NAME)" | tr 'A-Z' 'a-z' | tr -c 'a-z0-9\n' '-' | sed 's/-\+/-/g; s/^-//; s/-$$//')
+CI_COMMIT_REF_TILDE := $(shell printf '%s' "$(CI_COMMIT_REF_SLUG)" | tr '_/-' '~')
+
+OS_RELEASE_ID   := $(shell . /etc/os-release 2>/dev/null && printf '%s' "$$ID" || echo unknown)
+OS_RELEASE_NAME := $(shell . /etc/os-release 2>/dev/null && printf '%s' "$${VERSION_CODENAME:-$${VERSION_ID%%.*}}" || echo unknown)
+OS_RELEASE_NUM  := $(shell . /etc/os-release 2>/dev/null && printf '%04d' "$${VERSION_ID%%.*}" 2>/dev/null || printf '0000')
+
+DEB_PKG_SUFFIX  := +$(CI_COMMIT_DATE)+$(CI_PIPELINE_ID)+$(OS_RELEASE_NUM)+$(CI_COMMIT_REF_TILDE)+$(OS_RELEASE_NAME)
+RPM_PKG_SUFFIX  := $(CI_COMMIT_DATE).$(CI_PIPELINE_ID).$(OS_RELEASE_NUM).$(CI_COMMIT_REF_TILDE)
+
+# centos:8 -> result/centos/8, debian:bookworm -> result/debian/bookworm
+PKG_RESULT_DIR  ?= $(SRC_RESULTDIR)
+PKG_RELEASE_DIR  = $(PKG_RESULT_DIR)/$(OS_RELEASE_ID)/$(OS_RELEASE_NAME)

--- a/containers/packetfence-perl/debian11/Dockerfile_debian11
+++ b/containers/packetfence-perl/debian11/Dockerfile_debian11
@@ -44,13 +44,15 @@ RUN (echo o conf make_install_arg 'UNINST=1'; echo o conf commit)|PERL_MM_USE_DE
 # assertion at end of script will check everything is expected
     set -o nounset -o errexit && (echo o conf allow_installing_module_downgrades 'yes'; echo o conf commit)|${CPAN_BIN_PATH} && \
 # cpan.metacpan.org stays first: it keeps superseded releases, which the pinned
-# versions in dependencies.csv need. www.cpan.org and cpan.cpantesters.org are
-# fallbacks for when the primary indexes a release whose tarball it does not
+# versions in dependencies.csv need. www.cpan.org and mirror.csclub.uwaterloo.ca
+# are fallbacks for when the primary indexes a release whose tarball it does not
 # serve; URI-5.36 404'd there and took the whole Catalyst stack down with it.
+# All three are HTTPS: CPAN pulls CHECKSUMS from the same mirror as the tarball
+# and check_sigs is off, so a plaintext mirror would be a tampering surface.
 # disable pushy_https
     set -o nounset -o errexit &&  (echo o conf urllist 'https://cpan.metacpan.org'; \
         echo o conf urllist push 'https://www.cpan.org'; \
-        echo o conf urllist push 'http://cpan.cpantesters.org'; \
+        echo o conf urllist push 'https://mirror.csclub.uwaterloo.ca/CPAN'; \
         echo o conf commit)|${CPAN_BIN_PATH} && \
     set -o nounset -o errexit &&  (echo o conf pushy_https '0'; echo o conf commit)|${CPAN_BIN_PATH} && \
 #limit the cache to 100mb

--- a/containers/packetfence-perl/debian11/Dockerfile_debian11
+++ b/containers/packetfence-perl/debian11/Dockerfile_debian11
@@ -43,9 +43,15 @@ RUN (echo o conf make_install_arg 'UNINST=1'; echo o conf commit)|PERL_MM_USE_DE
 # allow to downgrade installed modules automatically
 # assertion at end of script will check everything is expected
     set -o nounset -o errexit && (echo o conf allow_installing_module_downgrades 'yes'; echo o conf commit)|${CPAN_BIN_PATH} && \
-# use cpan.metacpan.org to get outdated modules
+# cpan.metacpan.org stays first: it keeps superseded releases, which the pinned
+# versions in dependencies.csv need. www.cpan.org and cpan.cpantesters.org are
+# fallbacks for when the primary indexes a release whose tarball it does not
+# serve; URI-5.36 404'd there and took the whole Catalyst stack down with it.
 # disable pushy_https
-    set -o nounset -o errexit &&  (echo o conf urllist 'https://cpan.metacpan.org'; echo o conf commit)|${CPAN_BIN_PATH} && \
+    set -o nounset -o errexit &&  (echo o conf urllist 'https://cpan.metacpan.org'; \
+        echo o conf urllist push 'https://www.cpan.org'; \
+        echo o conf urllist push 'http://cpan.cpantesters.org'; \
+        echo o conf commit)|${CPAN_BIN_PATH} && \
     set -o nounset -o errexit &&  (echo o conf pushy_https '0'; echo o conf commit)|${CPAN_BIN_PATH} && \
 #limit the cache to 100mb
     set -o nounset -o errexit &&  (echo o conf build_cache 100; echo o conf commit)|${CPAN_BIN_PATH} 

--- a/containers/packetfence-perl/debian12/Dockerfile_debian12
+++ b/containers/packetfence-perl/debian12/Dockerfile_debian12
@@ -44,13 +44,15 @@ RUN (echo o conf make_install_arg 'UNINST=1'; echo o conf commit)|PERL_MM_USE_DE
 # assertion at end of script will check everything is expected
     set -o nounset -o errexit && (echo o conf allow_installing_module_downgrades 'yes'; echo o conf commit)|${CPAN_BIN_PATH} && \
 # cpan.metacpan.org stays first: it keeps superseded releases, which the pinned
-# versions in dependencies.csv need. www.cpan.org and cpan.cpantesters.org are
-# fallbacks for when the primary indexes a release whose tarball it does not
+# versions in dependencies.csv need. www.cpan.org and mirror.csclub.uwaterloo.ca
+# are fallbacks for when the primary indexes a release whose tarball it does not
 # serve; URI-5.36 404'd there and took the whole Catalyst stack down with it.
+# All three are HTTPS: CPAN pulls CHECKSUMS from the same mirror as the tarball
+# and check_sigs is off, so a plaintext mirror would be a tampering surface.
 # disable pushy_https
     set -o nounset -o errexit &&  (echo o conf urllist 'https://cpan.metacpan.org'; \
         echo o conf urllist push 'https://www.cpan.org'; \
-        echo o conf urllist push 'http://cpan.cpantesters.org'; \
+        echo o conf urllist push 'https://mirror.csclub.uwaterloo.ca/CPAN'; \
         echo o conf commit)|${CPAN_BIN_PATH} && \
     set -o nounset -o errexit &&  (echo o conf pushy_https '0'; echo o conf commit)|${CPAN_BIN_PATH} && \
 #limit the cache to 100mb

--- a/containers/packetfence-perl/debian12/Dockerfile_debian12
+++ b/containers/packetfence-perl/debian12/Dockerfile_debian12
@@ -43,9 +43,15 @@ RUN (echo o conf make_install_arg 'UNINST=1'; echo o conf commit)|PERL_MM_USE_DE
 # allow to downgrade installed modules automatically
 # assertion at end of script will check everything is expected
     set -o nounset -o errexit && (echo o conf allow_installing_module_downgrades 'yes'; echo o conf commit)|${CPAN_BIN_PATH} && \
-# use cpan.metacpan.org to get outdated modules
+# cpan.metacpan.org stays first: it keeps superseded releases, which the pinned
+# versions in dependencies.csv need. www.cpan.org and cpan.cpantesters.org are
+# fallbacks for when the primary indexes a release whose tarball it does not
+# serve; URI-5.36 404'd there and took the whole Catalyst stack down with it.
 # disable pushy_https
-    set -o nounset -o errexit &&  (echo o conf urllist 'https://cpan.metacpan.org'; echo o conf commit)|${CPAN_BIN_PATH} && \
+    set -o nounset -o errexit &&  (echo o conf urllist 'https://cpan.metacpan.org'; \
+        echo o conf urllist push 'https://www.cpan.org'; \
+        echo o conf urllist push 'http://cpan.cpantesters.org'; \
+        echo o conf commit)|${CPAN_BIN_PATH} && \
     set -o nounset -o errexit &&  (echo o conf pushy_https '0'; echo o conf commit)|${CPAN_BIN_PATH} && \
 #limit the cache to 100mb
     set -o nounset -o errexit &&  (echo o conf build_cache 100; echo o conf commit)|${CPAN_BIN_PATH} 

--- a/containers/packetfence-perl/rhel8/Dockerfile_rhel8
+++ b/containers/packetfence-perl/rhel8/Dockerfile_rhel8
@@ -61,9 +61,15 @@ RUN (echo o conf make_install_arg 'UNINST=1'; echo o conf commit)|PERL_MM_USE_DE
 # allow to downgrade installed modules automatically
 # assertion at end of script will check everything is expected
     set -o nounset -o errexit && (echo o conf allow_installing_module_downgrades 'yes'; echo o conf commit)|${CPAN_BIN_PATH} && \
-# use cpan.metacpan.org to get outdated modules
+# cpan.metacpan.org stays first: it keeps superseded releases, which the pinned
+# versions in dependencies.csv need. www.cpan.org and cpan.cpantesters.org are
+# fallbacks for when the primary indexes a release whose tarball it does not
+# serve; URI-5.36 404'd there and took the whole Catalyst stack down with it.
 # disable pushy_https
-    set -o nounset -o errexit &&  (echo o conf urllist 'https://cpan.metacpan.org'; echo o conf commit)|${CPAN_BIN_PATH} && \
+    set -o nounset -o errexit &&  (echo o conf urllist 'https://cpan.metacpan.org'; \
+        echo o conf urllist push 'https://www.cpan.org'; \
+        echo o conf urllist push 'http://cpan.cpantesters.org'; \
+        echo o conf commit)|${CPAN_BIN_PATH} && \
     set -o nounset -o errexit &&  (echo o conf pushy_https '0'; echo o conf commit)|${CPAN_BIN_PATH} && \
 #limit the cache to 100mb
     set -o nounset -o errexit &&  (echo o conf build_cache 100; echo o conf commit)|${CPAN_BIN_PATH} 

--- a/containers/packetfence-perl/rhel8/Dockerfile_rhel8
+++ b/containers/packetfence-perl/rhel8/Dockerfile_rhel8
@@ -62,13 +62,15 @@ RUN (echo o conf make_install_arg 'UNINST=1'; echo o conf commit)|PERL_MM_USE_DE
 # assertion at end of script will check everything is expected
     set -o nounset -o errexit && (echo o conf allow_installing_module_downgrades 'yes'; echo o conf commit)|${CPAN_BIN_PATH} && \
 # cpan.metacpan.org stays first: it keeps superseded releases, which the pinned
-# versions in dependencies.csv need. www.cpan.org and cpan.cpantesters.org are
-# fallbacks for when the primary indexes a release whose tarball it does not
+# versions in dependencies.csv need. www.cpan.org and mirror.csclub.uwaterloo.ca
+# are fallbacks for when the primary indexes a release whose tarball it does not
 # serve; URI-5.36 404'd there and took the whole Catalyst stack down with it.
+# All three are HTTPS: CPAN pulls CHECKSUMS from the same mirror as the tarball
+# and check_sigs is off, so a plaintext mirror would be a tampering surface.
 # disable pushy_https
     set -o nounset -o errexit &&  (echo o conf urllist 'https://cpan.metacpan.org'; \
         echo o conf urllist push 'https://www.cpan.org'; \
-        echo o conf urllist push 'http://cpan.cpantesters.org'; \
+        echo o conf urllist push 'https://mirror.csclub.uwaterloo.ca/CPAN'; \
         echo o conf commit)|${CPAN_BIN_PATH} && \
     set -o nounset -o errexit &&  (echo o conf pushy_https '0'; echo o conf commit)|${CPAN_BIN_PATH} && \
 #limit the cache to 100mb

--- a/containers/pfbuild-bookworm/Dockerfile
+++ b/containers/pfbuild-bookworm/Dockerfile
@@ -5,8 +5,10 @@ ENV PATH=/usr/local/go/bin:$PATH
 ARG GOVERSION
 ARG PF_MINOR_RELEASE
 
+# python3 + nacl + requests: addons/packetfence-perl/psono.py fetches build secrets.
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates curl gnupg devscripts equivs make git && \
+    apt-get install -y --no-install-recommends ca-certificates curl gnupg devscripts equivs make git \
+        python3 python3-nacl python3-requests && \
     install -d -m 0755 /etc/apt/keyrings && \
     curl -fsSL https://inverse.ca/downloads/GPG_PUBLIC_KEY \
         | gpg --dearmor -o /etc/apt/keyrings/packetfence.gpg && \

--- a/containers/pfbuild-centos-8/Dockerfile
+++ b/containers/pfbuild-centos-8/Dockerfile
@@ -9,7 +9,9 @@ ARG PF_MINOR_RELEASE
 RUN sed -i 's/mirrorlist/#mirrorlist/g; s|#baseurl=http://mirror.centos.org|baseurl=http://mirror.nsc.liu.se/centos-store|g' \
         /etc/yum.repos.d/CentOS-Linux-*.repo
 
-RUN dnf install -y python3 dnf-plugins-core rpm-build make git && \
+# python3-requests (baseos) pairs with python3-pynacl (EPEL, installed below):
+# addons/packetfence-perl/psono.py needs both to fetch build secrets.
+RUN dnf install -y python3 python3-requests dnf-plugins-core rpm-build make git && \
     alternatives --set python /usr/bin/python3
 
 RUN dnf -y module install ruby:3.0
@@ -34,6 +36,7 @@ RUN rpm --import https://inverse.ca/downloads/GPG_PUBLIC_KEY && \
         'module_hotfixes=1' \
         > /etc/yum.repos.d/nodejs.repo && \
     dnf install -y epel-release && \
+    dnf install -y python3-pynacl && \
     dnf upgrade -y
 
 # NodeSource workaround for https://github.com/nodesource/distributions/issues/845


### PR DESCRIPTION
# Description

Two unrelated failures had `devel` red on both package workflows. This fixes both.

**1. `perl-client_debian_rhel8_package` — wrong build container (latent since June)**

The rhel8 leg died in 56s:

```
yum install epel-release -y
sh: 1: yum: not found
make: *** [Makefile:164: build_rpm] Error 127
```

#9050 pointed the job at `signing-packages`, which is `debian:bookworm` carrying signing
tooling only, but `addons/perl-client/Makefile` still called `yum` and `ci-build-pkg` — the
last two references to gitlab-buildpkg-tools left in the tree. debian12 was broken the same
way (no `ci-build-pkg` there either); it just got cancelled by matrix fail-fast first.

It stayed hidden because `build_packages` is gated on a paths filter, and #9231 was the first
push since #9050 to touch `.github/workflows/*perl-client*`.

Fix: use the images the GitLab pipeline builds packages with (`pfbuild-centos-8`,
`pfbuild-debian-bookworm`) and call `rpmbuild`/`debuild` directly, mirroring `Makefile:248-278`.
The version-suffix and result-dir logic is ported from `config.mk:88-106` into perl-client's
`vars.mk`, so packages keep the suffix `ci-build-pkg` produced and still land in
`result/centos/8` and `result/debian/bookworm` where the upload step looks for them. The
`yum install epel-release` line is dropped — `pfbuild-centos-8` already enables EPEL.

**2. `packetfence-perl_debian_rhel8_package` — single CPAN mirror, one bad file**

The image build died after ~16 min inside `install_cpan.py`, taking ~20 Catalyst modules with it:

```
wget -O .../URI-5.36.tar.gz https://cpan.metacpan.org/authors/id/O/OA/OALDERS/URI-5.36.tar.gz
returned status 8 (wstat 2048), left ... with size 0
```

cpan.metacpan.org serves an index reading `URI 5.36  O/OA/OALDERS/URI-5.36.tar.gz` while
404'ing that exact file; www.cpan.org serves it fine. With a single-entry `urllist` CPAN has
nowhere to go, so one inconsistent mirror fails the whole image.

Fix: push `www.cpan.org` and `mirror.csclub.uwaterloo.ca` onto the list behind
`cpan.metacpan.org`. The primary stays first because it keeps superseded releases, which the
pinned versions in `dependencies.csv` rely on; the fallbacks are only reached when it cannot
serve a file. All three entries are HTTPS — CPAN fetches `CHECKSUMS` from the same mirror as
the tarball and `check_sigs` is off by default, so a plaintext entry would be a tampering
surface.

`psono.py` needs `requests` + PyNaCl, which `signing-packages` pre-baked and the pfbuild images
did not carry, so they are baked in there too. Those images are built by the GitLab pipeline, so
the workflow keeps a guarded install step that no-ops once the rebuilt images land — it can be
dropped in a follow-up.

# Impacts

CI only. No runtime or product code is touched.

- `.github/workflows/perl-client_build_package.yml` — per-distro build image, psono dep step, `CI_PIPELINE_ID`
- `addons/perl-client/Makefile`, `addons/perl-client/vars.mk` — `rpmbuild`/`debuild` instead of `ci-build-pkg`
- `containers/packetfence-perl/{rhel8,debian12,debian11}/Dockerfile_*` — CPAN mirror fallbacks
- `containers/pfbuild-{centos-8,bookworm}/Dockerfile` — psono deps pre-baked

Worth a reviewer's eye: the ported version-suffix logic in `vars.mk`, and whether the pfbuild
images are the right home for the psono python deps.

Both workflows were run green on this branch end to end — build, install test, sign, upload,
on both distros:

- `perl-client_debian_rhel8_package` — [run 32308360911](https://github.com/inverse-inc/packetfence/actions/runs/32308360911) (58m10s)
- `packetfence-perl_debian_rhel8_package` — [run 32308360898](https://github.com/inverse-inc/packetfence/actions/runs/32308360898) (58m41s)

The packetfence-perl images completed full uncached CPAN installs (34 min debian12, 48 min
rhel8) with zero `Error module installation` lines, and both fingerbank packages installed
cleanly on `redhat/ubi8:8.8` and bookworm.

Those runs were produced from a temporary `[perl-client] [perl]`-tagged commit that bypassed the
devel/maintenance branch gate; it has since been dropped from the branch. The only change after
them is the review fix below, whose effect was verified directly in a built container.

Review feedback from the automated reviewer is addressed in `fix(ci): address review on the
package build fixes`: the plaintext fallback mirror was replaced with an HTTPS one
(`cpan.cpantesters.org` serves a self-signed cert on 443, so it could not be upgraded in place),
and the `CI_COMMIT_TIMESTAMP` export was removed — it is unset for `workflow_dispatch` and
`schedule`, and under `make -e` an empty value wins over `vars.mk`'s `?=`, degrading the date
component to midnight. `vars.mk` derives it from git instead, which is correct for every event
type and identical on push.

# Delete branch after merge

YES

# Checklist
- [ ] Document the feature — n/a (CI only)
- [ ] Add OpenAPI specification — n/a
- [ ] Add unit tests — n/a; the existing `unit_tests_packages` jobs cover this and pass
- [ ] Add acceptance tests (TestLink) — n/a

# NEWS file entries

n/a — CI-only change with no user-visible behaviour.

