### PR TITLE
fix(radius): add Message-Authenticator to non-EAP (MAB) Access-Accept

### DIFF
--- a/conf/radiusd/packetfence.example
+++ b/conf/radiusd/packetfence.example
@@ -404,6 +404,18 @@ server packetfence {
 			}
 		}
 
+		# Force a Message-Authenticator into non-EAP (e.g. MAB) Access-Accept
+		# replies. FreeRADIUS only adds it automatically when the request
+		# carried an EAP-Message; MAB is non-EAP, so newer NAS firmware that
+		# requires attr 80 in the accept (e.g. Juniper Junos) would otherwise
+		# reject it. 0x00 is a placeholder; radiusd computes the real HMAC-MD5
+		# at send time.
+		if (!EAP-Message) {
+			update reply {
+				Message-Authenticator := 0x00
+			}
+		}
+
 		attr_filter.packetfence_post_auth
 		linelog
 		#


### PR DESCRIPTION
# Description
FreeRADIUS only adds a `Message-Authenticator` to an Access-Accept automatically when the request carried an `EAP-Message`. MAB is non-EAP, so the Access-Accept went out without attribute 80, and newer NAS firmware that requires it (e.g. Juniper Junos for MAB) rejected the session.

This adds a `Message-Authenticator := 0x00` placeholder in the `packetfence` virtual server post-auth section for non-EAP replies (`if (!EAP-Message)`). The value is a placeholder: radiusd computes the real HMAC-MD5 at send time. EAP flows are unaffected, FreeRADIUS already handles them.

# Impacts
- RADIUS authorize/post-auth workflow of the `packetfence` virtual server (`conf/radiusd/packetfence.example`): every non-EAP Access-Accept (MAB, and any other non-EAP authentication) now carries `Message-Authenticator`.
- To test: a MAB authentication against a NAS that enforces attribute 80 in the accept (Junos) must now succeed; check with `radsniff` or a `tcpdump` that the Access-Accept for a MAB request contains attribute 80 and that an 802.1X/EAP accept still contains exactly one.
- `radiusd-auth` must be restarted (the `.example` is rendered into the raddb at configuration time).

# Delete branch after merge
YES

# Checklist
- [n/a] Document the feature
- [n/a] Add OpenAPI specification
- [no] Add unit tests (FreeRADIUS configuration change, no unit test harness for it)
- [n/a] Add acceptance tests (TestLink)

# NEWS file entries
## Bug Fixes
* MAB (non-EAP) Access-Accept is sent without a Message-Authenticator, rejected by NAS firmware that requires it (e.g. Juniper Junos)
