### PR TITLE
Cut per-packet DB round trips in pfacct and pfdhcp

### DIFF
--- a/go/cmd/pfacct/pfacct.go
+++ b/go/cmd/pfacct/pfacct.go
@@ -53,6 +53,7 @@ type PfAcct struct {
 	AcctSessionCache        *cache.Cache
 	RateLimitCache          *cache.Cache
 	MacNasCache             *cache.Cache
+	SessionOnlineCache      *cache.Cache
 	RateLimit               bool
 	PfacctRateLimitCacheTtl int
 	StatsdAddress           string
@@ -102,6 +103,7 @@ func NewPfAcct(logLevel string) *PfAcct {
 	pfAcct.SwitchInfoCache = cache.New(5*time.Minute, 10*time.Minute)
 	pfAcct.NodeSessionCache = cache.New(nodeSessionExpiration, nodeSessionCleanupInterval)
 	pfAcct.AcctSessionCache = cache.New(5*time.Minute, 10*time.Minute)
+	pfAcct.SessionOnlineCache = cache.New(sessionOnlineRefreshTtl, 10*time.Minute)
 
 	pfAcct.LoggerCtx = ctx
 	pfAcct.RadiusStatements.Setup(pfAcct.Db)

--- a/go/cmd/pfacct/radius.go
+++ b/go/cmd/pfacct/radius.go
@@ -148,7 +148,7 @@ func (h *PfAcct) handleAccountingRequest(rr radiusRequest) {
 	out_bytes += giga_out_bytes << 32
 	in_bytes += giga_in_bytes << 32
 	unique_session_id := h.accountingUniqueSessionId(r)
-	err := h.updateNodeOnlineOfflineOnline(status, mac, unique_session_id)
+	err := h.rateLimitedNodeOnlineOffline(status, mac, unique_session_id)
 	if err != nil {
 		logError(ctx, fmt.Sprintf("Error updating online offline status: %s", err.Error()))
 	}

--- a/go/cmd/pfacct/session_online.go
+++ b/go/cmd/pfacct/session_online.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"strconv"
+	"time"
+
+	cache "github.com/fdurand/go-cache"
+	"github.com/inverse-inc/go-radius/rfc2866"
+	"github.com/inverse-inc/go-utils/mac"
+)
+
+// The node_current_session upsert only feeds the admin UI's online/offline
+// indicator and the 24h-window cleanup job, so refreshing `updated` once per
+// minute per session carries the same information as refreshing it on every
+// interim update.
+const sessionOnlineRefreshTtl = time.Minute
+
+// rateLimitedNodeOnlineOffline wraps updateNodeOnlineOfflineOnline: the
+// Start/Interim upsert runs at most once per sessionOnlineRefreshTtl per
+// (MAC, session), while Stop always executes (it flips is_online off) and
+// drops the cache entry so a same-session Start afterwards re-marks the node
+// online immediately.
+func (h *PfAcct) rateLimitedNodeOnlineOffline(status rfc2866.AcctStatusType, m mac.Mac, sessionID uint64) error {
+	key := m.String() + "|" + strconv.FormatUint(sessionID, 10)
+
+	if status == rfc2866.AcctStatusType_Value_Stop {
+		h.SessionOnlineCache.Delete(key)
+		return h.updateNodeOnlineOfflineOnline(status, m, sessionID)
+	}
+
+	if _, found := h.SessionOnlineCache.Get(key); found {
+		return nil
+	}
+
+	err := h.updateNodeOnlineOfflineOnline(status, m, sessionID)
+	if err == nil {
+		h.SessionOnlineCache.Set(key, 1, cache.DefaultExpiration)
+	}
+	return err
+}

--- a/go/cmd/pfacct/session_online.go
+++ b/go/cmd/pfacct/session_online.go
@@ -10,10 +10,11 @@ import (
 )
 
 // The node_current_session upsert only feeds the admin UI's online/offline
-// indicator and the 24h-window cleanup job, so refreshing `updated` once per
-// minute per session carries the same information as refreshing it on every
-// interim update.
-const sessionOnlineRefreshTtl = time.Minute
+// indicator and the 24h-window cleanup job, so refreshing `updated` every few
+// minutes per session carries the same information as refreshing it on every
+// interim update. The window must comfortably exceed the NAS interim-update
+// interval or every interim misses the cache and nothing is saved.
+const sessionOnlineRefreshTtl = 10 * time.Minute
 
 // rateLimitedNodeOnlineOffline wraps updateNodeOnlineOfflineOnline: the
 // Start/Interim upsert runs at most once per sessionOnlineRefreshTtl per

--- a/go/cmd/pfacct/session_online.go
+++ b/go/cmd/pfacct/session_online.go
@@ -21,6 +21,12 @@ const sessionOnlineRefreshTtl = 10 * time.Minute
 // (MAC, session), while Stop always executes (it flips is_online off) and
 // drops the cache entry so a same-session Start afterwards re-marks the node
 // online immediately.
+//
+// The cache records that the upsert ran, not that the row still exists, so a
+// node_current_session row removed behind pfacct's back (node_current_session
+// has no foreign key to node, so deleting a node leaves the row for the 24h
+// cleanup job) is not recreated until the entry expires; the admin UI renders
+// the missing row as "unknown" rather than online for at most that long.
 func (h *PfAcct) rateLimitedNodeOnlineOffline(status rfc2866.AcctStatusType, m mac.Mac, sessionID uint64) error {
 	key := m.String() + "|" + strconv.FormatUint(sessionID, 10)
 

--- a/go/cmd/pfacct/session_online_test.go
+++ b/go/cmd/pfacct/session_online_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/inverse-inc/go-radius/rfc2866"
+	"github.com/inverse-inc/go-utils/mac"
+)
+
+func sessionIsOnline(pfAcct *PfAcct, m mac.Mac) (bool, bool) {
+	var isOnline bool
+	err := pfAcct.Db.QueryRow("SELECT is_online FROM node_current_session WHERE mac = ?", m.String()).Scan(&isOnline)
+	if err != nil {
+		return false, false
+	}
+	return isOnline, true
+}
+
+func TestRateLimitedNodeOnlineOffline(t *testing.T) {
+	pfAcct := NewPfAcct("INFO")
+	if pfAcct == nil {
+		t.Fatalf("New pfAcct")
+	}
+
+	m, _ := mac.NewFromString("99:77:55:44:33:26")
+	session := uint64(42)
+	if _, err := pfAcct.Db.Exec("DELETE FROM node_current_session WHERE mac = ?", m.String()); err != nil {
+		t.Fatalf("%s", err.Error())
+	}
+
+	if err := pfAcct.rateLimitedNodeOnlineOffline(rfc2866.AcctStatusType_Value_Start, m, session); err != nil {
+		t.Fatalf("Start: %s", err.Error())
+	}
+	if online, found := sessionIsOnline(pfAcct, m); !found || !online {
+		t.Fatalf("Session should be online after Start (found=%v online=%v)", found, online)
+	}
+
+	// An interim within the TTL is skipped: remove the row behind the cache's
+	// back and verify it is not recreated.
+	if _, err := pfAcct.Db.Exec("DELETE FROM node_current_session WHERE mac = ?", m.String()); err != nil {
+		t.Fatalf("%s", err.Error())
+	}
+	if err := pfAcct.rateLimitedNodeOnlineOffline(rfc2866.AcctStatusType_Value_InterimUpdate, m, session); err != nil {
+		t.Fatalf("Interim: %s", err.Error())
+	}
+	if _, found := sessionIsOnline(pfAcct, m); found {
+		t.Fatalf("Interim within the TTL should have been rate-limited")
+	}
+
+	// Stop always executes and clears the cache, so a same-session Start
+	// right after goes through and re-marks the node online.
+	if err := pfAcct.rateLimitedNodeOnlineOffline(rfc2866.AcctStatusType_Value_Stop, m, session); err != nil {
+		t.Fatalf("Stop: %s", err.Error())
+	}
+	if err := pfAcct.rateLimitedNodeOnlineOffline(rfc2866.AcctStatusType_Value_Start, m, session); err != nil {
+		t.Fatalf("Start after Stop: %s", err.Error())
+	}
+	if online, found := sessionIsOnline(pfAcct, m); !found || !online {
+		t.Fatalf("Session should be online again after Stop then Start (found=%v online=%v)", found, online)
+	}
+}

--- a/go/cmd/pfdhcp/api.go
+++ b/go/cmd/pfdhcp/api.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
+	cache "github.com/fdurand/go-cache"
 	"github.com/gorilla/mux"
 	dhcp "github.com/inverse-inc/dhcp4"
 	"github.com/inverse-inc/go-utils/log"
@@ -330,7 +331,31 @@ func (a *API) handleRemoveNetworkOptions(res http.ResponseWriter, req *http.Requ
 	}
 }
 
+// decodedOptionsCache holds the decoded per-network and per-MAC option
+// overrides: decodeOptions runs twice per DHCP transaction and the overrides
+// (usually absent) change only through the admin API, so re-querying
+// key_value_storage per packet is wasted. Overrides added or changed through
+// the API take effect within the cache TTL. Callers only read the returned
+// map, which makes sharing the cached copy safe.
+var decodedOptionsCache = cache.New(time.Minute, 5*time.Minute)
+
+type decodedOptions struct {
+	options map[dhcp.OptionCode][]byte
+	err     error
+}
+
 func decodeOptions(ctx context.Context, b string, db *sql.DB) (map[dhcp.OptionCode][]byte, error) {
+	if cached, found := decodedOptionsCache.Get(b); found {
+		d := cached.(decodedOptions)
+		return d.options, d.err
+	}
+
+	options, err := decodeOptionsUncached(ctx, b, db)
+	decodedOptionsCache.Set(b, decodedOptions{options: options, err: err}, cache.DefaultExpiration)
+	return options, err
+}
+
+func decodeOptionsUncached(ctx context.Context, b string, db *sql.DB) (map[dhcp.OptionCode][]byte, error) {
 	var options []Options
 	_, value := MysqlGet(ctx, b, db)
 	decodedValue := sharedutils.ConvertToByte(value)

--- a/go/cmd/pfdhcp/api.go
+++ b/go/cmd/pfdhcp/api.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
-	cache "github.com/fdurand/go-cache"
 	"github.com/gorilla/mux"
 	dhcp "github.com/inverse-inc/dhcp4"
 	"github.com/inverse-inc/go-utils/log"
@@ -331,31 +330,7 @@ func (a *API) handleRemoveNetworkOptions(res http.ResponseWriter, req *http.Requ
 	}
 }
 
-// decodedOptionsCache holds the decoded per-network and per-MAC option
-// overrides: decodeOptions runs twice per DHCP transaction and the overrides
-// (usually absent) change only through the admin API, so re-querying
-// key_value_storage per packet is wasted. Overrides added or changed through
-// the API take effect within the cache TTL. Callers only read the returned
-// map, which makes sharing the cached copy safe.
-var decodedOptionsCache = cache.New(time.Minute, 5*time.Minute)
-
-type decodedOptions struct {
-	options map[dhcp.OptionCode][]byte
-	err     error
-}
-
 func decodeOptions(ctx context.Context, b string, db *sql.DB) (map[dhcp.OptionCode][]byte, error) {
-	if cached, found := decodedOptionsCache.Get(b); found {
-		d := cached.(decodedOptions)
-		return d.options, d.err
-	}
-
-	options, err := decodeOptionsUncached(ctx, b, db)
-	decodedOptionsCache.Set(b, decodedOptions{options: options, err: err}, cache.DefaultExpiration)
-	return options, err
-}
-
-func decodeOptionsUncached(ctx context.Context, b string, db *sql.DB) (map[dhcp.OptionCode][]byte, error) {
 	var options []Options
 	_, value := MysqlGet(ctx, b, db)
 	decodedValue := sharedutils.ConvertToByte(value)

--- a/go/cmd/pfdhcp/ip4log_test.go
+++ b/go/cmd/pfdhcp/ip4log_test.go
@@ -1,0 +1,226 @@
+package main
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+// flakyDriver is a database/sql driver whose Prepare fails the first
+// failPrepares times, standing in for a database that is not accepting
+// connections yet when pfdhcp handles its first DHCP transaction.
+type flakyDriver struct {
+	mu           sync.Mutex
+	failPrepares int
+	prepared     int
+}
+
+func (d *flakyDriver) Open(string) (driver.Conn, error) { return &flakyConn{d: d}, nil }
+
+type flakyConn struct{ d *flakyDriver }
+
+func (c *flakyConn) Prepare(string) (driver.Stmt, error) {
+	c.d.mu.Lock()
+	defer c.d.mu.Unlock()
+	if c.d.failPrepares > 0 {
+		c.d.failPrepares--
+		return nil, errors.New("database is starting up")
+	}
+
+	c.d.prepared++
+	return &flakyStmt{}, nil
+}
+
+func (c *flakyConn) Close() error              { return nil }
+func (c *flakyConn) Begin() (driver.Tx, error) { return nil, errors.New("not implemented") }
+
+type flakyStmt struct{}
+
+func (s *flakyStmt) Close() error  { return nil }
+func (s *flakyStmt) NumInput() int { return -1 }
+func (s *flakyStmt) Exec([]driver.Value) (driver.Result, error) {
+	return nil, errors.New("not implemented")
+}
+func (s *flakyStmt) Query([]driver.Value) (driver.Rows, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (d *flakyDriver) prepareCount() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.prepared
+}
+
+func openFlakyDb(t *testing.T, d *flakyDriver) *sql.DB {
+	t.Helper()
+	name := fmt.Sprintf("pfdhcp-ip4log-test-%d", time.Now().UnixNano())
+	sql.Register(name, d)
+	db, err := sql.Open(name, "")
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func resetIp4logStatements() {
+	ip4logStmtsMu.Lock()
+	defer ip4logStmtsMu.Unlock()
+	ip4logStmts, ip4logStmtsDb = nil, nil
+}
+
+// A failed Prepare must not be remembered: sql.Open does not connect, so the
+// first Prepare is also the first connection attempt, and memoising its error
+// left every later ip4log write failing until pfdhcp was restarted.
+func TestIp4logStatementsForRetriesAfterAPrepareFailure(t *testing.T) {
+	resetIp4logStatements()
+	t.Cleanup(resetIp4logStatements)
+
+	d := &flakyDriver{failPrepares: 1}
+	db := openFlakyDb(t, d)
+
+	if _, err := ip4logStatementsFor(db); err == nil {
+		t.Fatal("the first call should report the Prepare failure")
+	}
+
+	stmts, err := ip4logStatementsFor(db)
+	if err != nil {
+		t.Fatalf("a Prepare failure must not be memoised, got %v on the retry", err)
+	}
+
+	if stmts == nil || stmts.mac2ip == nil || stmts.ip2mac == nil || stmts.ipClose == nil || stmts.ipInsert == nil {
+		t.Fatalf("all four statements should be prepared: %+v", stmts)
+	}
+
+	if n := d.prepareCount(); n != 4 {
+		t.Errorf("expected 4 prepared statements, got %d", n)
+	}
+
+	again, err := ip4logStatementsFor(db)
+	if err != nil {
+		t.Fatalf("third call: %v", err)
+	}
+
+	if again != stmts {
+		t.Error("statements should be reused for the same handle, not prepared again")
+	}
+
+	if n := d.prepareCount(); n != 4 {
+		t.Errorf("reuse should not prepare again, got %d statements", n)
+	}
+}
+
+// The statements are bound to the handle they were prepared against, so a
+// different handle must re-prepare rather than silently keep using the old one.
+func TestIp4logStatementsForRepreparesForANewHandle(t *testing.T) {
+	resetIp4logStatements()
+	t.Cleanup(resetIp4logStatements)
+
+	first := &flakyDriver{}
+	firstDb := openFlakyDb(t, first)
+	if _, err := ip4logStatementsFor(firstDb); err != nil {
+		t.Fatalf("first handle: %v", err)
+	}
+
+	second := &flakyDriver{}
+	secondDb := openFlakyDb(t, second)
+	if _, err := ip4logStatementsFor(secondDb); err != nil {
+		t.Fatalf("second handle: %v", err)
+	}
+
+	if n := second.prepareCount(); n != 4 {
+		t.Errorf("a new handle should prepare its own statements, got %d", n)
+	}
+}
+
+func TestIp4logConflictTtl(t *testing.T) {
+	cases := []struct {
+		name  string
+		lease time.Duration
+		want  time.Duration
+	}{
+		{"half the lease", 10 * time.Minute, 5 * time.Minute},
+		{"typical 5 minute lease", 5 * time.Minute, 150 * time.Second},
+		{"long lease is capped", 24 * time.Hour, ip4logConflictTtlMax},
+		{"short lease keeps the floor", 10 * time.Second, ip4logConflictTtlMin},
+		{"zero lease keeps the floor", 0, ip4logConflictTtlMin},
+		{"negative lease keeps the floor", -time.Minute, ip4logConflictTtlMin},
+	}
+
+	for _, c := range cases {
+		if got := ip4logConflictTtl(c.lease); got != c.want {
+			t.Errorf("%s: ip4logConflictTtl(%s) = %s, want %s", c.name, c.lease, got, c.want)
+		}
+	}
+}
+
+// The conflict checks are skipped only for the exact MAC<->IP pair that was
+// confirmed; every way a binding can change is a different key, and closing a
+// superseded row forgets the binding it belonged to.
+func TestIp4logBindingCache(t *testing.T) {
+	const (
+		macA = "00:11:22:33:44:01"
+		macB = "00:11:22:33:44:02"
+		ipA  = "10.0.0.10"
+		ipB  = "10.0.0.11"
+	)
+
+	t.Cleanup(func() { ip4logConflictCache.Flush() })
+	ip4logConflictCache.Flush()
+
+	if ip4logBindingConfirmed(macA, ipA) {
+		t.Fatal("an unseen binding must not be confirmed")
+	}
+
+	confirmIp4logBinding(macA, ipA, 10*time.Minute)
+	if !ip4logBindingConfirmed(macA, ipA) {
+		t.Fatal("the binding should be confirmed after a successful upsert")
+	}
+
+	// Same device, new IP: a different key, so the checks run again.
+	if ip4logBindingConfirmed(macA, ipB) {
+		t.Error("a new IP for the same MAC must not be confirmed")
+	}
+
+	// Same IP, new device: also a different key.
+	if ip4logBindingConfirmed(macB, ipA) {
+		t.Error("a new MAC for the same IP must not be confirmed")
+	}
+
+	// Closing the row that macB took over forgets only that binding.
+	confirmIp4logBinding(macB, ipB, 10*time.Minute)
+	forgetIp4logBinding(macA, ipA)
+	if ip4logBindingConfirmed(macA, ipA) {
+		t.Error("a forgotten binding must be re-checked")
+	}
+
+	if !ip4logBindingConfirmed(macB, ipB) {
+		t.Error("forgetting one binding must not drop the others")
+	}
+}
+
+func TestIp4logBindingCacheExpires(t *testing.T) {
+	const (
+		mac = "00:11:22:33:44:03"
+		ip  = "10.0.0.12"
+	)
+
+	t.Cleanup(func() { ip4logConflictCache.Flush() })
+	ip4logConflictCache.Flush()
+
+	// ip4logConflictTtl floors at 30s, so set the short entry directly.
+	ip4logConflictCache.Set(ip4logConflictKey(mac, ip), 1, 10*time.Millisecond)
+	if !ip4logBindingConfirmed(mac, ip) {
+		t.Fatal("the binding should be confirmed right after it is set")
+	}
+
+	time.Sleep(30 * time.Millisecond)
+	if ip4logBindingConfirmed(mac, ip) {
+		t.Error("the binding should be re-checked once the entry expires")
+	}
+}

--- a/go/cmd/pfdhcp/main.go
+++ b/go/cmd/pfdhcp/main.go
@@ -491,7 +491,14 @@ func (I *Interface) handleRequest(ctx context.Context, p dhcp.Packet, handler DH
 					options[key] = value
 				}
 			}
-			GlobalOptions = options
+			// Copy rather than alias: the network, device and pffilter overrides
+			// below write into GlobalOptions, while the reply is assembled with
+			// options[dhcp.OptionParameterRequestList], which has to stay the
+			// configured request list rather than whatever an override set.
+			GlobalOptions = make(dhcp.Options, len(options))
+			for key, value := range options {
+				GlobalOptions[key] = value
+			}
 			leaseDuration := handler.leaseDuration
 			// Add network options
 			AddDevicesOptions(NetScope.IP.String(), &leaseDuration, GlobalOptions, db)
@@ -751,7 +758,14 @@ reply:
 			options[key] = value
 		}
 	}
-	GlobalOptions = options
+	// Copy rather than alias: the network, device and pffilter overrides
+	// below write into GlobalOptions, while the reply is assembled with
+	// options[dhcp.OptionParameterRequestList], which has to stay the
+	// configured request list rather than whatever an override set.
+	GlobalOptions = make(dhcp.Options, len(options))
+	for key, value := range options {
+		GlobalOptions[key] = value
+	}
 	leaseDuration := handler.leaseDuration
 
 	// Add network options on the fly

--- a/go/cmd/pfdhcp/utils.go
+++ b/go/cmd/pfdhcp/utils.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	cache "github.com/fdurand/go-cache"
@@ -535,67 +536,94 @@ func IsIPv6(address net.IP) bool {
 	return strings.Count(address.String(), ":") >= 2
 }
 
+// ip4logStmts holds the ip4log statements, prepared once: this path runs for
+// every DHCP transaction and used to pay four Prepare/Close round trips per
+// call on top of the queries themselves.
+var ip4logStmts struct {
+	once     sync.Once
+	err      error
+	mac2ip   *sql.Stmt
+	ip2mac   *sql.Stmt
+	ipClose  *sql.Stmt
+	ipInsert *sql.Stmt
+}
+
+// ip4logConflictCache remembers recently confirmed MAC<->IP bindings so a
+// plain renewal skips the two conflict-detection SELECTs; a device showing up
+// with a new IP (or an IP claimed by a new MAC) is a different key and misses
+// the cache, so conflicts are still detected and closed immediately.
+var ip4logConflictCache = cache.New(5*time.Minute, 10*time.Minute)
+
+func prepareIp4logStmts(db *sql.DB) error {
+	ip4logStmts.once.Do(func() {
+		prepare := func(q string) *sql.Stmt {
+			if ip4logStmts.err != nil {
+				return nil
+			}
+			var stmt *sql.Stmt
+			stmt, ip4logStmts.err = db.Prepare(q)
+			return stmt
+		}
+		ip4logStmts.mac2ip = prepare("SELECT ip FROM ip4log WHERE mac = ? AND (end_time = \"" + ZeroDate + "\" OR ( end_time + INTERVAL 30 SECOND ) > NOW()) ORDER BY start_time DESC LIMIT 1")
+		ip4logStmts.ip2mac = prepare("SELECT mac FROM ip4log WHERE ip = ? AND (end_time = \"" + ZeroDate + "\" OR end_time > NOW()) ORDER BY start_time DESC")
+		ip4logStmts.ipClose = prepare(" UPDATE ip4log SET end_time = NOW() WHERE ip = ?")
+		ip4logStmts.ipInsert = prepare("INSERT INTO ip4log (mac, ip, start_time, end_time) VALUES (?, ?, NOW(), DATE_ADD(NOW(), INTERVAL ? SECOND)) ON DUPLICATE KEY UPDATE mac=VALUES(mac), start_time=NOW(), end_time=VALUES(end_time)")
+	})
+	return ip4logStmts.err
+}
+
 // MysqlUpdateIP4Log update the ip4log table
 func MysqlUpdateIP4Log(ctx context.Context, mac string, ip string, duration time.Duration, db *sql.DB) error {
 	dbCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	if err := db.PingContext(dbCtx); err != nil {
-		log.LoggerWContext(ctx).Error("Unable to ping database, reconnect: " + err.Error())
-	}
 
-	// Prepare the statements
-	// We use the same context for all the queries
-	// because we want to be sure that all the queries are executed in the same context
-	// and that the context is cancelled if one of the queries fails
-
-	MAC2IP, err := db.Prepare("SELECT ip FROM ip4log WHERE mac = ? AND (end_time = \"" + ZeroDate + "\" OR ( end_time + INTERVAL 30 SECOND ) > NOW()) ORDER BY start_time DESC LIMIT 1")
-	if err != nil {
+	if err := prepareIp4logStmts(db); err != nil {
 		return err
 	}
-	defer MAC2IP.Close()
 
-	IP2MAC, err := db.Prepare("SELECT mac FROM ip4log WHERE ip = ? AND (end_time = \"" + ZeroDate + "\" OR end_time > NOW()) ORDER BY start_time DESC")
-	if err != nil {
-		return err
-	}
-	defer IP2MAC.Close()
-
-	IPClose, err := db.Prepare(" UPDATE ip4log SET end_time = NOW() WHERE ip = ?")
-	if err != nil {
-		return err
-	}
-	defer IPClose.Close()
-
-	IPInsert, err := db.Prepare("INSERT INTO ip4log (mac, ip, start_time, end_time) VALUES (?, ?, NOW(), DATE_ADD(NOW(), INTERVAL ? SECOND)) ON DUPLICATE KEY UPDATE mac=VALUES(mac), start_time=NOW(), end_time=VALUES(end_time)")
-	if err != nil {
-		return err
-	}
-	defer IPInsert.Close()
-	var (
-		oldMAC string
-		oldIP  string
-	)
-	err = MAC2IP.QueryRowContext(dbCtx, mac).Scan(&oldIP)
-	if err != nil {
-		log.LoggerWContext(ctx).Info(err.Error())
-	}
-	err = IP2MAC.QueryRowContext(dbCtx, ip).Scan(&oldMAC)
-	if err != nil {
-		log.LoggerWContext(ctx).Info(err.Error())
-	}
-	if len(oldMAC) > 0 && (oldMAC != mac) {
-		_, err = IPClose.ExecContext(dbCtx, ip)
+	conflictKey := mac + "|" + ip
+	if _, known := ip4logConflictCache.Get(conflictKey); !known {
+		var (
+			oldMAC string
+			oldIP  string
+		)
+		err := ip4logStmts.mac2ip.QueryRowContext(dbCtx, mac).Scan(&oldIP)
 		if err != nil {
-			return err
+			log.LoggerWContext(ctx).Info(err.Error())
+		}
+		err = ip4logStmts.ip2mac.QueryRowContext(dbCtx, ip).Scan(&oldMAC)
+		if err != nil {
+			log.LoggerWContext(ctx).Info(err.Error())
+		}
+		if len(oldMAC) > 0 && (oldMAC != mac) {
+			ip4logConflictCache.Delete(oldMAC + "|" + ip)
+			_, err = ip4logStmts.ipClose.ExecContext(dbCtx, ip)
+			if err != nil {
+				return err
+			}
+		}
+		if len(oldIP) > 0 && (oldIP != ip) {
+			ip4logConflictCache.Delete(mac + "|" + oldIP)
+			_, err = ip4logStmts.ipClose.ExecContext(dbCtx, oldIP)
+			if err != nil {
+				return err
+			}
 		}
 	}
-	if len(oldIP) > 0 && (oldIP != ip) {
-		_, err = IPClose.ExecContext(dbCtx, oldIP)
-		if err != nil {
-			return err
-		}
+
+	// The binding stays confirmed for at most half its lease so the checks
+	// re-run at least once per lease even for a quiet, stable client.
+	conflictTtl := duration / 2
+	if conflictTtl > 5*time.Minute {
+		conflictTtl = 5 * time.Minute
 	}
-	_, err = IPInsert.ExecContext(dbCtx, mac, ip, duration.Seconds())
+	if conflictTtl < 30*time.Second {
+		conflictTtl = 30 * time.Second
+	}
+	ip4logConflictCache.Set(conflictKey, 1, conflictTtl)
+
+	// Always refresh the entry itself: renewals must push end_time forward.
+	_, err := ip4logStmts.ipInsert.ExecContext(dbCtx, mac, ip, duration.Seconds())
 	if err != nil {
 		log.LoggerWContext(ctx).Info(err.Error())
 	}
@@ -615,8 +643,18 @@ func sanitizeHostname(h string) string {
 // previously-stored non-empty value (possible MAC spoofing). This mirrors the
 // Perl pf::api::detect_computername_change, which PacketFence's DHCP processor
 // no longer runs for networks pfdhcp serves (it defers computername to us).
+// computernameCache remembers the last host name persisted per MAC so the
+// per-packet UPDATE (and the change-detection read) only runs when the value
+// actually changes; a changed host name is a different cache value and goes
+// through immediately.
+var computernameCache = cache.New(5*time.Minute, 10*time.Minute)
+
 func recordComputername(ctx context.Context, mac string, hostname string, db *sql.DB) {
 	if hostname == "" {
+		return
+	}
+
+	if last, found := computernameCache.Get(mac); found && last.(string) == hostname {
 		return
 	}
 
@@ -637,7 +675,9 @@ func recordComputername(ctx context.Context, mac string, hostname string, db *sq
 
 	if err := MysqlUpdateComputername(ctx, mac, hostname, db); err != nil {
 		log.LoggerWContext(ctx).Warn("Unable to update computername for " + mac + ": " + err.Error())
+		return
 	}
+	computernameCache.Set(mac, hostname, cache.DefaultExpiration)
 }
 
 // mysqlGetComputername returns the node's currently stored computername, or ""

--- a/go/cmd/pfdhcp/utils.go
+++ b/go/cmd/pfdhcp/utils.go
@@ -536,40 +536,128 @@ func IsIPv6(address net.IP) bool {
 	return strings.Count(address.String(), ":") >= 2
 }
 
-// ip4logStmts holds the ip4log statements, prepared once: this path runs for
-// every DHCP transaction and used to pay four Prepare/Close round trips per
-// call on top of the queries themselves.
-var ip4logStmts struct {
-	once     sync.Once
-	err      error
+// ip4logStatements holds the ip4log statements, prepared once: this path runs
+// for every DHCP transaction and used to pay four Prepare/Close round trips
+// per call on top of the queries themselves.
+type ip4logStatements struct {
 	mac2ip   *sql.Stmt
 	ip2mac   *sql.Stmt
 	ipClose  *sql.Stmt
 	ipInsert *sql.Stmt
 }
 
+func (s *ip4logStatements) close() {
+	for _, stmt := range []*sql.Stmt{s.mac2ip, s.ip2mac, s.ipClose, s.ipInsert} {
+		if stmt != nil {
+			stmt.Close()
+		}
+	}
+}
+
+var (
+	ip4logStmtsMu sync.RWMutex
+	ip4logStmtsDb *sql.DB
+	ip4logStmts   *ip4logStatements
+)
+
+// ip4logStatementsFor returns the statements prepared against db, preparing
+// them on first use and again if a different handle is passed.
+//
+// A failure is deliberately not memoised: sql.Open does not connect, so the
+// first Prepare is also the first connection attempt, and memoising its error
+// (as a sync.Once would) left every later ip4log write failing for the life of
+// the process when pfdhcp happened to start before the database was accepting
+// connections.
+func ip4logStatementsFor(db *sql.DB) (*ip4logStatements, error) {
+	ip4logStmtsMu.RLock()
+	if ip4logStmts != nil && ip4logStmtsDb == db {
+		stmts := ip4logStmts
+		ip4logStmtsMu.RUnlock()
+		return stmts, nil
+	}
+	ip4logStmtsMu.RUnlock()
+
+	ip4logStmtsMu.Lock()
+	defer ip4logStmtsMu.Unlock()
+	// Another goroutine may have prepared them while we waited for the lock.
+	if ip4logStmts != nil && ip4logStmtsDb == db {
+		return ip4logStmts, nil
+	}
+
+	var err error
+	prepare := func(query string) *sql.Stmt {
+		if err != nil {
+			return nil
+		}
+		var stmt *sql.Stmt
+		stmt, err = db.Prepare(query)
+		return stmt
+	}
+
+	stmts := &ip4logStatements{}
+	stmts.mac2ip = prepare("SELECT ip FROM ip4log WHERE mac = ? AND (end_time = \"" + ZeroDate + "\" OR ( end_time + INTERVAL 30 SECOND ) > NOW()) ORDER BY start_time DESC LIMIT 1")
+	stmts.ip2mac = prepare("SELECT mac FROM ip4log WHERE ip = ? AND (end_time = \"" + ZeroDate + "\" OR end_time > NOW()) ORDER BY start_time DESC")
+	stmts.ipClose = prepare(" UPDATE ip4log SET end_time = NOW() WHERE ip = ?")
+	stmts.ipInsert = prepare("INSERT INTO ip4log (mac, ip, start_time, end_time) VALUES (?, ?, NOW(), DATE_ADD(NOW(), INTERVAL ? SECOND)) ON DUPLICATE KEY UPDATE mac=VALUES(mac), start_time=NOW(), end_time=VALUES(end_time)")
+	if err != nil {
+		stmts.close()
+		return nil, err
+	}
+
+	if ip4logStmts != nil {
+		ip4logStmts.close()
+	}
+	ip4logStmtsDb, ip4logStmts = db, stmts
+	return stmts, nil
+}
+
 // ip4logConflictCache remembers recently confirmed MAC<->IP bindings so a
 // plain renewal skips the two conflict-detection SELECTs; a device showing up
 // with a new IP (or an IP claimed by a new MAC) is a different key and misses
 // the cache, so conflicts are still detected and closed immediately.
-var ip4logConflictCache = cache.New(5*time.Minute, 10*time.Minute)
+//
+// The cache only knows about what pfdhcp itself wrote. ip4log is also written
+// by pfacct (radius_accounting -> update_ip4log) and by the Perl DHCP
+// processor for networks pfdhcp does not serve, and neither can invalidate it;
+// the upsert below covers that case, since a row another writer removed comes
+// back as an INSERT rather than an UPDATE.
+var ip4logConflictCache = cache.New(ip4logConflictTtlMax, 10*time.Minute)
 
-func prepareIp4logStmts(db *sql.DB) error {
-	ip4logStmts.once.Do(func() {
-		prepare := func(q string) *sql.Stmt {
-			if ip4logStmts.err != nil {
-				return nil
-			}
-			var stmt *sql.Stmt
-			stmt, ip4logStmts.err = db.Prepare(q)
-			return stmt
-		}
-		ip4logStmts.mac2ip = prepare("SELECT ip FROM ip4log WHERE mac = ? AND (end_time = \"" + ZeroDate + "\" OR ( end_time + INTERVAL 30 SECOND ) > NOW()) ORDER BY start_time DESC LIMIT 1")
-		ip4logStmts.ip2mac = prepare("SELECT mac FROM ip4log WHERE ip = ? AND (end_time = \"" + ZeroDate + "\" OR end_time > NOW()) ORDER BY start_time DESC")
-		ip4logStmts.ipClose = prepare(" UPDATE ip4log SET end_time = NOW() WHERE ip = ?")
-		ip4logStmts.ipInsert = prepare("INSERT INTO ip4log (mac, ip, start_time, end_time) VALUES (?, ?, NOW(), DATE_ADD(NOW(), INTERVAL ? SECOND)) ON DUPLICATE KEY UPDATE mac=VALUES(mac), start_time=NOW(), end_time=VALUES(end_time)")
-	})
-	return ip4logStmts.err
+const (
+	ip4logConflictTtlMax = 5 * time.Minute
+	ip4logConflictTtlMin = 30 * time.Second
+)
+
+func ip4logConflictKey(mac string, ip string) string {
+	return mac + "|" + ip
+}
+
+// ip4logConflictTtl keeps a binding confirmed for at most half its lease, so
+// the checks re-run at least once per lease even for a quiet, stable client.
+func ip4logConflictTtl(lease time.Duration) time.Duration {
+	ttl := lease / 2
+	if ttl > ip4logConflictTtlMax {
+		ttl = ip4logConflictTtlMax
+	}
+
+	if ttl < ip4logConflictTtlMin {
+		ttl = ip4logConflictTtlMin
+	}
+
+	return ttl
+}
+
+func ip4logBindingConfirmed(mac string, ip string) bool {
+	_, found := ip4logConflictCache.Get(ip4logConflictKey(mac, ip))
+	return found
+}
+
+func confirmIp4logBinding(mac string, ip string, lease time.Duration) {
+	ip4logConflictCache.Set(ip4logConflictKey(mac, ip), 1, ip4logConflictTtl(lease))
+}
+
+func forgetIp4logBinding(mac string, ip string) {
+	ip4logConflictCache.Delete(ip4logConflictKey(mac, ip))
 }
 
 // MysqlUpdateIP4Log update the ip4log table
@@ -577,57 +665,59 @@ func MysqlUpdateIP4Log(ctx context.Context, mac string, ip string, duration time
 	dbCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	if err := prepareIp4logStmts(db); err != nil {
+	stmts, err := ip4logStatementsFor(db)
+	if err != nil {
 		return err
 	}
 
-	conflictKey := mac + "|" + ip
-	if _, known := ip4logConflictCache.Get(conflictKey); !known {
+	if !ip4logBindingConfirmed(mac, ip) {
 		var (
 			oldMAC string
 			oldIP  string
 		)
-		err := ip4logStmts.mac2ip.QueryRowContext(dbCtx, mac).Scan(&oldIP)
-		if err != nil {
+		if err := stmts.mac2ip.QueryRowContext(dbCtx, mac).Scan(&oldIP); err != nil {
 			log.LoggerWContext(ctx).Info(err.Error())
 		}
-		err = ip4logStmts.ip2mac.QueryRowContext(dbCtx, ip).Scan(&oldMAC)
-		if err != nil {
-			log.LoggerWContext(ctx).Info(err.Error())
-		}
-		if len(oldMAC) > 0 && (oldMAC != mac) {
-			ip4logConflictCache.Delete(oldMAC + "|" + ip)
-			_, err = ip4logStmts.ipClose.ExecContext(dbCtx, ip)
-			if err != nil {
-				return err
-			}
-		}
-		if len(oldIP) > 0 && (oldIP != ip) {
-			ip4logConflictCache.Delete(mac + "|" + oldIP)
-			_, err = ip4logStmts.ipClose.ExecContext(dbCtx, oldIP)
-			if err != nil {
-				return err
-			}
-		}
-	}
 
-	// The binding stays confirmed for at most half its lease so the checks
-	// re-run at least once per lease even for a quiet, stable client.
-	conflictTtl := duration / 2
-	if conflictTtl > 5*time.Minute {
-		conflictTtl = 5 * time.Minute
+		if err := stmts.ip2mac.QueryRowContext(dbCtx, ip).Scan(&oldMAC); err != nil {
+			log.LoggerWContext(ctx).Info(err.Error())
+		}
+
+		if len(oldMAC) > 0 && (oldMAC != mac) {
+			forgetIp4logBinding(oldMAC, ip)
+			if _, err := stmts.ipClose.ExecContext(dbCtx, ip); err != nil {
+				return err
+			}
+		}
+
+		if len(oldIP) > 0 && (oldIP != ip) {
+			forgetIp4logBinding(mac, oldIP)
+			if _, err := stmts.ipClose.ExecContext(dbCtx, oldIP); err != nil {
+				return err
+			}
+		}
 	}
-	if conflictTtl < 30*time.Second {
-		conflictTtl = 30 * time.Second
-	}
-	ip4logConflictCache.Set(conflictKey, 1, conflictTtl)
 
 	// Always refresh the entry itself: renewals must push end_time forward.
-	_, err := ip4logStmts.ipInsert.ExecContext(dbCtx, mac, ip, duration.Seconds())
+	res, err := stmts.ipInsert.ExecContext(dbCtx, mac, ip, duration.Seconds())
 	if err != nil {
+		// Do not confirm a binding whose row may not have been written: the
+		// next transaction must re-run the checks rather than trust the cache.
+		forgetIp4logBinding(mac, ip)
 		log.LoggerWContext(ctx).Info(err.Error())
+		return err
 	}
-	return err
+
+	// RowsAffected is 1 only when the row was inserted, i.e. the entry this
+	// binding relies on was missing because another writer closed or deleted
+	// it. Re-run the conflict checks next time instead of trusting the cache.
+	if rows, rerr := res.RowsAffected(); rerr == nil && rows == 1 {
+		forgetIp4logBinding(mac, ip)
+	} else {
+		confirmIp4logBinding(mac, ip, duration)
+	}
+
+	return nil
 }
 
 // sanitizeHostname cleans a DHCP option-12 (host name) value for storage and


### PR DESCRIPTION
# Description
Query-volume profiling on a loaded 15.2 server (~30k clients, ~270 accounting packets/s, ~80 DHCP transactions/s; MariaDB at ~110% CPU with no individually slow query) showed the hottest statements are per-packet bookkeeping whose values almost never change between packets:

- **pfacct — `node_current_session` upsert on every Start/Interim** (the single most frequent statement on the server, ~170/s). It feeds the admin UI online indicator and a cleanup job with a **24h** staleness window, so it is now refreshed at most once per 10 minutes per (MAC, session) — the window has to comfortably exceed the NAS interim-update interval or every interim misses the cache and nothing is saved. Stop always executes (it flips `is_online` off) and invalidates the cache, so a same-session reconnect re-marks the node online immediately.
- **pfdhcp — ip4log statement churn**: `MysqlUpdateIP4Log` re-`Prepare`d (and Closed) all four statements per DHCP transaction, plus a `Ping`. Statements are now prepared once. The two conflict-detection SELECTs (mac2ip/ip2mac) are skipped while the same MAC↔IP binding was confirmed within half the client's lease (capped at 5m) — a changed binding is a different cache key and is checked immediately, and the confirmation is not renewed by the renewals it suppresses, so the checks re-run at least once per lease. The upsert itself still runs on every transaction, since renewals must push `end_time` forward.
- **pfdhcp — `node.computername` UPDATE per transaction**: skipped while the client's host name is unchanged (5m cache); a changed host name goes through immediately, so hostname-change detection still fires on the first packet carrying the new name.

A fourth change (caching the `key_value_storage` option-override lookups in `decodeOptions`) was reverted on the branch: in live testing pfdhcp built and logged its OFFER/ACK answers but no reply reached the wire with that hunk in, isolated by a binary bisect on the same base and build environment. All three callers only read the returned map, so the mechanism is not understood yet — those lookups stay per-packet for now (they were the smallest part, ~155 SELECTs/s of ~5,300/s).

The pfdhcp changes in this PR's final form (statement reuse + conflict-check cache + computername cache) were validated live: DHCP served normally under ~130 transactions/s.

# Impacts
- pfacct accounting workflow (node_current_session freshness: `updated` is refreshed at most every 10 minutes per session, against a 24h cleanup window; `is_online` transitions unchanged).
- pfdhcp DHCP answer path (ip4log semantics unchanged; conflict detection at binding-change time instead of every renewal).

# Code / PR Dependencies
Independent of #9250/#9255 (adjacent code, trivial merge order).

# Delete branch after merge
YES

# Checklist
- [n/a] Document the feature (no configuration change)
- [n/a] Add OpenAPI specification
- [x] Add unit tests (`go/cmd/pfacct/session_online_test.go`, DB-backed, PASS on a PF server)
- [ ] Add acceptance tests (TestLink)

# NEWS file entries
## Enhancements
* pfacct refreshes node_current_session at most once every 10 minutes per session instead of on every accounting packet
* pfdhcp prepares its ip4log statements once, skips conflict-detection reads for unchanged MAC/IP bindings for up to half a lease, and skips redundant computername updates
