### PR TITLE
Make the packetfence package conflict with fingerbank-collector-remote

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -25,7 +25,8 @@ Pre-Depends:  ca-certificates,
 # Removed for now
 # libmariadbd-dev (>= 10.1), libmariadbd-dev (<< 10.5.18)
 Breaks: libdata-alias-perl, packetfence-export
-Conflicts: packetfence-captive-portal-javascript, packetfence-doc, packetfence-pfappserver-javascript, packetfence-export
+# fingerbank-collector-remote ships /etc/systemd/system/packetfence-fingerbank-collector.service, which shadows the on-prem unit from fingerbank-collector
+Conflicts: packetfence-captive-portal-javascript, packetfence-doc, packetfence-pfappserver-javascript, packetfence-export, fingerbank-collector-remote
 Replaces: packetfence-captive-portal-javascript, packetfence-doc, packetfence-pfappserver-javascript
 Depends: ${misc:Depends}, vlan,
  packetfence-ntlm-wrapper (>= ${source:Version}), packetfence-golang-daemon (>= ${source:Version}),

--- a/rpm/packetfence.spec
+++ b/rpm/packetfence.spec
@@ -318,6 +318,8 @@ Requires: haproxy >= 2.2.0, keepalived >= 2.0.0
 # CAUTION: we need to require the version we want for Fingerbank and ensure we don't want anything equal or above the next major release as it can add breaking changes
 Requires: fingerbank >= 4.3.3, fingerbank < 5.0.0
 Requires: fingerbank-collector >= 1.4.1, fingerbank-collector < 2.0.0
+# fingerbank-collector-remote ships /etc/systemd/system/packetfence-fingerbank-collector.service, which shadows the on-prem unit from fingerbank-collector
+Conflicts: fingerbank-collector-remote
 #Requires: perl(File::Tempdir)
 
 # For NTLM-Auth


### PR DESCRIPTION
## Problem

On a 15.1 -> 15.2 on-prem upgrade, `packetfence-fingerbank-collector.service` failed to start in a restart loop:

```
pfconnector-remote-load.sh[2973385]: /usr/local/pfconnector-remote/conf/pfconnector-client.env not found
packetfence-fingerbank-collector.service: Control process exited, code=exited, status=1/FAILURE
```

`fingerbank-collector-remote` installs `/etc/systemd/system/packetfence-fingerbank-collector.service`, the same unit name the on-prem `fingerbank-collector` package ships under `/lib/systemd/system`. `/etc` takes precedence, so on a PacketFence server that ends up with both packages the collector runs the connector's `pfconnector-remote-load.sh` ExecStartPre, which exits 1 because the connector env file does not exist on an on-prem box.

Nothing prevented the co-installation: neither collector package conflicts with the other, and `packetfence` only depends on `fingerbank-collector`. The 15.2 repo carries a newer `fingerbank-collector-remote`, so `apt upgrade` pulled it in and its postinst restarted the shadowed unit.

## Fix

Declare `Conflicts: fingerbank-collector-remote` on the `packetfence` package in both `debian/control` and `rpm/packetfence.spec`, so the package manager refuses the co-installation instead of silently breaking the collector.

## Notes

- Does not repair a box that already has both packages. Remedy there: `apt purge fingerbank-collector-remote` (purge, so the `/etc` conffile is removed), `systemctl daemon-reload`, restart the collector.
- A follow-up in the fingerbank-collector repo should make the two collector packages mutually conflicting or rename the remote unit so it stops shadowing the on-prem one.