### PR TITLE
fix(radiusd): cache dynamic clients for 300s instead of per-packet lookups

### DIFF
--- a/NEWS.asciidoc
+++ b/NEWS.asciidoc
@@ -29,7 +29,7 @@ For a list of compatibility related changes see the <<PacketFence_Upgrade_Guide.
 
 === Enhancements
 
-  - RADIUS dynamic clients (switches resolved from radius_nas) are now cached for 300 seconds instead of being re-resolved from the database on every packet
+  - RADIUS dynamic clients (switches resolved from radius_nas) are now cached for 300 seconds. With the FreeRADIUS build shipped by PacketFence, `lifetime = 0` deleted the client after every request and re-ran the radius_nas lookups for every packet (fork commit b04cb25fe, reverted separately in inverse-inc/freeradius-server#3). A changed switch secret or type now applies to an already-known switch within five minutes
 
 === Bug Fixes
 

--- a/NEWS.asciidoc
+++ b/NEWS.asciidoc
@@ -29,6 +29,8 @@ For a list of compatibility related changes see the <<PacketFence_Upgrade_Guide.
 
 === Enhancements
 
+  - RADIUS dynamic clients (switches resolved from radius_nas) are now cached for 300 seconds instead of being re-resolved from the database on every packet
+
 === Bug Fixes
 
 === Security Fixes

--- a/addons/pfconnector/conf/radiusd/dynamic-clients
+++ b/addons/pfconnector/conf/radiusd/dynamic-clients
@@ -3,7 +3,9 @@ client dynamic {
         ipaddr = 0.0.0.0/0
         dynamic_clients = dynamic_clients_server
         directory = ${confdir}/dynamic-clients/
-        lifetime = 0
+        # Re-read the synced client file when it changes, at most once
+        # per lifetime; a client whose file is unchanged is simply renewed.
+        lifetime = 300
 }
 
 server dynamic_clients_server {

--- a/addons/pfconnector/conf/radiusd/dynamic-clients
+++ b/addons/pfconnector/conf/radiusd/dynamic-clients
@@ -3,8 +3,11 @@ client dynamic {
         ipaddr = 0.0.0.0/0
         dynamic_clients = dynamic_clients_server
         directory = ${confdir}/dynamic-clients/
-        # Re-read the synced client file when it changes, at most once
-        # per lifetime; a client whose file is unchanged is simply renewed.
+        # Client files are written by the sync-radius-nas oneshot at container
+        # start and not modified afterwards, so at expiry FreeRADIUS only
+        # stat()s the file and renews the entry.  Same value as the server side;
+        # do not use "0": the PacketFence FreeRADIUS build deletes lifetime-0
+        # dynamic clients after every request.
         lifetime = 300
 }
 

--- a/docs/PacketFence_Upgrade_Guide.asciidoc
+++ b/docs/PacketFence_Upgrade_Guide.asciidoc
@@ -938,6 +938,28 @@ Internet Explorer 11 on Windows 7 when an RSA certificate is in use.
 
 == Upgrading from a version prior to X.Y.Z
 
+=== RADIUS dynamic clients are now cached for 300 seconds
+
+[filename]`/usr/local/pf/raddb/sites-available/dynamic-clients` now sets
+`lifetime = 300` instead of `lifetime = "0"`. With the previous value every
+RADIUS packet re-resolved its switch from the `radius_nas` table (three SQL
+queries per packet); switches are now cached for five minutes, so a changed
+secret or type in the switch configuration takes up to five minutes to apply
+to an already-known switch.
+
+If you never modified that file, the package upgrade updates it automatically
+and the new value is applied when radiusd restarts at the end of the upgrade.
+
+If you customized it, the package manager keeps your version and ships the new
+default alongside (`.rpmnew` on RHEL, dpkg conffile prompt on Debian). Set
+`lifetime = 300` (or any positive number of seconds) in the `client dynamic`
+block of your file, then restart:
+
+[source,bash]
+----
+systemctl restart packetfence-radiusd-auth
+----
+
 == Troubleshooting Upgrades
 
 include::troubleshooting/service_failures.asciidoc[]

--- a/docs/PacketFence_Upgrade_Guide.asciidoc
+++ b/docs/PacketFence_Upgrade_Guide.asciidoc
@@ -941,23 +941,21 @@ Internet Explorer 11 on Windows 7 when an RSA certificate is in use.
 === RADIUS dynamic clients are now cached for 300 seconds
 
 [filename]`/usr/local/pf/raddb/sites-available/dynamic-clients` now sets
-`lifetime = 300` instead of `lifetime = "0"`. With the previous value every
-RADIUS packet re-resolved its switch from the `radius_nas` table (three SQL
-queries per packet); switches are now cached for five minutes, so a changed
-secret or type in the switch configuration takes up to five minutes to apply
-to an already-known switch.
+`lifetime = 300` instead of `lifetime = "0"`. With the FreeRADIUS build shipped
+by PacketFence the previous value re-resolved the switch from the `radius_nas`
+table on every RADIUS packet. Switches are now cached for five minutes, so a
+changed secret or type in a switch's configuration takes up to five minutes to
+apply to a switch radiusd already knows.
 
-If you never modified that file, the package upgrade updates it automatically
-and the new value is applied when radiusd restarts at the end of the upgrade.
-
-If you customized it, the package manager keeps your version and ships the new
-default alongside (`.rpmnew` on RHEL, dpkg conffile prompt on Debian). Set
-`lifetime = 300` (or any positive number of seconds) in the `client dynamic`
-block of your file, then restart:
+The file is a package configuration file: it is updated automatically unless
+you modified it (see the general procedure above). If you kept a customized
+copy, set `lifetime = 300` (or any positive number of seconds) in its
+`client dynamic` block and restart all RADIUS instances, since the file is
+included by the authentication, load-balancer and CLI servers:
 
 [source,bash]
 ----
-systemctl restart packetfence-radiusd-auth
+/usr/local/pf/bin/pfcmd service radiusd restart
 ----
 
 == Troubleshooting Upgrades

--- a/raddb/sites-available/dynamic-clients
+++ b/raddb/sites-available/dynamic-clients
@@ -69,7 +69,13 @@ client dynamic {
 	#  If the lifetime is "0", then the dynamic client is never
 	#  deleted.  The only way to delete the client is to re-start
 	#  the server.
-	lifetime = "0"
+	#
+	#  PacketFence resolves clients from the radius_nas table in the
+	#  dynamic_clients virtual server below (several SQL queries per
+	#  lookup).  A finite lifetime keeps that lookup off the per-packet
+	#  path while still picking up a changed secret or type from
+	#  radius_nas within this many seconds.
+	lifetime = 300
 }
 
 #

--- a/raddb/sites-available/dynamic-clients
+++ b/raddb/sites-available/dynamic-clients
@@ -66,15 +66,22 @@ client dynamic {
 	#  Define the lifetime (in seconds) for dynamic clients.
 	#  They will be cached for this lifetime, and deleted afterwards.
 	#
-	#  If the lifetime is "0", then the dynamic client is never
-	#  deleted.  The only way to delete the client is to re-start
-	#  the server.
-	#
 	#  PacketFence resolves clients from the radius_nas table in the
 	#  dynamic_clients virtual server below (several SQL queries per
-	#  lookup).  A finite lifetime keeps that lookup off the per-packet
-	#  path while still picking up a changed secret or type from
-	#  radius_nas within this many seconds.
+	#  lookup, run synchronously in the packet receive thread).  A finite
+	#  lifetime keeps that lookup off the per-packet path while still
+	#  picking up a changed secret or type from radius_nas within this
+	#  many seconds.
+	#
+	#  Do NOT set this to "0".  Upstream FreeRADIUS documents "0" as
+	#  "never expires", but the FreeRADIUS build shipped with PacketFence
+	#  deletes a lifetime-0 dynamic client after every request, which
+	#  re-runs the SQL lookups for every single packet.
+	#
+	#  Clients first seen in the same second (e.g. right after a restart)
+	#  expire together; each expiry costs the SQL lookups for that client.
+	#  Sites with thousands of RADIUS clients may prefer a longer lifetime
+	#  at the price of a longer delay before a changed secret applies.
 	lifetime = 300
 }
 


### PR DESCRIPTION
## Problem

`raddb/sites-available/dynamic-clients` ships `lifetime = "0"`. Our FreeRADIUS build carries fork commit b04cb25fe ("Remove client if lifetime equals to 0"), which deletes a lifetime-0 dynamic client after every request instead of caching it forever as upstream does. Net effect: every RADIUS packet re-runs the `dynamic_clients` virtual server, i.e. three `rlm_sql` queries against `radius_nas`, a client add, and the BlastRADIUS warning block in radius.log.

Measured on a load-test box at ~140 authz/s: ~490,000 "Adding client" lines per hour, `radmin show client list` holding zero switches, ~480 extra SQL queries/s on the request path.

## Fix

`lifetime = 300` in `raddb/sites-available/dynamic-clients` and in the pfconnector variant. A switch is resolved once and cached; a changed secret/type in `radius_nas` is picked up within 300 s. The pfconnector variant reads flat files synced from the server; FreeRADIUS renews an unchanged file at expiry (mtime check) and only re-reads a changed one.

Companion: inverse-inc/freeradius-server `fix/dynamic-clients-lifetime-0-revert` reverts the fork patch so `lifetime = 0` means "cached until restart" again, as the file's comments say. This config change is effective on the current binary on its own, because the fork patch only fires when lifetime is exactly 0.

## Validation (2026-09-11, ~140 authz/s, 15-min windows)

| | before | after |
|---|---|---|
| "Adding client" lines | ~122,000 | 18 (6 switches × one refresh per 300 s) |
| MariaDB queries/s | 19,800 | 3,400 (with the buffer-pool change from the same session) |
| rsyslogd CPU | 0.8 cores | 0.27 cores |