### PR TITLE
fix(radiusd): do not answer Access-Reject when the post-auth REST call fails

### DIFF
--- a/NEWS.asciidoc
+++ b/NEWS.asciidoc
@@ -31,7 +31,8 @@ For a list of compatibility related changes see the <<PacketFence_Upgrade_Guide.
 
 === Bug Fixes
 
-  - RADIUS: when the post-auth REST call to httpd.aaa fails (unreachable, timeout, 5xx), radiusd no longer answers with an Access-Reject but stays silent so the NAS retries or fails over; an Access-Reject tore down sessions the switch had already authorized on every httpd.aaa restart or stall
+  - RADIUS: for MAB and PAP requests, when the post-auth REST call to httpd.aaa fails (unreachable, timeout, 5xx) radiusd no longer answers with an Access-Reject but leaves the request unanswered, logging a "NoResponse" row in the RADIUS audit log. An Access-Reject tore down sessions the switch had already authorized on every httpd.aaa restart. EAP requests keep the Reject (the EAP conversation cannot be resumed on retransmit). Note: a NAS counts unanswered requests towards its dead-server criteria, so a stalled PacketFence now triggers the switch's fail-over behaviour (e.g. Cisco critical-auth) instead of de-authorizing ports
+  - RADIUS: /radius/rest/authorize now answers 503 instead of 401 when the request could not be evaluated (database unavailable, handler exception), so radiusd treats it as a failure rather than a deny; a database outage no longer turns every reauthentication into an Access-Reject
 
 === Security Fixes
 

--- a/NEWS.asciidoc
+++ b/NEWS.asciidoc
@@ -31,6 +31,8 @@ For a list of compatibility related changes see the <<PacketFence_Upgrade_Guide.
 
 === Bug Fixes
 
+  - RADIUS: when the post-auth REST call to httpd.aaa fails (unreachable, timeout, 5xx), radiusd no longer answers with an Access-Reject but stays silent so the NAS retries or fails over; an Access-Reject tore down sessions the switch had already authorized on every httpd.aaa restart or stall
+
 === Security Fixes
 
 == Version 15.2.0 released on 2026-08-24

--- a/conf/radiusd/packetfence-tunnel.example
+++ b/conf/radiusd/packetfence-tunnel.example
@@ -279,7 +279,20 @@ post-auth {
 		}
 	}
 	if !( ("%{client:shortname}" =~ /eduroam_tlrs/)  || (&request:PacketFence-ShortName && &request:PacketFence-ShortName =~ /eduroam_tlrs/)) {
-		rest
+		rest {
+			# httpd.aaa unreachable, timed out or answering 5xx: do not reply at all.
+			# Letting the section fail would send an Access-Reject, which tears down
+			# a session the NAS had already authorized (seen: every httpd.aaa restart
+			# disconnected thousands of devices on periodic reauth). Silence lets the
+			# NAS retry or fail over instead.
+			fail = 1
+		}
+		if (fail) {
+			update control {
+				&Response-Packet-Type := Do-Not-Respond
+			}
+			handled
+		}
 	}
 	update {
 		&request:User-Password := "******"
@@ -617,7 +630,20 @@ session {
 #  the ONLY safe way is to set "use_tunneled_reply = yes", and
 #  then update the inner-tunnel reply.
 post-auth {
-	rest
+	rest {
+		# httpd.aaa unreachable, timed out or answering 5xx: do not reply at all.
+		# Letting the section fail would send an Access-Reject, which tears down
+		# a session the NAS had already authorized (seen: every httpd.aaa restart
+		# disconnected thousands of devices on periodic reauth). Silence lets the
+		# NAS retry or fail over instead.
+		fail = 1
+	}
+	if (fail) {
+		update control {
+			&Response-Packet-Type := Do-Not-Respond
+		}
+		handled
+	}
 	update {
 		&request:User-Password := "******"
 	}

--- a/conf/radiusd/packetfence-tunnel.example
+++ b/conf/radiusd/packetfence-tunnel.example
@@ -279,20 +279,7 @@ post-auth {
 		}
 	}
 	if !( ("%{client:shortname}" =~ /eduroam_tlrs/)  || (&request:PacketFence-ShortName && &request:PacketFence-ShortName =~ /eduroam_tlrs/)) {
-		rest {
-			# httpd.aaa unreachable, timed out or answering 5xx: do not reply at all.
-			# Letting the section fail would send an Access-Reject, which tears down
-			# a session the NAS had already authorized (seen: every httpd.aaa restart
-			# disconnected thousands of devices on periodic reauth). Silence lets the
-			# NAS retry or fail over instead.
-			fail = 1
-		}
-		if (fail) {
-			update control {
-				&Response-Packet-Type := Do-Not-Respond
-			}
-			handled
-		}
+		rest
 	}
 	update {
 		&request:User-Password := "******"
@@ -630,20 +617,7 @@ session {
 #  the ONLY safe way is to set "use_tunneled_reply = yes", and
 #  then update the inner-tunnel reply.
 post-auth {
-	rest {
-		# httpd.aaa unreachable, timed out or answering 5xx: do not reply at all.
-		# Letting the section fail would send an Access-Reject, which tears down
-		# a session the NAS had already authorized (seen: every httpd.aaa restart
-		# disconnected thousands of devices on periodic reauth). Silence lets the
-		# NAS retry or fail over instead.
-		fail = 1
-	}
-	if (fail) {
-		update control {
-			&Response-Packet-Type := Do-Not-Respond
-		}
-		handled
-	}
+	rest
 	update {
 		&request:User-Password := "******"
 	}

--- a/conf/radiusd/packetfence.example
+++ b/conf/radiusd/packetfence.example
@@ -392,23 +392,8 @@ server packetfence {
 		# If the request has not been handled inside the inner-tunnel
 		# send it to packetfence
 		if (! EAP-Type || (EAP-Type != TTLS  && EAP-Type != PEAP) ) {
-			rest {
-				# httpd.aaa unreachable, timed out or answering 5xx: do not reply at all.
-				# Letting the section fail would send an Access-Reject, which tears down
-				# a session the NAS had already authorized (seen: every httpd.aaa restart
-				# disconnected thousands of devices on periodic reauth). Silence lets the
-				# NAS retry or fail over instead.
-				fail = 1
-			}
-			if (fail) {
-				update control {
-					&Response-Packet-Type := Do-Not-Respond
-				}
-				handled
-			}
-			update {
-				&request:User-Password := "******"
-			}
+			# rest + failure policy (see raddb/policy.d/packetfence)
+			packetfence-post-auth-rest
 			if ("%{%{control:PacketFence-Authorization-Status}:-Allow}" == "deny") {
 				packetfence-audit-log-reject
 				reject

--- a/conf/radiusd/packetfence.example
+++ b/conf/radiusd/packetfence.example
@@ -392,7 +392,20 @@ server packetfence {
 		# If the request has not been handled inside the inner-tunnel
 		# send it to packetfence
 		if (! EAP-Type || (EAP-Type != TTLS  && EAP-Type != PEAP) ) {
-			rest
+			rest {
+				# httpd.aaa unreachable, timed out or answering 5xx: do not reply at all.
+				# Letting the section fail would send an Access-Reject, which tears down
+				# a session the NAS had already authorized (seen: every httpd.aaa restart
+				# disconnected thousands of devices on periodic reauth). Silence lets the
+				# NAS retry or fail over instead.
+				fail = 1
+			}
+			if (fail) {
+				update control {
+					&Response-Packet-Type := Do-Not-Respond
+				}
+				handled
+			}
 			update {
 				&request:User-Password := "******"
 			}

--- a/lib/pf/radius.pm
+++ b/lib/pf/radius.pm
@@ -214,7 +214,7 @@ sub authorize {
         # registration VLAN and saving it at CLEANUP would clobber the real
         # row once the DB comes back; fail the request so the NAS retries.
         $logger->error("Unable to read node $mac from the database ($status_code). This request will be failed to avoid altering the access of the device.");
-        $RAD_REPLY_REF = [ $RADIUS::RLM_MODULE_FAIL, ('Reply-Message' => "Database is unavailable") ];
+        $RAD_REPLY_REF = [ $RADIUS::RLM_MODULE_FAIL, ('Reply-Message' => "Database is unavailable", RADIUS_FAILURE => 'database') ];
         goto AUDIT;
     }
     $node_obj->_load_locationlog;
@@ -985,7 +985,7 @@ sub vpn {
             # Node unreadable (e.g. DB down): fail instead of proceeding with
             # a fabricated default node that would be saved over the real row.
             $logger->error("Unable to read node $mac from the database ($status_code). This request will be failed to avoid altering the access of the device.");
-            return [ $RADIUS::RLM_MODULE_FAIL, ('Reply-Message' => "Database is unavailable") ];
+            return [ $RADIUS::RLM_MODULE_FAIL, ('Reply-Message' => "Database is unavailable", RADIUS_FAILURE => 'database') ];
         }
         $node_obj->_load_locationlog;
         if ($status_code != $STATUS::CREATED) {

--- a/lib/pf/radius/rest.pm
+++ b/lib/pf/radius/rest.pm
@@ -17,7 +17,7 @@ use warnings;
 
 use pf::log;
 use Apache2::Const -compile =>
-  qw(DONE OK DECLINED HTTP_UNAUTHORIZED HTTP_FORBIDDEN HTTP_NOT_IMPLEMENTED HTTP_UNSUPPORTED_MEDIA_TYPE HTTP_PRECONDITION_FAILED HTTP_NO_CONTENT HTTP_NOT_FOUND SERVER_ERROR HTTP_OK HTTP_INTERNAL_SERVER_ERROR);
+  qw(DONE OK DECLINED HTTP_UNAUTHORIZED HTTP_FORBIDDEN HTTP_NOT_IMPLEMENTED HTTP_UNSUPPORTED_MEDIA_TYPE HTTP_PRECONDITION_FAILED HTTP_NO_CONTENT HTTP_NOT_FOUND SERVER_ERROR HTTP_OK HTTP_INTERNAL_SERVER_ERROR HTTP_SERVICE_UNAVAILABLE);
 use pf::api::error;
 use pf::radius::constants;
 use MIME::Base64 qw(decode_base64);
@@ -31,9 +31,21 @@ Format a PacketFence RADIUS response to the format expected by the FreeRADIUS RE
 sub format_response {
     my ($response) = @_;
 
+    # No result at all: the handler died (caught in pf::api) or returned
+    # nothing. That is an infrastructure failure, not a policy decision, so
+    # answer 5xx: rlm_rest maps it to "fail", which the radiusd post-auth
+    # policy treats differently from a 401 "reject".
+    unless (ref($response) eq 'ARRAY' && @$response && defined $response->[0]) {
+        get_logger->error("RADIUS REST handler returned no result, answering 503");
+        die pf::api::error->new(status => Apache2::Const::HTTP_SERVICE_UNAVAILABLE, response => { 'control:PacketFence-Authorization-Status' => 'allow' });
+    }
+
     my $radius_return = shift @$response;
     my %mapped_object = @$response;
     my $radius_audit = delete $mapped_object{"RADIUS_AUDIT"} // {};
+    # Set by pf::radius when the request could not be evaluated for reasons
+    # unrelated to the device (e.g. database unavailable).
+    my $failure = delete $mapped_object{"RADIUS_FAILURE"};
     my %audit;
     while (my ($key, $value) = each %$radius_audit) {
         $audit{"control:$key"} = $value;
@@ -49,6 +61,14 @@ sub format_response {
     if($radius_return == $RADIUS::RLM_MODULE_USERLOCK) {
         $response->{'control:PacketFence-Authorization-Status'} = 'deny';
         $radius_return = $RADIUS::RLM_MODULE_OK
+    }
+
+    if ($radius_return == $RADIUS::RLM_MODULE_FAIL && $failure) {
+        # Infrastructure failure: 503 -> rlm_rest "fail". A 401 would be a
+        # "reject" and turn e.g. a database outage into Access-Rejects that
+        # tear down every session being reauthenticated.
+        get_logger->error("RADIUS request could not be evaluated ($failure failure), answering 503");
+        die pf::api::error->new(status => Apache2::Const::HTTP_SERVICE_UNAVAILABLE, response => $response);
     }
 
     unless ($radius_return == $RADIUS::RLM_MODULE_OK || $radius_return == $RADIUS::RLM_MODULE_NOOP || $radius_return == $RADIUS::RLM_MODULE_UPDATED || $radius_return == $RADIUS::RLM_MODULE_HANDLED) {

--- a/raddb/policy.d/packetfence
+++ b/raddb/policy.d/packetfence
@@ -237,3 +237,58 @@ packetfence-base64-password {
     }
 }
 
+#
+#  Audit row for a request that was deliberately left unanswered (see
+#  packetfence-post-auth-rest): keeps an httpd.aaa outage visible in the
+#  RADIUS audit log instead of a gap.
+#
+packetfence-audit-log-no-response {
+    if (&User-Name && (&User-Name == "dummy")) {
+        noop
+    }
+    else {
+        request-timing
+        %{redis:RPUSH RADIUS_AUDIT_LOG '%{base64:["NoResponse",%{json_encode:&request:[*]},%{json_encode:&reply:[*]},%{json_encode:control:PacketFence-Computer-Name control:PacketFence-Switch-Id control:PacketFence-Switch-Mac control:PacketFence-Switch-Ip-Address control:PacketFence-IfIndex control:PacketFence-Connection-Type control:Auth-Type control:PacketFence-Role control:PacketFence-Status control:PacketFence-Profile control:PacketFence-Source control:PacketFence-AutoReg control:PacketFence-IsPhone control:PacketFence-Request-Time Packet-Src-IP-Address}]}'}
+    }
+}
+
+#
+#  Post-auth call to httpd.aaa (/radius/rest/authorize) with a failure policy.
+#
+#  rlm_rest returns "fail" when httpd.aaa is unreachable, times out or answers
+#  5xx (which /radius/rest/authorize does for infrastructure failures such as
+#  an unavailable database). Letting the section fail sent an Access-Reject,
+#  which a NAS treats as authoritative: on a periodic reauthentication it tears
+#  down a session it had already authorized. Every httpd.aaa restart did that
+#  to thousands of devices.
+#
+#  MAB / PAP (no EAP): the request is left unanswered (do_not_respond). The
+#  NAS retransmits and, if PacketFence stays silent long enough, marks the
+#  server dead and applies its own fail-over policy (critical-auth on Cisco);
+#  the existing session is untouched.
+#
+#  EAP: the Reject is kept. rlm_eap has already freed the conversation when
+#  post-auth runs, so a retransmit cannot be resumed; silence would only delay
+#  the Reject while getting the server marked dead. Deliberate denials
+#  (PacketFence-Authorization-Status = deny, 401) are unaffected either way.
+#
+packetfence-post-auth-rest {
+    rest {
+        fail = 1
+    }
+    if (fail) {
+        update {
+            &request:User-Password := "******"
+        }
+        if (&EAP-Type) {
+            reject
+        }
+        else {
+            packetfence-audit-log-no-response
+            do_not_respond
+        }
+    }
+    update {
+        &request:User-Password := "******"
+    }
+}

--- a/t/unittest/radius_rest_format_response.t
+++ b/t/unittest/radius_rest_format_response.t
@@ -1,0 +1,104 @@
+#!/usr/bin/perl
+
+=head1 NAME
+
+radius_rest_format_response
+
+=head1 DESCRIPTION
+
+pf::radius::rest::format_response maps the pf::radius return code to the HTTP
+status rlm_rest sees: policy decisions stay 401 ("reject"), infrastructure
+failures become 503 ("fail") so the radiusd post-auth policy can leave the
+request unanswered instead of tearing the session down with an Access-Reject.
+
+=cut
+
+use strict;
+use warnings;
+
+BEGIN {
+    use lib qw(/usr/local/pf/t);
+    use setup_test_config;
+}
+
+use Test::More tests => 15;
+use pf::radius::constants;
+
+use_ok('pf::radius::rest');
+
+# Returns undef when format_response succeeds, the HTTP status of the
+# pf::api::error it died with otherwise.
+sub status_of {
+    my ($ret) = @_;
+    my $ok = eval { pf::radius::rest::format_response($ret); 1 };
+    return undef if $ok;
+    my $e = $@;
+    return ref($e) eq 'pf::api::error' ? $e->status : "unexpected: $e";
+}
+
+# Success codes pass through, flagged allow, with the audit stash mapped to control:
+my $r = pf::radius::rest::format_response([
+    $RADIUS::RLM_MODULE_OK,
+    'Reply-Message' => 'welcome',
+    RADIUS_AUDIT    => { 'PacketFence-Role' => 'employee' },
+]);
+is($r->{'control:PacketFence-Authorization-Status'}, 'allow', 'OK is allowed');
+is($r->{'Reply-Message'}, 'welcome', 'reply attributes preserved');
+is($r->{'control:PacketFence-Role'}, 'employee', 'RADIUS_AUDIT mapped to control attributes');
+ok(!exists $r->{RADIUS_AUDIT}, 'RADIUS_AUDIT pseudo attribute removed');
+
+is(status_of([$RADIUS::RLM_MODULE_NOOP]), undef, 'NOOP does not die');
+is(status_of([$RADIUS::RLM_MODULE_UPDATED]), undef, 'UPDATED does not die');
+
+# USERLOCK is a deliberate deny carried inside a 200 so radiusd can audit it.
+$r = pf::radius::rest::format_response([$RADIUS::RLM_MODULE_USERLOCK]);
+is($r->{'control:PacketFence-Authorization-Status'}, 'deny', 'USERLOCK is a deny');
+
+# Policy decisions: 401 -> rlm_rest "reject" -> Access-Reject.
+is(status_of([$RADIUS::RLM_MODULE_REJECT]), 401, 'REJECT answers 401');
+is(status_of([$RADIUS::RLM_MODULE_FAIL, 'Reply-Message' => 'Switch is not managed by PacketFence']),
+    401, 'a FAIL without failure marker is still a deny (401)');
+
+# Infrastructure failures: 503 -> rlm_rest "fail" -> radiusd policy decides.
+is(status_of([$RADIUS::RLM_MODULE_FAIL, 'Reply-Message' => 'Database is unavailable', RADIUS_FAILURE => 'database']),
+    503, 'FAIL flagged RADIUS_FAILURE answers 503');
+is(status_of(undef), 503, 'undef result (handler died) answers 503');
+is(status_of([]), 503, 'empty result answers 503');
+is(status_of([undef]), 503, 'undefined return code answers 503');
+
+# The marker never leaks into the response body.
+my $ok = eval {
+    pf::radius::rest::format_response([$RADIUS::RLM_MODULE_FAIL, RADIUS_FAILURE => 'database']);
+    1;
+};
+ok(!$ok && ref($@) eq 'pf::api::error' && !exists $@->response->{RADIUS_FAILURE},
+    'RADIUS_FAILURE pseudo attribute removed from the error response');
+
+=head1 AUTHOR
+
+Inverse inc. <info@inverse.ca>
+
+=head1 COPYRIGHT
+
+Copyright (C) 2005-2026 Inverse inc.
+
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+USA.
+
+=cut
+
+1;


### PR DESCRIPTION
## Problem

In the `packetfence` post-auth section the `rest` call to httpd.aaa ran unguarded. When httpd.aaa was unreachable, timed out or answered 5xx, rlm_rest returned `fail`, the section failed and FreeRADIUS sent an **Access-Reject**. A NAS treats that as authoritative: on a periodic reauthentication it tears down a session it had already authorized. On a load-test site (5 switches × 10k ports, MAB reauth every 300 s) every httpd.aaa restart or stall disconnected thousands of devices; PF's own audit log showed 1050 rejects in one hour for a single NAS during two short restarts.

## Fix (after review)

- **Scope: MAB / PAP only.** For requests without EAP the REST failure now leaves the request unanswered (`do_not_respond`); the NAS retransmits and, if PacketFence stays silent, applies its own dead-server policy (e.g. Cisco critical-auth) while the existing session is untouched. **EAP keeps the Reject**: rlm_eap has already freed the conversation when post-auth runs, so a retransmit cannot be resumed and silence would only delay the Reject. The inner PEAP/TTLS tunnels are unchanged (a `handled` there would have produced a fail-open Access-Accept).
- **One shared policy**, `packetfence-post-auth-rest` in `raddb/policy.d/packetfence`: `rest { fail = 1 }`, User-Password scrubbed on both paths, `reject` for EAP, otherwise `packetfence-audit-log-no-response` + the existing `do_not_respond` policy.
- **Audit trail kept**: a `NoResponse` row (same shape as accept/reject, Module-Failure-Message in `reason`) is written for every silenced request, so an httpd.aaa outage stays visible in the RADIUS audit log instead of becoming a gap.
- **503 for infrastructure failures** in `lib/pf/radius/rest.pm`: `RLM_MODULE_FAIL` flagged `RADIUS_FAILURE` by pf::radius (the two "Database is unavailable" sites) and a missing result after a handler exception now answer 503 → rlm_rest `fail` → same policy. Policy denials ("Switch is not managed", "Mac is empty", USERLOCK, …) keep 401/deny. Unit test: `t/unittest/radius_rest_format_response.t` (15 checks).
- NEWS spells out the scope, the dead-server / critical-auth consequence and the 503 change. eduroam / pfconnector sites are EAP-only and untouched.

## Validation (172.235.26.61, ~130 authz/s)

| httpd.aaa restart | rest failures | Access-Rejects | max_request_time stalls | audit rows |
|---|---|---|---|---|
| before the branch (18:07) | many | yes → +1202 disconnected ports on one switch | yes | Reject rows |
| this branch (00:17) | 1869 | **0** | **0** | **1869 NoResponse** (reason: `rest: Request failed: 28 - Timeout was reached`) |

`freeradius -Cxm` OK; unit test green in the pfperl-api container.

Companion on the simulator side: akainverse/virtualSwitch#90 (a reject on reauth no longer unplugs the device).