### PR TITLE
Add controllerPort option to make the Unifi controller API port configurable

### DIFF
--- a/html/pfappserver/lib/pfappserver/Form/Config/Switch.pm
+++ b/html/pfappserver/lib/pfappserver/Form/Config/Switch.pm
@@ -296,7 +296,7 @@ has_field macSearchesSleepInterval  =>
 
 has_block definition =>
   (
-   render_list => [ qw(description type mode group deauthMethod useCoA deauthOnPrevious cliAccess ExternalPortalEnforcement VoIPEnabled VoIPLLDPDetect VoIPCDPDetect VoIPDHCPDetect VoIPFullAuthorization PostMfaValidation uplink_dynamic uplink controllerIp disconnectPort coaPort) ],
+   render_list => [ qw(description type mode group deauthMethod useCoA deauthOnPrevious cliAccess ExternalPortalEnforcement VoIPEnabled VoIPLLDPDetect VoIPCDPDetect VoIPDHCPDetect VoIPFullAuthorization PostMfaValidation uplink_dynamic uplink controllerIp controllerPort disconnectPort coaPort) ],
   );
 
 has_field 'SNMPUseConnector' =>
@@ -468,6 +468,16 @@ has_field controllerIp =>
     tags => {
         after_element => \&help,
         help => 'Use instead this IP address for de-authentication requests. Normally used for Wi-Fi only'
+    },
+  );
+
+has_field controllerPort =>
+  (
+    type => 'PosInteger',
+    label => 'Controller Port',
+    tags => {
+        after_element => \&help,
+        help => 'Port to reach the controller API. If empty, the default ports of the module will be used'
     },
   );
 

--- a/html/pfappserver/root/src/views/Configuration/switchGroups/_components/TheForm.vue
+++ b/html/pfappserver/root/src/views/Configuration/switchGroups/_components/TheForm.vue
@@ -306,6 +306,12 @@
                                   :text="$i18n.t('Use instead this IP address for de-authentication requests. Normally used for Wi-Fi only.')"
         />
 
+        <form-group-controller-port namespace="controllerPort"
+                                    v-show="supports(['WirelessMacAuth', 'WirelessDot1x'])"
+                                    :column-label="$i18n.t('Controller Port')"
+                                    :text="$i18n.t('Port to reach the controller API. If empty, the default ports of the module will be used.')"
+        />
+
         <form-group-disconnect-port namespace="disconnectPort"
                                     v-show="supports(['WiredMacAuth', 'WiredDot1x', 'WirelessMacAuth', 'WirelessDot1x'])"
                                     :column-label="$i18n.t('Disconnect Port')"
@@ -587,6 +593,7 @@ import {
   FormGroupCliUser,
   FormGroupCoaPort,
   FormGroupControllerIp,
+  FormGroupControllerPort,
   FormGroupDeauthenticationMethod,
   FormGroupDescription,
   FormGroupDisconnectPort,
@@ -674,6 +681,7 @@ const components = {
   FormGroupCliUser,
   FormGroupCoaPort,
   FormGroupControllerIp,
+  FormGroupControllerPort,
   FormGroupDeauthenticationMethod,
   FormGroupDescription,
   FormGroupDisconnectPort,

--- a/html/pfappserver/root/src/views/Configuration/switchGroups/_components/index.js
+++ b/html/pfappserver/root/src/views/Configuration/switchGroups/_components/index.js
@@ -29,6 +29,7 @@ export {
   BaseFormGroupInput                      as FormGroupCliUser,
   BaseFormGroupInputNumber                as FormGroupCoaPort,
   BaseFormGroupInput                      as FormGroupControllerIp,
+  BaseFormGroupInput                      as FormGroupControllerPort,
   BaseFormGroupChosenOne                  as FormGroupDeauthenticationMethod,
   BaseFormGroupInput                      as FormGroupDescription,
   BaseFormGroupInput                      as FormGroupDisconnectPort,

--- a/html/pfappserver/root/src/views/Configuration/switchGroups/schema.js
+++ b/html/pfappserver/root/src/views/Configuration/switchGroups/schema.js
@@ -76,6 +76,7 @@ export const schema = (props, roles) => {
     wsPwd: yup.string().nullable().label(i18n.t('Password')),
     uplink: yup.string().nullable(),
     controllerIp: yup.string().nullable(),
+    controllerPort: yup.string().nullable().minAsInt(1, i18n.t('Invalid port.')),
     disconnectPort: yup.string().nullable().minAsInt(1, i18n.t('Invalid port.')),
     coaPort: yup.string().nullable().minAsInt(1, i18n.t('Invalid port.')),
     radiusSecret: yup.string().nullable(),

--- a/html/pfappserver/root/src/views/Configuration/switches/_components/TheForm.vue
+++ b/html/pfappserver/root/src/views/Configuration/switches/_components/TheForm.vue
@@ -311,6 +311,12 @@
           :text="$i18n.t('Use instead this IP address for de-authentication requests. Normally used for Wi-Fi only.')"
         />
 
+        <form-group-controller-port namespace="controllerPort"
+          v-show="supports(['WirelessMacAuth', 'WirelessDot1x'])"
+          :column-label="$i18n.t('Controller Port')"
+          :text="$i18n.t('Port to reach the controller API. If empty, the default ports of the module will be used.')"
+        />
+
         <form-group-disconnect-port namespace="disconnectPort"
           v-show="supports(['WiredMacAuth', 'WiredDot1x', 'WirelessMacAuth', 'WirelessDot1x'])"
           :column-label="$i18n.t('Disconnect Port')"
@@ -520,6 +526,7 @@ import {
   FormGroupCliUser,
   FormGroupCoaPort,
   FormGroupControllerIp,
+  FormGroupControllerPort,
   FormGroupDeauthenticationMethod,
   FormGroupDescription,
   FormGroupDisconnectPort,
@@ -605,6 +612,7 @@ const components = {
   FormGroupCliUser,
   FormGroupCoaPort,
   FormGroupControllerIp,
+  FormGroupControllerPort,
   FormGroupDeauthenticationMethod,
   FormGroupDescription,
   FormGroupDisconnectPort,

--- a/html/pfappserver/root/src/views/Configuration/switches/_components/index.js
+++ b/html/pfappserver/root/src/views/Configuration/switches/_components/index.js
@@ -30,6 +30,7 @@ export {
   BaseFormGroupInput                      as FormGroupCliUser,
   BaseFormGroupInputNumber                as FormGroupCoaPort,
   BaseFormGroupInput                      as FormGroupControllerIp,
+  BaseFormGroupInputNumber                as FormGroupControllerPort,
   BaseFormGroupChosenOne                  as FormGroupDeauthenticationMethod,
   BaseFormGroupInput                      as FormGroupDescription,
   BaseFormGroupInputNumber                as FormGroupDisconnectPort,

--- a/html/pfappserver/root/src/views/Configuration/switches/schema.js
+++ b/html/pfappserver/root/src/views/Configuration/switches/schema.js
@@ -85,6 +85,7 @@ export const schema = (props, roles) => {
     wsPwd: yup.string().nullable().label(i18n.t('Password')),
     uplink: yup.string().nullable(),
     controllerIp: yup.string().nullable(),
+    controllerPort: yup.string().nullable().minAsInt(1, i18n.t('Invalid port.')),
     disconnectPort: yup.string().nullable().minAsInt(1, i18n.t('Invalid port.')),
     coaPort: yup.string().nullable().minAsInt(1, i18n.t('Invalid port.')),
     radiusSecret: yup.string().nullable(),

--- a/lib/pf/Switch.pm
+++ b/lib/pf/Switch.pm
@@ -173,6 +173,7 @@ sub new {
         '_wsTransport'                  => undef,
         '_radiusSecret'                 => undef,
         '_controllerIp'                 => undef,
+        '_controllerPort'               => undef,
         '_disconnectPort'               => undef,
         '_coaPort'                      => undef,
         '_uplink'                       => undef,

--- a/lib/pf/Switch/Ubiquiti/Unifi.pm
+++ b/lib/pf/Switch/Ubiquiti/Unifi.pm
@@ -200,10 +200,11 @@ sub _connect {
     $ua->timeout(10);
     $ua->default_header('Content-Type' => "application/json");
 
+    my $controllerPort = $self->{_controllerPort};
     my $base_url = "$transport://$controllerIp";
     my $login_path = "/api/login";
     my $api_prefix = "";
-    my $url = "${base_url}:" . ($transport eq 'http' ? $DEFAULT_HTTP_PORT: $DEFAULT_HTTPS_PORT);
+    my $url = "${base_url}:" . ($controllerPort || ($transport eq 'http' ? $DEFAULT_HTTP_PORT: $DEFAULT_HTTPS_PORT));
 
     my $response = $ua->get($url."/proxy/network/status");
     my $cookie_invalid = $FALSE;
@@ -214,8 +215,8 @@ sub _connect {
         $api_prefix = "/proxy/network";
         $cookie_invalid = ($response->code == 401) ? $TRUE : $FALSE;
     } else {
-        # Old controller on port 8443
-        $url = "${base_url}:${ALT_DEFAULT_PORT}";
+        # Old controller on port 8443 unless a controller port is configured
+        $url = "${base_url}:" . ($controllerPort || $ALT_DEFAULT_PORT);
         # Check if cookie is still valid for old controller
         $response = $ua->get($url."/api/self");
         $cookie_invalid = ($response->code == 401) ? $TRUE : $FALSE;
@@ -223,7 +224,7 @@ sub _connect {
     if ($cookie_invalid) {
         # Clear old cookies before re-authenticating to avoid sending invalid session
         $ua->cookie_jar->clear();
-        $response = $ua->post($base_url.$login_path, Content => '{"username":"'.$username.'", "password":"'.$password.'", "remember": "true"}');
+        $response = $ua->post($url.$login_path, Content => '{"username":"'.$username.'", "password":"'.$password.'", "remember": "true"}');
 
         unless($response->is_success) {
             $logger->error("Can't login on the Unifi controller: ".$response->status_line);


### PR DESCRIPTION
# Description
When someone changes the default admin port of a Ubiquiti UniFi controller, PacketFence is no longer able to connect to the controller API since the port is hardcoded in `pf::Switch::Ubiquiti::Unifi` (80/443 for UniFi OS, 8443 for legacy controllers).

This PR adds a new `controllerPort` switch option, exposed in the admin UI next to *Controller IP Address* for both switches and switch groups (so it can be set once on an AP group and inherited by MAC-based AP entries). When set, it is used for both the UniFi OS detection probe and the legacy controller fallback; when empty, the previous default ports apply, so existing installs are unaffected. The option can also be set manually in `switches.conf` (`controllerPort=9443`).

It also fixes a bug in `_connect`: the login request was sent to the base URL without any port, breaking re-authentication on legacy controllers listening on 8443.

# Impacts
- Ubiquiti UniFi web services deauth / external portal workflow (`_connect` in `lib/pf/Switch/Ubiquiti/Unifi.pm`)
- Switch and switch group admin forms (Perl form + Vue frontend)
- New `_controllerPort` attribute in `pf::Switch` (unset for every other switch module, no behavior change)

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature [no]
- [ ] Add OpenAPI specification [n/a — generated from the form]
- [ ] Add unit tests [no]
- [ ] Add acceptance tests (TestLink) [no]

# NEWS file entries
## Enhancements
* Ubiquiti UniFi controller API port is now configurable via the new controllerPort switch option

## Bug Fixes
* Fixed UniFi controller login request sent without a port, breaking re-authentication on legacy controllers listening on 8443