### PR TITLE
fix(proxysql): route processlist SELECTs to the writer hostgroup

### DIFF
--- a/conf/proxysql.conf.example
+++ b/conf/proxysql.conf.example
@@ -104,7 +104,7 @@ scheduler =
      filename="/proxysql-read-only-handler.sh"
      arg1="{\"username\":\"administrator\", \"password\":\"admin\", \"host\":\"127.0.0.1\", \"port\":6032}"
      arg2="{\"username\":\"[% mysql_pf_user %]\", \"password\":\"[% mysql_pf_pass %]\"}"
-     arg3="{\"read_write_hostgroup\":10, \"read_hostgroup\":30, \"rule_ids\":\"1,2,4\"}"
+     arg3="{\"read_write_hostgroup\":10, \"read_hostgroup\":30, \"rule_ids\":\"1,2,5\"}"
      arg4="/proxysql-read-only-handler.log"
   [% ELSE %]
      id=11

--- a/lib/pf/services/manager/proxysql.pm
+++ b/lib/pf/services/manager/proxysql.pm
@@ -273,8 +273,15 @@ EOT
     #   rule 2 — SELECT            → HG 30 (readers preferred)
     #            writer is also in HG 30 (weight=50) only as fallback
     #            if all pure readers go down ✅
-    #   rule 4 — catch-all                 → HG 10 in normal mode
-    #            scheduler rewrites 1,2,4 during degraded mode
+    #   rule 3 — SELECT on processlist     → HG 10 (writer)
+    #            netdata's mysql collector runs SET SESSION sql_log_bin=OFF
+    #            which locks its session to HG 10; without this rule its
+    #            processlist SELECT matches rule 4 → HG 30 and ProxySQL
+    #            rejects it with error 9006 (locked to hostgroup)
+    #   rule 5 — catch-all                 → HG 10 in normal mode
+    #            scheduler rewrites 1,2,5 during degraded mode
+    #            (rule 3 is deliberately NOT rewritten: a SELECT still works
+    #            on a read-only writer, and replace_pattern would break it)
     # Only generated when we actually have a reader split
     #
     # IMPORTANT: the proxysql.conf template MUST reference [% mysql_query_rules %]
@@ -303,13 +310,21 @@ mysql_query_rules =
     {
         rule_id=3,
         active=1,
+        match_pattern="(information_schema|performance_schema).processlist",
+        destination_hostgroup=$writer_hostgroup,
+        apply=1,
+        comment="processlist SELECT stays on writer — netdata session is locked to HG $writer_hostgroup by SET sql_log_bin"
+    },
+    {
+        rule_id=4,
+        active=1,
         match_pattern="^SELECT",
         destination_hostgroup=$reader_hostgroup,
         apply=1,
         comment="SELECT goes to readers — writer is also in HG $reader_hostgroup as fallback"
     },
     {
-        rule_id=4,
+        rule_id=5,
         active=1,
         match_pattern=".*",
         destination_hostgroup=$writer_hostgroup,


### PR DESCRIPTION
## Problem

netdata's `go.d` mysql collector logs this on every collection cycle when PacketFence uses ProxySQL with the reader/writer split:

```
Error 9006 (Y0000): ProxySQL Error: connection is locked to hostgroup 10 but trying to reach hostgroup 30
```

The collector runs `SET SESSION sql_log_bin=OFF` at the start of each cycle, which makes ProxySQL lock its session to the writer hostgroup (10). All of its `SHOW` queries keep working (catch-all rule → HG 10), but the process-list query is a plain `SELECT ... FROM information_schema.processlist`, which matched the `^SELECT` rule → HG 30. ProxySQL refuses to switch a locked session and returns error 9006, so the process-list charts never populate.

## Fix

- Add `rule_id=3` matching `(information_schema|performance_schema).processlist` with `destination_hostgroup=10, apply=1`, so the collector's one SELECT stays on the writer with the rest of its locked session.
- The former `^SELECT` and catch-all rules are renumbered to 4 and 5, and the read-only scheduler's `rule_ids` list in `proxysql.conf.example` is updated from `1,2,4` to `1,2,5`.
- Rule 3 is deliberately excluded from the degraded-mode rewrite: a SELECT still works on a read-only writer, and the `replace_pattern='ERROR DB IS IN R/O'` rewrite would break it.

## Deployment note

ProxySQL only parses its config file when no `proxysql.db` exists in the datadir, so existing installs need `proxysql-initial` (or an admin-interface update) for the renumbered rules to take effect.