### PR TITLE
test(venom): keep apt working on EOL Debian VMs (bullseye)

### DIFF
--- a/addons/vagrant/playbooks/linux_servers/apt_update.yml
+++ b/addons/vagrant/playbooks/linux_servers/apt_update.yml
@@ -8,6 +8,8 @@
   #    ansible.builtin.setup:
   #      gather_subset:
   #        - "!all"
+  - import_tasks: ../tasks/apt_accept_eol_release.yml
+
   - name: AD Pretasks
     block:
     - name: AD => Populate service facts

--- a/addons/vagrant/playbooks/nodes/pre_prov/packages.yml
+++ b/addons/vagrant/playbooks/nodes/pre_prov/packages.yml
@@ -60,6 +60,8 @@
       gather_subset:
         - "!all"
 
+  - import_tasks: ../../tasks/apt_accept_eol_release.yml
+
   roles:
     - role: apt_preferences
 

--- a/addons/vagrant/playbooks/tasks/apt_accept_eol_release.yml
+++ b/addons/vagrant/playbooks/tasks/apt_accept_eol_release.yml
@@ -1,0 +1,23 @@
+---
+# Debian suites past EOL stop getting refreshed Release files (bullseye-security
+# expired on 2026-09-07), which makes every "apt update" on them fail.
+- name: Gather distribution only
+  ansible.builtin.setup:
+    gather_subset:
+      - "!all"
+      - "!min"
+      - "distribution"
+  when: ansible_distribution_release is not defined
+
+- name: Accept expired Release files on EOL Debian suites
+  ansible.builtin.copy:
+    dest: '/etc/apt/apt.conf.d/99-eol-check-valid-until'
+    content: |
+      Acquire::Check-Valid-Until "false";
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
+  when:
+    - ansible_distribution == 'Debian'
+    - ansible_distribution_release in (apt_eol_deb_releases
+        | default(['stretch', 'buster', 'bullseye']))

--- a/addons/vagrant/playbooks/tasks/apt_accept_eol_release.yml
+++ b/addons/vagrant/playbooks/tasks/apt_accept_eol_release.yml
@@ -9,15 +9,37 @@
       - "distribution"
   when: ansible_distribution_release is not defined
 
-- name: Accept expired Release files on EOL Debian suites
-  ansible.builtin.copy:
-    dest: '/etc/apt/apt.conf.d/99-eol-check-valid-until'
-    content: |
-      Acquire::Check-Valid-Until "false";
-    owner: 'root'
-    group: 'root'
-    mode: '0644'
+- name: Neutralize apt sources of EOL Debian suites
   when:
     - ansible_distribution == 'Debian'
     - ansible_distribution_release in (apt_eol_deb_releases
         | default(['stretch', 'buster', 'bullseye']))
+  block:
+    - name: Accept expired Release files
+      ansible.builtin.copy:
+        dest: '/etc/apt/apt.conf.d/99-eol-check-valid-until'
+        content: |
+          Acquire::Check-Valid-Until "false";
+        owner: 'root'
+        group: 'root'
+        mode: '0644'
+
+    - name: List apt source files
+      ansible.builtin.find:
+        paths: '/etc/apt'
+        patterns:
+          - 'sources.list'
+          - '*.list'
+        recurse: True
+      register: apt_eol_sources
+
+    # security.debian.org drops EOL suites without warning, and archive.debian.org
+    # has no replacement for them, so stop fetching what can no longer change.
+    - name: Comment out the frozen security suite
+      ansible.builtin.replace:
+        path: '{{ item.path }}'
+        regexp: '^(deb(-src)?\s+(\[[^]]*\]\s+)?\S+\s+\S*-security\b.*)$'
+        replace: '# \1'
+      loop: '{{ apt_eol_sources.files }}'
+      loop_control:
+        label: '{{ item.path }}'

--- a/addons/vagrant/playbooks/wireless/wireless.yml
+++ b/addons/vagrant/playbooks/wireless/wireless.yml
@@ -11,6 +11,8 @@
         - "!all"
 
   tasks:
+    - import_tasks: ../tasks/apt_accept_eol_release.yml
+
     - import_tasks: ../tasks/disable_apt_services.yml
       tags: apt_services
 


### PR DESCRIPTION
# Description
(REQUIRED)

Debian 11 went EOL, so `bullseye-security` stopped being refreshed: its `Release`
file expired on 2026-09-07 and the suite was then dropped from
`security.debian.org` altogether. Every `apt update` on the bullseye venom VMs
now fails, which takes down node pre-provisioning, the wireless VM and the
AD / linux_servers plays before a test ever runs.

New shared task file `playbooks/tasks/apt_accept_eol_release.yml`, imported by
the three plays that touch apt on those VMs. On Debian releases listed as EOL it:

1. writes `/etc/apt/apt.conf.d/99-eol-check-valid-until` with
   `Acquire::Check-Valid-Until "false"` — accept the expired `Release` file;
2. comments out every `*-security` line in `/etc/apt/**/*.list` — the suite is
   gone from `security.debian.org` and `archive.debian.org` carries no
   replacement, so a suite that can no longer change is better left unfetched.

Guarded on `ansible_distribution == 'Debian'` and the release being in
`apt_eol_deb_releases` (default `stretch`, `buster`, `bullseye`), so bookworm and
EL VMs are untouched and the next EOL is a one-variable change.

# Impacts
(REQUIRED)

- **`playbooks/tasks/apt_accept_eol_release.yml`** (new) — the whole change.
  Gathers the `distribution` subset itself, since all three callers run with
  `gather_facts: False`.
- **`playbooks/nodes/pre_prov/packages.yml`** (hosts `nodes`) — import added in
  `pre_tasks`, so it lands before the `apt_preferences` role and the PF repo
  pinning that follow.
- **`playbooks/wireless/wireless.yml`** (hosts `wireless`) — import added as the
  first task, before `disable_apt_services`.
- **`playbooks/linux_servers/apt_update.yml`** (hosts `linux_servers`) — import
  added first; the dropped config persists for the rest of the play chain,
  including the bullseye Samba repo added later by `linux_servers/samba4ad.yml`.

Reviewer focus: the `*-security` regexp
`^(deb(-src)?\s+(\[[^]]*\]\s+)?\S+\s+\S*-security\b.*)$`. It is anchored, keeps
`[signed-by=...]` options intact, matches only the suite field, and is
idempotent (an already-commented line no longer starts with `deb`).

Out of scope on purpose: `upgrade_deb_os.yml` (hosts `pfservers`) and `mcve.yml`
(hosts `dev`) also use apt but run on supported releases, so the guard would be
a no-op there.

# Delete branch after merge
(REQUIRED)

YES