### PR TITLE
feat(radiusd): make the FreeRADIUS thread pool size configurable, default 128

### DIFF
--- a/NEWS.asciidoc
+++ b/NEWS.asciidoc
@@ -29,6 +29,8 @@ For a list of compatibility related changes see the <<PacketFence_Upgrade_Guide.
 
 === Enhancements
 
+  - FreeRADIUS thread pool size (`max_servers`) is now configurable as `radius_configuration.radiusd_max_servers` (Configuration > RADIUS > General) and defaults to 128 instead of 64; it also bounds the rlm_rest connection pool to httpd.aaa
+
 === Bug Fixes
 
 === Security Fixes

--- a/conf/documentation.conf
+++ b/conf/documentation.conf
@@ -1977,6 +1977,13 @@ description=<<EOT
 The size of the queue for each AAA notification worker.
 EOT
 
+[radius_configuration.radiusd_max_servers]
+type=numeric
+description=<<EOT
+Maximum number of FreeRADIUS worker threads for radiusd-auth and radiusd-load_balancer.
+It also caps the number of concurrent REST connections to httpd.aaa. Requires a restart of radiusd to be effective.
+EOT
+
 [dns_configuration.record_dns_in_sql]
 type=toggle
 options=enabled|disabled

--- a/conf/pf.conf.defaults
+++ b/conf/pf.conf.defaults
@@ -1491,6 +1491,15 @@ pfacct_aaa_notify_workers=0
 #
 # The size of the queue for each AAA notification worker.
 pfacct_aaa_notify_queue_size=1000
+# radius_configuration.radiusd_max_servers
+#
+# Maximum number of worker threads in the radiusd-auth and radiusd-load_balancer
+# thread pools (FreeRADIUS "max_servers"). It also caps the number of concurrent
+# REST connections radiusd keeps open to httpd.aaa, so it bounds how many
+# authorizations can be in flight at once. When httpd.aaa latency spikes, a pool
+# that is too small makes requests wait for a free connection until
+# max_request_time and get rejected. Requires a restart of radiusd to be effective.
+radiusd_max_servers=128
 
 [dns_configuration]
 #

--- a/conf/radiusd/radiusd.conf.example
+++ b/conf/radiusd/radiusd.conf.example
@@ -476,7 +476,7 @@ thread pool {
 	#
 	#  For more information, see 'max_request_time', above.
 	#
-	max_servers = 64
+	max_servers = [% max_servers %]
 
 	#  Server-pool size regulation.  Rather than making you guess
 	#  how many servers you need, FreeRADIUS dynamically adapts to

--- a/conf/radiusd/radiusd_loadbalancer.conf.example
+++ b/conf/radiusd/radiusd_loadbalancer.conf.example
@@ -476,7 +476,7 @@ thread pool {
 	#
 	#  For more information, see 'max_request_time', above.
 	#
-	max_servers = 64
+	max_servers = [% max_servers %]
 
 	#  Server-pool size regulation.  Rather than making you guess
 	#  how many servers you need, FreeRADIUS dynamically adapts to

--- a/go/pfconfigdriver/structs.go
+++ b/go/pfconfigdriver/structs.go
@@ -721,6 +721,7 @@ type PfConfRadiusConfiguration struct {
 	PfacctSocketRecvBuffer             string   `json:"pfacct_socket_recv_buffer"`
 	PfacctAAANotifyWorkers             string   `json:"pfacct_aaa_notify_workers"`
 	PfacctAAANotifyQueueSize           string   `json:"pfacct_aaa_notify_queue_size"`
+	RadiusdMaxServers                  string   `json:"radiusd_max_servers"`
 }
 
 type PfQueueConfig struct {

--- a/html/pfappserver/root/src/views/Configuration/radius/general/_components/TheForm.vue
+++ b/html/pfappserver/root/src/views/Configuration/radius/general/_components/TheForm.vue
@@ -116,6 +116,11 @@
                                        :text="$i18n.t('Time to Live value in minutes, should be a little bit more than the Interim Update value. Requires a restart of pfacct to be effective')"
     />
 
+    <form-group-radiusd-max-servers namespace="radiusd_max_servers"
+                                    :column-label="$i18n.t('RADIUS worker threads')"
+                                    :text="$i18n.t('Maximum number of FreeRADIUS worker threads (max_servers). Also caps the concurrent REST connections to httpd.aaa. Requires a restart of radiusd to be effective')"
+    />
+
     <form-group-radius-attributes namespace="radius_attributes"
                                   :column-label="$i18n.t('RADIUS attributes')"
                                   :text="$i18n.t('List of RADIUS attributes that can be used in the sources configuration.')"
@@ -174,6 +179,7 @@ import {
   FormGroupPfacctRateLimit,
   FormGroupPfacctRateLimitCacheTtl,
   FormGroupProcessBandwidthAccounting,
+  FormGroupRadiusdMaxServers,
   FormGroupRadiusAttributes,
   FormGroupRecordAccountingInSql,
   FormGroupUsernameAttributes
@@ -204,7 +210,8 @@ const components = {
   FormGroupPfacctWorkers,
   FormGroupPfacctWorkQueueSize,
   FormGroupPfacctRateLimit,
-  FormGroupPfacctRateLimitCacheTtl
+  FormGroupPfacctRateLimitCacheTtl,
+  FormGroupRadiusdMaxServers
 }
 
 export const props = {

--- a/html/pfappserver/root/src/views/Configuration/radius/general/_components/index.js
+++ b/html/pfappserver/root/src/views/Configuration/radius/general/_components/index.js
@@ -32,6 +32,7 @@ export {
   BaseFormGroupInputNumber as FormGroupPfacctWorkQueueSize,
   BaseFormGroupSwitch as FormGroupPfacctRateLimit,
   BaseFormGroupInputNumber as FormGroupPfacctRateLimitCacheTtl,
+  BaseFormGroupInputNumber as FormGroupRadiusdMaxServers,
 
   BaseViewResource as BaseView,
   TheForm,

--- a/lib/pf/services/manager/radiusd_child.pm
+++ b/lib/pf/services/manager/radiusd_child.pm
@@ -345,6 +345,8 @@ sub generate_radiusd_mainconf {
     $tags{'rpc_port'} = $Config{webservices}{aaa_port} || "7070";
     $tags{'rpc_host'} = $Config{webservices}{aaa_host} || "127.0.0.1";
     $tags{'rpc_proto'} = $Config{webservices}{aaa_proto} || "http";
+    # thread pool max_servers; also caps the rlm_rest connection pool to httpd.aaa
+    $tags{'max_servers'} = $Config{radius_configuration}{radiusd_max_servers} || 128;
 
     $tt->process("$conf_dir/radiusd/radiusd.conf", \%tags, "$install_dir/raddb/radiusd.conf") or die $tt->error();
     $tt->process("$conf_dir/radiusd/radiusd_loadbalancer.conf", \%tags, "$install_dir/raddb/radiusd_loadbalancer.conf") or die $tt->error();


### PR DESCRIPTION
## Summary

- radiusd-auth's thread pool `max_servers` was hard-coded to 64 in the radiusd.conf template, and the rlm_rest connection pool inherits that value, so at most 64 authorizations could be in flight to httpd.aaa.
- At ~125 req/s any httpd.aaa latency tail above ~0.5s exhausted the pool. Further requests waited for a free connection until `max_request_time` (10s) and were rejected in post-auth, while httpd.aaa itself logged a normal reply. Seen on a load-test box with ~50% of Access-Requests rejected that way.
- Adds `radius_configuration.radiusd_max_servers` (default 128, exposed in Configuration > RADIUS > General) and renders it into the radiusd-auth and radiusd-load_balancer thread pools. The doc string notes it also bounds the REST pool, since each extra thread can hold one more httpd.aaa child busy.

## Files

- `conf/pf.conf.defaults`, `conf/documentation.conf`: new knob + documentation
- `conf/radiusd/radiusd.conf.example`, `conf/radiusd/radiusd_loadbalancer.conf.example`: template `max_servers` from the setting
- `lib/pf/services/manager/radiusd_child.pm`: pass the value into the templates
- `go/pfconfigdriver/structs.go`: struct field for the new setting
- `html/pfappserver/.../radius/general`: admin form field
- `NEWS.asciidoc`

## Test plan

- [ ] `pfcmd configreload hard` then `pfcmd service radiusd restart`; confirm generated `radiusd.conf` / `radiusd_loadbalancer.conf` carry `max_servers = 128`
- [ ] Change the value in Configuration > RADIUS > General, save, restart radiusd; confirm the new value is rendered
- [ ] Load test at >100 req/s with an induced httpd.aaa latency tail and confirm post-auth rejects from pool exhaustion disappear