### PR TITLE
fix(crypt): return a NUL terminated copy from pf_decrypt_with_key

### DIFF
--- a/lib/pf/config/crypt.pm
+++ b/lib/pf/config/crypt.pm
@@ -108,7 +108,12 @@ sub pf_decrypt_with_key {
     }
 
     my $tags = decode_tags($data);
-    return gcm_decrypt_verify('AES', $key, $tags->{iv}, $tags->{ad}, $tags->{data}, $tags->{tag});
+    my $plain = gcm_decrypt_verify('AES', $key, $tags->{iv}, $tags->{ad}, $tags->{data}, $tags->{tag});
+    return undef unless defined $plain;
+    # gcm_decrypt_verify returns a buffer that is not NUL terminated. Consumers
+    # that hand the value to a C API expecting a C string read past its end, so
+    # return a copy that carries the terminator.
+    return sprintf("%s", $plain);
 }
 
 =head1 AUTHOR

--- a/t/unittest/config/crypt.t
+++ b/t/unittest/config/crypt.t
@@ -20,15 +20,38 @@ BEGIN {
     use setup_test_config;
 }
 
-use Test::More tests => 3;
+use Test::More tests => 4;
 
 #This test will running last
 use Test::NoWarnings;
 use pf::config::crypt;
+use Devel::Peek ();
+use File::Temp ();
 my $str = qq[~`qwertyuiop[]asdfghjkl;'\\zxcvbnm,./1234567890-=!@#$%^&*()_+] x 3;
 ok ($str eq pf::config::crypt::pf_decrypt(pf::config::crypt::pf_encrypt($str)), "Checking $str");
 $str = '0123456789ABCDEF' x 3;
 ok ($str eq pf::config::crypt::pf_decrypt(pf::config::crypt::pf_encrypt($str)), "Checking $str");
+
+# gcm_decrypt_verify returns a buffer without a NUL terminator. Comparing with
+# eq does not catch it, since that uses the length. Consumers handing the value
+# to a C API expecting a C string do read past the end, so check the buffer
+# itself.
+ok (pv_is_nul_terminated(pf::config::crypt::pf_decrypt(pf::config::crypt::pf_encrypt('0123456789abcdef'))),
+    "Decrypted value is NUL terminated");
+
+sub pv_is_nul_terminated {
+    my ($sv) = @_;
+    my $tmp = File::Temp->new();
+    open(my $olderr, '>&', \*STDERR) or die "dup STDERR: $!";
+    open(STDERR, '>&', $tmp) or die "redirect STDERR: $!";
+    Devel::Peek::Dump($sv);
+    open(STDERR, '>&', $olderr) or die "restore STDERR: $!";
+    open(my $fh, '<', $tmp->filename) or die "read dump: $!";
+    local $/ = undef;
+    my $dump = <$fh>;
+    close($fh);
+    return scalar($dump =~ /^\s*PV = 0x[0-9a-f]+ ".*"\\0\s*$/m);
+}
 
 
 =head1 AUTHOR


### PR DESCRIPTION
`pf_decrypt_with_key()` returns the buffer it gets from `gcm_decrypt_verify()`
(Crypt::AuthEnc::GCM). That buffer is not NUL terminated, so any consumer that
hands the decrypted value to a C API expecting a C string reads past its end.

The visible case is `pf::CHI::db::db_connect()`, which passes the decrypted
database password to `DBI->connect()`. DBD::mysql forwards it to
`mysql_real_connect()` as a C string, so the server sees the password bytes plus
whatever follows on the heap:

```
unable to connect to database: Access denied for user 'pf'@'localhost'
(using password: YES) at lib/CHI/Driver/DBI.pm line 28
```

From there every operation that touches a DB backed CHI cache fails. Saving or
deleting a switch in the admin UI returns a 500 raised out of
`pf::ConfigStore::Switch::commit`, and RADIUS authorization over the REST path in
`httpd.aaa` ends in a reject.

### Why it is rarely seen

Two conditions have to meet:

1. The stored secret has to be encrypted, so the CryptX path runs at all. With a
   plain text value `pf_decrypt_with_key()` returns early at the prefix check and
   the string is a normal, terminated Perl scalar. An installation whose
   `database.pass` was never encrypted is not affected.
2. The heap byte behind the buffer has to be non zero. When it happens to be
   zero, everything works by accident.

So the symptom depends on the memory layout of the process, not on the secret.
It can appear after a restart and disappear again, which makes it easy to
mistake for a credentials problem.

Nothing about it is visible from Perl: `eq`, `length`, `unpack` and the SV flags
all use the length and compare equal to a value that connects fine.
`utf8::encode()` and `utf8::downgrade()` do not help either, since they are
no-ops for ASCII and leave the buffer untouched. Only a real copy allocates a
properly terminated buffer.

### Reproducing the defect

This part is deterministic and needs neither a database nor a PacketFence
installation:

```perl
use Crypt::AuthEnc::GCM qw(gcm_encrypt_authenticate gcm_decrypt_verify);
use Crypt::PRNG qw(random_bytes);
use Devel::Peek;

my $key = random_bytes(32);
my $iv  = random_bytes(12);
my ($ct, $tag) = gcm_encrypt_authenticate('AES', $key, $iv, '', '0123456789abcdef');

my $raw  = gcm_decrypt_verify('AES', $key, $iv, '', $ct, $tag);
my $copy = sprintf("%s", $raw);

Dump($raw);
Dump($copy);
```

```
PV = 0x562487f4f7a0 "0123456789abcdef"      <- no terminator
CUR = 16
LEN = 18

PV = 0x562487b39340 "0123456789abcdef"\0    <- terminated
CUR = 16
LEN = 18
```

Same bytes, same length, and `$raw eq $copy` is true.

To reproduce the resulting `Access denied` on a running installation, store
`database.pass` encrypted and call `pf::CHI::db::db_connect()` repeatedly inside
the `httpd.aaa` container. On an affected host it fails every time, and the same
call with a `sprintf` copy of the password succeeds.

### The change

Returning the copy from `pf_decrypt_with_key()` covers every consumer of a
decrypted secret rather than a single call site. `undef` from a failed
authentication is passed through unchanged.

The unit test inspects the buffer rather than the string, since a comparison
with `eq` passes either way. It fails on the current `devel` and passes with the
change.
