### PR TITLE
fix(httpd): expose LOG_LEVEL to mod_perl so the Apache services honour it

### DIFF
--- a/NEWS.asciidoc
+++ b/NEWS.asciidoc
@@ -31,6 +31,8 @@ For a list of compatibility related changes see the <<PacketFence_Upgrade_Guide.
 
 === Bug Fixes
 
+  - LOG_LEVEL was ignored by the mod_perl services (httpd.aaa, httpd.webservices, httpd.portal): the variable reached the container but Apache never exposed it to Perl, so log4perl stayed at INFO. The httpd templates now PerlPassEnv it
+
 === Security Fixes
 
 == Version 15.2.0 released on 2026-08-24

--- a/conf/httpd.conf.d/httpd.aaa.tt.example
+++ b/conf/httpd.conf.d/httpd.aaa.tt.example
@@ -57,6 +57,10 @@
 
 [% INSERT "/usr/local/pf/lib/pf/web/apache-env-variables.inc" %]
 
+# Make LOG_LEVEL (set on the container / systemd unit) visible to mod_perl.
+# Plain environment variables are not available to Perl code running under
+# Apache; without this the log4perl config falls back to INFO.
+PerlPassEnv LOG_LEVEL
 PerlSwitches -I[% install_dir %]/lib
 PerlSwitches -I[% install_dir %]/lib_perl/lib/perl5
 PerlSwitches -I[% install_dir %]/html/pfappserver/lib

--- a/conf/httpd.conf.d/httpd.portal.tt.example
+++ b/conf/httpd.conf.d/httpd.portal.tt.example
@@ -59,6 +59,10 @@ TraceEnable off
 # Limit mod_perl to 1024MB of RAM
 PerlModule Apache2::Resource
 PerlSetEnv PERL_RLIMIT_AS 1024
+# Make LOG_LEVEL (set on the container / systemd unit) visible to mod_perl.
+# Plain environment variables are not available to Perl code running under
+# Apache; without this the log4perl config falls back to INFO.
+PerlPassEnv LOG_LEVEL
 PerlChildInitHandler Apache2::Resource
 
 [% INSERT "/usr/local/pf/lib/pf/web/apache-env-variables.inc" %]

--- a/conf/httpd.conf.d/httpd.webservices.tt.example
+++ b/conf/httpd.conf.d/httpd.webservices.tt.example
@@ -57,6 +57,10 @@
 
 [% INSERT "/usr/local/pf/lib/pf/web/apache-env-variables.inc" %]
 
+# Make LOG_LEVEL (set on the container / systemd unit) visible to mod_perl.
+# Plain environment variables are not available to Perl code running under
+# Apache; without this the log4perl config falls back to INFO.
+PerlPassEnv LOG_LEVEL
 PerlSwitches -I[% install_dir %]/lib
 PerlSwitches -I[% install_dir %]/lib_perl/lib/perl5
 PerlSwitches -I[% install_dir %]/html/pfappserver/lib


### PR DESCRIPTION
## Problem

The systemd wrapper passes `LOG_LEVEL` into every container and the Go services honour it, but under Apache the variable never reached Perl. mod_perl sanitises `%ENV`, so the log4perl config's `($ENV{LOG_LEVEL} || 'INFO')` always evaluated to `INFO` for httpd.aaa, httpd.webservices and httpd.portal.

Verified on a loaded box: the apache parent process had `LOG_LEVEL=WARN` in its environment while the service kept logging INFO (~400 INFO lines/s).

## Fix

Add `PerlPassEnv LOG_LEVEL` to the three mod_perl templates, ahead of the `PerlConfigRequire` / `PerlPostConfigRequire` that loads `pf::log`, so the value is in `%ENV` at startup when log4perl is initialised.

## Validation

On 172.235.26.61 under ~130 authz/s, with the stock `conf/log.conf.d/httpd.aaa.conf` and only a systemd drop-in `Environment=LOG_LEVEL=WARN`:

| | INFO lines / 10 s from httpd.aaa |
|---|---|
| without the PerlPassEnv line | ~4000 |
| with the PerlPassEnv line | 0 |

Rendered config shows the line, and the service kept answering through the restart.