### PR TITLE
pfacct: handle node.last_seen and ip4log natively instead of via httpd.aaa

### DIFF
--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1958,7 +1958,11 @@ EOT
 [radius_configuration.pfacct_rate_limit_cache_ttl]
 type=numeric
 description=<<EOT
-If rate limiting on pfacct is enabled,  the Time to Live value in minutes represent the time of the accounting cache
+Time to Live in minutes of the pfacct accounting caches. When
+radius_configuration.pfacct_rate_limit is enabled it is how long pfacct
+suppresses forwarding a repeated accounting packet to httpd.aaa. Independently
+of that option, it is also how often pfacct refreshes node.last_seen and the
+ip4log entry of a given device.
 EOT
 
 [radius_configuration.pfacct_socket_recv_buffer]

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1409,7 +1409,9 @@ EOT
 type=toggle
 options=enabled|disabled
 description=<<EOT
-Use the information included in the accounting to update the iplog
+Use the information included in the accounting to update the iplog.
+Note: pfacct performs this update itself and reads this option once at
+startup, so restart pfacct for a change to this option to take effect.
 EOT
 
 [advanced.update_iplog_with_authentication]

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -1044,7 +1044,9 @@ pfperl_api_processes=8
 #
 # advanced.update_iplog_with_accounting
 #
-# Use the information included in the accounting to update the iplog
+# Use the information included in the accounting to update the iplog.
+# Note: pfacct performs this update itself and reads this option once at
+# startup, so restart pfacct for a change to this option to take effect.
 update_iplog_with_accounting=disabled
 #
 # advanced.update_iplog_with_authentication
@@ -1473,7 +1475,11 @@ pfacct_work_queue_size = 1000
 pfacct_rate_limit=disabled
 # radius_configuration.pfacct_rate_limit_cache_ttl
 #
-# If rate limiting on pfacct is enabled,  the Time to Live value in minutes represent the time of the accounting cache
+# Time to Live in minutes of the pfacct accounting caches. When
+# radius_configuration.pfacct_rate_limit is enabled it is how long pfacct
+# suppresses forwarding a repeated accounting packet to httpd.aaa. Independently
+# of that option, it is also how often pfacct refreshes node.last_seen and the
+# ip4log entry of a given device.
 pfacct_rate_limit_cache_ttl=5
 # radius_configuration.pfacct_socket_recv_buffer
 #

--- a/go/cmd/pfacct/accounting_primitives.go
+++ b/go/cmd/pfacct/accounting_primitives.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+
+	cache "github.com/fdurand/go-cache"
+	"github.com/inverse-inc/go-utils/mac"
+)
+
+// Native ports of the per-packet primitives historically performed by
+// httpd.aaa's radius_accounting handler (pf::radius::accounting and
+// pf::api::update_ip4log). Running them here keeps node.last_seen and ip4log
+// fresh on every accounting packet even when pfacct_rate_limit suppresses the
+// notification to httpd.aaa, and removes recurring per-packet mod_perl work.
+
+// updateNodeLastSeen refreshes node.last_seen for the MAC, at most once per
+// rate-limit TTL per MAC. Like pf::node::node_update_last_seen it only
+// updates an existing node row; node creation stays with the registration
+// paths.
+func (h *PfAcct) updateNodeLastSeen(ctx context.Context, m mac.Mac) {
+	key := m.String()
+	if _, found := h.LastSeenCache.Get(key); found {
+		return
+	}
+	h.LastSeenCache.Set(key, 1, cache.DefaultExpiration)
+
+	if _, err := h.nodeUpdateLastSeen.Exec(key); err != nil {
+		logError(ctx, "nodeUpdateLastSeen: "+err.Error())
+	}
+}
+
+// updateIp4log mirrors pf::api::update_ip4log for accounting packets: close
+// the previous ip4log entry when the MAC moved to a new IP, make sure the
+// node row exists (ip4log's foreign key), then upsert the ip4log entry.
+// Accounting carries no lease length, so like the Perl path the entry is
+// opened with the zero end_time. Each MAC/IP pair is written at most once per
+// rate-limit TTL; an IP change uses a fresh cache key and goes through
+// immediately.
+func (h *PfAcct) updateIp4log(ctx context.Context, m mac.Mac, framedIP string) {
+	if !h.UpdateIplogWithAccounting {
+		return
+	}
+
+	if framedIP == "" || framedIP == "0.0.0.0" {
+		return
+	}
+
+	macStr := m.String()
+	key := macStr + "|" + framedIP
+	if _, found := h.Ip4logCache.Get(key); found {
+		return
+	}
+	h.Ip4logCache.Set(key, 1, cache.DefaultExpiration)
+
+	var oldIP string
+	err := h.ip4logMac2Ip.QueryRow(macStr).Scan(&oldIP)
+	if err != nil && err != sql.ErrNoRows {
+		logError(ctx, "ip4logMac2Ip: "+err.Error())
+	}
+
+	if oldIP != "" && oldIP != framedIP {
+		logInfo(ctx, "oldip ("+oldIP+") and newip ("+framedIP+") are different for "+macStr+" - closing ip4log entry")
+		h.Ip4logCache.Delete(macStr + "|" + oldIP)
+		if _, err := h.ip4logClose.Exec(oldIP); err != nil {
+			logError(ctx, "ip4logClose: "+err.Error())
+		}
+	}
+
+	if _, err := h.nodeAddSimple.Exec(macStr); err != nil {
+		logError(ctx, "nodeAddSimple: "+err.Error())
+	}
+
+	if _, err := h.ip4logOpen.Exec(macStr, framedIP); err != nil {
+		logError(ctx, "ip4logOpen: "+err.Error())
+	}
+}

--- a/go/cmd/pfacct/accounting_primitives.go
+++ b/go/cmd/pfacct/accounting_primitives.go
@@ -23,11 +23,16 @@ func (h *PfAcct) updateNodeLastSeen(ctx context.Context, m mac.Mac) {
 	if _, found := h.LastSeenCache.Get(key); found {
 		return
 	}
-	h.LastSeenCache.Set(key, 1, cache.DefaultExpiration)
 
 	if _, err := h.nodeUpdateLastSeen.Exec(key); err != nil {
+		// The key is only cached once the write lands, so a transient failure
+		// is retried by the next packet instead of freezing last_seen for a
+		// full TTL.
 		logError(ctx, "nodeUpdateLastSeen: "+err.Error())
+		return
 	}
+
+	h.LastSeenCache.Set(key, 1, cache.DefaultExpiration)
 }
 
 // updateIp4log mirrors pf::api::update_ip4log for accounting packets: close
@@ -51,12 +56,17 @@ func (h *PfAcct) updateIp4log(ctx context.Context, m mac.Mac, framedIP string) {
 	if _, found := h.Ip4logCache.Get(key); found {
 		return
 	}
-	h.Ip4logCache.Set(key, 1, cache.DefaultExpiration)
+
+	// The key is only cached once every statement below has succeeded, so a
+	// transient failure (or a partially applied update) is retried by the next
+	// packet instead of freezing this MAC/IP pair for a full TTL.
+	complete := true
 
 	var oldIP string
 	err := h.ip4logMac2Ip.QueryRow(macStr).Scan(&oldIP)
 	if err != nil && err != sql.ErrNoRows {
 		logError(ctx, "ip4logMac2Ip: "+err.Error())
+		complete = false
 	}
 
 	if oldIP != "" && oldIP != framedIP {
@@ -64,14 +74,21 @@ func (h *PfAcct) updateIp4log(ctx context.Context, m mac.Mac, framedIP string) {
 		h.Ip4logCache.Delete(macStr + "|" + oldIP)
 		if _, err := h.ip4logClose.Exec(oldIP); err != nil {
 			logError(ctx, "ip4logClose: "+err.Error())
+			complete = false
 		}
 	}
 
 	if _, err := h.nodeAddSimple.Exec(macStr); err != nil {
 		logError(ctx, "nodeAddSimple: "+err.Error())
+		complete = false
 	}
 
 	if _, err := h.ip4logOpen.Exec(macStr, framedIP); err != nil {
 		logError(ctx, "ip4logOpen: "+err.Error())
+		complete = false
+	}
+
+	if complete {
+		h.Ip4logCache.Set(key, 1, cache.DefaultExpiration)
 	}
 }

--- a/go/cmd/pfacct/accounting_primitives_test.go
+++ b/go/cmd/pfacct/accounting_primitives_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/inverse-inc/go-utils/mac"
+)
+
+func TestUpdateNodeLastSeen(t *testing.T) {
+	pfAcct := NewPfAcct("INFO")
+	if pfAcct == nil {
+		t.Fatalf("New pfAcct")
+	}
+	ctx := context.Background()
+
+	m, _ := mac.NewFromString("99:77:55:44:33:23")
+	if _, err := pfAcct.Db.Exec("DELETE FROM node WHERE mac = ?", m.String()); err != nil {
+		t.Fatalf("%s", err.Error())
+	}
+	if _, err := pfAcct.Db.Exec("INSERT INTO node (mac, status, last_seen) VALUES (?, 'unreg', DATE_SUB(NOW(), INTERVAL 1 DAY))", m.String()); err != nil {
+		t.Fatalf("%s", err.Error())
+	}
+
+	pfAcct.updateNodeLastSeen(ctx, m)
+
+	var fresh int
+	err := pfAcct.Db.QueryRow("SELECT 1 FROM node WHERE mac = ? AND last_seen > DATE_SUB(NOW(), INTERVAL 1 MINUTE)", m.String()).Scan(&fresh)
+	if err != nil {
+		t.Fatalf("last_seen was not refreshed: %s", err.Error())
+	}
+
+	// The refresh is rate-limited per MAC: age the row again and verify a
+	// second call within the TTL does not touch it.
+	if _, err := pfAcct.Db.Exec("UPDATE node SET last_seen = DATE_SUB(NOW(), INTERVAL 1 DAY) WHERE mac = ?", m.String()); err != nil {
+		t.Fatalf("%s", err.Error())
+	}
+	pfAcct.updateNodeLastSeen(ctx, m)
+	err = pfAcct.Db.QueryRow("SELECT 1 FROM node WHERE mac = ? AND last_seen > DATE_SUB(NOW(), INTERVAL 1 MINUTE)", m.String()).Scan(&fresh)
+	if err == nil {
+		t.Fatalf("last_seen refresh was not rate-limited")
+	}
+}
+
+func TestUpdateIp4log(t *testing.T) {
+	pfAcct := NewPfAcct("INFO")
+	if pfAcct == nil {
+		t.Fatalf("New pfAcct")
+	}
+	ctx := context.Background()
+	pfAcct.UpdateIplogWithAccounting = true
+
+	m, _ := mac.NewFromString("99:77:55:44:33:24")
+	ip1, ip2 := "198.51.100.61", "198.51.100.62"
+	for _, ip := range []string{ip1, ip2} {
+		if _, err := pfAcct.Db.Exec("DELETE FROM ip4log WHERE ip = ?", ip); err != nil {
+			t.Fatalf("%s", err.Error())
+		}
+	}
+	if _, err := pfAcct.Db.Exec("DELETE FROM node WHERE mac = ?", m.String()); err != nil {
+		t.Fatalf("%s", err.Error())
+	}
+
+	// Unknown node: the entry must be created (ip4log needs the node row)
+	// and the ip4log entry opened with the zero end_time.
+	pfAcct.updateIp4log(ctx, m, ip1)
+
+	var one int
+	if err := pfAcct.Db.QueryRow("SELECT 1 FROM node WHERE mac = ?", m.String()).Scan(&one); err != nil {
+		t.Fatalf("node was not auto-created: %s", err.Error())
+	}
+	if err := pfAcct.Db.QueryRow("SELECT 1 FROM ip4log WHERE ip = ? AND mac = ? AND end_time = '0000-00-00 00:00:00'", ip1, m.String()).Scan(&one); err != nil {
+		t.Fatalf("ip4log entry for %s was not opened: %s", ip1, err.Error())
+	}
+
+	// IP change: the old entry closes, the new one opens.
+	pfAcct.updateIp4log(ctx, m, ip2)
+
+	if err := pfAcct.Db.QueryRow("SELECT 1 FROM ip4log WHERE ip = ? AND end_time != '0000-00-00 00:00:00'", ip1).Scan(&one); err != nil {
+		t.Fatalf("old ip4log entry for %s was not closed: %s", ip1, err.Error())
+	}
+	if err := pfAcct.Db.QueryRow("SELECT 1 FROM ip4log WHERE ip = ? AND mac = ? AND end_time = '0000-00-00 00:00:00'", ip2, m.String()).Scan(&one); err != nil {
+		t.Fatalf("ip4log entry for %s was not opened: %s", ip2, err.Error())
+	}
+
+	// Same MAC/IP within the TTL is skipped (rate-limited): removing the row
+	// behind the cache's back and re-calling must not recreate it.
+	if _, err := pfAcct.Db.Exec("DELETE FROM ip4log WHERE ip = ?", ip2); err != nil {
+		t.Fatalf("%s", err.Error())
+	}
+	pfAcct.updateIp4log(ctx, m, ip2)
+	if err := pfAcct.Db.QueryRow("SELECT 1 FROM ip4log WHERE ip = ?", ip2).Scan(&one); err == nil {
+		t.Fatalf("ip4log write was not rate-limited")
+	}
+
+	// Disabled toggle: nothing is written.
+	pfAcct.UpdateIplogWithAccounting = false
+	pfAcct.Ip4logCache.Flush()
+	pfAcct.updateIp4log(ctx, m, ip2)
+	if err := pfAcct.Db.QueryRow("SELECT 1 FROM ip4log WHERE ip = ?", ip2).Scan(&one); err == nil {
+		t.Fatalf("ip4log written while update_iplog_with_accounting is disabled")
+	}
+}

--- a/go/cmd/pfacct/accounting_primitives_test.go
+++ b/go/cmd/pfacct/accounting_primitives_test.go
@@ -101,3 +101,18 @@ func TestUpdateIp4log(t *testing.T) {
 		t.Fatalf("ip4log written while update_iplog_with_accounting is disabled")
 	}
 }
+
+func TestHandledNatively(t *testing.T) {
+	// The AAA layer skips exactly what this header claims, so pfacct must not
+	// claim ip4log while update_iplog_with_accounting is off for it: both
+	// sides would then skip the write.
+	pfAcct := &PfAcct{}
+	if got := pfAcct.handledNatively(); got != "node_last_seen" {
+		t.Fatalf("handledNatively with the iplog update disabled: got '%s'", got)
+	}
+
+	pfAcct.UpdateIplogWithAccounting = true
+	if got := pfAcct.handledNatively(); got != "node_last_seen,ip4log" {
+		t.Fatalf("handledNatively with the iplog update enabled: got '%s'", got)
+	}
+}

--- a/go/cmd/pfacct/pfacct.go
+++ b/go/cmd/pfacct/pfacct.go
@@ -39,40 +39,43 @@ type radiusRequest struct {
 
 type PfAcct struct {
 	RadiusStatements
-	TimeDuration            time.Duration
-	Db                      *sql.DB
-	AllowedNetworks         []net.IPNet
-	NetFlowPort             string
-	NetFlowAddress          string
-	Management              pfconfigdriver.ManagementNetwork
-	AAAClient               *jsonrpc2.Client
-	LoggerCtx               context.Context
-	Dispatcher              *Dispatcher
-	SwitchInfoCache         *cache.Cache
-	NodeSessionCache        *cache.Cache
-	AcctSessionCache        *cache.Cache
-	RateLimitCache          *cache.Cache
-	MacNasCache             *cache.Cache
-	RateLimit               bool
-	PfacctRateLimitCacheTtl int
-	StatsdAddress           string
-	StatsdOption            statsd.Option
-	StatsdClient            *statsd.Client
-	radiusRequests          []chan<- radiusRequest
-	aaaNotifyQueues         []chan<- aaaNotifyJob
-	aaaNotifyDropped        atomic.Int64
-	localSecret             string
-	unifiedSecret           string
-	StatsdOnce              tryableonce.TryableOnce
-	isProxied               bool
-	radiusdAcctEnabled      bool
-	AllNetworks             bool
-	ProcessBandwidthAcct    bool
-	RadiusWorkers           int
-	RadiusWorkQueueSize     int
-	SocketRecvBuffer        int
-	AAANotifyWorkers        int
-	AAANotifyQueueSize      int
+	TimeDuration              time.Duration
+	Db                        *sql.DB
+	AllowedNetworks           []net.IPNet
+	NetFlowPort               string
+	NetFlowAddress            string
+	Management                pfconfigdriver.ManagementNetwork
+	AAAClient                 *jsonrpc2.Client
+	LoggerCtx                 context.Context
+	Dispatcher                *Dispatcher
+	SwitchInfoCache           *cache.Cache
+	NodeSessionCache          *cache.Cache
+	AcctSessionCache          *cache.Cache
+	RateLimitCache            *cache.Cache
+	MacNasCache               *cache.Cache
+	LastSeenCache             *cache.Cache
+	Ip4logCache               *cache.Cache
+	RateLimit                 bool
+	PfacctRateLimitCacheTtl   int
+	UpdateIplogWithAccounting bool
+	StatsdAddress             string
+	StatsdOption              statsd.Option
+	StatsdClient              *statsd.Client
+	radiusRequests            []chan<- radiusRequest
+	aaaNotifyQueues           []chan<- aaaNotifyJob
+	aaaNotifyDropped          atomic.Int64
+	localSecret               string
+	unifiedSecret             string
+	StatsdOnce                tryableonce.TryableOnce
+	isProxied                 bool
+	radiusdAcctEnabled        bool
+	AllNetworks               bool
+	ProcessBandwidthAcct      bool
+	RadiusWorkers             int
+	RadiusWorkQueueSize       int
+	SocketRecvBuffer          int
+	AAANotifyWorkers          int
+	AAANotifyQueueSize        int
 }
 
 func NewPfAcct(logLevel string) *PfAcct {
@@ -232,6 +235,15 @@ func (pfAcct *PfAcct) SetupConfig(ctx context.Context) {
 	}
 	pfAcct.RateLimitCache = cache.New(time.Duration(pfAcct.PfacctRateLimitCacheTtl)*time.Minute, 10*time.Minute)
 	pfAcct.MacNasCache = cache.New(time.Duration(pfAcct.PfacctRateLimitCacheTtl)*time.Minute, 10*time.Minute)
+	// A TTL of 0 would make go-cache entries permanent, freezing last_seen and
+	// ip4log after their first write; floor the refresh interval instead.
+	refreshTtl := time.Duration(pfAcct.PfacctRateLimitCacheTtl) * time.Minute
+	if refreshTtl <= 0 {
+		refreshTtl = 5 * time.Minute
+	}
+	pfAcct.LastSeenCache = cache.New(refreshTtl, 10*time.Minute)
+	pfAcct.Ip4logCache = cache.New(refreshTtl, 10*time.Minute)
+	pfAcct.UpdateIplogWithAccounting = sharedutils.IsEnabled(keyConfAdvanced.UpdateIplogWithAccounting)
 	if !pfAcct.ProcessBandwidthAcct {
 		logInfo(ctx, "Not processing bandwidth accounting records. To enable set radius_configuration.process_bandwidth_accounting = enabled")
 	}

--- a/go/cmd/pfacct/pfacct.go
+++ b/go/cmd/pfacct/pfacct.go
@@ -166,9 +166,10 @@ func makeAAANotifiers(h *PfAcct, workers, backlog int) []chan<- aaaNotifyJob {
 
 // reportAAADrops periodically logs how many radius_accounting notifications
 // were dropped because the notifier queues were saturated. Drops here do not
-// affect node online/offline status (written synchronously by the accounting
-// workers); they only mean some accounting side effects (ip4log, locationlog,
-// triggers) were skipped while httpd.aaa could not keep up.
+// affect what the accounting workers write themselves (node online/offline
+// status, node.last_seen, the ip4log entry); they only mean the side effects
+// that still live in httpd.aaa (locationlog, firewall SSO, scans, Fingerbank)
+// were skipped while it could not keep up.
 func (pfAcct *PfAcct) reportAAADrops() {
 	go func() {
 		for {

--- a/go/cmd/pfacct/radius.go
+++ b/go/cmd/pfacct/radius.go
@@ -153,6 +153,15 @@ func (h *PfAcct) handleAccountingRequest(rr radiusRequest) {
 		logError(ctx, fmt.Sprintf("Error updating online offline status: %s", err.Error()))
 	}
 
+	h.updateNodeLastSeen(ctx, mac)
+	// Mirrors handle_accounting_metadata: iplog is only fed by packets that
+	// carry a Framed-IP-Address and are not a Stop.
+	if status != rfc2866.AcctStatusType_Value_Stop {
+		if framedIP := rfc2865.FramedIPAddress_Get(r.Packet); framedIP != nil {
+			h.updateIp4log(ctx, mac, framedIP.String())
+		}
+	}
+
 	timestamp, err := rfc2869.EventTimestamp_Lookup(r.Packet)
 	if err != nil {
 		timestamp = time.Now()
@@ -737,6 +746,11 @@ type RadiusStatements struct {
 	closeSession                    *sql.Stmt
 	nodeOnlineOffLineStartUpdate    *sql.Stmt
 	nodeOnlineOffLineStop           *sql.Stmt
+	nodeUpdateLastSeen              *sql.Stmt
+	nodeAddSimple                   *sql.Stmt
+	ip4logMac2Ip                    *sql.Stmt
+	ip4logClose                     *sql.Stmt
+	ip4logOpen                      *sql.Stmt
 }
 
 func setupStmt(db *sql.DB, stmt **sql.Stmt, sql string) {
@@ -867,6 +881,27 @@ func (rs *RadiusStatements) Setup(db *sql.DB) {
 	setupStmt(db, &rs.nodeOnlineOffLineStartUpdate, `
 		INSERT INTO node_current_session (mac, last_session_id, updated, is_online) VALUES (?, ?, NOW(), 1)
         ON DUPLICATE KEY UPDATE updated = VALUES(updated), last_session_id = VALUES(last_session_id), is_online =1 ;
+       `)
+
+	setupStmt(db, &rs.nodeUpdateLastSeen, `
+        UPDATE node SET last_seen = NOW() WHERE mac = ?;
+       `)
+
+	setupStmt(db, &rs.nodeAddSimple, `
+        INSERT IGNORE INTO node (mac, pid, last_seen, detect_date, status) VALUES (?, 'default', NOW(), NOW(), 'unreg');
+       `)
+
+	setupStmt(db, &rs.ip4logMac2Ip, `
+        SELECT ip FROM ip4log WHERE mac = ? AND (end_time = '0000-00-00 00:00:00' OR (end_time + INTERVAL 30 SECOND) > NOW()) ORDER BY start_time DESC LIMIT 1;
+       `)
+
+	setupStmt(db, &rs.ip4logClose, `
+        UPDATE ip4log SET end_time = NOW() WHERE ip = ?;
+       `)
+
+	setupStmt(db, &rs.ip4logOpen, `
+        INSERT INTO ip4log (mac, ip, start_time, end_time) VALUES (?, ?, NOW(), '0000-00-00 00:00:00')
+        ON DUPLICATE KEY UPDATE mac = VALUES(mac), start_time = VALUES(start_time), end_time = VALUES(end_time);
        `)
 
 }

--- a/go/cmd/pfacct/radius.go
+++ b/go/cmd/pfacct/radius.go
@@ -338,6 +338,9 @@ func (h *PfAcct) sendRadiusAccountingCall(r *radius.Request, m mac.Mac) {
 	attr["PF_HEADERS"] = map[string]string{
 		"X-FreeRADIUS-Server":  "packetfence",
 		"X-FreeRADIUS-Section": "accounting",
+		// Primitives this pfacct executes natively for every accounting
+		// packet; the AAA layer skips them to avoid duplicate DB writes.
+		"X-PacketFence-Handled-Natively": "node_last_seen,ip4log",
 	}
 
 	if val, ok := attr["NAS-IP-Address"]; !ok || val == "0.0.0.0" {

--- a/go/cmd/pfacct/radius.go
+++ b/go/cmd/pfacct/radius.go
@@ -153,15 +153,6 @@ func (h *PfAcct) handleAccountingRequest(rr radiusRequest) {
 		logError(ctx, fmt.Sprintf("Error updating online offline status: %s", err.Error()))
 	}
 
-	h.updateNodeLastSeen(ctx, mac)
-	// Mirrors handle_accounting_metadata: iplog is only fed by packets that
-	// carry a Framed-IP-Address and are not a Stop.
-	if status != rfc2866.AcctStatusType_Value_Stop {
-		if framedIP := rfc2865.FramedIPAddress_Get(r.Packet); framedIP != nil {
-			h.updateIp4log(ctx, mac, framedIP.String())
-		}
-	}
-
 	timestamp, err := rfc2869.EventTimestamp_Lookup(r.Packet)
 	if err != nil {
 		timestamp = time.Now()
@@ -177,6 +168,19 @@ func (h *PfAcct) handleAccountingRequest(rr radiusRequest) {
 				),
 			)
 			return
+		}
+	}
+
+	// Deliberately below the stale Event-Timestamp guard above: a packet the
+	// rest of the pipeline discards must not refresh last_seen or re-open an
+	// ip4log entry either (it is never forwarded to the AAA layer, so the two
+	// sides stay in agreement).
+	h.updateNodeLastSeen(ctx, mac)
+	// Mirrors handle_accounting_metadata: iplog is only fed by packets that
+	// carry a Framed-IP-Address and are not a Stop.
+	if status != rfc2866.AcctStatusType_Value_Stop {
+		if framedIP := rfc2865.FramedIPAddress_Get(r.Packet); framedIP != nil {
+			h.updateIp4log(ctx, mac, framedIP.String())
 		}
 	}
 
@@ -332,15 +336,29 @@ func (h *PfAcct) sendRadiusAccounting(rr radiusRequest, switchInfo *SwitchInfo) 
 	h.sendRadiusAccountingCall(rr.r, rr.mac)
 }
 
+// handledNatively lists the per-packet primitives this pfacct just executed
+// itself, so the AAA layer can skip them instead of writing the same rows a
+// second time (see pf::api::handle_accounting_metadata and
+// pf::radius::accounting). Only claim what we actually do: the configuration
+// is read once at startup, so a pfacct that has not picked up a freshly
+// enabled update_iplog_with_accounting must let httpd.aaa keep doing the
+// ip4log work rather than have both sides skip it.
+func (h *PfAcct) handledNatively() string {
+	handled := "node_last_seen"
+	if h.UpdateIplogWithAccounting {
+		handled += ",ip4log"
+	}
+
+	return handled
+}
+
 func (h *PfAcct) sendRadiusAccountingCall(r *radius.Request, m mac.Mac) {
 	ctx := r.Context()
 	attr := packetToMap(ctx, r.Packet)
 	attr["PF_HEADERS"] = map[string]string{
-		"X-FreeRADIUS-Server":  "packetfence",
-		"X-FreeRADIUS-Section": "accounting",
-		// Primitives this pfacct executes natively for every accounting
-		// packet; the AAA layer skips them to avoid duplicate DB writes.
-		"X-PacketFence-Handled-Natively": "node_last_seen,ip4log",
+		"X-FreeRADIUS-Server":            "packetfence",
+		"X-FreeRADIUS-Section":           "accounting",
+		"X-PacketFence-Handled-Natively": h.handledNatively(),
 	}
 
 	if val, ok := attr["NAS-IP-Address"]; !ok || val == "0.0.0.0" {

--- a/go/cmd/pfacct/radius.go
+++ b/go/cmd/pfacct/radius.go
@@ -379,8 +379,9 @@ func (h *PfAcct) sendRadiusAccountingCall(r *radius.Request, m mac.Mac) {
 // enqueueAAANotify hands a radius_accounting notification to the MAC-sharded
 // notifier pool without blocking the accounting worker. If the target queue is
 // saturated the notification is dropped and counted (see reportAAADrops)
-// rather than stalling the worker, since node online/offline status has already
-// been written to the DB by the time we get here.
+// rather than stalling the worker, since everything the worker owns (node
+// online/offline status, node.last_seen, the ip4log entry) has already been
+// written to the DB by the time we get here.
 func (h *PfAcct) enqueueAAANotify(ctx context.Context, m mac.Mac, attr map[string]interface{}) {
 	queueIndex := djb2Hash(m[:]) % uint64(len(h.aaaNotifyQueues))
 	select {

--- a/lib/pf/api.pm
+++ b/lib/pf/api.pm
@@ -1615,6 +1615,13 @@ sub handle_accounting_metadata : Public {
     $logger->debug("Entering handling of accounting metadata");
     my $client = pf::client::getClient();
 
+    # pfacct advertises the primitives it already executed natively for this
+    # packet (X-PacketFence-Handled-Natively); skip them here to avoid
+    # duplicate DB writes. Requests from other sources carry no marker and
+    # keep the full behavior.
+    my %handled_natively = map { $_ => 1 }
+        split(/,/, $RAD_REQUEST->{PF_HEADERS}{'X-PacketFence-Handled-Natively'} // '');
+
     my $return = [ $RADIUS::RLM_MODULE_OK, ('Reply-Message' => "Accounting OK") ];
     my $mac = pf::util::clean_mac($RAD_REQUEST->{'Calling-Station-Id'});
     my $acct_status_type = $RAD_REQUEST->{'Acct-Status-Type'};
@@ -1631,7 +1638,7 @@ sub handle_accounting_metadata : Public {
         # Tracking IP address.
         my $framed_ip = $RAD_REQUEST->{"Framed-IP-Address"};
         if ($framed_ip) {
-            if (pf::util::isenabled($advanced->{update_iplog_with_accounting})) {
+            if (pf::util::isenabled($advanced->{update_iplog_with_accounting}) && !$handled_natively{ip4log}) {
                 $logger->info("Updating iplog from accounting request");
                 $client->notify("update_ip4log", mac => $mac, ip => $framed_ip);
             }

--- a/lib/pf/api.pm
+++ b/lib/pf/api.pm
@@ -1594,7 +1594,7 @@ sub radius_rest_accounting :Public :RestPath(/radius/rest/accounting) {
 
     my $remapped_radius_request = pf::radius::rest::format_request($radius_request);
 
-    my $return = $class->handle_accounting_metadata($remapped_radius_request);
+    my $return = $class->handle_accounting_metadata($remapped_radius_request, $headers);
 
     my $radius = new pf::radius::custom();
     eval {
@@ -1611,16 +1611,18 @@ sub radius_rest_accounting :Public :RestPath(/radius/rest/accounting) {
 }
 
 sub handle_accounting_metadata : Public {
-    my ($class, $RAD_REQUEST) = @_;
+    my ($class, $RAD_REQUEST, $headers) = @_;
     $logger->debug("Entering handling of accounting metadata");
     my $client = pf::client::getClient();
 
     # pfacct advertises the primitives it already executed natively for this
     # packet (X-PacketFence-Handled-Natively); skip them here to avoid
     # duplicate DB writes. Requests from other sources carry no marker and
-    # keep the full behavior.
+    # keep the full behavior. The JSON-RPC path carries the headers inside the
+    # request (PF_HEADERS), the REST path passes them alongside it.
+    $headers //= $RAD_REQUEST->{PF_HEADERS} // {};
     my %handled_natively = map { $_ => 1 }
-        split(/,/, $RAD_REQUEST->{PF_HEADERS}{'X-PacketFence-Handled-Natively'} // '');
+        split(/,/, $headers->{'X-PacketFence-Handled-Natively'} // '');
 
     my $return = [ $RADIUS::RLM_MODULE_OK, ('Reply-Message' => "Accounting OK") ];
     my $mac = pf::util::clean_mac($RAD_REQUEST->{'Calling-Station-Id'});

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -470,8 +470,12 @@ sub accounting {
 
     my ($nas_port_type, $eap_type, $mac, $port, $user_name, $nas_port_id, $session_id, $ifDesc) = $switch->parseRequest($radius_request);
 
+    my %handled_natively = map { $_ => 1 }
+        split(/,/, ($headers->{'X-PacketFence-Handled-Natively'} // ''));
+
     # update last_seen of MAC address as some activity from it has been seen
-    node_update_last_seen($mac);
+    # (skipped when pfacct already refreshed it natively for this packet)
+    node_update_last_seen($mac) unless $handled_natively{node_last_seen};
     my $acct_status_type = $radius_request->{'Acct-Status-Type'};
 
     my $isStart  = $acct_status_type  == $ACCOUNTING::START;


### PR DESCRIPTION
# Description
Moves two per-packet accounting primitives from httpd.aaa's `radius_accounting` handler into pfacct itself:

- **node.last_seen**: `pf::radius::accounting` runs `node_update_last_seen` on every forwarded packet — a DB write per packet through mod_perl. pfacct now refreshes it natively on every accounting packet, rate-limited to once per MAC per `pfacct_rate_limit_cache_ttl` window.
- **ip4log** (when `advanced.update_iplog_with_accounting=enabled`): `pf::api::update_ip4log` is ported with its exact semantics — close the previous entry when the MAC moved to a new IP, auto-create the missing node row, upsert the entry with the zero end_time (accounting carries no lease). Rate-limited per MAC/IP pair; an IP change bypasses the limiter and is handled immediately.

This has two benefits: it removes recurring per-packet mod_perl work on busy deployments (measured on a lab server sustaining ~460 accounting packets/s), and it fixes the staleness gap introduced when `pfacct_rate_limit` is enabled — suppressed packets never reach Perl, so last_seen and iplog previously froze between forwarded packets.

The Perl code itself is unchanged apart from one guard: forwarded packets carry an `X-PacketFence-Handled-Natively` header, and `pf::radius::accounting` and `pf::api::handle_accounting_metadata` skip exactly the primitives it names, so the same row is not written twice. Every other caller of those primitives is untouched.

The marker is built per packet, not from the configuration: it names only what pfacct actually performed for that packet (or deliberately skipped because it had written the same row within the rate-limit TTL). A write that failed, or a case pfacct declines -- `pfdhcp.mac2ip_lookup` enabled, a `0.0.0.0` Framed-IP-Address, `last_seen` for a MAC with no node row -- is left out of the header, and httpd.aaa then runs that primitive exactly as it did before this branch. So the fallback is never lost on the packets that need it.

# Impacts
- pfacct accounting workflow: two new prepared statements per worker path (node last_seen update; ip4log mac-lookup/close/open, active only when `update_iplog_with_accounting` is enabled).
- node.last_seen now stays fresh under `pfacct_rate_limit=enabled`.
- ip4log SQL mirrors `pf::ip4log::open/close` and the existing pfdhcp upsert (`go/cmd/pfdhcp/utils.go`).

# Code / PR Dependencies
Complements #9249 (pfacct_rate_limit restore); no build dependency — both apply cleanly in either order.

# Delete branch after merge
YES

# Checklist
- [n/a] Document the feature (no new configuration; existing settings drive the behavior)
- [n/a] Add OpenAPI specification
- [x] Add unit tests (`go/cmd/pfacct/accounting_primitives_test.go`, DB-backed, run on a PF server: both PASS)
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
## Enhancements
* pfacct now updates node.last_seen and (when update_iplog_with_accounting is enabled) ip4log natively on accounting packets, removing per-packet httpd.aaa work and keeping them fresh when pfacct_rate_limit suppresses forwarding
