### PR TITLE
fix(services): tolerate an unset management network during the configurator

### DIFF
--- a/lib/pf/services/manager/haproxy_db.pm
+++ b/lib/pf/services/manager/haproxy_db.pm
@@ -67,10 +67,10 @@ sub generateConfig {
          $tags{'os_path'} = '/usr/share/haproxy/';
     }
     
-    $tags{'management_ip'}
-        = defined( $management_network->tag('vip') )
-        ? $management_network->tag('vip')
-        : $management_network->tag('ip');
+    # management_network stays undef until the mgmt interface is configured (configurator)
+    $tags{'management_ip'} = ref($management_network)
+        ? ($management_network->tag('vip') // $management_network->tag('ip') // '')
+        : '';
 
     my $i = 0;
     my @mysql_backend;

--- a/lib/pf/services/manager/netdata.pm
+++ b/lib/pf/services/manager/netdata.pm
@@ -66,10 +66,15 @@ sub generateConfig {
     my $logger = get_logger();
     my %tags;
 
+    # management_network stays undef until the mgmt interface is configured (configurator)
+    my $has_mgmt = ref($management_network) ? 1 : 0;
+    my $mgmt_ip  = $has_mgmt ? $management_network->tag('ip')  : '';
+    my $mgmt_vip = $has_mgmt ? $management_network->tag('vip') : undef;
+
     $tags{'hosts_cluster_members'} = '';
-    if ($cluster_enabled) {
+    if ($cluster_enabled && $has_mgmt) {
         my $int = $management_network->tag('int');
-        $tags{'hosts_cluster_members'} = join(",", grep( {$_ ne $management_network->tag('ip')} values %{pf::cluster::members_ips($int)}));
+        $tags{'hosts_cluster_members'} = join(",", grep( {$_ ne $mgmt_ip} values %{pf::cluster::members_ips($int)}));
     }
 
     $tags{'hosts_dns'} = join(",", @{pf::util::dns::get_resolv_dns_servers()});
@@ -163,10 +168,7 @@ EOT
     }
 
     $tags{'httpd_portal_modstatus_port'} = "$Config{'ports'}{'httpd_portal_modstatus'}";
-    $tags{'management_ip'}
-        = defined( $management_network->tag('vip') )
-        ? $management_network->tag('vip')
-        : $management_network->tag('ip');
+    $tags{'management_ip'} = $mgmt_vip // $mgmt_ip;
     $tags{'db_username'}   = "$Config{'database'}{'user'}";
     $tags{'db_password'}   = "$Config{'database'}{'pass'}";
     $tags{'db_database'}   = "$Config{'database'}{'db'}";
@@ -175,7 +177,7 @@ EOT
     } else {
         $tags{'db_dsn'} = "$Config{'database'}{'user'}:$Config{'database'}{'pass'}\@tcp($tags{'management_ip'}:$Config{'database'}{'port'})/$Config{'database'}{'db'}";
     }
-    $tags{'active_active_ip'} = pf::cluster::management_cluster_ip() || $management_network->tag('vip') || $management_network->tag('ip');
+    $tags{'active_active_ip'} = pf::cluster::management_cluster_ip() || $mgmt_vip || $mgmt_ip;
     $tags{'statsd_listen_port'} = $Config{'advanced'}{'statsd_listen_port'};
 
     parse_template( \%tags, "$conf_dir/monitoring/netdata.conf", "$generated_conf_dir/monitoring/netdata.conf" );

--- a/lib/pf/services/manager/pfacct.pm
+++ b/lib/pf/services/manager/pfacct.pm
@@ -69,9 +69,12 @@ sub generate_container_environments {
     my $port_save;
     my $listeningIp = "";
     if ($cluster_enabled || isenabled($Config{services}{radiusd_acct})) {
-        my $management_ip = $management_network->tag('ip');
-        $port = "-p $management_ip:1823:1813/udp";
-        $port_save = "1823"
+        $port_save = "1823";
+        # management_network stays undef until the mgmt interface is configured (configurator)
+        if (ref($management_network)) {
+            my $management_ip = $management_network->tag('ip');
+            $port = "-p $management_ip:1823:1813/udp";
+        }
     }
     if ($cluster_enabled && isenabled($Config{services}{radiusd_acct})) {
         $port = "-p 1833:1813/udp";

--- a/lib/pf/services/manager/radiusd_child.pm
+++ b/lib/pf/services/manager/radiusd_child.pm
@@ -1199,14 +1199,14 @@ sub generate_radiusd_cluster {
     my ($self, $tt) = @_;
     my %tags;
 
-    my $int = $management_network->{'Tint'};
-    my $cfg = $Config{"interface $int"};
-
     $tags{'members'} = '';
     $tags{'config'} ='';
     $tags{'home_server'} ='';
 
-    if ($cluster_enabled) {
+    # management_network stays undef until the mgmt interface is configured (configurator)
+    if ($cluster_enabled && ref($management_network)) {
+        my $int = $management_network->{'Tint'};
+        my $cfg = $Config{"interface $int"};
         my $cluster_ip = isenabled($Config{active_active}{radius_proxy_with_vip}) ? pf::cluster::management_cluster_ip() : $management_network->{Tip};
         my @radius_backend = values %{pf::cluster::members_ips($int)};
 

--- a/lib/pf/services/manager/radiusd_child.pm
+++ b/lib/pf/services/manager/radiusd_child.pm
@@ -125,6 +125,18 @@ sub _generateConfig {
     $self->generate_radiusd_certificates($tt);
 }
 
+=head2 _management_ip
+
+Management VIP, falling back to IP, and to '' while the management network is
+still unset (configurator).
+
+=cut
+
+sub _management_ip {
+    return '' unless ref($management_network);
+    return $management_network->tag('vip') // $management_network->tag('ip') // '';
+}
+
 
 =head2 generate_radiusd_sitesconf
 Generates the packetfence and packetfence-tunnel configuration file
@@ -204,7 +216,7 @@ EOT
     if (pf::cluster::isSlaveMode()) {
 
         $tags{'remote'} = "YES";
-        $tags{'management_ip'} = defined($management_network->tag('vip')) ? $management_network->tag('vip') : $management_network->tag('ip');
+        $tags{'management_ip'} = _management_ip();
 
         $tags{'members'} = '';
         $tags{'config'} ='';
@@ -338,7 +350,7 @@ sub generate_radiusd_mainconf {
 
     $tags{'template'}    = "$conf_dir/radiusd/radiusd.conf";
     $tags{'install_dir'} = $install_dir;
-    $tags{'management_ip'} = defined($management_network->tag('vip')) ? $management_network->tag('vip') : $management_network->tag('ip');
+    $tags{'management_ip'} = _management_ip();
     $tags{'arch'} = `uname -m` eq "x86_64" ? "64" : "";
     $tags{'rpc_pass'} = $Config{webservices}{pass} || "''";
     $tags{'rpc_user'} = $Config{webservices}{user} || "''";
@@ -397,7 +409,7 @@ sub generate_radiusd_authconf {
     my %tags;
     my @listen_ips;
     if ($cluster_enabled) {
-        my $ip = defined($management_network->tag('vip')) ? $management_network->tag('vip') : $management_network->tag('ip');
+        my $ip = _management_ip();
         push @listen_ips, $ip;
 
     } else {
@@ -425,7 +437,7 @@ sub generate_radiusd_acctconf {
     my %tags;
     my @listen_ips;
     if ($cluster_enabled) {
-        my $ip = defined($management_network->tag('vip')) ? $management_network->tag('vip') : $management_network->tag('ip');
+        my $ip = _management_ip();
         push @listen_ips, $ip;
 
     } else {
@@ -449,7 +461,7 @@ sub generate_radiusd_eduroamconf {
         my @eduroam_authentication_source = @{pf::authentication::getAuthenticationSourcesByType('Eduroam')};
         $tags{'template'}    = "$conf_dir/radiusd/eduroam.conf";
         if ($cluster_enabled) {
-            my $ip = defined($management_network->tag('vip')) ? $management_network->tag('vip') : $management_network->tag('ip');
+            my $ip = _management_ip();
             $tags{'listen'} .= << "EOT";
 listen {
     ipaddr = *
@@ -677,7 +689,7 @@ sub generate_radiusd_cliconf {
     if (@cli_switches > 0) {
         $tags{'template'}    = "$conf_dir/radiusd/cli.conf";
         if ($cluster_enabled) {
-            my $ip = defined($management_network->tag('vip')) ? $management_network->tag('vip') : $management_network->tag('ip');
+            my $ip = _management_ip();
 
 $tags{'listen'} .= <<"EOT";
 listen {
@@ -1115,7 +1127,7 @@ EOT
     }
 
     if(isenabled($Config{services}{pfacct})) {
-        my $management_ip = defined($management_network->tag('vip')) ? $management_network->tag('vip') : $management_network->tag('ip');
+        my $management_ip = _management_ip();
         my $port = '1813';
         if ($cluster_enabled || isenabled($Config{services}{radiusd_acct})) {
             $port = '1823';


### PR DESCRIPTION
# Description

During the configurator wizard the management interface does not exist yet, so
`$management_network` (a tied scalar) is `undef`. Four service managers called
`$management_network->tag(...)` unconditionally, which is a hard FATAL.

`packetfence-netdata.service` runs `generateConfig()` in `ExecStartPre` with
`Restart=on-failure` and is pulled in by `packetfence.target`, so that FATAL
failed the unit and every subsequent target/iptables restart re-triggered it —
a ~15s-cadence restart loop lasting the whole wizard (44 FATALs on pf1, 120
across the 3 nodes of `cluster_configurator_deb12`).

This guards the four managers so they generate config with an empty management
IP while the interface is unset, and pick up the real value once it is set.
The `pf::iptables` "Management Interface is not set" warnings are by design and
are left untouched — only the crash is fixed.

Guard idiom is `ref($management_network)`, matching the existing
`snmptrapd.pm::getManagementIp`, with `''` fallbacks so templates do not emit
uninitialized-value warnings.

Perl-side sibling of #9181, which fixed the same class of bug on the Go side
(pfcron / pfconfigdriver).

# Impacts

- `lib/pf/services/manager/netdata.pm` — IP/VIP lookups hoisted to the top of
  `generateConfig`; cluster-members block gated on the management network.
- `lib/pf/services/manager/radiusd_child.pm` — new `_management_ip()` helper
  replaces 7 duplicated `defined(...->tag('vip')) ? ... : ...` call sites.
- `lib/pf/services/manager/pfacct.pm` — only the IP-dependent part is guarded;
  `$port_save` is now set outside the guard because it is used later
  independently of the management IP.
- `lib/pf/services/manager/haproxy_db.pm` — single `//` chain.

Reviewer should confirm no behaviour change once the management network **is**
set: in that case every guard takes the same branch as before, and
`vip // ip` is equivalent to the previous `defined(vip) ? vip : ip`.

Worth exercising: cluster + standalone configurator runs, RADIUS config
generation (`radiusd_child` touches sites/main/auth/acct/eduroam/cli), and
`haproxy-db` in both slave and normal cluster mode.

# Backport

Backport scope is **15.x and devel**. Cherry-pick of `4524dfda53` was tested in
a throwaway worktree per branch and applies with no manual work:

| Branch             | Cherry-pick | Notes                                           |
|--------------------|-------------|-------------------------------------------------|
| `maintenance/15.2` | clean       | target branch of this PR                        |
| `maintenance/15.1` | clean       | —                                               |
| `maintenance/15.0` | clean       | —                                               |
| `devel`            | clean       | four files byte-identical to this branch's base |

The same unguarded pattern also exists on 14.x and older, but the surrounding
code has drifted there (cherry-pick conflicts in `pfacct.pm` /
`radiusd_child.pm` / `netdata.pm`), so those are deliberately out of scope.

# Delete branch after merge

YES

# Checklist

- [ ] Document the feature — n/a
- [ ] Add OpenAPI specification — n/a
- [ ] Add unit tests — no (see note below)
- [ ] Add acceptance tests (TestLink) — no; covered by the existing
      `cluster_configurator_deb12` venom suite, which this fix targets

Note: these `generateConfig` paths have no existing unit-test harness, and the
failure only reproduces with an unset management network during cluster
bring-up, which the venom configurator suite already exercises.

# NEWS file entries

## Bug Fixes

* Service config generation no longer crashes when the management network is
  unset, which caused netdata / pfacct / radiusd / haproxy-db to restart-loop
  throughout the configurator wizard