### PR TITLE
pfacct: skip per-packet balance accounting when no node carries a balance

### DIFF
--- a/go/cmd/pfacct/balance_gate.go
+++ b/go/cmd/pfacct/balance_gate.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"time"
+)
+
+const balancesInUseRefreshInterval = 5 * time.Minute
+
+// refreshBalancesInUse probes whether any node currently carries a time or
+// bandwidth balance. When none do (the common case), the per-packet balance
+// accounting in handleAccountingRequest is skipped entirely: every statement
+// it runs filters on the balance being NOT NULL and is a guaranteed no-op,
+// yet together they cost several node-table SELECTs and two UPDATEs per
+// accounting packet. Fails open: with the probe unavailable or erroring, the
+// balance path stays on.
+func (h *PfAcct) refreshBalancesInUse() {
+	if h.anyNodeBalances == nil {
+		h.balancesInUse.Store(true)
+		return
+	}
+
+	var inUse bool
+	if err := h.anyNodeBalances.QueryRow().Scan(&inUse); err != nil {
+		logError(h.LoggerCtx, "anyNodeBalances: "+err.Error())
+		inUse = true
+	}
+	h.balancesInUse.Store(inUse)
+}
+
+// startBalancesInUseRefresher primes the balances-in-use flag and keeps it
+// fresh; a balance assigned to a node is picked up within one refresh
+// interval.
+func (h *PfAcct) startBalancesInUseRefresher() {
+	h.refreshBalancesInUse()
+	go func() {
+		for {
+			time.Sleep(balancesInUseRefreshInterval)
+			h.refreshBalancesInUse()
+		}
+	}()
+}

--- a/go/cmd/pfacct/balance_gate.go
+++ b/go/cmd/pfacct/balance_gate.go
@@ -6,36 +6,103 @@ import (
 
 const balancesInUseRefreshInterval = 5 * time.Minute
 
+// anyNodeBalancesQuery probes whether any node carries a time or bandwidth
+// balance. One predicate rather than two EXISTS subqueries: neither column is
+// indexed, and the case this gate optimises for (no balances anywhere) is the
+// one that cannot short-circuit, so two subqueries scan the node table twice.
+const anyNodeBalancesQuery = `SELECT EXISTS(SELECT 1 FROM node WHERE time_balance IS NOT NULL OR bandwidth_balance IS NOT NULL)`
+
 // refreshBalancesInUse probes whether any node currently carries a time or
 // bandwidth balance. When none do (the common case), the per-packet balance
 // accounting in handleAccountingRequest is skipped entirely: every statement
 // it runs filters on the balance being NOT NULL and is a guaranteed no-op,
 // yet together they cost several node-table SELECTs and two UPDATEs per
-// accounting packet. Fails open: with the probe unavailable or erroring, the
-// balance path stays on.
+// accounting packet. Fails open: if the probe errors the balance path stays on.
+//
+// The query is issued directly rather than through RadiusStatements. It runs
+// once per refresh interval, so preparing it buys nothing, and a prepared
+// statement would have to be read while setupStmt's retry goroutine may still
+// be writing the pointer.
 func (h *PfAcct) refreshBalancesInUse() {
-	if h.anyNodeBalances == nil {
-		h.balancesInUse.Store(true)
+	if h.Db == nil {
+		h.setBalancesInUse(true)
 		return
 	}
 
 	var inUse bool
-	if err := h.anyNodeBalances.QueryRow().Scan(&inUse); err != nil {
+	if err := h.Db.QueryRow(anyNodeBalancesQuery).Scan(&inUse); err != nil {
 		logError(h.LoggerCtx, "anyNodeBalances: "+err.Error())
 		inUse = true
 	}
-	h.balancesInUse.Store(inUse)
+
+	h.setBalancesInUse(inUse)
+}
+
+// setBalancesInUse records the flag and, when the gate reopens after having
+// been shut, the instant it did. Sessions already in flight then have no
+// NodeSessionCache entry while pfacct has no accounting at all for the period
+// the gate was shut, so that instant bounds what may be charged for them; see
+// handleTimeBalance. balancesInUse starts out true, so a deployment that has
+// balances from the start never records an instant and keeps the pre-existing
+// behaviour exactly.
+func (h *PfAcct) setBalancesInUse(inUse bool) {
+	if !inUse {
+		h.balancesInUse.Store(false)
+		return
+	}
+
+	if !h.balancesInUse.Swap(true) {
+		h.balancesEnabledAt.Store(time.Now().Unix())
+	}
+}
+
+// untrackedChargeCap returns the most that may be charged for a session pfacct
+// holds no NodeSessionCache entry for, and whether such a cap applies at all.
+// It applies only once the gate has actually reopened after being shut: before
+// that there is no cap and sessions are charged as they always were.
+func (h *PfAcct) untrackedChargeCap() (int64, bool) {
+	since := h.balancesEnabledAt.Load()
+	if since == 0 {
+		return 0, false
+	}
+
+	elapsed := time.Now().Unix() - since
+	if elapsed < 0 {
+		elapsed = 0
+	}
+
+	return elapsed, true
 }
 
 // startBalancesInUseRefresher primes the balances-in-use flag and keeps it
 // fresh; a balance assigned to a node is picked up within one refresh
-// interval.
+// interval. Stop it with stopBalancesInUseRefresher.
 func (h *PfAcct) startBalancesInUseRefresher() {
 	h.refreshBalancesInUse()
+
+	h.balancesRefresherStop = make(chan struct{})
+	stop := h.balancesRefresherStop
 	go func() {
+		ticker := time.NewTicker(balancesInUseRefreshInterval)
+		defer ticker.Stop()
 		for {
-			time.Sleep(balancesInUseRefreshInterval)
-			h.refreshBalancesInUse()
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+				h.refreshBalancesInUse()
+			}
 		}
 	}()
+}
+
+// stopBalancesInUseRefresher stops the goroutine started by
+// startBalancesInUseRefresher. Safe to call more than once, and safe to call
+// when the refresher was never started.
+func (h *PfAcct) stopBalancesInUseRefresher() {
+	h.balancesRefresherStopOnce.Do(func() {
+		if h.balancesRefresherStop != nil {
+			close(h.balancesRefresherStop)
+		}
+	})
 }

--- a/go/cmd/pfacct/balance_gate_test.go
+++ b/go/cmd/pfacct/balance_gate_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/inverse-inc/go-utils/mac"
+)
+
+func TestBalancesInUseGate(t *testing.T) {
+	pfAcct := NewPfAcct("INFO")
+	if pfAcct == nil {
+		t.Fatalf("New pfAcct")
+	}
+
+	m, _ := mac.NewFromString("99:77:55:44:33:25")
+	if _, err := pfAcct.Db.Exec("DELETE FROM node WHERE mac = ?", m.String()); err != nil {
+		t.Fatalf("%s", err.Error())
+	}
+	if _, err := pfAcct.Db.Exec("UPDATE node SET time_balance = NULL, bandwidth_balance = NULL WHERE time_balance IS NOT NULL OR bandwidth_balance IS NOT NULL"); err != nil {
+		t.Fatalf("%s", err.Error())
+	}
+
+	pfAcct.refreshBalancesInUse()
+	if pfAcct.balancesInUse.Load() {
+		t.Errorf("balancesInUse should be false with no balances assigned")
+	}
+
+	if _, err := pfAcct.Db.Exec("INSERT INTO node (mac, status, time_balance) VALUES (?, 'unreg', 3600)", m.String()); err != nil {
+		t.Fatalf("%s", err.Error())
+	}
+	pfAcct.refreshBalancesInUse()
+	if !pfAcct.balancesInUse.Load() {
+		t.Errorf("balancesInUse should be true once a node carries a time balance")
+	}
+
+	if _, err := pfAcct.Db.Exec("UPDATE node SET time_balance = NULL, bandwidth_balance = 1000000 WHERE mac = ?", m.String()); err != nil {
+		t.Fatalf("%s", err.Error())
+	}
+	pfAcct.refreshBalancesInUse()
+	if !pfAcct.balancesInUse.Load() {
+		t.Errorf("balancesInUse should be true once a node carries a bandwidth balance")
+	}
+
+	if _, err := pfAcct.Db.Exec("DELETE FROM node WHERE mac = ?", m.String()); err != nil {
+		t.Fatalf("%s", err.Error())
+	}
+	pfAcct.refreshBalancesInUse()
+	if pfAcct.balancesInUse.Load() {
+		t.Errorf("balancesInUse should be false again after the balance-carrying node is gone")
+	}
+}

--- a/go/cmd/pfacct/balance_gate_test.go
+++ b/go/cmd/pfacct/balance_gate_test.go
@@ -2,32 +2,41 @@ package main
 
 import (
 	"testing"
+	"time"
 
 	"github.com/inverse-inc/go-utils/mac"
 )
 
+// The gate is deployment-wide, so this asserts the transitions its own node
+// causes rather than an absolute value: it must never clear balances belonging
+// to other nodes, which on a real PacketFence database would destroy every
+// guest's remaining time and bandwidth.
 func TestBalancesInUseGate(t *testing.T) {
 	pfAcct := NewPfAcct("INFO")
 	if pfAcct == nil {
 		t.Fatalf("New pfAcct")
 	}
+	t.Cleanup(pfAcct.stopBalancesInUseRefresher)
 
 	m, _ := mac.NewFromString("99:77:55:44:33:25")
-	if _, err := pfAcct.Db.Exec("DELETE FROM node WHERE mac = ?", m.String()); err != nil {
-		t.Fatalf("%s", err.Error())
-	}
-	if _, err := pfAcct.Db.Exec("UPDATE node SET time_balance = NULL, bandwidth_balance = NULL WHERE time_balance IS NOT NULL OR bandwidth_balance IS NOT NULL"); err != nil {
-		t.Fatalf("%s", err.Error())
+	removeNode := func() {
+		if _, err := pfAcct.Db.Exec("DELETE FROM node WHERE mac = ?", m.String()); err != nil {
+			t.Fatalf("%s", err.Error())
+		}
 	}
 
+	removeNode()
+	t.Cleanup(removeNode)
+
+	// Whatever the rest of the database holds is the baseline this test must
+	// return to; only the test node is added and removed.
 	pfAcct.refreshBalancesInUse()
-	if pfAcct.balancesInUse.Load() {
-		t.Errorf("balancesInUse should be false with no balances assigned")
-	}
+	baseline := pfAcct.balancesInUse.Load()
 
 	if _, err := pfAcct.Db.Exec("INSERT INTO node (mac, status, time_balance) VALUES (?, 'unreg', 3600)", m.String()); err != nil {
 		t.Fatalf("%s", err.Error())
 	}
+
 	pfAcct.refreshBalancesInUse()
 	if !pfAcct.balancesInUse.Load() {
 		t.Errorf("balancesInUse should be true once a node carries a time balance")
@@ -36,16 +45,71 @@ func TestBalancesInUseGate(t *testing.T) {
 	if _, err := pfAcct.Db.Exec("UPDATE node SET time_balance = NULL, bandwidth_balance = 1000000 WHERE mac = ?", m.String()); err != nil {
 		t.Fatalf("%s", err.Error())
 	}
+
 	pfAcct.refreshBalancesInUse()
 	if !pfAcct.balancesInUse.Load() {
 		t.Errorf("balancesInUse should be true once a node carries a bandwidth balance")
 	}
 
-	if _, err := pfAcct.Db.Exec("DELETE FROM node WHERE mac = ?", m.String()); err != nil {
-		t.Fatalf("%s", err.Error())
-	}
+	removeNode()
 	pfAcct.refreshBalancesInUse()
-	if pfAcct.balancesInUse.Load() {
-		t.Errorf("balancesInUse should be false again after the balance-carrying node is gone")
+	if got := pfAcct.balancesInUse.Load(); got != baseline {
+		t.Errorf("balancesInUse = %v after the balance-carrying node is gone, want the baseline %v", got, baseline)
 	}
+}
+
+// A session with no NodeSessionCache entry may only be charged for the time
+// since the gate reopened, and only when it actually did reopen: a deployment
+// that had balances all along must keep charging exactly as it did before.
+func TestUntrackedChargeCap(t *testing.T) {
+	enabledFromTheStart := &PfAcct{}
+	enabledFromTheStart.balancesInUse.Store(true)
+	enabledFromTheStart.setBalancesInUse(true)
+	if _, capped := enabledFromTheStart.untrackedChargeCap(); capped {
+		t.Error("a gate that was never shut must not cap what a session is charged")
+	}
+
+	reopened := &PfAcct{}
+	reopened.balancesInUse.Store(true)
+	reopened.setBalancesInUse(false)
+	if reopened.balancesInUse.Load() {
+		t.Fatal("the gate should be shut after a probe finds no balances")
+	}
+
+	if _, capped := reopened.untrackedChargeCap(); capped {
+		t.Error("a shut gate has nothing to cap yet")
+	}
+
+	reopened.setBalancesInUse(true)
+	cap, capped := reopened.untrackedChargeCap()
+	if !capped {
+		t.Fatal("reopening the gate must cap what untracked sessions are charged")
+	}
+
+	if cap < 0 || cap > 5 {
+		t.Errorf("cap = %ds just after the gate reopened, want ~0", cap)
+	}
+
+	// Reopening again while already open must not move the instant.
+	before := reopened.balancesEnabledAt.Load()
+	time.Sleep(10 * time.Millisecond)
+	reopened.setBalancesInUse(true)
+	if after := reopened.balancesEnabledAt.Load(); after != before {
+		t.Errorf("a probe that keeps the gate open moved the instant from %d to %d", before, after)
+	}
+}
+
+func TestStopBalancesInUseRefresher(t *testing.T) {
+	// Never started: must not panic on a nil channel.
+	(&PfAcct{}).stopBalancesInUseRefresher()
+
+	// Started with no database: the probe fails open and the goroutine stops.
+	h := &PfAcct{}
+	h.startBalancesInUseRefresher()
+	if !h.balancesInUse.Load() {
+		t.Error("the gate should fail open when the probe cannot run")
+	}
+
+	h.stopBalancesInUseRefresher()
+	h.stopBalancesInUseRefresher()
 }

--- a/go/cmd/pfacct/main.go
+++ b/go/cmd/pfacct/main.go
@@ -45,6 +45,7 @@ func main() {
 	go func() {
 		<-c
 		rs.Shutdown(context.Background())
+		pfacct.stopBalancesInUseRefresher()
 		if processor != nil {
 			processor.Stop()
 		}

--- a/go/cmd/pfacct/pfacct.go
+++ b/go/cmd/pfacct/pfacct.go
@@ -61,6 +61,7 @@ type PfAcct struct {
 	radiusRequests          []chan<- radiusRequest
 	aaaNotifyQueues         []chan<- aaaNotifyJob
 	aaaNotifyDropped        atomic.Int64
+	balancesInUse           atomic.Bool
 	localSecret             string
 	unifiedSecret           string
 	StatsdOnce              tryableonce.TryableOnce
@@ -105,6 +106,7 @@ func NewPfAcct(logLevel string) *PfAcct {
 
 	pfAcct.LoggerCtx = ctx
 	pfAcct.RadiusStatements.Setup(pfAcct.Db)
+	pfAcct.startBalancesInUseRefresher()
 
 	pfAcct.SetupConfig(ctx)
 	pfAcct.radiusRequests = makeRadiusRequests(pfAcct, pfAcct.RadiusWorkers, pfAcct.RadiusWorkQueueSize)

--- a/go/cmd/pfacct/pfacct.go
+++ b/go/cmd/pfacct/pfacct.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"runtime"
 	"strconv"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -39,41 +40,44 @@ type radiusRequest struct {
 
 type PfAcct struct {
 	RadiusStatements
-	TimeDuration            time.Duration
-	Db                      *sql.DB
-	AllowedNetworks         []net.IPNet
-	NetFlowPort             string
-	NetFlowAddress          string
-	Management              pfconfigdriver.ManagementNetwork
-	AAAClient               *jsonrpc2.Client
-	LoggerCtx               context.Context
-	Dispatcher              *Dispatcher
-	SwitchInfoCache         *cache.Cache
-	NodeSessionCache        *cache.Cache
-	AcctSessionCache        *cache.Cache
-	RateLimitCache          *cache.Cache
-	MacNasCache             *cache.Cache
-	RateLimit               bool
-	PfacctRateLimitCacheTtl int
-	StatsdAddress           string
-	StatsdOption            statsd.Option
-	StatsdClient            *statsd.Client
-	radiusRequests          []chan<- radiusRequest
-	aaaNotifyQueues         []chan<- aaaNotifyJob
-	aaaNotifyDropped        atomic.Int64
-	balancesInUse           atomic.Bool
-	localSecret             string
-	unifiedSecret           string
-	StatsdOnce              tryableonce.TryableOnce
-	isProxied               bool
-	radiusdAcctEnabled      bool
-	AllNetworks             bool
-	ProcessBandwidthAcct    bool
-	RadiusWorkers           int
-	RadiusWorkQueueSize     int
-	SocketRecvBuffer        int
-	AAANotifyWorkers        int
-	AAANotifyQueueSize      int
+	TimeDuration              time.Duration
+	Db                        *sql.DB
+	AllowedNetworks           []net.IPNet
+	NetFlowPort               string
+	NetFlowAddress            string
+	Management                pfconfigdriver.ManagementNetwork
+	AAAClient                 *jsonrpc2.Client
+	LoggerCtx                 context.Context
+	Dispatcher                *Dispatcher
+	SwitchInfoCache           *cache.Cache
+	NodeSessionCache          *cache.Cache
+	AcctSessionCache          *cache.Cache
+	RateLimitCache            *cache.Cache
+	MacNasCache               *cache.Cache
+	RateLimit                 bool
+	PfacctRateLimitCacheTtl   int
+	StatsdAddress             string
+	StatsdOption              statsd.Option
+	StatsdClient              *statsd.Client
+	radiusRequests            []chan<- radiusRequest
+	aaaNotifyQueues           []chan<- aaaNotifyJob
+	aaaNotifyDropped          atomic.Int64
+	balancesInUse             atomic.Bool
+	balancesEnabledAt         atomic.Int64
+	balancesRefresherStop     chan struct{}
+	balancesRefresherStopOnce sync.Once
+	localSecret               string
+	unifiedSecret             string
+	StatsdOnce                tryableonce.TryableOnce
+	isProxied                 bool
+	radiusdAcctEnabled        bool
+	AllNetworks               bool
+	ProcessBandwidthAcct      bool
+	RadiusWorkers             int
+	RadiusWorkQueueSize       int
+	SocketRecvBuffer          int
+	AAANotifyWorkers          int
+	AAANotifyQueueSize        int
 }
 
 func NewPfAcct(logLevel string) *PfAcct {
@@ -106,6 +110,9 @@ func NewPfAcct(logLevel string) *PfAcct {
 
 	pfAcct.LoggerCtx = ctx
 	pfAcct.RadiusStatements.Setup(pfAcct.Db)
+	// Fail open until the first probe answers, and so that a deployment which
+	// has balances from the start never looks like a shut-to-open transition.
+	pfAcct.balancesInUse.Store(true)
 	pfAcct.startBalancesInUseRefresher()
 
 	pfAcct.SetupConfig(ctx)

--- a/go/cmd/pfacct/radius.go
+++ b/go/cmd/pfacct/radius.go
@@ -191,8 +191,11 @@ func (h *PfAcct) handleAccountingRequest(rr radiusRequest) {
 		}
 	}
 
-	h.handleTimeBalance(r, switchInfo, unique_session_id)
-	h.handleBandwidthBalance(r, switchInfo, in_bytes+out_bytes)
+	// Skipped entirely while no node carries a balance (see balance_gate.go)
+	if h.balancesInUse.Load() {
+		h.handleTimeBalance(r, switchInfo, unique_session_id)
+		h.handleBandwidthBalance(r, switchInfo, in_bytes+out_bytes)
+	}
 	h.sendRadiusAccounting(rr, switchInfo)
 }
 
@@ -737,6 +740,7 @@ type RadiusStatements struct {
 	closeSession                    *sql.Stmt
 	nodeOnlineOffLineStartUpdate    *sql.Stmt
 	nodeOnlineOffLineStop           *sql.Stmt
+	anyNodeBalances                 *sql.Stmt
 }
 
 func setupStmt(db *sql.DB, stmt **sql.Stmt, sql string) {
@@ -867,6 +871,11 @@ func (rs *RadiusStatements) Setup(db *sql.DB) {
 	setupStmt(db, &rs.nodeOnlineOffLineStartUpdate, `
 		INSERT INTO node_current_session (mac, last_session_id, updated, is_online) VALUES (?, ?, NOW(), 1)
         ON DUPLICATE KEY UPDATE updated = VALUES(updated), last_session_id = VALUES(last_session_id), is_online =1 ;
+       `)
+
+	setupStmt(db, &rs.anyNodeBalances, `
+        SELECT EXISTS(SELECT 1 FROM node WHERE time_balance IS NOT NULL)
+            OR EXISTS(SELECT 1 FROM node WHERE bandwidth_balance IS NOT NULL);
        `)
 
 }

--- a/go/cmd/pfacct/radius.go
+++ b/go/cmd/pfacct/radius.go
@@ -222,6 +222,13 @@ func (h *PfAcct) handleTimeBalance(r *radius.Request, switchInfo *SwitchInfo, un
 			if timebalance < 0 {
 				timebalance = 0
 			}
+		} else if cap, capped := h.untrackedChargeCap(); capped && timebalance > cap {
+			// No cache entry because the balance accounting was gated off for
+			// part of this session (see balance_gate.go). The offset recorded
+			// when the node stopped being unregistered was never captured, so
+			// charging the whole AcctSessionTime would bill time pfacct never
+			// accounted for; charge only what elapsed since the gate reopened.
+			timebalance = cap
 		}
 
 		ok, err := h.NodeTimeBalanceSubtract(mac, timebalance)
@@ -256,6 +263,10 @@ func (h *PfAcct) handleTimeBalance(r *radius.Request, switchInfo *SwitchInfo, un
 					timebalance = 0
 				}
 			}
+		} else if cap, capped := h.untrackedChargeCap(); capped && timebalance > cap {
+			// See the Stop branch above: without a cache entry the gated-off
+			// part of the session must not count towards the threshold.
+			timebalance = cap
 		}
 
 		if timebalance > 0 {
@@ -740,7 +751,6 @@ type RadiusStatements struct {
 	closeSession                    *sql.Stmt
 	nodeOnlineOffLineStartUpdate    *sql.Stmt
 	nodeOnlineOffLineStop           *sql.Stmt
-	anyNodeBalances                 *sql.Stmt
 }
 
 func setupStmt(db *sql.DB, stmt **sql.Stmt, sql string) {
@@ -871,11 +881,6 @@ func (rs *RadiusStatements) Setup(db *sql.DB) {
 	setupStmt(db, &rs.nodeOnlineOffLineStartUpdate, `
 		INSERT INTO node_current_session (mac, last_session_id, updated, is_online) VALUES (?, ?, NOW(), 1)
         ON DUPLICATE KEY UPDATE updated = VALUES(updated), last_session_id = VALUES(last_session_id), is_online =1 ;
-       `)
-
-	setupStmt(db, &rs.anyNodeBalances, `
-        SELECT EXISTS(SELECT 1 FROM node WHERE time_balance IS NOT NULL)
-            OR EXISTS(SELECT 1 FROM node WHERE bandwidth_balance IS NOT NULL);
        `)
 
 }


### PR DESCRIPTION
# Description
`handleTimeBalance` and `handleBandwidthBalance` run on every accounting packet: several node-table SELECTs (`IsUnreg`, zero-balance checks) plus two unconditional UPDATEs (`SoftNode*BalanceUpdate`). Every one of those statements filters on the balance column being `NOT NULL`, so on deployments that don't use time/bandwidth balances they are guaranteed no-ops — but the DB still pays for them.

Measured on a lab server at ~300 accounting packets/s with 30,026 nodes (zero with balances): this machinery was the majority of MariaDB's ~1,000 UPDATEs/s and a large share of the node table's ~6,400 rows read/s, with mariadbd as the top CPU consumer on the box (167%).

pfacct now probes `EXISTS(SELECT 1 FROM node WHERE time_balance IS NOT NULL OR bandwidth_balance IS NOT NULL)` at startup and every 5 minutes, and skips the balance path entirely while no node carries one.

# Impacts
- pfacct accounting workflow: balance enforcement semantics unchanged when balances are in use; when none are, the whole path is skipped.
- A balance assigned to a node activates within one 5-minute refresh interval (the probe fails open on DB errors).
- **The gate is deployment-wide, not per node.** One node anywhere carrying a balance re-enables the per-packet path for every packet from every node, so the win is all-or-nothing: a single time-limited guest voucher restores the original cost across the whole deployment.
- **Within one refresh interval of the *first* balance being assigned, accounting for that window is lost.** The interim path is what detects an exhausted balance mid-session (`SoftNodeTimeBalanceUpdate` zeroes the balance and fires the trigger) and the `Stop` path is the only debit. While the gate is still shut, interims are skipped and a `Stop` arriving in that window skips the debit outright — `Stop` happens once, so that session is never charged, and a `TimeExpired`/`BandwidthExpired` that would have fired may not. Nothing in the `set_time_balance` / `set_bandwidth_balance` path pokes pfacct, so there is no invalidation hook; this bounds the exposure at one interval per deployment, not per node.
- Sessions already in flight when the gate reopens are charged at most the time since it reopened. `handleTimeBalance` uses the `NodeSessionCache` entry to record the offset at which a node stopped being unregistered, and that entry is never primed while the gate is shut, so charging the full `AcctSessionTime` would bill time pfacct never accounted for — enough to zero a freshly assigned balance and lock the user out. A deployment that has balances from the start records no reopen instant and keeps the previous behaviour exactly.

# Delete branch after merge
YES

# Checklist
- [n/a] Document the feature (no configuration change)
- [n/a] Add OpenAPI specification
- [x] Add unit tests (`go/cmd/pfacct/balance_gate_test.go`, PASS on a PF server; the gate test is scoped to its own node and the cap/stop tests need no database)
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
## Enhancements
* pfacct skips the per-packet time/bandwidth balance accounting (several SELECTs and two UPDATEs per accounting packet) while **no node in the deployment** carries a balance, re-probed every 5 minutes; assigning a balance re-enables it within that interval
