### PR TITLE
[pfcron] pfflow: remove consumer throughput ceiling and recover from stranded group offset

### DIFF
--- a/go/cron/aggregator.go
+++ b/go/cron/aggregator.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/inverse-inc/go-utils/log"
-	"github.com/inverse-inc/packetfence/go/db"
 )
 
 type EventKey struct {
@@ -390,14 +389,16 @@ func logPfFlow(ctx context.Context, header *PfFlowHeader, f *PfFlow) {
 }
 
 func (a *Aggregator) handleEvents() {
-	ctx := context.Background()
+	// A context carrying a logger: with a bare context every Log*f call
+	// rebuilds a logger (including a syslog dial) before filtering the line.
+	ctx := log.LoggerNewContext(context.Background())
 	ticker := time.NewTicker(a.timeout)
 	defer ticker.Stop()
 
 	go a.flusher(ctx)
 	defer close(a.flushChan)
 
-	stats := windowStats{}
+	stats := newWindowStats()
 loop:
 	for {
 		select {
@@ -407,17 +408,14 @@ loop:
 					continue
 				}
 
-				log.LogDebugf(ctx, "Received %d flows of FlowType %s", len(*pfflows.Flows), flowType(pfflows.Header.FlowType))
 				stats.messages++
 				stats.flows += len(*pfflows.Flows)
-				// The agent address is the exporter (switch) IP. Older collectors do not
-				// fill it in for NetFlow/IPFIX, in which case it prints as "invalid IP",
-				// and an sFlow exporter without an agent-ip sends 0.0.0.0; neither must
-				// be recorded as a switch.
-				if addr := pfflows.Header.AgentAddr; a.db != nil && addr.IsValid() && !addr.IsUnspecified() {
-					if err := db.MarkSwitchAsSeen(a.db, pfflows.Header.AgentAddr.String()); err != nil {
-						log.LogErrorf(ctx, "handleEvents: failed to mark switch %s as seen: %s", pfflows.Header.AgentAddr.String(), err.Error())
-					}
+				// The agent address is the exporter (switch) IP. Older collectors
+				// leave it unset for NetFlow/IPFIX ("invalid IP") and an sFlow
+				// exporter without an agent-ip sends 0.0.0.0; neither is a switch.
+				// Marked as seen once per window by the flusher, off this goroutine.
+				if addr := pfflows.Header.AgentAddr; addr.IsValid() && !addr.IsUnspecified() {
+					stats.noteAgent(addr.String())
 				}
 
 				for _, f := range *pfflows.Flows {
@@ -431,21 +429,25 @@ loop:
 			}
 		case <-ticker.C:
 			if len(a.events) == 0 {
-				stats = windowStats{}
+				if stats.messages > 0 {
+					log.LogDebugf(ctx, "pfflow aggregator: %d messages carried no flows this window", stats.messages)
+				}
+				stats = newWindowStats()
 				continue
 			}
 
 			batch := flushBatch{events: a.events, stats: stats, tickedAt: time.Now()}
 			a.events = make(map[EventKey][]PfFlow, len(batch.events))
-			stats = windowStats{}
+			stats = newWindowStats()
 
-			// Hand the window to the flusher. If the previous flush is still
-			// running we block here (bounded memory), which is visible as
+			// Hand the window to the flusher. The channel holds one window, so
+			// this only blocks when the flusher is already a full window behind;
+			// then ingestion pauses (bounded memory) and the delay shows up as
 			// consumer lag rather than silent loss.
 			select {
 			case a.flushChan <- batch:
 			default:
-				log.LogWarnf(ctx, "pfflow aggregator: previous flush still running, pausing ingestion until it completes")
+				log.LogWarnf(ctx, "pfflow aggregator: flusher is one window (%s) behind, pausing ingestion until the previous flush completes", a.timeout)
 				a.flushChan <- batch
 			}
 		case <-a.stop:

--- a/go/cron/aggregator.go
+++ b/go/cron/aggregator.go
@@ -1,11 +1,9 @@
 package maint
 
 import (
-	"cmp"
 	"context"
 	"database/sql"
 	"fmt"
-	"math"
 	"net/netip"
 	"time"
 
@@ -33,6 +31,7 @@ func NewAggregator(o *AggregatorOptions) *Aggregator {
 		PfFlowsChan:      ChanPfFlow,
 		Heuristics:       o.Heuristics,
 		db:               o.Db,
+		flushChan:        make(chan flushBatch, 1),
 	}
 }
 
@@ -57,37 +56,12 @@ type Aggregator struct {
 	timeout          time.Duration
 	Heuristics       bool
 	db               *sql.DB
+	flushChan        chan flushBatch
 }
 
 func emptyMac(mac string) bool {
 	return mac == "00:00:00:00:00:00" || mac == ""
 }
-
-func updateMacs(ctx context.Context, f *PfFlow, stmt *sql.Stmt) {
-	if !emptyMac(f.SrcMac) && !emptyMac(f.DstMac) {
-		return
-	}
-
-	var srcMac, dstMac string
-	err := stmt.QueryRowContext(ctx, f.SrcIp.String(), f.DstIp.String()).Scan(&srcMac, &dstMac)
-	if err != nil {
-		log.LogErrorf(ctx, "updateMacs Database Error: %s", err.Error())
-	}
-
-	if emptyMac(f.SrcMac) {
-		f.SrcMac = srcMac
-	}
-
-	if emptyMac(f.DstMac) {
-		f.DstMac = dstMac
-	}
-}
-
-const updateMacsSql = `
-SELECT
-	COALESCE((SELECT mac FROM ip4log WHERE ip = ?), "00:00:00:00:00:00") as src_mac,
-	COALESCE((SELECT mac FROM ip4log WHERE ip = ?), "00:00:00:00:00:00") as dst_mac;
-`
 
 func flowType(t uint16) string {
 	switch t {
@@ -418,100 +392,62 @@ func logPfFlow(ctx context.Context, header *PfFlowHeader, f *PfFlow) {
 func (a *Aggregator) handleEvents() {
 	ctx := context.Background()
 	ticker := time.NewTicker(a.timeout)
-	stmt, err := new(sql.Stmt), error(nil)
-	//	if a.db != nil {
-	stmt, err = a.db.PrepareContext(ctx, updateMacsSql)
-	if err != nil {
-		log.LogErrorf(ctx, "handleEvents Database Error: %s %s", updateMacsSql, err.Error())
-		stmt = nil
-	} else {
-		defer stmt.Close()
-	}
-	//	}
+	defer ticker.Stop()
 
+	go a.flusher(ctx)
+	defer close(a.flushChan)
+
+	stats := windowStats{}
 loop:
 	for {
 		select {
-		case pfflowsArray := <-ChanPfFlow:
+		case pfflowsArray := <-a.PfFlowsChan:
 			for _, pfflows := range pfflowsArray {
-				log.LogInfof(ctx, "Received %d flows of FlowType %s", len(*pfflows.Flows), flowType(pfflows.Header.FlowType))
+				if pfflows.Flows == nil {
+					continue
+				}
+
+				log.LogDebugf(ctx, "Received %d flows of FlowType %s", len(*pfflows.Flows), flowType(pfflows.Header.FlowType))
+				stats.messages++
+				stats.flows += len(*pfflows.Flows)
 				// The agent address is the exporter (switch) IP. Older collectors do not
 				// fill it in for NetFlow/IPFIX, in which case it prints as "invalid IP",
 				// and an sFlow exporter without an agent-ip sends 0.0.0.0; neither must
 				// be recorded as a switch.
-				if addr := pfflows.Header.AgentAddr; addr.IsValid() && !addr.IsUnspecified() {
+				if addr := pfflows.Header.AgentAddr; a.db != nil && addr.IsValid() && !addr.IsUnspecified() {
 					if err := db.MarkSwitchAsSeen(a.db, pfflows.Header.AgentAddr.String()); err != nil {
 						log.LogErrorf(ctx, "handleEvents: failed to mark switch %s as seen: %s", pfflows.Header.AgentAddr.String(), err.Error())
 					}
 				}
-				for _, f := range *pfflows.Flows {
-					if stmt != nil {
-						updateMacs(ctx, &f, stmt)
-					}
 
-					key := f.Key(&pfflows.Header)
-					val := a.events[key]
+				for _, f := range *pfflows.Flows {
 					if a.Heuristics {
 						f.Heuristics()
 					}
 
-					a.events[key] = append(val, f)
+					key := f.Key(&pfflows.Header)
+					a.events[key] = append(a.events[key], f)
 				}
 			}
 		case <-ticker.C:
-			networkEvents := []*NetworkEvent{}
-			for _, events := range a.events {
-				startTime := int64(math.MaxInt64)
-				endTime := int64(0)
-				connectionCount := uint64(0)
-				var networkEvent *NetworkEvent
-				for _, e := range events {
-					networkEvent = e.ToNetworkEvent()
-					if networkEvent != nil {
-						break
-					}
-				}
-
-				if networkEvent == nil {
-					continue
-				}
-
-				ports := map[AggregatorSession]struct{}{}
-				for _, e := range events {
-					startTime = min(startTime, e.StartTime)
-					endTime = max(endTime, e.EndTime)
-					sessionKey := e.SessionKey()
-					if _, ok := ports[sessionKey]; !ok {
-						ports[sessionKey] = struct{}{}
-						connectionCount += e.ConnectionCount
-					}
-				}
-
-				networkEvent.Count = cmp.Or(int(connectionCount), len(ports))
-				if startTime != 0 {
-					networkEvent.StartTime = uint64(startTime)
-				}
-
-				if endTime != 0 {
-					networkEvent.EndTime = uint64(endTime)
-				}
-
-				if networkEvent.EndTime == 0 {
-					networkEvent.EndTime = networkEvent.StartTime
-				}
-
-				networkEvents = append(networkEvents, networkEvent)
+			if len(a.events) == 0 {
+				stats = windowStats{}
+				continue
 			}
 
-			for _, e := range networkEvents {
-				e.UpdateEnforcementInfo(ctx, a.db)
-			}
+			batch := flushBatch{events: a.events, stats: stats, tickedAt: time.Now()}
+			a.events = make(map[EventKey][]PfFlow, len(batch.events))
+			stats = windowStats{}
 
-			if len(networkEvents) > 0 && a.networkEventChan != nil {
-				a.networkEventChan <- networkEvents
+			// Hand the window to the flusher. If the previous flush is still
+			// running we block here (bounded memory), which is visible as
+			// consumer lag rather than silent loss.
+			select {
+			case a.flushChan <- batch:
+			default:
+				log.LogWarnf(ctx, "pfflow aggregator: previous flush still running, pausing ingestion until it completes")
+				a.flushChan <- batch
 			}
-
-			clear(a.events)
 		case <-a.stop:
 			break loop
 		}

--- a/go/cron/aggregator_flush.go
+++ b/go/cron/aggregator_flush.go
@@ -1,0 +1,201 @@
+package maint
+
+import (
+	"cmp"
+	"context"
+	"database/sql"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/inverse-inc/go-utils/log"
+)
+
+// windowStats counts what the aggregator ingested during one flush interval.
+type windowStats struct {
+	messages int
+	flows    int
+}
+
+// flushBatch is one interval's worth of aggregated flows handed to the flusher.
+type flushBatch struct {
+	events   map[EventKey][]PfFlow
+	stats    windowStats
+	tickedAt time.Time
+}
+
+// flusher turns each batch into network events off the ingest goroutine so
+// that Kafka consumption keeps going while the (DB heavy) flush runs.
+func (a *Aggregator) flusher(ctx context.Context) {
+	for batch := range a.flushChan {
+		a.flush(ctx, batch)
+	}
+}
+
+func (a *Aggregator) flush(ctx context.Context, batch flushBatch) {
+	start := time.Now()
+	ipsLookedUp := resolveMissingMacs(ctx, a.db, batch.events)
+	macDone := time.Now()
+
+	networkEvents := buildNetworkEvents(batch.events)
+	buildDone := time.Now()
+
+	UpdateNetworkEvents(ctx, a.db, networkEvents)
+	rolesDone := time.Now()
+
+	if len(networkEvents) > 0 && a.networkEventChan != nil {
+		a.networkEventChan <- networkEvents
+	}
+
+	log.LogInfof(
+		ctx,
+		"pfflow aggregator: %d messages, %d flows, %d keys -> %d network events (ip4log lookups %d in %s, aggregate %s, policy lookup %s, total %s, queued %s)",
+		batch.stats.messages, batch.stats.flows, len(batch.events), len(networkEvents),
+		ipsLookedUp, macDone.Sub(start).Round(time.Millisecond),
+		buildDone.Sub(macDone).Round(time.Millisecond),
+		rolesDone.Sub(buildDone).Round(time.Millisecond),
+		time.Since(start).Round(time.Millisecond),
+		start.Sub(batch.tickedAt).Round(time.Millisecond),
+	)
+}
+
+// buildNetworkEvents collapses each aggregation key into one network event.
+func buildNetworkEvents(events map[EventKey][]PfFlow) []*NetworkEvent {
+	networkEvents := make([]*NetworkEvent, 0, len(events))
+	for _, flows := range events {
+		startTime := int64(math.MaxInt64)
+		endTime := int64(0)
+		connectionCount := uint64(0)
+		var networkEvent *NetworkEvent
+		for i := range flows {
+			networkEvent = flows[i].ToNetworkEvent()
+			if networkEvent != nil {
+				break
+			}
+		}
+
+		if networkEvent == nil {
+			continue
+		}
+
+		ports := map[AggregatorSession]struct{}{}
+		for i := range flows {
+			e := &flows[i]
+			startTime = min(startTime, e.StartTime)
+			endTime = max(endTime, e.EndTime)
+			sessionKey := e.SessionKey()
+			if _, ok := ports[sessionKey]; !ok {
+				ports[sessionKey] = struct{}{}
+				connectionCount += e.ConnectionCount
+			}
+		}
+
+		networkEvent.Count = cmp.Or(int(connectionCount), len(ports))
+		if startTime != 0 {
+			networkEvent.StartTime = uint64(startTime)
+		}
+
+		if endTime != 0 {
+			networkEvent.EndTime = uint64(endTime)
+		}
+
+		if networkEvent.EndTime == 0 {
+			networkEvent.EndTime = networkEvent.StartTime
+		}
+
+		networkEvents = append(networkEvents, networkEvent)
+	}
+
+	return networkEvents
+}
+
+const ip4logLookupChunk = 1000
+
+// resolveMissingMacs fills in empty src/dst MACs from ip4log with one query
+// per chunk of distinct IPs instead of one query per flow. IPs without an
+// ip4log entry get the zero MAC, matching the previous per-flow COALESCE.
+// Returns the number of distinct IPs looked up.
+func resolveMissingMacs(ctx context.Context, dbh *sql.DB, events map[EventKey][]PfFlow) int {
+	if dbh == nil {
+		return 0
+	}
+
+	ipSet := map[string]struct{}{}
+	for _, flows := range events {
+		for i := range flows {
+			f := &flows[i]
+			if !emptyMac(f.SrcMac) && !emptyMac(f.DstMac) {
+				continue
+			}
+
+			if emptyMac(f.SrcMac) && f.SrcIp.IsValid() {
+				ipSet[f.SrcIp.String()] = struct{}{}
+			}
+
+			if emptyMac(f.DstMac) && f.DstIp.IsValid() {
+				ipSet[f.DstIp.String()] = struct{}{}
+			}
+		}
+	}
+
+	macs := map[string]string{}
+	if len(ipSet) > 0 {
+		ips := make([]string, 0, len(ipSet))
+		for ip := range ipSet {
+			ips = append(ips, ip)
+		}
+
+		macs = lookupIp4logMacs(ctx, dbh, ips)
+	}
+
+	for _, flows := range events {
+		for i := range flows {
+			f := &flows[i]
+			if !emptyMac(f.SrcMac) && !emptyMac(f.DstMac) {
+				continue
+			}
+
+			if emptyMac(f.SrcMac) {
+				f.SrcMac = cmp.Or(macs[f.SrcIp.String()], "00:00:00:00:00:00")
+			}
+
+			if emptyMac(f.DstMac) {
+				f.DstMac = cmp.Or(macs[f.DstIp.String()], "00:00:00:00:00:00")
+			}
+		}
+	}
+
+	return len(ipSet)
+}
+
+func lookupIp4logMacs(ctx context.Context, dbh *sql.DB, ips []string) map[string]string {
+	macs := make(map[string]string, len(ips))
+	for start := 0; start < len(ips); start += ip4logLookupChunk {
+		chunk := ips[start:min(start+ip4logLookupChunk, len(ips))]
+		query := "SELECT ip, mac FROM ip4log WHERE ip IN (?" + strings.Repeat(", ?", len(chunk)-1) + ")"
+		args := make([]interface{}, len(chunk))
+		for i, ip := range chunk {
+			args[i] = ip
+		}
+
+		rows, err := dbh.QueryContext(ctx, query, args...)
+		if err != nil {
+			log.LogErrorf(ctx, "lookupIp4logMacs Database Error: %s", err.Error())
+			continue
+		}
+
+		for rows.Next() {
+			var ip, mac string
+			if err := rows.Scan(&ip, &mac); err != nil {
+				log.LogErrorf(ctx, "lookupIp4logMacs Scan Error: %s", err.Error())
+				break
+			}
+
+			macs[ip] = mac
+		}
+
+		rows.Close()
+	}
+
+	return macs
+}

--- a/go/cron/aggregator_flush.go
+++ b/go/cron/aggregator_flush.go
@@ -9,12 +9,28 @@ import (
 	"time"
 
 	"github.com/inverse-inc/go-utils/log"
+	"github.com/inverse-inc/packetfence/go/db"
 )
 
 // windowStats counts what the aggregator ingested during one flush interval.
 type windowStats struct {
 	messages int
 	flows    int
+	// agents holds the distinct exporter addresses seen in the window; they
+	// are marked as seen in switch_observability once per flush instead of
+	// once per Kafka message on the ingest goroutine.
+	agents map[string]struct{}
+}
+
+func newWindowStats() windowStats {
+	return windowStats{agents: map[string]struct{}{}}
+}
+
+func (s *windowStats) noteAgent(addr string) {
+	if s.agents == nil {
+		s.agents = map[string]struct{}{}
+	}
+	s.agents[addr] = struct{}{}
 }
 
 // flushBatch is one interval's worth of aggregated flows handed to the flusher.
@@ -34,6 +50,7 @@ func (a *Aggregator) flusher(ctx context.Context) {
 
 func (a *Aggregator) flush(ctx context.Context, batch flushBatch) {
 	start := time.Now()
+	a.markSwitchesSeen(ctx, batch.stats.agents)
 	ipsLookedUp := resolveMissingMacs(ctx, a.db, batch.events)
 	macDone := time.Now()
 
@@ -111,6 +128,22 @@ func buildNetworkEvents(events map[EventKey][]PfFlow) []*NetworkEvent {
 
 const ip4logLookupChunk = 1000
 
+// markSwitchesSeen records the window's exporters in switch_observability.
+// MarkSwitchAsSeen keeps its own per-switch cache, so this costs at most one
+// statement per switch per minute, and a slow database only delays the flush
+// rather than the Kafka consumer.
+func (a *Aggregator) markSwitchesSeen(ctx context.Context, agents map[string]struct{}) {
+	if a.db == nil {
+		return
+	}
+
+	for addr := range agents {
+		if err := db.MarkSwitchAsSeen(a.db, addr); err != nil {
+			log.LogErrorf(ctx, "pfflow aggregator: failed to mark switch %s as seen: %s", addr, err.Error())
+		}
+	}
+}
+
 // resolveMissingMacs fills in empty src/dst MACs from ip4log with one query
 // per chunk of distinct IPs instead of one query per flow. IPs without an
 // ip4log entry get the zero MAC, matching the previous per-flow COALESCE.
@@ -139,13 +172,35 @@ func resolveMissingMacs(ctx context.Context, dbh *sql.DB, events map[EventKey][]
 	}
 
 	macs := map[string]string{}
+	complete := true
 	if len(ipSet) > 0 {
 		ips := make([]string, 0, len(ipSet))
 		for ip := range ipSet {
 			ips = append(ips, ip)
 		}
 
-		macs = lookupIp4logMacs(ctx, dbh, ips)
+		macs, complete = lookupIp4logMacs(ctx, dbh, ips)
+	}
+
+	applyResolvedMacs(events, macs, complete)
+	return len(ipSet)
+}
+
+// applyResolvedMacs writes the looked-up MACs into the flows. When the lookup
+// was complete, an IP absent from macs has no ip4log row and gets the zero
+// MAC (the previous per-flow COALESCE); when a chunk query failed, absent IPs
+// keep their empty MAC so the flows still become IP-only network events, as
+// the previous per-flow lookup did on a database error, instead of being
+// dropped by ToNetworkEvent for carrying two zero MACs.
+func applyResolvedMacs(events map[EventKey][]PfFlow, macs map[string]string, complete bool) {
+	resolve := func(ip string) (string, bool) {
+		if mac, ok := macs[ip]; ok {
+			return mac, true
+		}
+		if complete {
+			return "00:00:00:00:00:00", true
+		}
+		return "", false
 	}
 
 	for _, flows := range events {
@@ -156,46 +211,70 @@ func resolveMissingMacs(ctx context.Context, dbh *sql.DB, events map[EventKey][]
 			}
 
 			if emptyMac(f.SrcMac) {
-				f.SrcMac = cmp.Or(macs[f.SrcIp.String()], "00:00:00:00:00:00")
+				if mac, ok := resolve(f.SrcIp.String()); ok {
+					f.SrcMac = mac
+				}
 			}
 
 			if emptyMac(f.DstMac) {
-				f.DstMac = cmp.Or(macs[f.DstIp.String()], "00:00:00:00:00:00")
+				if mac, ok := resolve(f.DstIp.String()); ok {
+					f.DstMac = mac
+				}
 			}
 		}
 	}
-
-	return len(ipSet)
 }
 
-func lookupIp4logMacs(ctx context.Context, dbh *sql.DB, ips []string) map[string]string {
-	macs := make(map[string]string, len(ips))
-	for start := 0; start < len(ips); start += ip4logLookupChunk {
-		chunk := ips[start:min(start+ip4logLookupChunk, len(ips))]
-		query := "SELECT ip, mac FROM ip4log WHERE ip IN (?" + strings.Repeat(", ?", len(chunk)-1) + ")"
+// lookupIp4logMacs returns the ip4log MAC of each IP that has one. complete is
+// false when at least one chunk query failed or was cut short, in which case
+// absent IPs cannot be distinguished from IPs without an ip4log row.
+func lookupIp4logMacs(ctx context.Context, dbh *sql.DB, ips []string) (map[string]string, bool) {
+	return queryStringPairs(ctx, dbh, "lookupIp4logMacs", "SELECT ip, mac FROM ip4log WHERE ip IN (", ips, ip4logLookupChunk)
+}
+
+// queryStringPairs runs sqlPrefix + "?, ?, ..." + ")" for each chunk of keys
+// and collects the (key, value) string pairs it returns. Errors are logged
+// under name; the boolean is false when any chunk failed or its iteration was
+// cut short, so callers can tell "no row" from "unknown".
+func queryStringPairs(ctx context.Context, dbh *sql.DB, name, sqlPrefix string, keys []string, chunkSize int) (map[string]string, bool) {
+	result := make(map[string]string, len(keys))
+	complete := true
+	for start := 0; start < len(keys); start += chunkSize {
+		chunk := keys[start:min(start+chunkSize, len(keys))]
+		query := sqlPrefix + "?" + strings.Repeat(", ?", len(chunk)-1) + ")"
 		args := make([]interface{}, len(chunk))
-		for i, ip := range chunk {
-			args[i] = ip
+		for i, k := range chunk {
+			args[i] = k
 		}
 
 		rows, err := dbh.QueryContext(ctx, query, args...)
 		if err != nil {
-			log.LogErrorf(ctx, "lookupIp4logMacs Database Error: %s", err.Error())
+			log.LogErrorf(ctx, "%s Database Error: %s", name, err.Error())
+			complete = false
 			continue
 		}
 
 		for rows.Next() {
-			var ip, mac string
-			if err := rows.Scan(&ip, &mac); err != nil {
-				log.LogErrorf(ctx, "lookupIp4logMacs Scan Error: %s", err.Error())
+			var k, v string
+			if err := rows.Scan(&k, &v); err != nil {
+				log.LogErrorf(ctx, "%s Scan Error: %s", name, err.Error())
+				complete = false
 				break
 			}
 
-			macs[ip] = mac
+			result[k] = v
+		}
+
+		// rows.Next() returns false on a mid-stream failure too (connection
+		// reset, killed query); without this the chunk silently comes back
+		// truncated.
+		if err := rows.Err(); err != nil {
+			log.LogErrorf(ctx, "%s Rows Error: %s", name, err.Error())
+			complete = false
 		}
 
 		rows.Close()
 	}
 
-	return macs
+	return result, complete
 }

--- a/go/cron/aggregator_flush_test.go
+++ b/go/cron/aggregator_flush_test.go
@@ -1,0 +1,85 @@
+package maint
+
+import (
+	"net/netip"
+	"testing"
+)
+
+func flowWithMacs(src, dst string, srcMac, dstMac string) PfFlow {
+	return PfFlow{
+		SrcIp:  netip.MustParseAddr(src),
+		DstIp:  netip.MustParseAddr(dst),
+		SrcMac: srcMac,
+		DstMac: dstMac,
+	}
+}
+
+func TestApplyResolvedMacsComplete(t *testing.T) {
+	events := map[EventKey][]PfFlow{
+		{}: {
+			flowWithMacs("10.0.0.1", "10.0.0.2", "", ""),                                   // both resolved
+			flowWithMacs("10.0.0.1", "10.0.0.9", "", ""),                                   // dst has no ip4log row
+			flowWithMacs("10.0.0.3", "10.0.0.2", "aa:aa:aa:aa:aa:aa", ""),                  // src already known
+			flowWithMacs("10.0.0.9", "10.0.0.8", "", "00:00:00:00:00:00"),                  // neither known
+			flowWithMacs("10.0.0.3", "10.0.0.4", "aa:aa:aa:aa:aa:aa", "bb:bb:bb:bb:bb:bb"), // untouched
+		},
+	}
+	macs := map[string]string{
+		"10.0.0.1": "11:11:11:11:11:11",
+		"10.0.0.2": "22:22:22:22:22:22",
+	}
+
+	applyResolvedMacs(events, macs, true)
+	flows := events[EventKey{}]
+
+	want := [][2]string{
+		{"11:11:11:11:11:11", "22:22:22:22:22:22"},
+		{"11:11:11:11:11:11", "00:00:00:00:00:00"}, // complete lookup: no row -> zero MAC
+		{"aa:aa:aa:aa:aa:aa", "22:22:22:22:22:22"},
+		{"00:00:00:00:00:00", "00:00:00:00:00:00"},
+		{"aa:aa:aa:aa:aa:aa", "bb:bb:bb:bb:bb:bb"},
+	}
+	for i, w := range want {
+		if flows[i].SrcMac != w[0] || flows[i].DstMac != w[1] {
+			t.Errorf("flow %d: got %s/%s want %s/%s", i, flows[i].SrcMac, flows[i].DstMac, w[0], w[1])
+		}
+	}
+}
+
+func TestApplyResolvedMacsIncompleteKeepsUnknownEmpty(t *testing.T) {
+	// A chunk query failed: IPs missing from the map must not be coalesced to
+	// the zero MAC, otherwise ToNetworkEvent drops flows with two zero MACs
+	// that the previous per-flow lookup still emitted as IP-only events.
+	events := map[EventKey][]PfFlow{
+		{}: {
+			flowWithMacs("10.0.0.1", "10.0.0.9", "", ""),
+			flowWithMacs("10.0.0.8", "10.0.0.9", "", ""),
+		},
+	}
+	macs := map[string]string{"10.0.0.1": "11:11:11:11:11:11"}
+
+	applyResolvedMacs(events, macs, false)
+	flows := events[EventKey{}]
+
+	if flows[0].SrcMac != "11:11:11:11:11:11" {
+		t.Errorf("resolved IP must still be filled: got %q", flows[0].SrcMac)
+	}
+	if flows[0].DstMac != "" || flows[1].SrcMac != "" || flows[1].DstMac != "" {
+		t.Errorf("unknown IPs must keep an empty MAC after a failed lookup: got %q %q %q", flows[0].DstMac, flows[1].SrcMac, flows[1].DstMac)
+	}
+}
+
+func TestWindowStatsNoteAgent(t *testing.T) {
+	var s windowStats // zero value, as after `stats = windowStats{}`
+	s.noteAgent("10.1.1.1")
+	s.noteAgent("10.1.1.1")
+	s.noteAgent("10.1.1.2")
+	if len(s.agents) != 2 {
+		t.Fatalf("want 2 distinct agents, got %d", len(s.agents))
+	}
+
+	n := newWindowStats()
+	if n.agents == nil || len(n.agents) != 0 {
+		t.Fatalf("newWindowStats must start with an empty, non-nil agent set")
+	}
+}

--- a/go/cron/network_event.go
+++ b/go/cron/network_event.go
@@ -1,16 +1,12 @@
 package maint
 
 import (
-	"context"
-	"database/sql"
 	"errors"
 	"net/netip"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
-
-	"github.com/inverse-inc/go-utils/log"
 )
 
 var UUID = ""
@@ -53,10 +49,6 @@ type NetworkEvent struct {
 	EndTime             uint64                  `json:"end-time"`
 	Count               int                     `json:"count"`
 	ReportingEntity     *ReportingEntity        `json:"reporting-entity"` //   integration-specific e.g. broker-id, cloud-app
-}
-
-func (n *NetworkEvent) UpdateEnforcementInfo(ctx context.Context, db *sql.DB) {
-	UpdateNetworkEvent(ctx, db, n)
 }
 
 var GlobalReportingEntity = ReportingEntity{
@@ -194,14 +186,6 @@ type NetworkTranslationInfo struct {
 	Type     NetworkTranslationType `json:"type"`
 }
 
-func (ne *NetworkEvent) GetSrcRole(ctx context.Context, db *sql.DB) (string, string) {
-	return ne.getRoleFromInventory(ctx, db, ne.SourceInventoryItem)
-}
-
-func (ne *NetworkEvent) GetDstRole(ctx context.Context, db *sql.DB) (string, string) {
-	return ne.getRoleFromInventory(ctx, db, ne.DestInventoryitem)
-}
-
 // inventoryMac returns the MAC of an inventory item, or "" when the item is
 // missing or carries no usable MAC.
 func inventoryMac(item *InventoryItem) string {
@@ -215,27 +199,6 @@ func inventoryMac(item *InventoryItem) string {
 	}
 
 	return mac
-}
-
-func (ne *NetworkEvent) getRoleFromInventory(ctx context.Context, db *sql.DB, item *InventoryItem) (string, string) {
-	mac := inventoryMac(item)
-	if mac == "" {
-		return "", ""
-	}
-
-	query := `SELECT name FROM node_category WHERE category_id IN (SELECT category_id FROM node WHERE mac = ?);`
-	role := ""
-	err := db.QueryRowContext(ctx, query, mac).Scan(&role)
-	if err == sql.ErrNoRows {
-		return mac, ""
-	}
-
-	if err != nil {
-		log.LogError(ctx, err.Error())
-		return mac, ""
-	}
-
-	return mac, role
 }
 
 type NetworkTranslationType string

--- a/go/cron/network_event.go
+++ b/go/cron/network_event.go
@@ -202,17 +202,24 @@ func (ne *NetworkEvent) GetDstRole(ctx context.Context, db *sql.DB) (string, str
 	return ne.getRoleFromInventory(ctx, db, ne.DestInventoryitem)
 }
 
-func (ne *NetworkEvent) getRoleFromInventory(ctx context.Context, db *sql.DB, item *InventoryItem) (string, string) {
-	if item == nil {
-		return "", ""
-	}
-
-	if len(item.ExternalIDS) == 0 {
-		return "", ""
+// inventoryMac returns the MAC of an inventory item, or "" when the item is
+// missing or carries no usable MAC.
+func inventoryMac(item *InventoryItem) string {
+	if item == nil || len(item.ExternalIDS) == 0 {
+		return ""
 	}
 
 	mac := item.ExternalIDS[0]
 	if mac == "" || mac == "00:00:00:00:00:00" {
+		return ""
+	}
+
+	return mac
+}
+
+func (ne *NetworkEvent) getRoleFromInventory(ctx context.Context, db *sql.DB, item *InventoryItem) (string, string) {
+	mac := inventoryMac(item)
+	if mac == "" {
 		return "", ""
 	}
 

--- a/go/cron/pfflowjob.go
+++ b/go/cron/pfflowjob.go
@@ -165,7 +165,32 @@ func (j *PfFlowJob) newReader(ctx context.Context, dialer *kafka.Dialer) *kafka.
 		ErrorLogger: kafka.LoggerFunc(func(msg string, args ...interface{}) {
 			log.LogErrorf(ctx, "kafka reader: "+msg, args...)
 		}),
+		// Return OffsetOutOfRange from ReadMessage instead of retrying the
+		// fetch forever, so Run() can repair a stranded group offset as soon
+		// as the broker reports it rather than after readTimeout of silence.
+		OffsetOutOfRangeError: true,
 	})
+}
+
+// strandedCheckInterval bounds how long a stranded partition can go unnoticed
+// while other partitions of the topic keep delivering messages (the idle-read
+// path only fires when the whole topic is silent).
+const strandedCheckInterval = 5 * time.Minute
+
+// repairCooldown is how long Run() waits before retrying a failed offset
+// reset, so a reset that cannot succeed (see commitGroupOffsets) does not
+// close and rebuild the reader every readTimeout.
+const repairCooldown = 5 * time.Minute
+
+// isStrandedOffset reports whether a committed group offset lies past the end
+// of its partition, which happens when the topic was deleted and recreated
+// behind the consumer: kafka-go then fetches from an offset that does not
+// exist and never advances. lastOffset <= 0 means the log end is unknown or
+// the partition is empty and is never treated as stranded (an empty answer
+// from ListOffsets must not rewind a healthy group to 0); committed < 0 means
+// the group has no offset for the partition.
+func isStrandedOffset(committed, lastOffset int64) bool {
+	return lastOffset > 0 && committed > lastOffset
 }
 
 // WaitForTopic polls the broker until the topic appears or the context times out
@@ -239,27 +264,10 @@ func (j *PfFlowJob) staleGroupOffsets(ctx context.Context, client *kafka.Client)
 		return nil, nil
 	}
 
-	offsetRequests := make([]kafka.OffsetRequest, 0, len(partitions))
-	for _, p := range partitions {
-		offsetRequests = append(offsetRequests, kafka.LastOffsetOf(p))
-	}
-
-	listed, err := client.ListOffsets(ctx, &kafka.ListOffsetsRequest{
-		Topics: map[string][]kafka.OffsetRequest{j.ReadTopic: offsetRequests},
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	lastOffsets := map[int]int64{}
-	for _, po := range listed.Topics[j.ReadTopic] {
-		if po.Error != nil {
-			return nil, po.Error
-		}
-
-		lastOffsets[po.Partition] = po.LastOffset
-	}
-
+	// Committed offsets first, log ends second. Both only grow, so a commit
+	// by another group member landing between the two calls can only make
+	// the log end larger than what was committed, never the reverse; the
+	// opposite order produced false "reset behind the consumer" alarms.
 	fetched, err := client.OffsetFetch(ctx, &kafka.OffsetFetchRequest{
 		GroupID: j.GroupID,
 		Topics:  map[string][]int{j.ReadTopic: partitions},
@@ -272,32 +280,59 @@ func (j *PfFlowJob) staleGroupOffsets(ctx context.Context, client *kafka.Client)
 		return nil, fetched.Error
 	}
 
+	offsetRequests := make([]kafka.OffsetRequest, 0, 2*len(partitions))
+	for _, p := range partitions {
+		offsetRequests = append(offsetRequests, kafka.FirstOffsetOf(p), kafka.LastOffsetOf(p))
+	}
+
+	listed, err := client.ListOffsets(ctx, &kafka.ListOffsetsRequest{
+		Topics: map[string][]kafka.OffsetRequest{j.ReadTopic: offsetRequests},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	logOffsets := map[int]kafka.PartitionOffsets{}
+	for _, po := range listed.Topics[j.ReadTopic] {
+		if po.Error != nil {
+			return nil, po.Error
+		}
+
+		logOffsets[po.Partition] = po
+	}
+
 	stale := []kafka.OffsetCommit{}
 	for _, p := range fetched.Topics[j.ReadTopic] {
 		if p.Error != nil {
 			return nil, p.Error
 		}
 
-		last, ok := lastOffsets[p.Partition]
-		if !ok || p.CommittedOffset <= last {
+		lo, ok := logOffsets[p.Partition]
+		if !ok || !isStrandedOffset(p.CommittedOffset, lo.LastOffset) {
 			continue
 		}
 
+		// Everything on the recreated partition is still unread: restart from
+		// its first offset rather than skipping to the end.
+		target := max(lo.FirstOffset, 0)
 		log.LogErrorf(
 			ctx,
-			"consumer group %s offset %d on %s/%d is past the log end offset %d (topic reset behind the consumer), resetting to %d",
-			j.GroupID, p.CommittedOffset, j.ReadTopic, p.Partition, last, last,
+			"consumer group %s offset %d on %s/%d is past the log end offset %d (topic recreated behind the consumer), resetting to %d",
+			j.GroupID, p.CommittedOffset, j.ReadTopic, p.Partition, lo.LastOffset, target,
 		)
-		stale = append(stale, kafka.OffsetCommit{Partition: p.Partition, Offset: last})
+		stale = append(stale, kafka.OffsetCommit{Partition: p.Partition, Offset: target})
 	}
 
 	return stale, nil
 }
 
-// commitGroupOffsets commits offsets for the group outside of any generation.
-// The broker only accepts that while the group is empty, so the reader must
-// have been closed (and have left the group) first; retry to cover the leave
-// propagating.
+// commitGroupOffsets commits offsets for the group outside of any generation
+// (GenerationID -1, the admin / simple-consumer path). The broker only accepts
+// that while the consumer group is Empty, so this process's reader must have
+// been closed (and have left the group) first; the retries cover the leave
+// propagating. It cannot succeed while another member is in the group, e.g. a
+// second pfcron instance consuming the same topic: the caller then backs off
+// for repairCooldown instead of rebuilding the reader every readTimeout.
 func (j *PfFlowJob) commitGroupOffsets(ctx context.Context, client *kafka.Client, commits []kafka.OffsetCommit) error {
 	var err error
 	for attempt := 0; attempt < 5; attempt++ {
@@ -358,6 +393,40 @@ func (j *PfFlowJob) Run() {
 	WaitForTopic(dialer, ctx, j.Brokers[0], j.ReadTopic)
 	client := j.kafkaClient()
 
+	nextStrandedCheck := time.Now().Add(strandedCheckInterval)
+	var repairBlockedUntil time.Time
+
+	// repairStrandedOffsets looks for group offsets past their partition's log
+	// end and resets them. It returns true when a reset was attempted (the
+	// reader is closed either way in that case).
+	repairStrandedOffsets := func(reason string) bool {
+		nextStrandedCheck = time.Now().Add(strandedCheckInterval)
+		if time.Now().Before(repairBlockedUntil) {
+			log.LogDebugf(ctx, "consumer group %s offset repair (%s) skipped, previous attempt failed, retrying after %s", j.GroupID, reason, repairBlockedUntil.Format(time.RFC3339))
+			return false
+		}
+
+		stale, err := j.staleGroupOffsets(ctx, client)
+		if err != nil {
+			log.LogWarnf(ctx, "unable to check consumer group %s offsets (%s): %s", j.GroupID, reason, err.Error())
+			return false
+		}
+
+		if len(stale) == 0 {
+			return false
+		}
+
+		closeReader()
+		if err := j.commitGroupOffsets(ctx, client, stale); err != nil {
+			repairBlockedUntil = time.Now().Add(repairCooldown)
+			log.LogErrorf(ctx, "failed to reset consumer group %s offsets: %s (the reset is only accepted while the group is empty; another consumer of %s in the same group, e.g. a second pfcron instance, prevents it; next attempt after %s)", j.GroupID, err.Error(), j.ReadTopic, repairBlockedUntil.Format(time.RFC3339))
+			return true
+		}
+
+		log.LogInfof(ctx, "consumer group %s offsets reset on %d partition(s) of %s", j.GroupID, len(stale), j.ReadTopic)
+		return true
+	}
+
 	for {
 		// Create or recreate the reader
 		if r == nil {
@@ -377,22 +446,20 @@ func (j *PfFlowJob) Run() {
 				// No message for a whole readTimeout: either the topic is idle
 				// or the group offset is stranded past the end of a recreated
 				// topic, which kafka-go never recovers from on its own.
-				stale, err := j.staleGroupOffsets(ctx, client)
-				if err != nil {
-					log.LogWarnf(ctx, "unable to check consumer group %s offsets: %s", j.GroupID, err.Error())
-					continue
-				}
-
-				if len(stale) == 0 {
+				if !repairStrandedOffsets("idle topic") {
 					log.LogDebugf(ctx, "no message on %s for %s", j.ReadTopic, readTimeout)
-					continue
 				}
 
+				continue
+			}
+
+			if errors.Is(err, kafka.OffsetOutOfRange) {
+				// The broker told us directly that our offset does not exist
+				// (OffsetOutOfRangeError in the reader config): repair now
+				// instead of waiting for readTimeout of silence.
+				log.LogErrorf(ctx, "consumer group %s offset out of range on %s: %s", j.GroupID, j.ReadTopic, err.Error())
 				closeReader()
-				if err := j.commitGroupOffsets(ctx, client, stale); err != nil {
-					log.LogErrorf(ctx, "failed to reset consumer group %s offsets: %s", j.GroupID, err.Error())
-				}
-
+				repairStrandedOffsets("offset out of range")
 				continue
 			}
 
@@ -420,6 +487,14 @@ func (j *PfFlowJob) Run() {
 			log.LogInfof(ctx, "Successfully reconnected to Kafka after %d errors", consecutiveErrors)
 			consecutiveErrors = 0
 			reconnectDelay = 1 * time.Second
+		}
+
+		// A partition can be stranded while the others keep delivering, in
+		// which case the idle-read path above never fires; check periodically.
+		// The message just read is processed below either way; if a reset
+		// closed the reader, the next iteration recreates it.
+		if time.Now().After(nextStrandedCheck) {
+			repairStrandedOffsets("periodic check")
 		}
 
 		pfFlows := &PfFlows{}

--- a/go/cron/pfflowjob.go
+++ b/go/cron/pfflowjob.go
@@ -5,11 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	"net"
 	"strconv"
 	"sync/atomic"
 	"time"
 
+	"github.com/inverse-inc/go-utils/log"
 	"github.com/robfig/cron/v3"
 	"github.com/segmentio/kafka-go"
 	"github.com/segmentio/kafka-go/sasl/plain"
@@ -116,6 +117,57 @@ func (j *PfFlowJob) kafkaDialer() *kafka.Dialer {
 	return &dialer
 }
 
+// kafkaClient returns a low level client used for consumer group offset
+// inspection and repair.
+func (j *PfFlowJob) kafkaClient() *kafka.Client {
+	transport := &kafka.Transport{
+		Dial: (&net.Dialer{
+			Timeout:   10 * time.Second,
+			DualStack: true,
+		}).DialContext,
+	}
+
+	if j.UserName != "" && j.Password != "" {
+		transport.SASL = plain.Mechanism{
+			Username: j.UserName,
+			Password: j.Password,
+		}
+	}
+
+	return &kafka.Client{
+		Addr:      kafka.TCP(j.Brokers...),
+		Timeout:   10 * time.Second,
+		Transport: transport,
+	}
+}
+
+// readTimeout bounds one ReadMessage call. When it expires without a message
+// the consumer group offset is checked against the partition log end.
+const readTimeout = 60 * time.Second
+
+func (j *PfFlowJob) newReader(ctx context.Context, dialer *kafka.Dialer) *kafka.Reader {
+	return kafka.NewReader(kafka.ReaderConfig{
+		Brokers:  j.Brokers,
+		Topic:    j.ReadTopic,
+		GroupID:  j.GroupID,
+		MaxBytes: 10e6, // 10MB
+		Dialer:   dialer,
+		// Commit offsets asynchronously once a second. With the default (0)
+		// kafka-go commits synchronously after every ReadMessage, which costs
+		// one broker round trip per flow and caps the consumer well below the
+		// flow rate of a large deployment.
+		CommitInterval: time.Second,
+		Logger: kafka.LoggerFunc(func(msg string, args ...interface{}) {
+			log.LogDebugf(ctx, "kafka reader: "+msg, args...)
+		}),
+		// Without an ErrorLogger kafka-go silently retries forever when the
+		// group offset is past the end of the partition.
+		ErrorLogger: kafka.LoggerFunc(func(msg string, args ...interface{}) {
+			log.LogErrorf(ctx, "kafka reader: "+msg, args...)
+		}),
+	})
+}
+
 // WaitForTopic polls the broker until the topic appears or the context times out
 func WaitForTopic(dialer *kafka.Dialer, ctx context.Context, brokerAddr string, topic string) error {
 	// 1. Establish a connection to the broker
@@ -140,7 +192,7 @@ func WaitForTopic(dialer *kafka.Dialer, ctx context.Context, brokerAddr string, 
 			if err != nil {
 				// Optional: You might want to log this error, but generally
 				// we keep retrying in case the broker is temporarily restarting.
-				fmt.Printf("Failed to read partitions, retrying: %v\n", err)
+				log.LogWarnf(ctx, "Failed to read partitions, retrying: %v", err)
 				continue
 			}
 
@@ -157,59 +209,198 @@ func WaitForTopic(dialer *kafka.Dialer, ctx context.Context, brokerAddr string, 
 	}
 }
 
+// staleGroupOffsets returns, for every partition of the read topic whose
+// committed group offset is past the partition's last offset, the commit that
+// moves it back to the log end. This happens when the topic is deleted and
+// recreated behind the consumer: the group keeps its old (now unreachable)
+// offset and kafka-go waits forever for the log to catch up with it.
+func (j *PfFlowJob) staleGroupOffsets(ctx context.Context, client *kafka.Client) ([]kafka.OffsetCommit, error) {
+	meta, err := client.Metadata(ctx, &kafka.MetadataRequest{Topics: []string{j.ReadTopic}})
+	if err != nil {
+		return nil, err
+	}
+
+	partitions := []int{}
+	for _, t := range meta.Topics {
+		if t.Name != j.ReadTopic {
+			continue
+		}
+
+		if t.Error != nil {
+			return nil, t.Error
+		}
+
+		for _, p := range t.Partitions {
+			partitions = append(partitions, p.ID)
+		}
+	}
+
+	if len(partitions) == 0 {
+		return nil, nil
+	}
+
+	offsetRequests := make([]kafka.OffsetRequest, 0, len(partitions))
+	for _, p := range partitions {
+		offsetRequests = append(offsetRequests, kafka.LastOffsetOf(p))
+	}
+
+	listed, err := client.ListOffsets(ctx, &kafka.ListOffsetsRequest{
+		Topics: map[string][]kafka.OffsetRequest{j.ReadTopic: offsetRequests},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	lastOffsets := map[int]int64{}
+	for _, po := range listed.Topics[j.ReadTopic] {
+		if po.Error != nil {
+			return nil, po.Error
+		}
+
+		lastOffsets[po.Partition] = po.LastOffset
+	}
+
+	fetched, err := client.OffsetFetch(ctx, &kafka.OffsetFetchRequest{
+		GroupID: j.GroupID,
+		Topics:  map[string][]int{j.ReadTopic: partitions},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if fetched.Error != nil {
+		return nil, fetched.Error
+	}
+
+	stale := []kafka.OffsetCommit{}
+	for _, p := range fetched.Topics[j.ReadTopic] {
+		if p.Error != nil {
+			return nil, p.Error
+		}
+
+		last, ok := lastOffsets[p.Partition]
+		if !ok || p.CommittedOffset <= last {
+			continue
+		}
+
+		log.LogErrorf(
+			ctx,
+			"consumer group %s offset %d on %s/%d is past the log end offset %d (topic reset behind the consumer), resetting to %d",
+			j.GroupID, p.CommittedOffset, j.ReadTopic, p.Partition, last, last,
+		)
+		stale = append(stale, kafka.OffsetCommit{Partition: p.Partition, Offset: last})
+	}
+
+	return stale, nil
+}
+
+// commitGroupOffsets commits offsets for the group outside of any generation.
+// The broker only accepts that while the group is empty, so the reader must
+// have been closed (and have left the group) first; retry to cover the leave
+// propagating.
+func (j *PfFlowJob) commitGroupOffsets(ctx context.Context, client *kafka.Client, commits []kafka.OffsetCommit) error {
+	var err error
+	for attempt := 0; attempt < 5; attempt++ {
+		if attempt > 0 {
+			time.Sleep(2 * time.Second)
+		}
+
+		var resp *kafka.OffsetCommitResponse
+		resp, err = client.OffsetCommit(ctx, &kafka.OffsetCommitRequest{
+			GroupID:      j.GroupID,
+			GenerationID: -1,
+			Topics:       map[string][]kafka.OffsetCommit{j.ReadTopic: commits},
+		})
+		if err == nil {
+			for _, p := range resp.Topics[j.ReadTopic] {
+				if p.Error != nil {
+					err = p.Error
+					break
+				}
+			}
+		}
+
+		if err == nil {
+			return nil
+		}
+
+		log.LogWarnf(ctx, "resetting consumer group %s offsets (attempt %d): %s", j.GroupID, attempt+1, err.Error())
+	}
+
+	return err
+}
+
 func (j *PfFlowJob) Run() {
+	ctx := context.Background()
 	var r *kafka.Reader
 	maxReconnectDelay := 60 * time.Second
 	reconnectDelay := 1 * time.Second
 	consecutiveErrors := 0
 
-	defer func() {
-		if r != nil {
-			if err := r.Close(); err != nil {
-				log.Printf("failed to close reader: %v", err)
-			}
+	closeReader := func() {
+		if r == nil {
+			return
 		}
 
+		if err := r.Close(); err != nil {
+			log.LogErrorf(ctx, "failed to close kafka reader: %v", err)
+		}
+
+		r = nil
+	}
+
+	defer func() {
+		closeReader()
 		j.schedule.ran.Store(false)
 	}()
 
 	dialer := j.kafkaDialer()
-	WaitForTopic(dialer, context.Background(), j.Brokers[0], j.ReadTopic)
+	WaitForTopic(dialer, ctx, j.Brokers[0], j.ReadTopic)
+	client := j.kafkaClient()
 
 	for {
 		// Create or recreate the reader
 		if r == nil {
-			log.Printf("Connecting to Kafka brokers: %v, topic: %s", j.Brokers, j.ReadTopic)
-			r = kafka.NewReader(kafka.ReaderConfig{
-				Brokers:  j.Brokers,
-				Topic:    j.ReadTopic,
-				GroupID:  j.GroupID,
-				MaxBytes: 10e6, // 10MB
-				Dialer:   dialer,
-			})
+			log.LogInfof(ctx, "Connecting to Kafka brokers: %v, topic: %s, group: %s", j.Brokers, j.ReadTopic, j.GroupID)
+			r = j.newReader(ctx, dialer)
 		}
 
 		// Use a timeout context to avoid blocking forever if Kafka is unresponsive
-		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-		m, err := r.ReadMessage(ctx)
+		readCtx, cancel := context.WithTimeout(ctx, readTimeout)
+		m, err := r.ReadMessage(readCtx)
 		cancel()
 		if err != nil {
 			// Check if it's just a timeout (no messages available) vs a real error.
 			// kafka-go's ReadMessage wraps the error ("fetching message: %w"), so a
 			// plain == comparison never matches — use errors.Is to unwrap.
 			if errors.Is(err, context.DeadlineExceeded) {
-				// Timeout waiting for messages is normal, just retry without reconnecting
+				// No message for a whole readTimeout: either the topic is idle
+				// or the group offset is stranded past the end of a recreated
+				// topic, which kafka-go never recovers from on its own.
+				stale, err := j.staleGroupOffsets(ctx, client)
+				if err != nil {
+					log.LogWarnf(ctx, "unable to check consumer group %s offsets: %s", j.GroupID, err.Error())
+					continue
+				}
+
+				if len(stale) == 0 {
+					log.LogDebugf(ctx, "no message on %s for %s", j.ReadTopic, readTimeout)
+					continue
+				}
+
+				closeReader()
+				if err := j.commitGroupOffsets(ctx, client, stale); err != nil {
+					log.LogErrorf(ctx, "failed to reset consumer group %s offsets: %s", j.GroupID, err.Error())
+				}
+
 				continue
 			}
 
 			consecutiveErrors++
-			log.Printf("Error reading from Kafka (attempt %d): %s", consecutiveErrors, err.Error())
+			log.LogErrorf(ctx, "Error reading from Kafka (attempt %d): %s", consecutiveErrors, err.Error())
 
 			// Close the current reader on error
-			if closeErr := r.Close(); closeErr != nil {
-				log.Printf("Error closing reader: %v", closeErr)
-			}
-			r = nil
+			closeReader()
 
 			// Exponential backoff with max delay
 			if reconnectDelay < maxReconnectDelay {
@@ -219,21 +410,21 @@ func (j *PfFlowJob) Run() {
 				}
 			}
 
-			log.Printf("Reconnecting to Kafka in %v...", reconnectDelay)
+			log.LogWarnf(ctx, "Reconnecting to Kafka in %v...", reconnectDelay)
 			time.Sleep(reconnectDelay)
 			continue
 		}
 
 		// Reset error counter and delay on successful read
 		if consecutiveErrors > 0 {
-			log.Printf("Successfully reconnected to Kafka after %d errors", consecutiveErrors)
+			log.LogInfof(ctx, "Successfully reconnected to Kafka after %d errors", consecutiveErrors)
 			consecutiveErrors = 0
 			reconnectDelay = 1 * time.Second
 		}
 
 		pfFlows := &PfFlows{}
 		if err := json.Unmarshal(m.Value, pfFlows); err != nil {
-			log.Printf("Error unmarshaling message: %v", err)
+			log.LogErrorf(ctx, "Error unmarshaling message: %v", err)
 			continue
 		}
 

--- a/go/cron/pfflowjob_test.go
+++ b/go/cron/pfflowjob_test.go
@@ -9,3 +9,24 @@ func TestKafkaSubmitter(t *testing.T) {
 	jobsConfig := GetMaintenanceConfig(context.Background())
 	SetupKafka(jobsConfig["pfflow"].(map[string]interface{}))
 }
+
+func TestIsStrandedOffset(t *testing.T) {
+	cases := []struct {
+		name            string
+		committed, last int64
+		want            bool
+	}{
+		{"no committed offset (-1) on a live partition", -1, 100, false},
+		{"committed behind the log end", 50, 100, false},
+		{"committed equals the log end (caught up)", 100, 100, false},
+		{"committed past the log end: topic recreated", 5_000_000, 110_000, true},
+		{"log end unknown / not returned (0) must never rewind", 5_000_000, 0, false},
+		{"negative log end must never rewind", 5_000_000, -1, false},
+		{"empty recreated partition (log end 0) is left alone until it fills", 5_000_000, 0, false},
+	}
+	for _, c := range cases {
+		if got := isStrandedOffset(c.committed, c.last); got != c.want {
+			t.Errorf("%s: isStrandedOffset(%d, %d) = %v, want %v", c.name, c.committed, c.last, got, c.want)
+		}
+	}
+}

--- a/go/cron/policy_lookup.go
+++ b/go/cron/policy_lookup.go
@@ -246,14 +246,9 @@ type PolicyLookup struct {
 	ImplictPolices []Policy
 }
 
-func (l PolicyLookup) Lookup(ctx context.Context, db *sql.DB, ne *NetworkEvent) *EnforcementInfo {
-	srcMac, srcRole := ne.GetSrcRole(ctx, db)
-	dstMac, dstRole := ne.GetDstRole(ctx, db)
-	return l.LookupWithRoles(ne, srcMac, srcRole, dstMac, dstRole)
-}
-
-// LookupWithRoles is Lookup with the node roles already resolved, so callers
-// can batch the role queries for many events (see UpdateNetworkEvents).
+// LookupWithRoles resolves the enforcement info of an event whose node roles
+// were already looked up, so callers can batch the role queries for many
+// events (see UpdateNetworkEvents).
 func (l PolicyLookup) LookupWithRoles(ne *NetworkEvent, srcMac, srcRole, dstMac, dstRole string) *EnforcementInfo {
 	if ei := l.LookupByMac(srcMac, ne); ei != nil {
 		return ei
@@ -352,15 +347,14 @@ func StorePolicyLookup(p *PolicyLookup) {
 	storePolicyLookup.Store(p)
 }
 
-func UpdateNetworkEvent(ctx context.Context, db *sql.DB, ne *NetworkEvent) {
-	lookup := GetPolicyLookup()
-	ei := lookup.Lookup(ctx, db, ne)
-	if ei != nil {
-		ne.EnforcementInfo = ei
-	}
-}
-
 const nodeRolesLookupChunk = 1000
+
+// roleKey normalizes a MAC for the nodeRoles map. node.mac is compared
+// case-insensitively by MariaDB (utf8mb4_general_ci) but a Go map is not, and
+// MACs filled in from ip4log keep whatever case the writer used.
+func roleKey(mac string) string {
+	return strings.ToLower(mac)
+}
 
 // UpdateNetworkEvents sets the enforcement info of every event, resolving the
 // node roles with one query per chunk of distinct MACs instead of two queries
@@ -369,11 +363,11 @@ func UpdateNetworkEvents(ctx context.Context, db *sql.DB, events []*NetworkEvent
 	macSet := make(map[string]struct{}, len(events))
 	for _, ne := range events {
 		if mac := inventoryMac(ne.SourceInventoryItem); mac != "" {
-			macSet[mac] = struct{}{}
+			macSet[roleKey(mac)] = struct{}{}
 		}
 
 		if mac := inventoryMac(ne.DestInventoryitem); mac != "" {
-			macSet[mac] = struct{}{}
+			macSet[roleKey(mac)] = struct{}{}
 		}
 	}
 
@@ -387,48 +381,24 @@ func UpdateNetworkEvents(ctx context.Context, db *sql.DB, events []*NetworkEvent
 	for _, ne := range events {
 		srcMac := inventoryMac(ne.SourceInventoryItem)
 		dstMac := inventoryMac(ne.DestInventoryitem)
-		if ei := lookup.LookupWithRoles(ne, srcMac, roles[srcMac], dstMac, roles[dstMac]); ei != nil {
+		if ei := lookup.LookupWithRoles(ne, srcMac, roles[roleKey(srcMac)], dstMac, roles[roleKey(dstMac)]); ei != nil {
 			ne.EnforcementInfo = ei
 		}
 	}
 }
 
-// nodeRoles maps each known MAC to its role name ("" when the node has no
-// role). MACs absent from the node table are absent from the result, which
-// also yields "" on lookup, the same as the per-event query did.
+// nodeRoles maps each known MAC (lower-cased, see roleKey) to its role name
+// ("" when the node has no role). MACs absent from the node table are absent
+// from the result, which also yields "" on lookup, the same as the per-event
+// query did. macs must already be roleKey-normalized.
 func nodeRoles(ctx context.Context, db *sql.DB, macs []string) map[string]string {
-	roles := make(map[string]string, len(macs))
 	if db == nil {
-		return roles
+		return map[string]string{}
 	}
 
-	for start := 0; start < len(macs); start += nodeRolesLookupChunk {
-		chunk := macs[start:min(start+nodeRolesLookupChunk, len(macs))]
-		query := `SELECT node.mac, COALESCE(node_category.name, '') FROM node LEFT JOIN node_category ON node_category.category_id = node.category_id WHERE node.mac IN (?` + strings.Repeat(", ?", len(chunk)-1) + `)`
-		args := make([]interface{}, len(chunk))
-		for i, mac := range chunk {
-			args[i] = mac
-		}
-
-		rows, err := db.QueryContext(ctx, query, args...)
-		if err != nil {
-			log.LogErrorf(ctx, "nodeRoles Database Error: %s", err.Error())
-			continue
-		}
-
-		for rows.Next() {
-			var mac, role string
-			if err := rows.Scan(&mac, &role); err != nil {
-				log.LogErrorf(ctx, "nodeRoles Scan Error: %s", err.Error())
-				break
-			}
-
-			roles[mac] = role
-		}
-
-		rows.Close()
-	}
-
+	roles, _ := queryStringPairs(ctx, db, "nodeRoles",
+		`SELECT LOWER(node.mac), COALESCE(node_category.name, '') FROM node LEFT JOIN node_category ON node_category.category_id = node.category_id WHERE node.mac IN (`,
+		macs, nodeRolesLookupChunk)
 	return roles
 }
 

--- a/go/cron/policy_lookup.go
+++ b/go/cron/policy_lookup.go
@@ -249,6 +249,12 @@ type PolicyLookup struct {
 func (l PolicyLookup) Lookup(ctx context.Context, db *sql.DB, ne *NetworkEvent) *EnforcementInfo {
 	srcMac, srcRole := ne.GetSrcRole(ctx, db)
 	dstMac, dstRole := ne.GetDstRole(ctx, db)
+	return l.LookupWithRoles(ne, srcMac, srcRole, dstMac, dstRole)
+}
+
+// LookupWithRoles is Lookup with the node roles already resolved, so callers
+// can batch the role queries for many events (see UpdateNetworkEvents).
+func (l PolicyLookup) LookupWithRoles(ne *NetworkEvent, srcMac, srcRole, dstMac, dstRole string) *EnforcementInfo {
 	if ei := l.LookupByMac(srcMac, ne); ei != nil {
 		return ei
 	}
@@ -352,6 +358,78 @@ func UpdateNetworkEvent(ctx context.Context, db *sql.DB, ne *NetworkEvent) {
 	if ei != nil {
 		ne.EnforcementInfo = ei
 	}
+}
+
+const nodeRolesLookupChunk = 1000
+
+// UpdateNetworkEvents sets the enforcement info of every event, resolving the
+// node roles with one query per chunk of distinct MACs instead of two queries
+// per event.
+func UpdateNetworkEvents(ctx context.Context, db *sql.DB, events []*NetworkEvent) {
+	macSet := make(map[string]struct{}, len(events))
+	for _, ne := range events {
+		if mac := inventoryMac(ne.SourceInventoryItem); mac != "" {
+			macSet[mac] = struct{}{}
+		}
+
+		if mac := inventoryMac(ne.DestInventoryitem); mac != "" {
+			macSet[mac] = struct{}{}
+		}
+	}
+
+	macs := make([]string, 0, len(macSet))
+	for mac := range macSet {
+		macs = append(macs, mac)
+	}
+
+	roles := nodeRoles(ctx, db, macs)
+	lookup := GetPolicyLookup()
+	for _, ne := range events {
+		srcMac := inventoryMac(ne.SourceInventoryItem)
+		dstMac := inventoryMac(ne.DestInventoryitem)
+		if ei := lookup.LookupWithRoles(ne, srcMac, roles[srcMac], dstMac, roles[dstMac]); ei != nil {
+			ne.EnforcementInfo = ei
+		}
+	}
+}
+
+// nodeRoles maps each known MAC to its role name ("" when the node has no
+// role). MACs absent from the node table are absent from the result, which
+// also yields "" on lookup, the same as the per-event query did.
+func nodeRoles(ctx context.Context, db *sql.DB, macs []string) map[string]string {
+	roles := make(map[string]string, len(macs))
+	if db == nil {
+		return roles
+	}
+
+	for start := 0; start < len(macs); start += nodeRolesLookupChunk {
+		chunk := macs[start:min(start+nodeRolesLookupChunk, len(macs))]
+		query := `SELECT node.mac, COALESCE(node_category.name, '') FROM node LEFT JOIN node_category ON node_category.category_id = node.category_id WHERE node.mac IN (?` + strings.Repeat(", ?", len(chunk)-1) + `)`
+		args := make([]interface{}, len(chunk))
+		for i, mac := range chunk {
+			args[i] = mac
+		}
+
+		rows, err := db.QueryContext(ctx, query, args...)
+		if err != nil {
+			log.LogErrorf(ctx, "nodeRoles Database Error: %s", err.Error())
+			continue
+		}
+
+		for rows.Next() {
+			var mac, role string
+			if err := rows.Scan(&mac, &role); err != nil {
+				log.LogErrorf(ctx, "nodeRoles Scan Error: %s", err.Error())
+				break
+			}
+
+			roles[mac] = role
+		}
+
+		rows.Close()
+	}
+
+	return roles
 }
 
 func init() {

--- a/go/cron/policy_lookup_test.go
+++ b/go/cron/policy_lookup_test.go
@@ -1,6 +1,7 @@
 package maint
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -660,4 +661,29 @@ func TestPolicyLoad(t *testing.T) {
 		t.Fatalf("LookupByRoles does not match %s", diff)
 	}
 
+}
+
+func TestRoleKeyIsCaseInsensitive(t *testing.T) {
+	// node.mac is compared case-insensitively by MariaDB but a Go map is not;
+	// MACs filled in from ip4log keep whatever case the writer used.
+	if roleKey("AA:BB:CC:DD:EE:FF") != roleKey("aa:bb:cc:dd:ee:ff") {
+		t.Fatal("roleKey must normalize case")
+	}
+	if roleKey("aa:bb:cc:dd:ee:ff") != "aa:bb:cc:dd:ee:ff" {
+		t.Fatal("roleKey must leave a lower-case MAC unchanged")
+	}
+}
+
+func TestUpdateNetworkEventsWithoutDatabase(t *testing.T) {
+	// No database: roles resolve to "" and the lookup must still run (and not
+	// panic) so that MAC/implicit policies keep applying.
+	StorePolicyLookup(&PolicyLookup{}) // no pfconfig in unit tests
+	ne := &NetworkEvent{
+		SourceInventoryItem: &InventoryItem{ExternalIDS: []string{"AA:BB:CC:DD:EE:01"}},
+		DestInventoryitem:   &InventoryItem{ExternalIDS: []string{"aa:bb:cc:dd:ee:02"}},
+	}
+	UpdateNetworkEvents(context.Background(), nil, []*NetworkEvent{ne})
+	if ne.EnforcementInfo != nil {
+		t.Fatalf("no policies loaded: expected no enforcement info, got %+v", ne.EnforcementInfo)
+	}
 }


### PR DESCRIPTION
# Description
The pfcron `pfflow` task (Kafka `pfflows_events` → `network_events`) could not keep up with a large deployment: with ~30K devices on a virtualSwitch producing ~110K flows/min, only ~25-30K network events/min were pushed and the consumer lag grew without bound. Separately, when the `pfflows_events` topic was deleted/recreated behind the consumer group, the consumer stopped producing anything, silently.

Root causes and fixes (all in `go/cron`):

* **Synchronous offset commit per message.** `kafka.Reader` had no `CommitInterval`, so kafka-go committed after every `ReadMessage`: one broker round trip per flow, ~650 msg/s ceiling. Offsets are now committed asynchronously once per second.
* **Flush on the ingest goroutine with per-event queries.** Every minute the aggregator ran two node-role queries per network event (~50K queries for 25K events) while not reading Kafka, pausing consumption ~19 s per minute. The flush now runs in its own goroutine (`aggregator_flush.go`), and ip4log MAC and node-role lookups are batched in chunks of 1000 distinct keys (`resolveMissingMacs`, `UpdateNetworkEvents` / `PolicyLookup.LookupWithRoles`). Semantics of the per-flow/per-event queries are preserved.
* **Per-flow INFO log line** ("Received N flows", ~4 GB/day of pfcron.log) is now DEBUG, replaced by one INFO summary per window with counts and timings.
* **Stranded group offset.** When the committed offset is past the partition log end, kafka-go retries forever and, with no `ErrorLogger`, silently. kafka-go's loggers are now wired into pfcron logging and, after a 60 s read timeout, the group offset is compared with the log end; if it is past the end the reader is closed, the log-end offset is committed and the reader reconnects.
* `MarkSwitchAsSeen` is skipped when the flow header has no valid agent address (it was inserting an `invalid IP` row into `switch_observability`).

Verified on a 15.2 load-test box: after deploy the guard reset the stranded offset within a minute, then ~110K flows/min were consumed with a ~0.8 s flush (down from ~19 s) and consumer lag stayed in the hundreds of messages. pfcron CPU ~11%.

# Impacts
* pfcron `pfflow` task: Kafka consumer (`go/cron/pfflowjob.go`), aggregator/flush (`go/cron/aggregator.go`, `go/cron/aggregator_flush.go`), enforcement lookup (`go/cron/policy_lookup.go`, `go/cron/network_event.go`).
* Offsets are now committed asynchronously (1 s), so a pfcron crash can replay up to ~1 s of flows into `network_events`.
* Log volume of pfcron.log drops sharply on flow-heavy deployments; look for the new `pfflow aggregator:` summary line and for `consumer group ... is past the log end offset` when a topic reset is detected.
* Node role and ip4log lookups are now `IN (...)` queries of up to 1000 bindings each.

# Delete branch after merge
YES

# Checklist
- [ ] Document the feature — n/a
- [ ] Add OpenAPI specification — n/a
- [ ] Add unit tests — no (existing `TestAggregator` covers the aggregation semantics; the go/cron test binary needs a live pfconfig socket)
- [ ] Add acceptance tests (TestLink) — no

# NEWS file entries
## Enhancements
* pfcron pfflow: commit Kafka offsets asynchronously and batch the DB lookups of the network event flush, removing the ~650 flows/s ceiling of the pfflows_events consumer
* pfcron pfflow: replace the per-flow INFO log line with a per-window summary

## Bug Fixes
* pfcron pfflow: recover automatically when the consumer group offset is past the end of a recreated pfflows_events topic instead of silently stalling forever
* pfcron pfflow: do not record an "invalid IP" switch in switch_observability for flows without an agent address
