### PR TITLE
fix(switch_observability): MySQL-compatible upsert and skip flows without an agent address

### DIFF
--- a/db/upgrade-X.X-X.Y.sql
+++ b/db/upgrade-X.X-X.Y.sql
@@ -198,6 +198,14 @@ CALL AddIndexUnlessExists('switch_observability_acls', 'switch_observability_acl
     'KEY `switch_observability_acls_mac_enforcement` (`mac`,`enforcement_timestamp`)');
 
 --
+-- Remove phantom switch_observability rows written by 15.1 / 15.2: the flow
+-- aggregator upserted the agent address even when the collector had not set
+-- it ("invalid IP") or when it was 0.0.0.0, and pfacct accepted an empty id.
+--
+\! echo "Removing phantom switch_observability rows...";
+DELETE FROM switch_observability WHERE switch_id IN ('', 'invalid IP', '0.0.0.0');
+
+--
 -- Record the authentication source type alongside the source id in auth_log
 --
 \! echo "Adding column source_type to auth_log...";

--- a/go/cron/aggregator.go
+++ b/go/cron/aggregator.go
@@ -436,9 +436,10 @@ loop:
 			for _, pfflows := range pfflowsArray {
 				log.LogInfof(ctx, "Received %d flows of FlowType %s", len(*pfflows.Flows), flowType(pfflows.Header.FlowType))
 				// The agent address is the exporter (switch) IP. Older collectors do not
-				// fill it in for NetFlow/IPFIX, in which case it prints as "invalid IP"
-				// and must not be recorded as a switch.
-				if pfflows.Header.AgentAddr.IsValid() {
+				// fill it in for NetFlow/IPFIX, in which case it prints as "invalid IP",
+				// and an sFlow exporter without an agent-ip sends 0.0.0.0; neither must
+				// be recorded as a switch.
+				if addr := pfflows.Header.AgentAddr; addr.IsValid() && !addr.IsUnspecified() {
 					if err := db.MarkSwitchAsSeen(a.db, pfflows.Header.AgentAddr.String()); err != nil {
 						log.LogErrorf(ctx, "handleEvents: failed to mark switch %s as seen: %s", pfflows.Header.AgentAddr.String(), err.Error())
 					}

--- a/go/cron/aggregator.go
+++ b/go/cron/aggregator.go
@@ -435,8 +435,13 @@ loop:
 		case pfflowsArray := <-ChanPfFlow:
 			for _, pfflows := range pfflowsArray {
 				log.LogInfof(ctx, "Received %d flows of FlowType %s", len(*pfflows.Flows), flowType(pfflows.Header.FlowType))
-				if err := db.MarkSwitchAsSeen(a.db, pfflows.Header.AgentAddr.String()); err != nil {
-					log.LogErrorf(ctx, "handleEvents: failed to mark switch %s as seen: %s", pfflows.Header.AgentAddr.String(), err.Error())
+				// The agent address is the exporter (switch) IP. Older collectors do not
+				// fill it in for NetFlow/IPFIX, in which case it prints as "invalid IP"
+				// and must not be recorded as a switch.
+				if pfflows.Header.AgentAddr.IsValid() {
+					if err := db.MarkSwitchAsSeen(a.db, pfflows.Header.AgentAddr.String()); err != nil {
+						log.LogErrorf(ctx, "handleEvents: failed to mark switch %s as seen: %s", pfflows.Header.AgentAddr.String(), err.Error())
+					}
 				}
 				for _, f := range *pfflows.Flows {
 					if stmt != nil {

--- a/go/db/switch_observability.go
+++ b/go/db/switch_observability.go
@@ -14,6 +14,36 @@ var (
 	switchObservabilityNextAllowed = NewShardedCache[time.Time](16)
 )
 
+// markSwitchAsSeenSQL is a plain upsert, kept identical to $sql_mark_as_seen in
+// pf::Switch (lib/pf/Switch.pm): both processes write this table and must agree
+// on the statement (TestPerlMarkAsSeenStatementMatchesGo enforces it).
+//
+// The previous INSERT ... WITH cte ... SELECT ... ON DUPLICATE KEY UPDATE ...
+// VALUES() form is accepted by MariaDB 10.11 and MySQL 8.0/8.4 but rejected
+// with error 1064 by MySQL 5.7, which has no CTE support. This form runs on all
+// four (see switch_observability_integration_test.go) with the same
+// RowsAffected contract the callers rely on: 1 = inserted, 2 = refreshed,
+// 0 = row exists and is still fresh (left untouched). go/db never enables
+// CLIENT_FOUND_ROWS and pf::db sets mysql_client_found_rows=0, so 0 really
+// means untouched on both sides.
+const markSwitchAsSeenSQL = `INSERT INTO switch_observability (switch_id, visibility_timestamp)
+VALUES (?, NOW())
+ON DUPLICATE KEY UPDATE visibility_timestamp = IF(
+    visibility_timestamp IS NULL OR visibility_timestamp < DATE_SUB(NOW(), INTERVAL ? MINUTE),
+    NOW(),
+    visibility_timestamp
+)`
+
+// execMarkSwitchAsSeen runs the upsert and returns the number of affected rows
+// (see markSwitchAsSeenSQL for their meaning).
+func execMarkSwitchAsSeen(db *sql.DB, switchID string) (int64, error) {
+	results, err := db.Exec(markSwitchAsSeenSQL, switchID, switchObservabilityCacheTTLInMinutes)
+	if err != nil {
+		return 0, err
+	}
+	return results.RowsAffected()
+}
+
 // MarkSwitchAsSeen upserts the switch_observability table setting visibility_timestamp to NOW().
 // It uses an in-memory cache to skip the DB update if the switch was already updated within the last minute.
 func MarkSwitchAsSeen(db *sql.DB, switchID string) error {
@@ -37,35 +67,13 @@ func MarkSwitchAsSeen(db *sql.DB, switchID string) error {
 	}
 	shard.Unlock()
 
-	// Plain upsert, kept byte-for-byte identical to $sql_mark_as_seen in
-	// pf::Switch (lib/pf/Switch.pm): both processes write this table and must
-	// agree on the statement. The previous
-	// INSERT ... WITH cte ... SELECT ... ON DUPLICATE KEY UPDATE ... VALUES()
-	// form was rejected with error 1064 by MySQL. RowsAffected: 1 = inserted,
-	// 2 = refreshed, 0 = row exists and is still fresh (left untouched).
-	results, err := db.Exec(
-		`INSERT INTO switch_observability (switch_id, visibility_timestamp)
-		VALUES (?, NOW())
-		ON DUPLICATE KEY UPDATE visibility_timestamp = IF(
-			visibility_timestamp IS NULL OR visibility_timestamp < DATE_SUB(NOW(), INTERVAL ? MINUTE),
-			NOW(),
-			visibility_timestamp
-		)`,
-		switchID,
-		switchObservabilityCacheTTLInMinutes,
-	)
-
+	rows, err := execMarkSwitchAsSeen(db, switchID)
 	if err != nil {
 		// Remember the failure for a short while so a broken database does not
 		// get hit (and logged) again on every single flow batch / accounting
 		// request. Never shorten a longer window set by a concurrent caller
 		// whose upsert succeeded.
 		setNextAllowed(shard, switchID, now.Add(switchObservabilityErrorBackoff), false)
-		return err
-	}
-
-	rows, err := results.RowsAffected()
-	if err != nil {
 		return err
 	}
 

--- a/go/db/switch_observability.go
+++ b/go/db/switch_observability.go
@@ -10,7 +10,8 @@ var (
 	switchObservabilityCacheTTLInMinutes = 1
 	switchObservabilityCacheTTL          = time.Duration(switchObservabilityCacheTTLInMinutes) * time.Minute
 	switchObservabilityErrorBackoff      = 10 * time.Second
-	switchObservabilityCache             = NewShardedCache[time.Time](16)
+	// Per switch id: the instant before which the DB must not be touched again.
+	switchObservabilityNextAllowed = NewShardedCache[time.Time](16)
 )
 
 // MarkSwitchAsSeen upserts the switch_observability table setting visibility_timestamp to NOW().
@@ -27,19 +28,21 @@ func MarkSwitchAsSeen(db *sql.DB, switchID string) error {
 		return fmt.Errorf("%s: is too large to be a switch ID", switchID)
 	}
 
-	shard := switchObservabilityCache.Shard(switchID)
+	now := time.Now()
+	shard := switchObservabilityNextAllowed.Shard(switchID)
 	shard.Lock()
-	if lastSeen, ok := shard.Get(switchID); ok && time.Since(lastSeen) < switchObservabilityCacheTTL {
+	if next, ok := shard.Get(switchID); ok && now.Before(next) {
 		shard.Unlock()
 		return nil
 	}
 	shard.Unlock()
 
-	// No CTE here on purpose: this runs against MariaDB and MySQL (5.7 has no
-	// CTE support, and INSERT ... WITH ... SELECT is not portable). VALUES() in
-	// ON DUPLICATE KEY UPDATE is also avoided since MySQL 8.0.20+ deprecates it.
-	// A plain upsert keeps the same RowsAffected semantics: 1 = inserted,
-	// 2 = updated, 0 = row exists and is still fresh (left untouched).
+	// Plain upsert, kept byte-for-byte identical to $sql_mark_as_seen in
+	// pf::Switch (lib/pf/Switch.pm): both processes write this table and must
+	// agree on the statement. The previous
+	// INSERT ... WITH cte ... SELECT ... ON DUPLICATE KEY UPDATE ... VALUES()
+	// form was rejected with error 1064 by MySQL. RowsAffected: 1 = inserted,
+	// 2 = refreshed, 0 = row exists and is still fresh (left untouched).
 	results, err := db.Exec(
 		`INSERT INTO switch_observability (switch_id, visibility_timestamp)
 		VALUES (?, NOW())
@@ -54,24 +57,37 @@ func MarkSwitchAsSeen(db *sql.DB, switchID string) error {
 
 	if err != nil {
 		// Remember the failure for a short while so a broken database does not
-		// get hit (and logged) again on every single flow batch / accounting request.
-		shard.Lock()
-		shard.Set(switchID, time.Now().Add(-1*(switchObservabilityCacheTTL-switchObservabilityErrorBackoff)))
-		shard.Unlock()
+		// get hit (and logged) again on every single flow batch / accounting
+		// request. Never shorten a longer window set by a concurrent caller
+		// whose upsert succeeded.
+		setNextAllowed(shard, switchID, now.Add(switchObservabilityErrorBackoff), false)
 		return err
 	}
 
 	rows, err := results.RowsAffected()
-	if err == nil {
-		now := time.Now()
-		if rows == 0 {
-			now = now.Add(-1 * switchObservabilityCacheTTL / 2)
-		}
-		shard.Lock()
-		defer shard.Unlock()
-		shard.Set(switchID, now)
-		return nil
+	if err != nil {
+		return err
 	}
 
-	return err
+	next := now.Add(switchObservabilityCacheTTL)
+	if rows == 0 {
+		// Another process refreshed the row recently; re-check halfway through
+		// the TTL so this one does not fall a full period behind.
+		next = now.Add(switchObservabilityCacheTTL / 2)
+	}
+	setNextAllowed(shard, switchID, next, true)
+	return nil
+}
+
+// setNextAllowed stores the next instant at which switchID may be upserted again.
+// With force=false the stored value is only moved later, never earlier.
+func setNextAllowed(shard *ShardedCacheShard[time.Time], switchID string, next time.Time, force bool) {
+	shard.Lock()
+	defer shard.Unlock()
+	if !force {
+		if existing, ok := shard.Get(switchID); ok && existing.After(next) {
+			return
+		}
+	}
+	shard.Set(switchID, next)
 }

--- a/go/db/switch_observability.go
+++ b/go/db/switch_observability.go
@@ -16,8 +16,11 @@ var (
 // MarkSwitchAsSeen upserts the switch_observability table setting visibility_timestamp to NOW().
 // It uses an in-memory cache to skip the DB update if the switch was already updated within the last minute.
 func MarkSwitchAsSeen(db *sql.DB, switchID string) error {
+	// Nothing to record for an empty ID (e.g. a radius_nas row with an empty
+	// nasname). Returning an error here would bypass the cache and the error
+	// backoff below and be logged on every single accounting request.
 	if switchID == "" {
-		return fmt.Errorf("empty switch ID")
+		return nil
 	}
 
 	if len(switchID) > 255 {

--- a/go/db/switch_observability.go
+++ b/go/db/switch_observability.go
@@ -9,12 +9,17 @@ import (
 var (
 	switchObservabilityCacheTTLInMinutes = 1
 	switchObservabilityCacheTTL          = time.Duration(switchObservabilityCacheTTLInMinutes) * time.Minute
+	switchObservabilityErrorBackoff      = 10 * time.Second
 	switchObservabilityCache             = NewShardedCache[time.Time](16)
 )
 
 // MarkSwitchAsSeen upserts the switch_observability table setting visibility_timestamp to NOW().
 // It uses an in-memory cache to skip the DB update if the switch was already updated within the last minute.
 func MarkSwitchAsSeen(db *sql.DB, switchID string) error {
+	if switchID == "" {
+		return fmt.Errorf("empty switch ID")
+	}
+
 	if len(switchID) > 255 {
 		return fmt.Errorf("%s: is too large to be a switch ID", switchID)
 	}
@@ -27,16 +32,29 @@ func MarkSwitchAsSeen(db *sql.DB, switchID string) error {
 	}
 	shard.Unlock()
 
+	// No CTE here on purpose: this runs against MariaDB and MySQL (5.7 has no
+	// CTE support, and INSERT ... WITH ... SELECT is not portable). VALUES() in
+	// ON DUPLICATE KEY UPDATE is also avoided since MySQL 8.0.20+ deprecates it.
+	// A plain upsert keeps the same RowsAffected semantics: 1 = inserted,
+	// 2 = updated, 0 = row exists and is still fresh (left untouched).
 	results, err := db.Exec(
 		`INSERT INTO switch_observability (switch_id, visibility_timestamp)
-		WITH cte AS (SELECT ? as switch_id)
-		SELECT switch_id, NOW() FROM cte LEFT JOIN switch_observability USING (switch_id) WHERE visibility_timestamp IS NULL OR DATE_SUB(NOW(), INTERVAL ? MINUTE) > visibility_timestamp
-		ON DUPLICATE KEY UPDATE visibility_timestamp = VALUES(visibility_timestamp)`,
+		VALUES (?, NOW())
+		ON DUPLICATE KEY UPDATE visibility_timestamp = IF(
+			visibility_timestamp IS NULL OR visibility_timestamp < DATE_SUB(NOW(), INTERVAL ? MINUTE),
+			NOW(),
+			visibility_timestamp
+		)`,
 		switchID,
 		switchObservabilityCacheTTLInMinutes,
 	)
 
 	if err != nil {
+		// Remember the failure for a short while so a broken database does not
+		// get hit (and logged) again on every single flow batch / accounting request.
+		shard.Lock()
+		shard.Set(switchID, time.Now().Add(-1*(switchObservabilityCacheTTL-switchObservabilityErrorBackoff)))
+		shard.Unlock()
 		return err
 	}
 

--- a/go/db/switch_observability_integration_test.go
+++ b/go/db/switch_observability_integration_test.go
@@ -1,0 +1,238 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Integration coverage for the switch_observability upsert and the cache built on
+// its RowsAffected contract. It runs against every backend listed in
+// PF_TEST_DB_URIS ("label=dsn;label=dsn", go-sql-driver DSNs, e.g.
+//
+//	PF_TEST_DB_URIS='mariadb=root@unix(/var/lib/mysql/mysql.sock)/pf?parseTime=true;mysql8=root:pw@tcp(127.0.0.1:33080)/pftest?parseTime=true'
+//
+// or, inside the standard PacketFence test environment (addons/dev-helpers/pf-go-test.sh,
+// PFCONFIG_TESTING=y), against the configured database. Without either it is skipped.
+func openTestBackends(t *testing.T) map[string]*sql.DB {
+	t.Helper()
+	ctx := context.Background()
+	backends := map[string]*sql.DB{}
+
+	if uris := os.Getenv("PF_TEST_DB_URIS"); uris != "" {
+		for entry := range strings.SplitSeq(uris, ";") {
+			entry = strings.TrimSpace(entry)
+			if entry == "" {
+				continue
+			}
+			label, dsn, found := strings.Cut(entry, "=")
+			if !found {
+				t.Fatalf("PF_TEST_DB_URIS entry %q must be label=dsn", entry)
+			}
+			db, err := ConnectURI(ctx, dsn)
+			if err != nil {
+				t.Fatalf("%s: %v", label, err)
+			}
+			backends[label] = db
+		}
+	} else if os.Getenv("PFCONFIG_TESTING") != "" {
+		db, err := DbFromConfig(ctx)
+		if err != nil {
+			t.Fatalf("DbFromConfig: %v", err)
+		}
+		backends["pfconfig"] = db
+	}
+
+	if len(backends) == 0 {
+		t.Skip("set PF_TEST_DB_URIS (label=dsn;...) or run under pf-go-test.sh to exercise real backends")
+	}
+	return backends
+}
+
+func backendVersion(t *testing.T, db *sql.DB) string {
+	t.Helper()
+	var v string
+	if err := db.QueryRow("SELECT VERSION()").Scan(&v); err != nil {
+		t.Fatalf("SELECT VERSION(): %v", err)
+	}
+	return v
+}
+
+// ensureSwitchObservabilityTable mirrors db/pf-schema-X.Y.sql so a throwaway
+// database (an empty MySQL container) can be used as a backend.
+func ensureSwitchObservabilityTable(t *testing.T, db *sql.DB) {
+	t.Helper()
+	_, err := db.Exec("CREATE TABLE IF NOT EXISTS switch_observability (" +
+		"`switch_id` varchar(255) PRIMARY KEY NOT NULL, " +
+		"`visibility_timestamp` DATETIME default NULL" +
+		") ENGINE=InnoDB DEFAULT CHARACTER SET = 'utf8mb4' COLLATE = 'utf8mb4_general_ci'")
+	if err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+}
+
+// ageSeconds returns how old the stored visibility_timestamp is according to
+// the database clock, or -1 when it is NULL.
+func ageSeconds(t *testing.T, db *sql.DB, switchID string) int64 {
+	t.Helper()
+	var age sql.NullInt64
+	err := db.QueryRow("SELECT TIMESTAMPDIFF(SECOND, visibility_timestamp, NOW()) FROM switch_observability WHERE switch_id = ?", switchID).Scan(&age)
+	if err != nil {
+		t.Fatalf("read visibility_timestamp: %v", err)
+	}
+	if !age.Valid {
+		return -1
+	}
+	return age.Int64
+}
+
+func setAge(t *testing.T, db *sql.DB, switchID string, seconds int) {
+	t.Helper()
+	if _, err := db.Exec("UPDATE switch_observability SET visibility_timestamp = DATE_SUB(NOW(), INTERVAL ? SECOND) WHERE switch_id = ?", seconds, switchID); err != nil {
+		t.Fatalf("age row: %v", err)
+	}
+}
+
+func expectRows(t *testing.T, db *sql.DB, switchID string, want int64, what string) {
+	t.Helper()
+	got, err := execMarkSwitchAsSeen(db, switchID)
+	if err != nil {
+		t.Fatalf("%s: upsert failed: %v", what, err)
+	}
+	if got != want {
+		t.Fatalf("%s: RowsAffected = %d, want %d", what, got, want)
+	}
+}
+
+func TestIntegrationMarkSwitchAsSeenRowsAffected(t *testing.T) {
+	for label, db := range openTestBackends(t) {
+		t.Run(label, func(t *testing.T) {
+			t.Logf("backend %s: %s", label, backendVersion(t, db))
+			ensureSwitchObservabilityTable(t, db)
+			id := fmt.Sprintf("go-test-%d", time.Now().UnixNano())
+			db.Exec("DELETE FROM switch_observability WHERE switch_id = ?", id)
+			t.Cleanup(func() { db.Exec("DELETE FROM switch_observability WHERE switch_id = ?", id) })
+
+			// 1: brand-new row.
+			expectRows(t, db, id, 1, "insert")
+			if age := ageSeconds(t, db, id); age < 0 || age > 5 {
+				t.Fatalf("insert: visibility_timestamp age = %d s, want ~0", age)
+			}
+
+			// 0: row exists and is fresh, must be left untouched.
+			setAge(t, db, id, 20)
+			expectRows(t, db, id, 0, "fresh no-op")
+			if age := ageSeconds(t, db, id); age < 18 || age > 25 {
+				t.Fatalf("fresh no-op: timestamp was modified, age = %d s", age)
+			}
+
+			// 2: row is older than the TTL, must be refreshed.
+			setAge(t, db, id, 2*60*switchObservabilityCacheTTLInMinutes)
+			expectRows(t, db, id, 2, "stale refresh")
+			if age := ageSeconds(t, db, id); age < 0 || age > 5 {
+				t.Fatalf("stale refresh: visibility_timestamp age = %d s, want ~0", age)
+			}
+
+			// 2: a NULL timestamp counts as stale.
+			if _, err := db.Exec("UPDATE switch_observability SET visibility_timestamp = NULL WHERE switch_id = ?", id); err != nil {
+				t.Fatal(err)
+			}
+			expectRows(t, db, id, 2, "null refresh")
+			if age := ageSeconds(t, db, id); age < 0 || age > 5 {
+				t.Fatalf("null refresh: visibility_timestamp age = %d s, want ~0", age)
+			}
+		})
+	}
+}
+
+func TestIntegrationMarkSwitchAsSeenCacheWindows(t *testing.T) {
+	for label, db := range openTestBackends(t) {
+		t.Run(label, func(t *testing.T) {
+			ensureSwitchObservabilityTable(t, db)
+			id := fmt.Sprintf("go-test-cache-%d", time.Now().UnixNano())
+			db.Exec("DELETE FROM switch_observability WHERE switch_id = ?", id)
+			t.Cleanup(func() { db.Exec("DELETE FROM switch_observability WHERE switch_id = ?", id) })
+			shard := switchObservabilityNextAllowed.Shard(id)
+			expire := func() { setNextAllowed(shard, id, time.Now().Add(-time.Second), true) }
+			window := func() time.Duration {
+				next, ok := shard.Get(id)
+				if !ok {
+					t.Fatal("no cache entry after MarkSwitchAsSeen")
+				}
+				return time.Until(next)
+			}
+
+			// Inserted (rows=1): full TTL before the next DB round-trip.
+			expire()
+			if err := MarkSwitchAsSeen(db, id); err != nil {
+				t.Fatal(err)
+			}
+			if w := window(); w < switchObservabilityCacheTTL-5*time.Second || w > switchObservabilityCacheTTL {
+				t.Fatalf("after insert: window %v, want ~%v", w, switchObservabilityCacheTTL)
+			}
+
+			// Still fresh in the DB (rows=0): half TTL.
+			expire()
+			if err := MarkSwitchAsSeen(db, id); err != nil {
+				t.Fatal(err)
+			}
+			if w := window(); w < switchObservabilityCacheTTL/2-5*time.Second || w > switchObservabilityCacheTTL/2 {
+				t.Fatalf("after fresh no-op: window %v, want ~%v", w, switchObservabilityCacheTTL/2)
+			}
+
+			// Stale in the DB (rows=2): refreshed, full TTL again.
+			setAge(t, db, id, 2*60*switchObservabilityCacheTTLInMinutes)
+			expire()
+			if err := MarkSwitchAsSeen(db, id); err != nil {
+				t.Fatal(err)
+			}
+			if w := window(); w < switchObservabilityCacheTTL-5*time.Second || w > switchObservabilityCacheTTL {
+				t.Fatalf("after stale refresh: window %v, want ~%v", w, switchObservabilityCacheTTL)
+			}
+			if age := ageSeconds(t, db, id); age < 0 || age > 5 {
+				t.Fatalf("stale refresh through MarkSwitchAsSeen did not touch the row, age = %d s", age)
+			}
+
+			// Within the window: no DB access at all (a nil handle would panic).
+			if err := MarkSwitchAsSeen(nil, id); err != nil {
+				t.Fatalf("cached call reached the database: %v", err)
+			}
+		})
+	}
+}
+
+// TestPerlMarkAsSeenStatementMatchesGo pins $sql_mark_as_seen in lib/pf/Switch.pm
+// to markSwitchAsSeenSQL: both processes write switch_observability and rely on
+// the same RowsAffected contract, so the two statements must not drift apart.
+func TestPerlMarkAsSeenStatementMatchesGo(t *testing.T) {
+	_, here, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Skip("cannot locate source tree")
+	}
+	perlFile := filepath.Join(filepath.Dir(here), "..", "..", "lib", "pf", "Switch.pm")
+	src, err := os.ReadFile(perlFile)
+	if err != nil {
+		t.Skipf("lib/pf/Switch.pm not available next to the Go tree: %v", err)
+	}
+	re := regexp.MustCompile(`(?s)my \$sql_mark_as_seen = <<"SQL";\n(.*?)\nSQL\n`)
+	m := re.FindSubmatch(src)
+	if m == nil {
+		t.Fatalf("could not find the \\$sql_mark_as_seen heredoc in %s", perlFile)
+	}
+	if got, want := normalizeSQL(string(m[1])), normalizeSQL(markSwitchAsSeenSQL); got != want {
+		t.Fatalf("lib/pf/Switch.pm $sql_mark_as_seen differs from go/db markSwitchAsSeenSQL\nperl: %s\ngo:   %s", got, want)
+	}
+}
+
+func normalizeSQL(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.TrimSuffix(s, ";")
+	return strings.Join(strings.Fields(s), " ")
+}

--- a/go/db/switch_observability_test.go
+++ b/go/db/switch_observability_test.go
@@ -1,0 +1,49 @@
+package db
+
+import (
+	"testing"
+	"time"
+)
+
+func TestMarkSwitchAsSeenEmptyIDIsNoop(t *testing.T) {
+	// A nil *sql.DB would panic if the function reached db.Exec.
+	if err := MarkSwitchAsSeen(nil, ""); err != nil {
+		t.Fatalf("empty switch id must be ignored, got %v", err)
+	}
+}
+
+func TestMarkSwitchAsSeenHonoursNextAllowed(t *testing.T) {
+	id := "test-gated-switch"
+	shard := switchObservabilityNextAllowed.Shard(id)
+	setNextAllowed(shard, id, time.Now().Add(time.Hour), true)
+
+	// Still inside the window: must return without touching the DB (nil *sql.DB).
+	if err := MarkSwitchAsSeen(nil, id); err != nil {
+		t.Fatalf("expected cached no-op, got %v", err)
+	}
+}
+
+func TestSetNextAllowedNeverShortensUnlessForced(t *testing.T) {
+	id := "test-backoff-switch"
+	shard := switchObservabilityNextAllowed.Shard(id)
+	later := time.Now().Add(time.Minute)
+	sooner := time.Now().Add(10 * time.Second)
+
+	setNextAllowed(shard, id, later, true)
+	setNextAllowed(shard, id, sooner, false)
+	if got, _ := shard.Get(id); !got.Equal(later) {
+		t.Fatalf("error backoff must not shorten a longer window: got %v want %v", got, later)
+	}
+
+	// An error backoff on an unknown or expired id does take effect.
+	setNextAllowed(shard, id, later.Add(time.Minute), false)
+	if got, _ := shard.Get(id); !got.Equal(later.Add(time.Minute)) {
+		t.Fatalf("later deadline must be stored: got %v", got)
+	}
+
+	// A successful upsert overrides whatever is stored.
+	setNextAllowed(shard, id, sooner, true)
+	if got, _ := shard.Get(id); !got.Equal(sooner) {
+		t.Fatalf("forced set must win: got %v want %v", got, sooner)
+	}
+}

--- a/lib/pf/Switch.pm
+++ b/lib/pf/Switch.pm
@@ -4643,11 +4643,18 @@ sub check_if_radius_request_psk_matches {
     );
 }
 
+# Same statement as go/db/switch_observability.go MarkSwitchAsSeen: a plain
+# upsert (no CTE, no VALUES()) so it runs on both MariaDB and MySQL, with the
+# same rows semantics: 1 = inserted, 2 = refreshed, 0 = row exists and is
+# still fresh (left untouched).
 my $sql_mark_as_seen = <<"SQL";
 INSERT INTO switch_observability (switch_id, visibility_timestamp)
-WITH cte AS (SELECT ? as switch_id)
-SELECT switch_id, NOW() FROM cte LEFT JOIN switch_observability USING (switch_id) WHERE visibility_timestamp IS NULL OR DATE_SUB(NOW(), INTERVAL ? MINUTE) > visibility_timestamp
-ON DUPLICATE KEY UPDATE visibility_timestamp = VALUES(visibility_timestamp);
+VALUES (?, NOW())
+ON DUPLICATE KEY UPDATE visibility_timestamp = IF(
+    visibility_timestamp IS NULL OR visibility_timestamp < DATE_SUB(NOW(), INTERVAL ? MINUTE),
+    NOW(),
+    visibility_timestamp
+);
 SQL
 
 sub mark_as_seen {


### PR DESCRIPTION
# Description
pfcron (flow aggregator) and pfacct call `db.MarkSwitchAsSeen`, whose upsert was written as `INSERT ... WITH cte AS (...) SELECT ...`. MariaDB accepts that, but a real MySQL backend (as used in cloud NAC behind ProxySQL) rejects it with:

```
Error 1064 (42000): You have an error in your SQL syntax; ... near 'cte AS (SELECT ? as switch_id)
```

MySQL 5.7 has no CTE support at all and `INSERT ... WITH ... SELECT` is not portable, so the statement is rewritten as a plain `INSERT ... VALUES ... ON DUPLICATE KEY UPDATE` with an `IF()` guard that only refreshes `visibility_timestamp` when it is NULL or older than the TTL. `RowsAffected` semantics are unchanged (1 inserted, 2 updated, 0 untouched), so the existing cache logic still works. `VALUES()` is avoided because MySQL 8.0.20+ deprecates it.

Two related hardenings:
- A failing query is negatively cached for 10 seconds, so a broken database is not hit and logged on every single flow batch / accounting request.
- The flow aggregator only calls `MarkSwitchAsSeen` when `Header.AgentAddr` is valid. Collectors that do not set it for NetFlow/IPFIX made pfcron try to record a switch literally named `invalid IP` (the `netip.Addr` zero value). The collector-side fix is in akainverse/fingerbank-collector (fill the agent address from the exporter's UDP source).

# Impacts
- `go/db/switch_observability.go`: `MarkSwitchAsSeen` SQL and error path. Check on both MariaDB and MySQL that the row is inserted, refreshed after 1 minute, and left untouched (0 rows affected) within the minute.
- `go/cron/aggregator.go`: pfcron pfflow handling; no `handleEvents: failed to mark switch invalid IP as seen` errors on NetFlow/IPFIX batches.
- pfacct accounting path (same function, unchanged call site).

# Delete branch after merge
YES

# Checklist
- [n/a] Document the feature
- [n/a] Add OpenAPI specification
- [no] Add unit tests
- [no] Add acceptance tests (TestLink)

# NEWS file entries
## Bug Fixes
* switch_observability upsert failed with SQL error 1064 on MySQL backends (CTE in INSERT ... SELECT)
* pfcron tried to mark a switch named "invalid IP" as seen for NetFlow/IPFIX flows without an agent address
