### PR TITLE
Jitter the pfdhcplistener rate-limit window to break synchronized renew waves

### DIFF
--- a/sbin/pfdhcplistener
+++ b/sbin/pfdhcplistener
@@ -354,7 +354,7 @@ sub process_pkt {
                     $logger->trace("Rate limit key : $rate_limit_key");
                 }
 
-                my $rate_limiting = $Config{network}->{dhcp_rate_limiting} // 300;
+                my $rate_limiting = normalize_time($Config{network}->{dhcp_rate_limiting} // 300);
                 # We send the packet to be processed if:
                 #  - there is no rate limit key (packet doesn't contain info to be rate-limited)
                 #  - there is no rate limiting configured
@@ -363,7 +363,10 @@ sub process_pkt {
                     my $apiclient = api_client();
                     $apiclient->notify_hashed($dhcp_mac, 'process_dhcpv4', %args);
                     if(defined($rate_limit_key) && $rate_limiting != 0) {
-                        $rate_limit_cache->set($rate_limit_key, 1, $rate_limiting);
+                        # Jitter the suppression window (+/- 25%): endpoints whose leases
+                        # renew in lockstep would otherwise all leave the cache in the same
+                        # second and re-flood pfqueue in one synchronized wave every cycle.
+                        $rate_limit_cache->set($rate_limit_key, 1, add_jitter($rate_limiting, int($rate_limiting / 4)));
                     }
                 }
                 else {


### PR DESCRIPTION
# Description
With a fixed TTL on the pfdhcplistener rate-limit cache, every endpoint that renews its DHCP lease in the same wave gets a cache entry that expires in the same second — so the entire population re-floods the pfqueue `pfdhcplistener` queue in one synchronized burst every `dhcp_rate_limiting` cycle. Observed on a lab server with ~30k clients on a 300s lease and `dhcp_rate_limiting=610s`: ~19k tasks landing at once per cycle, with the tail of each burst aging past the 300s task TTL ("Data not found for task" drops).

This jitters the suppression window by ±25% (`add_jitter($rate_limiting, $rate_limiting/4)`), so expirations spread across the cycle and de-correlate further every cycle. The average window stays at the configured value, and the minimum (75%) stays well above the renew interval so suppression still works. Also runs the config value through `normalize_time()` so `type=time` values like `610s` are handled properly instead of via numeric coercion.

Measured on the lab server (peak queue depth per cycle): 19,335 → 9,596 → 4,890 over three consecutive cycles, with zero drops from the second cycle on.

# Impacts
- pfdhcplistener packet rate limiting: per-packet cache TTL becomes `dhcp_rate_limiting` ±25% instead of exact; behavior with `dhcp_rate_limiting=0` (disabled) is unchanged.
- pfqueue `pfdhcplistener` queue inflow shape on short-lease networks.

# Delete branch after merge
YES

# Checklist
- [n/a] Document the feature (no new configuration; documentation.conf already describes dhcp_rate_limiting)
- [n/a] Add OpenAPI specification
- [n/a] Add unit tests (sbin daemon path; validated with perl -c and three measured cycles in production-like load)
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
## Enhancements
* pfdhcplistener jitters its DHCP rate-limiting cache window (±25%) so short-lease networks no longer re-flood pfqueue in one synchronized wave every dhcp_rate_limiting cycle