### PR TITLE
fix(ci): check runner disk per volume, and make the reclaim actually reclaim

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -636,6 +636,9 @@ variables:
           exit 0
         fi
       fi
+    # What this runner is holding, and what a reclaim would free on it. Dry-run,
+    # so nothing is deleted; only useful on the host about to run the test.
+    - ${CILIBDIR}/vagrant/cleanup-runner-disk.sh || true
     # || EXIT_CODE=$? prevents script to finish at first command
     - timeout ${PIPELINE_TIMEOUT_SCRIPT} make -e -C ${TESTDIR} MAKE_TARGET=run ${CI_JOB_NAME} || EXIT_CODE=$?
     - JOB_STATUS=$EXIT_CODE timeout ${PIPELINE_TIMEOUT_CLEANUP} ${TESTCIDIR}/clean-test-environment.sh

--- a/ci/lib/ensure-runner-disk-free.sh
+++ b/ci/lib/ensure-runner-disk-free.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
-# build_pf_img preflight: reclaim runner disk if low, else abort before the long
-# build instead of failing mid-convert with "No space left on device". CI-only:
-# the purge is destructive. Guards both / and /var/lib (separate volumes on the
-# lab runners: build dir + boxes on /, libvirt pool on /var/lib).
+# Preflight for the disk-hungry jobs: reclaim if low, else abort up front
+# instead of failing mid-build with "No space left on device". CI-only.
+#
+# Each path is checked on its own volume, never summed: / and /var/lib are
+# separate on the lab runners, so a total hides a full one behind a roomy one.
 set -o nounset -o pipefail
 
-# --purge wipes vagrant boxes + libvirt volumes; never do that on a dev box.
+# The reclaim wipes vagrant boxes + libvirt volumes; never do that on a dev box.
 if [ -z "${CI:-}" ] && [ "${FORCE_RUNNER_DISK_RECLAIM:-}" != yes ]; then
     echo "===> not in CI -- skipping (set FORCE_RUNNER_DISK_RECLAIM=yes to override)"
     exit 0
@@ -19,14 +20,36 @@ RECLAIM_SCRIPT=${RECLAIM_SCRIPT:-${SCRIPT_DIR}/vagrant/cleanup-runner-disk.sh}
 
 free_gb() { df -B1G --output=avail "$1" 2>/dev/null | awk 'NR==2 {print $1+0}'; }
 
-# stderr: per-volume report; stdout: under-floor paths for the caller to capture.
+# Nearest existing ancestor, so df has a target for a path not created yet.
+existing_ancestor() {
+    local p=$1
+    while [ ! -e "${p}" ] && [ -n "${p}" ]; do p=${p%/*}; done
+    echo "${p:-/}"
+}
+
+# stderr: per-volume report; stdout: under-floor paths for the caller to
+# capture. A path may carry its own floor as "<path>:<GB>".
 below_floor() {
-    local p f
-    for p in "${CHECK_PATHS[@]}"; do
-        [ -e "${p}" ] || continue
+    local spec p floor f
+    for spec in "${CHECK_PATHS[@]}"; do
+        case "${spec}" in
+            *:*) p=${spec%:*}; floor=${spec##*:} ;;
+            *)   p=${spec};    floor=${MIN_FREE_GB} ;;
+        esac
+        p=$(existing_ancestor "${p}")
         f=$(free_gb "${p}")
-        echo "  ${p}: ${f:-0}G free (floor ${MIN_FREE_GB}G)" >&2
-        [ "${f:-0}" -lt "${MIN_FREE_GB}" ] && echo "${p}"
+        echo "  ${p}: ${f:-0}G free (floor ${floor}G)" >&2
+        [ "${f:-0}" -lt "${floor}" ] && echo "${p}"
+    done
+}
+
+# What is using a volume we could not free; "how little is left" is not enough.
+report_usage() {
+    local p mount
+    for p in $1; do
+        mount=$(df --output=target "${p}" 2>/dev/null | tail -1)
+        echo "===> biggest consumers of ${mount}:" >&2
+        du -xh -d1 "${mount}" 2>/dev/null | sort -h | tail -8 | sed 's/^/    /' >&2
     done
 }
 
@@ -34,10 +57,9 @@ echo "===> runner disk preflight"
 short=$(below_floor)
 [ -z "${short}" ] && { echo "===> all guarded volumes above floor"; exit 0; }
 
-echo "===> below floor on: ${short//$'\n'/ } -- purging vagrant boxes and libvirt pool volumes"
+echo "===> below floor on: ${short//$'\n'/ } -- reclaiming vagrant boxes, VMs and pool volumes"
 if [ -x "${RECLAIM_SCRIPT}" ]; then
-    # --purge is host-idle-guarded; non-zero here just means busy, so re-check.
-    "${RECLAIM_SCRIPT}" --purge --apply || echo "WARN: reclaim non-zero (busy?)" >&2
+    "${RECLAIM_SCRIPT}" --apply || echo "WARN: reclaim non-zero" >&2
 else
     echo "WARN: ${RECLAIM_SCRIPT} not executable -- skipping reclaim" >&2
 fi
@@ -45,6 +67,7 @@ fi
 echo "===> free space after reclaim:"
 short=$(below_floor)
 if [ -n "${short}" ]; then
-    echo "ERROR: still below ${MIN_FREE_GB}G floor on: ${short//$'\n'/ } -- aborting" >&2
+    report_usage "${short}"
+    echo "ERROR: still below floor on: ${short//$'\n'/ } -- aborting" >&2
     exit 1
 fi

--- a/ci/lib/vagrant/cleanup-runner-disk.sh
+++ b/ci/lib/vagrant/cleanup-runner-disk.sh
@@ -1,59 +1,33 @@
 #!/bin/bash
-# Reclaim disk on a runner host that runs vagrant-libvirt PF bakes and
-# tests. Safe by default: only sweeps stale/legacy artifacts, never the
-# currently-active inverse-inc/pf*branch base boxes.
+# Reclaim runner disk: every vagrant box, prefetch archive, Tempfile, libvirt
+# box_image volume and vagrant-* domain, for each $HOME under /var/local/<user>.
+# Boxes come back from Linode next pipeline and test-wrapper.sh rebuilds any VM
+# it cannot boot, so nothing here is worth keeping. Runners hold one job at a
+# time; a second concurrent job would lose its boxes and VMs to this.
 #
-# Targets every user account whose $HOME sits under /var/local/<name>
-# (e.g. gitlab-runner, plus any sibling runner/service account). The
-# libvirt pool sweep is system-wide and runs once at the end.
-#
-# Modes:
-#   (default) sweep — legacy pf*dev boxes, stale Tempfiles, prefetch
-#                     scratch, libvirt-pool backings for legacy boxes
-#   --purge         — wipe ALL vagrant boxes, ALL .vagrant.d/tmp, ALL
-#                     prefetch cache, ALL pool 'vagrant_box_image' volumes.
-#                     Next pipeline re-downloads everything. Requires the
-#                     host to be idle (no vagrant proc on any tracked
-#                     user, no running libvirt domain) — refuses otherwise.
-#
-# Per-user targets (relative to each detected $HOME):
-#   1. Vagrant boxes under .vagrant.d/boxes/ (sweep: legacy pf*dev only;
-#      purge: every locally-registered box).
-#   2. Empty orphan version dirs under .vagrant.d/boxes/*/*/.
-#   3. Vagrant Tempfiles under .vagrant.d/tmp (sweep: >$TMP_AGE_MIN min
-#      old; purge: everything).
-#   4. Prefetch scratch under $HOME/vagrant_img_cache/*.
-#
-# Global target:
-#   5. libvirt-pool backing files in pool 'default' (sweep: matching
-#      legacy pf*dev; purge: every '*_vagrant_box_image_*' volume).
-#
-# Usage:
-#   sudo ./cleanup-runner-disk.sh                       # dry-run sweep
-#   sudo ./cleanup-runner-disk.sh --apply               # apply sweep
-#   sudo ./cleanup-runner-disk.sh --purge               # dry-run purge
-#   sudo ./cleanup-runner-disk.sh --purge --apply       # apply purge
+# Usage: [--apply]                  dry-run unless --apply
 #   ONLY_USERS="gitlab-runner" sudo ./cleanup-runner-disk.sh --apply
-#   TMP_AGE_MIN=60 sudo ./cleanup-runner-disk.sh --apply
 
 set -o nounset -o pipefail
 
 VAR_LOCAL=${VAR_LOCAL:-/var/local}
-PROVIDER=${PROVIDER:-libvirt}
-TMP_AGE_MIN=${TMP_AGE_MIN:-30}
+VIRSH_URI=${VIRSH_URI:-qemu:///system}
+
+# Our own account, defaulted here and not in a caller: /var/local holds people's
+# homes, and naming them in a job log of a public project is a disclosure. Set
+# ONLY_USERS deliberately to widen it.
+ONLY_USERS=${ONLY_USERS:-$(id -un)}
 
 APPLY=no
-PURGE=no
 for arg in "$@"; do
     case "${arg}" in
         --apply|-y)    APPLY=yes ;;
         --dry-run)     APPLY=no ;;
-        --purge)       PURGE=yes ;;
         -h|--help)
             sed -n '2,/^$/{s/^# \{0,1\}//;p}' "$0"
             exit 0 ;;
         *)
-            echo "Usage: $0 [--apply|--dry-run] [--purge] [-h]" >&2
+            echo "Usage: $0 [--apply|--dry-run] [-h]" >&2
             exit 2 ;;
     esac
 done
@@ -69,16 +43,17 @@ run() {
 
 hdr() { printf '\n=== %s\n' "$*"; }
 
-# True if user $1 runs the vagrant CLI. Match the executable, not the substring:
-# plain -f vagrant also hits paths like ci/lib/vagrant/ and vim on *vagrant* files.
-VAGRANT_PROC_RE='(^|[ /])vagrant( |$)'
-vagrant_running() { pgrep -u "$1" -af "${VAGRANT_PROC_RE}"; }
+virsh_sys() { virsh -c "${VIRSH_URI}" "$@"; }
 
 # Emit "user:home" lines for every $VAR_LOCAL/<name> dir whose <name>
 # resolves to a real account whose $HOME equals the dir. Filter with
-# ONLY_USERS="a b c" if you want a subset.
+# ONLY_USERS="a b c" if you want a subset, or USER_HOMES to bypass discovery.
 discover_users() {
     local d name pw home
+    if [ -n "${USER_HOMES:-}" ]; then
+        printf '%s\n' ${USER_HOMES}
+        return
+    fi
     for d in "${VAR_LOCAL}"/*/; do
         [ -d "${d}" ] || continue
         name=$(basename "${d%/}")
@@ -106,106 +81,114 @@ as_user() {
     fi
 }
 
-show_disk() {
-    df -h / /var/lib 2>/dev/null | sed 's/^/  /'
-    for ent in ${USERS}; do
-        local user=${ent%%:*} home=${ent##*:}
-        du -sh "${home}/.vagrant.d/boxes" "${home}/.vagrant.d/tmp" \
-               "${home}/vagrant_img_cache" 2>/dev/null \
-            | sed 's/^/  /' || true
+# df only: du would walk tens of GB of images to report what free space says.
+show_disk() { df -h / /var/lib 2>/dev/null | sed 's/^/  /'; }
+
+# Print what find(1) matches, then delete it. A missing dir matches nothing.
+clean_find() {
+    local label=$1; shift
+    hdr "${label}"
+    local hits
+    hits=$(find "$@" 2>/dev/null || true)
+    if [ -z "${hits}" ]; then
+        echo "  (none)"
+    else
+        echo "${hits}" | sed 's/^/  /'
+        run find "$@" -delete
+    fi
+}
+
+# "<name>,<provider>" per registered box; the provider keeps `box remove` from
+# failing on a box registered for something other than libvirt.
+box_entries() {
+    local user=$1 home=$2 out
+    if ! out=$(as_user "${user}" "${home}" vagrant box list --machine-readable 2>&1); then
+        echo "WARN: vagrant box list failed for ${user}: ${out}" >&2
+        return 1
+    fi
+    printf '%s\n' "${out}" \
+        | awk -F, '$3=="box-name"{n=$4} $3=="box-provider" && n!=""{print n","$4}' \
+        | sort -u
+}
+
+# No libvirt access looks exactly like an empty host, so say which it was.
+virsh_or_warn() {
+    local out
+    if ! out=$(virsh_sys "$@" 2>&1); then
+        echo "WARN: virsh $* failed: ${out}" >&2
+        return 1
+    fi
+    printf '%s\n' "${out}"
+}
+
+# vol-list has no --name, so parse the table (two header lines). Asking for a
+# flag it does not support is what made this step report "(none)" against 71G.
+pools() { virsh_or_warn pool-list | awk 'NR>2 && $1 {print $1}'; }
+
+pool_vol_names() { virsh_or_warn vol-list --pool "$1" | awk 'NR>2 && $1 {print $1}'; }
+
+# destroy first: undefine --remove-all-storage refuses a running domain
+force_undefine_domain() {
+    virsh_sys destroy --domain "$1" >/dev/null 2>&1 || true
+    virsh_sys undefine --domain "$1" --remove-all-storage
+}
+
+# Accounts with a home under $VAR_LOCAL other than ours. DOMAIN_PREFIX falls
+# back to $USER, so vagrant-<acct>-* is a person's VM and not ours to destroy.
+list_local_accounts() {
+    local d name pw
+    for d in "${VAR_LOCAL}"/*/; do
+        [ -d "${d}" ] || continue
+        name=$(basename "${d%/}")
+        pw=$(getent passwd "${name}" 2>/dev/null) || continue
+        [ "$(echo "${pw}" | cut -d: -f6)" = "${d%/}" ] || continue
+        [ "${name}" = "$(id -un)" ] || echo "${name}"
     done
 }
 
-# Per-user cleanup steps 1-4. Step 5 (libvirt pool) is global.
+# Their name stays out of the log too: CI logs are as public as the project.
+owned_by_person() {
+    local acct
+    for acct in ${PROTECTED_ACCOUNTS}; do
+        case "$1" in "vagrant-${acct}-"*) return 0 ;; esac
+    done
+    return 1
+}
+
 clean_user_home() {
-    local user=$1 home=$2
+    local user=$1 home=$2 entry
     local VAGRANT_BOXES="${home}/.vagrant.d/boxes"
     local VAGRANT_TMP="${home}/.vagrant.d/tmp"
     local PREFETCH_CACHE="${home}/vagrant_img_cache"
 
-    hdr "User ${user} — vagrant box list"
-    as_user "${user}" "${home}" vagrant box list 2>/dev/null \
-        | sed 's/^/  /' || echo "  (vagrant box list failed)"
-
-    # 1) Vagrant boxes
-    local targets
-    if [ "${PURGE}" = yes ]; then
-        hdr "User ${user} — ALL local vagrant boxes (purge mode)"
-        targets=$(as_user "${user}" "${home}" vagrant box list --machine-readable 2>/dev/null \
-            | awk -F, '$3=="box-name"{print $4}' | sort -u || true)
-    else
-        hdr "User ${user} — legacy 'inverse-inc/pf*dev' boxes"
-        targets=$(as_user "${user}" "${home}" vagrant box list --machine-readable 2>/dev/null \
-            | awk -F, '$3=="box-name"{print $4}' \
-            | grep -E '^inverse-inc/pf[a-z0-9]+dev$' \
-            | sort -u || true)
-    fi
-    if [ -z "${targets}" ]; then
+    # 1) Vagrant boxes, ours and public alike
+    hdr "User ${user} — ALL local vagrant boxes"
+    local entries
+    entries=$(box_entries "${user}" "${home}")
+    if [ -z "${entries}" ]; then
         echo "  (none)"
     else
-        echo "${targets}" | sed 's/^/  /'
-        for box in ${targets}; do
+        echo "${entries}" | sed 's/^/  /'
+        for entry in ${entries}; do
             run as_user "${user}" "${home}" vagrant box remove \
-                --force --all --provider "${PROVIDER}" "${box}"
+                --force --all --provider "${entry##*,}" "${entry%%,*}"
         done
     fi
 
     # 2) Empty orphan version dirs
-    hdr "User ${user} — empty orphan version dirs under ${VAGRANT_BOXES}"
-    local orphans
-    orphans=$(find "${VAGRANT_BOXES}" -mindepth 2 -maxdepth 2 -type d -empty 2>/dev/null || true)
-    if [ -z "${orphans}" ]; then
-        echo "  (none)"
-    else
-        echo "${orphans}" | sed 's/^/  /'
-        run find "${VAGRANT_BOXES}" -mindepth 2 -maxdepth 2 -type d -empty -delete
-    fi
+    clean_find "User ${user} — empty orphan version dirs under ${VAGRANT_BOXES}" \
+        "${VAGRANT_BOXES}" -mindepth 2 -maxdepth 2 -type d -empty
 
     # 3) Vagrant Tempfiles
-    if [ "${PURGE}" = yes ]; then
-        hdr "User ${user} — ALL Vagrant Tempfiles under ${VAGRANT_TMP}"
-        local entries
-        entries=$(find "${VAGRANT_TMP}" -mindepth 1 -maxdepth 1 2>/dev/null || true)
-        if [ -z "${entries}" ]; then
-            echo "  (none)"
-        else
-            echo "${entries}" | sed 's/^/  /'
-            run find "${VAGRANT_TMP}" -mindepth 1 -delete
-        fi
-    else
-        hdr "User ${user} — Vagrant Tempfiles older than ${TMP_AGE_MIN}min"
-        if vagrant_running "${user}" >/dev/null; then
-            echo "  SKIPPED — vagrant process is running as ${user}:"
-            vagrant_running "${user}" | sed 's/^/    /'
-        else
-            local stale
-            stale=$(find "${VAGRANT_TMP}" -mindepth 1 -mmin "+${TMP_AGE_MIN}" 2>/dev/null || true)
-            if [ -z "${stale}" ]; then
-                echo "  (none)"
-            else
-                echo "${stale}" | sed 's/^/  /'
-                run find "${VAGRANT_TMP}" -mindepth 1 -mmin "+${TMP_AGE_MIN}" -delete
-            fi
-        fi
-    fi
+    clean_find "User ${user} — ALL Vagrant Tempfiles under ${VAGRANT_TMP}" \
+        "${VAGRANT_TMP}" -mindepth 1
 
-    # 4) Prefetch scratch
-    hdr "User ${user} — prefetch scratch under ${PREFETCH_CACHE}"
-    if [ -d "${PREFETCH_CACHE}" ]; then
-        local leftovers
-        leftovers=$(find "${PREFETCH_CACHE}" -mindepth 1 -maxdepth 1 2>/dev/null || true)
-        if [ -z "${leftovers}" ]; then
-            echo "  (none)"
-        else
-            echo "${leftovers}" | sed 's/^/  /'
-            for entry in ${leftovers}; do
-                run rm -rf "${entry}"
-            done
-        fi
-    else
-        echo "  (no ${PREFETCH_CACHE})"
-    fi
+    # 4) Prefetch scratch: dropping a version marker only costs a re-download
+    clean_find "User ${user} — prefetch scratch under ${PREFETCH_CACHE}" \
+        "${PREFETCH_CACHE}" -mindepth 1
 }
+
+PROTECTED_ACCOUNTS=${PROTECTED_ACCOUNTS:-$(list_local_accounts)}
 
 USERS=$(discover_users)
 if [ -z "${USERS}" ]; then
@@ -213,29 +196,9 @@ if [ -z "${USERS}" ]; then
     exit 0
 fi
 
-hdr "Mode: $([ "${PURGE}" = yes ] && echo 'PURGE — wipes everything' || echo 'sweep')  Action: $([ ${APPLY} = yes ] && echo APPLY || echo dry-run)"
+hdr "Action: $([ ${APPLY} = yes ] && echo APPLY || echo dry-run)"
 echo "  Detected user homes:"
 echo "${USERS}" | sed 's/^/    /'
-
-# Purge needs the host idle — abort if any tracked user has a running
-# vagrant proc or any libvirt domain is up. Pool box-image deletes would
-# otherwise yank backing files out from under live snapshots.
-if [ "${PURGE}" = yes ]; then
-    busy=
-    for ent in ${USERS}; do
-        user=${ent%%:*}
-        if vagrant_running "${user}" >/dev/null; then
-            busy="${busy}vagrant process running as ${user}\n"
-        fi
-    done
-    if virsh -c qemu:///system list --name 2>/dev/null | grep -q .; then
-        busy="${busy}libvirt domain(s) running:\n$(virsh -c qemu:///system list --name | sed 's/^/  /')\n"
-    fi
-    if [ -n "${busy}" ]; then
-        printf 'PURGE refused — host is not idle:\n%b' "${busy}" >&2
-        exit 1
-    fi
-fi
 
 hdr "Disk usage before"
 show_disk
@@ -244,24 +207,47 @@ for ent in ${USERS}; do
     clean_user_home "${ent%%:*}" "${ent##*:}"
 done
 
-# 5) libvirt-pool box backing files (system-wide; one sweep).
-if [ "${PURGE}" = yes ]; then
-    hdr "ALL libvirt-pool box backing volumes (purge mode)"
-    pool_vols=$(virsh -c qemu:///system vol-list default 2>/dev/null \
-        | awk '/_vagrant_box_image_/{print $1}' || true)
+# A running domain is a live job: its overlay and the box image under it both
+# have to survive, so skip the whole pool instead of picking volumes apart.
+live=$(virsh_or_warn list --state-running --name | grep '^vagrant-' || true)
+if [ -n "${live}" ]; then
+    hdr "Vagrant domains and pool volumes"
+    echo "  SKIPPED — live vagrant domain(s), another job is using them:"
+    echo "${live}" | sed 's/^/    /'
 else
-    hdr "libvirt-pool backing for legacy pf*dev boxes"
-    pool_vols=$(virsh -c qemu:///system vol-list default 2>/dev/null \
-        | awk '/inverse-inc-VAGRANTSLASH-pf[a-z0-9]+dev_vagrant_box_image_/{print $1}' \
-        || true)
-fi
-if [ -z "${pool_vols}" ]; then
-    echo "  (none)"
-else
-    echo "${pool_vols}" | sed 's/^/  /'
-    for vol in ${pool_vols}; do
-        run virsh -c qemu:///system vol-delete --pool default "${vol}"
+    # 5) Vagrant domains and their disks. DOMAIN_PREFIX comes from
+    #    addons/vagrant/Vagrantfile; any project sharing it goes too.
+    hdr "Vagrant domains"
+    skipped=0
+    ours=
+    for dom in $(virsh_or_warn list --all --name | grep '^vagrant-' || true); do
+        if owned_by_person "${dom}"; then
+            skipped=$((skipped + 1))
+        else
+            ours="${ours} ${dom}"
+        fi
     done
+    [ "${skipped}" -eq 0 ] || echo "  (left ${skipped} domain(s) belonging to a local account)"
+    if [ -z "${ours}" ]; then
+        echo "  (none)"
+    else
+        for dom in ${ours}; do
+            echo "  ${dom}"
+            run force_undefine_domain "${dom}"
+        done
+    fi
+
+    # 6) libvirt-pool box backing files, across every pool
+    hdr "libvirt-pool box backing volumes"
+    found=no
+    for pool in $(pools); do
+        for vol in $(pool_vol_names "${pool}" | grep -F '_vagrant_box_image_'); do
+            found=yes
+            echo "  ${pool}/${vol}"
+            run virsh_sys vol-delete --pool "${pool}" "${vol}"
+        done
+    done
+    [ "${found}" = yes ] || echo "  (none)"
 fi
 
 hdr "Disk usage after"

--- a/ci/lib/vagrant/setup-vagrant-box.sh
+++ b/ci/lib/vagrant/setup-vagrant-box.sh
@@ -19,6 +19,7 @@ set -o nounset -o pipefail -o errexit
 #   PROVIDER                (default: libvirt)
 #   VAGRANT_BOX_LOCAL_NAME  (default: inverse-inc/${BOX_NAME})
 #   WORK_DIR                (default: ~/vagrant_img_cache)
+#   KEEP_BOX_ARCHIVE        keep the .box after unpacking (default: no)
 #
 # Usage:
 #   BOX_NAME=pfdeb12dev RCLONE_LINODE_URL=https://us-ord-1.linodeobjects.com \
@@ -32,6 +33,16 @@ WORK_DIR=${WORK_DIR:-${HOME}/vagrant_img_cache}
 BOX_VERSION=${BOX_VERSION:-}
 
 VERSION_MARKER="${WORK_DIR}/${BOX_NAME}.version"
+
+# Drop the archive however we exit: beside the unpacked box it doubles each
+# box's footprint, and on an ENOSPC failure it is what filled the volume.
+META_BODY=""
+ARCHIVE=""
+on_exit() {
+    rm -f ${META_BODY}
+    [ "${KEEP_BOX_ARCHIVE:-no}" = yes ] || rm -f ${ARCHIVE} ${ARCHIVE:+${ARCHIVE}.md5sums.txt}
+}
+trap on_exit EXIT
 
 # Configure rclone via env-var remote so credentials never appear on the
 # command line (visible to `ps`, debug traces, etc.).
@@ -66,7 +77,6 @@ else
     echo "===> Resolving latest box version for ${BOX_NAME}"
     # Newest entry is versions[0]; upload-to-linode.sh prepends on each build.
     META_BODY=$(mktemp)
-    trap 'rm -f "${META_BODY}"' EXIT
     if ! rclone copyto "${METADATA_REMOTE}" "${META_BODY}"; then
         echo "ERROR: failed to fetch ${METADATA_REMOTE}"
         exit 1
@@ -77,6 +87,7 @@ fi
 
 # Box file matches the layout written by upload-to-linode.sh: <box>/<version>.box
 BOX_FILENAME="${BOX_VERSION}.box"
+ARCHIVE="${WORK_DIR}/${BOX_FILENAME}"
 
 # Skip download if the same version is already installed locally
 if [ -f "${VERSION_MARKER}" ] && [ "$(cat "${VERSION_MARKER}")" = "${BOX_VERSION}" ]; then
@@ -104,6 +115,30 @@ echo "===> Verifying checksum"
 
 echo "===> Removing any existing local box for ${VAGRANT_BOX_LOCAL_NAME} (${PROVIDER})"
 vagrant box remove "${VAGRANT_BOX_LOCAL_NAME}" --provider "${PROVIDER}" --all --force || true
+
+# `box remove` leaves the pool volume behind, so every prefetch of a new
+# version orphans the last one until a disk emergency collects it.
+prune_superseded_pool_volumes() {
+    local escaped="${VAGRANT_BOX_LOCAL_NAME//\//-VAGRANTSLASH-}"
+    local ver_re pool vol
+    if virsh -c qemu:///system list --state-running --name 2>/dev/null | grep -q '^vagrant-'; then
+        echo "     a vagrant domain is running, leaving the pool alone"
+        return 0
+    fi
+    ver_re=$(printf '%s' "${BOX_VERSION}" | sed 's/[.[\*^$]/\\&/g')
+    for pool in $(virsh -c qemu:///system pool-list 2>/dev/null | awk 'NR>2 && $1 {print $1}'); do
+        for vol in $(virsh -c qemu:///system vol-list --pool "${pool}" 2>/dev/null \
+                       | awk 'NR>2 && $1 {print $1}' \
+                       | grep -F "${escaped}_vagrant_box_image_" \
+                       | grep -vE "_vagrant_box_image_${ver_re}([_.]|$)" || true); do
+            echo "     removing superseded pool volume ${vol}"
+            virsh -c qemu:///system vol-delete --pool "${pool}" "${vol}" || true
+        done
+    done
+}
+
+echo "===> Removing superseded pool volumes for ${VAGRANT_BOX_LOCAL_NAME}"
+prune_superseded_pool_volumes
 
 # Synthesize metadata.json so vagrant registers the box at BOX_VERSION;
 # adding the bare .box would register as v0 and trigger a re-fetch from box_url.

--- a/ci/lib/vagrant/setup-vagrant-box.sh
+++ b/ci/lib/vagrant/setup-vagrant-box.sh
@@ -89,9 +89,21 @@ fi
 BOX_FILENAME="${BOX_VERSION}.box"
 ARCHIVE="${WORK_DIR}/${BOX_FILENAME}"
 
+# True if this exact name+provider+version is installed. Machine-readable
+# because `vagrant box list` pads the name column to its longest entry, so a
+# fixed-string match on "<name> (<provider>," stops working as boxes pile up.
+box_installed() {
+    vagrant box list --machine-readable 2>/dev/null \
+        | awk -F, -v n="${VAGRANT_BOX_LOCAL_NAME}" -v p="${PROVIDER}" -v v="${BOX_VERSION}" '
+            $3=="box-name"     {name=$4}
+            $3=="box-provider" {prov=$4}
+            $3=="box-version" && name==n && prov==p && $4==v {found=1}
+            END {exit !found}'
+}
+
 # Skip download if the same version is already installed locally
 if [ -f "${VERSION_MARKER}" ] && [ "$(cat "${VERSION_MARKER}")" = "${BOX_VERSION}" ]; then
-    if vagrant box list | grep -qF "${VAGRANT_BOX_LOCAL_NAME} (${PROVIDER},"; then
+    if box_installed; then
         echo "===> Box ${VAGRANT_BOX_LOCAL_NAME} (${PROVIDER}) version ${BOX_VERSION} already present, skipping download"
         vagrant box list
         exit 0

--- a/t/venom/test-wrapper.sh
+++ b/t/venom/test-wrapper.sh
@@ -94,51 +94,15 @@ configure_and_check() {
     export VENOM_ROOT_DIR
 }
 
+# Space for a full run, on each volume it lands on. The shared preflight owns
+# the measure/reclaim/re-measure loop and keeps the reclaim CI-only.
 check_free_space() {
-    # https://www.gnu.org/software/coreutils/manual/html_node/Block-size.html
-    # "the block size currently defaults to 1024 bytes"
-    # 30GiB (1,073,741,824 * 30 ) = 32,212,254,720
-    # size necessary to run a full test with pf*dev, switch, ad, wireless and node0*
-    # it's a bit over than necessary because ad, switch and wireless could have been
-    # already provisioned
-    MANDATORY_SPACE='32212254'
-    AVAILABLE_SPACE=$(df --total -x tmpfs -x vfat -x devtmpfs --output=avail | tail -n 1)
-
-    # Low on space: reclaim from old/unused images, then re-measure.
-    if (( AVAILABLE_SPACE <= MANDATORY_SPACE )); then
-        reclaim_disk_space
-        AVAILABLE_SPACE=$(df --total -x tmpfs -x vfat -x devtmpfs --output=avail | tail -n 1)
-    fi
-
-    if ((  $AVAILABLE_SPACE > $MANDATORY_SPACE )); then
-        echo "Enough space on system to run tests."
-    else
-        die "There is not enough space on system to run tests, even after cleanup. Skipping tests."
-    fi
-}
-
-# Reclaim disk on low space. Only touches things not in use (concurrent jobs
-# stay safe); does not delete /var/lib/libvirt/images base volumes.
-reclaim_disk_space() {
-    log_subsection "Low disk space: reclaiming from old/unused images"
-    local vm
-
-    for vm in $(virsh list --inactive --name); do
-        echo "Undefining shut-off VM: $vm"
-        virsh undefine "$vm" --remove-all-storage || true
-    done
-    for vm in $(virsh list --name --state-paused); do
-        echo "Destroying paused VM: $vm"
-        virsh destroy "$vm" && virsh undefine "$vm" --remove-all-storage || true
-    done
-
-    ( cd "${VAGRANT_DIR}" && vagrant box prune --force ) || true
-
-    local cache="${VAGRANT_IMG_CACHE:-${HOME}/vagrant_img_cache}"
-    if [ -d "${cache}" ]; then
-        find "${cache}" -maxdepth 1 -type f \( -name '*.box' -o -name '*.box.md5sums.txt' \) \
-             -atime +3 -print -delete || true
-    fi
+    local preflight="${CI_LIB_DIR:-${VENOM_ROOT_DIR}/../../ci/lib}/ensure-runner-disk-free.sh"
+    RUNNER_MIN_FREE_GB="${VENOM_MIN_FREE_GB:-30}" \
+    RUNNER_DISK_CHECK_PATHS="${VAGRANT_HOME:-${HOME}/.vagrant.d} \
+${VAGRANT_IMG_CACHE:-${HOME}/vagrant_img_cache} \
+${LIBVIRT_IMAGES_DIR:-/var/lib/libvirt/images}" \
+        "${preflight}" || die "Not enough space to run tests. Skipping tests."
 }
 
 run_ansible_galaxy() {
@@ -229,19 +193,43 @@ PY
     BOX_NAME="${box_name}" "${setup_script}" || die "failed to fetch box ${box_name} for ${vm}"
 }
 
-# start via libvirt without waiting; callers poll readiness with wait_for_ssh
+# start via libvirt without waiting; callers poll readiness with wait_for_ssh.
+# Non-zero means the saved domain is unusable, not that the run is over.
 start_existing_vm() {
     local vm=$1
     local dotfile_path=$2
     local machine_uuid machine_state
-    machine_uuid=$(cat "${dotfile_path}/machines/${vm}/libvirt/id")
-    machine_state=$(virsh -c qemu:///system domstate --domain "${machine_uuid}")
+    machine_uuid=$(cat "${dotfile_path}/machines/${vm}/libvirt/id" 2>/dev/null) || return 1
+    machine_state=$(virsh -c qemu:///system domstate --domain "${machine_uuid}" 2>/dev/null) || return 1
     if [ "${machine_state}" = "shut off" ]; then
         echo "Starting ${vm} using libvirt"
-        virsh -c qemu:///system start --domain "${machine_uuid}"
+        virsh -c qemu:///system start --domain "${machine_uuid}" || return 1
     else
         echo "Machine already started"
     fi
+}
+
+# Forget a VM we cannot boot so Vagrant builds it again from scratch.
+discard_stale_vm() {
+    local vm=$1 dotfile_path=$2 machine_uuid
+    machine_uuid=$(cat "${dotfile_path}/machines/${vm}/libvirt/id" 2>/dev/null || true)
+    if [ -n "${machine_uuid}" ]; then
+        virsh -c qemu:///system destroy --domain "${machine_uuid}" >/dev/null 2>&1 || true
+        virsh -c qemu:///system undefine --domain "${machine_uuid}" \
+              --remove-all-storage >/dev/null 2>&1 || true
+    fi
+    rm -rf "${dotfile_path}/machines/${vm}"
+}
+
+# A reclaim on this or another job's behalf can leave a saved domain gone or
+# its backing file deleted. Rebuild then, re-download included, don't fail.
+vm_is_usable() {
+    local vm=$1 dotfile_path=$2
+    [ -e "${dotfile_path}/machines/${vm}/libvirt/id" ] || return 1
+    start_existing_vm "${vm}" "${dotfile_path}" && return 0
+    echo "Machine ${vm} exists but won't boot, discarding it"
+    discard_stale_vm "${vm}" "${dotfile_path}"
+    return 1
 }
 
 # wait for SSH and default route (mgmt SSH answers before eth0 DHCP is done)
@@ -258,9 +246,8 @@ start_vm() {
     local dotfile_path=$2
     declare -p dotfile_path
     run_ansible_galaxy_once ${VAGRANT_DIR}/requirements.yml
-    if [ -e "${dotfile_path}/machines/${vm}/libvirt/id" ]; then
+    if vm_is_usable ${vm} ${dotfile_path}; then
         echo "Machine $vm already exists"
-        start_existing_vm ${vm} ${dotfile_path}
         wait_for_ssh ${vm}
         ( cd ${VAGRANT_DIR}; \
           ansible-playbook site.yml -l $vm )
@@ -283,9 +270,8 @@ start_and_provision_pf_vm() {
     # wait for SSH on all and install PacketFence in a single ansible run
     local new_vms=""
     for vm in ${vm_names}; do
-        if [ -e "${VAGRANT_PF_DOTFILE_PATH}/machines/${vm}/libvirt/id" ]; then
+        if vm_is_usable ${vm} ${VAGRANT_PF_DOTFILE_PATH}; then
             echo "Machine $vm already exists"
-            start_existing_vm ${vm} ${VAGRANT_PF_DOTFILE_PATH}
         else
             echo "Machine $vm doesn't exist, will start with Vagrant"
             prefetch_private_box ${vm}


### PR DESCRIPTION

# Description
(REQUIRED)

Venom test jobs were failing with `No space left on device` while unpacking a vagrant box. Two root causes:

1. **The check measured the wrong thing.** `check_free_space` used `df --total`, which *sums* every filesystem. On the lab runners `/` (box store) and `/var/lib` (libvirt pool) are separate volumes, so a full box volume passed the check behind a roomy pool and `vagrant box add` then died mid-unpack.
2. **The reclaim it called freed nothing.** Its box filter only matched the retired `pf*dev` names, and `vagrant box prune` had nothing to prune because `setup-vagrant-box.sh` already removes the old version before adding.

The check is now per volume via the existing `ci/lib/ensure-runner-disk-free.sh`, and the reclaim takes everything of ours. Boxes also stop leaving debris behind: the `.box` archive is dropped once unpacked, and the superseded pool volume is pruned at prefetch — `vagrant box remove` never deletes it, which is where the accumulation came from.

# Impacts
(REQUIRED)

- **`t/venom/test-wrapper.sh`** — `check_free_space` delegates to the shared preflight instead of carrying its own copy of the logic; calling the reclaim directly would have bypassed its CI guard and wiped a developer's boxes on `make -C t/venom`. `start_existing_vm` now reports an unbootable domain and the caller rebuilds the VM rather than failing the run.
- **`ci/lib/vagrant/cleanup-runner-disk.sh`** — destructive by design. Worth reviewing what it *spares*: a running domain (a live job needs its backing file), domains prefixed with a local account's name (a person's VM — and their name must not reach a public job log), and other accounts' box stores. `virsh`/`vagrant` failures now print their stderr instead of reading as `(none)`.
- **`ci/lib/vagrant/setup-vagrant-box.sh`** — archive removal moved to a trap so an ENOSPC failure also drops it; the "already installed" check no longer depends on `vagrant box list` column padding, which had it re-downloading a box it already had on every job.
- **`.gitlab-ci.yml`** — 3 lines: a dry-run report at the top of `.test_script_job`, on the runner that will run the test. Deletes nothing.

Reviewer focus: the reclaim's blast radius, and the floors (30 G per volume — a `pfel8stable` box image alone is 18 G in the pool).

# Delete branch after merge
(REQUIRED)

YES

# Checklist
(REQUIRED) - [yes, no or n/a]
- [ ] Add unit tests — no. A stubbed test was written and removed: it tested its own fakes, stayed green while `vol-list --name` broke every runner, and never modelled the caller bug that leaked account names. The dry-run in each test job exercises the same paths against real `virsh`.
- [ ] Add acceptance tests (TestLink) — n/a

# NEWS file entries
(REQUIRED, but may be optional...)

## Bug Fixes
* Venom test jobs aborting with "No space left on device" while unpacking a vagrant box
* Runner disk reclaim freeing nothing, leaving orphaned libvirt pool volumes to accumulate