### PR TITLE
Release fingerbank 4.3.5 with the read_config fast-path fix

### DIFF
--- a/addons/perl-client/debian/changelog
+++ b/addons/perl-client/debian/changelog
@@ -1,3 +1,13 @@
+fingerbank (4.3.5) unstable; urgency=medium
+
+  * Stop re-materializing the config graph on every read_config call: the
+    $LOCAL_CACHED_AT fast path avoids re-deserializing the tied IniFiles
+    object graph from the cache per call, which cost ~35ms CPU and leaked
+    multi-MB per request in httpd.aaa (fix was in the lib since v15.2.0
+    sources but never shipped in a fingerbank package)
+
+ -- Inverse inc. <info@inverse.ca>  Tue, 01 Sep 2026 11:00:00 -0400
+
 fingerbank (4.3.4) unstable; urgency=medium
 
   * Fix collector.port field type from numeric to text to allow the env variable default


### PR DESCRIPTION
# Description
Bumps the fingerbank package changelog to 4.3.5 so a package containing the `read_config` fast-path fix (6e450329e6, merged Aug 12) finally ships.

The fix has been in `addons/perl-client/lib` since before the v15.2.0 tag, but no fingerbank package was ever released with it: the 15.2 apt repo still serves `4.3.3+20250416182522+...+feature~cloud~nac` (an April 2025 feature-branch build). Every pfdebian-based container therefore runs the pre-fix code and pays the cost the fix removes — measured on a loaded 15.2 server at ~90 MAB auths/s: **httpd.aaa at ~300% CPU (~35ms per request re-deserializing the tied IniFiles config graph after every response, multi-MB allocation churn per request) vs 59% with the fixed lib**, child RSS 330MB → 252MB.

# Impacts
- fingerbank Debian/RHEL package version 4.3.4 → 4.3.5 (the `[perl-client]` marker / path filter triggers the package workflow on this PR's merge).
- Needs a cherry-pick to `maintenance/15.2` and a publish of the resulting package to the 15.2 apt repo, followed by a pfdebian base image refresh, for 15.2 deployments to actually receive it.
- No code change: the lib content already carries the fix on devel and maintenance/15.2.

# Delete branch after merge
YES

# Checklist
- [n/a] Document the feature
- [n/a] Add OpenAPI specification
- [n/a] Add unit tests (changelog-only; the fix itself merged in 6e450329e6)
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
## Bug Fixes
* Ship the fingerbank read_config fast-path fix in the fingerbank package (4.3.5); the 15.2 repo was still serving a pre-fix April 2025 build